### PR TITLE
Fix @TestHTTPResource when quarkus.http.root-path doesn't start with "/"

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/path/RootPathTestHTTPResourceTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/path/RootPathTestHTTPResourceTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.reactive.server.test.path;
+
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.RestAssured;
+
+public class RootPathTestHTTPResourceTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.http.root-path", "app/")
+            .withApplicationRoot((jar) -> jar
+                    .addClass(HelloResource.class));
+
+    @TestHTTPEndpoint(HelloResource.class)
+    @TestHTTPResource
+    String url;
+
+    @Test
+    public void testRestAssured() {
+        RestAssured.basePath = "/";
+        when().get("/app/hello").then().statusCode(200).body(Matchers.is("hello"));
+        when().get("/app/hello/nested").then().statusCode(200).body(Matchers.is("world hello"));
+    }
+
+    @Test
+    public void testTestHTTPResource() {
+        assertThat(url).isEqualTo("http://localhost:8081/app/hello");
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceInterceptor.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceInterceptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.common.http;
 
+import static io.quarkus.test.common.http.TestHTTPConfigSourceProvider.HTTP_ROOT_PATH_KEY;
+import static io.quarkus.test.common.http.TestHTTPConfigSourceProvider.MANAGEMENT_ROOT_PATH_KEY;
 import static io.quarkus.test.common.http.TestHTTPConfigSourceProvider.TEST_MANAGEMENT_URL_KEY;
 import static io.quarkus.test.common.http.TestHTTPConfigSourceProvider.TEST_MANAGEMENT_URL_SSL_KEY;
 import static io.quarkus.test.common.http.TestHTTPConfigSourceProvider.TEST_URL_KEY;
@@ -28,6 +30,14 @@ public class TestHTTPConfigSourceInterceptor extends ExpressionConfigSourceInter
                 name.equals(TEST_MANAGEMENT_URL_SSL_KEY)) {
 
             return sanitizeUrl(super.getValue(context, name));
+        } else if (name.equals(HTTP_ROOT_PATH_KEY) || name.equals(MANAGEMENT_ROOT_PATH_KEY)) {
+            ConfigValue configValue = super.getValue(context, name);
+            if ((configValue == null) || (configValue.getRawValue() == null) || configValue.getRawValue().isEmpty()
+                    || configValue.getRawValue().startsWith("/")) {
+                return configValue;
+            }
+            return configValue.from().withValue("/" + configValue.getValue()).withRawValue("/" + configValue.getRawValue())
+                    .build();
         }
 
         return context.proceed(name);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceProvider.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceProvider.java
@@ -24,6 +24,9 @@ public class TestHTTPConfigSourceProvider implements ConfigSourceProvider {
     static final String TEST_MANAGEMENT_URL_SSL_VALUE = "https://${quarkus.management.host:localhost}:${quarkus.management.test-port:9001}${quarkus.management.root-path:/q}";
     static final String TEST_MANAGEMENT_URL_SSL_KEY = "test.management.url.ssl";
 
+    static final String HTTP_ROOT_PATH_KEY = "quarkus.http.root-path";
+    static final String MANAGEMENT_ROOT_PATH_KEY = "quarkus.http.management-path";
+
     static final Map<String, String> entries = Map.of(
             TEST_URL_KEY, TEST_URL_VALUE,
             TEST_URL_SSL_KEY, TEST_URL_SSL_VALUE,


### PR DESCRIPTION
- Fixes: #47369