### PR TITLE
Introduce OAuth2 Step Up Authentication for Bearer token authentication

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -1604,6 +1604,57 @@ public class OidcStartup {
 For more complex setup involving multiple tenants please see the xref:security-openid-connect-multitenancy.adoc#programmatic-startup[Programmatic OIDC start-up for multitenant application]
 section of the OpenID Connect Multi-Tenancy guide.
 
+== OAuth 2.0 Step Up Authentication
+
+The `io.quarkus.oidc.AuthenticationContext` annotation can be used to enforce required authentication level for the Jakarta REST resource classes and methods.
+The https://datatracker.ietf.org/doc/rfc9470/[OAuth 2.0 Step Up Authentication Challenge Protocol] introduced a mechanism for resource servers like Quarkus to challenge authentication requirements.
+Consider following example:
+
+[source,properties]
+----
+quarkus.http.auth.proactive=false <1>
+----
+<1> Disable proactive authentication so that the `@AuthenticationContext` annotation can be matched with the endpoint before Quarkus authenticates incoming requests.
+
+[source,java]
+----
+package io.quarkus.it.oidc;
+
+import io.quarkus.oidc.AuthenticationContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("hello")
+public class HelloResource {
+
+    @AuthenticationContext("myACR") <1>
+    @GET
+    public String hello() {
+        return "hello";
+    }
+
+}
+----
+<1> Only HTTP requests with valid Bearer access token with `acr` claim value that contains `myACR` can access this endpoint.
+
+If the Bearer token claim `acr` does not contain `myACR`, Quarkus returns the Authentication Requirements Challenge indicating required `acr_values`:
+
+----
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer error="insufficient_user_authentication",
+ error_description="A different authentication level is required",
+ acr_values="myACR"
+----
+
+A client receiving the challenge from the Quarkus server carrying the `insufficient_user_authentication` error code should parse `acr_values` from the `WWW-Authenticate` header and use them when constructing new authorization request.
+
+[NOTE]
+====
+The `io.quarkus.oidc.AuthenticationContext` annotation can be used to enforce required authentication level for a WebSockets Next server endpoint.
+The annotation must be placed on the endpoint class, because the `SecurityIdentity` is created before the HTTP connection is upgraded to a WebSocket connection.
+For more information about the HTTP upgrade security, see the xref:websockets-next-reference.adoc#secure-http-upgrade[Secure HTTP upgrade] section of the Quarkus "WebSockets Next reference" guide.
+====
+
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/EmptyAuthenticationContextValidationFailureTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/EmptyAuthenticationContextValidationFailureTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.oidc.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.AuthenticationContext;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EmptyAuthenticationContextValidationFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    // starting the dev service would be a waste
+                    .addClass(StepUpAuthResource.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.devservices.enabled=false
+                            quarkus.http.auth.proactive=false
+                            """), "application.properties"))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                Assertions.assertNotNull(rootCause);
+                String message = rootCause.getMessage();
+                Assertions.assertNotNull(message);
+                Assertions.assertTrue(message.contains("io.quarkus.oidc.AuthenticationContext"), message);
+                Assertions.assertTrue(message.contains("has no value"), message);
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail("Validation should fail");
+    }
+
+    @AuthenticationContext
+    @Path("step-up-auth")
+    public static class StepUpAuthResource {
+
+        @GET
+        public String stepUpAuth() {
+            return "step-up-auth";
+        }
+
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProactiveAuthenticationContextValidationFailureTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProactiveAuthenticationContextValidationFailureTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.oidc.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.AuthenticationContext;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ProactiveAuthenticationContextValidationFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    // starting the dev service would be a waste
+                    .addClass(StepUpAuthResource.class)
+                    .addAsResource(new StringAsset("quarkus.devservices.enabled=false"), "application.properties"))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                Assertions.assertNotNull(rootCause);
+                String message = rootCause.getMessage();
+                Assertions.assertNotNull(message);
+                Assertions.assertTrue(message.contains("proactive authentication is disabled"), message);
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail("Validation should fail");
+    }
+
+    @AuthenticationContext("ignored")
+    @Path("step-up-auth")
+    public static class StepUpAuthResource {
+
+        @GET
+        public String stepUpAuth() {
+            return "step-up-auth";
+        }
+
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthenticationContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthenticationContext.java
@@ -1,0 +1,25 @@
+package io.quarkus.oidc;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation which can be used to enforce required authentication level for the endpoint classes and methods.
+ * If presented Bearer access token offer insufficient authentication strength, Quarkus will challenge the authentication
+ * requirements according to the <a href="https://datatracker.ietf.org/doc/rfc9470/">OAuth 2.0 Step Up Authentication
+ * Challenge Protocol</a>.
+ */
+@Target({ TYPE, METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationContext {
+
+    /**
+     * Required `acr` (Authentication Context Class Reference) claim values.
+     */
+    String[] value() default {};
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationPolicy.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationPolicy.java
@@ -1,0 +1,121 @@
+package io.quarkus.oidc.runtime;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.jboss.logging.Logger;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
+import io.vertx.ext.web.RoutingContext;
+
+sealed interface OidcAuthenticationPolicy extends Consumer<SecurityIdentity>
+        permits OidcAuthenticationPolicy.OAuth2StepUpAuthenticationPolicy {
+
+    String AUTHENTICATION_POLICY_KEY = "io.quarkus.oidc.runtime.OidcAuthenticationPolicy";
+
+    void validate(SecurityIdentity securityIdentity);
+
+    default void accept(SecurityIdentity securityIdentity) {
+        validate(securityIdentity);
+    }
+
+    final class OAuth2StepUpAuthenticationPolicy implements OidcAuthenticationPolicy {
+
+        private static final Logger LOG = Logger.getLogger(OAuth2StepUpAuthenticationPolicy.class);
+        private static final String ACR_VALUES = "acr_values";
+        private static final String INSUFFICIENT_USER_AUTH_FAILURE_KEY = "io.quarkus.oidc.runtime#insufficientUserAuthFailure";
+        private final String[] expectedAcrValues;
+
+        private OAuth2StepUpAuthenticationPolicy(String[] expectedAcrValues) {
+            this.expectedAcrValues = expectedAcrValues;
+        }
+
+        @Override
+        public void validate(SecurityIdentity identity) {
+            if (identity == null) {
+                // the acr values are required, therefore authentication is required
+                throw new AuthenticationFailedException(
+                        "Valid token with '%s' acr claim values is required".formatted(Arrays.toString(expectedAcrValues)));
+            }
+            final List<String> actualAcrValues = getActualAcrValues(identity);
+            if (expectedAcrValuesAreMissing(actualAcrValues)) {
+                LOG.debug("Token does not contain all of required 'acr' values: " + Arrays.toString(expectedAcrValues));
+                throw insufficientUserAuthException(identity, null);
+            }
+        }
+
+        private boolean expectedAcrValuesAreMissing(List<String> actualAcrValues) {
+            if (actualAcrValues.isEmpty()) {
+                return true;
+            }
+            for (String expectedAcrValue : expectedAcrValues) {
+                if (!actualAcrValues.contains(expectedAcrValue)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private List<String> getActualAcrValues(SecurityIdentity identity) {
+            final List<String> actualAcrValues;
+            if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal principal
+                    && principal.getCredential() instanceof AccessTokenCredential) {
+                try {
+                    actualAcrValues = principal.getClaims().getStringListClaimValue(Claims.acr.name());
+                } catch (MalformedClaimException e) {
+                    throw insufficientUserAuthException(identity, e);
+                }
+            } else {
+                AccessTokenCredential credential = OidcUtils.getTokenCredential(identity, AccessTokenCredential.class);
+                if (credential == null) {
+                    LOG.debug("No access token credential found");
+                    throw insufficientUserAuthException(identity, null);
+                }
+                try {
+                    actualAcrValues = new JwtConsumerBuilder()
+                            .setSkipSignatureVerification()
+                            .setSkipAllValidators()
+                            .build().processToClaims(credential.getToken())
+                            .getStringListClaimValue(Claims.acr.name());
+                } catch (InvalidJwtException | MalformedClaimException e) {
+                    throw insufficientUserAuthException(identity, e);
+                }
+            }
+            return actualAcrValues;
+        }
+
+        private AuthenticationFailedException insufficientUserAuthException(SecurityIdentity identity, Exception e) {
+            var authenticationFailedEx = new AuthenticationFailedException(e,
+                    Map.of(ACR_VALUES, String.join(",", expectedAcrValues)));
+            RoutingContext routingContext = HttpSecurityUtils.getRoutingContextAttribute(identity);
+            routingContext.put(INSUFFICIENT_USER_AUTH_FAILURE_KEY, authenticationFailedEx);
+            return authenticationFailedEx;
+        }
+
+        static boolean isInsufficientUserAuth(RoutingContext routingContext) {
+            return routingContext.get(INSUFFICIENT_USER_AUTH_FAILURE_KEY) != null;
+        }
+
+        static String getAuthRequirementChallenge(RoutingContext context) {
+            String acrValues = ((AuthenticationFailedException) context.get(INSUFFICIENT_USER_AUTH_FAILURE_KEY))
+                    .getAttribute(ACR_VALUES);
+            return " error=\"insufficient_user_authentication\"," +
+                    " error_description=\"A different authentication level is required\"," +
+                    " acr_values=\"" + acrValues + "\"";
+        }
+
+        static OidcAuthenticationPolicy create(String acrValues) {
+            return new OAuth2StepUpAuthenticationPolicy(acrValues.split(","));
+        }
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/EagerSecurityInterceptorBindingBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/EagerSecurityInterceptorBindingBuildItem.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -66,7 +67,20 @@ public final class EagerSecurityInterceptorBindingBuildItem extends MultiBuildIt
         if (bindingToValue.containsKey(annotation.toString())) {
             return bindingToValue.get(annotation.toString());
         }
-        if (annotationInstance.value() == null || annotationInstance.value().asString().isBlank()) {
+        AnnotationValue annotationValue = annotationInstance.value();
+        if (annotationValue == null) {
+            throw new ConfigurationException("Annotation '" + annotation + "' placed on '"
+                    + toTargetName(annotationTarget) + "' has no value");
+        }
+        if (annotationValue.kind() == AnnotationValue.Kind.ARRAY) {
+            String[] annotationValues = annotationValue.asStringArray();
+            if (annotationValues.length == 0) {
+                throw new ConfigurationException("Annotation '" + annotation + "' placed on '"
+                        + toTargetName(annotationTarget) + "' has no value");
+            }
+            return String.join(",", annotationValues);
+        }
+        if (annotationValue.asString().isBlank()) {
             throw new ConfigurationException("Annotation '" + annotation + "' placed on '"
                     + toTargetName(annotationTarget) + "' must not have blank value");
         }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -659,7 +659,7 @@ public class HttpSecurityProcessor {
         return !ClientAuth.NONE.equals(httpBuildTimeConfig.tlsClientAuth());
     }
 
-    private static Set<MethodInfo> collectClassMethodsWithoutRbacAnnotation(Collection<ClassInfo> classes) {
+    public static Set<MethodInfo> collectClassMethodsWithoutRbacAnnotation(Collection<ClassInfo> classes) {
         return classes
                 .stream()
                 .filter(c -> !HttpSecurityUtils.hasSecurityAnnotation(c))
@@ -670,14 +670,14 @@ public class HttpSecurityProcessor {
                 .collect(Collectors.toSet());
     }
 
-    private static Set<MethodInfo> collectMethodsWithoutRbacAnnotation(Collection<MethodInfo> methods) {
+    public static Set<MethodInfo> collectMethodsWithoutRbacAnnotation(Collection<MethodInfo> methods) {
         return methods
                 .stream()
                 .filter(m -> !HttpSecurityUtils.hasSecurityAnnotation(m))
                 .collect(Collectors.toSet());
     }
 
-    private static Set<ClassInfo> collectAnnotatedClasses(Collection<AnnotationInstance> instances,
+    public static Set<ClassInfo> collectAnnotatedClasses(Collection<AnnotationInstance> instances,
             Predicate<ClassInfo> filter) {
         return instances
                 .stream()

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
@@ -494,7 +494,12 @@ public class AnnotationBasedTenantTest {
     }
 
     private void callWebSocketEndpoint(URI uri, String expectedResponsePrefix, String token, boolean expectFailure)
-            throws InterruptedException, ExecutionException, TimeoutException {
+            throws ExecutionException, InterruptedException, TimeoutException {
+        callWebSocketEndpoint(uri, expectedResponsePrefix, token, expectFailure, vertx);
+    }
+
+    static void callWebSocketEndpoint(URI uri, String expectedResponsePrefix, String token, boolean expectFailure,
+            Vertx vertx) throws InterruptedException, ExecutionException, TimeoutException {
         CountDownLatch connectedLatch = new CountDownLatch(1);
         CountDownLatch messagesLatch = new CountDownLatch(2);
         List<String> messages = new CopyOnWriteArrayList<>();

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenStepUpAuthenticationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenStepUpAuthenticationTest.java
@@ -1,0 +1,307 @@
+package io.quarkus.it.keycloak;
+
+import static io.quarkus.it.keycloak.AnnotationBasedTenantTest.callWebSocketEndpoint;
+import static org.hamcrest.Matchers.*;
+
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.AuthenticationContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.Tenant;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.build.Jwt;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.RoutingContext;
+
+@QuarkusTest
+@QuarkusTestResource(CustomOidcWiremockTestResource.class)
+@TestProfile(BearerTokenStepUpAuthenticationTest.LazyAuthenticationTestProfile.class)
+public class BearerTokenStepUpAuthenticationTest {
+
+    @TestHTTPResource("/ws/tenant-annotation/bearer-step-up-auth")
+    URI websocketAuthCtxUri;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testMethodLevelAuthCtxNoRbac() {
+        // anonymous, no RBAC annotations on endpoint but acr required -> fail
+        RestAssured.given()
+                .when().get("/step-up-auth/method-level/no-rbac-annotation")
+                .then().statusCode(401);
+        // no acr -> fail
+        stepUpMethodLevelRequest(Set.of(), Set.of(), "no-rbac-annotation").statusCode(401);
+        // wrong single acr -> fail
+        stepUpMethodLevelRequest(Set.of(), Set.of("3"), "no-rbac-annotation").statusCode(401);
+        // wrong multiple acr -> fail
+        stepUpMethodLevelRequest(Set.of(), Set.of("3", "4"), "no-rbac-annotation").statusCode(401);
+        // correct acr -> pass
+        stepUpMethodLevelRequest(Set.of(), Set.of("1"), "no-rbac-annotation").statusCode(200).body(is("no-rbac-annotation"));
+    }
+
+    @Test
+    public void testClassLevelAuthCtxNoRbac() {
+        // anonymous, no RBAC annotations on endpoint but acr required -> fail
+        RestAssured.given()
+                .when().get("/step-up-auth/class-level/no-rbac-annotation")
+                .then().statusCode(401);
+        // no acr -> fail
+        stepUpClassLevelRequest(Set.of(), Set.of(), "no-rbac-annotation").statusCode(401);
+        // wrong single acr -> fail
+        stepUpClassLevelRequest(Set.of(), Set.of("3"), "no-rbac-annotation").statusCode(401);
+        // wrong multiple acr -> fail
+        stepUpClassLevelRequest(Set.of(), Set.of("3", "4"), "no-rbac-annotation").statusCode(401);
+        // correct acr -> pass
+        stepUpClassLevelRequest(Set.of(), Set.of("2"), "no-rbac-annotation").statusCode(200).body(is("no-rbac-annotation"));
+    }
+
+    @Test
+    public void testMethodLevelAuthCtxRolesAllowed() {
+        // no acr -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of(), "admin-role").statusCode(401);
+        // wrong single acr -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("1"), "admin-role").statusCode(401);
+        // wrong multiple acr -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("1", "4"), "admin-role").statusCode(401)
+                .header("www-authenticate", containsString("insufficient_user_authentication"))
+                .header("www-authenticate", containsString("3"));
+        // correct acr & wrong role -> fail
+        stepUpMethodLevelRequest(Set.of("user"), Set.of("3"), "admin-role").statusCode(403);
+        // correct acr & correct role -> pass
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("3"), "admin-role").statusCode(200).body(is("admin-role"));
+    }
+
+    @Test
+    public void testMethodLevelAuthTenantAnnotationSelection() {
+        // wrong acr & correct tenant -> fail
+        RestAssured.given()
+                .auth().oauth2(getAccessToken(Set.of(), Set.of("3")))
+                .when().get("/tenant-ann-step-up-auth/bearer-step-up-auth-1")
+                .then()
+                .statusCode(401);
+        // correct acr & tenant -> pass
+        RestAssured.given()
+                .auth().oauth2(getAccessToken(Set.of(), Set.of("6")))
+                .when().get("/tenant-ann-step-up-auth/bearer-step-up-auth-1")
+                .then()
+                .statusCode(200)
+                .body(is("bearer-step-up-auth"));
+        // correct acr & second tenant -> pass
+        RestAssured.given()
+                .auth().oauth2(getAccessToken(Set.of(), Set.of("6")))
+                .when().get("/tenant-ann-step-up-auth/bearer-step-up-auth-2")
+                .then()
+                .statusCode(200)
+                .body(is("bearer-step-up-auth-2"));
+    }
+
+    @Test
+    public void testClassLevelAuthCtxRolesAllowed() {
+        // no acr -> fail
+        stepUpClassLevelRequest(Set.of("admin"), Set.of(), "admin-role").statusCode(401);
+        // wrong single acr -> fail
+        stepUpClassLevelRequest(Set.of("admin"), Set.of("1"), "admin-role").statusCode(401);
+        // wrong multiple acr -> fail
+        stepUpClassLevelRequest(Set.of("admin"), Set.of("1", "4"), "admin-role").statusCode(401);
+        // correct acr & wrong role -> fail
+        stepUpClassLevelRequest(Set.of("user"), Set.of("2"), "admin-role").statusCode(403);
+        // correct acr & correct role -> pass
+        stepUpClassLevelRequest(Set.of("admin"), Set.of("2"), "admin-role").statusCode(200).body(is("admin-role"));
+    }
+
+    @Test
+    public void testMethodLevelMultipleAcrsRequired() {
+        // no acr -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of(), "multiple-acr-required").statusCode(401);
+        // wrong single acr -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("4"), "multiple-acr-required").statusCode(401);
+        // wrong multiple acr -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("4", "5"), "multiple-acr-required").statusCode(401)
+                .header("www-authenticate", containsString("insufficient_user_authentication"))
+                .header("www-authenticate", containsString("1"))
+                .header("www-authenticate", containsString("2"))
+                .header("www-authenticate", containsString("3"));
+        // one wrong, one correct acr -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("1", "4"), "multiple-acr-required").statusCode(401);
+        // one wrong, two correct acrs -> fail
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("1", "2", "4"), "multiple-acr-required").statusCode(401);
+        // correct acrs -> pass
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("1", "2", "3"), "multiple-acr-required").statusCode(200)
+                .body(is("multiple-acr-required"));
+        // correct acrs & an irrelevant extra acr -> pass
+        stepUpMethodLevelRequest(Set.of("admin"), Set.of("1", "2", "3", "4"), "multiple-acr-required").statusCode(200)
+                .body(is("multiple-acr-required"));
+    }
+
+    @Test
+    public void testWebSocketsClassLevelAuthContextAnnotation()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        // wrong acr -> fail
+        String wrongToken = getAccessToken(Set.of(), Set.of("3"));
+        Assertions.assertThrows(RuntimeException.class,
+                () -> callWebSocketEndpoint(websocketAuthCtxUri, "bearer-step-up-auth", wrongToken, true, vertx));
+        // correct acr -> pass
+        String correctToken = getAccessToken(Set.of(), Set.of("7"));
+        callWebSocketEndpoint(websocketAuthCtxUri, "bearer-step-up-auth", correctToken, false, vertx);
+    }
+
+    private static ValidatableResponse stepUpMethodLevelRequest(Set<String> roles, Set<String> acrValues, String path) {
+        return stepUpRequest(roles, acrValues, "method", path);
+    }
+
+    private static ValidatableResponse stepUpClassLevelRequest(Set<String> roles, Set<String> acrValues, String path) {
+        return stepUpRequest(roles, acrValues, "class", path);
+    }
+
+    private static ValidatableResponse stepUpRequest(Set<String> roles, Set<String> acrValues, String level, String path) {
+        return RestAssured.given()
+                .auth().oauth2(getAccessToken(roles, acrValues))
+                .when().get("/step-up-auth/" + level + "-level/" + path)
+                .then();
+    }
+
+    private static String getAccessToken(Set<String> roles, Set<String> acrValues) {
+        return Jwt.preferredUserName("Pete")
+                .groups(roles)
+                .claim(Claims.acr, acrValues)
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
+                .jws().algorithm(SignatureAlgorithm.PS256)
+                .sign();
+    }
+
+    public static final class LazyAuthenticationTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            var props = new HashMap<String, String>();
+            props.put("quarkus.http.auth.proactive", "false");
+            props.put("quarkus.oidc.bearer-step-up-auth.auth-server-url",
+                    "${keycloak.url:replaced-by-test-resource}/realms/quarkus/");
+            props.put("quarkus.oidc.bearer-step-up-auth.client-id", "quarkus-app");
+            props.put("quarkus.oidc.bearer-step-up-auth.credentials.secret", "secret");
+            props.put("quarkus.oidc.bearer-step-up-auth.token.signature-algorithm", "PS256");
+            props.put("quarkus.oidc.bearer-step-up-auth.tenant-paths", "/step-up-auth/*");
+            props.put("quarkus.oidc.bearer-step-up-auth-2.auth-server-url",
+                    "${keycloak.url:replaced-by-test-resource}/realms/quarkus/");
+            props.put("quarkus.oidc.bearer-step-up-auth-2.client-id", "quarkus-app");
+            props.put("quarkus.oidc.bearer-step-up-auth-2.credentials.secret", "secret");
+            return Map.copyOf(props);
+        }
+    }
+
+    @Path("/step-up-auth/method-level")
+    public static class StepUpAuthMethodLevelResource {
+
+        @GET
+        @AuthenticationContext("1")
+        @Path("no-rbac-annotation")
+        public String noRbacAnnotationMethodLevel() {
+            return "no-rbac-annotation";
+        }
+
+        @GET
+        @AuthenticationContext("3")
+        @RolesAllowed("admin")
+        @Path("admin-role")
+        public String adminRoleMethodLevel() {
+            return "admin-role";
+        }
+
+        @GET
+        @AuthenticationContext({ "1", "2", "3" })
+        @Path("multiple-acr-required")
+        public String multipleAcrRequiredMethodLevel() {
+            return "multiple-acr-required";
+        }
+
+    }
+
+    @Path("/tenant-ann-step-up-auth")
+    public static class TenantAnnotationStepUpAuthResource {
+
+        @Inject
+        RoutingContext routingContext;
+
+        @Tenant("bearer-step-up-auth")
+        @AuthenticationContext("6")
+        @GET
+        @Path("/bearer-step-up-auth-1")
+        public String firstTenantSelectedMethodLevel() {
+            return getTenantId();
+        }
+
+        @Tenant("bearer-step-up-auth-2")
+        @AuthenticationContext("6")
+        @GET
+        @Path("/bearer-step-up-auth-2")
+        public String secondTenantSelectedMethodLevel() {
+            return getTenantId();
+        }
+
+        private String getTenantId() {
+            OidcTenantConfig tenantConfig = routingContext.get(OidcTenantConfig.class.getName());
+            return tenantConfig.tenantId().get();
+        }
+
+    }
+
+    @AuthenticationContext("2")
+    @Path("/step-up-auth/class-level")
+    public static class StepUpAuthClassLevelResource {
+
+        @GET
+        @Path("no-rbac-annotation")
+        public String noRbacAnnotationMethodLevel() {
+            return "no-rbac-annotation";
+        }
+
+        @GET
+        @RolesAllowed("admin")
+        @Path("admin-role")
+        public String adminRoleMethodLevel() {
+            return "admin-role";
+        }
+
+    }
+
+    @AuthenticationContext("7")
+    @Tenant("bearer-step-up-auth")
+    @WebSocket(path = "/ws/tenant-annotation/bearer-step-up-auth")
+    public static class WebSocketEndpointWithTenantAnnotationAndAuthCtx {
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @OnTextMessage
+        String echo(String message) {
+            return "bearer-step-up-auth echo: " + message;
+        }
+
+    }
+}


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/46213
- scope is: allow to enforce `acr` values for WS Next and Jakarta REST endpoints
- `max_age` is not covered per Sergey request as OIDC already has own way to require token max age
- actual client re-authentication is out of scope
