### PR TITLE
Increase Keycloak container memory limit by 500MB

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -206,9 +206,9 @@ public interface KeycloakDevServicesConfig {
     /**
      * Memory limit for Keycloak container, up to {@code Long.MAX_VALUE} bytes.
      * </p>
-     * If not specified, 750MiB is the default memory limit.
+     * If not specified, 1250MiB is the default memory limit.
      */
-    @WithDefault("750M")
+    @WithDefault("1250M")
     MemorySize containerMemoryLimit();
 
     /**


### PR DESCRIPTION
Fixes #47102.

The current Keycloak container memory limit was designed to support running it in constrained environments, but unfortunately it causes side-effects, with no obvious logic.

For example, on my laptop I've never heard any issues with the `750 MB` limit.
On my new laptop, which has twice as much memory and disk storage compared to the old laptop, it fails.

Users who have reported the side-effect before, confirmed 1.2 GB is sufficient for a case with the custom realm, and it works on my laptop.

I propose to increase it now and for Keycloak experts, @mabartos, and others, to investigate further. 
I'm not sure about setting `JAVA_OPTS_KC_HEAP="-XX:MaxRAMPercentage=50 -XX:MinRAMPercentage=50"` by default without further analysis
