### PR TITLE
Bump all SmallRye projects that have a new Jandex index

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <microprofile-jwt.version>2.1</microprofile-jwt.version>
         <microprofile-lra.version>2.0.1</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
-        <smallrye-common.version>2.11.0</smallrye-common.version>
+        <smallrye-common.version>2.12.0</smallrye-common.version>
         <smallrye-config.version>3.12.4</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
@@ -54,9 +54,9 @@
         <smallrye-graphql.version>2.12.2</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.9.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>
-        <smallrye-context-propagation.version>2.2.0</smallrye-context-propagation.version>
+        <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
-        <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
+        <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.18.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.27.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/boot/StaticInitFailureTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/boot/StaticInitFailureTest.java
@@ -27,9 +27,7 @@ public class StaticInitFailureTest {
                     .addClass(EntityWithIncorrectMapping.class))
             .withConfigurationResource("application.properties")
             // Expect only one error: the one we triggered
-            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
-                    // Ignore these particular warnings: they are not relevant to this test.
-                    && !record.getMessage().contains("must be used to index an application dependency")) // too old Jandex
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             // In particular we don't want a log telling us JPAConfig could not be created
             // because HibernateOrmRuntimeConfig is not initialized yet.
             // JPAConfig should not be created in the first place!

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionExtraSpaceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionExtraSpaceTest.java
@@ -37,8 +37,7 @@ public class DbVersionExtraSpaceTest {
                     // Ignore these particular warnings: they are not relevant to this test.
                     && !record.getMessage().contains("has been blocked for") //sometimes CI has a super slow moment and this triggers the blocked thread detector
                     && !record.getMessage().contains("Agroal")
-                    && !record.getMessage().contains("Netty DefaultChannelId initialization")
-                    && !record.getMessage().contains("must be used to index an application dependency")) // too old Jandex
+                    && !record.getMessage().contains("Netty DefaultChannelId initialization"))
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage) // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
                     .isEmpty());

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
@@ -49,8 +49,7 @@ public abstract class AbstractTransactionLifecycleTest {
                     && !record.getMessage().contains("has been blocked for") //sometimes CI has a super slow moment and this triggers the blocked thread detector
                     && !record.getMessage().contains("Using Java versions older than 11 to build Quarkus applications")
                     && !record.getMessage().contains("Agroal does not support detecting if a connection is still usable")
-                    && !record.getMessage().contains("Netty DefaultChannelId initialization")
-                    && !record.getMessage().contains("must be used to index an application dependency")) // too old Jandex
+                    && !record.getMessage().contains("Netty DefaultChannelId initialization"))
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage) // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
                     .isEmpty());

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -49,7 +49,7 @@
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.mutiny>2.8.0</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
-        <version.smallrye-common>2.11.0</version.smallrye-common>
+        <version.smallrye-common>2.12.0</version.smallrye-common>
         <!-- test versions -->
         <version.assertj>3.27.3</version.assertj>
         <version.junit5>5.12.1</version.junit5>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -70,7 +70,7 @@
         <plexus-interpolation.version>1.26</plexus-interpolation.version>
         <plexus-sec-dispatcher.version>2.0</plexus-sec-dispatcher.version>
         <plexus-utils.version>3.5.1</plexus-utils.version>
-        <smallrye-common.version>2.11.0</smallrye-common.version>
+        <smallrye-common.version>2.12.0</smallrye-common.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
         <gradle-tooling.version>8.13</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.10</quarkus-fs-util.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -43,7 +43,7 @@
         <version.jandex>3.3.0</version.jandex>
         <version.gizmo>1.9.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
-        <version.smallrye-common>2.11.0</version.smallrye-common>
+        <version.smallrye-common>2.12.0</version.smallrye-common>
         <version.smallrye-mutiny>2.8.0</version.smallrye-mutiny>
     </properties>
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,7 +57,7 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>2.8.0</mutiny.version>
-        <smallrye-common.version>2.11.0</smallrye-common.version>
+        <smallrye-common.version>2.12.0</smallrye-common.version>
         <vertx.version>4.5.14</vertx.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>


### PR DESCRIPTION
This is:

- SmallRye Common: from 2.11.0 to 2.12.0
- SmallRye Context Propagation: from 2.2.0 to 2.2.1
- SmallRye Reactive Converters: from 3.0.1 to 3.0.3

Also, this commit removes configuration from a few Hibernate ORM tests to ignore the "too old Jandex" warning. That warning should no longer occur now, so that configuration is no longer needed.

Follows up to #47283