### PR TITLE
Add detailed Javadoc for ApplicationInfoBuildItem class

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
@@ -4,6 +4,17 @@ import java.util.Optional;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * This build item holds essential metadata about the application, specifically its name and version.
+ * The values can be configured using the following properties:
+ * <ul>
+ * <li>{@code quarkus.application.name} - Sets the application name</li>
+ * <li>{@code quarkus.application.version} - Sets the application version</li>
+ * </ul>
+ *
+ * This configuration is intended to be used by extensions that require application metadata,
+ * such as the kubernetes extension.
+ */
 public final class ApplicationInfoBuildItem extends SimpleBuildItem {
 
     public static final String UNSET_VALUE = "<<unset>>";


### PR DESCRIPTION
Hi!

Please let me know if any changes are needed. This is my first PR here, so there might be something wrong beyond what I understood from the CONTRIBUTING.md .

Related to issue #37290 

Path: core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java