### PR TITLE
Catch Docker check exceptions in lightweight OIDC devservice

### DIFF
--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
@@ -161,12 +161,27 @@ public class OidcDevServicesProcessor {
             LOG.debug("Not starting Dev Services for OIDC as 'quarkus.oidc.provider' has been provided");
             return true;
         }
-        if (devServicesConfig.enabled().isEmpty() && dockerStatusBuildItem.isContainerRuntimeAvailable()) {
-            LOG.debug(
-                    "Not starting Dev Services for OIDC as a container runtime is available and a Keycloak Dev Services will be started");
-            return true;
+        if (devServicesConfig.enabled().isEmpty()) {
+            if (isDockerAvailable(dockerStatusBuildItem)) {
+                LOG.debug(
+                        "Not starting Dev Services for OIDC as a container runtime is available and a Keycloak Dev Services will be started."
+                                + " Set 'quarkus.oidc.devservices.enabled=true' if you prefer to start Dev Services for OIDC.");
+                return true;
+            } else {
+                LOG.debug(
+                        "Starting Dev Services for OIDC as a container runtime is not available."
+                                + "Set 'quarkus.oidc.devservices.enabled=false' if you prefer not to start Dev Services for OIDC.");
+            }
         }
         return false;
+    }
+
+    private static boolean isDockerAvailable(DockerStatusBuildItem dockerStatusBuildItem) {
+        try {
+            return dockerStatusBuildItem.isContainerRuntimeAvailable();
+        } catch (Throwable t) {
+            return false;
+        }
     }
 
     private static void updateDevSvcConfigProperties() {


### PR DESCRIPTION
I've noticed `integration-tests/oidc-wiremock-logout` is failing periodically on Windows, I looked at the stacktrace,

```
2025-04-13T22:15:17.6845464Z [INFO] --- surefire:3.5.2:test (default-test) @ quarkus-integration-test-oidc-wiremock-logout ...
2025-04-13T22:15:25.1747536Z 2025-04-13 22:15:24,935 INFO  [org.tes.DockerClientFactory] (build-49) Testcontainers version: 1.20.6
2025-04-13T22:15:26.2371962Z 2025-04-13 22:15:26,233 INFO  [org.tes.doc.DockerClientProviderStrategy] (build-49) Found Docker environment with local Npipe socket (npipe:////./pipe/docker_engine)
2025-04-13T22:15:26.2411325Z 2025-04-13 22:15:26,233 WARN  [org.tes.doc.DockerClientProviderStrategy] (build-49) windows is currently not supported

2025-04-13T22:15:26.3392629Z 2025-04-13 22:15:26,240 INFO  [org.tes.doc.DockerMachineClientProviderStrategy] (build-49) docker-machine executable was not found on PATH ...

2025-04-13T22:15:26.3401567Z 2025-04-13 22:15:26,242 ERROR [org.tes.doc.DockerClientProviderStrategy] (build-49) Could not find a valid Docker environment. Please check configuration. Attempted configurations were:
2025-04-13T22:15:26.3402733Z 	NpipeSocketClientProviderStrategy: failed with exception InvalidConfigurationException (windows containers are currently not supported)As no valid configuration was found, execution cannot continue.
2025-04-13T22:15:26.3403611Z See https://java.testcontainers.org/on_failure.html for more details.
2025-04-13T22:15:36.5670701Z java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
2025-04-13T22:15:36.5672877Z 	[error]: Build step io.quarkus.devservices.oidc.OidcDevServicesProcessor#startServer threw an exception: java.lang.IllegalThreadStateException: process has not exited
2025-04-13T22:15:36.5675023Z 	at java.base/java.lang.ProcessImpl.exitValue(ProcessImpl.java:566)
2025-04-13T22:15:36.5677248Z 	at io.quarkus.deployment.util.ContainerRuntimeUtil.getVersionOutputFor(ContainerRuntimeUtil.java:239)
2025-04-13T22:15:36.5679890Z 	at io.quarkus.deployment.util.ContainerRuntimeUtil.getContainerRuntimeEnvironment(ContainerRuntimeUtil.java:116)
2025-04-13T22:15:36.5685047Z 	at io.quarkus.deployment.util.ContainerRuntimeUtil.detectContainerRuntime(ContainerRuntimeUtil.java:66)
2025-04-13T22:15:36.5690161Z 	at io.quarkus.deployment.util.ContainerRuntimeUtil.detectContainerRuntime(ContainerRuntimeUtil.java:55)
2025-04-13T22:15:36.5692352Z 	at io.quarkus.deployment.IsDockerWorking$DockerBinaryStrategy.get(IsDockerWorking.java:23)
2025-04-13T22:15:36.5693435Z 	at io.quarkus.deployment.IsDockerWorking$DockerBinaryStrategy.get(IsDockerWorking.java:20)
2025-04-13T22:15:36.5694790Z 	at io.quarkus.deployment.IsContainerRuntimeWorking.getAsBoolean(IsContainerRuntimeWorking.java:37)
2025-04-13T22:15:36.5696365Z 	at io.quarkus.deployment.builditem.ContainerRuntimeStatusBuildItem.isContainerRuntimeAvailable(ContainerRuntimeStatusBuildItem.java:18)
2025-04-13T22:15:36.5698449Z 	at io.quarkus.devservices.oidc.OidcDevServicesProcessor.shouldNotStartServer(OidcDevServicesProcessor.java:164)
```

so I hope just wrapping the check in a catch block will help, the lightweight OIDC devservice only checks if the Docker is available to figure out if Keycloak dev service may have to start instead, it does not start any container itself

- Fixes: #47396