### PR TITLE
Define the main class in shaded jar quarkus-grpc-protoc-plugin

### DIFF
--- a/extensions/grpc/protoc/pom.xml
+++ b/extensions/grpc/protoc/pom.xml
@@ -50,6 +50,11 @@
                             <createSourcesJar>true</createSourcesJar>
                             <shadedClassifierName>shaded</shadedClassifierName>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator</mainClass>
+                                </transformer>
+                            </transformers>
                             <filters>
                                 <filter>
                                     <artifact>com.salesforce.servicelibs:jprotoc</artifact>


### PR DESCRIPTION
As discussed in https://github.com/quarkusio/quarkus/issues/27388#issuecomment-2796132420 in order to ease usage of artifact `io.quarkus:quarkus-grpc-protoc-plugin:$quarkusPlatformVersion:shaded@jar` as protoc plugin, I think the main class should be present in the Manifest of the shaded jar.

---

Work-around: modify the jar locally in order to be able to use it without having to specify the main class

<details><summary>Ant task to modify the existing jar</summary>
<p>

```xml
<?xml version="1.0"?>
<project name="ExampleProject" default="jar" basedir=".">

    <target name="jar" depends="init">
        <jar file="quarkus-grpc-protoc-plugin-3.21.1-shaded.jar" update="true">
            <manifest>
                <attribute name="Main-Class" value="io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator"/>
                <section name="Mapping Info">
                    <attribute name="Built-By" value="${user.name}"/>
                </section>
            </manifest>
        </jar>
    </target>
</project>
```

</p>
</details> 

<details><summary>Gradle task to modify the existing jar</summary>
<p>

```gradle
plugins {
    id 'java'
}

repositories {
    mavenCentral()
}

configurations {
    pluginDownload
}

dependencies {
    pluginDownload "io.quarkus:quarkus-grpc-protoc-plugin:$quarkusPlatformVersion:shaded@jar"
}

var pluginJarFixTask = tasks.register('pluginJarFix', Jar) {
    archiveFileName = "patched-quarkus-grpc-protoc-plugin-$quarkusPlatformVersion-shaded.jar"

    manifest {
        attributes["Main-Class"] = 'io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator'
    }

    from zipTree(configurations.pluginDownload.singleFile)
}
```

</p>
</details> 