### PR TITLE
Leave the TCCL how we found it after test discovery

### DIFF
--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>quarkus-test-test-profile</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>\${quarkus.platform.group-id}</groupId>
+                <artifactId>\${quarkus.platform.artifact-id}</artifactId>
+                <version>\${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>\${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>\${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>\${quarkus-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>\${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>\${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,18 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/java/org/acme/MyApplication.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/java/org/acme/MyApplication.java
@@ -1,0 +1,9 @@
+package org.acme;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/app")
+public class MyApplication extends Application {
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>acme - 1.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>Do you like Quarkus?</h2>
+        <p>Go give it a star on <a href="https://github.com/quarkusio/quarkus">GitHub</a>.</p>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: org.acme</li>
+                <li>ArtifactId: acme</li>
+                <li>Version: 1.0-SNAPSHOT</li>
+                <li>Quarkus Version: 999-SNAPSHOT</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <!-- the url have been erased on purpose -->
+                <li><a href="#">Setup your IDE</a></li>
+                <li><a href="#">Getting started</a></li>
+                <li><a href="#">Documentation</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.test.continuous-testing=enabled

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/test/java/org/acme/AlwaysEnabled.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/test/java/org/acme/AlwaysEnabled.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(AlwaysEnabledCondition.class)
+public @interface AlwaysEnabled {
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/test/java/org/acme/AlwaysEnabledCondition.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/test/java/org/acme/AlwaysEnabledCondition.java
@@ -1,0 +1,15 @@
+package org.acme;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class AlwaysEnabledCondition implements ExecutionCondition {
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        String os = ConfigProvider.getConfig().getValue("os.name", String.class);
+        return ConditionEvaluationResult.enabled("enabled");
+
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/test/java/org/acme/GreetingResourceTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-conditions/src/test/java/org/acme/GreetingResourceTest.java
@@ -1,0 +1,13 @@
+package org.acme;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@AlwaysEnabled
+@QuarkusTest
+class GreetingResourceTest {
+    @Test
+    void testThatAlwaysRuns() {
+    }
+}

--- a/test-framework/junit5-config/src/main/java/io/quarkus/test/config/TestConfigProviderResolver.java
+++ b/test-framework/junit5-config/src/main/java/io/quarkus/test/config/TestConfigProviderResolver.java
@@ -62,7 +62,8 @@ public class TestConfigProviderResolver extends SmallRyeConfigProviderResolver {
             resolver.registerConfig(config, classLoader);
             return config;
         }
-        throw new IllegalStateException();
+        throw new IllegalStateException("Context ClassLoader mismatch. Should be " + classLoader + " but was "
+                + Thread.currentThread().getContextClassLoader());
     }
 
     public void restoreConfig() {
@@ -70,7 +71,8 @@ public class TestConfigProviderResolver extends SmallRyeConfigProviderResolver {
             resolver.releaseConfig(classLoader);
             resolver.registerConfig(configs.get(LaunchMode.TEST), classLoader);
         } else {
-            throw new IllegalStateException();
+            throw new IllegalStateException("Context ClassLoader mismatch. Should be " + classLoader + " but was "
+                    + Thread.currentThread().getContextClassLoader());
         }
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
@@ -566,6 +566,10 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
 
     }
 
+    public boolean isServiceLoaderMechanism() {
+        return isServiceLoaderMechanism;
+    }
+
     @Override
     public String getName() {
         return NAME;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
@@ -1,21 +1,29 @@
 package io.quarkus.test.junit.launcher;
 
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherInterceptor;
 
 import io.quarkus.test.junit.classloading.FacadeClassLoader;
 
-public class CustomLauncherInterceptor implements LauncherInterceptor {
+public class CustomLauncherInterceptor implements LauncherDiscoveryListener, LauncherInterceptor {
 
-    private FacadeClassLoader facadeLoader = null;
-    private ClassLoader origCl = null;
+    private static FacadeClassLoader facadeLoader = null;
+    // Also use a static variable to store a 'first' starting state that we can reset to
+    private static ClassLoader origCl = null;
 
     public CustomLauncherInterceptor() {
+    }
+
+    private static boolean isProductionModeTests() {
+        // We're too early for config to be available, so just check the system props
+        return System.getProperty("prod.mode.tests") != null;
     }
 
     @Override
     public <T> T intercept(Invocation<T> invocation) {
         // Do not do any classloading dance for prod mode tests;
-        if (System.getProperty("prod.mode.tests") != null) {
+        if (isProductionModeTests()) {
             return invocation.proceed();
 
         } else {
@@ -25,29 +33,78 @@ public class CustomLauncherInterceptor implements LauncherInterceptor {
     }
 
     private <T> T actuallyIntercept(Invocation<T> invocation) {
+        if (origCl == null) {
+            origCl = Thread.currentThread()
+                    .getContextClassLoader();
+        }
+        ClassLoader currentCl = Thread.currentThread().getContextClassLoader();
+        // Be aware, this method might be called more than once, for different kinds of invocations; especially for Gradle executions, the executions could happen before the TCCL gets constructed and set by JUnitTestRunner
+        // We might not be in the same classloader as the Facade ClassLoader, so use a name comparison instead of an instanceof
+        if (true || currentCl == null
+                || (currentCl != facadeLoader && !currentCl.getClass().getName().equals(FacadeClassLoader.class.getName()))) {
+            initializeFacadeClassLoader();
+            adjustContextClassLoader();
+            return invocation.proceed();
+
+            // It's tempting to tidy up in a finally block by resetting the TCCL, but the gradle tests
+            // do discovery 'between' invocation blocks, and outside the main
+
+        } else {
+            return invocation.proceed();
+        }
+    }
+
+    // Make a facade classloader if needed, so that we can close it at the end of the launcher session
+    private void initializeFacadeClassLoader() {
         ClassLoader currentCl = Thread.currentThread().getContextClassLoader();
         // Be aware, this method might be called more than once, for different kinds of invocations; especially for Gradle executions, the executions could happen before the TCCL gets constructed and set by JUnitTestRunner
         // We might not be in the same classloader as the Facade ClassLoader, so use a name comparison instead of an instanceof
         if (currentCl == null
                 || (currentCl != facadeLoader && !currentCl.getClass().getName().equals(FacadeClassLoader.class.getName()))) {
-            this.origCl = currentCl;
 
             // We don't ever want more than one FacadeClassLoader active, especially since config gets initialised on it.
             // The gradle test execution can make more than one, perhaps because of its threading model.
             if (facadeLoader == null) {
-                // We want to tidy up classloaders we created, but not ones created upstream, so keep a record of what we created
                 facadeLoader = new FacadeClassLoader(currentCl);
             }
+        }
+    }
+
+    @Override
+    public void launcherDiscoveryStarted(LauncherDiscoveryRequest request) {
+        // Do not do any classloading dance for prod mode tests;
+        if (!isProductionModeTests()) {
+            adjustContextClassLoader();
+        }
+
+    }
+
+    private void adjustContextClassLoader() {
+        ClassLoader currentCl = Thread.currentThread().getContextClassLoader();
+        // Be aware, this method might be called more than once, for different kinds of invocations; especially for Gradle executions, the executions could happen before the TCCL gets constructed and set by JUnitTestRunner
+        // We might not be in the same classloader as the Facade ClassLoader, so use a name comparison instead of an instanceof
+        if (currentCl == null
+                || (currentCl != facadeLoader && !currentCl.getClass().getName().equals(FacadeClassLoader.class.getName()))) {
             Thread.currentThread().setContextClassLoader(facadeLoader);
-            return invocation.proceed();
+        }
+    }
 
-            // It's tempting to tidy up in a finally block by resetting the TCCL, but it looks like the gradle
-            // devtools tests may be asynchronous, because if we reset the TCCL
-            // at this point, the test loads with the wrong classloader.
-            // Instead, reset the TCCL when close() is called
+    @Override
+    public void launcherDiscoveryFinished(LauncherDiscoveryRequest request) {
 
-        } else {
-            return invocation.proceed();
+        // We need to support two somewhat incompatible scenarios.
+        // If there are user extensions present which implement `ExecutionCondition`, and they call config in `evaluateExecutionCondition`,
+        // they need the TCCL to be right for reading config (that is, the app classloader)
+        // On the other hand, if the QuarkusTestExtension is registered by a service loader mechanism, it gets loaded after the discovery phase finishes,
+        // so needs the TCCL to still be the facade classloader.
+        // This compromise does mean you can't use the service loader mechanism to avoid having to use `@QuarkusTest` and also use Quarkus config in your own test extensions, but that combination is very unlikely.
+        if (!facadeLoader.isServiceLoaderMechanism()) {
+            // Do not close the facade loader at this stage, because discovery finished may be called several times within a single run
+            // Ideally we would reset to what the TCCL was when we started discovery, but we can't,
+            // because the intercept method will have set something before the discovery start is triggered.
+            // So, rather annoyingly and clumsily, reset the TCCL to what it was when the first interception happened
+            Thread.currentThread().setContextClassLoader(origCl);
+
         }
     }
 
@@ -68,6 +125,8 @@ public class CustomLauncherInterceptor implements LauncherInterceptor {
                 facadeLoader = null;
 
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException("Failed to close custom classloader", e);
         }

--- a/test-framework/junit5/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherDiscoveryListener
+++ b/test-framework/junit5/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherDiscoveryListener
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.launcher.CustomLauncherInterceptor


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/47081

The problem happened because at the end of test discovery, we leave the TCCL as the FacadeClassLoader. That classloader isn't really much use, outside the context of discovery, and it's actively unhelpful when other code is trying to evaluate JUnit conditions. The ideal TCCL for doing that is the system classloader. 

We do have the option to listen to an event when discovery finishes, so I've hooked that event to reset the TCCL. For symmetry, I've also switched from intercepting the whole invocation to just hooking the discovery start. 

My fix does not fix the continuous testing case; in that case, something in the runner is setting the TCCL to be the deployment classloader, which is still wrong for the condition execution code. I've committed a reproducer and raised https://github.com/quarkusio/quarkus/issues/47364. 