### PR TITLE
Support for decrypting OIDC access tokens

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -193,6 +193,7 @@ When a client secret is configured with `quarkus.oidc.credentials.secret`, it is
 
 The remaining three properties in the `quarkus.oidc.credentials.client-secret.provider.*` namespace allow to customize how a custom xref:credentials-provider.adoc[CredentialsProvider] can be used to provide secrets stored in secure locations. Alternatively, you can use Quarkus Configuration system to manage secrets, see the xref:config-secrets.adoc[Secrets in Configuration] guide.
 
+[[jwt-client-credentials]]
 === JWT client credentials
 
 Instead of sending a client secret, Quarkus OIDC can authenticate to OIDC providers by sending a generated JWT authentication token signed with either a client secret or private key.
@@ -715,7 +716,7 @@ Token properties cover a lot of requirements related to the token verification, 
 [[token-preprocessing]]
 === Token preprocessing
 
-Some tokens may have to decrypted or their headers preprocessed for the verification process to start and succeed.
+ID and access tokens may have to be decrypted or their headers preprocessed for the verification process to start and succeed.
 
 .Token preprocessing properties
 [options="header"]
@@ -723,10 +724,18 @@ Some tokens may have to decrypted or their headers preprocessed for the verifica
 |Property | Default |Description
 
 |quarkus.oidc.token.decryption-key-location || Decryption key location
+|quarkus.oidc.token.decrypt-id-token || Decrypt ID token if this property is `true` or if `quarkus.oidc.token.decryption-key-location` is set
+|quarkus.oidc.token.decrypt-access-token |false| Decrypt access token
 |quarkus.oidc.token.customizer-name || Customizer name
 |====
 
