### PR TITLE
Avoid NPE in ResetMockitoMocksAfterAllCallback

### DIFF
--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksAfterAllCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksAfterAllCallback.java
@@ -7,7 +7,9 @@ public class ResetMockitoMocksAfterAllCallback implements QuarkusTestAfterAllCal
 
     @Override
     public void afterAll(QuarkusTestContext context) {
-        MockitoMocksTracker.clear(context.getTestInstance());
+        if (context.getTestInstance() != null) {
+            MockitoMocksTracker.clear(context.getTestInstance());
+        }
 
         if (context.getOuterInstances() != null) {
             for (Object outerInstance : context.getOuterInstances()) {


### PR DESCRIPTION
In integration tests, when
quarkus.test.enable-callbacks-for-integration-tests is enabled, the test instance can be null so we need to guard against it.

Reported by Cristiano Nicolai.