### PR TITLE
Support overlapping paths on resource classes

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/OverlappingResourceClassPathTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/OverlappingResourceClassPathTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.simple.PortProviderUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+class OverlappingResourceClassPathTest {
+    @RegisterExtension
+    static QuarkusUnitTest testExtension = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    JavaArchive war = ShrinkWrap.create(JavaArchive.class);
+                    war.addClasses(PortProviderUtil.class);
+                    war.addClasses(UsersResource.class);
+                    war.addClasses(UserResource.class);
+                    war.addClasses(GreetingResource.class);
+                    return war;
+                }
+            });
+
+    @Test
+    void basicTest() {
+        given()
+                .get("/users/userId")
+                .then()
+                .statusCode(200)
+                .body(equalTo("userId"));
+
+        given()
+                .get("/users/userId/by-id")
+                .then()
+                .statusCode(200)
+                .body(equalTo("getByIdInUserResource-userId"));
+    }
+
+    @Path("/users")
+    public static class UsersResource {
+
+        @GET
+        @Path("{id}")
+        public String getByIdInUsersResource(@RestPath String id) {
+            return id;
+        }
+    }
+
+    @Path("/users/{id}")
+    public static class UserResource {
+
+        @GET
+        @Path("by-id")
+        public String getByIdInUserResource(@RestPath String id) {
+            return "getByIdInUserResource-" + id;
+        }
+    }
+
+    @Path("/i-do-not-match")
+    public static class GreetingResource {
+
+        @GET
+        @Path("greet")
+        public String greet() {
+            return "Hello";
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
@@ -66,6 +66,9 @@ public class ClassRoutingHandler implements ServerRestHandler {
                 mapper = mappers.get(null);
             }
             if (mapper == null) {
+                if (requestContext.restartWithNextInitialMatch()) {
+                    return;
+                }
                 // The idea here is to check if any of the mappers of the class could map the request - if the HTTP Method were correct
                 String remaining = getRemaining(requestContext);
                 for (RequestMapper<RuntimeResource> existingMapper : mappers.values()) {
@@ -89,6 +92,9 @@ public class ClassRoutingHandler implements ServerRestHandler {
             }
 
             if (target == null) {
+                if (requestContext.restartWithNextInitialMatch()) {
+                    return;
+                }
                 // The idea here is to check if any of the mappers of the class could map the request - if the HTTP Method were correct
                 for (Map.Entry<String, RequestMapper<RuntimeResource>> entry : mappers.entrySet()) {
                     if (entry.getKey() == null) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
@@ -73,16 +73,7 @@ public class RestInitialHandler implements ServerRestHandler {
                 return;
             }
         }
-        requestContext.restart(target.value.handlers);
-        requestContext.setMaxPathParams(target.value.maxPathParams);
-        requestContext.setRemaining(target.remaining);
-        for (int i = 0; i < target.pathParamValues.length; ++i) {
-            String pathParamValue = target.pathParamValues[i];
-            if (pathParamValue == null) {
-                break;
-            }
-            requestContext.setPathParamValue(i, target.pathParamValues[i]);
-        }
+        requestContext.setupInitialMatchAndRestart(target);
     }
 
     public static class InitialMatch {


### PR DESCRIPTION
Having partially matching paths on resource classes could lead to 404s, even though a matching resource method existed.

Lets take the example from #26496.

```java
@Path("/base")
class Base {
   @GET
   @Path("{id}") 
   public Uni<RestResponse<?>> base() {..}
}
@Path("/base/{id}")
class Extension {
   @GET
   @Path("extension") 
   public Uni<RestResponse<?>> extension() {..}
}
```

Calling `GET /base/123` would result in a 404. `/base/{id}` is a perfect match for that request, which result in the `Extension` resource class being used.
Quarkus-rest always only works on the basis of one resource class - the one with the best match.

I however believe that is not up to spec.

https://jakarta.ee/specifications/restful-ws/4.0/jakarta-restful-ws-spec-4.0.pdf

Chapter 3.5.2 Request Matching
Stage 1 only handles matching of the resource class path to the request uri -> both classes match.
Stage 2 figures out which of all resource methods in all matched resource classes matches against the request uri.

So basically, the current implementation results in Stage 1 only reporting one matching resource class, altough it should report 2.

This PR adds additional logic, so that all matching resource classes are remembered, and the handler chain is restarted if the current resource class does not contain a matchin sub resource method, or sub resource locator.

- Closes: #26496

