### PR TITLE
Issue #47302 Migrate to Java 17

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
@@ -159,7 +159,7 @@ public final class BuildContext {
      * Emit a build note. This indicates information that the user may be interested in.
      *
      * @param location the location of interest (may be {@code null})
-     * @param format the format string (see {@link String#format(String, Object...)})
+     * @param format the format string (see {@link String#formatted(Object...)})
      * @param args the format arguments
      */
     public void note(Location location, String format, Object... args) {
@@ -171,7 +171,7 @@ public final class BuildContext {
      * Emit a build warning. This indicates a significant build problem that the user should be made aware of.
      *
      * @param location the location of interest (may be {@code null})
-     * @param format the format string (see {@link String#format(String, Object...)})
+     * @param format the format string (see {@link String#formatted(Object...)})
      * @param args the format arguments
      */
     public void warn(Location location, String format, Object... args) {
@@ -183,7 +183,7 @@ public final class BuildContext {
      * Emit a build error. This indicates a build problem that prevents the build from proceeding.
      *
      * @param location the location of interest (may be {@code null})
-     * @param format the format string (see {@link String#format(String, Object...)})
+     * @param format the format string (see {@link String#formatted(Object...)})
      * @param args the format arguments
      */
     public void error(Location location, String format, Object... args) {

--- a/core/builder/src/main/java/io/quarkus/builder/BuildException.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildException.java
@@ -1,5 +1,6 @@
 package io.quarkus.builder;
 
+import java.io.Serial;
 import java.util.Collections;
 import java.util.List;
 
@@ -10,6 +11,7 @@ import io.smallrye.common.constraint.Assert;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public class BuildException extends Exception {
+    @Serial
     private static final long serialVersionUID = -2190774463525631311L;
 
     private final List<Diagnostic> diagnostics;

--- a/core/builder/src/main/java/io/quarkus/builder/BuildResult.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildResult.java
@@ -116,18 +116,18 @@ public final class BuildResult {
      */
     public void closeAll() throws RuntimeException {
         for (BuildItem obj : simpleItems.values()) {
-            if (obj instanceof AutoCloseable)
+            if (obj instanceof AutoCloseable closeable)
                 try {
-                    ((AutoCloseable) obj).close();
+                    closeable.close();
                 } catch (Exception e) {
                     Messages.msg.closeFailed(obj, e);
                 }
         }
         for (List<? extends BuildItem> list : multiItems.values()) {
             for (BuildItem obj : list) {
-                if (obj instanceof AutoCloseable)
+                if (obj instanceof AutoCloseable closeable)
                     try {
-                        ((AutoCloseable) obj).close();
+                        closeable.close();
                     } catch (Exception e) {
                         Messages.msg.closeFailed(obj, e);
                     }

--- a/core/builder/src/main/java/io/quarkus/builder/ChainBuildException.java
+++ b/core/builder/src/main/java/io/quarkus/builder/ChainBuildException.java
@@ -1,11 +1,14 @@
 package io.quarkus.builder;
 
+import java.io.Serial;
+
 /**
  * The exception thrown when a deployer chain build fails.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class ChainBuildException extends Exception {
+    @Serial
     private static final long serialVersionUID = -1143606746171493097L;
 
     /**

--- a/core/builder/src/main/java/io/quarkus/builder/ConsumeFlags.java
+++ b/core/builder/src/main/java/io/quarkus/builder/ConsumeFlags.java
@@ -26,7 +26,7 @@ public final class ConsumeFlags extends Flags<ConsumeFlag, ConsumeFlags> {
 
     @Override
     protected ConsumeFlag castItemOrNull(final Object obj) {
-        return obj instanceof ConsumeFlag ? (ConsumeFlag) obj : null;
+        return obj instanceof ConsumeFlag cf ? cf : null;
     }
 
     @Override

--- a/core/builder/src/main/java/io/quarkus/builder/ItemId.java
+++ b/core/builder/src/main/java/io/quarkus/builder/ItemId.java
@@ -20,7 +20,7 @@ final class ItemId {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof ItemId && equals((ItemId) obj);
+        return obj instanceof ItemId ii && equals(ii);
     }
 
     boolean equals(ItemId obj) {

--- a/core/builder/src/main/java/io/quarkus/builder/Json.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Json.java
@@ -42,7 +42,7 @@ public final class Json {
         REPLACEMENTS = new HashMap<>();
         // control characters
         for (int i = CONTROL_CHAR_START; i <= CONTROL_CHAR_END; i++) {
-            REPLACEMENTS.put((char) i, String.format("\\u%04x", i));
+            REPLACEMENTS.put((char) i, "\\u%04x".formatted(i));
         }
         // quotation mark
         REPLACEMENTS.put('"', "\\\"");
@@ -127,7 +127,7 @@ public final class Json {
          *         otherwise
          */
         protected boolean isIgnored(Object value) {
-            return value == null || (ignoreEmptyBuilders && value instanceof JsonBuilder && ((JsonBuilder<?>) value).isEmpty());
+            return value == null || (ignoreEmptyBuilders && value instanceof JsonBuilder<?> jb && jb.isEmpty());
         }
 
         protected boolean isValuesEmpty(Collection<Object> values) {
@@ -135,8 +135,8 @@ public final class Json {
                 return true;
             }
             for (Object object : values) {
-                if (object instanceof JsonBuilder) {
-                    if (!((JsonBuilder<?>) object).isEmpty()) {
+                if (object instanceof JsonBuilder<?> builder) {
+                    if (!builder.isEmpty()) {
                         return false;
                     }
                 } else {
@@ -250,25 +250,25 @@ public final class Json {
 
         @Override
         void add(JsonValue element) {
-            if (element instanceof JsonString) {
-                add(((JsonString) element).value());
-            } else if (element instanceof JsonInteger) {
-                final long longValue = ((JsonInteger) element).longValue();
+            if (element instanceof JsonString string) {
+                add(string.value());
+            } else if (element instanceof JsonInteger integer) {
+                final long longValue = integer.longValue();
                 final int intValue = (int) longValue;
                 if (longValue == intValue) {
                     add(intValue);
                 } else {
                     add(longValue);
                 }
-            } else if (element instanceof JsonBoolean) {
-                add(((JsonBoolean) element).value());
-            } else if (element instanceof JsonArray) {
+            } else if (element instanceof JsonBoolean bool) {
+                add(bool.value());
+            } else if (element instanceof JsonArray array) {
                 final JsonArrayBuilder arrayBuilder = Json.array(ignoreEmptyBuilders, skipEscapeCharacters);
-                arrayBuilder.transform((JsonArray) element, transform);
+                arrayBuilder.transform(array, transform);
                 add(arrayBuilder);
-            } else if (element instanceof JsonObject) {
+            } else if (element instanceof JsonObject object) {
                 final JsonObjectBuilder objectBuilder = Json.object(ignoreEmptyBuilders, skipEscapeCharacters);
-                objectBuilder.transform((JsonObject) element, transform);
+                objectBuilder.transform(object, transform);
                 if (!objectBuilder.isEmpty()) {
                     add(objectBuilder);
                 }
@@ -368,30 +368,29 @@ public final class Json {
 
         @Override
         void add(JsonValue element) {
-            if (element instanceof JsonMember) {
-                final JsonMember member = (JsonMember) element;
+            if (element instanceof JsonMember member) {
                 final String attribute = member.attribute().value();
                 final JsonValue value = member.value();
-                if (value instanceof JsonString) {
-                    put(attribute, ((JsonString) value).value());
-                } else if (value instanceof JsonInteger) {
-                    final long longValue = ((JsonInteger) value).longValue();
+                if (value instanceof JsonString string) {
+                    put(attribute, string.value());
+                } else if (value instanceof JsonInteger integer) {
+                    final long longValue = integer.longValue();
                     final int intValue = (int) longValue;
                     if (longValue == intValue) {
                         put(attribute, intValue);
                     } else {
                         put(attribute, longValue);
                     }
-                } else if (value instanceof JsonBoolean) {
-                    final boolean booleanValue = ((JsonBoolean) value).value();
+                } else if (value instanceof JsonBoolean bool) {
+                    final boolean booleanValue = bool.value();
                     put(attribute, booleanValue);
-                } else if (value instanceof JsonArray) {
+                } else if (value instanceof JsonArray array) {
                     final JsonArrayBuilder arrayBuilder = Json.array(ignoreEmptyBuilders, skipEscapeCharacters);
-                    arrayBuilder.transform((JsonArray) value, transform);
+                    arrayBuilder.transform(array, transform);
                     put(attribute, arrayBuilder);
-                } else if (value instanceof JsonObject) {
+                } else if (value instanceof JsonObject object) {
                     final JsonObjectBuilder objectBuilder = Json.object(ignoreEmptyBuilders, skipEscapeCharacters);
-                    objectBuilder.transform((JsonObject) value, transform);
+                    objectBuilder.transform(object, transform);
                     if (!objectBuilder.isEmpty()) {
                         put(attribute, objectBuilder);
                     }
@@ -401,10 +400,10 @@ public final class Json {
     }
 
     static void appendValue(Appendable appendable, Object value, boolean skipEscapeCharacters) throws IOException {
-        if (value instanceof JsonObjectBuilder) {
-            appendable.append(((JsonObjectBuilder) value).build());
-        } else if (value instanceof JsonArrayBuilder) {
-            appendable.append(((JsonArrayBuilder) value).build());
+        if (value instanceof JsonObjectBuilder builder) {
+            appendable.append(builder.build());
+        } else if (value instanceof JsonArrayBuilder builder) {
+            appendable.append(builder.build());
         } else if (value instanceof String) {
             appendStringValue(appendable, value.toString(), skipEscapeCharacters);
         } else if (value instanceof Boolean || value instanceof Integer || value instanceof Long) {

--- a/core/builder/src/main/java/io/quarkus/builder/ProduceFlags.java
+++ b/core/builder/src/main/java/io/quarkus/builder/ProduceFlags.java
@@ -26,7 +26,7 @@ public final class ProduceFlags extends Flags<ProduceFlag, ProduceFlags> {
 
     @Override
     protected ProduceFlag castItemOrNull(final Object obj) {
-        return obj instanceof ProduceFlag ? (ProduceFlag) obj : null;
+        return obj instanceof ProduceFlag pf ? pf : null;
     }
 
     @Override

--- a/core/builder/src/main/java/io/quarkus/builder/diag/Diagnostic.java
+++ b/core/builder/src/main/java/io/quarkus/builder/diag/Diagnostic.java
@@ -57,7 +57,7 @@ public final class Diagnostic {
             b.append(location).append(": ");
         }
         b.append('[').append(level).append("]: ");
-        b.append(String.format(format, args));
+        b.append(format.formatted(args));
         if (thrown != null) {
             Writer stacktraceWriter = new StringWriter();
             thrown.printStackTrace(new PrintWriter(stacktraceWriter));

--- a/core/builder/src/main/java/io/quarkus/builder/location/Location.java
+++ b/core/builder/src/main/java/io/quarkus/builder/location/Location.java
@@ -15,7 +15,7 @@ public abstract class Location {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof Location && Objects.equals(parent, ((Location) obj).getParent());
+        return obj instanceof Location l && Objects.equals(parent, l.getParent());
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/ConstructorPropertiesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ConstructorPropertiesProcessor.java
@@ -29,8 +29,7 @@ public class ConstructorPropertiesProcessor {
 
     private void registerInstance(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, AnnotationInstance instance) {
         AnnotationTarget annotationTarget = instance.target();
-        if (annotationTarget instanceof MethodInfo) {
-            MethodInfo methodInfo = (MethodInfo) annotationTarget;
+        if (annotationTarget instanceof MethodInfo methodInfo) {
             String classname = methodInfo.declaringClass().toString();
             reflectiveClass.produce(asReflectiveClassBuildItem(classname));
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -620,8 +620,7 @@ public final class ExtensionLoader {
                             if (ctors.length == 1 || ctor.isAnnotationPresent(Inject.class)) {
                                 for (var type : ctor.getGenericParameterTypes()) {
                                     Class<?> theType = null;
-                                    if (type instanceof ParameterizedType) {
-                                        ParameterizedType pt = (ParameterizedType) type;
+                                    if (type instanceof ParameterizedType pt) {
                                         if (pt.getRawType().equals(RuntimeValue.class)) {
                                             theType = (Class<?>) pt.getActualTypeArguments()[0];
                                         } else {
@@ -823,8 +822,8 @@ public final class ExtensionLoader {
                                                 clazz.getSimpleName(), method.getName(),
                                                 Integer.toString(Math.abs(method.toString().hashCode())), identityComparison,
                                                 s -> {
-                                                    if (s instanceof Class) {
-                                                        var cfg = ((Class<?>) s).getAnnotation(ConfigRoot.class);
+                                                    if (s instanceof Class<?> clazz) {
+                                                        var cfg = clazz.getAnnotation(ConfigRoot.class);
                                                         if (cfg == null
                                                                 || (cfg.phase() != ConfigPhase.BUILD_AND_RUN_TIME_FIXED
                                                                         && recordAnnotation
@@ -835,8 +834,7 @@ public final class ExtensionLoader {
                                                         }
                                                         return runTimeProxies.get(s);
                                                     }
-                                                    if (s instanceof ParameterizedType) {
-                                                        ParameterizedType p = (ParameterizedType) s;
+                                                    if (s instanceof ParameterizedType p) {
                                                         if (p.getRawType() == RuntimeValue.class) {
                                                             Object object = runTimeProxies.get(p.getActualTypeArguments()[0]);
                                                             if (object == null) {
@@ -945,11 +943,11 @@ public final class ExtensionLoader {
     }
 
     static IllegalArgumentException reportError(AnnotatedElement e, String msg) {
-        if (e instanceof Member) {
-            return new IllegalArgumentException(msg + " at " + e + " of " + ((Member) e).getDeclaringClass());
-        } else if (e instanceof Parameter) {
-            return new IllegalArgumentException(msg + " at " + e + " of " + ((Parameter) e).getDeclaringExecutable() + " of "
-                    + ((Parameter) e).getDeclaringExecutable().getDeclaringClass());
+        if (e instanceof Member member) {
+            return new IllegalArgumentException(msg + " at " + e + " of " + member.getDeclaringClass());
+        } else if (e instanceof Parameter parameter) {
+            return new IllegalArgumentException(msg + " at " + e + " of " + parameter.getDeclaringExecutable() + " of "
+                    + parameter.getDeclaringExecutable().getDeclaringClass());
         } else {
             return new IllegalArgumentException(msg + " at " + e);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/SnapStartProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/SnapStartProcessor.java
@@ -37,7 +37,7 @@ public class SnapStartProcessor {
                 return;
             }
 
-        } else if (defaultVal == null || !defaultVal.isPresent() || !defaultVal.get().isDefaultValue()) {
+        } else if (defaultVal == null || defaultVal.isEmpty() || !defaultVal.get().isDefaultValue()) {
             return;
         }
         snapStartEnabled.produce(SnapStartEnabledBuildItem.INSTANCE);
@@ -58,7 +58,7 @@ public class SnapStartProcessor {
             if (!config.enable().get()) {
                 return;
             }
-        } else if (defaultVal == null || !defaultVal.isPresent() || !defaultVal.get().isDefaultValue()) {
+        } else if (defaultVal == null || defaultVal.isEmpty() || !defaultVal.get().isDefaultValue()) {
             return;
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/DefaultValuesConfigurationSource.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/DefaultValuesConfigurationSource.java
@@ -34,8 +34,7 @@ public class DefaultValuesConfigurationSource implements ConfigSource {
             return null;
         }
         final ClassDefinition.ClassMember member = match.getClassMember();
-        if (member instanceof ClassDefinition.ItemMember) {
-            final ClassDefinition.ItemMember leafMember = (ClassDefinition.ItemMember) member;
+        if (member instanceof ClassDefinition.ItemMember leafMember) {
             return leafMember.getDefaultValue();
         }
         return null;

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/definition/Definition.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/definition/Definition.java
@@ -19,11 +19,11 @@ public abstract class Definition {
     }
 
     static IllegalArgumentException reportError(AnnotatedElement e, String msg) {
-        if (e instanceof Member) {
-            return new IllegalArgumentException(msg + " at " + e + " of " + ((Member) e).getEnclosingDefinition());
-        } else if (e instanceof Parameter) {
-            return new IllegalArgumentException(msg + " at " + e + " of " + ((Parameter) e).getDeclaringExecutable() + " of "
-                    + ((Parameter) e).getDeclaringExecutable().getDeclaringClass());
+        if (e instanceof Member member) {
+            return new IllegalArgumentException(msg + " at " + e + " of " + member.getEnclosingDefinition());
+        } else if (e instanceof Parameter parameter) {
+            return new IllegalArgumentException(msg + " at " + e + " of " + parameter.getDeclaringExecutable() + " of "
+                    + parameter.getDeclaringExecutable().getDeclaringClass());
         } else {
             return new IllegalArgumentException(msg + " at " + e);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/matching/FieldContainer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/matching/FieldContainer.java
@@ -30,8 +30,7 @@ public final class FieldContainer extends Container {
             parent.getCombinedName(sb);
         }
         final ClassDefinition enclosing = member.getEnclosingDefinition();
-        if (enclosing instanceof RootDefinition) {
-            RootDefinition rootDefinition = (RootDefinition) enclosing;
+        if (enclosing instanceof RootDefinition rootDefinition) {
             String rootName = rootDefinition.getRootName();
             if (!rootName.isEmpty()) {
                 sb.append(rootName.replace('.', ':'));
@@ -51,8 +50,7 @@ public final class FieldContainer extends Container {
             parent.getPropertyName(sb);
         }
         final ClassDefinition enclosing = member.getEnclosingDefinition();
-        if (enclosing instanceof RootDefinition) {
-            RootDefinition rootDefinition = (RootDefinition) enclosing;
+        if (enclosing instanceof RootDefinition rootDefinition) {
             String rootName = rootDefinition.getRootName();
             if (!rootName.isEmpty()) {
                 sb.append(rootName);

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/matching/PatternMapBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/matching/PatternMapBuilder.java
@@ -69,8 +69,7 @@ public final class PatternMapBuilder {
                                 + ". This is likely because you have an incompatible combination of extensions that both define the same properties (e.g. including both reactive and blocking database extensions)");
             }
             patternMap.setMatched(container);
-        } else if (member instanceof ClassDefinition.MapMember) {
-            ClassDefinition.MapMember mapMember = (ClassDefinition.MapMember) member;
+        } else if (member instanceof ClassDefinition.MapMember mapMember) {
             ConfigPatternMap<Container> addTo = patternMap.getChild(ConfigPatternMap.WILD_CARD);
             if (addTo == null) {
                 patternMap.addChild(ConfigPatternMap.WILD_CARD, addTo = new ConfigPatternMap<>());

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/ArrayOf.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/ArrayOf.java
@@ -47,7 +47,7 @@ public final class ArrayOf extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof ArrayOf && equals((ArrayOf) obj);
+        return obj instanceof ArrayOf ao && equals(ao);
     }
 
     public boolean equals(final ArrayOf obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/CollectionOf.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/CollectionOf.java
@@ -43,7 +43,7 @@ public final class CollectionOf extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof CollectionOf && equals((CollectionOf) obj);
+        return obj instanceof CollectionOf co && equals(co);
     }
 
     public boolean equals(final CollectionOf obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/ConverterType.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/ConverterType.java
@@ -37,12 +37,9 @@ public abstract class ConverterType {
     }
 
     public static ConverterType of(Type type, AnnotatedElement element) {
-        if (type instanceof GenericArrayType) {
-            GenericArrayType genericArrayType = (GenericArrayType) type;
+        if (type instanceof GenericArrayType genericArrayType) {
             return new ArrayOf(of(genericArrayType.getGenericComponentType(), element));
-        } else if (type instanceof Class<?>) {
-            // simple type
-            Class<?> clazz = (Class<?>) type;
+        } else if (type instanceof Class<?> clazz) {
             if (clazz.isArray()) {
                 return new ArrayOf(of(clazz.getComponentType(), element));
             }
@@ -57,16 +54,14 @@ public abstract class ConverterType {
             // vvv todo: add validations here vvv
             // return result
             return leaf;
-        } else if (type instanceof ParameterizedType) {
-            final ParameterizedType paramType = (ParameterizedType) type;
+        } else if (type instanceof ParameterizedType paramType) {
             final Class<?> rawType = ReflectUtil.rawTypeOf(paramType);
             final Type[] args = paramType.getActualTypeArguments();
             if (args.length == 1) {
                 final Type arg = args[0];
                 if (rawType == Class.class) {
                     ConverterType result = of(Class.class, element);
-                    if (arg instanceof WildcardType) {
-                        final WildcardType wcType = (WildcardType) arg;
+                    if (arg instanceof WildcardType wcType) {
                         // gather bounds for validation
                         Class<?>[] upperBounds = ReflectUtil.rawTypesOfDestructive(wcType.getUpperBounds());
                         Class<?>[] lowerBounds = ReflectUtil.rawTypesOfDestructive(wcType.getLowerBounds());

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/Leaf.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/Leaf.java
@@ -41,7 +41,7 @@ public final class Leaf extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof Leaf && equals((Leaf) obj);
+        return obj instanceof Leaf l && equals(l);
     }
 
     public boolean equals(final Leaf obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/LowerBoundCheckOf.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/LowerBoundCheckOf.java
@@ -43,7 +43,7 @@ public final class LowerBoundCheckOf extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof LowerBoundCheckOf && equals((LowerBoundCheckOf) obj);
+        return obj instanceof LowerBoundCheckOf lbco && equals(lbco);
     }
 
     public boolean equals(final LowerBoundCheckOf obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/MinMaxValidated.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/MinMaxValidated.java
@@ -62,7 +62,7 @@ public final class MinMaxValidated extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof MinMaxValidated && equals((MinMaxValidated) obj);
+        return obj instanceof MinMaxValidated mmv && equals(mmv);
     }
 
     public boolean equals(final MinMaxValidated obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/OptionalOf.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/OptionalOf.java
@@ -32,7 +32,7 @@ public final class OptionalOf extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof OptionalOf && equals((OptionalOf) obj);
+        return obj instanceof OptionalOf oo && equals(oo);
     }
 
     public boolean equals(final OptionalOf obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/PatternValidated.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/PatternValidated.java
@@ -38,7 +38,7 @@ public final class PatternValidated extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof PatternValidated && equals((PatternValidated) obj);
+        return obj instanceof PatternValidated pv && equals(pv);
     }
 
     public boolean equals(final PatternValidated obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/UpperBoundCheckOf.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/type/UpperBoundCheckOf.java
@@ -43,7 +43,7 @@ public final class UpperBoundCheckOf extends ConverterType {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof UpperBoundCheckOf && equals((UpperBoundCheckOf) obj);
+        return obj instanceof UpperBoundCheckOf ubco && equals(ubco);
     }
 
     public boolean equals(final UpperBoundCheckOf obj) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
@@ -2,7 +2,7 @@ package io.quarkus.deployment.console;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -572,7 +572,7 @@ public class AeshConsole extends QuarkusConsole {
                     .enableExport(false)
                     .enableAlias(true)
                     .aliasManager(
-                            new AliasManager(Paths.get(System.getProperty("user.home")).resolve(ALIAS_FILE).toFile(), true))
+                            new AliasManager(Path.of(System.getProperty("user.home")).resolve(ALIAS_FILE).toFile(), true))
                     .connection(delegateConnection)
                     .commandRegistry(registry)
                     .build();
@@ -597,7 +597,7 @@ public class AeshConsole extends QuarkusConsole {
     @Override
     public Map<Character, String> singleLetterAliases() {
         try {
-            var manager = new AliasManager(Paths.get(System.getProperty("user.home")).resolve(ALIAS_FILE).toFile(), true);
+            var manager = new AliasManager(Path.of(System.getProperty("user.home")).resolve(ALIAS_FILE).toFile(), true);
             Map<Character, String> ret = new HashMap<>();
             for (String alias : manager.getAllNames()) {
                 if (alias.length() == 1) {
@@ -624,7 +624,7 @@ public class AeshConsole extends QuarkusConsole {
                     .inputStream(new ByteArrayInputStream(new byte[] { (byte) alias, '\n' }))
                     .enableAlias(true)
                     .aliasManager(
-                            new AliasManager(Paths.get(System.getProperty("user.home")).resolve(ALIAS_FILE).toFile(), true))
+                            new AliasManager(Path.of(System.getProperty("user.home")).resolve(ALIAS_FILE).toFile(), true))
                     .connection(delegateConnection)
                     .commandRegistry(registry)
                     .build();

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilerFlags.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilerFlags.java
@@ -81,7 +81,7 @@ public class CompilerFlags {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof CompilerFlags && toList().equals(((CompilerFlags) obj).toList());
+        return obj instanceof CompilerFlags cf && toList().equals(cf.toList());
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.dev;
 
 import java.io.File;
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.URL;
 import java.nio.file.Path;
@@ -28,6 +29,7 @@ import io.quarkus.paths.PathList;
  */
 public class DevModeContext implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4688502145533897982L;
 
     public static final CompilationUnit EMPTY_COMPILATION_UNIT = new CompilationUnit(PathList.of(), null, null, null, null);
@@ -260,6 +262,7 @@ public class DevModeContext implements Serializable {
 
     public static class ModuleInfo implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -1376678003747618410L;
 
         private final ArtifactKey appArtifactKey;
@@ -309,7 +312,7 @@ public class DevModeContext implements Serializable {
         public void addSourcePaths(Collection<String> additionalPaths) {
             this.main.sourcePaths = this.main.sourcePaths.add(
                     additionalPaths.stream()
-                            .map(p -> Paths.get(p).isAbsolute() ? p : (projectDirectory + File.separator + p))
+                            .map(p -> Path.of(p).isAbsolute() ? p : (projectDirectory + File.separator + p))
                             .map(Paths::get)
                             .toArray(Path[]::new));
         }
@@ -335,9 +338,9 @@ public class DevModeContext implements Serializable {
         }
 
         public void addSourcePathFirst(String path) {
-            String absolutePath = Paths.get(path).isAbsolute() ? path
+            String absolutePath = Path.of(path).isAbsolute() ? path
                     : (projectDirectory + File.separator + path);
-            this.main.sourcePaths = this.main.sourcePaths.addFirst(Paths.get(absolutePath));
+            this.main.sourcePaths = this.main.sourcePaths.addFirst(Path.of(absolutePath));
         }
 
         public static class Builder {
@@ -443,6 +446,7 @@ public class DevModeContext implements Serializable {
 
     public static class CompilationUnit implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -511238068393954948L;
 
         private PathCollection sourcePaths;

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
@@ -15,7 +15,6 @@ import java.net.URL;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -110,7 +109,7 @@ public class DevModeMain implements Closeable {
                     map);
         } catch (Throwable t) {
             log.error("Quarkus dev mode failed to start", t);
-            throw (t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t));
+            throw (t instanceof RuntimeException re ? re : new RuntimeException(t));
             //System.exit(1);
         }
     }
@@ -188,7 +187,7 @@ public class DevModeMain implements Closeable {
         if (projectDir == null) { // this is the case for QuarkusDevModeTest
             return;
         }
-        Path currentDir = Paths.get("").toAbsolutePath().normalize();
+        Path currentDir = Path.of("").toAbsolutePath().normalize();
         if (projectDir.toPath().equals(currentDir)) {
             // the current directory is the same as the project directory so there is no need to copy the file as it's already in the proper location
             // see https://github.com/quarkusio/quarkus/issues/8812

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -400,8 +400,8 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
             curatedApplication = o;
 
             Object potentialContext = params.get(DevModeContext.class.getName());
-            if (potentialContext instanceof DevModeContext) {
-                context = (DevModeContext) potentialContext;
+            if (potentialContext instanceof DevModeContext modeContext) {
+                context = modeContext;
             } else {
                 //this was from the external class loader
                 //we need to copy it into this one
@@ -434,7 +434,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                             ? RuntimeUpdatesProcessor.INSTANCE.getCompileProblem()
                             : deploymentProblem.get();
 
-                    throw (throwable instanceof RuntimeException ? (RuntimeException) throwable
+                    throw (throwable instanceof RuntimeException re ? re
                             : new RuntimeException(throwable));
                 }
             }
@@ -455,7 +455,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
             }, "Quarkus Shutdown Thread");
             Runtime.getRuntime().addShutdownHook(shutdownThread);
         } catch (Exception e) {
-            RuntimeException toThrow = (e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e));
+            RuntimeException toThrow = (e instanceof RuntimeException re ? re : new RuntimeException(e));
             try {
                 close();
             } catch (IllegalStateException x) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
@@ -204,8 +204,8 @@ public class IsolatedRemoteDevModeMain implements BiConsumer<CuratedApplication,
         try {
             curatedApplication = o;
             Object potentialContext = o2.get(DevModeContext.class.getName());
-            if (potentialContext instanceof DevModeContext) {
-                context = (DevModeContext) potentialContext;
+            if (potentialContext instanceof DevModeContext modeContext) {
+                context = modeContext;
             } else {
                 //this was from the external class loader
                 //we need to copy it into this one

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedTestModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedTestModeMain.java
@@ -110,8 +110,8 @@ public class IsolatedTestModeMain extends IsolatedDevModeMain {
         try {
             curatedApplication = o;
             Object potentialContext = params.get(DevModeContext.class.getName());
-            if (potentialContext instanceof DevModeContext) {
-                context = (DevModeContext) potentialContext;
+            if (potentialContext instanceof DevModeContext modeContext) {
+                context = modeContext;
             } else {
                 //this was from the external class loader
                 //we need to copy it into this one

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -130,6 +130,6 @@ public class JavaCompilationProvider implements CompilationProvider {
     private String extractCompilationErrorMessage(final DiagnosticCollector<JavaFileObject> diagnosticsCollector) {
         StringBuilder builder = new StringBuilder();
         diagnosticsCollector.getDiagnostics().forEach(diagnostic -> builder.append("\n").append(diagnostic));
-        return String.format("\u001B[91mCompilation Failed:%s\u001b[0m", builder);
+        return "\u001B[91mCompilation Failed:%s\u001b[0m".formatted(builder);
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusCompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusCompiler.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
@@ -159,7 +158,7 @@ public class QuarkusCompiler implements Closeable {
                                     f = new File(cpEntryURI.getPath());
                                 } else {
                                     try {
-                                        f = Paths.get(new URI("file", null, "/", null).resolve(cpEntryURI)).toFile();
+                                        f = Path.of(new URI("file", null, "/", null).resolve(cpEntryURI)).toFile();
                                     } catch (URISyntaxException e) {
                                         f = new File(file.getParentFile(), classPathEntry);
                                     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesClassVisitor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesClassVisitor.java
@@ -3,7 +3,6 @@ package io.quarkus.deployment.dev;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.objectweb.asm.ClassVisitor;
 
@@ -28,7 +27,7 @@ public class RuntimeUpdatesClassVisitor extends ClassVisitor {
 
     public Path getSourceFileForClass(final Path classFilePath) {
         for (Path sourcesDir : sourcePaths) {
-            final Path classesDir = Paths.get(classesPath);
+            final Path classesDir = Path.of(classesPath);
             final StringBuilder sourceRelativeDir = new StringBuilder();
             sourceRelativeDir.append(classesDir.relativize(classFilePath.getParent()));
             sourceRelativeDir.append(File.separator);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -388,7 +388,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                     ret.add(path);
                 }
             } else if (i.getMain().getResourcesOutputPath() != null) {
-                ret.add(Paths.get(i.getMain().getResourcesOutputPath()));
+                ret.add(Path.of(i.getMain().getResourcesOutputPath()));
             }
         }
         Collections.reverse(ret); //make sure the actual project is before dependencies
@@ -838,7 +838,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
         try {
             for (String folder : cuf.apply(module).getClassesPath().split(File.pathSeparator)) {
-                final Path moduleClassesPath = Paths.get(folder);
+                final Path moduleClassesPath = Path.of(folder);
                 if (!Files.exists(moduleClassesPath)) {
                     continue;
                 }
@@ -953,7 +953,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
             if (rootPaths.isEmpty()) {
                 String rootPath = compilationUnit.getClassesPath();
                 if (rootPath != null) {
-                    rootPaths = PathList.of(Paths.get(rootPath));
+                    rootPaths = PathList.of(Path.of(rootPath));
                 }
                 outputPath = rootPath;
                 doCopy = false;
@@ -961,7 +961,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
             if (rootPaths.isEmpty() || outputPath == null) {
                 continue;
             }
-            Path outputDir = Paths.get(outputPath);
+            Path outputDir = Path.of(outputPath);
             final List<Path> roots = rootPaths.stream()
                     .filter(Files::exists)
                     .filter(Files::isReadable)
@@ -1216,7 +1216,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                     // Then process glob patterns
                     for (Entry<String, Boolean> e : watchedFilePaths.entrySet()) {
                         String watchedFilePath = e.getKey();
-                        Path path = Paths.get(sanitizedPattern(watchedFilePath));
+                        Path path = Path.of(sanitizedPattern(watchedFilePath));
                         if (!path.isAbsolute() && !watchedRootPaths.contains(e.getKey())
                                 && maybeGlobPattern(watchedFilePath)) {
                             try {
@@ -1252,9 +1252,9 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         // Finally process watched absolute paths
         for (Entry<String, Boolean> e : watchedFilePaths.entrySet()) {
             String watchedFilePath = e.getKey();
-            Path path = Paths.get(sanitizedPattern(watchedFilePath));
+            Path path = Path.of(sanitizedPattern(watchedFilePath));
             if (path.isAbsolute()) {
-                path = Paths.get(watchedFilePath);
+                path = Path.of(watchedFilePath);
                 log.debugf("Watch %s", path);
                 if (Files.exists(path)) {
                     putLastModifiedTime(path, path, e.getValue(), timestamps);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -11,7 +11,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -573,7 +572,7 @@ public class JunitTestRunner {
         //we also only run tests from the current module, which we can also revisit later
         Indexer indexer = new Indexer();
         moduleInfo.getTest().ifPresent(test -> {
-            try (Stream<Path> files = Files.walk(Paths.get(test.getClassesPath()))) {
+            try (Stream<Path> files = Files.walk(Path.of(test.getClassesPath()))) {
                 files.filter(s -> s.getFileName().toString().endsWith(".class")).forEach(s -> {
                     try (InputStream in = Files.newInputStream(s)) {
                         indexer.index(in);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
@@ -73,8 +73,8 @@ public class TestClassUsages implements Serializable {
                     return FilterResult.included("Class was touched");
                 }
                 TestSource source = testDescriptor.getSource().get();
-                if (source instanceof ClassSource) {
-                    String testClassName = ((ClassSource) source).getClassName();
+                if (source instanceof ClassSource classSource) {
+                    String testClassName = classSource.getClassName();
                     ClassAndMethod cm = new ClassAndMethod(testClassName, null);
                     if (!classNames.containsKey(cm)) {
                         return FilterResult.included("No test information");
@@ -85,8 +85,7 @@ public class TestClassUsages implements Serializable {
                     } else {
                         return FilterResult.excluded("Has no tests");
                     }
-                } else if (source instanceof MethodSource) {
-                    MethodSource ms = (MethodSource) source;
+                } else if (source instanceof MethodSource ms) {
                     ClassAndMethod cm = new ClassAndMethod(ms.getClassName(), testDescriptor.getUniqueId());
                     if (!classNames.containsKey(cm)) {
                         return FilterResult.included("No test information");

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
@@ -61,8 +61,7 @@ public class IndexWrapper implements IndexView {
             return index.getKnownClasses();
         }
         Collection<ClassInfo> known = index.getKnownClasses();
-        Collection<ClassInfo> additional = additionalClasses.values().stream().filter(Optional::isPresent)
-                .map(Optional::get)
+        Collection<ClassInfo> additional = additionalClasses.values().stream().flatMap(Optional::stream)
                 .collect(Collectors.toList());
         List<ClassInfo> all = new ArrayList<>(known.size() + additional.size());
         all.addAll(known);
@@ -207,7 +206,7 @@ public class IndexWrapper implements IndexView {
         }
         Set<ClassInfo> directImplementors = new HashSet<ClassInfo>(index.getKnownDirectImplementors(className));
         for (Optional<ClassInfo> additional : additionalClasses.values()) {
-            if (!additional.isPresent()) {
+            if (additional.isEmpty()) {
                 continue;
             }
             for (Type interfaceType : additional.get().interfaceTypes()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -4,7 +4,6 @@ import static io.quarkus.runtime.logging.LoggingSetupRecorder.initializeBuildTim
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -757,7 +756,7 @@ public final class LoggingResourceProcessor {
             }
             return baseDir.resolve(SRC_MAIN_JAVA);
         }
-        return Paths.get(SRC_MAIN_JAVA);
+        return Path.of(SRC_MAIN_JAVA);
     }
 
     private static final String SRC_MAIN_JAVA = "src/main/java";

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -20,7 +20,6 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -633,7 +632,7 @@ public class JarResultBuildStep {
             FileUtil.deleteDirectory(decompiledOutputDir);
             Files.createDirectory(decompiledOutputDir);
             decompiler = new Decompiler.VineflowerDecompiler();
-            Path jarDirectory = Paths.get(decompilerConfig.jarDirectory());
+            Path jarDirectory = Path.of(decompilerConfig.jarDirectory());
             if (!Files.exists(jarDirectory)) {
                 Files.createDirectory(jarDirectory);
             }
@@ -1451,8 +1450,8 @@ public class JarResultBuildStep {
             });
         } catch (RuntimeException re) {
             final Throwable cause = re.getCause();
-            if (cause instanceof IOException) {
-                throw (IOException) cause;
+            if (cause instanceof IOException exception) {
+                throw exception;
             }
             throw re;
         }
@@ -1645,7 +1644,7 @@ public class JarResultBuildStep {
             @Override
             public void init(Context context) {
                 this.context = context;
-                this.decompilerJar = context.jarLocation.resolve(String.format("vineflower-%s.jar", context.versionStr));
+                this.decompilerJar = context.jarLocation.resolve("vineflower-%s.jar".formatted(context.versionStr));
             }
 
             @Override
@@ -1653,9 +1652,9 @@ public class JarResultBuildStep {
                 if (Files.exists(decompilerJar)) {
                     return true;
                 }
-                String downloadURL = String.format(
-                        "https://repo.maven.apache.org/maven2/org/vineflower/vineflower/%s/vineflower-%s.jar",
-                        context.versionStr, context.versionStr);
+                String downloadURL = "https://repo.maven.apache.org/maven2/org/vineflower/vineflower/%s/vineflower-%s.jar"
+                        .formatted(
+                                context.versionStr, context.versionStr);
                 try (BufferedInputStream in = new BufferedInputStream(new URL(downloadURL).openStream());
                         OutputStream fileOutputStream = Files.newOutputStream(decompilerJar)) {
                     in.transferTo(fileOutputStream);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
@@ -103,17 +103,19 @@ public class JvmStartupOptimizerArchiveBuildStep {
         if (containerImage == null) {
             if (archiveType == JvmStartupOptimizerArchiveType.AppCDS) {
                 log.infof(
-                        "To ensure they are loaded properly, " +
-                                "run the application jar from its directory and also add the '-XX:SharedArchiveFile=app-cds.jsa' "
-                                +
-                                "JVM flag.\nMoreover, make sure to use the exact same Java version (%s) to run the application as was used to build it.",
+                        """
+                                To ensure they are loaded properly, \
+                                run the application jar from its directory and also add the '-XX:SharedArchiveFile=app-cds.jsa' \
+                                JVM flag.
+                                Moreover, make sure to use the exact same Java version (%s) to run the application as was used to build it.""",
                         System.getProperty("java.version"));
             } else {
                 log.infof(
-                        "To ensure they are loaded properly, " +
-                                "run the application jar from its directory and also add the '-XX:AOTCache=app.aot' "
-                                +
-                                "JVM flag.\nMoreover, make sure to use the exact same Java version (%s) to run the application as was used to build it.",
+                        """
+                                To ensure they are loaded properly, \
+                                run the application jar from its directory and also add the '-XX:AOTCache=app.aot' \
+                                JVM flag.
+                                Moreover, make sure to use the exact same Java version (%s) to run the application as was used to build it.""",
                         System.getProperty("java.version"));
             }
         }
@@ -182,7 +184,7 @@ public class JvmStartupOptimizerArchiveBuildStep {
         boolean debug = log.isDebugEnabled();
         List<String> javaArgs = new ArrayList<>(debug ? 4 : 3);
         javaArgs.add("-XX:ArchiveClassesAtExit=" + appCDSPath.getFileName().toString());
-        javaArgs.add(String.format("-D%s=true", MainClassBuildStep.GENERATE_APP_CDS_SYSTEM_PROPERTY));
+        javaArgs.add("-D%s=true".formatted(MainClassBuildStep.GENERATE_APP_CDS_SYSTEM_PROPERTY));
         if (debug) {
             javaArgs.add("-Xlog:cds=debug");
         }
@@ -247,7 +249,7 @@ public class JvmStartupOptimizerArchiveBuildStep {
         List<String> javaArgs = new ArrayList<>();
         javaArgs.add("-XX:AOTMode=record");
         javaArgs.add("-XX:AOTConfiguration=" + aotConfigPathContainers.resultingFile.getFileName().toString());
-        javaArgs.add(String.format("-D%s=true", MainClassBuildStep.GENERATE_APP_CDS_SYSTEM_PROPERTY));
+        javaArgs.add("-D%s=true".formatted(MainClassBuildStep.GENERATE_APP_CDS_SYSTEM_PROPERTY));
         javaArgs.add("-jar");
 
         List<String> command;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRemoteContainerRunner.java
@@ -85,8 +85,8 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
                 final JsonObject jsonRead = JsonReader.of(buildArtifactsJson).read();
                 final JsonValue jdkLibraries = jsonRead.get("jdk_libraries");
                 // The jdk_libraries field is optional, there might not be any.
-                if (jdkLibraries instanceof JsonArray) {
-                    for (JsonValue lib : ((JsonArray) jdkLibraries).value()) {
+                if (jdkLibraries instanceof JsonArray array) {
+                    for (JsonValue lib : array.value()) {
                         copyFromContainerVolume(outputDir, ((JsonString) lib).value(),
                                 "Failed to copy " + lib + " from container volume back to the host.");
                     }
@@ -99,7 +99,7 @@ public class NativeImageBuildRemoteContainerRunner extends NativeImageBuildConta
         if (nativeConfig.debug().enabled()) {
             copyFromContainerVolume(outputDir, "sources",
                     "Failed to copy sources from container volume back to the host.");
-            final String symbols = String.format("%s.debug", nativeImageName);
+            final String symbols = "%s.debug".formatted(nativeImageName);
             copyFromContainerVolume(outputDir, symbols,
                     "Failed to copy debug symbols from container volume back to the host.");
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -8,7 +8,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -291,7 +290,7 @@ public class NativeImageBuildStep {
             IoUtils.copy(generatedExecutablePath, finalExecutablePath);
             Files.delete(generatedExecutablePath);
             if (nativeConfig.debug().enabled()) {
-                final String symbolsName = String.format("%s.debug", nativeImageName);
+                final String symbolsName = "%s.debug".formatted(nativeImageName);
                 Path generatedSymbols = outputDir.resolve(symbolsName);
                 if (generatedSymbols.toFile().exists()) {
                     Path finalSymbolsPath = outputTargetBuildItem.getOutputDirectory().resolve(symbolsName);
@@ -332,7 +331,7 @@ public class NativeImageBuildStep {
         } finally {
             if (nativeConfig.debug().enabled()) {
                 removeJarSourcesFromLib(outputTargetBuildItem);
-                IoUtils.recursiveDelete(outputDir.resolve(Paths.get(APP_SOURCES)));
+                IoUtils.recursiveDelete(outputDir.resolve(Path.of(APP_SOURCES)));
             }
         }
     }
@@ -439,7 +438,7 @@ public class NativeImageBuildStep {
         final Path parent = path.getParent();
         final String fileName = path.getFileName().toString();
         final int extensionIndex = fileName.lastIndexOf('.');
-        final String sourcesFileName = String.format("%s-sources.jar", fileName.substring(0, extensionIndex));
+        final String sourcesFileName = "%s-sources.jar".formatted(fileName.substring(0, extensionIndex));
         return parent.resolve(sourcesFileName);
     }
 
@@ -457,19 +456,19 @@ public class NativeImageBuildStep {
         Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
 
-        final Path targetSrc = targetDirectory.resolve(Paths.get(APP_SOURCES));
+        final Path targetSrc = targetDirectory.resolve(Path.of(APP_SOURCES));
         final File targetSrcFile = targetSrc.toFile();
         if (!targetSrcFile.exists()) {
             targetSrcFile.mkdirs();
         }
 
         final Path javaSourcesPath = outputTargetBuildItem.getOutputDirectory().resolve(
-                Paths.get("..", "src", "main", "java"));
+                Path.of("..", "src", "main", "java"));
 
         if (Files.exists(javaSourcesPath)) {
             try (Stream<Path> paths = Files.walk(javaSourcesPath)) {
                 paths.forEach(path -> {
-                    Path targetPath = Paths.get(targetSrc.toString(),
+                    Path targetPath = Path.of(targetSrc.toString(),
                             path.toString().substring(javaSourcesPath.toString().length()));
                     try {
                         Files.copy(path, targetPath, StandardCopyOption.REPLACE_EXISTING);
@@ -518,7 +517,7 @@ public class NativeImageBuildStep {
     private static NativeImageBuildLocalRunner getNativeImageBuildLocalRunner(NativeConfig nativeConfig) {
         String executableName = getNativeImageExecutableName();
         if (nativeConfig.graalvmHome().isPresent()) {
-            File file = Paths.get(nativeConfig.graalvmHome().get(), "bin", executableName).toFile();
+            File file = Path.of(nativeConfig.graalvmHome().get(), "bin", executableName).toFile();
             if (file.exists()) {
                 return new NativeImageBuildLocalRunner(file.getAbsolutePath());
             }
@@ -1078,7 +1077,7 @@ public class NativeImageBuildStep {
                                 String configuredTrustStorePath = trimmedBuildArg
                                         .substring(index + TRUST_STORE_SYSTEM_PROPERTY_MARKER.length());
                                 try {
-                                    IoUtils.copy(Paths.get(configuredTrustStorePath),
+                                    IoUtils.copy(Path.of(configuredTrustStorePath),
                                             outputDir.resolve(MOVED_TRUST_STORE_NAME));
                                     command.add(trimmedBuildArg.substring(0, index) + TRUST_STORE_SYSTEM_PROPERTY_MARKER
                                             + CONTAINER_BUILD_VOLUME_PATH + "/" + MOVED_TRUST_STORE_NAME);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ReportAnalyzer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ReportAnalyzer.java
@@ -2,7 +2,7 @@ package io.quarkus.deployment.pkg.steps;
 
 import java.io.BufferedReader;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -26,7 +26,7 @@ public class ReportAnalyzer {
     public ReportAnalyzer(String report) {
         try {
             Deque<String> lines = new ArrayDeque<>();
-            try (BufferedReader in = Files.newBufferedReader(Paths.get(report))) {
+            try (BufferedReader in = Files.newBufferedReader(Path.of(report))) {
                 for (String re = in.readLine(); re != null; re = in.readLine()) {
                     lines.add(re);
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/AnnotationProxyProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/AnnotationProxyProvider.java
@@ -143,7 +143,7 @@ public class AnnotationProxyProvider {
                 String name = annotationInstance.name().toString();
 
                 // Ljakarta/enterprise/util/AnnotationLiteral<Lcom/foo/MyAnnotation;>;Lcom/foo/MyAnnotation;
-                String signature = String.format("L%1$s<L%2$s;>;L%2$s;",
+                String signature = "L%1$s<L%2$s;>;L%2$s;".formatted(
                         AnnotationLiteral.class.getName().replace('.', '/'),
                         name.replace('.', '/'));
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/RecordingProxyFactories.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/RecordingProxyFactories.java
@@ -14,8 +14,8 @@ class RecordingProxyFactories {
         RECORDING_PROXY_FACTORIES.put(clazz, proxyFactory);
 
         ClassLoader proxyClassLoader = proxyFactory.getClassLoader();
-        if (proxyClassLoader instanceof QuarkusClassLoader) {
-            ((QuarkusClassLoader) proxyClassLoader).addCloseTask(new Runnable() {
+        if (proxyClassLoader instanceof QuarkusClassLoader loader) {
+            loader.addCloseTask(new Runnable() {
                 @Override
                 public void run() {
                     RecordingProxyFactories.RECORDING_PROXY_FACTORIES.remove(clazz);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -360,8 +360,8 @@ public class ClassTransformingBuildStep {
             ClassVisitor visitor = writer;
             for (BiFunction<String, ClassVisitor, ClassVisitor> i : visitors) {
                 visitor = i.apply(className, visitor);
-                if (visitor instanceof QuarkusClassVisitor) {
-                    ((QuarkusClassVisitor) visitor).setOriginalClassReaderOptions(classReaderOptions);
+                if (visitor instanceof QuarkusClassVisitor classVisitor) {
+                    classVisitor.setOriginalClassReaderOptions(classReaderOptions);
                 }
             }
             cr.accept(visitor, classReaderOptions);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigDescriptionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigDescriptionBuildStep.java
@@ -127,8 +127,7 @@ public class ConfigDescriptionBuildStep {
                 Method method = property.getMethod();
 
                 String defaultValue = null;
-                if (property instanceof PrimitiveProperty) {
-                    PrimitiveProperty primitiveProperty = (PrimitiveProperty) property;
+                if (property instanceof PrimitiveProperty primitiveProperty) {
                     if (primitiveProperty.hasDefaultValue()) {
                         defaultValue = primitiveProperty.getDefaultValue();
                     } else if (primitiveProperty.getPrimitiveType() == boolean.class) {
@@ -136,8 +135,7 @@ public class ConfigDescriptionBuildStep {
                     } else if (primitiveProperty.getPrimitiveType() != char.class) {
                         defaultValue = "0";
                     }
-                } else if (property instanceof LeafProperty) {
-                    LeafProperty leafProperty = (LeafProperty) property;
+                } else if (property instanceof LeafProperty leafProperty) {
                     if (leafProperty.hasDefaultValue()) {
                         defaultValue = leafProperty.getDefaultValue();
                     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -17,7 +17,6 @@ import java.net.URI;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -446,23 +445,23 @@ public class ConfigGenerationBuildStep {
         // Main files
         configWatchedFiles.add("application.properties");
         configWatchedFiles.add("META-INF/microprofile-config.properties");
-        configWatchedFiles.add(Paths.get(userDir, ".env").toAbsolutePath().toString());
-        configWatchedFiles.add(Paths.get(userDir, "config", "application.properties").toAbsolutePath().toString());
+        configWatchedFiles.add(Path.of(userDir, ".env").toAbsolutePath().toString());
+        configWatchedFiles.add(Path.of(userDir, "config", "application.properties").toAbsolutePath().toString());
 
         // Profiles
         for (String profile : config.getProfiles()) {
-            configWatchedFiles.add(String.format("application-%s.properties", profile));
-            configWatchedFiles.add(String.format("META-INF/microprofile-config-%s.properties", profile));
-            configWatchedFiles.add(Paths.get(userDir, String.format(".env-%s", profile)).toAbsolutePath().toString());
-            configWatchedFiles.add(Paths.get(userDir, "config", String.format("application-%s.properties", profile))
+            configWatchedFiles.add("application-%s.properties".formatted(profile));
+            configWatchedFiles.add("META-INF/microprofile-config-%s.properties".formatted(profile));
+            configWatchedFiles.add(Path.of(userDir, ".env-%s".formatted(profile)).toAbsolutePath().toString());
+            configWatchedFiles.add(Path.of(userDir, "config", "application-%s.properties".formatted(profile))
                     .toAbsolutePath().toString());
         }
 
         Optional<List<URI>> optionalLocations = config.getOptionalValues(SMALLRYE_CONFIG_LOCATIONS, URI.class);
         optionalLocations.ifPresent(locations -> {
             for (URI location : locations) {
-                Path path = location.getScheme() != null && location.getScheme().equals("file") ? Paths.get(location)
-                        : Paths.get(location.getPath());
+                Path path = location.getScheme() != null && location.getScheme().equals("file") ? Path.of(location)
+                        : Path.of(location.getPath());
                 if (Files.isRegularFile(path)) {
                     configWatchedFiles.add(path.toAbsolutePath().toString());
                     for (String profile : config.getProfiles()) {
@@ -542,7 +541,7 @@ public class ConfigGenerationBuildStep {
 
     private String appendProfileToFilename(Path path, String activeProfile) {
         String pathWithoutExtension = getPathWithoutExtension(path);
-        return String.format("%s-%s.%s", pathWithoutExtension, activeProfile, getFileExtension(path));
+        return "%s-%s.%s".formatted(pathWithoutExtension, activeProfile, getFileExtension(path));
     }
 
     private static String getFileExtension(Path path) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageResourcesStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageResourcesStep.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -31,7 +31,7 @@ public class NativeImageResourcesStep {
         for (NativeImageResourceDirectoryBuildItem nativeImageResourceDirectory : nativeImageResourceDirectories) {
             String path = Thread.currentThread().getContextClassLoader().getResource(nativeImageResourceDirectory.getPath())
                     .getPath();
-            File resourceFile = Paths.get(new URL(path.substring(0, path.indexOf("!"))).toURI()).toFile();
+            File resourceFile = Path.of(new URL(path.substring(0, path.indexOf("!"))).toURI()).toFile();
             try (JarFile jarFile = new JarFile(resourceFile)) {
                 Enumeration<JarEntry> entries = jarFile.entries();
                 while (entries.hasMoreElements()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/PreloadClassesBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/PreloadClassesBuildStep.java
@@ -19,7 +19,7 @@ public class PreloadClassesBuildStep {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     public void preInit(Optional<PreloadClassesEnabledBuildItem> preload, PreloadClassesRecorder recorder) {
-        if (!preload.isPresent())
+        if (preload.isEmpty())
             return;
         recorder.invokePreloadClasses(preload.get().doInitialize());
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -172,7 +172,7 @@ public class ReflectiveHierarchyStep {
                     type.asArrayType().constituent(),
                     processedReflectiveHierarchies,
                     unindexedClasses, finalFieldsWritable, reflectiveClass, visits));
-        } else if (type instanceof ParameterizedType) {
+        } else if (type instanceof ParameterizedType parameterizedType) {
             if (!reflectiveHierarchyBuildItem.getIgnoreTypePredicate().test(type.name())) {
                 addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, newSource,
                         type.name(),
@@ -180,7 +180,6 @@ public class ReflectiveHierarchyStep {
                         processedReflectiveHierarchies,
                         unindexedClasses, finalFieldsWritable, reflectiveClass, visits);
             }
-            final ParameterizedType parameterizedType = (ParameterizedType) type;
             for (Type typeArgument : parameterizedType.arguments()) {
                 visits.addLast(
                         () -> addReflectiveHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem,

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ArtifactInfoUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ArtifactInfoUtil.java
@@ -6,7 +6,6 @@ import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,7 +47,7 @@ public final class ArtifactInfoUtil {
         try {
             URL codeLocation = clazz.getProtectionDomain().getCodeSource().getLocation();
             if (curateOutcomeBuildItem != null) {
-                Path path = Paths.get(codeLocation.toURI());
+                Path path = Path.of(codeLocation.toURI());
                 String pathAsString = path.toString();
                 // Workspace artifacts paths are resolved to the maven module, not the jar file
                 // If the clazz is inside a jar, but does not contain the artifact name, we have to open
@@ -74,7 +73,7 @@ public final class ArtifactInfoUtil {
 
             if (codeLocation.toString().endsWith(".jar")) {
                 // Search inside the jar for pom properties, needed for workspace artifacts
-                try (FileSystem fs = ZipUtils.newFileSystem(Paths.get(codeLocation.toURI()),
+                try (FileSystem fs = ZipUtils.newFileSystem(Path.of(codeLocation.toURI()),
                         Thread.currentThread().getContextClassLoader())) {
                     Entry<String, String> ret = groupIdAndArtifactId(fs);
                     if (ret == null) {
@@ -89,7 +88,7 @@ public final class ArtifactInfoUtil {
                 // and this app is part of a multi-module project which also declares the extension
                 // Just try to locate the pom.properties file in the target/maven-archiver directory
                 // Note that this hack will not work if addMavenDescriptor=false or if the pomPropertiesFile is overridden
-                Path location = Paths.get(codeLocation.toURI());
+                Path location = Path.of(codeLocation.toURI());
                 while (!isDeploymentTargetClasses(location) && location.getParent() != null) {
                     location = location.getParent();
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/DeploymentUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/DeploymentUtil.java
@@ -38,7 +38,7 @@ public class DeploymentUtil {
      * @return a {@link Predicate} that tests if deployer is enabled.
      */
     public static Predicate<String> isDeployExplicitlyEnabled() {
-        return deployer -> ConfigProvider.getConfig().getOptionalValue(String.format(DEPLOY, deployer), Boolean.class)
+        return deployer -> ConfigProvider.getConfig().getOptionalValue(DEPLOY.formatted(deployer), Boolean.class)
                 .orElse(false);
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ReflectUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ReflectUtil.java
@@ -24,16 +24,16 @@ public final class ReflectUtil {
 
     public static boolean rawTypeIs(Type type, Class<?> clazz) {
         return type instanceof Class<?> && clazz == type
-                || type instanceof ParameterizedType && ((ParameterizedType) type).getRawType() == clazz
-                || type instanceof GenericArrayType && clazz.isArray()
-                        && rawTypeIs(((GenericArrayType) type).getGenericComponentType(), clazz.getComponentType());
+                || type instanceof ParameterizedType pt && pt.getRawType() == clazz
+                || type instanceof GenericArrayType gat && clazz.isArray()
+                        && rawTypeIs(gat.getGenericComponentType(), clazz.getComponentType());
     }
 
     public static boolean rawTypeExtends(Type type, Class<?> clazz) {
-        return type instanceof Class<?> && clazz.isAssignableFrom((Class<?>) type)
-                || type instanceof ParameterizedType && rawTypeExtends(((ParameterizedType) type).getRawType(), clazz)
-                || type instanceof GenericArrayType
-                        && rawTypeExtends(((GenericArrayType) type).getGenericComponentType(), clazz.getComponentType());
+        return type instanceof Class<?> c && clazz.isAssignableFrom(c)
+                || type instanceof ParameterizedType pt && rawTypeExtends(pt.getRawType(), clazz)
+                || type instanceof GenericArrayType gat
+                        && rawTypeExtends(gat.getGenericComponentType(), clazz.getComponentType());
     }
 
     public static boolean isListOf(Type type, Class<?> nestedType) {
@@ -67,12 +67,12 @@ public final class ReflectUtil {
     }
 
     public static Class<?> rawTypeOf(final Type type) {
-        if (type instanceof Class<?>) {
-            return (Class<?>) type;
-        } else if (type instanceof ParameterizedType) {
-            return rawTypeOf(((ParameterizedType) type).getRawType());
-        } else if (type instanceof GenericArrayType) {
-            return Array.newInstance(rawTypeOf(((GenericArrayType) type).getGenericComponentType()), 0).getClass();
+        if (type instanceof Class<?> clazz) {
+            return clazz;
+        } else if (type instanceof ParameterizedType parameterizedType) {
+            return rawTypeOf(parameterizedType.getRawType());
+        } else if (type instanceof GenericArrayType arrayType) {
+            return Array.newInstance(rawTypeOf(arrayType.getGenericComponentType()), 0).getClass();
         } else {
             throw new IllegalArgumentException("Type has no raw type class: " + type);
         }
@@ -97,8 +97,8 @@ public final class ReflectUtil {
     }
 
     public static Type typeOfParameter(final Type type, final int paramIdx) {
-        if (type instanceof ParameterizedType) {
-            return ((ParameterizedType) type).getActualTypeArguments()[paramIdx];
+        if (type instanceof ParameterizedType parameterizedType) {
+            return parameterizedType.getActualTypeArguments()[paramIdx];
         } else {
             throw new IllegalArgumentException("Type is not parameterized: " + type);
         }
@@ -171,15 +171,15 @@ public final class ReflectUtil {
     }
 
     public static IllegalArgumentException reportError(AnnotatedElement e, String fmt, Object... args) {
-        if (e instanceof Member) {
+        if (e instanceof Member member) {
             return new IllegalArgumentException(
-                    String.format(fmt, args) + " at " + e + " of " + ((Member) e).getDeclaringClass());
-        } else if (e instanceof Parameter) {
+                    fmt.formatted(args) + " at " + e + " of " + member.getDeclaringClass());
+        } else if (e instanceof Parameter parameter) {
             return new IllegalArgumentException(
-                    String.format(fmt, args) + " at " + e + " of " + ((Parameter) e).getDeclaringExecutable() + " of "
-                            + ((Parameter) e).getDeclaringExecutable().getDeclaringClass());
+                    fmt.formatted(args) + " at " + e + " of " + parameter.getDeclaringExecutable() + " of "
+                            + parameter.getDeclaringExecutable().getDeclaringClass());
         } else {
-            return new IllegalArgumentException(String.format(fmt, args) + " at " + e);
+            return new IllegalArgumentException(fmt.formatted(args) + " at " + e);
         }
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -22,57 +22,64 @@ public class GraalVMTest {
     public void testGraalVMVersionDetected() {
         // Version detection after: https://github.com/oracle/graal/pull/6302 (3 lines of version output)
         assertVersion(new Version("GraalVM 23.0.0", "23.0.0", GRAALVM), MANDREL,
-                Version.of(Stream.of(("native-image 17.0.6 2023-01-17\n"
-                        + "OpenJDK Runtime Environment Mandrel-23.0.0-dev (build 17.0.6+10)\n"
-                        + "OpenJDK 64-Bit Server VM Mandrel-23.0.0-dev (build 17.0.6+10, mixed mode)").split("\\n"))));
+                Version.of(Stream.of(("""
+                        native-image 17.0.6 2023-01-17
+                        OpenJDK Runtime Environment Mandrel-23.0.0-dev (build 17.0.6+10)
+                        OpenJDK 64-Bit Server VM Mandrel-23.0.0-dev (build 17.0.6+10, mixed mode)""").split("\\n"))));
         assertVersion(new Version("GraalVM 23.0.0", "23.0.0", GRAALVM), MANDREL,
-                Version.of(Stream.of(("native-image 17.0.6 2023-01-17\n"
-                        + "GraalVM Runtime Environment Mandrel-23.0.0-dev (build 17.0.6+10)\n"
-                        + "Substrate VM Mandrel-23.0.0-dev (build 17.0.6+10, serial gc)").split("\\n"))));
+                Version.of(Stream.of(("""
+                        native-image 17.0.6 2023-01-17
+                        GraalVM Runtime Environment Mandrel-23.0.0-dev (build 17.0.6+10)
+                        Substrate VM Mandrel-23.0.0-dev (build 17.0.6+10, serial gc)""").split("\\n"))));
         assertVersion(new Version("GraalVM 23.0.0", "23.0.0", GRAALVM), MANDREL,
-                Version.of(Stream.of(("native-image 17.0.7 2023-04-18\n"
-                        + "OpenJDK Runtime Environment Mandrel-23.0.0.0-Final (build 17.0.7+7)\n"
-                        + "OpenJDK 64-Bit Server VM Mandrel-23.0.0.0-Final (build 17.0.7+7, mixed mode)").split("\\n"))));
+                Version.of(Stream.of(("""
+                        native-image 17.0.7 2023-04-18
+                        OpenJDK Runtime Environment Mandrel-23.0.0.0-Final (build 17.0.7+7)
+                        OpenJDK 64-Bit Server VM Mandrel-23.0.0.0-Final (build 17.0.7+7, mixed mode)""").split("\\n"))));
         // should also work when the image is not around and we have to download it
         assertVersion(new Version("GraalVM 23.0.0", "23.0.0", GRAALVM), MANDREL,
                 Version.of(
-                        Stream.of(("Unable to find image 'quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17' locally\n"
-                                + "jdk-17: Pulling from quarkus/ubi-quarkus-mandrel-builder-image\n"
-                                + "a49367d57626: Already exists\n"
-                                + "3a83b3d8356a: Already exists\n"
-                                + "d8dd24f2bc88: Already exists\n"
-                                + "99bd64fd6c37: Already exists\n"
-                                + "7a13281b4a63: Already exists\n"
-                                + "ae3db351551e: Already exists\n"
-                                + "eee108cfab2c: Already exists\n"
-                                + "d38abde1651d: Already exists\n"
-                                + "cac4ef5d11c0: Already exists\n"
-                                + "89e5b13e9084: Already exists\n"
-                                + "68897e59054c: Already exists\n"
-                                + "774633828afc: Already exists\n"
-                                + "6708d473f3dc: Already exists\n"
-                                + "4f4fb700ef54: Already exists\n"
-                                + "4f4fb700ef54: Already exists\n"
-                                + "Digest: sha256:2833f8ed2cdfcbdf88134a46b5ab7e4dfee8f7cbde60f819f86e59eb73c2491c\n"
-                                + "Status: Downloaded newer image for quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17\n"
-                                + "native-image 17.0.7 2023-04-18\n"
-                                + "OpenJDK Runtime Environment Mandrel-23.0.0.0-Final (build 17.0.7+7)\n"
-                                + "OpenJDK 64-Bit Server VM Mandrel-23.0.0.0-Final (build 17.0.7+7, mixed mode)")
+                        Stream.of(("""
+                                Unable to find image 'quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17' locally
+                                jdk-17: Pulling from quarkus/ubi-quarkus-mandrel-builder-image
+                                a49367d57626: Already exists
+                                3a83b3d8356a: Already exists
+                                d8dd24f2bc88: Already exists
+                                99bd64fd6c37: Already exists
+                                7a13281b4a63: Already exists
+                                ae3db351551e: Already exists
+                                eee108cfab2c: Already exists
+                                d38abde1651d: Already exists
+                                cac4ef5d11c0: Already exists
+                                89e5b13e9084: Already exists
+                                68897e59054c: Already exists
+                                774633828afc: Already exists
+                                6708d473f3dc: Already exists
+                                4f4fb700ef54: Already exists
+                                4f4fb700ef54: Already exists
+                                Digest: sha256:2833f8ed2cdfcbdf88134a46b5ab7e4dfee8f7cbde60f819f86e59eb73c2491c
+                                Status: Downloaded newer image for quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
+                                native-image 17.0.7 2023-04-18
+                                OpenJDK Runtime Environment Mandrel-23.0.0.0-Final (build 17.0.7+7)
+                                OpenJDK 64-Bit Server VM Mandrel-23.0.0.0-Final (build 17.0.7+7, mixed mode)""")
                                 .split("\\n"))));
         assertVersion(new Version("GraalVM 23.0", "23.0", GRAALVM), GRAALVM,
-                Version.of(Stream.of(("native-image 20 2023-03-21\n"
-                        + "GraalVM Runtime Environment GraalVM CE (build 20+34-jvmci-23.0-b10)\n"
-                        + "Substrate VM GraalVM CE (build 20+34, serial gc)").split("\\n"))));
+                Version.of(Stream.of(("""
+                        native-image 20 2023-03-21
+                        GraalVM Runtime Environment GraalVM CE (build 20+34-jvmci-23.0-b10)
+                        Substrate VM GraalVM CE (build 20+34, serial gc)""").split("\\n"))));
 
         // Should also work for other unknown implementations of GraalVM
         assertVersion(new Version("GraalVM 23.0", "23.0", GRAALVM), GRAALVM,
-                Version.of(Stream.of(("native-image 20 2023-07-30\n"
-                        + "Foo Runtime Environment whatever (build 20+34-jvmci-23.0-b7)\n"
-                        + "Foo VM whatever (build 20+34, serial gc)").split("\\n"))));
+                Version.of(Stream.of(("""
+                        native-image 20 2023-07-30
+                        Foo Runtime Environment whatever (build 20+34-jvmci-23.0-b7)
+                        Foo VM whatever (build 20+34, serial gc)""").split("\\n"))));
         assertVersion(new Version("GraalVM 23.0", "23.0", GRAALVM), GRAALVM,
-                Version.of(Stream.of(("native-image 20 2023-07-30\n"
-                        + "Another Runtime Environment whatever (build 20+34-jvmci-23.0-b7)\n"
-                        + "Another VM whatever (build 20+34, serial gc)").split("\\n"))));
+                Version.of(Stream.of(("""
+                        native-image 20 2023-07-30
+                        Another Runtime Environment whatever (build 20+34-jvmci-23.0-b7)
+                        Another VM whatever (build 20+34, serial gc)""").split("\\n"))));
 
         // Older version parsing
         assertVersion(new Version("GraalVM 20.1", "20.1", GRAALVM), GRAALVM,
@@ -104,9 +111,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVM21LibericaVersionParser() {
-        Version graalVM21Dev = Version.of(Stream.of(("native-image 21.0.1 2023-10-17\n"
-                + "GraalVM Runtime Environment Liberica-NIK-23.1.1-1 (build 21.0.1+12-LTS)\n"
-                + "Substrate VM Liberica-NIK-23.1.1-1 (build 21.0.1+12-LTS, serial gc)").split("\\n")));
+        Version graalVM21Dev = Version.of(Stream.of(("""
+                native-image 21.0.1 2023-10-17
+                GraalVM Runtime Environment Liberica-NIK-23.1.1-1 (build 21.0.1+12-LTS)
+                Substrate VM Liberica-NIK-23.1.1-1 (build 21.0.1+12-LTS, serial gc)""").split("\\n")));
         assertThat(graalVM21Dev.toString()).contains(LIBERICA.name());
         assertThat(graalVM21Dev.getVersionAsString()).isEqualTo("23.1.1");
         assertThat(graalVM21Dev.javaVersion.toString()).isEqualTo("21.0.1+12-LTS");
@@ -116,9 +124,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVM21VersionParser() {
-        Version graalVM21Dev = Version.of(Stream.of(("native-image 21 2023-09-19\n"
-                + "GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n"
-                + "Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)").split("\\n")));
+        Version graalVM21Dev = Version.of(Stream.of(("""
+                native-image 21 2023-09-19
+                GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)
+                Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)""").split("\\n")));
         assertThat(graalVM21Dev.toString()).contains(GRAALVM.name());
         assertThat(graalVM21Dev.getVersionAsString()).isEqualTo("23.1");
         assertThat(graalVM21Dev.javaVersion.toString()).isEqualTo("21+35-jvmci-23.1-b15");
@@ -128,9 +137,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVM21DevVersionParser() {
-        Version graalVM21Dev = Version.of(Stream.of(("native-image 21 2023-09-19\n" +
-                "GraalVM Runtime Environment GraalVM CE 21-dev+35.1 (build 21+35-jvmci-23.1-b14)\n" +
-                "Substrate VM GraalVM CE 21-dev+35.1 (build 21+35, serial gc)").split("\\n")));
+        Version graalVM21Dev = Version.of(Stream.of(("""
+                native-image 21 2023-09-19
+                GraalVM Runtime Environment GraalVM CE 21-dev+35.1 (build 21+35-jvmci-23.1-b14)
+                Substrate VM GraalVM CE 21-dev+35.1 (build 21+35, serial gc)""").split("\\n")));
         assertThat(graalVM21Dev.toString()).contains(GRAALVM.name());
         assertThat(graalVM21Dev.getVersionAsString()).isEqualTo("23.1-dev");
         assertThat(graalVM21Dev.javaVersion.toString()).isEqualTo("21+35-jvmci-23.1-b14");
@@ -140,9 +150,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVM22DevVersionParser() {
-        Version graalVM22Dev = Version.of(Stream.of(("native-image 22 2024-03-19\n"
-                + "GraalVM Runtime Environment GraalVM CE 22-dev+16.1 (build 22+16-jvmci-b01)\n"
-                + "Substrate VM GraalVM CE 22-dev+16.1 (build 22+16, serial gc)").split("\\n")));
+        Version graalVM22Dev = Version.of(Stream.of(("""
+                native-image 22 2024-03-19
+                GraalVM Runtime Environment GraalVM CE 22-dev+16.1 (build 22+16-jvmci-b01)
+                Substrate VM GraalVM CE 22-dev+16.1 (build 22+16, serial gc)""").split("\\n")));
         assertThat(graalVM22Dev.toString()).contains(GRAALVM.name());
         assertThat(graalVM22Dev.getVersionAsString()).isEqualTo("24.0-dev");
         assertThat(graalVM22Dev.javaVersion.toString()).isEqualTo("22+16-jvmci-b01");
@@ -152,9 +163,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVMEE22DevVersionParser() {
-        Version graalVMEE22Dev = Version.of(Stream.of(("native-image 22 2024-03-19\n"
-                + "Java(TM) SE Runtime Environment Oracle GraalVM 22-dev+25.1 (build 22+25-jvmci-b01)\n"
-                + "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 22-dev+25.1 (build 22+25-jvmci-b01, mixed mode, sharing)")
+        Version graalVMEE22Dev = Version.of(Stream.of(("""
+                native-image 22 2024-03-19
+                Java(TM) SE Runtime Environment Oracle GraalVM 22-dev+25.1 (build 22+25-jvmci-b01)
+                Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 22-dev+25.1 (build 22+25-jvmci-b01, mixed mode, sharing)""")
                 .split("\\n")));
         assertThat(graalVMEE22Dev.toString()).contains(GRAALVM.name());
         assertThat(graalVMEE22Dev.getVersionAsString()).isEqualTo("24.0-dev");
@@ -165,9 +177,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVMEA24DevVersionParser() {
-        final Version graalVMEA24Dev = Version.of(Stream.of(("native-image 24-ea 2025-03-18\n"
-                + "OpenJDK Runtime Environment Oracle GraalVM 24-dev.ea+10.1 (build 24-ea+10-1076)\n"
-                + "OpenJDK 64-Bit Server VM Oracle GraalVM 24-dev.ea+10.1 (build 24-ea+10-1076, mixed mode, sharing)")
+        final Version graalVMEA24Dev = Version.of(Stream.of(("""
+                native-image 24-ea 2025-03-18
+                OpenJDK Runtime Environment Oracle GraalVM 24-dev.ea+10.1 (build 24-ea+10-1076)
+                OpenJDK 64-Bit Server VM Oracle GraalVM 24-dev.ea+10.1 (build 24-ea+10-1076, mixed mode, sharing)""")
                 .split("\\n")));
         assertThat(graalVMEA24Dev.toString()).contains(GRAALVM.name());
         assertThat(graalVMEA24Dev.getVersionAsString()).isEqualTo("24.2-dev");
@@ -178,9 +191,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVM23_1CommunityVersionParser() {
-        final Version version = Version.of(Stream.of(("native-image 21.0.5-beta 2024-10-15\n"
-                + "GraalVM Runtime Environment GraalVM CE 21.0.5-dev.beta+3.1 (build 21.0.5-beta+3-ea)\n"
-                + "Substrate VM GraalVM CE 21.0.5-dev.beta+3.1 (build 21.0.5-beta+3-ea, serial gc)")
+        final Version version = Version.of(Stream.of(("""
+                native-image 21.0.5-beta 2024-10-15
+                GraalVM Runtime Environment GraalVM CE 21.0.5-dev.beta+3.1 (build 21.0.5-beta+3-ea)
+                Substrate VM GraalVM CE 21.0.5-dev.beta+3.1 (build 21.0.5-beta+3-ea, serial gc)""")
                 .split("\\n")));
         assertThat(version.toString().contains(GRAALVM.name()));
         assertThat(version.getVersionAsString()).isEqualTo("23.1-dev");
@@ -196,18 +210,24 @@ public class GraalVMTest {
         assertOlderThan("GraalVM Version 20.0.0 (Java Version 11.0.7)", "GraalVM Version 20.1.0 (Java Version 11.0.8)");
         assertOlderThan("GraalVM Version 21.2.0 (Java Version 11.0.12)", Version.VERSION_21_3);
         assertOlderThan("GraalVM Version 21.2.0 (Java Version 11.0.12)", Version.VERSION_21_3_0);
-        assertOlderThan("native-image 21 2023-09-19\n" +
-                "GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +
-                "Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)\n",
-                "native-image 21-beta 2023-09-19\n" +
-                        "OpenJDK Runtime Environment Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea)\n" +
-                        "OpenJDK 64-Bit Server VM Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)");
-        assertOlderThan("native-image 21-beta 2023-09-19\n" +
-                "OpenJDK Runtime Environment Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea)\n" +
-                "OpenJDK 64-Bit Server VM Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)",
-                "native-image 21 2023-09-19\n" +
-                        "GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +
-                        "Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)\n");
+        assertOlderThan("""
+                native-image 21 2023-09-19
+                GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)
+                Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)
+                """,
+                """
+                        native-image 21-beta 2023-09-19
+                        OpenJDK Runtime Environment Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea)
+                        OpenJDK 64-Bit Server VM Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)""");
+        assertOlderThan("""
+                native-image 21-beta 2023-09-19
+                OpenJDK Runtime Environment Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea)
+                OpenJDK 64-Bit Server VM Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)""",
+                """
+                        native-image 21 2023-09-19
+                        GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)
+                        Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)
+                        """);
     }
 
     /**
@@ -235,12 +255,15 @@ public class GraalVMTest {
         assertCompareEqualTo("GraalVM 21.3.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)",
                 "GraalVM 21.3.0.0.0.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)");
         assertThat(Version.VERSION_21_3.compareTo(Version.VERSION_21_3_0)).isEqualTo(0);
-        assertCompareEqualTo("native-image 21-beta 2023-09-19\n" +
-                "OpenJDK Runtime Environment Mandrel-23.1.0.0-devde078ae3bea (build 21-beta+35-ea)\n" +
-                "OpenJDK 64-Bit Server VM Mandrel-23.1.0.0-devde078ae3bea (build 21-beta+35-ea, mixed mode)",
-                "native-image 21 2023-09-19\n" +
-                        "GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +
-                        "Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)\n");
+        assertCompareEqualTo("""
+                native-image 21-beta 2023-09-19
+                OpenJDK Runtime Environment Mandrel-23.1.0.0-devde078ae3bea (build 21-beta+35-ea)
+                OpenJDK 64-Bit Server VM Mandrel-23.1.0.0-devde078ae3bea (build 21-beta+35-ea, mixed mode)""",
+                """
+                        native-image 21 2023-09-19
+                        GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)
+                        Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)
+                        """);
     }
 
     /**
@@ -266,18 +289,24 @@ public class GraalVMTest {
                 "GraalVM 21.3 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)");
         assertNewerThan("native-image 22.3.0-dev6d51160e2f3 Mandrel Distribution (Java Version 17.0.4-beta+7-202206162318)",
                 "native-image 22.2.0-dev6d51160e2f3 Mandrel Distribution (Java Version 17.0.4-beta+7-202206162318)");
-        assertNewerThan("native-image 21-beta 2023-09-19\n" +
-                "OpenJDK Runtime Environment Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea)\n" +
-                "OpenJDK 64-Bit Server VM Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)",
-                "native-image 21 2023-09-19\n" +
-                        "GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +
-                        "Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)\n");
-        assertNewerThan("native-image 21 2023-09-19\n" +
-                "GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +
-                "Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)\n",
-                "native-image 21-beta 2023-09-19\n" +
-                        "OpenJDK Runtime Environment Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea)\n" +
-                        "OpenJDK 64-Bit Server VM Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)");
+        assertNewerThan("""
+                native-image 21-beta 2023-09-19
+                OpenJDK Runtime Environment Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea)
+                OpenJDK 64-Bit Server VM Mandrel-23.1.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)""",
+                """
+                        native-image 21 2023-09-19
+                        GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)
+                        Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)
+                        """);
+        assertNewerThan("""
+                native-image 21 2023-09-19
+                GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)
+                Substrate VM GraalVM CE 21+35.1 (build 21+35, serial gc)
+                """,
+                """
+                        native-image 21-beta 2023-09-19
+                        OpenJDK Runtime Environment Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea)
+                        OpenJDK 64-Bit Server VM Mandrel-23.0.0.1-devde078ae3bea (build 21-beta+35-ea, mixed mode)""");
     }
 
     /**
@@ -336,26 +365,26 @@ public class GraalVMTest {
         switch (cmp) {
             case "<":
                 Assertions.assertTrue(b.jdkVersionGreaterOrEqualTo(aMinimal),
-                        String.format("JDK %s greater or equal to JDK %s.",
+                        "JDK %s greater or equal to JDK %s.".formatted(
                                 b.javaVersion, a.javaVersion));
                 Assertions.assertFalse(a.jdkVersionGreaterOrEqualTo(bMinimal),
-                        String.format("JDK %s smaller than JDK %s.",
+                        "JDK %s smaller than JDK %s.".formatted(
                                 a.javaVersion, b.javaVersion));
                 break;
             case ">":
                 Assertions.assertTrue(a.jdkVersionGreaterOrEqualTo(bMinimal),
-                        String.format("JDK %s greater or equal to JDK %s.",
+                        "JDK %s greater or equal to JDK %s.".formatted(
                                 a.javaVersion, b.javaVersion));
                 Assertions.assertFalse(b.jdkVersionGreaterOrEqualTo(aMinimal),
-                        String.format("JDK %s smaller than JDK %s.",
+                        "JDK %s smaller than JDK %s.".formatted(
                                 b.javaVersion, a.javaVersion));
                 break;
             case "==":
                 Assertions.assertEquals(0, a.javaVersion.compareToIgnoreOptional(b.javaVersion),
-                        String.format("JDK %s equal to JDK %s.",
+                        "JDK %s equal to JDK %s.".formatted(
                                 b.javaVersion, a.javaVersion));
                 Assertions.assertTrue(a.jdkVersionGreaterOrEqualTo(bMinimal),
-                        String.format("JDK %s greater or equal to JDK %s.",
+                        "JDK %s greater or equal to JDK %s.".formatted(
                                 a.javaVersion, b.javaVersion));
                 break;
             default:

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -404,12 +404,12 @@ public class BytecodeRecorderTestCase {
         assertEquals(expected.length, TestRecorder.RESULT.size());
         for (Object i : expected) {
             if (i.getClass().isArray()) {
-                if (i instanceof int[]) {
-                    assertArrayEquals((int[]) i, (int[]) TestRecorder.RESULT.poll());
-                } else if (i instanceof double[]) {
-                    assertArrayEquals((double[]) i, (double[]) TestRecorder.RESULT.poll(), 0);
-                } else if (i instanceof Object[]) {
-                    assertArrayEquals((Object[]) i, (Object[]) TestRecorder.RESULT.poll());
+                if (i instanceof int[] ints) {
+                    assertArrayEquals(ints, (int[]) TestRecorder.RESULT.poll());
+                } else if (i instanceof double[] doubles) {
+                    assertArrayEquals(doubles, (double[]) TestRecorder.RESULT.poll(), 0);
+                } else if (i instanceof Object[] objects) {
+                    assertArrayEquals(objects, (Object[]) TestRecorder.RESULT.poll());
                 } else {
                     throw new RuntimeException("not implemented");
                 }

--- a/core/launcher/src/main/java/io/quarkus/launcher/QuarkusLauncher.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/QuarkusLauncher.java
@@ -5,7 +5,6 @@ import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,9 +36,9 @@ public class QuarkusLauncher {
             if ("jar".equals(uri.getScheme())) {
                 JarURLConnection connection = (JarURLConnection) uri.toURL().openConnection();
                 connection.setDefaultUseCaches(false);
-                appClasses = Paths.get(connection.getJarFileURL().toURI());
+                appClasses = Path.of(connection.getJarFileURL().toURI());
             } else {
-                appClasses = Paths.get(uri);
+                appClasses = Path.of(uri);
             }
             if (quarkusApplication != null) {
                 System.setProperty("quarkus.package.main-class", quarkusApplication);

--- a/core/processor/pom.xml
+++ b/core/processor/pom.xml
@@ -50,6 +50,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
@@ -105,8 +105,7 @@ public final class JavadocToAsciidocTransformer {
         Map<Integer, String> inlineTagsReplacements = new TreeMap<>();
 
         for (JavadocDescriptionElement javadocDescriptionElement : parsedJavadoc.getDescription().getElements()) {
-            if (javadocDescriptionElement instanceof JavadocInlineTag) {
-                JavadocInlineTag inlineTag = (JavadocInlineTag) javadocDescriptionElement;
+            if (javadocDescriptionElement instanceof JavadocInlineTag inlineTag) {
                 String content = inlineTag.getContent().trim();
                 switch (inlineTag.getType()) {
                     case CODE:
@@ -209,7 +208,7 @@ public final class JavadocToAsciidocTransformer {
                     sb.append(link);
                     final StringBuilder caption = new StringBuilder();
                     htmlToAsciidoc(caption, childNode, inlineMacroMode, context);
-                    sb.append(String.format(LINK_ATTRIBUTE_FORMAT, trim(caption)));
+                    sb.append(LINK_ATTRIBUTE_FORMAT.formatted(trim(caption)));
                     break;
                 case CODE_NODE:
                     sb.append(BACKTICK);

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
@@ -44,8 +44,7 @@ public class JavadocToMarkdownTransformer {
         StringBuilder sb = new StringBuilder();
 
         for (JavadocDescriptionElement javadocDescriptionElement : javadocDescription.getElements()) {
-            if (javadocDescriptionElement instanceof JavadocInlineTag) {
-                JavadocInlineTag inlineTag = (JavadocInlineTag) javadocDescriptionElement;
+            if (javadocDescriptionElement instanceof JavadocInlineTag inlineTag) {
                 String content = inlineTag.getContent().trim();
                 switch (inlineTag.getType()) {
                     case CODE:

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigItemCollection.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigItemCollection.java
@@ -11,8 +11,8 @@ public interface ConfigItemCollection {
     @JsonIgnore
     default List<AbstractConfigItem> getNonDeprecatedItems() {
         return getItems().stream()
-                .filter(i -> (i instanceof ConfigSection)
-                        ? !i.isDeprecated() && ((ConfigSection) i).getNonDeprecatedItems().size() > 0
+                .filter(i -> (i instanceof ConfigSection cs)
+                        ? !i.isDeprecated() && cs.getNonDeprecatedItems().size() > 0
                         : !i.isDeprecated())
                 .toList();
     }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
@@ -243,8 +243,7 @@ public class ConfigResolver {
     }
 
     public static String getType(TypeMirror typeMirror) {
-        if (typeMirror instanceof DeclaredType) {
-            DeclaredType declaredType = (DeclaredType) typeMirror;
+        if (typeMirror instanceof DeclaredType declaredType) {
             TypeElement typeElement = (TypeElement) declaredType.asElement();
             return typeElement.getQualifiedName().toString();
         }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/ConfigNamingUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/ConfigNamingUtil.java
@@ -214,6 +214,6 @@ public final class ConfigNamingUtil {
     }
 
     public static String getMapKey(String mapKey) {
-        return String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, mapKey);
+        return NAMED_MAP_CONFIG_ITEM_FORMAT.formatted(mapKey);
     }
 }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/AccessorGenerator.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/AccessorGenerator.java
@@ -91,8 +91,7 @@ public final class AccessorGenerator {
                 // 1) the field is public
                 // 2) the enclosing class is public
                 // 3) the class type of the field is public
-                if (fieldType instanceof DeclaredType) {
-                    final DeclaredType declaredType = (DeclaredType) fieldType;
+                if (fieldType instanceof DeclaredType declaredType) {
                     final TypeElement typeElement = (TypeElement) declaredType.asElement();
                     if (typeElement.getModifiers()
                             .contains(Modifier.PUBLIC)) {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/ElementUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/ElementUtil.java
@@ -67,8 +67,8 @@ public class ElementUtil {
 
     StringBuilder buildRelativeBinaryName(TypeElement typeElement, StringBuilder builder) {
         final Element enclosing = typeElement.getEnclosingElement();
-        if (enclosing instanceof TypeElement) {
-            buildRelativeBinaryName((TypeElement) enclosing, builder);
+        if (enclosing instanceof TypeElement element) {
+            buildRelativeBinaryName(element, builder);
             builder.append('$');
         }
         builder.append(typeElement.getSimpleName());
@@ -82,9 +82,9 @@ public class ElementUtil {
         if (typeArguments.isEmpty()) {
             return simpleName;
         } else if (typeArguments.size() == 1) {
-            return String.format("%s<%s>", simpleName, simplifyGenericType(typeArguments.get(0)));
+            return "%s<%s>".formatted(simpleName, simplifyGenericType(typeArguments.get(0)));
         } else if (typeArguments.size() == 2) {
-            return String.format("%s<%s,%s>", simpleName, simplifyGenericType(typeArguments.get(0)),
+            return "%s<%s,%s>".formatted(simpleName, simplifyGenericType(typeArguments.get(0)),
                     simplifyGenericType(typeArguments.get(1)));
         }
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/ExtensionUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/ExtensionUtil.java
@@ -3,7 +3,6 @@ package io.quarkus.annotation.processor.util;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 
@@ -191,8 +190,8 @@ public final class ExtensionUtil {
 
     private ExtensionModuleType detectExtensionModuleType(String artifactId) {
         try {
-            Path runtimeMarkerFile = Paths
-                    .get(processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", RUNTIME_MARKER_FILE).toUri());
+            Path runtimeMarkerFile = Path
+                    .of(processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", RUNTIME_MARKER_FILE).toUri());
             if (Files.exists(runtimeMarkerFile)) {
                 return ExtensionModuleType.RUNTIME;
             }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/FilerUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/FilerUtil.java
@@ -11,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -143,7 +142,7 @@ public class FilerUtil {
     public Path getTargetPath() {
         try {
             FileObject dummyFile = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", "dummy");
-            return Paths.get(dummyFile.toUri()).getParent().getParent();
+            return Path.of(dummyFile.toUri()).getParent().getParent();
         } catch (IOException e) {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Unable to determine the path of target/" + e);
             throw new UncheckedIOException(e);
@@ -152,7 +151,7 @@ public class FilerUtil {
 
     public Optional<Path> getPomPath() {
         try {
-            Path pomPath = Paths.get(processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", "dummy").toUri())
+            Path pomPath = Path.of(processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", "dummy").toUri())
                     .getParent().getParent().getParent().resolve("pom.xml");
 
             if (!Files.isReadable(pomPath)) {

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigItemTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigItemTest.java
@@ -116,12 +116,12 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
     @Test
     public void parseJavaDocWithLiTagsInsideUlTag() {
-        String javaDoc = "List:" +
-                "<ul>\n" +
-                "<li>1</li>\n" +
-                "<li>2</li>\n" +
-                "</ul>" +
-                "";
+        String javaDoc = """
+                List:\
+                <ul>
+                <li>1</li>
+                <li>2</li>
+                </ul>""";
         String expectedOutput = "List:\n\n - 1\n - 2";
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
@@ -131,12 +131,12 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
     @Test
     public void parseJavaDocWithLiTagsInsideOlTag() {
-        String javaDoc = "List:" +
-                "<ol>\n" +
-                "<li>1</li>\n" +
-                "<li>2</li>\n" +
-                "</ol>" +
-                "";
+        String javaDoc = """
+                List:\
+                <ol>
+                <li>1</li>
+                <li>2</li>
+                </ol>""";
         String expectedOutput = "List:\n\n . 1\n . 2";
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
@@ -217,22 +217,26 @@ public class JavadocToAsciidocTransformerConfigItemTest {
     @Test
     public void parseJavaDocWithBlockquoteBlock() {
         ParsedJavadoc parsed = JavadocUtil
-                .parseConfigItemJavadoc("See Section 4.5.5 of the JSR 380 specification, specifically\n"
-                        + "\n"
-                        + "<blockquote>\n"
-                        + "In sub types (be it sub classes/interfaces or interface implementations), no parameter constraints may\n"
-                        + "be declared on overridden or implemented methods, nor may parameters be marked for cascaded validation.\n"
-                        + "This would pose a strengthening of preconditions to be fulfilled by the caller.\n"
-                        + "</blockquote>\nThat was interesting, wasn't it?");
+                .parseConfigItemJavadoc("""
+                        See Section 4.5.5 of the JSR 380 specification, specifically
 
-        assertEquals("See Section 4.5.5 of the JSR 380 specification, specifically\n"
-                + "\n"
-                + "[quote]\n"
-                + "____\n"
-                + "In sub types (be it sub classes/interfaces or interface implementations), no parameter constraints may be declared on overridden or implemented methods, nor may parameters be marked for cascaded validation. This would pose a strengthening of preconditions to be fulfilled by the caller.\n"
-                + "____\n"
-                + "\n"
-                + "That was interesting, wasn't it?",
+                        <blockquote>
+                        In sub types (be it sub classes/interfaces or interface implementations), no parameter constraints may
+                        be declared on overridden or implemented methods, nor may parameters be marked for cascaded validation.
+                        This would pose a strengthening of preconditions to be fulfilled by the caller.
+                        </blockquote>
+                        That was interesting, wasn't it?""");
+
+        assertEquals(
+                """
+                        See Section 4.5.5 of the JSR 380 specification, specifically
+
+                        [quote]
+                        ____
+                        In sub types (be it sub classes/interfaces or interface implementations), no parameter constraints may be declared on overridden or implemented methods, nor may parameters be marked for cascaded validation. This would pose a strengthening of preconditions to be fulfilled by the caller.
+                        ____
+
+                        That was interesting, wasn't it?""",
                 JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format()));
 
         parsed = JavadocUtil.parseConfigItemJavadoc(
@@ -268,19 +272,20 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
     @Test
     public void asciidoc() {
-        String asciidoc = "== My Asciidoc\n" +
-                "\n" +
-                "Let's have a https://quarkus.io[link to our website].\n" +
-                "\n" +
-                "[TIP]\n" +
-                "====\n" +
-                "A nice tip\n" +
-                "====\n" +
-                "\n" +
-                "[source,java]\n" +
-                "----\n" +
-                "And some code\n" +
-                "----";
+        String asciidoc = """
+                == My Asciidoc
+
+                Let's have a https://quarkus.io[link to our website].
+
+                [TIP]
+                ====
+                A nice tip
+                ====
+
+                [source,java]
+                ----
+                And some code
+                ----""";
 
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(asciidoc + "\n" + "@asciidoclet");
 
@@ -289,12 +294,13 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
     @Test
     public void asciidocLists() {
-        String asciidoc = "* A list\n" +
-                "\n" +
-                "* 1\n" +
-                "  * 1.1\n" +
-                "  * 1.2\n" +
-                "* 2";
+        String asciidoc = """
+                * A list
+
+                * 1
+                  * 1.1
+                  * 1.2
+                * 2""";
 
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(asciidoc + "\n" + "@asciidoclet");
 

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigSectionTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigSectionTest.java
@@ -23,17 +23,18 @@ public class JavadocToAsciidocTransformerConfigSectionTest {
     @Test
     public void passThroughAConfigSectionInAsciiDoc() {
         String title = "My Asciidoc";
-        String details = "Let's have a https://quarkus.io[link to our website].\n" +
-                "\n" +
-                "[TIP]\n" +
-                "====\n" +
-                "A nice tip\n" +
-                "====\n" +
-                "\n" +
-                "[source,java]\n" +
-                "----\n" +
-                "And some code\n" +
-                "----";
+        String details = """
+                Let's have a https://quarkus.io[link to our website].
+
+                [TIP]
+                ====
+                A nice tip
+                ====
+
+                [source,java]
+                ----
+                And some code
+                ----""";
 
         String asciidoc = "=== " + title + "\n\n" + details;
 
@@ -41,19 +42,20 @@ public class JavadocToAsciidocTransformerConfigSectionTest {
         assertEquals(title, JavadocToAsciidocTransformer.toAsciidoc(sectionHolder.title(), sectionHolder.format()));
         assertEquals(details, JavadocToAsciidocTransformer.toAsciidoc(sectionHolder.details(), sectionHolder.format()));
 
-        asciidoc = "Asciidoc title. \n" +
-                "\n" +
-                "Let's have a https://quarkus.io[link to our website].\n" +
-                "\n" +
-                "[TIP]\n" +
-                "====\n" +
-                "A nice tip\n" +
-                "====\n" +
-                "\n" +
-                "[source,java]\n" +
-                "----\n" +
-                "And some code\n" +
-                "----";
+        asciidoc = """
+                Asciidoc title.\s
+
+                Let's have a https://quarkus.io[link to our website].
+
+                [TIP]
+                ====
+                A nice tip
+                ====
+
+                [source,java]
+                ----
+                And some code
+                ----""";
 
         sectionHolder = JavadocUtil.parseConfigSectionJavadoc(asciidoc + "\n" + "@asciidoclet");
         assertEquals("Asciidoc title", JavadocToAsciidocTransformer.toAsciidoc(sectionHolder.title(), sectionHolder.format()));

--- a/core/runtime/src/main/java/io/quarkus/logging/Log.java
+++ b/core/runtime/src/main/java/io/quarkus/logging/Log.java
@@ -226,7 +226,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the parameters
      */
     public static void tracef(String format, Object... params) {
@@ -239,7 +239,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void tracef(String format, Object param1) {
@@ -252,7 +252,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -266,7 +266,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -282,7 +282,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param params the parameters
      */
     public static void tracef(Throwable t, String format, Object... params) {
@@ -296,7 +296,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the sole parameter
      */
     public static void tracef(Throwable t, String format, Object param1) {
@@ -310,7 +310,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -325,7 +325,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -340,7 +340,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void tracef(String format, int arg) {
@@ -353,7 +353,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -367,7 +367,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -381,7 +381,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -396,7 +396,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -411,7 +411,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -427,7 +427,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void tracef(Throwable t, String format, int arg) {
@@ -441,7 +441,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -456,7 +456,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -471,7 +471,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -487,7 +487,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -503,7 +503,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -518,7 +518,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void tracef(String format, long arg) {
@@ -531,7 +531,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -545,7 +545,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -559,7 +559,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -574,7 +574,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -589,7 +589,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of TRACE.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -605,7 +605,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void tracef(Throwable t, String format, long arg) {
@@ -619,7 +619,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -634,7 +634,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -649,7 +649,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -665,7 +665,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -681,7 +681,7 @@ public final class Log {
      * Issue a formatted log message with a level of TRACE.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -877,7 +877,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the parameters
      */
     public static void debugf(String format, Object... params) {
@@ -890,7 +890,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void debugf(String format, Object param1) {
@@ -903,7 +903,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -917,7 +917,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -933,7 +933,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param params the parameters
      */
     public static void debugf(Throwable t, String format, Object... params) {
@@ -947,7 +947,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the sole parameter
      */
     public static void debugf(Throwable t, String format, Object param1) {
@@ -961,7 +961,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -976,7 +976,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -991,7 +991,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void debugf(String format, int arg) {
@@ -1004,7 +1004,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1018,7 +1018,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1032,7 +1032,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1047,7 +1047,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1062,7 +1062,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1078,7 +1078,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void debugf(Throwable t, String format, int arg) {
@@ -1092,7 +1092,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1107,7 +1107,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1122,7 +1122,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1138,7 +1138,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1154,7 +1154,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1169,7 +1169,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void debugf(String format, long arg) {
@@ -1182,7 +1182,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1196,7 +1196,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1210,7 +1210,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1225,7 +1225,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1240,7 +1240,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of DEBUG.
      *
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1256,7 +1256,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg the parameter
      */
     public static void debugf(Throwable t, String format, long arg) {
@@ -1270,7 +1270,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1285,7 +1285,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      */
@@ -1300,7 +1300,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1316,7 +1316,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1332,7 +1332,7 @@ public final class Log {
      * Issue a formatted log message with a level of DEBUG.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param arg1 the first parameter
      * @param arg2 the second parameter
      * @param arg3 the third parameter
@@ -1528,7 +1528,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of INFO.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the parameters
      */
     public static void infof(String format, Object... params) {
@@ -1541,7 +1541,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of INFO.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void infof(String format, Object param1) {
@@ -1554,7 +1554,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of INFO.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -1568,7 +1568,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of INFO.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -1584,7 +1584,7 @@ public final class Log {
      * Issue a formatted log message with a level of INFO.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param params the parameters
      */
     public static void infof(Throwable t, String format, Object... params) {
@@ -1598,7 +1598,7 @@ public final class Log {
      * Issue a formatted log message with a level of INFO.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the sole parameter
      */
     public static void infof(Throwable t, String format, Object param1) {
@@ -1612,7 +1612,7 @@ public final class Log {
      * Issue a formatted log message with a level of INFO.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -1627,7 +1627,7 @@ public final class Log {
      * Issue a formatted log message with a level of INFO.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -1810,7 +1810,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of WARN.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the parameters
      */
     public static void warnf(String format, Object... params) {
@@ -1823,7 +1823,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of WARN.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void warnf(String format, Object param1) {
@@ -1836,7 +1836,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of WARN.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -1850,7 +1850,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of WARN.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -1866,7 +1866,7 @@ public final class Log {
      * Issue a formatted log message with a level of WARN.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param params the parameters
      */
     public static void warnf(Throwable t, String format, Object... params) {
@@ -1880,7 +1880,7 @@ public final class Log {
      * Issue a formatted log message with a level of WARN.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the sole parameter
      */
     public static void warnf(Throwable t, String format, Object param1) {
@@ -1894,7 +1894,7 @@ public final class Log {
      * Issue a formatted log message with a level of WARN.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -1909,7 +1909,7 @@ public final class Log {
      * Issue a formatted log message with a level of WARN.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2092,7 +2092,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of ERROR.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the parameters
      */
     public static void errorf(String format, Object... params) {
@@ -2105,7 +2105,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of ERROR.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void errorf(String format, Object param1) {
@@ -2118,7 +2118,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of ERROR.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -2132,7 +2132,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of ERROR.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2148,7 +2148,7 @@ public final class Log {
      * Issue a formatted log message with a level of ERROR.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param params the parameters
      */
     public static void errorf(Throwable t, String format, Object... params) {
@@ -2162,7 +2162,7 @@ public final class Log {
      * Issue a formatted log message with a level of ERROR.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the sole parameter
      */
     public static void errorf(Throwable t, String format, Object param1) {
@@ -2176,7 +2176,7 @@ public final class Log {
      * Issue a formatted log message with a level of ERROR.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -2191,7 +2191,7 @@ public final class Log {
      * Issue a formatted log message with a level of ERROR.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2374,7 +2374,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of FATAL.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the parameters
      */
     public static void fatalf(String format, Object... params) {
@@ -2387,7 +2387,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of FATAL.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void fatalf(String format, Object param1) {
@@ -2400,7 +2400,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of FATAL.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -2414,7 +2414,7 @@ public final class Log {
     /**
      * Issue a formatted log message with a level of FATAL.
      *
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2430,7 +2430,7 @@ public final class Log {
      * Issue a formatted log message with a level of FATAL.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param params the parameters
      */
     public static void fatalf(Throwable t, String format, Object... params) {
@@ -2444,7 +2444,7 @@ public final class Log {
      * Issue a formatted log message with a level of FATAL.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the sole parameter
      */
     public static void fatalf(Throwable t, String format, Object param1) {
@@ -2458,7 +2458,7 @@ public final class Log {
      * Issue a formatted log message with a level of FATAL.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -2473,7 +2473,7 @@ public final class Log {
      * Issue a formatted log message with a level of FATAL.
      *
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2737,7 +2737,7 @@ public final class Log {
      * Issue a formatted log message at the given log level.
      *
      * @param level the level
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the parameters
      */
     public static void logf(Logger.Level level, String format, Object... params) {
@@ -2751,7 +2751,7 @@ public final class Log {
      * Issue a formatted log message at the given log level.
      *
      * @param level the level
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void logf(Logger.Level level, String format, Object param1) {
@@ -2765,7 +2765,7 @@ public final class Log {
      * Issue a formatted log message at the given log level.
      *
      * @param level the level
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -2780,7 +2780,7 @@ public final class Log {
      * Issue a formatted log message at the given log level.
      *
      * @param level the level
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2797,7 +2797,7 @@ public final class Log {
      *
      * @param level the level
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param params the parameters
      */
     public static void logf(Logger.Level level, Throwable t, String format, Object... params) {
@@ -2812,7 +2812,7 @@ public final class Log {
      *
      * @param level the level
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the sole parameter
      */
     public static void logf(Logger.Level level, Throwable t, String format, Object param1) {
@@ -2827,7 +2827,7 @@ public final class Log {
      *
      * @param level the level
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -2843,7 +2843,7 @@ public final class Log {
      *
      * @param level the level
      * @param t the throwable
-     * @param format the format string, as per {@link String#format(String, Object...)}
+     * @param format the format string, as per {@link String#formatted(Object...)}
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2861,7 +2861,7 @@ public final class Log {
      * @param loggerFqcn the logger class name
      * @param level the level
      * @param t the throwable cause
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the sole parameter
      */
     public static void logf(String loggerFqcn, Logger.Level level, Throwable t, String format, Object param1) {
@@ -2877,7 +2877,7 @@ public final class Log {
      * @param loggerFqcn the logger class name
      * @param level the level
      * @param t the throwable cause
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      */
@@ -2894,7 +2894,7 @@ public final class Log {
      * @param loggerFqcn the logger class name
      * @param level the level
      * @param t the throwable cause
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param param1 the first parameter
      * @param param2 the second parameter
      * @param param3 the third parameter
@@ -2913,7 +2913,7 @@ public final class Log {
      * @param loggerFqcn the logger class name
      * @param level the level
      * @param t the throwable cause
-     * @param format the format string as per {@link String#format(String, Object...)} or resource bundle key therefor
+     * @param format the format string as per {@link String#formatted(Object...)} or resource bundle key therefor
      * @param params the message parameters
      */
     public static void logf(String loggerFqcn, Logger.Level level, Throwable t, String format, Object... params) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -210,8 +210,8 @@ public class ApplicationLifecycleManager {
                 stateLock.unlock();
             }
             application.stop();
-            int exceptionExitCode = rootCause instanceof PreventFurtherStepsException
-                    ? ((PreventFurtherStepsException) rootCause).getExitCode()
+            int exceptionExitCode = rootCause instanceof PreventFurtherStepsException pfse
+                    ? pfse.getExitCode()
                     : 1;
             currentApplication = null;
             (exitCodeHandler == null ? defaultExitCodeHandler : exitCodeHandler).accept(exceptionExitCode, e);
@@ -238,8 +238,8 @@ public class ApplicationLifecycleManager {
     private static void ensureConsoleLogsDrained() {
         AsyncHandler asyncHandler = null;
         for (Handler handler : InitialConfigurator.DELAYED_HANDLER.getHandlers()) {
-            if (handler instanceof AsyncHandler) {
-                asyncHandler = (AsyncHandler) handler;
+            if (handler instanceof AsyncHandler asyncHandler1) {
+                asyncHandler = asyncHandler1;
                 Handler[] nestedHandlers = asyncHandler.getHandlers();
                 boolean foundNestedConsoleHandler = false;
                 for (Handler nestedHandler : nestedHandlers) {
@@ -272,8 +272,7 @@ public class ApplicationLifecycleManager {
      */
     private static void longLivedPostBootCleanup() {
         final ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        if (cl instanceof RunnerClassLoader) {
-            RunnerClassLoader rcl = (RunnerClassLoader) cl;
+        if (cl instanceof RunnerClassLoader rcl) {
             rcl.resetInternalCaches();
         }
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
@@ -123,13 +123,13 @@ public class TemplateHtmlBuilder {
                     </div>
             """;
 
-    private static final String HTML_TEMPLATE_START_NO_STACK = "" +
-            "<!doctype html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "    <title>%1$s%2$s</title>\n" +
-            "    <meta charset=\"utf-8\">\n" +
-            "</head>";
+    private static final String HTML_TEMPLATE_START_NO_STACK = """
+            <!doctype html>
+            <html lang="en">
+            <head>
+                <title>%1$s%2$s</title>
+                <meta charset="utf-8">
+            </head>""";
 
     private static final String HTML_TEMPLATE_START = "" +
             "<!doctype html>\n" +
@@ -195,25 +195,29 @@ public class TemplateHtmlBuilder {
             "   </svg>\n" +
             "</div> ";
 
-    private static final String HTML_TEMPLATE_END = "</div></body>\n" +
-            "</html>\n";
+    private static final String HTML_TEMPLATE_END = """
+            </div></body>
+            </html>
+            """;
 
-    private static final String HEADER_TEMPLATE = "<div class=\"banner\">\n" +
-            "                            <div class=\"callout\">%1$s</div>\n" +
-            "                        </div>"
-            + ""
-            + ""
-            + "<header>\n" +
-            "    <div class=\"exception-message\">\n" +
-            "        <h2 class=\"container\">%2$s</h2>\n" +
-            "        <div class=\"actions\">%3$s</div>\n" +
-            "    </div>\n" +
-            "</header>\n" +
-            "<div class=\"container content\">\n";
+    private static final String HEADER_TEMPLATE = """
+            <div class="banner">
+                                        <div class="callout">%1$s</div>
+                                    </div>\
+            <header>
+                <div class="exception-message">
+                    <h2 class="container">%2$s</h2>
+                    <div class="actions">%3$s</div>
+                </div>
+            </header>
+            <div class="container content">
+            """;
 
-    private static final String HEADER_TEMPLATE_NO_STACK = "<h1>%1$s</h1>\n" +
-            "%2$s \n" +
-            "<div class=\"container content\">\n";
+    private static final String HEADER_TEMPLATE_NO_STACK = """
+            <h1>%1$s</h1>
+            %2$s\s
+            <div class="container content">
+            """;
 
     private static final String RESOURCES_START = "<div class=\"intro\">%1$s</div><div class=\"resources\">";
 
@@ -228,15 +232,18 @@ public class TemplateHtmlBuilder {
 
     private static final String LIST_START = "<ul>\n";
 
-    private static final String METHOD_START = "<li> %1$s <strong>%2$s</strong>\n"
-            + "    <ul>\n";
+    private static final String METHOD_START = """
+            <li> %1$s <strong>%2$s</strong>
+                <ul>
+            """;
 
     private static final String METHOD_IO = "<li>%1$s: %2$s</li>\n";
 
     private static final String LIST_ITEM = "<li>%s</li>\n";
 
-    private static final String METHOD_END = "    </ul>\n"
-            + "</li>";
+    private static final String METHOD_END = """
+                </ul>
+            </li>""";
 
     private static final String LIST_END = "</ul>\n";
 
@@ -249,26 +256,32 @@ public class TemplateHtmlBuilder {
 
     private static final String OPEN_IDE_LINK = "<div class='rel-stacktrace-item' onclick=\"event.preventDefault(); fetch('/q/open-in-ide/%s/%s/%d');\">";
 
-    private static final String ORIGINAL_STACK_TRACE = "    <div id=\"original-stacktrace\" class=\"trace hidden\">\n" +
-            "<h3>The stacktrace below is the original. " +
-            "<a href=\"\" onClick=\"toggleStackTraceOrder(); return false;\">See the stacktrace in reversed order</a> (root-cause first)</h3>"
-            +
-            "        <code class=\"stacktrace\"><pre>%1$s</pre></code>\n" +
-            "    </div>\n";
+    private static final String ORIGINAL_STACK_TRACE = """
+                <div id="original-stacktrace" class="trace hidden">
+            <h3>The stacktrace below is the original. \
+            <a href="" onClick="toggleStackTraceOrder(); return false;">See the stacktrace in reversed order</a> (root-cause first)</h3>\
+                    <code class="stacktrace"><pre>%1$s</pre></code>
+                </div>
+            """;
 
-    private static final String ERROR_STACK_REVERSED = "    <div id=\"reversed-stacktrace\" class=\"trace hidden\">\n" +
-            "<h3>The stacktrace below has been reversed to show the root cause first. " +
-            "<a href=\"\" onClick=\"toggleStackTraceOrder(); return false;\">See the original stacktrace</a></h3>" +
-            "        <code class=\"stacktrace\"><pre>%1$s</pre></code>\n" +
-            "    </div>\n";
+    private static final String ERROR_STACK_REVERSED = """
+                <div id="reversed-stacktrace" class="trace hidden">
+            <h3>The stacktrace below has been reversed to show the root cause first. \
+            <a href="" onClick="toggleStackTraceOrder(); return false;">See the original stacktrace</a></h3>\
+                    <code class="stacktrace"><pre>%1$s</pre></code>
+                </div>
+            """;
 
     private static final String DECORATE_DIV = "<pre class='decorate'>%s</pre>";
     private static final String CONFIG_EDITOR_HEAD = "<h3>The following incorrect config values were detected:</h3>" +
             "<form class=\"updateConfigForm\" method=\"post\" enctype=\"application/x-www-form-urlencoded\"  action=\"/io.quarkus.vertx-http.devmode.config.fix\">"
             + "<input type=\"hidden\" name=\"redirect\" value=\"%s\"/>\n";
 
-    private static final String CONFIG_EDITOR_ROW = "<code class=\"configKey\">%s\n</code>\n" +
-            "                <input class=\"configValue\" type=\"text\" name=\"key.%s\" value=\"%s\"/>\n";
+    private static final String CONFIG_EDITOR_ROW = """
+            <code class="configKey">%s
+            </code>
+                            <input class="configValue" type="text" name="key.%s" value="%s"/>
+            """;
 
     private static final String CONFIG_UPDATE_BUTTON = "<input class=\"cta-button\" type=\"submit\" value=\"Update\" >";
 
@@ -318,20 +331,20 @@ public class TemplateHtmlBuilder {
                 actionLinks.append(buildLink(epa.name(), epa.url()));
             }
 
-            result = new StringBuilder(String.format(HTML_TEMPLATE_START, escapeHtml(title),
+            result = new StringBuilder(HTML_TEMPLATE_START.formatted(escapeHtml(title),
                     subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), CSS));
-            result.append(String.format(HEADER_TEMPLATE, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
+            result.append(HEADER_TEMPLATE.formatted(escapeHtml(title), escapeHtml(details), actionLinks.toString()));
         } else {
-            result = new StringBuilder(String.format(HTML_TEMPLATE_START_NO_STACK, escapeHtml(title),
+            result = new StringBuilder(HTML_TEMPLATE_START_NO_STACK.formatted(escapeHtml(title),
                     subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), CSS));
             result.append(
-                    String.format(HEADER_TEMPLATE_NO_STACK, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
+                    HEADER_TEMPLATE_NO_STACK.formatted(escapeHtml(title), escapeHtml(details), actionLinks.toString()));
         }
 
         if (!config.isEmpty()) {
-            result.append(String.format(CONFIG_EDITOR_HEAD, redirect));
+            result.append(CONFIG_EDITOR_HEAD.formatted(redirect));
             for (CurrentConfig i : config) {
-                result.append(String.format(CONFIG_EDITOR_ROW, escapeHtml(i.getPropertyName()), escapeHtml(i.getPropertyName()),
+                result.append(CONFIG_EDITOR_ROW.formatted(escapeHtml(i.getPropertyName()), escapeHtml(i.getPropertyName()),
                         escapeHtml(i.getCurrentValue())));
             }
             result.append(CONFIG_EDITOR_TAIL);
@@ -341,7 +354,7 @@ public class TemplateHtmlBuilder {
     public TemplateHtmlBuilder decorate(final Throwable throwable, String srcMainJava, List<String> knowClasses) {
         String decoratedString = DecorateStackUtil.getDecoratedString(throwable, srcMainJava, knowClasses);
         if (decoratedString != null) {
-            result.append(String.format(DECORATE_DIV, decoratedString));
+            result.append(DECORATE_DIV.formatted(decoratedString));
         }
 
         return this;
@@ -385,16 +398,16 @@ public class TemplateHtmlBuilder {
             String rootFirst = escapeHtml(ExceptionUtil.rootCauseFirstStackTrace(throwable));
             if (original.contains(BRSTI)) {
                 original = original.replace(BRSTI,
-                        String.format(OPEN_IDE_LINK, className, type, lineNumber));
+                        OPEN_IDE_LINK.formatted(className, type, lineNumber));
                 original = original.replace(ERSTI, "</div>");
                 rootFirst = rootFirst.replace(BRSTI,
-                        String.format(OPEN_IDE_LINK, className, type, lineNumber));
+                        OPEN_IDE_LINK.formatted(className, type, lineNumber));
                 rootFirst = rootFirst.replace(ERSTI, "</div>");
             }
 
             result.append(UTILITIES);
-            result.append(String.format(ORIGINAL_STACK_TRACE, original));
-            result.append(String.format(ERROR_STACK_REVERSED, rootFirst));
+            result.append(ORIGINAL_STACK_TRACE.formatted(original));
+            result.append(ERROR_STACK_REVERSED.formatted(rootFirst));
             result.append(STACKTRACE_DISPLAY_DIV);
 
             throwable.setStackTrace(originalStackTrace);
@@ -403,12 +416,12 @@ public class TemplateHtmlBuilder {
     }
 
     public TemplateHtmlBuilder resourcesStart(String title) {
-        result.append(String.format(RESOURCES_START, title));
+        result.append(RESOURCES_START.formatted(title));
         return this;
     }
 
     public TemplateHtmlBuilder resourcesStart(String title, String cssclass) {
-        result.append(String.format(RESOURCES_START_WITH_CLASS, title, cssclass));
+        result.append(RESOURCES_START_WITH_CLASS.formatted(title, cssclass));
         return this;
     }
 
@@ -418,7 +431,7 @@ public class TemplateHtmlBuilder {
     }
 
     public TemplateHtmlBuilder noResourcesFound() {
-        result.append(String.format(RESOURCE_TEMPLATE, "No resources discovered"));
+        result.append(RESOURCE_TEMPLATE.formatted("No resources discovered"));
         return this;
     }
 
@@ -448,14 +461,14 @@ public class TemplateHtmlBuilder {
             if (!title.startsWith("http") && baseUrl != null) {
                 title = baseUrl + title;
             }
-            content = String.format(ANCHOR_TEMPLATE_ABSOLUTE, title, escapeHtml(title));
+            content = ANCHOR_TEMPLATE_ABSOLUTE.formatted(title, escapeHtml(title));
         } else {
             content = escapeHtml(title);
         }
         if (description != null && !description.isEmpty()) {
-            content = String.format(DESCRIPTION_TEMPLATE, content, description);
+            content = DESCRIPTION_TEMPLATE.formatted(content, description);
         }
-        result.append(String.format(RESOURCE_TEMPLATE, content));
+        result.append(RESOURCE_TEMPLATE.formatted(content));
         if (withListStart) {
             result.append(LIST_START);
         }
@@ -471,22 +484,22 @@ public class TemplateHtmlBuilder {
                 fullPath = "<a href='" + fullPath + "' target='_blank'>" + fullPath + "</a>";
             }
         }
-        result.append(String.format(METHOD_START, escapeHtml(method), fullPath));
+        result.append(METHOD_START.formatted(escapeHtml(method), fullPath));
         return this;
     }
 
     public TemplateHtmlBuilder consumes(String consumes) {
-        result.append(String.format(METHOD_IO, "Consumes", escapeHtml(consumes)));
+        result.append(METHOD_IO.formatted("Consumes", escapeHtml(consumes)));
         return this;
     }
 
     public TemplateHtmlBuilder produces(String produces) {
-        result.append(String.format(METHOD_IO, "Produces", escapeHtml(produces)));
+        result.append(METHOD_IO.formatted("Produces", escapeHtml(produces)));
         return this;
     }
 
     public TemplateHtmlBuilder listItem(String content) {
-        result.append(String.format(LIST_ITEM, escapeHtml(content)));
+        result.append(LIST_ITEM.formatted(escapeHtml(content)));
         return this;
     }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/CharsetConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/CharsetConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 
@@ -15,6 +16,7 @@ import org.eclipse.microprofile.config.spi.Converter;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class CharsetConverter implements Converter<Charset>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 2320905063828247874L;
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/CidrAddressConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/CidrAddressConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import jakarta.annotation.Priority;
@@ -17,6 +18,7 @@ import io.smallrye.common.net.Inet;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class CidrAddressConverter implements Converter<CidrAddress>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 2023552088048952902L;
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -8,7 +8,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -44,7 +43,7 @@ public final class ConfigDiagnostic {
     public static void invalidValue(String name, IllegalArgumentException ex) {
         final String message = ex.getMessage();
         final String loggedMessage = message != null ? message
-                : String.format("An invalid value was given for configuration key \"%s\"", name);
+                : "An invalid value was given for configuration key \"%s\"".formatted(name);
         errorsMessages.add(loggedMessage);
         errorKeys.add(name);
     }
@@ -52,13 +51,13 @@ public final class ConfigDiagnostic {
     public static void missingValue(String name, NoSuchElementException ex) {
         final String message = ex.getMessage();
         final String loggedMessage = message != null ? message
-                : String.format("Configuration key \"%s\" is required, but its value is empty/missing", name);
+                : "Configuration key \"%s\" is required, but its value is empty/missing".formatted(name);
         errorsMessages.add(loggedMessage);
         errorKeys.add(name);
     }
 
     public static void duplicate(String name) {
-        final String loggedMessage = String.format("Configuration key \"%s\" was specified more than once", name);
+        final String loggedMessage = "Configuration key \"%s\" was specified more than once".formatted(name);
         errorsMessages.add(loggedMessage);
         errorKeys.add(name);
     }
@@ -214,14 +213,14 @@ public final class ConfigDiagnostic {
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
 
         Set<String> configFiles = new HashSet<>();
-        configFiles.addAll(configFiles(Paths.get(System.getProperty("user.dir"), "config")));
+        configFiles.addAll(configFiles(Path.of(System.getProperty("user.dir"), "config")));
         Optional<List<URI>> optionalLocations = config.getOptionalValues(SMALLRYE_CONFIG_LOCATIONS, URI.class);
         optionalLocations.ifPresent(new Consumer<List<URI>>() {
             @Override
             public void accept(final List<URI> locations) {
                 for (URI location : locations) {
-                    Path path = location.getScheme() != null && location.getScheme().equals("file") ? Paths.get(location)
-                            : Paths.get(location.getPath());
+                    Path path = location.getScheme() != null && location.getScheme().equals("file") ? Path.of(location)
+                            : Path.of(location.getPath());
                     if (Files.isDirectory(path)) {
                         try {
                             configFiles.addAll(configFiles(path));

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
@@ -166,11 +166,11 @@ public class ConfigInstantiator {
             var nextFullName = fullNameWithDot + segment;
             var mapValueType = typeOfParameter(genericType, 1);
             Object mapValue;
-            if (mapValueType instanceof ParameterizedType
-                    && ((ParameterizedType) mapValueType).getRawType().equals(Map.class)) {
+            if (mapValueType instanceof ParameterizedType type
+                    && type.getRawType().equals(Map.class)) {
                 mapValue = handleMap(nextFullName, mapValueType, config, quarkusPropertyNames);
             } else {
-                Class<?> mapValueClass = mapValueType instanceof Class ? (Class<?>) mapValueType : null;
+                Class<?> mapValueClass = mapValueType instanceof Class<?> c ? c : null;
                 if (mapValueClass != null && mapValueClass.isAnnotationPresent(ConfigGroup.class)) {
                     Constructor<?> constructor = mapValueClass.getConstructor();
                     constructor.setAccessible(true);
@@ -206,20 +206,20 @@ public class ConfigInstantiator {
 
     // cribbed from io.quarkus.deployment.util.ReflectUtil
     private static Class<?> rawTypeOf(final Type type) {
-        if (type instanceof Class<?>) {
-            return (Class<?>) type;
-        } else if (type instanceof ParameterizedType) {
-            return rawTypeOf(((ParameterizedType) type).getRawType());
-        } else if (type instanceof GenericArrayType) {
-            return Array.newInstance(rawTypeOf(((GenericArrayType) type).getGenericComponentType()), 0).getClass();
+        if (type instanceof Class<?> clazz) {
+            return clazz;
+        } else if (type instanceof ParameterizedType parameterizedType) {
+            return rawTypeOf(parameterizedType.getRawType());
+        } else if (type instanceof GenericArrayType arrayType) {
+            return Array.newInstance(rawTypeOf(arrayType.getGenericComponentType()), 0).getClass();
         } else {
             throw new IllegalArgumentException("Type has no raw type class: " + type);
         }
     }
 
     static Type typeOfParameter(final Type type, final int paramIdx) {
-        if (type instanceof ParameterizedType) {
-            return ((ParameterizedType) type).getActualTypeArguments()[paramIdx];
+        if (type instanceof ParameterizedType parameterizedType) {
+            return parameterizedType.getActualTypeArguments()[paramIdx];
         } else {
             throw new IllegalArgumentException("Type is not parameterized: " + type);
         }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -30,8 +30,8 @@ public class ConfigRecorder {
         Optional<ConfigSource> builtTimeRunTimeFixedConfigSource = config.getConfigSource("BuildTime RunTime Fixed");
         if (builtTimeRunTimeFixedConfigSource.isPresent()) {
             ConfigSource configSource = builtTimeRunTimeFixedConfigSource.get();
-            if (configSource instanceof DisableableConfigSource) {
-                ((DisableableConfigSource) configSource).disable();
+            if (configSource instanceof DisableableConfigSource source) {
+                source.disable();
             }
         }
 
@@ -53,8 +53,8 @@ public class ConfigRecorder {
         // Enable the BuildTime RunTime Fixed. It should be fine doing these operations, because this is on startup
         if (builtTimeRunTimeFixedConfigSource.isPresent()) {
             ConfigSource configSource = builtTimeRunTimeFixedConfigSource.get();
-            if (configSource instanceof DisableableConfigSource) {
-                ((DisableableConfigSource) configSource).enable();
+            if (configSource instanceof DisableableConfigSource source) {
+                source.enable();
             }
         }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigurationException.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigurationException.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime.configuration;
 
+import java.io.Serial;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -10,6 +11,7 @@ import io.quarkus.dev.config.ConfigurationProblem;
  * An exception indicating that a configuration failure has occurred.
  */
 public class ConfigurationException extends RuntimeException implements ConfigurationProblem {
+    @Serial
     private static final long serialVersionUID = 4445679764085720090L;
 
     private final Set<String> configKeys;
@@ -91,9 +93,9 @@ public class ConfigurationException extends RuntimeException implements Configur
     }
 
     private static Set<String> forwardCauseConfigKeys(Set<String> configKeys, Throwable cause) {
-        if (cause instanceof ConfigurationProblem) {
+        if (cause instanceof ConfigurationProblem problem) {
             var merged = new HashSet<String>(configKeys);
-            merged.addAll(((ConfigurationProblem) cause).getConfigKeys());
+            merged.addAll(problem.getConfigKeys());
         }
         return configKeys;
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
@@ -16,6 +17,7 @@ import org.eclipse.microprofile.config.spi.Converter;
  */
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class DurationConverter implements Converter<Duration>, Serializable {
+    @Serial
     private static final long serialVersionUID = 7499347081928776532L;
     private static final String PERIOD = "P";
     private static final String PERIOD_OF_TIME = "PT";

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/HyphenateEnumConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/HyphenateEnumConverter.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime.configuration;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +21,7 @@ import io.quarkus.runtime.util.StringUtil;
 public final class HyphenateEnumConverter<E extends Enum<E>> implements Converter<E>, Serializable {
     private static final String HYPHEN = "-";
     private static final Pattern PATTERN = Pattern.compile("([-_]+)");
+    @Serial
     private static final long serialVersionUID = 5675903245398498741L;
 
     private final Class<E> enumType;
@@ -52,7 +54,7 @@ public final class HyphenateEnumConverter<E extends Enum<E>> implements Converte
             return enumType.cast(enumValue);
         }
 
-        throw new IllegalArgumentException(String.format("Cannot convert %s to enum %s", value, enumType));
+        throw new IllegalArgumentException("Cannot convert %s to enum %s".formatted(value, enumType));
     }
 
     private String hyphenate(String value) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/InetAddressConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/InetAddressConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -18,6 +19,7 @@ import io.smallrye.common.net.Inet;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class InetAddressConverter implements Converter<InetAddress>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4539214213710330204L;
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/InetSocketAddressConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/InetSocketAddressConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -20,6 +21,7 @@ import io.smallrye.common.net.Inet;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class InetSocketAddressConverter implements Converter<InetSocketAddress>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1928336763333858343L;
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySizeConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySizeConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.HashMap;
@@ -21,6 +22,7 @@ public class MemorySizeConverter implements Converter<MemorySize>, Serializable 
     private static final Pattern MEMORY_SIZE_PATTERN = Pattern.compile("^(\\d+)([BbKkMmGgTtPpEeZzYy]?)$");
     static final BigInteger KILO_BYTES = BigInteger.valueOf(1024);
     private static final Map<String, BigInteger> MEMORY_SIZE_MULTIPLIERS;
+    @Serial
     private static final long serialVersionUID = -1988485929047973068L;
 
     static {
@@ -57,6 +59,6 @@ public class MemorySizeConverter implements Converter<MemorySize>, Serializable 
         }
 
         throw new IllegalArgumentException(
-                String.format("value %s not in correct format (regular expression): [0-9]+[BbKkMmGgTtPpEeZzYy]?", value));
+                "value %s not in correct format (regular expression): [0-9]+[BbKkMmGgTtPpEeZzYy]?".formatted(value));
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/PathConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/PathConverter.java
@@ -2,9 +2,9 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import jakarta.annotation.Priority;
 
@@ -16,10 +16,11 @@ import org.eclipse.microprofile.config.spi.Converter;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class PathConverter implements Converter<Path>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4452863383998867844L;
 
     @Override
     public Path convert(String value) {
-        return value.isEmpty() ? null : Paths.get(value);
+        return value.isEmpty() ? null : Path.of(value);
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/RegexConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/RegexConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.regex.Pattern;
 
@@ -15,6 +16,7 @@ import org.eclipse.microprofile.config.spi.Converter;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class RegexConverter implements Converter<Pattern>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = -2627801624423530576L;
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
@@ -278,24 +278,24 @@ final class Substitutions {
 
                 @Override
                 public Object get(final Object key) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.get(key);
                 }
 
                 @Override
                 public synchronized Object put(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.put(key, value);
                 }
 
                 @Override
                 public synchronized Object remove(final Object key) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.remove(key);
                 }
@@ -347,8 +347,8 @@ final class Substitutions {
 
                 @Override
                 public Object getOrDefault(final Object key, final Object defaultValue) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.getOrDefault(key, defaultValue);
                 }
@@ -367,32 +367,32 @@ final class Substitutions {
 
                 @Override
                 public synchronized Object putIfAbsent(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.putIfAbsent(key, value);
                 }
 
                 @Override
                 public synchronized boolean remove(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.remove(key, value);
                 }
 
                 @Override
                 public synchronized boolean replace(final Object key, final Object oldValue, final Object newValue) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.replace(key, oldValue, newValue);
                 }
 
                 @Override
                 public synchronized Object replace(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.replace(key, value);
                 }
@@ -401,8 +401,8 @@ final class Substitutions {
                 public synchronized Object computeIfAbsent(
                         final Object key,
                         final Function<? super Object, ?> mappingFunction) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.computeIfAbsent(key, mappingFunction);
                 }
@@ -411,8 +411,8 @@ final class Substitutions {
                 public synchronized Object computeIfPresent(
                         final Object key,
                         final BiFunction<? super Object, ? super Object, ?> remappingFunction) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.computeIfPresent(key, remappingFunction);
                 }
@@ -421,8 +421,8 @@ final class Substitutions {
                 public synchronized Object compute(
                         final Object key,
                         final BiFunction<? super Object, ? super Object, ?> remappingFunction) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.compute(key, remappingFunction);
                 }
@@ -432,8 +432,8 @@ final class Substitutions {
                         final Object key,
                         final Object value,
                         final BiFunction<? super Object, ? super Object, ?> remappingFunction) {
-                    if (key instanceof String) {
-                        initializeLazyValue((String) key);
+                    if (key instanceof String string) {
+                        initializeLazyValue(string);
                     }
                     return properties.merge(key, value, remappingFunction);
                 }
@@ -611,24 +611,24 @@ final class Substitutions {
 
                 @Override
                 public Object get(final Object key) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.get(key);
                 }
 
                 @Override
                 public synchronized Object put(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.put(key, value);
                 }
 
                 @Override
                 public synchronized Object remove(final Object key) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.remove(key);
                 }
@@ -680,8 +680,8 @@ final class Substitutions {
 
                 @Override
                 public Object getOrDefault(final Object key, final Object defaultValue) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.getOrDefault(key, defaultValue);
                 }
@@ -700,32 +700,32 @@ final class Substitutions {
 
                 @Override
                 public synchronized Object putIfAbsent(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.putIfAbsent(key, value);
                 }
 
                 @Override
                 public synchronized boolean remove(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.remove(key, value);
                 }
 
                 @Override
                 public synchronized boolean replace(final Object key, final Object oldValue, final Object newValue) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.replace(key, oldValue, newValue);
                 }
 
                 @Override
                 public synchronized Object replace(final Object key, final Object value) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.replace(key, value);
                 }
@@ -734,8 +734,8 @@ final class Substitutions {
                 public synchronized Object computeIfAbsent(
                         final Object key,
                         final Function<? super Object, ?> mappingFunction) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.computeIfAbsent(key, mappingFunction);
                 }
@@ -744,8 +744,8 @@ final class Substitutions {
                 public synchronized Object computeIfPresent(
                         final Object key,
                         final BiFunction<? super Object, ? super Object, ?> remappingFunction) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.computeIfPresent(key, remappingFunction);
                 }
@@ -754,8 +754,8 @@ final class Substitutions {
                 public synchronized Object compute(
                         final Object key,
                         final BiFunction<? super Object, ? super Object, ?> remappingFunction) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.compute(key, remappingFunction);
                 }
@@ -765,8 +765,8 @@ final class Substitutions {
                         final Object key,
                         final Object value,
                         final BiFunction<? super Object, ? super Object, ?> remappingFunction) {
-                    if (key instanceof String) {
-                        ensurePropertyInitialized((String) key);
+                    if (key instanceof String string) {
+                        ensurePropertyInitialized(string);
                     }
                     return currentProperties.merge(key, value, remappingFunction);
                 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ZoneIdConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ZoneIdConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.ZoneId;
 
@@ -15,6 +16,7 @@ import org.eclipse.microprofile.config.spi.Converter;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class ZoneIdConverter implements Converter<ZoneId>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = -439010527617997936L;
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
@@ -34,7 +34,7 @@ public abstract class InheritableLevel {
     public abstract String toString();
 
     public final boolean equals(Object obj) {
-        return obj instanceof InheritableLevel && equals((InheritableLevel) obj);
+        return obj instanceof InheritableLevel il && equals(il);
     }
 
     public abstract boolean equals(InheritableLevel other);
@@ -61,7 +61,7 @@ public abstract class InheritableLevel {
         }
 
         public boolean equals(final InheritableLevel other) {
-            return other instanceof ActualLevel && level.equals(((ActualLevel) other).level);
+            return other instanceof ActualLevel al && level.equals(al.level);
         }
 
         public int hashCode() {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LevelConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LevelConverter.java
@@ -2,6 +2,7 @@ package io.quarkus.runtime.logging;
 
 import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.logging.Level;
@@ -17,6 +18,7 @@ import org.jboss.logmanager.LogContext;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public final class LevelConverter implements Converter<Level>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 704275577610445233L;
 
     public Level convert(final String value) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilter.java
@@ -31,8 +31,7 @@ public class LogCleanupFilter implements Filter {
         //we also use this filter to add a warning about errors generated after shutdown
         if (record.getLevel().intValue() >= org.jboss.logmanager.Level.ERROR.intValue() && shutdownNotifier.shutdown) {
             if (!record.getMessage().endsWith(SHUTDOWN_MESSAGE)) {
-                if (record instanceof ExtLogRecord) {
-                    ExtLogRecord elr = (ExtLogRecord) record;
+                if (record instanceof ExtLogRecord elr) {
                     elr.setMessage(record.getMessage() + SHUTDOWN_MESSAGE, elr.getFormatStyle());
                 } else {
                     record.setMessage(record.getMessage() + SHUTDOWN_MESSAGE);

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -468,7 +468,7 @@ public class LoggingSetupRecorder {
 
     private static void addToNamedHandlers(Map<String, Handler> namedHandlers, Handler handler, String handlerName) {
         if (namedHandlers.containsKey(handlerName)) {
-            throw new RuntimeException(String.format("Only one handler can be configured with the same name '%s'",
+            throw new RuntimeException("Only one handler can be configured with the same name '%s'".formatted(
                     handlerName));
         }
         namedHandlers.put(handlerName, handler);
@@ -496,7 +496,7 @@ public class LoggingSetupRecorder {
                     }
                 });
             } else if (checkHandlerLinks) {
-                errorManager.error(String.format("Handler with name '%s' is linked to a category but not configured.",
+                errorManager.error("Handler with name '%s' is linked to a category but not configured.".formatted(
                         categoryNamedHandler), null, ErrorManager.GENERIC_FAILURE);
             }
         }
@@ -553,7 +553,7 @@ public class LoggingSetupRecorder {
             if (handler != null) {
                 effectiveHandlers.add(handler);
             } else {
-                errorManager.error(String.format("Handler with name '%s' is linked to a category but not configured.",
+                errorManager.error("Handler with name '%s' is linked to a category but not configured.".formatted(
                         namedHandler), null, ErrorManager.GENERIC_FAILURE);
             }
         }
@@ -884,8 +884,7 @@ public class LoggingSetupRecorder {
         public void accept(String name, Handler handler) {
             Handler previous = additionalNamedHandlersMap.putIfAbsent(name, handler);
             if (previous != null) {
-                throw new IllegalStateException(String.format(
-                        "Duplicate key %s (attempted merging values %s and %s)",
+                throw new IllegalStateException("Duplicate key %s (attempted merging values %s and %s)".formatted(
                         name, previous, handler));
             }
             handler.setErrorManager(errorManager);

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
@@ -31,8 +31,7 @@ public class GenericArrayTypeImpl implements GenericArrayType {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof GenericArrayType) {
-            GenericArrayType that = (GenericArrayType) obj;
+        if (obj instanceof GenericArrayType that) {
             if (genericComponentType == null) {
                 return that.getGenericComponentType() == null;
             } else {

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/ParameterizedTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/ParameterizedTypeImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime.types;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -7,6 +8,7 @@ import java.util.Arrays;
 
 public class ParameterizedTypeImpl implements ParameterizedType, Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3005183010706452884L;
 
     private final Type[] actualTypeArguments;
@@ -63,16 +65,16 @@ public class ParameterizedTypeImpl implements ParameterizedType, Serializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        if (rawType instanceof Class) {
-            sb.append(((Class<?>) rawType).getName());
+        if (rawType instanceof Class<?> clazz) {
+            sb.append(clazz.getName());
         } else {
             sb.append(rawType);
         }
         if (actualTypeArguments.length > 0) {
             sb.append("<");
             for (Type actualType : actualTypeArguments) {
-                if (actualType instanceof Class) {
-                    sb.append(((Class<?>) actualType).getName());
+                if (actualType instanceof Class<?> clazz) {
+                    sb.append(clazz.getName());
                 } else {
                     sb.append(actualType);
                 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
@@ -10,7 +10,6 @@ import java.net.URLConnection;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -221,7 +220,7 @@ public class ClassPathUtils {
      */
     public static Path toLocalPath(final URL url) {
         try {
-            return Paths.get(url.toURI());
+            return Path.of(url.toURI());
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Failed to translate " + url + " to local path", e);
         }

--- a/core/runtime/src/test/java/io/quarkus/logging/GenerateLog.java
+++ b/core/runtime/src/test/java/io/quarkus/logging/GenerateLog.java
@@ -38,10 +38,10 @@ import com.github.javaparser.ast.type.PrimitiveType;
 import io.quarkus.runtime.Application;
 
 public class GenerateLog {
-    private static final String CLASS_JAVADOC = "" +
-            "Copy of {@link org.jboss.logging.BasicLogger}.\n" +
-            "Invocations of all {@code static} methods of this class are, during build time, replaced by invocations\n" +
-            "of the same methods on a generated instance of {@link Logger}.";
+    private static final String CLASS_JAVADOC = """
+            Copy of {@link org.jboss.logging.BasicLogger}.
+            Invocations of all {@code static} methods of this class are, during build time, replaced by invocations
+            of the same methods on a generated instance of {@link Logger}.""";
 
     public static void main(String[] args) throws Exception {
         String source = BasicLogger.class.getProtectionDomain().getCodeSource().getLocation().getPath();

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
@@ -144,7 +144,7 @@ public class ConfigInstantiatorTestCase {
 
         @Override
         public String toString() {
-            return String.format("MapValueConfig[%s]", value);
+            return "MapValueConfig[%s]".formatted(value);
         }
     }
 


### PR DESCRIPTION
### Migrate to Java 17

I was wondering if the codebase has already been migrated to the latest LTS Java version. While the migration to Java 21 didn't work out, the Java 17 migration still appears to be an open issue. There are some changes made by the corresponding migration tool that need to be addressed.

This migration will adhere to best practices and remove a lot of unwanted boilerplate code. For example, much of the bulky casting will be handled by Java itself, eliminating the need for verbose and explicit type casting.

<img width="1490" alt="Migration Example" src="https://github.com/user-attachments/assets/33b1f660-f941-4dc7-a9f2-1020478e1b84" />

### Implementation ideas

This recipe will apply changes commonly needed when migrating to Java 17.

Specifically, for applications built on Java 8, this recipe will:
- Update and add dependencies on J2EE libraries no longer bundled with the JDK
- Replace deprecated APIs with equivalents when there's a clear migration strategy
- Update build files to use Java 17 as the target/source version
- Upgrade plugins to versions compatible with Java 17

[Upgrade to Java 17 Recipe Documentation](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava17)