-OIDC providers usually issue signed ID tokens but they may also issue encrypted ID tokens which Quarkus needs to decrypt. Use the `quarkus.oidc.token.decryption-key-location` property to point to a JWK or PEM decryption key file in this case.
+OIDC providers usually issue signed ID and access tokens but may also additionally encrypt these tokens which Quarkus needs to decrypt to verify them. Choose which token types must be decrypted: the ID token with `quarkus.oidc.token.decrypt-id-token`, or the access token with `quarkus.oidc.token.decrypt-access-token`.
+
+Both ID and access tokens are considered encrypted if they contain 5 parts separated by the dot character, indicating that the JWE encryption was used.
+
+For backward compatibility reasons, ID token decryption is attempted if  `quarkus.oidc.token.decryption-key-location` is configured, but using an optional `quarkus.oidc.token.decrypt-id-token` boolean property is RECOMMENDED instead, to allow for more flexibility in selecting decryption keys.
+
+When either ID or access token must be decrypted, `quarkus.oidc.token.decryption-key-location` is checked first. If this property is not configured, then the <<jwt-client-credentials>> key, if available, is used. Finally, if the decryption key is still not initialized, the configured client secret is used as a decryption key.
 
 `quarkus.oidc.token.customizer-name` is an advanced property that may be used to select a specific `io.quarkus.oidc.TokenCustomizer` implementation which can pre-process JWT token headers before its signature can be verified. The main use-case is to support verifying legacy Azure JWT tokens which must have their `nonce` header recalculated for the signature verification to succeed.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -2333,6 +2333,16 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         public Optional<String> decryptionKeyLocation = Optional.empty();
 
         /**
+         * Decrypt ID token.
+         */
+        Optional<Boolean> decryptIdToken = Optional.empty();
+
+        /**
+         * Decrypt access token.
+         */
+        boolean decryptAccessToken;
+
+        /**
          * Allow the remote introspection of JWT tokens when no matching JWK key is available.
          *
          * This property is set to `true` by default for backward-compatibility reasons. It is planned that this default value
@@ -2572,6 +2582,8 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             authorizationScheme = mapping.authorizationScheme();
             signatureAlgorithm = mapping.signatureAlgorithm().map(Enum::toString).map(SignatureAlgorithm::valueOf);
             decryptionKeyLocation = mapping.decryptionKeyLocation();
+            decryptIdToken = mapping.decryptIdToken();
+            decryptAccessToken = mapping.decryptAccessToken();
             allowJwtIntrospection = mapping.allowJwtIntrospection();
             requireJwtIntrospectionOnly = mapping.requireJwtIntrospectionOnly();
             allowOpaqueTokenIntrospection = mapping.allowOpaqueTokenIntrospection();
@@ -2659,6 +2671,16 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         @Override
         public Optional<String> decryptionKeyLocation() {
             return decryptionKeyLocation;
+        }
+
+        @Override
+        public Optional<Boolean> decryptIdToken() {
+            return decryptIdToken;
+        }
+
+        @Override
+        public boolean decryptAccessToken() {
+            return decryptAccessToken;
         }
 
         @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -228,7 +228,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
             try {
                 KeyEncryptionAlgorithm encAlgorithm = KeyEncryptionAlgorithm
                         .valueOf(oidcConfig.tokenStateManager().encryptionAlgorithm().name());
-                return OidcUtils.encryptString(token, configContext.getTokenEncSecretKey(), encAlgorithm);
+                return OidcUtils.encryptString(token, configContext.getSessionCookieEncryptionKey(), encAlgorithm);
             } catch (Exception ex) {
                 throw new AuthenticationFailedException(ex);
             }
@@ -242,7 +242,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
             try {
                 KeyEncryptionAlgorithm encAlgorithm = KeyEncryptionAlgorithm
                         .valueOf(oidcConfig.tokenStateManager().encryptionAlgorithm().name());
-                return OidcUtils.decryptString(token, configContext.getTokenEncSecretKey(), encAlgorithm);
+                return OidcUtils.decryptString(token, configContext.getSessionCookieEncryptionKey(), encAlgorithm);
             } catch (Exception ex) {
                 throw new AuthenticationFailedException(ex);
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc.runtime;
 
+import java.security.Key;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -66,18 +67,23 @@ final class LazyTenantConfigContext implements TenantConfigContext {
     }
 
     @Override
-    public SecretKey getStateEncryptionKey() {
-        return delegate.getStateEncryptionKey();
+    public SecretKey getStateCookieEncryptionKey() {
+        return delegate.getStateCookieEncryptionKey();
     }
 
     @Override
-    public SecretKey getTokenEncSecretKey() {
-        return delegate.getTokenEncSecretKey();
+    public SecretKey getSessionCookieEncryptionKey() {
+        return delegate.getSessionCookieEncryptionKey();
     }
 
     @Override
-    public SecretKey getInternalIdTokenSecretKey() {
-        return delegate.getInternalIdTokenSecretKey();
+    public SecretKey getInternalIdTokenSigningKey() {
+        return delegate.getInternalIdTokenSigningKey();
+    }
+
+    @Override
+    public Key getTokenDecryptionKey() {
+        return delegate.getTokenDecryptionKey();
     }
 
     @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -86,17 +86,15 @@ public class OidcProvider implements Closeable {
     final String issuer;
     final String[] audience;
     final Map<String, Set<String>> requiredClaims;
-    final Key tokenDecryptionKey;
     final AlgorithmConstraints requiredAlgorithmConstraints;
 
-    public OidcProvider(OidcProviderClientImpl client, OidcTenantConfig oidcConfig, JsonWebKeySet jwks,
-            Key tokenDecryptionKey) {
-        this(client, oidcConfig, jwks, TenantFeatureFinder.find(oidcConfig), tokenDecryptionKey,
+    public OidcProvider(OidcProviderClientImpl client, OidcTenantConfig oidcConfig, JsonWebKeySet jwks) {
+        this(client, oidcConfig, jwks, TenantFeatureFinder.find(oidcConfig),
                 TenantFeatureFinder.find(oidcConfig, Validator.class));
     }
 
     public OidcProvider(OidcProviderClientImpl client, OidcTenantConfig oidcConfig, JsonWebKeySet jwks,
-            TokenCustomizer tokenCustomizer, Key tokenDecryptionKey, List<Validator> customValidators) {
+            TokenCustomizer tokenCustomizer, List<Validator> customValidators) {
         this.client = client;
         this.oidcConfig = oidcConfig;
         this.tokenCustomizer = tokenCustomizer;
@@ -116,7 +114,6 @@ public class OidcProvider implements Closeable {
         this.issuer = checkIssuerProp();
         this.audience = checkAudienceProp();
         this.requiredClaims = checkRequiredClaimsProp();
-        this.tokenDecryptionKey = tokenDecryptionKey;
         this.requiredAlgorithmConstraints = checkSignatureAlgorithm();
         this.customValidators = customValidators == null ? List.of() : customValidators;
         if (client != null) {
@@ -124,7 +121,7 @@ public class OidcProvider implements Closeable {
         }
     }
 
-    public OidcProvider(String publicKeyEnc, OidcTenantConfig oidcConfig, Key tokenDecryptionKey) {
+    public OidcProvider(String publicKeyEnc, OidcTenantConfig oidcConfig) {
         this.client = null;
         this.oidcConfig = oidcConfig;
         this.tokenCustomizer = TenantFeatureFinder.find(oidcConfig);
@@ -139,7 +136,6 @@ public class OidcProvider implements Closeable {
         this.issuer = checkIssuerProp();
         this.audience = checkAudienceProp();
         this.requiredClaims = checkRequiredClaimsProp();
-        this.tokenDecryptionKey = tokenDecryptionKey;
         this.requiredAlgorithmConstraints = checkSignatureAlgorithm();
         this.customValidators = TenantFeatureFinder.find(oidcConfig, Validator.class);
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -1112,16 +1112,30 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         Optional<SignatureAlgorithm> signatureAlgorithm();
 
         /**
-         * Decryption key location.
-         * JWT tokens can be inner-signed and encrypted by OpenId Connect providers.
-         * However, it is not always possible to remotely introspect such tokens because
-         * the providers might not control the private decryption keys.
-         * In such cases set this property to point to the file containing the decryption private key in
-         * PEM or JSON Web Key (JWK) format.
-         * If this property is not set and the `private_key_jwt` client authentication method is used, the private key
-         * used to sign the client authentication JWT tokens are also used to decrypt the encrypted ID tokens.
+         * Decryption key location for encrypted ID and access tokens.
          */
         Optional<String> decryptionKeyLocation();
