### PR TITLE
Higher Xmx and MaxMetaspaceSize for deploy-snapshots build

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'quarkusio/quarkus'
     env:
-      MAVEN_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=1000m
+      MAVEN_OPTS: -Xmx6g -XX:MaxMetaspaceSize=2g
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,7 +45,6 @@ jobs:
             ${{ steps.cache-key.outputs.m2-monthly-cache-key }}-
       - name: Build and Deploy
         env:
-          MAVEN_OPTS: -Xmx3g -XX:MaxMetaspaceSize=1g
           GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
           SERVER_USERNAME: ${{ secrets.SERVER_USERNAME }}
           SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}


### PR DESCRIPTION
Higher Xmx and MaxMetaspaceSize for deploy-snapshots build

GH runners have 16 GB of RAM
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Related to https://github.com/quarkusio/quarkus/issues/47168