### PR TITLE
Don't use logging on failed start

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -132,11 +132,15 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                                 }
                             } catch (Exception e) {
                                 close();
-                                log.error("Failed to start quarkus", t);
-                                log.error("Failed to recover after failed start", e);
+                                // Don't use logs here, as logging might not be setup yet
+                                // Resulting in a silent exit
+                                System.err.println("Failed to start quarkus");
+                                t.printStackTrace();
+                                System.err.println("Failed to recover after failed start");
+                                e.printStackTrace();
                                 //this is the end of the road, we just exit
                                 //generally we only hit this if something is already listening on the HTTP port
-                                //or the system config is so broken we can't start HTTP
+                                //or the system config is so broken we can't start HTTP]
                                 System.exit(1);
                             }
                         }


### PR DESCRIPTION
There is a good change that logging has not been setup yet, and the logging will not be written out.

A better approach would probable be to register a shutdown hook in the delayed log handler to make sure the messages are written out before exit, but this is better than nothing.