### PR TITLE
Dev UI - Only display exposed ports

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -155,6 +155,7 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
             let ports = devService.containerInfo.exposedPorts;
             
             const p = ports
+                .filter(p => p.publicPort != null)
                 .map(p => p.ip + ":" + p.publicPort + "->" + p.privatePort + "/" + p.type)
                 .join(', ');
 


### PR DESCRIPTION
We were displaying the private ports with null values, which is counter productive.

I applied the same logic as what is in `ContainerInfo` format methods.