### PR TITLE
Set the TCCL to the CL of the test class super-early

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
@@ -23,6 +23,40 @@ import io.quarkus.maven.it.verifier.RunningInvoker;
  */
 public class QuarkusTestIT extends RunAndCheckMojoTestBase {
 
+    @Test
+    public void testQuarkusTestWithThirdPartyExtensionContinuousTesting()
+            throws MavenInvocationException, FileNotFoundException {
+        //we also check continuous testing
+        String sourceDir = "projects/test-third-party-junit-extension";
+        testDir = initProject(sourceDir, sourceDir + "-processed-devmode");
+
+        runAndCheck();
+
+        ContinuousTestingMavenTestUtils testingTestUtils = new ContinuousTestingMavenTestUtils(getPort());
+        ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
+        // This is a bit brittle when we add tests, but failures are often so catastrophic they're not even reported as failures,
+        // so we need to check the pass count explicitly
+        Assertions.assertEquals(0, results.getTestsFailed());
+        Assertions.assertEquals(1, results.getTestsPassed());
+    }
+
+    @Test
+    public void testQuarkusTestWithThirdPartyExtension()
+            throws MavenInvocationException, InterruptedException {
+        String sourceDir = "projects/test-third-party-junit-extension";
+        testDir = initProject(sourceDir, sourceDir + "-processed");
+        RunningInvoker invoker = new RunningInvoker(testDir, false);
+
+        // to properly surface the problem of multiple classpath entries, we need to install the project to the local m2
+        MavenProcessInvocationResult installInvocation = invoker.execute(
+                List.of("clean", "verify", "-Dquarkus.analytics.disabled=true"),
+                Collections.emptyMap());
+        assertThat(installInvocation.getProcess().waitFor(2, TimeUnit.MINUTES)).isTrue();
+        assertThat(installInvocation.getExecutionException()).isNull();
+        assertThat(installInvocation.getExitCode()).isEqualTo(0);
+
+    }
+
     /**
      * Tests that if @QuarkusTest is added as a JUnitExtension through META-INF/services, things still work.
      * JBeret does this, for example.
@@ -89,4 +123,5 @@ public class QuarkusTestIT extends RunAndCheckMojoTestBase {
         assertThat(installInvocation.getExitCode()).isEqualTo(0);
 
     }
+
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>quarkus-test-test-profile</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>\${quarkus.platform.group-id}</groupId>
+                <artifactId>\${quarkus.platform.artifact-id}</artifactId>
+                <version>\${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Dependency which uses a service loader to do stuff -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>\${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>\${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>\${quarkus-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>\${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>\${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,18 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/java/org/acme/MyApplication.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/java/org/acme/MyApplication.java
@@ -1,0 +1,9 @@
+package org.acme;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/app")
+public class MyApplication extends Application {
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>acme - 1.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>Do you like Quarkus?</h2>
+        <p>Go give it a star on <a href="https://github.com/quarkusio/quarkus">GitHub</a>.</p>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: org.acme</li>
+                <li>ArtifactId: acme</li>
+                <li>Version: 1.0-SNAPSHOT</li>
+                <li>Quarkus Version: 999-SNAPSHOT</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <!-- the url have been erased on purpose -->
+                <li><a href="#">Setup your IDE</a></li>
+                <li><a href="#">Getting started</a></li>
+                <li><a href="#">Documentation</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.test.continuous-testing=enabled

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/test/java/org/acme/CustomBeforeAllCallback.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/test/java/org/acme/CustomBeforeAllCallback.java
@@ -1,0 +1,23 @@
+package org.acme;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.DockerClientFactory;
+
+public class CustomBeforeAllCallback implements BeforeAllCallback {
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        // Under the covers, this uses a service loader
+        try {
+            DockerClientFactory.instance()
+                    .dockerHostIpAddress();
+        } catch (IllegalStateException e) {
+            // Docker won't work on windows CI
+            if (System.getProperty("os.name").contains("indows") && e.getMessage().contains("valid Docker environment")) {
+                // This is expected on windows
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/test/java/org/acme/ExampleTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-third-party-junit-extension/src/test/java/org/acme/ExampleTest.java
@@ -1,0 +1,15 @@
+package org.acme;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@ExtendWith(CustomBeforeAllCallback.class)
+@QuarkusTest
+class ExampleTest {
+    @Test
+    void testSomething() {
+    }
+
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ExecutionListener.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ExecutionListener.java
@@ -1,0 +1,51 @@
+package io.quarkus.test.junit.launcher;
+
+import java.util.Optional;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+
+/**
+ * The earliest hook a test extension can have is BeforeAllCallback.
+ * Since we don't know if other extensions might be registered, we want to get in before that callback and set the TCCL to be
+ * the classloader of the test class.
+ */
+public class ExecutionListener implements TestExecutionListener {
+
+    private ClassLoader origCl = null;
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        // This will be called for various levels of containers, only some of which are tests, so check carefully and do not assume
+        Optional<TestSource> oSource = testIdentifier.getSource();
+        if (oSource.isPresent()) {
+            TestSource source = oSource.get();
+            if (source instanceof ClassSource) {
+                ClassSource cs = (ClassSource) source;
+                ClassLoader classLoader = cs.getJavaClass().getClassLoader();
+                // Only adjust the TCCL in cases where we know the QuarkusTestExtension would be about to do it anyway
+                // We could check annotations, but that would be slow, and the assumption that only Quarkus Tests are loaded with the quarkus classloader should be a fair one
+                if (classLoader instanceof QuarkusClassLoader) {
+                    origCl = Thread.currentThread()
+                            .getContextClassLoader();
+                    Thread.currentThread().setContextClassLoader(classLoader);
+                } else {
+                    origCl = null;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult result) {
+        if (origCl != null) {
+            // If execution is parallel this could be odd, but if execution is parallel any kind of TCCL manipulation will be ill-fated
+            Thread.currentThread().setContextClassLoader(origCl);
+        }
+    }
+}

--- a/test-framework/junit5/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/test-framework/junit5/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.launcher.ExecutionListener


### PR DESCRIPTION
Resolves #47082 

The problem happens if a test extension is declared to execute *before* `QuarkusTestExtension`, and that extension uses a ServiceLoader in a `BeforeAllCallback`. The TCCL needs to be the classloader of the test class, but our extensions haven't been invoked yet.
At first, I thought it wouldn't be possible to solve this, because there's no callback on the extension lifecycle before `BeforeEach`. However, we can hook the execution before it even happens, and set the TCCL there. 

A consequence of this change is that we can remove a bunch of TCCL-setting from `QuarkusTestExtension`, but I didn't do that in this PR, because I think this change is a candidate for back-porting, and the refactor of `QuarkusTestExtension` will need several CI runs to validate nothing breaks.