+
+        /**
+         * Decrypt ID token.
+         *
+         * If the {@link Token#decryptionKeyLocation()} property is configured then the decryption key will be loaded from this
+         * location.
+         * Otherwise, if the JWT authentication token key is available, then it will be used to decrypt the token.
+         * Finally, if a client secret is configured, it will be used as a secret key to decrypt the token.
+         */
+        Optional<Boolean> decryptIdToken();
+
+        /**
+         * Decrypt access token.
+         *
+         * If the {@link Token#decryptionKeyLocation()} property is configured then the decryption key will be loaded from this
+         * location.
+         * Otherwise, if the JWT authentication token key is available, then it will be used to decrypt the token.
+         * Finally, if a client secret is configured, it will be used as a secret key to decrypt the token.
+         */
+        @WithDefault("false")
+        boolean decryptAccessToken();
 
         /**
          * Allow the remote introspection of JWT tokens when no matching JWK key is available.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc.runtime;
 
+import java.security.Key;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -31,11 +32,13 @@ public sealed interface TenantConfigContext permits TenantConfigContextImpl, Laz
 
     OidcProviderClientImpl getOidcProviderClient();
 
-    SecretKey getStateEncryptionKey();
+    SecretKey getStateCookieEncryptionKey();
 
-    SecretKey getTokenEncSecretKey();
+    SecretKey getSessionCookieEncryptionKey();
 
-    SecretKey getInternalIdTokenSecretKey();
+    SecretKey getInternalIdTokenSigningKey();
+
+    Key getTokenDecryptionKey();
 
     List<OidcRedirectFilter> getOidcRedirectFilters(Redirect.Location loc);
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/TokenConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/TokenConfigBuilder.java
@@ -27,7 +27,8 @@ public final class TokenConfigBuilder {
             Optional<Duration> age, boolean issuedAtRequired, Optional<String> principalClaim, boolean refreshExpired,
             Optional<Duration> refreshTokenTimeSkew, Duration forcedJwkRefreshInterval, Optional<String> header,
             String authorizationScheme, Optional<OidcTenantConfig.SignatureAlgorithm> signatureAlgorithm,
-            Optional<String> decryptionKeyLocation, boolean allowJwtIntrospection, boolean requireJwtIntrospectionOnly,
+            Optional<String> decryptionKeyLocation, Optional<Boolean> decryptIdToken, boolean decryptAccessToken,
+            boolean allowJwtIntrospection, boolean requireJwtIntrospectionOnly,
             boolean allowOpaqueTokenIntrospection, Optional<String> customizerName,
             Optional<Boolean> verifyAccessTokenWithUserInfo, Binding binding) implements OidcTenantConfig.Token {
     }
@@ -49,6 +50,8 @@ public final class TokenConfigBuilder {
     private String authorizationScheme;
     private Optional<OidcTenantConfig.SignatureAlgorithm> signatureAlgorithm;
     private Optional<String> decryptionKeyLocation;
+    Optional<Boolean> decryptIdToken;
+    private boolean decryptAccessToken;
     private boolean allowJwtIntrospection;
     private boolean requireJwtIntrospectionOnly;
     private boolean allowOpaqueTokenIntrospection;
@@ -83,6 +86,8 @@ public final class TokenConfigBuilder {
         this.authorizationScheme = token.authorizationScheme();
         this.signatureAlgorithm = token.signatureAlgorithm();
         this.decryptionKeyLocation = token.decryptionKeyLocation();
+        this.decryptIdToken = token.decryptIdToken();
+        this.decryptAccessToken = token.decryptAccessToken();
         this.allowJwtIntrospection = token.allowJwtIntrospection();
         this.requireJwtIntrospectionOnly = token.requireJwtIntrospectionOnly();
         this.allowOpaqueTokenIntrospection = token.allowOpaqueTokenIntrospection();
@@ -333,6 +338,42 @@ public final class TokenConfigBuilder {
     }
 
     /**
+     * Sets {@link OidcTenantConfig.Token#decryptIdToken()} to true
+     *
+     * @return this builder
+     */
+    public TokenConfigBuilder decryptIdToken() {
+        return decryptIdToken(true);
+    }
+
+    /**
+     * @param decryptIdToken {@link OidcTenantConfig.Token#decryptIdToken()}
+     * @return this builder
+     */
+    public TokenConfigBuilder decryptIdToken(boolean decryptIdToken) {
+        this.decryptIdToken = Optional.of(decryptIdToken);
+        return this;
+    }
+
+    /**
+     * Sets {@link OidcTenantConfig.Token#decryptAccessToken()} to true.
+     *
+     * @return this builder
+     */
+    public TokenConfigBuilder decryptAccessToken() {
+        return decryptAccessToken(true);
+    }
+
+    /**
+     * @param decryptAccessToken {@link OidcTenantConfig.Token#decryptAccessToken()}
+     * @return this builder
+     */
+    public TokenConfigBuilder decryptAccessToken(boolean decryptAccessToken) {
+        this.decryptAccessToken = decryptAccessToken;
+        return this;
+    }
+
+    /**
      * Sets {@link OidcTenantConfig.Token#allowJwtIntrospection()} to true.
      *
      * @return this builder
@@ -447,7 +488,9 @@ public final class TokenConfigBuilder {
         return new TokenImpl(issuer, optionalAudience, subjectRequired, Map.copyOf(requiredClaims), tokenType,
                 lifespanGrace, age, issuedAtRequired, principalClaim, refreshExpired, refreshTokenTimeSkew,
                 forcedJwkRefreshInterval, header, authorizationScheme, signatureAlgorithm, decryptionKeyLocation,
-                allowJwtIntrospection, requireJwtIntrospectionOnly, allowOpaqueTokenIntrospection, customizerName,
+                decryptIdToken,
+                decryptAccessToken, allowJwtIntrospection, requireJwtIntrospectionOnly, allowOpaqueTokenIntrospection,
+                customizerName,
                 verifyAccessTokenWithUserInfo, binding);
     }
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
@@ -45,7 +45,7 @@ public class OidcProviderTest {
         JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "]}");
         OidcTenantConfig oidcConfig = new OidcTenantConfig();
 
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             try {
                 provider.verifyJwtToken(newToken, false, false, null);
                 fail("InvalidJwtException expected");
@@ -61,7 +61,7 @@ public class OidcProviderTest {
                 return Json.createObjectBuilder(headers).add("alg", "RS256").build();
             }
 
-        }, null, null)) {
+        }, null)) {
             TokenVerificationResult result = provider.verifyJwtToken(newToken, false, false, null);
             assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
         }
@@ -76,7 +76,7 @@ public class OidcProviderTest {
 
         final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey.getPrivateKey());
 
-        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
             assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
         }
@@ -91,7 +91,7 @@ public class OidcProviderTest {
 
         final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey1.getPrivateKey());
 
-        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet)) {
             try {
                 provider.verifyJwtToken(token, false, false, null);
                 fail("InvalidJwtException expected");
@@ -112,7 +112,7 @@ public class OidcProviderTest {
         final OidcTenantConfig config = new OidcTenantConfig();
         config.jwks.tryAll = true;
 
-        try (OidcProvider provider = new OidcProvider(null, config, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, config, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
             assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
         }
@@ -130,7 +130,7 @@ public class OidcProviderTest {
         final OidcTenantConfig config = new OidcTenantConfig();
         config.jwks.tryAll = true;
 
-        try (OidcProvider provider = new OidcProvider(null, config, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, config, jwkSet)) {
             try {
                 provider.verifyJwtToken(token, false, false, null);
                 fail("InvalidJwtException expected");
@@ -161,13 +161,13 @@ public class OidcProviderTest {
 
         final String tokenWithSub = Jwt.subject("subject").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
 
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(tokenWithSub, false, true, null);
             assertEquals("subject", result.localVerificationResult.getString(Claims.sub.name()));
         }
 
         final String tokenWithoutSub = Jwt.claims().jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             try {
                 provider.verifyJwtToken(tokenWithoutSub, false, true, null);
                 fail("InvalidJwtException expected");
@@ -188,13 +188,13 @@ public class OidcProviderTest {
 
         final String tokenWithNonce = Jwt.claim("nonce", "123456").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
 
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(tokenWithNonce, false, false, "123456");
             assertEquals("123456", result.localVerificationResult.getString(Claims.nonce.name()));
         }
 
         final String tokenWithoutNonce = Jwt.claims().jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             try {
                 provider.verifyJwtToken(tokenWithoutNonce, false, false, "123456");
                 fail("InvalidJwtException expected");
@@ -225,7 +225,7 @@ public class OidcProviderTest {
         OidcTenantConfig oidcConfig = new OidcTenantConfig();
         oidcConfig.token.issuedAtRequired = false;
 
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
             assertNull(result.localVerificationResult.getString(Claims.iat.name()));
         }
@@ -233,7 +233,7 @@ public class OidcProviderTest {
         OidcTenantConfig oidcConfigRequireAge = new OidcTenantConfig();
         oidcConfigRequireAge.token.issuedAtRequired = true;
 
-        try (OidcProvider provider = new OidcProvider(null, oidcConfigRequireAge, jwkSet, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfigRequireAge, jwkSet)) {
             try {
                 provider.verifyJwtToken(token, false, false, null);
                 fail("InvalidJwtException expected");
@@ -255,7 +255,7 @@ public class OidcProviderTest {
                 .sign(rsaJsonWebKey.getPrivateKey());
 
         // no validators
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null, null)) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
             assertEquals("claimValue1", result.localVerificationResult.getString("claim1"));
             assertEquals("claimValue2", result.localVerificationResult.getString("claim2"));
@@ -271,7 +271,7 @@ public class OidcProviderTest {
                 return null;
             }
         };
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null, List.of(validator1))) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, List.of(validator1))) {
             try {
                 provider.verifyJwtToken(token, false, false, null);
                 fail("InvalidJwtException expected");
@@ -291,7 +291,7 @@ public class OidcProviderTest {
             }
         };
         // check the first validator is still run
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null, List.of(validator1, validator2))) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, List.of(validator1, validator2))) {
             try {
                 provider.verifyJwtToken(token, false, false, null);
                 fail("InvalidJwtException expected");
@@ -301,7 +301,7 @@ public class OidcProviderTest {
         }
         // check the second validator is applied
         token = Jwt.claim("claim2", "claimValue2").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
-        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null, List.of(validator1, validator2))) {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, List.of(validator1, validator2))) {
             try {
                 provider.verifyJwtToken(token, false, false, null);
                 fail("InvalidJwtException expected");

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -187,6 +187,8 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         TOKEN_AUTHORIZATION_SCHEME,
         TOKEN_SIGNATURE_ALGORITHM,
         TOKEN_DECRYPTION_KEY_LOCATION,
+        TOKEN_DECRYPT_ID_TOKEN,
+        TOKEN_DECRYPT_ACCESS_TOKEN,
         TOKEN_ALLOW_JWT_INTROSPECTION,
         TOKEN_REQUIRE_JWT_INTROSPECTION_ONLY,
         TOKEN_ALLOW_OPAQUE_TOKEN_INTROSPECTION,
@@ -412,6 +414,18 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             public Optional<String> decryptionKeyLocation() {
                 invocationsRecorder.put(ConfigMappingMethods.TOKEN_DECRYPTION_KEY_LOCATION, true);
                 return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> decryptIdToken() {
+                invocationsRecorder.put(ConfigMappingMethods.TOKEN_DECRYPT_ID_TOKEN, true);
+                return Optional.of(false);
+            }
+
+            @Override
+            public boolean decryptAccessToken() {
+                invocationsRecorder.put(ConfigMappingMethods.TOKEN_DECRYPT_ACCESS_TOKEN, true);
+                return false;
             }
 
             @Override

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -75,6 +75,30 @@ public class AdminResource {
         return "static.tenant.id=" + routingContext.get("static.tenant.id");
     }
 
+    @Path("bearer-encrypted-with-decryption-key")
+    @GET
+    @RolesAllowed("admin")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String bearerEncryptedWithDecryptionKey() {
+        return "granted:" + identity.getRoles();
+    }
+
+    @Path("bearer-encrypted-with-client-secret")
+    @GET
+    @RolesAllowed("admin")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String bearerEncryptedWithClientSecret() {
+        return "granted:" + identity.getRoles();
+    }
+
+    @Path("bearer-encrypted-without-decryption-key")
+    @GET
+    @RolesAllowed("admin")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String bearerEncryptedWithoutDecryptionKey() {
+        throw new RuntimeException("Unencrypted token can not be validated");
+    }
+
     @Path("bearer-certificate-full-chain")
     @GET
     @RolesAllowed("admin")

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowEncryptedIdTokenResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowEncryptedIdTokenResource.java
@@ -29,4 +29,11 @@ public class CodeFlowEncryptedIdTokenResource {
     public String accessPem() {
         return "user: " + idToken.getName();
     }
+
+    @GET
+    @Authenticated
+    @Path("/code-flow-encrypted-id-token-disabled")
+    public String idTokenDecryptionDisabled() {
+        throw new RuntimeException("ID token decryption disabled");
+    }
 }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -62,6 +62,15 @@ quarkus.oidc.code-flow-encrypted-id-token-pem.token-path=encrypted-id-token
 quarkus.oidc.code-flow-encrypted-id-token-pem.token.decryption-key-location=privateKey.pem
 quarkus.oidc.code-flow-encrypted-id-token-pem.token.audience=any
 
+quarkus.oidc.code-flow-encrypted-id-token-disabled.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
+quarkus.oidc.code-flow-encrypted-id-token-disabled.client-id=quarkus-web-app
+quarkus.oidc.code-flow-encrypted-id-token-disabled.credentials.secret=secret
+quarkus.oidc.code-flow-encrypted-id-token-disabled.application-type=web-app
+quarkus.oidc.code-flow-encrypted-id-token-disabled.token-path=encrypted-id-token
+quarkus.oidc.code-flow-encrypted-id-token-disabled.token.decryption-key-location=privateKey.pem
+quarkus.oidc.code-flow-encrypted-id-token-disabled.token.decryption-id-token=false
+quarkus.oidc.code-flow-encrypted-id-token-disabled.token.audience=any
+
 quarkus.oidc.code-flow-form-post.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus-form-post/
 quarkus.oidc.code-flow-form-post.authentication.user-info-required=false
 quarkus.oidc.code-flow-form-post.client-id=quarkus-web-app
@@ -196,6 +205,17 @@ quarkus.oidc.bearer-required-algorithm.auth-server-url=${keycloak.url:replaced-b
 quarkus.oidc.bearer-required-algorithm.client-id=quarkus-app
 quarkus.oidc.bearer-required-algorithm.credentials.secret=secret
 quarkus.oidc.bearer-required-algorithm.token.signature-algorithm=PS256
+
+quarkus.oidc.bearer-encrypted-without-decryption-key.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
+
+quarkus.oidc.bearer-encrypted-with-decryption-key.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
+quarkus.oidc.bearer-encrypted-with-decryption-key.token.decrypt-access-token=true
+quarkus.oidc.bearer-encrypted-with-decryption-key.token.decryption-key-location=privateKeyEncryptedIdToken.jwk
+
+quarkus.oidc.bearer-encrypted-with-client-secret.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
+quarkus.oidc.bearer-encrypted-with-client-secret.client-id=quarkus-web-app
+quarkus.oidc.bearer-encrypted-with-client-secret.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.oidc.bearer-encrypted-with-client-secret.token.decrypt-access-token=true
 
 quarkus.oidc.bearer-permission-checker.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
 quarkus.oidc.bearer-permission-checker.client-id=quarkus-app

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -204,6 +204,29 @@ public class CodeFlowAuthorizationTest {
         clearCache();
     }
 
+    @Test
+    public void testCodeFlowEncryptedIdTokenDisabled() throws IOException {
+        try (final WebClient webClient = createWebClient()) {
+            webClient.getOptions().setRedirectEnabled(true);
+            HtmlPage page = webClient
+                    .getPage("http://localhost:8081/code-flow-encrypted-id-token/code-flow-encrypted-id-token-disabled");
+
+            HtmlForm form = page.getFormByName("form");
+            form.getInputByName("username").type("alice");
+            form.getInputByName("password").type("alice");
+
+            try {
+                form.getInputByValue("login").click();
+                fail("ID token decryption is disabled");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(500, ex.getResponse().getStatusCode());
+            }
+
+            webClient.getCookieManager().clearCookies();
+        }
+        clearCache();
+    }
+
     private static boolean isEncryptedToken(String token, KeyEncryptionAlgorithm alg) {
         int expectedNonEmptyParts = alg == KeyEncryptionAlgorithm.DIR ? 4 : 5;
         return new StringTokenizer(token, ".").countTokens() == expectedNonEmptyParts;


### PR DESCRIPTION
Fixes #47319

Currently, on main, only ID token decryption is supported, to support a user case, where the OIDC provider, as allowed by the OIDC spec, sends an inner-signed and encrypted ID token - with Quarkus not being able to consume it unless it can decrypt it. It was done a long time ago, and the way it was done was not ideal: if `quarkus.oidc.token.decryption-key-location` is set, then check if ID token is a JWE sequence and if yes - try to decrypt it.

It in itself is not bad, as the case where Quarkus has to decrypt `bearer access tokens` before it can verify such tokens has never been raised, and no external clients would encrypt access tokens themselves. But, in context of the MCP authorization work, and with the OIDC proxy now being ready to encrypt tokens, Quarkus OIDC should now be able to decrypt access tokens if required.

So this PR introduces 2 properties allowing users to choose which token type must be decrypted, and if the access token must be decrypted then it will also decrypt it. A lot of files have been changed - but nearly all changes are just about the refactoring to make sure both the access token and the ID token decryption logic is the same and that the decryption key is created at the startup such that not only  `quarkus.oidc.token.decryption-key-location` can be used but also the client secret but also renaming various existing key properties in the code to make it clearer which key is used for what.

Key code is  here:

1. [OidcUtils.decryptToken](https://github.com/quarkusio/quarkus/pull/47320/files#diff-8af2ccae2405932ff99db333a8b3932c5df400268993c83c38210a1e18fd762eR898) - this is now used not only for decrypting ID tokens but also bearer and code flow access tokens
2. [decrypt-id-token and decrypt-access-token](https://github.com/quarkusio/quarkus/pull/47320/files#diff-8af2ccae2405932ff99db333a8b3932c5df400268993c83c38210a1e18fd762eR898) properties. ID token is an optional property to work around the fact that as mentioned above it is attempted to be decrypted if the `quarkus.oidc.token.decryption-key-location`  is set - which makes it difficult to choose correctly when to decrypt which token and also using another type of keys such as client secrets. 
3. Token decryption key initialization code was now moved to the same place where other keys are initialized, to [TokenConfigContextImpl](https://github.com/quarkusio/quarkus/pull/47320/files#diff-5b0fefa9428e513ec373909997cff5f0958e34885950589f5408d327af6aaae9R88), and I renamed there those other key properties to make it clearer what they are used for.

This is really it, mainly the refactoring and making the decryption code a bit more reusable. All other changes are just various minor touches.

This `quarkus-oidc-proxy` [PR](https://github.com/quarkiverse/quarkus-oidc-proxy/pull/85) is aligned with this one. Once this PR is merged, that PR will also get merged.

This PR will need some follow up to be able to customize the decryption algorithm, but it can be done later, to avoid further code changes in this PR

CC @BarDweller