### PR TITLE
Remove unnecessary file from Dockerfile example

### DIFF
--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -72,7 +72,6 @@ COPY --from=BUILD \
    /lib64/libpng16.so.16 \
    /lib64/libm.so.6 \
    /lib64/libbz2.so.1 \
-   /lib64/libexpat.so.1 \
    /lib64/libuuid.so.1 \
    /lib64/
 


### PR DESCRIPTION
Closes https://github.com/quarkusio/quarkus/issues/47265

### Change

Removes copying `libexpat.so.1`, given that it was removed on UBI9, and it's not required. 


### Additional Info

Given that `3.19`, `3.20`, `3.21` also reference UBI9, they are also affected by the same issue (backport needed?)