### PR TITLE
Code tidying in azure functions extension

### DIFF
--- a/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsDeployCommand.java
+++ b/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsDeployCommand.java
@@ -2,6 +2,7 @@ package io.quarkus.azure.functions.deployment;
 
 import static com.microsoft.azure.toolkit.lib.appservice.utils.AppServiceConfigUtils.fromAppService;
 import static com.microsoft.azure.toolkit.lib.appservice.utils.AppServiceConfigUtils.mergeAppServiceConfig;
+import static java.lang.String.format;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -69,7 +70,7 @@ public class AzureFunctionsDeployCommand {
     private static final String RESOURCE_GROUP_PATTERN = "[a-zA-Z0-9._\\-()]{1,90}";
     private static final String APP_SERVICE_PLAN_NAME_PATTERN = "[a-zA-Z0-9\\-]{1,40}";
     private static final String EMPTY_APP_NAME = "Please config the <appName> in pom.xml.";
-    private static final String INVALID_APP_NAME = "The <appName> only allow alphanumeric characters, hyphens and cannot start or end in a hyphen.";
+    private static final String INVALID_APP_NAME = "The app name '%s' is not valid. The <appName> only allow alphanumeric characters, hyphens and cannot start or end in a hyphen.";
     private static final String EMPTY_RESOURCE_GROUP = "Please config the <resourceGroup> in pom.xml.";
     private static final String INVALID_RESOURCE_GROUP_NAME = "The <resourceGroup> only allow alphanumeric characters, periods, underscores, "
             +
@@ -102,8 +103,9 @@ public class AzureFunctionsDeployCommand {
             OutputTargetBuildItem output,
 
             BuildProducer<DeployCommandActionBuildItem> producer) throws Exception {
-        if (!deployConfig.isEnabled(AZURE_FUNCTIONS))
+        if (!deployConfig.isEnabled(AZURE_FUNCTIONS)) {
             return;
+        }
         validateParameters(config, appName.getAppName());
         setCurrentOperation();
         AzureMessager.setDefaultMessager(new QuarkusAzureMessager());
@@ -115,7 +117,7 @@ public class AzureFunctionsDeployCommand {
         final FunctionAppBase<?, ?, ?> target = createOrUpdateResource(
                 config.toFunctionAppConfig(subscriptionId, appName.getAppName()));
         Path outputDirectory = output.getOutputDirectory();
-        Path functionStagingDir = outputDirectory.resolve("azure-functions").resolve(appName.getAppName());
+        Path functionStagingDir = outputDirectory.resolve(AZURE_FUNCTIONS).resolve(appName.getAppName());
 
         deployArtifact(functionStagingDir, target);
         producer.produce(new DeployCommandActionBuildItem(AZURE_FUNCTIONS, true));
@@ -164,7 +166,7 @@ public class AzureFunctionsDeployCommand {
             throw new BuildException(EMPTY_APP_NAME);
         }
         if (appName.startsWith("-") || !appName.matches(APP_NAME_PATTERN)) {
-            throw new BuildException(INVALID_APP_NAME);
+            throw new BuildException(format(INVALID_APP_NAME, appName));
         }
         // resource group
         if (StringUtils.isBlank(config.resourceGroup())) {
@@ -176,7 +178,7 @@ public class AzureFunctionsDeployCommand {
         // asp name & resource group
         if (StringUtils.isNotEmpty(config.appServicePlanName())
                 && !config.appServicePlanName().matches(APP_SERVICE_PLAN_NAME_PATTERN)) {
-            throw new BuildException(String.format(INVALID_SERVICE_PLAN_NAME, APP_SERVICE_PLAN_NAME_PATTERN));
+            throw new BuildException(format(INVALID_SERVICE_PLAN_NAME, APP_SERVICE_PLAN_NAME_PATTERN));
         }
         if (config.appServicePlanResourceGroup().isPresent()
                 && StringUtils.isNotEmpty(config.appServicePlanResourceGroup().orElse(null))
@@ -197,7 +199,7 @@ public class AzureFunctionsDeployCommand {
          */
         // region
         if (StringUtils.isNotEmpty(config.region()) && Region.fromName(config.region()).isExpandedValue()) {
-            log.warn(String.format(EXPANDABLE_REGION_WARNING, config.region()));
+            log.warn(format(EXPANDABLE_REGION_WARNING, config.region()));
         }
         // os
         if (StringUtils.isNotEmpty(config.runtime().os()) && OperatingSystem.fromString(config.runtime().os()) == null) {
@@ -206,12 +208,12 @@ public class AzureFunctionsDeployCommand {
         // java version
         if (StringUtils.isNotEmpty(config.runtime().javaVersion())
                 && JavaVersion.fromString(config.runtime().javaVersion()).isExpandedValue()) {
-            log.warn(String.format(EXPANDABLE_JAVA_VERSION_WARNING, config.runtime().javaVersion()));
+            log.warn(format(EXPANDABLE_JAVA_VERSION_WARNING, config.runtime().javaVersion()));
         }
         // pricing tier
         if (config.pricingTier().isPresent() && StringUtils.isNotEmpty(config.pricingTier().orElse(null))
                 && PricingTier.fromString(config.pricingTier().orElse(null)).isExpandedValue()) {
-            log.warn(String.format(EXPANDABLE_PRICING_TIER_WARNING, config.pricingTier().orElse(null)));
+            log.warn(format(EXPANDABLE_PRICING_TIER_WARNING, config.pricingTier().orElse(null)));
         }
         // docker image
         if (OperatingSystem.fromString(config.runtime().os()) == OperatingSystem.DOCKER
@@ -249,7 +251,7 @@ public class AzureFunctionsDeployCommand {
                 .filter(subscription -> StringUtils.equals(subscription.getId(), targetSubscriptionId))
                 .findAny();
         if (!optionalSubscription.isPresent()) {
-            throw new BuildException(String.format(SUBSCRIPTION_NOT_FOUND, targetSubscriptionId));
+            throw new BuildException(format(SUBSCRIPTION_NOT_FOUND, targetSubscriptionId));
         }
     }
 
@@ -326,7 +328,7 @@ public class AzureFunctionsDeployCommand {
         final List<Subscription> subscriptions = Azure.az(IAzureAccount.class).account().getSelectedSubscriptions();
         final Subscription subscription = subscriptions.get(0);
         if (subscription != null) {
-            Log.info(String.format(SUBSCRIPTION_TEMPLATE, TextUtils.cyan(subscription.getName()),
+            Log.info(format(SUBSCRIPTION_TEMPLATE, TextUtils.cyan(subscription.getName()),
                     TextUtils.cyan(subscription.getId())));
         }
     }

--- a/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsProcessor.java
+++ b/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.azure.functions.deployment;
 
+import static io.quarkus.azure.functions.deployment.AzureFunctionsDeployCommand.AZURE_FUNCTIONS;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -104,7 +106,7 @@ public class AzureFunctionsProcessor {
 
         Path rootPath = target.getOutputDirectory().resolve("..");
         Path outputDirectory = target.getOutputDirectory();
-        Path functionStagingDir = outputDirectory.resolve("azure-functions").resolve(appName.getAppName());
+        Path functionStagingDir = outputDirectory.resolve(AZURE_FUNCTIONS).resolve(appName.getAppName());
 
         copyHostJson(rootPath, functionStagingDir);
 
@@ -113,7 +115,7 @@ public class AzureFunctionsProcessor {
         writeFunctionJsonFiles(objectWriter, configMap, functionStagingDir);
 
         copyJarsToStageDirectory(jar, functionStagingDir);
-        return new ArtifactResultBuildItem(functionStagingDir, "azure-functions", Collections.EMPTY_MAP);
+        return new ArtifactResultBuildItem(functionStagingDir, AZURE_FUNCTIONS, Collections.EMPTY_MAP);
     }
 
     protected void writeFunctionJsonFiles(final ObjectWriter objectWriter,

--- a/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsRunCommand.java
+++ b/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsRunCommand.java
@@ -1,5 +1,7 @@
 package io.quarkus.azure.functions.deployment;
 
+import static io.quarkus.azure.functions.deployment.AzureFunctionsDeployCommand.AZURE_FUNCTIONS;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -27,10 +29,8 @@ public class AzureFunctionsRunCommand {
     private static final Logger log = Logger.getLogger(AzureFunctionsRunCommand.class);
     protected static final String FUNC_CMD = "func -v";
     protected static final String FUNC_HOST_START_CMD = "func host start -p %s";
-    protected static final String RUN_FUNCTIONS_FAILURE = "Failed to run Azure Functions. Please checkout console output.";
     protected static final String RUNTIME_NOT_FOUND = "Azure Functions Core Tools not found. " +
             "Please go to https://aka.ms/azfunc-install to install Azure Functions Core Tools first.";
-    private static final String STAGE_DIR_NOT_FOUND = "Stage directory not found. Please run mvn package first.";
     private static final String FUNC_HOST_START_WITH_DEBUG_CMD = "func host start -p %s --language-worker -- " +
             "\"-agentlib:jdwp=%s\"";
     private static final String STARTED_EXPRESSION = "Host lock lease acquired";
@@ -52,14 +52,14 @@ public class AzureFunctionsRunCommand {
         String cmd = getStartFunctionHostCommand(config);
         List<String> args = new LinkedList<>();
         Arrays.stream(cmd.split(" ")).forEach(s -> args.add(s));
-        RunCommandActionBuildItem launcher = new RunCommandActionBuildItem("azure-functions", args, stagingDir,
+        RunCommandActionBuildItem launcher = new RunCommandActionBuildItem(AZURE_FUNCTIONS, args, stagingDir,
                 STARTED_EXPRESSION, null,
                 true);
         return launcher;
     }
 
     protected Path getDeploymentStagingDirectoryPath(OutputTargetBuildItem target, String appName) {
-        return target.getOutputDirectory().resolve("azure-functions").resolve(appName);
+        return target.getOutputDirectory().resolve(AZURE_FUNCTIONS).resolve(appName);
     }
 
     protected void checkRuntimeExistence(final CommandHandler handler) throws AzureExecutionException {


### PR DESCRIPTION
While debugging something, I did a bit of code tidying. 

- Consolidate hardcoded strings into constant. The string is used both for the staging directory path and the extension type, but I kept everything as a single constant
- Add more detail to exception, which had been "your app name is invalid but I won't tell you what the app name is"
- Removed unused constants
- Replaced `String.format` with a static import of `format` (the IDE did that and I left it :) )