### PR TITLE
Do not do preloading of test resource classes in FacadeClassLoader

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainBuilderConsumer.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainBuilderConsumer.java
@@ -12,7 +12,7 @@ import io.quarkus.builder.BuildStep;
 import io.quarkus.builder.BuildStepBuilder;
 import io.quarkus.builder.item.BuildItem;
 
-// needs to be in a class of it's own in order to avoid java.lang.IncompatibleClassChangeError
+// needs to be in a class of its own in order to avoid java.lang.IncompatibleClassChangeError
 public class ProdModeTestBuildChainBuilderConsumer implements Consumer<BuildChainBuilder> {
     private final String buildStepClassName;
     private final List<String> producesClassNames;

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainCustomizerProducer.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainCustomizerProducer.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 
 import io.quarkus.builder.BuildChainBuilder;
 
-// needs to be in a class of it's own in order to avoid java.lang.IncompatibleClassChangeError
+// needs to be in a class of its own in order to avoid java.lang.IncompatibleClassChangeError
 public class ProdModeTestBuildChainCustomizerProducer
         implements Function<Map<String, Object>, List<Consumer<BuildChainBuilder>>> {
 


### PR DESCRIPTION
In order to get the test classloading rewrite to run cleanly, I had to hold my nose and do an icky pre-load of some classes so that they could set system properties. 

I was planning to remove the changes as part of #45785, but I noticed while working on that fix for that issue that even without my fix, the preload code wasn't needed anymore. I'm not sure which intervening change made it no-longer-needed, but since the code was horrible, good riddance. :) 

I also fixed two typos.