### PR TITLE
Expose DevUI's capabilities as MCP functions

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/JsonRpcDescription.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/JsonRpcDescription.java
@@ -1,0 +1,24 @@
+package io.quarkus.runtime.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Adds metadata to a JsonRPC method to control its behavior and appearance.
+ */
+@Retention(RUNTIME)
+@Target({ METHOD, PARAMETER })
+@Documented
+public @interface JsonRpcDescription {
+
+    /**
+     * @return the description text
+     */
+    String value();
+
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/JsonRpcUsage.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/JsonRpcUsage.java
@@ -1,0 +1,18 @@
+package io.quarkus.runtime.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Defines where the JsonRPC method should be available.
+ */
+@Retention(RUNTIME)
+@Target({ METHOD })
+@Documented
+public @interface JsonRpcUsage {
+    Usage[] value();
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/Usage.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/Usage.java
@@ -1,0 +1,20 @@
+package io.quarkus.runtime.annotations;
+
+import java.util.EnumSet;
+
+public enum Usage {
+    DEV_UI,
+    DEV_MCP;
+
+    public static EnumSet<Usage> onlyDevUI() {
+        return EnumSet.of(Usage.DEV_UI);
+    }
+
+    public static EnumSet<Usage> onlyDevMCP() {
+        return EnumSet.of(Usage.DEV_MCP);
+    }
+
+    public static EnumSet<Usage> devUIandDevMCP() {
+        return EnumSet.of(Usage.DEV_UI, Usage.DEV_MCP);
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/AbstractDevUIBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/AbstractDevUIBuildItem.java
@@ -1,6 +1,6 @@
 package io.quarkus.devui.spi;
 
-import java.util.List;
+import java.lang.invoke.MethodHandle;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.util.ArtifactInfoUtil;
+import io.quarkus.maven.dependency.ArtifactKey;
 
 /**
  * For All DEV UI Build Item, we need to distinguish between the extensions, and the internal usage of Dev UI
@@ -16,30 +17,33 @@ public abstract class AbstractDevUIBuildItem extends MultiBuildItem {
 
     private final Class<?> callerClass;
     private String extensionIdentifier = null;
-
+    private ArtifactKey artifactKey;
     private static final String DOT = ".";
-    private final String customIdentifier;
+    private final boolean isInternal;
 
     public AbstractDevUIBuildItem() {
         this(null);
     }
 
     public AbstractDevUIBuildItem(String customIdentifier) {
-        this.customIdentifier = customIdentifier;
-
-        if (this.customIdentifier == null) {
+        this.extensionIdentifier = customIdentifier;
+        isInternal = customIdentifier == null;
+        if (customIdentifier == null) {
             // Get the class that will be used to auto-detect the name
             StackWalker stackWalker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 
-            List<StackWalker.StackFrame> stackFrames = stackWalker.walk(frames -> frames.collect(Collectors.toList()));
+            stackWalker.walk(frames -> frames.collect(Collectors.toList()));
 
             Optional<StackWalker.StackFrame> stackFrame = stackWalker.walk(frames -> frames
                     .filter(frame -> (!frame.getDeclaringClass().getPackageName().startsWith("io.quarkus.devui.spi")
-                            && !frame.getDeclaringClass().getPackageName().startsWith("io.quarkus.devui.deployment")))
+                            && !frame.getDeclaringClass().getPackageName().startsWith("io.quarkus.devui.deployment")
+                            && !frame.getDeclaringClass().equals(MethodHandle.class)))
                     .findFirst());
 
             if (stackFrame.isPresent()) {
                 this.callerClass = stackFrame.get().getDeclaringClass();
+                if (this.callerClass == null)
+                    this.extensionIdentifier = DEV_UI;
             } else {
                 throw new RuntimeException("Could not detect extension identifier automatically");
             }
@@ -48,26 +52,28 @@ public abstract class AbstractDevUIBuildItem extends MultiBuildItem {
         }
     }
 
+    public ArtifactKey getArtifactKey(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        if (this.artifactKey == null) {
+            if (callerClass != null) {
+                Map.Entry<String, String> groupIdAndArtifactId = ArtifactInfoUtil.groupIdAndArtifactId(callerClass,
+                        curateOutcomeBuildItem);
+                this.artifactKey = ArtifactKey.ga(groupIdAndArtifactId.getKey(), groupIdAndArtifactId.getValue());
+            }
+        }
+        return this.artifactKey;
+    }
+
     public String getExtensionPathName(CurateOutcomeBuildItem curateOutcomeBuildItem) {
-        if (this.customIdentifier != null) {
-            return customIdentifier;
-        }
-        if (this.callerClass == null) {
-            return DEV_UI;
-        }
-
         if (this.extensionIdentifier == null) {
-
-            Map.Entry<String, String> groupIdAndArtifactId = ArtifactInfoUtil.groupIdAndArtifactId(callerClass,
-                    curateOutcomeBuildItem);
-            this.extensionIdentifier = groupIdAndArtifactId.getKey() + DOT + groupIdAndArtifactId.getValue();
+            ArtifactKey ak = getArtifactKey(curateOutcomeBuildItem);
+            this.extensionIdentifier = ak.getGroupId() + DOT + ak.getArtifactId();
         }
 
         return this.extensionIdentifier;
     }
 
     public boolean isInternal() {
-        return this.customIdentifier != null;
+        return this.isInternal;
     }
 
     public static final String DEV_UI = "devui";

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/DevUIContent.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/DevUIContent.java
@@ -10,11 +10,13 @@ public class DevUIContent {
     private final String fileName;
     private final byte[] template;
     private final Map<String, Object> data;
+    private final Map<String, String> descriptions;
 
     private DevUIContent(DevUIContent.Builder builder) {
         this.fileName = builder.fileName;
         this.template = builder.template;
         this.data = builder.data;
+        this.descriptions = builder.descriptions;
     }
 
     public String getFileName() {
@@ -29,6 +31,10 @@ public class DevUIContent {
         return data;
     }
 
+    public Map<String, String> getDescriptions() {
+        return descriptions;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -37,6 +43,7 @@ public class DevUIContent {
         private String fileName;
         private byte[] template;
         private Map<String, Object> data;
+        private Map<String, String> descriptions;
 
         private Builder() {
             this.data = new HashMap<>();
@@ -66,6 +73,11 @@ public class DevUIContent {
 
         public Builder addData(String key, Object value) {
             this.data.put(key, value);
+            return this;
+        }
+
+        public Builder descriptions(Map<String, String> descriptions) {
+            this.descriptions = descriptions;
             return this;
         }
 

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeAction.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeAction.java
@@ -10,6 +10,7 @@ import io.quarkus.runtime.RuntimeValue;
  * Define a action that can be executed against the deployment classpath in runtime
  * This means a call will still be make with Json-RPC to the backend, but fall through to this action
  */
+@Deprecated
 public class BuildTimeAction {
 
     private final String methodName;

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
@@ -1,21 +1,30 @@
 package io.quarkus.devui.spi.buildtime;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import io.quarkus.devui.spi.AbstractDevUIBuildItem;
+import io.quarkus.devui.spi.buildtime.jsonrpc.AbstractJsonRpcMethod;
+import io.quarkus.devui.spi.buildtime.jsonrpc.DeploymentJsonRpcMethod;
+import io.quarkus.devui.spi.buildtime.jsonrpc.RecordedJsonRpcMethod;
 import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Usage;
 
 /**
  * Holds any Build time actions for Dev UI the extension has
  */
 public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
 
-    private final List<BuildTimeAction> actions = new ArrayList<>();
-    private final List<BuildTimeAction> subscriptions = new ArrayList<>();
+    private final List<DeploymentJsonRpcMethod> deploymentActions = new ArrayList<>();
+    private final List<DeploymentJsonRpcMethod> deploymentSubscriptions = new ArrayList<>();
+
+    private final List<RecordedJsonRpcMethod> recordedActions = new ArrayList<>();
+    private final List<RecordedJsonRpcMethod> recordedSubscriptions = new ArrayList<>();
 
     public BuildTimeActionBuildItem() {
         super();
@@ -25,44 +34,221 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
         super(customIdentifier);
     }
 
-    private void addAction(BuildTimeAction buildTimeAction) {
-        this.actions.add(buildTimeAction);
+    public List<DeploymentJsonRpcMethod> getDeploymentActions() {
+        return this.deploymentActions;
     }
 
+    public List<RecordedJsonRpcMethod> getRecordedActions() {
+        return this.recordedActions;
+    }
+
+    public List<DeploymentJsonRpcMethod> getDeploymentSubscriptions() {
+        return deploymentSubscriptions;
+    }
+
+    public List<RecordedJsonRpcMethod> getRecordedSubscriptions() {
+        return recordedSubscriptions;
+    }
+
+    public ActionBuilder actionBuilder() {
+        return new ActionBuilder();
+    }
+
+    public SubscriptionBuilder subscriptionBuilder() {
+        return new SubscriptionBuilder();
+    }
+
+    @Deprecated
     public <T> void addAction(String methodName,
             Function<Map<String, String>, T> action) {
-        this.addAction(new BuildTimeAction(methodName, action));
+        this.addAction(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), action));
     }
 
+    @Deprecated
     public <T> void addAssistantAction(String methodName,
             BiFunction<Object, Map<String, String>, T> action) {
-        this.addAction(new BuildTimeAction(methodName, action));
+        this.addAction(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), action));
     }
 
+    @Deprecated
     public <T> void addAction(String methodName,
             RuntimeValue runtimeValue) {
-        this.addAction(new BuildTimeAction(methodName, runtimeValue));
+        this.addAction(new RecordedJsonRpcMethod(methodName, null, Usage.onlyDevUI(), runtimeValue));
     }
 
-    public List<BuildTimeAction> getActions() {
-        return actions;
-    }
-
-    public void addSubscription(BuildTimeAction buildTimeAction) {
-        this.subscriptions.add(buildTimeAction);
-    }
-
+    @Deprecated
     public <T> void addSubscription(String methodName,
             Function<Map<String, String>, T> action) {
-        this.addSubscription(new BuildTimeAction(methodName, action));
+        this.addSubscription(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), action));
     }
 
+    @Deprecated
     public <T> void addSubscription(String methodName,
             RuntimeValue runtimeValue) {
-        this.addSubscription(new BuildTimeAction(methodName, runtimeValue));
+        this.addSubscription(new RecordedJsonRpcMethod(methodName, null, Usage.onlyDevUI(), runtimeValue));
     }
 
-    public List<BuildTimeAction> getSubscriptions() {
-        return subscriptions;
+    private BuildTimeActionBuildItem addAction(DeploymentJsonRpcMethod deploymentJsonRpcMethod) {
+        this.deploymentActions.add(deploymentJsonRpcMethod);
+        return this;
+    }
+
+    private BuildTimeActionBuildItem addAction(RecordedJsonRpcMethod recordedJsonRpcMethod) {
+        this.recordedActions.add(recordedJsonRpcMethod);
+        return this;
+    }
+
+    private BuildTimeActionBuildItem addSubscription(DeploymentJsonRpcMethod deploymentJsonRpcMethod) {
+        this.deploymentSubscriptions.add(deploymentJsonRpcMethod);
+        return this;
+    }
+
+    private BuildTimeActionBuildItem addSubscription(RecordedJsonRpcMethod recordedJsonRpcMethod) {
+        this.recordedSubscriptions.add(recordedJsonRpcMethod);
+        return this;
+    }
+
+    public final class ActionBuilder {
+        private String methodName;
+        private String description;
+        private Map<String, AbstractJsonRpcMethod.Parameter> parameters = new LinkedHashMap<>();
+        private EnumSet<Usage> usage;
+        private Function<Map<String, String>, ?> function;
+        private BiFunction<Object, Map<String, String>, ?> assistantFunction;
+        private RuntimeValue<?> runtimeValue;
+
+        public ActionBuilder methodName(String methodName) {
+            this.methodName = methodName;
+            return this;
+        }
+
+        public ActionBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public ActionBuilder parameter(String name, String description) {
+            return parameter(name, String.class, description);
+        }
+
+        public ActionBuilder parameter(String name, Class<?> type, String description) {
+            this.parameters.put(name, new AbstractJsonRpcMethod.Parameter(type, description));
+            return this;
+        }
+
+        public ActionBuilder usage(EnumSet<Usage> usage) {
+            this.usage = usage;
+            return this;
+        }
+
+        public <T> ActionBuilder function(Function<Map<String, String>, T> function) {
+            if (this.runtimeValue != null || this.assistantFunction != null)
+                throw new IllegalStateException("Only one of runtimeValue, function or assistantFunction is allowed");
+            this.function = function;
+            return this;
+        }
+
+        public <T> ActionBuilder assistantFunction(BiFunction<Object, Map<String, String>, ?> assistantFunction) {
+            if (this.function != null || this.runtimeValue != null)
+                throw new IllegalStateException("Only one of runtimeValue, function or assistantFunction is allowed");
+            this.assistantFunction = assistantFunction;
+            return this;
+        }
+
+        public ActionBuilder runtime(RuntimeValue<?> runtimeValue) {
+            if (this.function != null || this.assistantFunction != null)
+                throw new IllegalStateException("Only one of runtimeValue, function or assistantFunction is allowed");
+            this.runtimeValue = runtimeValue;
+            return this;
+        }
+
+        public BuildTimeActionBuildItem build() {
+            if (methodName == null || methodName.isBlank())
+                throw new IllegalStateException("methodName must be provided");
+            if (parameters.isEmpty())
+                parameters = null;
+            if (function != null) {
+                return addAction(
+                        new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                                function));
+            } else if (runtimeValue != null) {
+                return addAction(
+                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description), runtimeValue));
+            } else if (assistantFunction != null) {
+                return addAction(
+                        new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                                assistantFunction));
+            } else {
+                throw new IllegalStateException("Either function, assistantFunction or runtimeValue must be provided");
+            }
+        }
+    }
+
+    public final class SubscriptionBuilder {
+        private String methodName;
+        private String description;
+        private Map<String, AbstractJsonRpcMethod.Parameter> parameters = new LinkedHashMap<>();;
+        private EnumSet<Usage> usage;
+        private Function<Map<String, String>, ?> function;
+        private RuntimeValue<?> runtimeValue;
+
+        public SubscriptionBuilder methodName(String methodName) {
+            this.methodName = methodName;
+            return this;
+        }
+
+        public SubscriptionBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public SubscriptionBuilder parameter(String name, String description) {
+            return parameter(name, String.class, description);
+        }
+
+        public SubscriptionBuilder parameter(String name, Class<?> type, String description) {
+            this.parameters.put(name, new AbstractJsonRpcMethod.Parameter(type, description));
+            return this;
+        }
+
+        public SubscriptionBuilder usage(EnumSet<Usage> usage) {
+            this.usage = usage;
+            return this;
+        }
+
+        public <T> SubscriptionBuilder function(Function<Map<String, String>, T> function) {
+            this.function = function;
+            return this;
+        }
+
+        public SubscriptionBuilder runtime(RuntimeValue<?> runtimeValue) {
+            this.runtimeValue = runtimeValue;
+            return this;
+        }
+
+        public void build() {
+            if (methodName == null || methodName.isBlank())
+                throw new IllegalStateException("methodName must be provided");
+            if (parameters.isEmpty())
+                parameters = null;
+            if (function != null) {
+                addSubscription(new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                        function));
+            } else if (runtimeValue != null) {
+                addSubscription(
+                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description), runtimeValue));
+            } else {
+                throw new IllegalStateException("Either function or runtimeValue must be provided");
+            }
+        }
+    }
+
+    private EnumSet<Usage> autoUsage(EnumSet<Usage> usage, String description) {
+        if (usage == null && description == null) {
+            usage = Usage.onlyDevUI();
+        } else if (usage == null) {
+            usage = Usage.devUIandDevMCP();
+        }
+        return usage;
     }
 }

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeData.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeData.java
@@ -1,0 +1,38 @@
+package io.quarkus.devui.spi.buildtime;
+
+/**
+ * Holds the actual data and optionally a description for Build Time Data
+ */
+public class BuildTimeData {
+    private Object content;
+    private String description;
+
+    public BuildTimeData() {
+
+    }
+
+    public BuildTimeData(Object content) {
+        this(content, null);
+    }
+
+    public BuildTimeData(Object content, String description) {
+        this.content = content;
+        this.description = description;
+    }
+
+    public Object getContent() {
+        return content;
+    }
+
+    public void setContent(Object content) {
+        this.content = content;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/QuteTemplateBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/QuteTemplateBuildItem.java
@@ -33,22 +33,24 @@ public final class QuteTemplateBuildItem extends AbstractDevUIBuildItem {
     }
 
     public void add(String templatename, Map<String, Object> data) {
-        templateDatas.add(new TemplateData(templatename, templatename, data)); // By default the template is used for only one file.
+        templateDatas.add(new TemplateData(templatename, templatename, data, Map.of())); // By default the template is used for only one file.
     }
 
-    public void add(String templatename, String fileName, Map<String, Object> data) {
-        templateDatas.add(new TemplateData(templatename, fileName, data));
+    public void add(String templatename, String fileName, Map<String, Object> data, Map<String, String> descriptions) {
+        templateDatas.add(new TemplateData(templatename, fileName, data, descriptions));
     }
 
     public static class TemplateData {
         final String templateName;
         final String fileName;
         final Map<String, Object> data;
+        final Map<String, String> descriptions;
 
-        private TemplateData(String templateName, String fileName, Map<String, Object> data) {
+        private TemplateData(String templateName, String fileName, Map<String, Object> data, Map<String, String> descriptions) {
             this.templateName = templateName;
             this.fileName = fileName;
             this.data = data;
+            this.descriptions = descriptions;
         }
 
         public String getTemplateName() {
@@ -61,6 +63,10 @@ public final class QuteTemplateBuildItem extends AbstractDevUIBuildItem {
 
         public Map<String, Object> getData() {
             return data;
+        }
+
+        public Map<String, String> getDescriptions() {
+            return descriptions;
         }
     }
 }

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/AbstractJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/AbstractJsonRpcMethod.java
@@ -1,0 +1,114 @@
+package io.quarkus.devui.spi.buildtime.jsonrpc;
+
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.Usage;
+
+/**
+ * Base class for json-rpc methods
+ */
+public abstract class AbstractJsonRpcMethod {
+
+    private String methodName;
+    private String description;
+    private Map<String, Parameter> parameters;
+    private EnumSet<Usage> usage;
+
+    public AbstractJsonRpcMethod() {
+    }
+
+    public AbstractJsonRpcMethod(String methodName, String description,
+            EnumSet<Usage> usage) {
+        this.methodName = methodName;
+        this.description = description;
+        this.usage = usage;
+    }
+
+    public AbstractJsonRpcMethod(String methodName, String description, Map<String, Parameter> parameters,
+            EnumSet<Usage> usage) {
+        this.methodName = methodName;
+        this.description = description;
+        this.parameters = parameters;
+        this.usage = usage;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, Parameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, Parameter> parameters) {
+        this.parameters = parameters;
+    }
+
+    public void addParameter(String name, String description) {
+        if (this.parameters == null)
+            this.parameters = new LinkedHashMap<>();
+        this.parameters.put(name, new Parameter(String.class, description));
+    }
+
+    public void addParameter(String name, Class<?> type, String description) {
+        if (this.parameters == null)
+            this.parameters = new LinkedHashMap<>();
+        this.parameters.put(name, new Parameter(type, description));
+    }
+
+    public boolean hasParameters() {
+        return this.parameters != null && !this.parameters.isEmpty();
+    }
+
+    public EnumSet<Usage> getUsage() {
+        return usage;
+    }
+
+    public void setUsage(EnumSet<Usage> usage) {
+        this.usage = usage;
+    }
+
+    public static class Parameter {
+        private Class<?> type;
+        private String description;
+
+        public Parameter() {
+
+        }
+
+        public Parameter(Class<?> type, String description) {
+            this.type = type;
+            this.description = description;
+        }
+
+        public Class<?> getType() {
+            return type;
+        }
+
+        public void setType(Class<?> type) {
+            this.type = type;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/DeploymentJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/DeploymentJsonRpcMethod.java
@@ -1,0 +1,78 @@
+package io.quarkus.devui.spi.buildtime.jsonrpc;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import io.quarkus.runtime.annotations.Usage;
+
+/**
+ * Deployment json-rpc methods. Here we need to know the function to call
+ */
+public final class DeploymentJsonRpcMethod extends AbstractJsonRpcMethod {
+
+    private Function<Map<String, String>, ?> action;
+    private BiFunction<Object, Map<String, String>, ?> assistantAction;
+
+    public DeploymentJsonRpcMethod() {
+    }
+
+    public DeploymentJsonRpcMethod(String methodName,
+            String description,
+            EnumSet<Usage> usage,
+            Function<Map<String, String>, ?> action) {
+        super(methodName, description, usage);
+        this.action = action;
+    }
+
+    public DeploymentJsonRpcMethod(String methodName,
+            String description,
+            Map<String, Parameter> parameters,
+            EnumSet<Usage> usage,
+            Function<Map<String, String>, ?> action) {
+        super(methodName, description, parameters, usage);
+        this.action = action;
+    }
+
+    public DeploymentJsonRpcMethod(String methodName,
+            String description,
+            EnumSet<Usage> usage,
+            BiFunction<Object, Map<String, String>, ?> assistantAction) {
+        super(methodName, description, usage);
+        this.assistantAction = assistantAction;
+    }
+
+    public DeploymentJsonRpcMethod(String methodName,
+            String description,
+            Map<String, Parameter> parameters,
+            EnumSet<Usage> usage,
+            BiFunction<Object, Map<String, String>, ?> assistantAction) {
+        super(methodName, description, parameters, usage);
+        this.assistantAction = assistantAction;
+    }
+
+    public Function<Map<String, String>, ?> getAction() {
+        return action;
+    }
+
+    public void setAction(Function<Map<String, String>, ?> action) {
+        this.action = action;
+    }
+
+    public boolean hasAction() {
+        return this.action != null;
+    }
+
+    public BiFunction<Object, Map<String, String>, ?> getAssistantAction() {
+        return assistantAction;
+    }
+
+    public void setAssistantAction(BiFunction<Object, Map<String, String>, ?> assistantAction) {
+        this.assistantAction = assistantAction;
+    }
+
+    public boolean hasAssistantAction() {
+        return this.assistantAction != null;
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RecordedJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RecordedJsonRpcMethod.java
@@ -1,0 +1,33 @@
+package io.quarkus.devui.spi.buildtime.jsonrpc;
+
+import java.util.EnumSet;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Usage;
+
+/**
+ * Recorded json-rpc methods. Here we need to know the recorded value
+ */
+public final class RecordedJsonRpcMethod extends AbstractJsonRpcMethod {
+
+    private RuntimeValue runtimeValue;
+
+    public RecordedJsonRpcMethod() {
+    }
+
+    public RecordedJsonRpcMethod(String methodName,
+            String description,
+            EnumSet<Usage> usage,
+            RuntimeValue runtimeValue) {
+        super(methodName, description, usage);
+        this.runtimeValue = runtimeValue;
+    }
+
+    public RuntimeValue getRuntimeValue() {
+        return runtimeValue;
+    }
+
+    public void setRuntimeValue(RuntimeValue runtimeValue) {
+        this.runtimeValue = runtimeValue;
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RuntimeJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RuntimeJsonRpcMethod.java
@@ -1,0 +1,57 @@
+package io.quarkus.devui.spi.buildtime.jsonrpc;
+
+import java.util.EnumSet;
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.Usage;
+
+/**
+ * Runtime json-rpc methods. Here we need to know the CDI bean to call
+ */
+public final class RuntimeJsonRpcMethod extends AbstractJsonRpcMethod {
+
+    private Class<?> bean;
+    private boolean blocking;
+    private boolean nonBlocking;
+
+    public RuntimeJsonRpcMethod() {
+        super();
+    }
+
+    public RuntimeJsonRpcMethod(String methodName,
+            String description,
+            Map<String, Parameter> parameters,
+            EnumSet<Usage> usage,
+            Class<?> bean,
+            boolean blocking,
+            boolean nonBlocking) {
+        super(methodName, description, parameters, usage);
+        this.bean = bean;
+        this.blocking = blocking;
+        this.nonBlocking = nonBlocking;
+    }
+
+    public Class<?> getBean() {
+        return bean;
+    }
+
+    public void setBean(Class<?> bean) {
+        this.bean = bean;
+    }
+
+    public boolean isExplicitlyBlocking() {
+        return blocking;
+    }
+
+    public void setExplicitlyBlocking(boolean blocking) {
+        this.blocking = blocking;
+    }
+
+    public boolean isExplicitlyNonBlocking() {
+        return nonBlocking;
+    }
+
+    public void setExplicitlyNonBlocking(boolean nonBlocking) {
+        this.nonBlocking = nonBlocking;
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
@@ -7,13 +7,14 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.devui.spi.AbstractDevUIBuildItem;
+import io.quarkus.devui.spi.buildtime.BuildTimeData;
 
 /**
  * Any of card, menu or footer pages
  */
 public abstract class AbstractPageBuildItem extends AbstractDevUIBuildItem {
 
-    protected final Map<String, Object> buildTimeData;
+    protected final Map<String, BuildTimeData> buildTimeData;
     protected final List<PageBuilder> pageBuilders;
     protected String headlessComponentLink = null;
 
@@ -54,10 +55,14 @@ public abstract class AbstractPageBuildItem extends AbstractDevUIBuildItem {
     }
 
     public void addBuildTimeData(String fieldName, Object fieldData) {
-        this.buildTimeData.put(fieldName, fieldData);
+        this.addBuildTimeData(fieldName, fieldData, null);
     }
 
-    public Map<String, Object> getBuildTimeData() {
+    public void addBuildTimeData(String fieldName, Object fieldData, String description) {
+        this.buildTimeData.put(fieldName, new BuildTimeData(fieldData, description));
+    }
+
+    public Map<String, BuildTimeData> getBuildTimeData() {
         return this.buildTimeData;
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeConstBuildItem.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeConstBuildItem.java
@@ -4,19 +4,20 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.quarkus.devui.spi.AbstractDevUIBuildItem;
+import io.quarkus.devui.spi.buildtime.BuildTimeData;
 
 /**
  * Write javascript file containing const vars with build time data
  */
 public final class BuildTimeConstBuildItem extends AbstractDevUIBuildItem {
 
-    private final Map<String, Object> buildTimeData;
+    private final Map<String, BuildTimeData> buildTimeData;
 
     public BuildTimeConstBuildItem() {
         this(new HashMap<>());
     }
 
-    public BuildTimeConstBuildItem(Map<String, Object> buildTimeData) {
+    public BuildTimeConstBuildItem(Map<String, BuildTimeData> buildTimeData) {
         super();
         this.buildTimeData = buildTimeData;
     }
@@ -25,20 +26,24 @@ public final class BuildTimeConstBuildItem extends AbstractDevUIBuildItem {
         this(customIdentifier, new HashMap<>());
     }
 
-    public BuildTimeConstBuildItem(String customIdentifier, Map<String, Object> buildTimeData) {
+    public BuildTimeConstBuildItem(String customIdentifier, Map<String, BuildTimeData> buildTimeData) {
         super(customIdentifier);
         this.buildTimeData = buildTimeData;
     }
 
     public void addBuildTimeData(String fieldName, Object fieldData) {
-        this.buildTimeData.put(fieldName, fieldData);
+        this.addBuildTimeData(fieldName, fieldData, null);
     }
 
-    public void addAllBuildTimeData(Map<String, Object> buildTimeData) {
+    public void addBuildTimeData(String fieldName, Object fieldData, String description) {
+        this.buildTimeData.put(fieldName, new BuildTimeData(fieldData, description));
+    }
+
+    public void addAllBuildTimeData(Map<String, BuildTimeData> buildTimeData) {
         this.buildTimeData.putAll(buildTimeData);
     }
 
-    public Map<String, Object> getBuildTimeData() {
+    public Map<String, BuildTimeData> getBuildTimeData() {
         return this.buildTimeData;
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DeploymentMethodBuildItem.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DeploymentMethodBuildItem.java
@@ -1,28 +1,33 @@
 package io.quarkus.devui.deployment;
 
-import java.util.List;
 import java.util.Map;
 
 import io.quarkus.builder.item.SimpleBuildItem;
-import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.devui.spi.buildtime.jsonrpc.DeploymentJsonRpcMethod;
+import io.quarkus.devui.spi.buildtime.jsonrpc.RecordedJsonRpcMethod;
 
 /**
  * Hold add discovered build time methods that can be executed via json-rpc
  */
 public final class DeploymentMethodBuildItem extends SimpleBuildItem {
 
-    private final List<String> methods;
-    private final List<String> subscriptions;
-    private final Map<String, RuntimeValue> recordedValues;
+    private final Map<String, DeploymentJsonRpcMethod> methods;
+    private final Map<String, DeploymentJsonRpcMethod> subscriptions;
+    private final Map<String, RecordedJsonRpcMethod> recordedMethods;
+    private final Map<String, RecordedJsonRpcMethod> recordedSubscriptions;
 
-    public DeploymentMethodBuildItem(List<String> methods, List<String> subscriptions,
-            Map<String, RuntimeValue> recordedValues) {
+    public DeploymentMethodBuildItem(Map<String, DeploymentJsonRpcMethod> methods,
+            Map<String, DeploymentJsonRpcMethod> subscriptions,
+            Map<String, RecordedJsonRpcMethod> recordedMethods, Map<String, RecordedJsonRpcMethod> recordedSubscriptions) {
         this.methods = methods;
         this.subscriptions = subscriptions;
-        this.recordedValues = recordedValues;
+        this.recordedMethods = recordedMethods;
+        this.recordedSubscriptions = recordedSubscriptions;
     }
 
-    public List<String> getMethods() {
+    // Methods
+
+    public Map<String, DeploymentJsonRpcMethod> getMethods() {
         return this.methods;
     }
 
@@ -30,7 +35,9 @@ public final class DeploymentMethodBuildItem extends SimpleBuildItem {
         return this.methods != null && !this.methods.isEmpty();
     }
 
-    public List<String> getSubscriptions() {
+    // Subscriptions
+
+    public Map<String, DeploymentJsonRpcMethod> getSubscriptions() {
         return this.subscriptions;
     }
 
@@ -38,11 +45,23 @@ public final class DeploymentMethodBuildItem extends SimpleBuildItem {
         return this.subscriptions != null && !this.subscriptions.isEmpty();
     }
 
-    public Map<String, RuntimeValue> getRecordedValues() {
-        return this.recordedValues;
+    // Recorded Methods
+
+    public Map<String, RecordedJsonRpcMethod> getRecordedMethods() {
+        return this.recordedMethods;
     }
 
-    public boolean hasRecordedValues() {
-        return this.recordedValues != null && !this.recordedValues.isEmpty();
+    public boolean hasRecordedMethods() {
+        return this.recordedMethods != null && !this.recordedMethods.isEmpty();
+    }
+
+    // Recorded Subscriptions
+
+    public Map<String, RecordedJsonRpcMethod> getRecordedSubscriptions() {
+        return this.recordedSubscriptions;
+    }
+
+    public boolean hasRecordedSubscriptions() {
+        return this.recordedSubscriptions != null && !this.recordedSubscriptions.isEmpty();
     }
 }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevMCPConfig.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevMCPConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.devui.deployment;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot
+@ConfigMapping(prefix = "quarkus.dev-mcp")
+public interface DevMCPConfig {
+
+    /**
+     * Enable/disable the Dev MCP Server
+     */
+    @WithDefault("false")
+    boolean enabled();
+
+}

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -22,10 +23,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Scanner;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -42,6 +48,7 @@ import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsLocalDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -49,23 +56,29 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.devui.deployment.extension.Codestart;
 import io.quarkus.devui.deployment.extension.Extension;
 import io.quarkus.devui.deployment.jsonrpc.DevUIDatabindCodec;
+import io.quarkus.devui.runtime.DevUIBuildTimeStaticService;
 import io.quarkus.devui.runtime.DevUIRecorder;
 import io.quarkus.devui.runtime.VertxRouteInfoService;
 import io.quarkus.devui.runtime.comms.JsonRpcRouter;
 import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
-import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethodName;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.spi.DevUIContent;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.BuildTimeData;
 import io.quarkus.devui.spi.buildtime.FooterLogBuildItem;
 import io.quarkus.devui.spi.buildtime.StaticContentBuildItem;
+import io.quarkus.devui.spi.buildtime.jsonrpc.AbstractJsonRpcMethod;
+import io.quarkus.devui.spi.buildtime.jsonrpc.DeploymentJsonRpcMethod;
+import io.quarkus.devui.spi.buildtime.jsonrpc.RecordedJsonRpcMethod;
+import io.quarkus.devui.spi.buildtime.jsonrpc.RuntimeJsonRpcMethod;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.FooterPageBuildItem;
 import io.quarkus.devui.spi.page.LibraryLink;
@@ -80,6 +93,9 @@ import io.quarkus.maven.dependency.GACT;
 import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.qute.Qute;
+import io.quarkus.runtime.annotations.JsonRpcDescription;
+import io.quarkus.runtime.annotations.JsonRpcUsage;
+import io.quarkus.runtime.annotations.Usage;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
@@ -103,8 +119,8 @@ import io.vertx.ext.web.RoutingContext;
 public class DevUIProcessor {
     private static final String FOOTER_LOG_NAMESPACE = "devui-footer-log";
     private static final String DEVUI = "dev-ui";
+    private static final String UNDERSCORE = "_";
     private static final String SLASH = "/";
-    private static final String DOT = ".";
     private static final String SLASH_ALL = SLASH + "*";
     private static final String JSONRPC = "json-rpc-ws";
 
@@ -142,6 +158,7 @@ public class DevUIProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     void registerDevUiHandlers(
             DevUIConfig devUIConfig,
+            BeanContainerBuildItem beanContainer,
             MvnpmBuildItem mvnpmBuildItem,
             List<DevUIRoutesBuildItem> devUIRoutesBuildItems,
             List<StaticContentBuildItem> staticContentBuildItems,
@@ -172,7 +189,7 @@ public class DevUIProcessor {
         routeProducer.produce(
                 nonApplicationRootPathBuildItem
                         .routeBuilder().route(DEVUI + SLASH + JSONRPC)
-                        .handler(recorder.communicationHandler())
+                        .handler(recorder.devUIWebSocketHandler())
                         .build());
 
         // Static handler for components
@@ -207,7 +224,7 @@ public class DevUIProcessor {
         for (StaticContentBuildItem staticContentBuildItem : staticContentBuildItems) {
 
             Map<String, String> urlAndPath = new HashMap<>();
-
+            Map<String, String> descriptions = new HashMap<>();
             List<DevUIContent> content = staticContentBuildItem.getContent();
             for (DevUIContent c : content) {
                 String parsedContent = Qute.fmt(new String(c.getTemplate()), c.getData());
@@ -216,8 +233,12 @@ public class DevUIProcessor {
                 Files.writeString(tempFile, parsedContent);
 
                 urlAndPath.put(c.getFileName(), tempFile.toString());
+                if (c.getDescriptions() != null && !c.getDescriptions().isEmpty()) {
+                    descriptions.putAll(c.getDescriptions());
+                }
             }
-            Handler<RoutingContext> buildTimeStaticHandler = recorder.buildTimeStaticHandler(basepath, urlAndPath);
+            Handler<RoutingContext> buildTimeStaticHandler = recorder.buildTimeStaticHandler(beanContainer.getValue(), basepath,
+                    urlAndPath, descriptions);
 
             routeProducer.produce(
                     nonApplicationRootPathBuildItem.routeBuilder().route(DEVUI + SLASH_ALL)
@@ -258,16 +279,16 @@ public class DevUIProcessor {
         // Redirect naked to welcome if there is no index.html
         if (!hasOwnIndexHtml()) {
             routeProducer.produce(httpRootPathBuildItem.routeBuilder()
-                    .orderedRoute("/", Integer.MAX_VALUE)
+                    .orderedRoute(SLASH, Integer.MAX_VALUE)
                     .handler(recorder.redirect(contextRoot, "welcome"))
                     .build());
         }
     }
 
     private boolean hasOwnIndexHtml() {
-        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         try {
-            Enumeration<URL> jarsWithIndexHtml = tccl.getResources("META-INF/resources/index.html");
+            Enumeration<URL> jarsWithIndexHtml = Thread.currentThread().getContextClassLoader()
+                    .getResources("META-INF/resources/index.html");
             return jarsWithIndexHtml.hasMoreElements();
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
@@ -275,7 +296,8 @@ public class DevUIProcessor {
     }
 
     /**
-     * This makes sure the JsonRPC Classes for both the internal Dev UI and extensions is available as a bean and on the index.
+     * This makes sure the Runtime JsonRPC Classes for both the internal Dev UI and extensions is available as a bean and on the
+     * index.
      */
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     void additionalBean(BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer,
@@ -283,7 +305,6 @@ public class DevUIProcessor {
             List<JsonRPCProvidersBuildItem> jsonRPCProvidersBuildItems) {
 
         additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClass(JsonRpcRouter.class)
                 .addBeanClass(VertxRouteInfoService.class)
                 .setUnremovable().build());
 
@@ -307,6 +328,10 @@ public class DevUIProcessor {
                 .setDefaultScope(BuiltinScope.APPLICATION.getName())
                 .setUnremovable().build());
 
+        additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClass(DevUIBuildTimeStaticService.class)
+                .setDefaultScope(BuiltinScope.APPLICATION.getName())
+                .setUnremovable().build());
     }
 
     /**
@@ -327,92 +352,122 @@ public class DevUIProcessor {
 
         IndexView index = combinedIndexBuildItem.getIndex();
 
-        Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> extensionMethodsMap = new HashMap<>(); // All methods so that we can build the reflection
-
-        List<String> requestResponseMethods = new ArrayList<>(); // All requestResponse methods for validation on the client side
-        List<String> subscriptionMethods = new ArrayList<>(); // All subscription methods for validation on the client side
+        Map<String, RuntimeJsonRpcMethod> runtimeMethodsMap = new HashMap<>();// All methods to execute against the runtime classpath
+        Map<String, RuntimeJsonRpcMethod> runtimeSubscriptionsMap = new HashMap<>();// All subscriptions to execute against the runtime classpath
 
         // Let's use the Jandex index to find all methods
         for (JsonRPCProvidersBuildItem jsonRPCProvidersBuildItem : jsonRPCProvidersBuildItems) {
 
             Class clazz = jsonRPCProvidersBuildItem.getJsonRPCMethodProviderClass();
             String extension = jsonRPCProvidersBuildItem.getExtensionPathName(curateOutcomeBuildItem);
-            Map<JsonRpcMethodName, JsonRpcMethod> jsonRpcMethods = new HashMap<>();
-            if (extensionMethodsMap.containsKey(extension)) {
-                jsonRpcMethods = extensionMethodsMap.get(extension);
-            }
 
             ClassInfo classInfo = index.getClassByName(DotName.createSimple(clazz.getName()));
+            if (classInfo != null) {// skip if not found
+                for (MethodInfo method : classInfo.methods()) {
+                    // Ignore constructor, Only allow public methods, Only allow method with response
+                    if (!method.name().equals(CONSTRUCTOR) && Modifier.isPublic(method.flags())
+                            && method.returnType().kind() != Type.Kind.VOID) {
 
-            List<MethodInfo> methods = classInfo.methods();
+                        String methodName = extension + UNDERSCORE + method.name();
 
-            for (MethodInfo method : methods) {
-                if (!method.name().equals(CONSTRUCTOR)) { // Ignore constructor
-                    if (Modifier.isPublic(method.flags())) { // Only allow public methods
-                        if (method.returnType().kind() != Type.Kind.VOID) { // Only allow method with response
+                        Map<String, AbstractJsonRpcMethod.Parameter> parameters = new LinkedHashMap<>(); // Keep the order
+                        for (int i = 0; i < method.parametersCount(); i++) {
+                            Type parameterType = method.parameterType(i);
+                            Class<?> parameterClass = toClass(parameterType);
+                            String parameterName = method.parameterName(i);
+                            parameters.put(parameterName, new AbstractJsonRpcMethod.Parameter(parameterClass, null)); // TODO: description
+                        }
 
-                            // Create list of available methods for the Javascript side.
-                            if (method.returnType().name().equals(DotName.createSimple(Multi.class.getName()))) {
-                                subscriptionMethods.add(extension + DOT + method.name());
-                            } else {
-                                requestResponseMethods.add(extension + DOT + method.name());
-                            }
+                        // Look for @JsonRpcUsage annotation
+                        EnumSet<Usage> usage = EnumSet.noneOf(Usage.class);
+                        AnnotationInstance jsonRpcUsageAnnotation = method.annotation(DotName.createSimple(JsonRpcUsage.class));
+                        if (jsonRpcUsageAnnotation != null) {
+                            AnnotationInstance[] usageArray = jsonRpcUsageAnnotation.value().asNestedArray();
 
-                            // Also create the map to pass to the runtime for the relection calls
-                            JsonRpcMethodName jsonRpcMethodName = new JsonRpcMethodName(method.name());
-                            if (method.parametersCount() > 0) {
-                                Map<String, Class> params = new LinkedHashMap<>(); // Keep the order
-                                for (int i = 0; i < method.parametersCount(); i++) {
-                                    Type parameterType = method.parameterType(i);
-                                    Class parameterClass = toClass(parameterType);
-                                    String parameterName = method.parameterName(i);
-                                    params.put(parameterName, parameterClass);
-                                }
-                                JsonRpcMethod jsonRpcMethod = new JsonRpcMethod(clazz, method.name(), params);
-                                jsonRpcMethod.setExplicitlyBlocking(method.hasAnnotation(Blocking.class));
-                                jsonRpcMethod
-                                        .setExplicitlyNonBlocking(method.hasAnnotation(NonBlocking.class));
-                                jsonRpcMethods.put(jsonRpcMethodName, jsonRpcMethod);
-                            } else {
-                                JsonRpcMethod jsonRpcMethod = new JsonRpcMethod(clazz, method.name(), null);
-                                jsonRpcMethod.setExplicitlyBlocking(method.hasAnnotation(Blocking.class));
-                                jsonRpcMethod
-                                        .setExplicitlyNonBlocking(method.hasAnnotation(NonBlocking.class));
-                                jsonRpcMethods.put(jsonRpcMethodName, jsonRpcMethod);
+                            for (AnnotationInstance usageInstance : usageArray) {
+                                String usageStr = usageInstance.value().asEnum();
+                                usage.add(Usage.valueOf(usageStr));
                             }
                         }
+
+                        // Look for @JsonRpcDescription annotation
+                        String description = null;
+                        AnnotationInstance jsonRpcDescriptionAnnotation = method
+                                .annotation(DotName.createSimple(JsonRpcDescription.class));
+                        if (jsonRpcDescriptionAnnotation != null) {
+                            AnnotationValue descriptionValue = jsonRpcDescriptionAnnotation.value();
+                            if (descriptionValue != null && !descriptionValue.asString().isBlank()) {
+                                description = descriptionValue.asString();
+                                usage = Usage.devUIandDevMCP();
+                            }
+                        } else {
+                            usage = Usage.onlyDevUI();
+                        }
+
+                        RuntimeJsonRpcMethod runtimeJsonRpcMethod = new RuntimeJsonRpcMethod(methodName, description,
+                                parameters,
+                                usage, clazz,
+                                method.hasAnnotation(Blocking.class), method.hasAnnotation(NonBlocking.class));
+
+                        // Create list of available methods for the Javascript side.
+                        if (method.returnType().name().equals(DotName.createSimple(Multi.class.getName()))) {
+                            runtimeSubscriptionsMap.put(methodName, runtimeJsonRpcMethod);
+                        } else {
+                            runtimeMethodsMap.put(methodName, runtimeJsonRpcMethod);
+                        }
+
                     }
                 }
             }
-
-            if (!jsonRpcMethods.isEmpty()) {
-                extensionMethodsMap.put(extension, jsonRpcMethods);
-            }
         }
 
-        if (deploymentMethodBuildItem.hasMethods()) {
-            requestResponseMethods.addAll(deploymentMethodBuildItem.getMethods());
-        }
+        jsonRPCMethodsProvider.produce(new JsonRPCRuntimeMethodsBuildItem(runtimeMethodsMap, runtimeSubscriptionsMap));
 
-        if (deploymentMethodBuildItem.hasSubscriptions()) {
-            subscriptionMethods.addAll(deploymentMethodBuildItem.getSubscriptions());
-        }
-
-        if (!extensionMethodsMap.isEmpty()) {
-            jsonRPCMethodsProvider.produce(new JsonRPCRuntimeMethodsBuildItem(extensionMethodsMap));
-        }
+        // Get all names for UI validation
+        Set<String> allMethodsNames = Stream
+                .<Map<String, ?>> of(runtimeMethodsMap, deploymentMethodBuildItem.getMethods(),
+                        deploymentMethodBuildItem.getRecordedMethods())
+                .flatMap(m -> m.keySet().stream())
+                .collect(Collectors.toSet());
+        Set<String> allSubscriptionNames = Stream
+                .<Map<String, ?>> of(runtimeSubscriptionsMap, deploymentMethodBuildItem.getSubscriptions(),
+                        deploymentMethodBuildItem.getRecordedSubscriptions())
+                .flatMap(m -> m.keySet().stream())
+                .collect(Collectors.toSet());
 
         BuildTimeConstBuildItem methodInfo = new BuildTimeConstBuildItem("devui-jsonrpc");
-
-        if (!subscriptionMethods.isEmpty()) {
-            methodInfo.addBuildTimeData("jsonRPCSubscriptions", subscriptionMethods);
+        if (!allSubscriptionNames.isEmpty()) {
+            methodInfo.addBuildTimeData("jsonRPCSubscriptions", allSubscriptionNames);
         }
-        if (!requestResponseMethods.isEmpty()) {
-            methodInfo.addBuildTimeData("jsonRPCMethods", requestResponseMethods);
+        if (!allMethodsNames.isEmpty()) {
+            methodInfo.addBuildTimeData("jsonRPCMethods", allMethodsNames);
         }
-
         buildTimeConstProducer.produce(methodInfo);
 
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<RemovedResourceBuildItem> producer,
+            List<JsonRPCProvidersBuildItem> jsonRPCProvidersBuildItems,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
+
+        List<RemovedResourceBuildItem> removedResourceBuildItems = new ArrayList<>();
+
+        for (JsonRPCProvidersBuildItem jsonRPCProvidersBuildItem : jsonRPCProvidersBuildItems) {
+
+            ArtifactKey artifactKey = jsonRPCProvidersBuildItem.getArtifactKey(curateOutcomeBuildItem);
+            if (artifactKey != null) {
+                removedResourceBuildItems.add(new RemovedResourceBuildItem(artifactKey,
+                        Set.of(jsonRPCProvidersBuildItem.getJsonRPCMethodProviderClass().getName())));
+            } else if (jsonRPCProvidersBuildItem.getJsonRPCMethodProviderClass().getName()
+                    .startsWith("io.quarkus.devui.runtime")
+                    || jsonRPCProvidersBuildItem.getJsonRPCMethodProviderClass().getName()
+                            .startsWith("io.quarkus.vertx.http.runtime")) {
+                removedResourceBuildItems.add(new RemovedResourceBuildItem(INTERNAL_KEY,
+                        Set.of(jsonRPCProvidersBuildItem.getJsonRPCMethodProviderClass().getName())));
+            }
+        }
+        producer.produce(removedResourceBuildItems);
     }
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)
@@ -423,19 +478,73 @@ public class DevUIProcessor {
             DeploymentMethodBuildItem deploymentMethodBuildItem) {
 
         if (jsonRPCMethodsBuildItem != null) {
-            Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> extensionMethodsMap = jsonRPCMethodsBuildItem
-                    .getExtensionMethodsMap();
+            Map<String, RuntimeJsonRpcMethod> runtimeMethodsMap = jsonRPCMethodsBuildItem.getRuntimeMethodsMap();
+            Map<String, RuntimeJsonRpcMethod> runtimeSubscriptionsMap = jsonRPCMethodsBuildItem.getRuntimeSubscriptionsMap();
 
             DevConsoleManager.setGlobal(DevUIRecorder.DEV_MANAGER_GLOBALS_JSON_MAPPER_FACTORY,
                     JsonMapper.Factory.deploymentLinker().createLinkData(new DevUIDatabindCodec.Factory()));
-            recorder.createJsonRpcRouter(beanContainer.getValue(), extensionMethodsMap, deploymentMethodBuildItem.getMethods(),
-                    deploymentMethodBuildItem.getSubscriptions(), deploymentMethodBuildItem.getRecordedValues());
+
+            recorder.createJsonRpcRouter(beanContainer.getValue(),
+                    runtimeToJsonRpcMethods(runtimeMethodsMap),
+                    runtimeToJsonRpcMethods(runtimeSubscriptionsMap),
+                    deploymentToJsonRpcMethods(deploymentMethodBuildItem.getMethods()),
+                    deploymentToJsonRpcMethods(deploymentMethodBuildItem.getSubscriptions()),
+                    recordedToJsonRpcMethods(deploymentMethodBuildItem.getRecordedMethods()),
+                    recordedToJsonRpcMethods(deploymentMethodBuildItem.getRecordedSubscriptions()));
         }
     }
 
-    /**
-     * This build all the pages for dev ui, based on the extension included
-     */
+    private Map<String, JsonRpcMethod> runtimeToJsonRpcMethods(Map<String, RuntimeJsonRpcMethod> m) {
+        return mapToJsonRpcMethods(m, this::runtimeToJsonRpcMethod);
+    }
+
+    private Map<String, JsonRpcMethod> deploymentToJsonRpcMethods(Map<String, DeploymentJsonRpcMethod> m) {
+        return mapToJsonRpcMethods(m, this::toJsonRpcMethod);
+    }
+
+    private Map<String, JsonRpcMethod> recordedToJsonRpcMethods(Map<String, RecordedJsonRpcMethod> m) {
+        return mapToJsonRpcMethods(m, this::recordedToJsonRpcMethod);
+    }
+
+    private <T extends AbstractJsonRpcMethod> Map<String, JsonRpcMethod> mapToJsonRpcMethods(
+            Map<String, T> input,
+            Function<T, JsonRpcMethod> converter) {
+
+        return input.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> converter.apply(e.getValue())));
+    }
+
+    private JsonRpcMethod runtimeToJsonRpcMethod(RuntimeJsonRpcMethod i) {
+        JsonRpcMethod o = toJsonRpcMethod(i);
+
+        o.setBean(i.getBean());
+        o.setIsExplicitlyBlocking(i.isExplicitlyBlocking());
+        o.setIsExplicitlyNonBlocking(i.isExplicitlyNonBlocking());
+
+        return o;
+    }
+
+    private JsonRpcMethod recordedToJsonRpcMethod(RecordedJsonRpcMethod i) {
+        JsonRpcMethod o = toJsonRpcMethod(i);
+        o.setRuntimeValue(i.getRuntimeValue());
+        return o;
+    }
+
+    private JsonRpcMethod toJsonRpcMethod(AbstractJsonRpcMethod i) {
+        JsonRpcMethod o = new JsonRpcMethod();
+
+        o.setMethodName(i.getMethodName());
+        o.setDescription(i.getDescription());
+        o.setUsage(List.copyOf(i.getUsage()));
+        if (i.hasParameters()) {
+            for (Map.Entry<String, AbstractJsonRpcMethod.Parameter> ip : i.getParameters().entrySet()) {
+                o.addParameter(ip.getKey(), ip.getValue().getType(), ip.getValue().getDescription());
+            }
+        }
+
+        return o;
+    }
+
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     void processFooterLogs(BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
             BuildProducer<FooterPageBuildItem> footerPageProducer,
@@ -450,27 +559,35 @@ public class DevUIProcessor {
 
             BuildTimeActionBuildItem devServiceLogActions = new BuildTimeActionBuildItem(FOOTER_LOG_NAMESPACE);
             if (footerLogBuildItem.hasRuntimePublisher()) {
-                devServiceLogActions.addSubscription(name + "Log", footerLogBuildItem.getRuntimePublisher());
+                devServiceLogActions.subscriptionBuilder()
+                        .methodName(name + "Log")
+                        .description("Streams the " + name + " log")
+                        .runtime(footerLogBuildItem.getRuntimePublisher())
+                        .build();
             } else {
-                devServiceLogActions.addSubscription(name + "Log", ignored -> {
-                    try {
-                        return footerLogBuildItem.getPublisher();
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+                devServiceLogActions.subscriptionBuilder()
+                        .methodName(name + "Log")
+                        .description("Streams the " + name + " log")
+                        .function(ignored -> {
+                            try {
+                                return footerLogBuildItem.getPublisher();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .build();
             }
             devServiceLogs.add(devServiceLogActions);
 
             // Create the Footer in the Dev UI
-            WebComponentPageBuilder log = Page.webComponentPageBuilder().internal()
+            WebComponentPageBuilder footerLogComponent = Page.webComponentPageBuilder().internal()
                     .namespace(FOOTER_LOG_NAMESPACE)
                     .icon("font-awesome-regular:file-lines")
                     .title(capitalizeFirstLetter(footerLogBuildItem.getName()))
                     .metadata("jsonRpcMethodName", footerLogBuildItem.getName() + "Log")
                     .componentLink("qwc-footer-log.js");
 
-            FooterPageBuildItem footerPageBuildItem = new FooterPageBuildItem(FOOTER_LOG_NAMESPACE, log);
+            FooterPageBuildItem footerPageBuildItem = new FooterPageBuildItem(FOOTER_LOG_NAMESPACE, footerLogComponent);
             footers.add(footerPageBuildItem);
         }
 
@@ -606,7 +723,7 @@ public class DevUIProcessor {
                                     // Add all card links
                                     List<PageBuilder> cardPageBuilders = cardPageBuildItem.getPages();
 
-                                    Map<String, Object> buildTimeData = cardPageBuildItem.getBuildTimeData();
+                                    Map<String, BuildTimeData> buildTimeData = cardPageBuildItem.getBuildTimeData();
                                     for (PageBuilder pageBuilder : cardPageBuilders) {
                                         Page page = buildFinalPage(pageBuilder, extension, buildTimeData);
                                         if (!page.isAssistantPage() || assistantIsAvailable) {
@@ -649,7 +766,7 @@ public class DevUIProcessor {
                                     MenuPageBuildItem menuPageBuildItem = menuPagesMap.get(namespace);
                                     List<PageBuilder> menuPageBuilders = menuPageBuildItem.getPages();
 
-                                    Map<String, Object> buildTimeData = menuPageBuildItem.getBuildTimeData();
+                                    Map<String, BuildTimeData> buildTimeData = menuPageBuildItem.getBuildTimeData();
                                     for (PageBuilder pageBuilder : menuPageBuilders) {
                                         Page page = buildFinalPage(pageBuilder, extension, buildTimeData);
                                         if (!page.isAssistantPage() || assistantIsAvailable) {
@@ -664,11 +781,11 @@ public class DevUIProcessor {
                                 // Tabs in the footer
                                 if (footerPagesMap.containsKey(namespace)) {
 
-                                    List<FooterPageBuildItem> fbis = footerPagesMap.get(namespace);
+                                    List<FooterPageBuildItem> fbis = footerPagesMap.remove(namespace);
                                     for (FooterPageBuildItem footerPageBuildItem : fbis) {
                                         List<PageBuilder> footerPageBuilders = footerPageBuildItem.getPages();
 
-                                        Map<String, Object> buildTimeData = footerPageBuildItem.getBuildTimeData();
+                                        Map<String, BuildTimeData> buildTimeData = footerPageBuildItem.getBuildTimeData();
                                         for (PageBuilder pageBuilder : footerPageBuilders) {
                                             Page page = buildFinalPage(pageBuilder, extension, buildTimeData);
                                             if (!page.isAssistantPage() || assistantIsAvailable) {
@@ -698,23 +815,22 @@ public class DevUIProcessor {
             for (Map.Entry<String, List<FooterPageBuildItem>> footer : footerPagesMap.entrySet()) {
                 List<FooterPageBuildItem> fbis = footer.getValue();
                 for (FooterPageBuildItem footerPageBuildItem : fbis) {
-                    if (footerPageBuildItem.isInternal()) {
-                        Extension deploymentOnlyExtension = new Extension();
-                        deploymentOnlyExtension.setName(footer.getKey());
-                        deploymentOnlyExtension.setNamespace(FOOTER_LOG_NAMESPACE);
 
-                        List<PageBuilder> footerPageBuilders = footerPageBuildItem.getPages();
+                    Extension deploymentOnlyExtension = new Extension();
+                    deploymentOnlyExtension.setName(footer.getKey());
+                    deploymentOnlyExtension.setNamespace(FOOTER_LOG_NAMESPACE);
 
-                        for (PageBuilder pageBuilder : footerPageBuilders) {
-                            pageBuilder.namespace(deploymentOnlyExtension.getNamespace());
-                            pageBuilder.extension(deploymentOnlyExtension.getName());
-                            pageBuilder.internal();
-                            Page page = pageBuilder.build();
-                            deploymentOnlyExtension.addFooterPage(page);
-                        }
+                    List<PageBuilder> footerPageBuilders = footerPageBuildItem.getPages();
 
-                        footerTabExtensions.add(deploymentOnlyExtension);
+                    for (PageBuilder pageBuilder : footerPageBuilders) {
+                        pageBuilder.namespace(deploymentOnlyExtension.getNamespace());
+                        pageBuilder.extension(deploymentOnlyExtension.getName());
+                        pageBuilder.internal();
+                        Page page = pageBuilder.build();
+                        deploymentOnlyExtension.addFooterPage(page);
                     }
+
+                    footerTabExtensions.add(deploymentOnlyExtension);
                 }
             }
         }
@@ -903,27 +1019,31 @@ public class DevUIProcessor {
         return namespace;
     }
 
-    private Page buildFinalPage(PageBuilder pageBuilder, Extension extension, Map<String, Object> buildTimeData) {
+    private Page buildFinalPage(PageBuilder pageBuilder, Extension extension, Map<String, BuildTimeData> buildTimeData) {
         pageBuilder.namespace(extension.getNamespace());
         pageBuilder.extension(extension.getName());
 
         // TODO: Have a nice factory way to load this...
         // Some preprocessing for certain builds
         if (pageBuilder.getClass().equals(QuteDataPageBuilder.class)) {
-            return buildQutePage(pageBuilder, extension, buildTimeData);
+            return buildQutePage(pageBuilder, buildTimeData);
         }
 
         return pageBuilder.build();
     }
 
-    private Page buildQutePage(PageBuilder pageBuilder, Extension extension, Map<String, Object> buildTimeData) {
+    private Page buildQutePage(PageBuilder pageBuilder, Map<String, BuildTimeData> buildTimeData) {
         try {
             QuteDataPageBuilder quteDataPageBuilder = (QuteDataPageBuilder) pageBuilder;
             String templatePath = quteDataPageBuilder.getTemplatePath();
             ClassPathUtils.consumeAsPaths(templatePath, p -> {
                 try {
                     String template = Files.readString(p);
-                    String fragment = Qute.fmt(template, buildTimeData);
+                    Map<String, Object> contentMap = buildTimeData.entrySet().stream()
+                            .collect(Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    e -> e.getValue().getContent()));
+                    String fragment = Qute.fmt(template, contentMap);
                     pageBuilder.metadata("htmlFragment", fragment);
                 } catch (IOException ex) {
                     throw new UncheckedIOException(ex);
@@ -972,7 +1092,6 @@ public class DevUIProcessor {
             List<FooterPageBuildItem> pages) {
         Map<String, List<FooterPageBuildItem>> m = new HashMap<>();
         for (FooterPageBuildItem pageBuildItem : pages) {
-
             String key = pageBuildItem.getExtensionPathName(curateOutcomeBuildItem);
             if (m.containsKey(key)) {
                 m.get(key).add(pageBuildItem);
@@ -1019,4 +1138,6 @@ public class DevUIProcessor {
             }
         }
     };
+
+    private static final ArtifactKey INTERNAL_KEY = ArtifactKey.ga("io.quarkus", "quarkus-vertx-http");
 }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.devui.spi.buildtime.BuildTimeData;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.page.PageBuilder;
 
@@ -17,7 +18,7 @@ public final class InternalPageBuildItem extends MultiBuildItem {
     private final String namespaceLabel;
     private final int position;
     private final List<Page> pages = new ArrayList<>();
-    private final Map<String, Object> buildTimeData = new HashMap<>();
+    private final Map<String, BuildTimeData> buildTimeData = new HashMap<>();
     private final String menuActionComponent;
     private String headlessComponentLink = null;
 
@@ -37,7 +38,11 @@ public final class InternalPageBuildItem extends MultiBuildItem {
     }
 
     public void addBuildTimeData(String key, Object value) {
-        this.buildTimeData.put(key, value);
+        this.addBuildTimeData(key, value, null);
+    }
+
+    public void addBuildTimeData(String key, Object value, String description) {
+        this.buildTimeData.put(key, new BuildTimeData(value, description));
     }
 
     public List<Page> getPages() {
@@ -56,7 +61,7 @@ public final class InternalPageBuildItem extends MultiBuildItem {
         return namespaceLabel;
     }
 
-    public Map<String, Object> getBuildTimeData() {
+    public Map<String, BuildTimeData> getBuildTimeData() {
         return buildTimeData;
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/JsonRPCRuntimeMethodsBuildItem.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/JsonRPCRuntimeMethodsBuildItem.java
@@ -3,21 +3,27 @@ package io.quarkus.devui.deployment;
 import java.util.Map;
 
 import io.quarkus.builder.item.SimpleBuildItem;
-import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
-import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethodName;
+import io.quarkus.devui.spi.buildtime.jsonrpc.RuntimeJsonRpcMethod;
 
 /**
- * Simple holder for all discovered Json RPC Methods
+ * Simple holder for all discovered Json RPC Runtime Endpoints
  */
 public final class JsonRPCRuntimeMethodsBuildItem extends SimpleBuildItem {
 
-    private final Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> extensionMethodsMap;
+    private final Map<String, RuntimeJsonRpcMethod> runtimeMethodsMap;
+    private final Map<String, RuntimeJsonRpcMethod> runtimeSubscriptionsMap;
 
-    public JsonRPCRuntimeMethodsBuildItem(Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> extensionMethodsMap) {
-        this.extensionMethodsMap = extensionMethodsMap;
+    public JsonRPCRuntimeMethodsBuildItem(Map<String, RuntimeJsonRpcMethod> runtimeMethodsMap,
+            Map<String, RuntimeJsonRpcMethod> runtimeSubscriptionsMap) {
+        this.runtimeMethodsMap = runtimeMethodsMap;
+        this.runtimeSubscriptionsMap = runtimeSubscriptionsMap;
     }
 
-    public Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> getExtensionMethodsMap() {
-        return extensionMethodsMap;
+    public Map<String, RuntimeJsonRpcMethod> getRuntimeMethodsMap() {
+        return runtimeMethodsMap;
+    }
+
+    public Map<String, RuntimeJsonRpcMethod> getRuntimeSubscriptionsMap() {
+        return runtimeSubscriptionsMap;
     }
 }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/ide/IdeProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/ide/IdeProcessor.java
@@ -48,21 +48,28 @@ public class IdeProcessor {
                 // For Dev UI (like from the server log)
                 BuildTimeActionBuildItem ideActions = new BuildTimeActionBuildItem(NAMESPACE);
 
-                ideActions.addAction("open", map -> {
-                    String fileName = map.get("fileName");
-                    String lang = map.get("lang");
-                    String lineNumber = map.get("lineNumber");
+                ideActions.actionBuilder()
+                        .methodName("open")
+                        .description("Opens a certain workspace item in the user's IDE")
+                        .parameter("fileName", "The filename that should be opened")
+                        .parameter("lang", "The language of that file, example java or js")
+                        .parameter("lineNumber", "The lineNumber where the cursor should be in the IDE. Use 0 if unknown")
+                        .function(map -> {
+                            String fileName = map.get("fileName");
+                            String lang = map.get("lang");
+                            String lineNumber = map.get("lineNumber");
 
-                    if (fileName != null && fileName.startsWith(FILE_PROTOCOL)) {
-                        fileName = fileName.substring(FILE_PROTOCOL.length());
-                        return typicalProcessLaunch(fileName, lineNumber, ide);
-                    } else {
-                        if (isNullOrEmpty(fileName) || isNullOrEmpty(lang)) {
-                            return false;
-                        }
-                        return typicalProcessLaunch(fileName, lang, lineNumber, ide);
-                    }
-                });
+                            if (fileName != null && fileName.startsWith(FILE_PROTOCOL)) {
+                                fileName = fileName.substring(FILE_PROTOCOL.length());
+                                return typicalProcessLaunch(fileName, lineNumber, ide);
+                            } else {
+                                if (isNullOrEmpty(fileName) || isNullOrEmpty(lang)) {
+                                    return false;
+                                }
+                                return typicalProcessLaunch(fileName, lang, lineNumber, ide);
+                            }
+                        })
+                        .build();
 
                 buildTimeActionProducer.produce(ideActions);
             }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
@@ -55,79 +55,107 @@ public class LogStreamProcessor {
 
         BuildTimeActionBuildItem keyStrokeActions = new BuildTimeActionBuildItem(namespace);
 
-        keyStrokeActions.addAction("forceRestart", ignored -> {
-            RuntimeUpdatesProcessor.INSTANCE.doScan(true, true);
-            return Map.of();
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("forceRestart")
+                .description("This force a Quarkus application restart (like pressing 's' in the console)")
+                .function(ignored -> {
+                    RuntimeUpdatesProcessor.INSTANCE.doScan(true, true);
+                    return Map.of();
+                })
+                .build();
 
-        keyStrokeActions.addAction("rerunAllTests", ignored -> {
-            if (testsDisabled(launchModeBuildItem, ts)) {
-                return Map.of();
-            }
-            if (ts.get().isStarted()) {
-                ts.get().runAllTests();
-                return Map.of();
-            } else {
-                ts.get().start();
-                return Map.of("running", ts.get().isRunning());
-            }
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("rerunAllTests")
+                .function(ignored -> {
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return Map.of();
+                    }
+                    if (ts.get().isStarted()) {
+                        ts.get().runAllTests();
+                        return Map.of();
+                    } else {
+                        ts.get().start();
+                        return Map.of("running", ts.get().isRunning());
+                    }
+                })
+                .build();
 
-        keyStrokeActions.addAction("rerunFailedTests", ignored -> {
-            if (testsDisabled(launchModeBuildItem, ts)) {
-                return Map.of();
-            }
-            ts.get().runFailedTests();
-            return Map.of();
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("rerunFailedTests")
+                .function(ignored -> {
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return Map.of();
+                    }
+                    ts.get().runFailedTests();
+                    return Map.of();
+                })
+                .build();
 
-        keyStrokeActions.addAction("toggleBrokenOnly", ignored -> {
-            if (testsDisabled(launchModeBuildItem, ts)) {
-                return Map.of();
-            }
-            boolean brokenOnlyMode = ts.get().toggleBrokenOnlyMode();
-            return Map.of("brokenOnlyMode", brokenOnlyMode);
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("toggleBrokenOnly")
+                .function(ignored -> {
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return Map.of();
+                    }
+                    boolean brokenOnlyMode = ts.get().toggleBrokenOnlyMode();
+                    return Map.of("brokenOnlyMode", brokenOnlyMode);
+                })
+                .build();
 
-        keyStrokeActions.addAction("printFailures", ignored -> {
-            if (testsDisabled(launchModeBuildItem, ts)) {
-                return Map.of();
-            }
-            ts.get().printFullResults();
-            return Map.of();
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("printFailures")
+                .function(ignored -> {
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return Map.of();
+                    }
+                    ts.get().printFullResults();
+                    return Map.of();
+                })
+                .build();
 
-        keyStrokeActions.addAction("toggleTestOutput", ignored -> {
-            if (testsDisabled(launchModeBuildItem, ts)) {
-                return Map.of();
-            }
-            boolean isTestOutput = ts.get().toggleTestOutput();
-            return Map.of("isTestOutput", isTestOutput);
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("toggleTestOutput")
+                .function(ignored -> {
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return Map.of();
+                    }
+                    boolean isTestOutput = ts.get().toggleTestOutput();
+                    return Map.of("isTestOutput", isTestOutput);
+                })
+                .build();
 
-        keyStrokeActions.addAction("toggleInstrumentationReload", ignored -> {
-            boolean instrumentationEnabled = RuntimeUpdatesProcessor.INSTANCE.toggleInstrumentation();
-            return Map.of("instrumentationEnabled", instrumentationEnabled);
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("toggleInstrumentationReload")
+                .function(ignored -> {
+                    boolean instrumentationEnabled = RuntimeUpdatesProcessor.INSTANCE.toggleInstrumentation();
+                    return Map.of("instrumentationEnabled", instrumentationEnabled);
+                })
+                .build();
 
-        keyStrokeActions.addAction("pauseTests", ignored -> {
-            if (testsDisabled(launchModeBuildItem, ts)) {
-                return Map.of();
-            }
-            if (ts.get().isStarted()) {
-                ts.get().stop();
-                return Map.of("running", ts.get().isRunning());
-            }
-            return Map.of();
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("pauseTests")
+                .function(ignored -> {
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return Map.of();
+                    }
+                    if (ts.get().isStarted()) {
+                        ts.get().stop();
+                        return Map.of("running", ts.get().isRunning());
+                    }
+                    return Map.of();
+                })
+                .build();
 
-        keyStrokeActions.addAction("toggleLiveReload", ignored -> {
-            if (testsDisabled(launchModeBuildItem, ts)) {
-                return Map.of();
-            }
-            boolean liveReloadEnabled = ts.get().toggleLiveReloadEnabled();
-            return Map.of("liveReloadEnabled", liveReloadEnabled);
-        });
+        keyStrokeActions.actionBuilder()
+                .methodName("toggleLiveReload")
+                .function(ignored -> {
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return Map.of();
+                    }
+                    boolean liveReloadEnabled = ts.get().toggleLiveReloadEnabled();
+                    return Map.of("liveReloadEnabled", liveReloadEnabled);
+                })
+                .build();
 
         buildTimeActionProducer.produce(keyStrokeActions);
     }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/BuildMetricsProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/BuildMetricsProcessor.java
@@ -1,16 +1,26 @@
 package io.quarkus.devui.deployment.menu;
 
+import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
+import io.quarkus.devui.runtime.build.BuildMetricsDevUIRecorder;
+import io.quarkus.devui.runtime.build.BuildMetricsJsonRPCService;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
 /**
  * This creates Build Metrics Page
  */
+@BuildSteps(onlyIf = { IsLocalDevelopment.class })
 public class BuildMetricsProcessor {
 
-    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    @BuildStep
     InternalPageBuildItem createBuildMetricsPages() {
 
         InternalPageBuildItem buildMetricsPages = new InternalPageBuildItem("Build Metrics", 50);
@@ -28,5 +38,27 @@ public class BuildMetricsProcessor {
                 .componentLink("qwc-build-items.js"));
 
         return buildMetricsPages;
+    }
+
+    @BuildStep
+    @io.quarkus.deployment.annotations.Record(RUNTIME_INIT)
+    public void create(BuildMetricsDevUIRecorder recorder,
+            BuildSystemTargetBuildItem buildSystemTarget) {
+        recorder.setBuildMetricsPath(buildSystemTarget.getOutputDirectory().resolve("build-metrics.json").toString());
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem additionalBeans() {
+        return AdditionalBeanBuildItem
+                .builder()
+                .addBeanClass(BuildMetricsJsonRPCService.class)
+                .setUnremovable()
+                .setDefaultScope(DotNames.APPLICATION_SCOPED)
+                .build();
+    }
+
+    @BuildStep
+    JsonRPCProvidersBuildItem createJsonRPCService() {
+        return new JsonRPCProvidersBuildItem("devui-build-metrics", BuildMetricsJsonRPCService.class);
     }
 }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -16,7 +16,6 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.dev.testing.TestRunResults;
 import io.quarkus.deployment.dev.testing.TestSupport;
 import io.quarkus.dev.spi.DevModeType;
-import io.quarkus.dev.testing.results.TestRunResultsInterface;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.runtime.continuoustesting.ContinuousTestingJsonRPCService;
 import io.quarkus.devui.runtime.continuoustesting.ContinuousTestingRecorder;
@@ -92,174 +91,200 @@ public class ContinuousTestingProcessor {
     }
 
     private void registerStartMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.addAction("start", ignored -> {
+        actions.actionBuilder()
+                .methodName("start")
+                .description("Start the Continuous Testing")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return false;
+                        }
+                        TestSupport testSupport = ts.get();
 
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return false;
-                }
-                TestSupport testSupport = ts.get();
-
-                if (testSupport.isStarted()) {
-                    return false; // Already running
-                } else {
-                    testSupport.start();
-                    return true;
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+                        if (testSupport.isStarted()) {
+                            return false; // Already running
+                        } else {
+                            testSupport.start();
+                            return true;
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private void registerStopMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.addAction("stop", ignored -> {
+        actions.actionBuilder()
+                .methodName("stop")
+                .description("Stop the Continuous Testing")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return false;
+                        }
+                        TestSupport testSupport = ts.get();
 
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return false;
-                }
-                TestSupport testSupport = ts.get();
-
-                if (testSupport.isStarted()) {
-                    testSupport.stop();
-                    return true;
-                } else {
-                    return false; // Already running
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+                        if (testSupport.isStarted()) {
+                            testSupport.stop();
+                            return true;
+                        } else {
+                            return false; // Already running
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private void registerRunAllMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.addAction("runAll", ignored -> {
-
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return false;
-                }
-                TestSupport testSupport = ts.get();
-                testSupport.runAllTests();
-                return true;
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        actions.actionBuilder()
+                .methodName("runAll")
+                .description("Run all tests in Continuous Testing if it's started")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return false;
+                        }
+                        TestSupport testSupport = ts.get();
+                        testSupport.runAllTests();
+                        return true;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private void registerRunFailedMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.addAction("runFailed", ignored -> {
-
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return false;
-                }
-                TestSupport testSupport = ts.get();
-                testSupport.runFailedTests();
-                return true;
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        actions.actionBuilder()
+                .methodName("runFailed")
+                .description("Run all failed tests in Continuous Testing if it's started")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return false;
+                        }
+                        TestSupport testSupport = ts.get();
+                        testSupport.runFailedTests();
+                        return true;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private void registerToggleBrokenOnlyMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.addAction("toggleBrokenOnly", ignored -> {
-
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return false;
-                }
-                TestSupport testSupport = ts.get();
-                return testSupport.toggleBrokenOnlyMode();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        actions.actionBuilder()
+                .methodName("toggleBrokenOnly")
+                .description("Toggle broken only in Continuous Testing")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return false;
+                        }
+                        TestSupport testSupport = ts.get();
+                        return testSupport.toggleBrokenOnlyMode();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private void registerToggleInstrumentationMethod(LaunchModeBuildItem launchModeBuildItem,
             BuildTimeActionBuildItem actions) {
-        actions.addAction("toggleInstrumentation", ignored -> {
-
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return false;
-                }
-                TestSupport testSupport = ts.get();
-                return testSupport.toggleInstrumentation();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        actions.actionBuilder()
+                .methodName("toggleInstrumentation")
+                .description("Toggle instrumentation in Continuous Testing")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return false;
+                        }
+                        TestSupport testSupport = ts.get();
+                        return testSupport.toggleInstrumentation();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private void registerGetStatusMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.addAction("getStatus", ignored -> {
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return null;
-                }
-                TestSupport testSupport = ts.get();
-                TestSupport.RunStatus status = testSupport.getStatus();
+        actions.actionBuilder()
+                .methodName("getStatus")
+                .description("Get the status of Continuous Testing")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return null;
+                        }
+                        TestSupport testSupport = ts.get();
+                        TestSupport.RunStatus status = testSupport.getStatus();
 
-                if (status == null) {
-                    return null;
-                }
+                        if (status == null) {
+                            return null;
+                        }
 
-                Map<String, Long> testStatus = new HashMap<>();
+                        Map<String, Long> testStatus = new HashMap<>();
 
-                long lastRun = status.getLastRun();
-                testStatus.put("lastRun", lastRun);
-                if (lastRun > 0) {
-                    TestRunResults result = testSupport.getResults();
-                    testStatus.put("testsFailed", result.getCurrentFailedCount());
-                    testStatus.put("testsPassed", result.getCurrentPassedCount());
-                    testStatus.put("testsSkipped", result.getCurrentSkippedCount());
-                    testStatus.put("testsRun", result.getFailedCount() + result.getPassedCount());
-                    testStatus.put("totalTestsFailed", result.getFailedCount());
-                    testStatus.put("totalTestsPassed", result.getPassedCount());
-                    testStatus.put("totalTestsSkipped", result.getSkippedCount());
-                }
-                //get running last, as otherwise if the test completes in the meantime you could see
-                //both running and last run being the same number
-                testStatus.put("running", status.getRunning());
-                return testStatus;
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+                        long lastRun = status.getLastRun();
+                        testStatus.put("lastRun", lastRun);
+                        if (lastRun > 0) {
+                            TestRunResults result = testSupport.getResults();
+                            testStatus.put("testsFailed", result.getCurrentFailedCount());
+                            testStatus.put("testsPassed", result.getCurrentPassedCount());
+                            testStatus.put("testsSkipped", result.getCurrentSkippedCount());
+                            testStatus.put("testsRun", result.getFailedCount() + result.getPassedCount());
+                            testStatus.put("totalTestsFailed", result.getFailedCount());
+                            testStatus.put("totalTestsPassed", result.getPassedCount());
+                            testStatus.put("totalTestsSkipped", result.getSkippedCount());
+                        }
+                        //get running last, as otherwise if the test completes in the meantime you could see
+                        //both running and last run being the same number
+                        testStatus.put("running", status.getRunning());
+                        return testStatus;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private void registerGetResultsMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.<TestRunResultsInterface> addAction("getResults", ignored -> {
-            try {
-                Optional<TestSupport> ts = TestSupport.instance();
-                if (testsDisabled(launchModeBuildItem, ts)) {
-                    return null;
-                }
-                TestSupport testSupport = ts.get();
-                TestRunResults testRunResults = testSupport.getResults();
+        actions.actionBuilder()
+                .methodName("getResults")
+                .description("Get the results of a Continuous testing test run")
+                .function(ignored -> {
+                    try {
+                        Optional<TestSupport> ts = TestSupport.instance();
+                        if (testsDisabled(launchModeBuildItem, ts)) {
+                            return null;
+                        }
+                        TestSupport testSupport = ts.get();
+                        TestRunResults testRunResults = testSupport.getResults();
 
-                if (testRunResults == null) {
-                    return null;
-                }
+                        if (testRunResults == null) {
+                            return null;
+                        }
 
-                return testRunResults;
+                        return testRunResults;
 
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
     }
 
     private static final String NAMESPACE = "devui-continuous-testing";

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
@@ -42,7 +42,8 @@ public class DevServicesProcessor {
 
         Collection<DevServiceDescriptionBuildItem> services = getServices(devServiceDescriptions, otherDevServices);
 
-        devServicesPages.addBuildTimeData("devServices", services);
+        devServicesPages.addBuildTimeData("devServices", services,
+                "All the DevServices started by this Quarkus app, including information on container (if any) and the config that is being set automatically");
 
         if (launchModeBuildItem.getDevModeType().isPresent()
                 && launchModeBuildItem.getDevModeType().get().equals(DevModeType.LOCAL)

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
@@ -1,0 +1,89 @@
+package io.quarkus.devui.deployment.menu;
+
+import java.io.IOException;
+import java.util.List;
+
+import io.quarkus.builder.Version;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.devui.deployment.DevMCPConfig;
+import io.quarkus.devui.deployment.InternalPageBuildItem;
+import io.quarkus.devui.runtime.DevUIRecorder;
+import io.quarkus.devui.runtime.mcp.DevMcpJsonRpcService;
+import io.quarkus.devui.runtime.mcp.McpResourcesService;
+import io.quarkus.devui.runtime.mcp.McpToolsService;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devui.spi.page.Page;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+
+public class MCPProcessor {
+
+    private static final String DEVMCP = "dev-mcp";
+
+    private static final String NS_MCP = "devmcp";
+    private static final String NS_RESOURCES = "resources";
+    private static final String NS_TOOLS = "tools";
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void createMCPPage(BuildProducer<InternalPageBuildItem> internalPageProducer,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem, DevMCPConfig devMCPConfig) {
+        if (devMCPConfig.enabled()) {
+            InternalPageBuildItem mcpServerPage = new InternalPageBuildItem("Dev MCP", 80);
+
+            // Pages
+            mcpServerPage.addPage(Page.webComponentPageBuilder()
+                    .namespace(NS_MCP)
+                    .title("Info")
+                    .icon("font-awesome-solid:robot")
+                    .componentLink("qwc-dev-mcp-info.js"));
+
+            mcpServerPage.addPage(Page.webComponentPageBuilder()
+                    .namespace(NS_MCP)
+                    .title("Tools")
+                    .icon("font-awesome-solid:screwdriver-wrench")
+                    .componentLink("qwc-dev-mcp-tools.js"));
+
+            mcpServerPage.addPage(Page.webComponentPageBuilder()
+                    .namespace(NS_MCP)
+                    .title("Resources")
+                    .icon("font-awesome-solid:file-invoice")
+                    .componentLink("qwc-dev-mcp-resources.js"));
+            internalPageProducer.produce(mcpServerPage);
+        }
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    @io.quarkus.deployment.annotations.Record(ExecutionTime.STATIC_INIT)
+    void registerDevUiHandlers(
+            BuildProducer<RouteBuildItem> routeProducer,
+            DevUIRecorder recorder,
+            LaunchModeBuildItem launchModeBuildItem,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
+            DevMCPConfig devMCPConfig) throws IOException {
+
+        if (launchModeBuildItem.isNotLocalDevModeType() || !devMCPConfig.enabled()) {
+            return;
+        }
+
+        // Streamable HTTP for JsonRPC comms
+        routeProducer.produce(
+                nonApplicationRootPathBuildItem
+                        .routeBuilder().route(DEVMCP)
+                        .handler(recorder.mcpStreamableHTTPHandler(Version.getVersion()))
+                        .build());
+
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void createMCPJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> bp, DevMCPConfig devMCPConfig) {
+        if (devMCPConfig.enabled()) {
+            bp.produce(List.of(new JsonRPCProvidersBuildItem(NS_RESOURCES, McpResourcesService.class),
+                    new JsonRPCProvidersBuildItem(NS_TOOLS, McpToolsService.class),
+                    new JsonRPCProvidersBuildItem(NS_MCP, DevMcpJsonRpcService.class)));
+        }
+    }
+}

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ReadmeProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ReadmeProcessor.java
@@ -30,8 +30,7 @@ public class ReadmeProcessor {
         if (readme != null) {
             InternalPageBuildItem readmePage = new InternalPageBuildItem("Readme", 51);
 
-            readmePage.addBuildTimeData("readme", readme);
-
+            readmePage.addBuildTimeData("readme", readme, "The current readme of this Quarkus Application.");
             readmePage.addPage(Page.webComponentPageBuilder()
                     .namespace(NS)
                     .title("Readme")

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/welcome/WelcomeProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/welcome/WelcomeProcessor.java
@@ -30,7 +30,8 @@ public class WelcomeProcessor {
 
         InternalPageBuildItem welcomePageBuildItem = new InternalPageBuildItem("Welcome", 99999);
 
-        welcomePageBuildItem.addBuildTimeData("welcomeData", createWelcomeData(curateOutcomeBuildItem, extensionsBuildItem));
+        welcomePageBuildItem.addBuildTimeData("welcomeData", createWelcomeData(curateOutcomeBuildItem, extensionsBuildItem),
+                "Contains high level information about the Quarkus application, including the configFile, resourcesDir, sourceDir and selectedExtensions");
 
         welcomePageBuildItem.addPage(Page.webComponentPageBuilder()
                 .namespace("devui-welcome")

--- a/extensions/devui/deployment/src/test/java/io/quarkus/vertx/http/devmcp/DevMcpTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/vertx/http/devmcp/DevMcpTest.java
@@ -1,0 +1,193 @@
+package io.quarkus.vertx.http.devmcp;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.vertx.http.testrunner.HelloResource;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class DevMcpTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class).addClasses(HelloResource.class)
+                            .add(new StringAsset("quarkus.dev-mcp.enabled=true"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testInitialize() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "method": "initialize",
+                      "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                          "name": "JUnitTestClient",
+                          "version": "1.0.0"
+                        }
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(1))
+                .body("result.serverInfo.name", CoreMatchers.equalTo("Quarkus Dev MCP"));
+
+    }
+
+    @Test
+    public void testInitializedNotification() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "method": "notifications/initialized"
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(202);
+    }
+
+    @Test
+    public void testToolsList() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 3,
+                      "method": "tools/list"
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(3))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("result.tools.name", CoreMatchers.hasItem("devui-logstream_getLogger"));
+
+    }
+
+    @Test
+    public void testToolsCall() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 4,
+                      "method": "tools/call",
+                      "params": {
+                        "name": "devui-logstream_getLogger",
+                        "arguments": {
+                          "loggerName": "io.quarkus"
+                        }
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(4))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("result.content.type", CoreMatchers.hasItem("text"))
+                .body("result.content.text", CoreMatchers.notNullValue());
+
+    }
+
+    @Test
+    public void testResourcesList() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 5,
+                      "method": "resources/list"
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(5))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("result.resources.name", CoreMatchers.hasItem("devui/extensions"))
+                .body("result.resources.uri", CoreMatchers.hasItem("quarkus://resource/build-time/devui/extensions"));
+
+    }
+
+    @Test
+    public void testResourcesRead() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 6,
+                      "method": "resources/read",
+                      "params": {
+                           "uri": "quarkus://resource/build-time/devui/extensions"
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(6))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("result.contents.uri", CoreMatchers.hasItem("quarkus://resource/build-time/devui/extensions"))
+                .body("result.contents.text", CoreMatchers.notNullValue());
+
+    }
+
+}

--- a/extensions/devui/resources/src/main/resources/dev-ui/controller/jsonrpc.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/controller/jsonrpc.js
@@ -137,11 +137,11 @@ export class JsonRpc {
 
                 const origMethod = target[prop];
 
-                if (typeof origMethod == 'undefined') {
+                if (typeof origMethod === 'undefined') {
                     return function (...args) {
                         var uid = JsonRpc.messageCounter++;
 
-                        let method = this._extensionName + "." + prop.toString();
+                        let method = this._extensionName + "_" + prop.toString();
 
                         let params = new Object();
                         if (args.length > 0) {

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
@@ -283,7 +283,7 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
                                     linkText="Read more about Continuous Testing">
                             ${this._renderPlayButton()}
                 </qwc-no-data>
-            `
+            `;
         }
     }
 

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-info.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-info.js
@@ -1,0 +1,101 @@
+import { QwcHotReloadElement, html, css} from 'qwc-hot-reload-element';
+import 'qwc-no-data';
+import { basepath } from 'devui-data';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/grid';
+
+/**
+ * This component show details on the MCP Server
+ */
+export class QwcDevMCPInfo extends QwcHotReloadElement {
+    jsonRpc = new JsonRpc("devmcp");
+    
+    static styles = css`
+        .serverDetails {
+            display: flex;
+            gap: 20px;
+            padding-top: 40px;
+        }
+        
+        .serverDetailsText {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+        }
+        .connected {
+            display: flex;
+            flex-direction: column;
+            gap:10px;
+            padding: 5px;
+        }
+    `;
+
+    static properties = {
+        _mcpPath: {state: false},
+        _connectedClients: {state: true}
+    }
+
+    constructor() {
+        super();
+        this._mcpPath = null;
+        this._connectedClients = null;
+    }
+    
+    connectedCallback() {
+        super.connectedCallback();
+        this._mcpPath = window.location.origin + basepath.replace("/dev-ui", "/dev-mcp");
+        this._getConnectedClients();
+        this._observer = this.jsonRpc.getConnectedClientStream().onNext(jsonRpcResponse => { 
+            this._getConnectedClients();
+        });
+    }
+
+    disconnectedCallback() {
+        this._observer.cancel();
+        super.disconnectedCallback();
+    }
+
+    render() {
+        if(this._connectedClients){
+            return html`<div class="connected">
+                            ${this._renderServerDetails()}
+                            <vaadin-grid .items="${this._connectedClients}">
+                                <vaadin-grid-column path="name"></vaadin-grid-column>
+                                <vaadin-grid-column path="version"></vaadin-grid-column>
+                            </vaadin-grid>
+                        </div>`;
+        }else{
+            return html`<qwc-no-data message="No MCP Client is connected to Dev MCP."
+                                    link="https://quarkus.io/guides/dev-mcp"
+                                    linkText="Read more about Dev MCP">
+                            ${this._renderServerDetails()}
+                </qwc-no-data>
+            `;
+        }
+    }
+
+    hotReload(){
+        this._getConnectedClients();
+    }
+    
+    _getConnectedClients(){
+        this.jsonRpc.getConnectedClients().then(jsonRpcResponse => {
+            this._connectedClients = jsonRpcResponse.result;            
+        });
+        
+        
+    }
+    
+    _renderServerDetails(){
+        return html`<div class="serverDetails">
+                        <vaadin-icon icon="font-awesome-solid:circle-info"></vaadin-icon>
+                        <div class="serverDetailsText">
+                            <span>Connect to the Quarkus Dev MCP Server with:</span>
+                            <span><b>Protocol:</b> Remote Streamable HTTP</span>
+                            <span><b>URL:</b> ${this._mcpPath}</span>
+                        <div/>
+
+                </div>`;
+    }
+}
+customElements.define('qwc-dev-mcp-info', QwcDevMCPInfo);

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-resources.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-resources.js
@@ -1,0 +1,186 @@
+import { LitElement, html, css} from 'lit';
+import '@vaadin/progress-bar';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/grid';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+import '@vaadin/tabs';
+import '@vaadin/tabsheet';
+import { observeState } from 'lit-element-state';
+import { themeState } from 'theme-state';
+import '@qomponent/qui-code-block';
+import '@vaadin/dialog';
+import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+
+/**
+ * This component show all available resources for MCP clients
+ */
+export class QwcDevMCPResources extends observeState(LitElement) {
+    jsonRpc = new JsonRpc("resources");
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display:flex;
+            width: 100%;
+        }
+    
+        vaadin-tabsheet {
+            width: 100%;
+            height: 100%;
+        }
+    
+        vaadin-grid {
+            height: 100%;
+        }
+    `;
+
+    static properties = {
+        _resources: {state: true},
+        _selectedResource: {state: true},
+        _selectedResourceContent: {state: true},
+        _busyReading: {state: true}
+    }
+
+    constructor() {
+        super();
+        this._selectedResource = [];
+        this._selectedResourceContent = null;
+        this._busyReading = false;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._loadResources();
+    }
+
+    render() {
+        if (this._resources) {    
+            return html`${this._renderResources()}`;
+        }else{
+            return this._renderProgressBar("Fetching resources...");
+        }
+    }
+
+    _renderResources(){
+
+        let dialogTitle = "";
+        if(this._selectedResource.length>0)dialogTitle = this._selectedResource[0].name;
+
+        return html`
+                    <vaadin-dialog
+                        header-title="Read resource: ${dialogTitle}"
+                        .opened="${this._selectedResourceContent!==null}"
+                        @opened-changed="${(event) => {
+                            if(!event.detail.value){
+                                this._selectedResource = [];
+                                this._selectedResourceContent = null;
+                            }
+                        }}"
+                        ${dialogHeaderRenderer(
+                            () => html`
+                              <vaadin-button theme="tertiary" @click="${this._closeDialog}">
+                                <vaadin-icon icon="font-awesome-solid:xmark"></vaadin-icon>
+                              </vaadin-button>
+                            `,
+                            []
+                        )}
+                        ${dialogRenderer(() => this._renderResourceContent(), this._selectedResource)}
+                      ></vaadin-dialog>    
+                    <vaadin-tabsheet>
+                        <vaadin-tabs slot="tabs">
+                            <vaadin-tab id="list-tab">List</vaadin-tab>
+                            <vaadin-tab id="raw-tab">Raw json</vaadin-tab>
+                        </vaadin-tabs>
+                        <div tab="list-tab">
+                            <vaadin-grid .items="${this._resources.resources}" .selectedItems="${this._selectedResource}" theme="row-stripes" all-rows-visible 
+                                @active-item-changed="${(e) => {
+                                    const item = e.detail.value;
+                                    this._selectedResource = item ? [item] : [];
+                                    
+                                    if(this._selectedResource.length>0){
+                                        this._readSelectedResourceContents();
+                                    }else{
+                                        this._selectedResourceContent = null;
+                                    }
+                                }}">
+                                <vaadin-grid-sort-column 
+                                    header='Name'
+                                    path="name"
+                                    auto-width>
+                                </vaadin-grid-sort-column>
+                                <vaadin-grid-sort-column 
+                                    header='Description'
+                                    path="description"
+                                    auto-width>
+                                </vaadin-grid-sort-column>
+                            </vaadin-grid>
+                        </div>
+                        <div tab="raw-tab">
+                            <div class="codeBlock">
+                                <qui-code-block 
+                                    mode='json'
+                                    content='${JSON.stringify(this._resources, null, 2)}'
+                                    theme='${themeState.theme.name}'
+                                    showLineNumbers>
+                                </qui-code-block>
+                            </div>
+                    </vaadin-tabsheet>
+                `;
+    }
+
+    _renderResourceContent(){
+        return html`<div class="codeBlock">
+                                <qui-code-block 
+                                    mode='json'
+                                    content='${this._selectedResourceContent}'
+                                    theme='${themeState.theme.name}'
+                                    showLineNumbers>
+                                </qui-code-block>`;
+    }
+
+    _loadResources(){
+        this.jsonRpc.list().then(jsonRpcResponse => {
+            this._resources = jsonRpcResponse.result;
+        });
+    }
+
+    _closeDialog(){
+        this._selectedResourceContent = null;
+    }
+
+    _readSelectedResourceContents(){
+        if(this._selectedResource.length>0 && !this._busyReading){
+
+            this._busyReading = true;
+            this.jsonRpc.read({uri:this._selectedResource[0].uri}).then(jsonRpcResponse => {
+
+                if(jsonRpcResponse.result.contents.length>0){
+                    let c = jsonRpcResponse.result.contents[0].text;
+                    if(this._isJsonSerializable(c)){
+                        this._selectedResourceContent = JSON.stringify(c, null, 2);
+                    }else {
+                        this._selectedResourceContent = c;
+                    }
+                }else{
+                    this._selectedResourceContent = "No data found";
+                }
+                this._busyReading = false;
+            });            
+        }
+    }
+
+    _isJsonSerializable(value) {
+      return value !== null && (typeof value === 'object');
+    }
+
+    _renderProgressBar(title){
+        return html`
+            <div style="color: var(--lumo-secondary-text-color);width: 95%;" >
+                <div>${title}</div>
+                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
+            </div>`;
+    }
+
+}
+customElements.define('qwc-dev-mcp-resources', QwcDevMCPResources);

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-tools.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-tools.js
@@ -1,0 +1,272 @@
+import { QwcHotReloadElement, html, css} from 'qwc-hot-reload-element';
+import '@vaadin/progress-bar';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/grid';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+import '@vaadin/tabs';
+import '@vaadin/tabsheet';
+import '@vaadin/text-field';
+import '@vaadin/button';
+import '@vaadin/dialog';
+import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import '@vaadin/vertical-layout';
+import 'qui-themed-code-block';
+import '@qomponent/qui-badge';
+
+/**
+ * This component show all available tools for MCP clients
+ */
+export class QwcDevMCPTools extends QwcHotReloadElement {
+    jsonRpc = new JsonRpc("tools");
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display:flex;
+            width: 100%;
+        }
+    
+        vaadin-tabsheet {
+            width: 100%;
+            height: 100%;
+        }
+    
+        vaadin-grid {
+            height: 100%;
+        }
+    `;
+
+    static properties = {
+        _tools: {state: true},
+        _showInputDialog: {state: true, type: Boolean},
+        _selectedTool: {state: true},
+        _inputvalues: { type: Object },
+        _toolResult: {state: true}
+    }
+
+    constructor() {
+        super();
+        this._showInputDialog = false;
+        this._selectedTool = [];
+        this._inputvalues = new Map();
+        this._toolResult = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._loadTools();
+        this._inputvalues.clear();
+    }
+
+    render() {
+        if (this._tools) {    
+            return html`${this._renderTools()}`;
+        }else{
+            return html`
+            <div style="color: var(--lumo-secondary-text-color);width: 95%;" >
+                <div>Fetching tools...</div>
+                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
+            </div>
+            `;
+        }
+    }
+
+    hotReload(){
+        this._loadTools();
+        this._inputvalues.clear();
+    }
+
+    _renderTools(){
+        return html`
+                    <vaadin-dialog
+                        header-title="Tool invocation result"
+                        .opened="${this._toolResult!==null}"
+                        @opened-changed="${(event) => {
+                            if(!event.detail.value){
+                                this._toolResult = null;
+                            }
+                        }}"
+                        ${dialogHeaderRenderer(
+                            () => html`
+                              <vaadin-button theme="tertiary" @click="${this._closeDialog}">
+                                <vaadin-icon icon="font-awesome-solid:xmark"></vaadin-icon>
+                              </vaadin-button>
+                            `,
+                            []
+                        )}
+                        ${dialogRenderer(() => this._renderToolResult())}
+                    ></vaadin-dialog>  
+                    
+                    <vaadin-dialog
+                        header-title="Input"
+                        .opened="${this._showInputDialog}"
+                        @opened-changed="${(event) => {
+                            if(!event.detail.value){
+                                this._showInputDialog = false;
+                            }
+                        }}"
+                        ${dialogHeaderRenderer(
+                            () => html`
+                              <vaadin-button theme="tertiary" @click="${this._closeDialog}">
+                                <vaadin-icon icon="font-awesome-solid:xmark"></vaadin-icon>
+                              </vaadin-button>
+                            `,
+                            []
+                        )}
+                        ${dialogRenderer(this._renderToolInput)}
+                    ></vaadin-dialog>
+                    
+                    <vaadin-tabsheet>
+                        <vaadin-tabs slot="tabs">
+                            <vaadin-tab id="list-tab">List</vaadin-tab>
+                            <vaadin-tab id="raw-tab">Raw json</vaadin-tab>
+                        </vaadin-tabs>
+                        <div tab="list-tab">
+                            <vaadin-grid .items="${this._tools.tools}" .selectedItems="${this._selectedTool}" theme="row-stripes" all-rows-visible
+                                @active-item-changed="${(e) => {
+                                    const item = e.detail.value;
+                                    this._selectedTool = item ? [item] : [];
+                                    
+                                    if(this._selectedTool.length>0){
+                                        let parameters = Object.keys(this._selectedTool[0].inputSchema.properties);
+                                        const propertyCount = parameters.length;
+                                        if(propertyCount>0) {
+                                            this._showInputDialog = true;
+                                        }else {
+                                            this._testJsonRpcCall(this._selectedTool[0], null);
+                                        }
+                                    }
+                                }}">
+                                <vaadin-grid-sort-column 
+                                    header='Name'
+                                    path="name" 
+                                    auto-width>
+                                </vaadin-grid-sort-column>
+                                <vaadin-grid-sort-column 
+                                    header='Description'
+                                    path="description" 
+                                    auto-width>
+                                </vaadin-grid-sort-column>
+                                <vaadin-grid-column
+                                    header="Params"
+                                    frozen-to-end
+                                    auto-width
+                                    flex-grow="0"
+                                    ${columnBodyRenderer(this._noOfParameterRenderer, [])}
+                                ></vaadin-grid-column>    
+                            </vaadin-grid>
+                        </div>
+                        <div tab="raw-tab">
+                            <div class="codeBlock">
+                                <qui-themed-code-block 
+                                    mode='json'
+                                    content='${JSON.stringify(this._tools, null, 2)}'
+                                    showLineNumbers>
+                                </qui-themed-code-block>
+                            </div>
+                    </vaadin-tabsheet>
+                `;
+    }
+
+    _renderToolResult(){
+        return html`<div class="codeBlock">
+                                <qui-themed-code-block
+                                    mode='json'
+                                    content='${this._toolResult}'
+                                    showLineNumbers>
+                                </qui-themed-code-block>`;
+    }
+
+    _renderToolInput(){
+        if(this._selectedTool.length>0){
+            let prop = this._selectedTool[0];
+
+            const keys = Object.keys(prop.inputSchema.properties);
+
+            return html`<vaadin-vertical-layout>
+                           ${keys.map(
+                                (key) => html`
+                                  <vaadin-text-field
+                                    label="${key}"
+                                    @input=${(e) => this._updateSelectedValue(prop.name, key, e)}
+                                    @blur=${(e) => this._updateSelectedValue(prop.name, key, e)}
+                                  ></vaadin-text-field>
+                                `
+                              )}
+                              <vaadin-button @click="${() => this._getInputValuesAndTest(prop)}">Test</vaadin-button>
+                        </vaadin-vertical-layout>`;
+        }
+    }
+
+    _closeDialog(){
+        this._toolResult = null;
+        this._showInputDialog = false;
+    }
+
+    _noOfParameterRenderer(prop) {
+        let parameters = Object.keys(prop.inputSchema.properties);
+        const propertyCount = parameters.length;
+        if(propertyCount>0) {
+            return html`<qui-badge pill title="${parameters}"><span>${propertyCount}</span></qui-badge>`;
+        }        
+    }
+
+    _updateSelectedValue(name, key, e){
+        let params = new Map();
+        if(this._inputvalues.has(name)){
+            params = this._inputvalues.get(name);
+        }
+
+        params.set(key, e.target.value);
+
+        this._inputvalues.set(name, params);
+
+    }
+
+    _getInputValuesAndTest(prop){
+        this._showInputDialog = false;
+        let params = null;
+        if(this._inputvalues.has(prop.name)){
+            params = this._inputvalues.get(prop.name);
+            this._testJsonRpcCall(prop, params);
+        }
+
+    }
+
+    _testJsonRpcCall(prop, params){
+        const [namespace, method] = prop.name.split('_');
+
+        let rpcClient = new JsonRpc(namespace);
+
+        if(params){
+            rpcClient[method](Object.fromEntries(params)).then(jsonRpcResponse => {
+                this._setToolResult(jsonRpcResponse.result);
+            });
+        }else {
+            rpcClient[method]().then(jsonRpcResponse => {
+                this._setToolResult(jsonRpcResponse.result);
+            });
+        }
+    }
+
+    _setToolResult(result){
+        if(this._isJsonSerializable(result)){
+            this._toolResult = JSON.stringify(result, null, 2);
+        }else {
+            this._toolResult = result;
+        }
+    }
+
+    _loadTools(){
+        this.jsonRpc.list().then(jsonRpcResponse => {
+            this._tools = jsonRpcResponse.result;            
+        });
+    }
+
+    _isJsonSerializable(value) {
+        return value !== null && (typeof value === 'object');
+    }
+
+}
+customElements.define('qwc-dev-mcp-tools', QwcDevMCPTools);

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
@@ -105,15 +105,6 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
             justify-content: end;
             padding-right: 10px;
         }
-
-        .assistant {
-            position: absolute;
-            top: 0;
-            right: 0;
-            padding-top: 8px;
-            padding-right: 16px;
-            z-index:9;
-        }
     
         .actionResult {
             display: flex;
@@ -177,6 +168,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     }
 
     disconnectedCallback() {
+        document.body.style.cursor = 'default';
         RouterController.unregisterGuardedComponent(this);
         window.removeEventListener('beforeunload', this._beforeUnloadHandler);
         super.disconnectedCallback();      
@@ -296,7 +288,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     
     _renderResultDialog(){
         if(this._actionResult && this._actionResult.content && this._actionResult.display === "dialog"){
-            return html`<vaadin-dialog style="min-width=50vw;"
+            return html`<vaadin-dialog style="min-width: 50vw;"
                             header-title="${this._actionResult?.name ?? this._actionResult?.path}"
                             resizable
                             draggable
@@ -360,7 +352,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     _renderActions(){
         if(this._filteredActions){
             if(this._showActionProgress){
-                return html`<vaadin-progress-bar style="width:400px;" indeterminate></vaadin-progress-bar>`;
+                return html`<vaadin-progress-bar style="width:75px;" indeterminate></vaadin-progress-bar>`;
             }else{
                 return html`<div class="actions">
                             <vaadin-menu-bar .items="${this._filteredActions}" theme="dropdown-indicators tertiary" @item-selected="${(e) => this._actionSelected(e)}"></vaadin-menu-bar>
@@ -394,24 +386,19 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     }
     
     _renderTextContent(){
-        return html`<qui-themed-code-block id="code" class='codeBlock' @keydown="${this._onKeyDown}"
+        return html`${this._renderAssistantWarning()}
+                    <qui-themed-code-block id="code" class='codeBlock' @keydown="${this._onKeyDown}"
                         mode='${this._getMode(this._selectedWorkspaceItem.name)}'
                         .content='${this._selectedWorkspaceItem.content}'
                         value='${this._selectedWorkspaceItem.content}'
                         showLineNumbers
                         editable>
                     </qui-themed-code-block>
-                    ${this._renderAssistantWarningInline()}`;
-    }
-
-    _renderAssistantWarningInline(){
-        if(this._selectedWorkspaceItem.isAssistant){
-            return html`<qui-assistant-warning class="assistant"></qui-assistant-warning>`;
-        }
+                    `;
     }
 
     _renderAssistantWarning(){
-        if(this._actionResult.isAssistant){
+        if((this._selectedWorkspaceItem && this._selectedWorkspaceItem.isAssistant) || this._actionResult && this._actionResult.isAssistant){
              return html`<qui-assistant-warning></qui-assistant-warning>`;
         }   
     }
@@ -465,6 +452,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     
     _actionSelected(e){
         this._showActionProgress = true;
+        document.body.style.cursor = 'progress'; 
         this._clearActionResult();
         let actionId = e.detail.value.id;
         
@@ -523,6 +511,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
                 this._actionResult.displayType = e.detail.value.displayType;
             }
             this._showActionProgress = false;
+            document.body.style.cursor = 'default';
         });
     }
     
@@ -659,6 +648,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
 
         this._clearActionResult();
         this._showActionProgress = false;
+        document.body.style.cursor = 'default';
     }
     
     shouldConfirmAwayNavigation(){

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIBuildTimeStaticService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIBuildTimeStaticService.java
@@ -1,0 +1,31 @@
+package io.quarkus.devui.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Holds information of Build Time static data
+ */
+public class DevUIBuildTimeStaticService {
+    private final Map<String, String> urlAndPath = new HashMap<>();
+    private final Map<String, String> descriptions = new HashMap<>();
+    private String basePath; // Like /q/dev-ui
+
+    public void addData(String basePath, Map<String, String> urlAndPath, Map<String, String> descriptions) {
+        this.basePath = basePath;
+        this.urlAndPath.putAll(urlAndPath);
+        this.descriptions.putAll(descriptions);
+    }
+
+    public Map<String, String> getUrlAndPath() {
+        return urlAndPath;
+    }
+
+    public Map<String, String> getDescriptions() {
+        return descriptions;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
@@ -21,11 +21,11 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.devui.runtime.comms.JsonRpcRouter;
+import io.quarkus.devui.runtime.js.DevUIWebSocketHandler;
 import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
-import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethodName;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonTypeAdapter;
-import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.devui.runtime.mcp.McpHttpHandler;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.devmode.FileSystemStaticHandler;
@@ -46,16 +46,16 @@ public class DevUIRecorder {
     }
 
     public void createJsonRpcRouter(BeanContainer beanContainer,
-            Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> extensionMethodsMap,
-            List<String> deploymentMethods,
-            List<String> deploymentSubscriptions,
-            Map<String, RuntimeValue> recordedValues) {
+            Map<String, JsonRpcMethod> runtimeMethods,
+            Map<String, JsonRpcMethod> runtimeSubscriptions,
+            Map<String, JsonRpcMethod> deploymentMethods,
+            Map<String, JsonRpcMethod> deploymentSubscriptions,
+            Map<String, JsonRpcMethod> recordedMethods,
+            Map<String, JsonRpcMethod> recordedSubscriptions) {
+
         JsonRpcRouter jsonRpcRouter = beanContainer.beanInstance(JsonRpcRouter.class);
-        jsonRpcRouter.populateJsonRPCRuntimeMethods(extensionMethodsMap);
-        jsonRpcRouter.setJsonRPCDeploymentActions(deploymentMethods, deploymentSubscriptions);
-        if (recordedValues != null && !recordedValues.isEmpty()) {
-            jsonRpcRouter.setRecordedValues(recordedValues);
-        }
+        jsonRpcRouter.populateJsonRpcEndpoints(runtimeMethods, runtimeSubscriptions, deploymentMethods, deploymentSubscriptions,
+                recordedMethods, recordedSubscriptions);
 
         jsonRpcRouter.initializeCodec(createJsonMapper());
     }
@@ -68,7 +68,7 @@ public class DevUIRecorder {
         // We need to pass some information so that the mapper, who lives in the deployment classloader,
         // knows how to deal with JsonObject/JsonArray/JsonBuffer, who live in the runtime classloader.
         return factory.create(new JsonTypeAdapter<>(JsonObject.class, JsonObject::getMap, JsonObject::new),
-                new JsonTypeAdapter<JsonArray, List<?>>(JsonArray.class, JsonArray::getList, JsonArray::new),
+                new JsonTypeAdapter<>(JsonArray.class, JsonArray::getList, JsonArray::new),
                 new JsonTypeAdapter<>(Buffer.class, buffer -> BASE64_ENCODER.encodeToString(buffer.getBytes()), text -> {
                     try {
                         return Buffer.buffer(BASE64_DECODER.decode(text));
@@ -78,8 +78,12 @@ public class DevUIRecorder {
                 }));
     }
 
-    public Handler<RoutingContext> communicationHandler() {
-        return new DevUIWebSocket();
+    public Handler<RoutingContext> devUIWebSocketHandler() {
+        return new DevUIWebSocketHandler();
+    }
+
+    public Handler<RoutingContext> mcpStreamableHTTPHandler(String quarkusVersion) {
+        return new McpHttpHandler(quarkusVersion, createJsonMapper());
     }
 
     public Handler<RoutingContext> uiHandler(String finalDestination,
@@ -92,8 +96,14 @@ public class DevUIRecorder {
         return handler;
     }
 
-    public Handler<RoutingContext> buildTimeStaticHandler(String basePath, Map<String, String> urlAndPath) {
-        return new DevUIBuildTimeStaticHandler(basePath, urlAndPath);
+    public Handler<RoutingContext> buildTimeStaticHandler(BeanContainer beanContainer,
+            String basePath,
+            Map<String, String> urlAndPath,
+            Map<String, String> descriptions) {
+        DevUIBuildTimeStaticService buildTimeStaticService = beanContainer.beanInstance(DevUIBuildTimeStaticService.class);
+        buildTimeStaticService.addData(basePath, urlAndPath, descriptions);
+
+        return new DevUIBuildTimeStaticHandler();
     }
 
     public Handler<RoutingContext> endpointInfoHandler(String basePath) {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/comms/JsonRpcResponseWriter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/comms/JsonRpcResponseWriter.java
@@ -1,0 +1,15 @@
+package io.quarkus.devui.runtime.comms;
+
+public interface JsonRpcResponseWriter {
+
+    void write(String message);
+
+    void close();
+
+    boolean isOpen();
+
+    boolean isClosed();
+
+    Object decorateObject(Object object, MessageType messageType);
+
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigJsonRPCService.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.quarkus.vertx.http.runtime.devmode.ConfigDescription;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -22,6 +23,7 @@ public class ConfigJsonRPCService {
         return new JsonArray(configDescriptionBean.getAllConfig());
     }
 
+    @JsonRpcDescription("Get all configurations and their values for the Quarkus application")
     public JsonObject getAllValues() {
         JsonObject values = new JsonObject();
         for (ConfigDescription configDescription : configDescriptionBean.getAllConfig()) {
@@ -30,6 +32,7 @@ public class ConfigJsonRPCService {
         return values;
     }
 
+    @JsonRpcDescription("Get the project properties for the Quarkus application")
     public JsonObject getProjectProperties() {
         JsonObject response = new JsonObject();
         try {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/continuoustesting/ContinuousTestingJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/continuoustesting/ContinuousTestingJsonRPCService.java
@@ -30,7 +30,7 @@ public class ContinuousTestingJsonRPCService implements Consumer<ContinuousTesti
 
     @Override
     public void accept(final ContinuousTestingSharedStateManager.State state) {
-        final var results = DevConsoleManager.<TestRunResultsInterface> invoke("devui-continuous-testing.getResults");
+        final var results = DevConsoleManager.<TestRunResultsInterface> invoke("devui-continuous-testing_getResults");
         final List<Item> passedTests = new LinkedList<>();
         final List<Item> failedTests = new LinkedList<>();
         final List<Item> skippedTests = new LinkedList<>();

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/js/DevUIWebSocketHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/js/DevUIWebSocketHandler.java
@@ -1,4 +1,4 @@
-package io.quarkus.devui.runtime;
+package io.quarkus.devui.runtime.js;
 
 import jakarta.enterprise.inject.spi.CDI;
 
@@ -13,8 +13,8 @@ import io.vertx.ext.web.RoutingContext;
 /**
  * This is the main entry point for Dev UI Json RPC communication
  */
-public class DevUIWebSocket implements Handler<RoutingContext> {
-    private static final Logger LOG = Logger.getLogger(DevUIWebSocket.class.getName());
+public class DevUIWebSocketHandler implements Handler<RoutingContext> {
+    private static final Logger LOG = Logger.getLogger(DevUIWebSocketHandler.class.getName());
 
     @Override
     public void handle(RoutingContext event) {
@@ -26,7 +26,7 @@ public class DevUIWebSocket implements Handler<RoutingContext> {
                         ServerWebSocket socket = event.result();
                         addSocket(socket);
                     } else {
-                        LOG.debug("Failed to connect to dev ui communication server", event.cause());
+                        LOG.debug("Failed to connect to dev ui ws server", event.cause());
                     }
                 }
             });
@@ -40,7 +40,7 @@ public class DevUIWebSocket implements Handler<RoutingContext> {
             JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
             jsonRpcRouter.addSocket(session);
         } catch (IllegalStateException ise) {
-            LOG.debug("Failed to connect to dev ui communication server, " + ise.getMessage());
+            LOG.debug("Failed to connect to dev ui ws server, " + ise.getMessage());
         }
     }
 

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/js/JavaScriptResponseWriter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/js/JavaScriptResponseWriter.java
@@ -1,0 +1,40 @@
+package io.quarkus.devui.runtime.js;
+
+import io.quarkus.devui.runtime.comms.JsonRpcResponseWriter;
+import io.quarkus.devui.runtime.comms.MessageType;
+import io.vertx.core.http.ServerWebSocket;
+
+public class JavaScriptResponseWriter implements JsonRpcResponseWriter {
+    private final ServerWebSocket socket;
+
+    public JavaScriptResponseWriter(ServerWebSocket socket) {
+        this.socket = socket;
+    }
+
+    @Override
+    public void write(String message) {
+        if (!socket.isClosed()) {
+            socket.writeTextMessage(message);
+        }
+    }
+
+    @Override
+    public void close() {
+        socket.close();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !socket.isClosed();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return socket.isClosed();
+    }
+
+    @Override
+    public Object decorateObject(Object object, MessageType messageType) {
+        return new Result(messageType.name(), object);
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/js/Result.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/js/Result.java
@@ -1,0 +1,22 @@
+package io.quarkus.devui.runtime.js;
+
+/**
+ * A UI (JavaScript) specific response that contains some more details
+ */
+public class Result {
+    public final String messageType;
+    public final Object object;
+
+    public Result(String messageType, Object object) {
+        this.messageType = messageType;
+        this.object = object;
+    }
+
+    @Override
+    public String toString() {
+        return "Result{" +
+                "messageType='" + messageType + '\'' +
+                ", object=" + object +
+                '}';
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcCodec.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcCodec.java
@@ -5,42 +5,48 @@ import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.METHOD_NOT_FOUND;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.devui.runtime.comms.JsonRpcResponseWriter;
 import io.quarkus.devui.runtime.comms.MessageType;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
-import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
 
 public final class JsonRpcCodec {
     private static final Logger LOG = Logger.getLogger(JsonRpcCodec.class);
     private final JsonMapper jsonMapper;
+    private final JsonRpcRequestCreator jsonRpcRequestCreator;
 
     public JsonRpcCodec(JsonMapper jsonMapper) {
         this.jsonMapper = jsonMapper;
+        this.jsonRpcRequestCreator = new JsonRpcRequestCreator(jsonMapper);
     }
 
     public JsonRpcRequest readRequest(String json) {
-        return new JsonRpcRequest(jsonMapper, (JsonObject) jsonMapper.fromString(json, Object.class));
+        return jsonRpcRequestCreator.create((JsonObject) jsonMapper.fromString(json, Object.class));
     }
 
-    public void writeResponse(ServerWebSocket socket, int id, Object object, MessageType messageType) {
-        writeResponse(socket, new JsonRpcResponse(id,
-                new JsonRpcResponse.Result(messageType.name(), object)));
+    public JsonRpcRequest readMCPRequest(String json) {
+        return jsonRpcRequestCreator.mcpCreate((JsonObject) jsonMapper.fromString(json, Object.class));
     }
 
-    public void writeMethodNotFoundResponse(ServerWebSocket socket, int id, String jsonRpcMethodName) {
-        writeResponse(socket, new JsonRpcResponse(id,
+    public void writeResponse(JsonRpcResponseWriter writer, int id, Object object, MessageType messageType) {
+        Object decoratedObject = writer.decorateObject(object, messageType);
+        writeResponse(writer, new JsonRpcResponse(id, decoratedObject));
+    }
+
+    public void writeMethodNotFoundResponse(JsonRpcResponseWriter writer, int id, String jsonRpcMethodName) {
+        writeResponse(writer, new JsonRpcResponse(id,
                 new JsonRpcResponse.Error(METHOD_NOT_FOUND, "Method [" + jsonRpcMethodName + "] not found")));
     }
 
-    public void writeErrorResponse(ServerWebSocket socket, int id, String jsonRpcMethodName, Throwable exception) {
+    public void writeErrorResponse(JsonRpcResponseWriter writer, int id, String jsonRpcMethodName, Throwable exception) {
         LOG.error("Error in JsonRPC Call", exception);
-        writeResponse(socket, new JsonRpcResponse(id,
+        writeResponse(writer, new JsonRpcResponse(id,
                 new JsonRpcResponse.Error(INTERNAL_ERROR,
                         "Method [" + jsonRpcMethodName + "] failed: " + exception.getMessage())));
     }
 
-    private void writeResponse(ServerWebSocket socket, JsonRpcResponse response) {
-        socket.writeTextMessage(jsonMapper.toString(response, true));
+    private void writeResponse(JsonRpcResponseWriter writer, JsonRpcResponse response) {
+        writer.write(jsonMapper.toString(response, true));
     }
 
     public JsonMapper getJsonMapper() {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
@@ -1,11 +1,27 @@
 package io.quarkus.devui.runtime.jsonrpc;
 
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Usage;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 public final class JsonRpcMethod {
-    private Class clazz;
+    private Class bean;
     private String methodName;
-    private Map<String, Class> params;
+    private String description;
+    private Method javaMethod;
+    private Map<String, Parameter> parameters;
+
+    private List<Usage> usage;
+
+    private RuntimeValue runtimeValue;
 
     private boolean isExplicitlyBlocking;
     private boolean isExplicitlyNonBlocking;
@@ -13,59 +29,147 @@ public final class JsonRpcMethod {
     public JsonRpcMethod() {
     }
 
-    public JsonRpcMethod(Class clazz, String methodName, Map<String, Class> params) {
-        this.clazz = clazz;
-        this.methodName = methodName;
-        this.params = params;
+    public Class getBean() {
+        return bean;
     }
 
-    public Class getClazz() {
-        return clazz;
+    public void setBean(Class bean) {
+        this.bean = bean;
     }
 
     public String getMethodName() {
         return methodName;
     }
 
-    public Map<String, Class> getParams() {
-        return params;
-    }
-
-    public boolean hasParams() {
-        return this.params != null && !this.params.isEmpty();
-    }
-
-    public void setClazz(Class clazz) {
-        this.clazz = clazz;
+    public String getJavaMethodName() {
+        if (methodName.contains(UNDERSCORE)) {
+            return methodName.substring(methodName.indexOf(UNDERSCORE) + 1);
+        }
+        return methodName;
     }
 
     public void setMethodName(String methodName) {
         this.methodName = methodName;
     }
 
-    public void setParams(Map<String, Class> params) {
-        this.params = params;
+    public String getDescription() {
+        return description;
     }
 
-    public boolean getExplicitlyBlocking() {
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<Usage> getUsage() {
+        return usage;
+    }
+
+    public void setUsage(List<Usage> usage) {
+        this.usage = usage;
+    }
+
+    public Method getJavaMethod() {
+        return javaMethod;
+    }
+
+    public void setJavaMethod(Method javaMethod) {
+        this.javaMethod = javaMethod;
+    }
+
+    public Map<String, Parameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, Parameter> parameters) {
+        this.parameters = parameters;
+    }
+
+    public void addParameter(String name, String description) {
+        if (this.parameters == null)
+            this.parameters = new LinkedHashMap<>();
+        this.parameters.put(name, new Parameter(String.class, description));
+    }
+
+    public void addParameter(String name, Class<?> type, String description) {
+        if (this.parameters == null)
+            this.parameters = new LinkedHashMap<>();
+        this.parameters.put(name, new Parameter(type, description));
+    }
+
+    public boolean hasParameters() {
+        return this.parameters != null && !this.parameters.isEmpty();
+    }
+
+    public RuntimeValue getRuntimeValue() {
+        return runtimeValue;
+    }
+
+    public void setRuntimeValue(RuntimeValue runtimeValue) {
+        this.runtimeValue = runtimeValue;
+    }
+
+    public boolean isIsExplicitlyBlocking() {
         return isExplicitlyBlocking;
     }
 
-    public void setExplicitlyBlocking(boolean blocking) {
-        isExplicitlyBlocking = blocking;
+    public void setIsExplicitlyBlocking(boolean isExplicitlyBlocking) {
+        this.isExplicitlyBlocking = isExplicitlyBlocking;
     }
 
-    public boolean getExplicitlyNonBlocking() {
+    public boolean isIsExplicitlyNonBlocking() {
         return isExplicitlyNonBlocking;
     }
 
-    public void setExplicitlyNonBlocking(boolean nonblocking) {
-        isExplicitlyNonBlocking = nonblocking;
+    public void setIsExplicitlyNonBlocking(boolean isExplicitlyNonBlocking) {
+        this.isExplicitlyNonBlocking = isExplicitlyNonBlocking;
     }
 
-    @Override
-    public String toString() {
-        return clazz.getName() + ":" + methodName + "(" + params + ")";
+    public boolean isReturningMulti() {
+        return javaMethod.getReturnType().getName().equals(Multi.class.getName());
     }
+
+    public boolean isReturningUni() {
+        return javaMethod.getReturnType().getName().equals(Uni.class.getName());
+    }
+
+    public boolean isReturningCompletionStage() {
+        return javaMethod.getReturnType().getName().equals(CompletionStage.class.getName());
+    }
+
+    public boolean isReturningCompletableFuture() {
+        return javaMethod.getReturnType().getName().equals(CompletableFuture.class.getName());
+    }
+
+    public static class Parameter {
+        private Class<?> type;
+        private String description;
+
+        public Parameter() {
+
+        }
+
+        public Parameter(Class<?> type, String description) {
+            this.type = type;
+            this.description = description;
+        }
+
+        public Class<?> getType() {
+            return type;
+        }
+
+        public void setType(Class<?> type) {
+            this.type = type;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+
+    private static final String UNDERSCORE = "_";
 
 }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequest.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequest.java
@@ -1,64 +1,58 @@
 package io.quarkus.devui.runtime.jsonrpc;
 
-import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.ID;
-import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.JSONRPC;
-import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.METHOD;
-import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.PARAMS;
-import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.VERSION;
-
 import java.util.Map;
 
-import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
-import io.vertx.core.json.JsonObject;
-
-public class JsonRpcRequest {
-
-    private final JsonMapper jsonMapper;
-    private final JsonObject jsonObject;
-
-    JsonRpcRequest(JsonMapper jsonMapper, JsonObject jsonObject) {
-        this.jsonMapper = jsonMapper;
-        this.jsonObject = jsonObject;
-    }
+public final class JsonRpcRequest {
+    private int id;
+    private String jsonrpc = JsonRpcKeys.VERSION;
+    private String method;
+    private Map params;
 
     public int getId() {
-        return jsonObject.getInteger(ID);
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
     }
 
     public String getJsonrpc() {
-        String value = jsonObject.getString(JSONRPC);
-        if (value != null) {
-            return value;
-        }
-        return VERSION;
+        return jsonrpc;
+    }
+
+    public void setJsonrpc(String jsonrpc) {
+        this.jsonrpc = jsonrpc;
     }
 
     public String getMethod() {
-        return jsonObject.getString(METHOD);
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public Map getParams() {
+        return params;
+    }
+
+    public void setParams(Map params) {
+        this.params = params;
     }
 
     public boolean hasParams() {
-        return this.getParams() != null;
+        return this.params != null && !this.params.isEmpty();
     }
 
-    public Map<?, ?> getParams() {
-        JsonObject paramsObject = jsonObject.getJsonObject(PARAMS);
-        if (paramsObject != null && paramsObject.getMap() != null && !paramsObject.getMap().isEmpty()) {
-            return paramsObject.getMap();
+    public boolean hasParam(String key) {
+        return this.params != null && this.params.containsKey(key);
+    }
+
+    public <T> T getParam(String key, Class<T> paramType) {
+        if (hasParam(key)) {
+            return (T) this.params.get(key);
         }
         return null;
     }
 
-    public <T> T getParam(String key, Class<T> paramType) {
-        Map<?, ?> params = getParams();
-        if (params == null || !params.containsKey(key)) {
-            return null;
-        }
-        return jsonMapper.fromValue(params.get(key), paramType);
-    }
-
-    @Override
-    public String toString() {
-        return jsonMapper.toString(jsonObject, true);
-    }
 }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequestCreator.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcRequestCreator.java
@@ -1,0 +1,79 @@
+package io.quarkus.devui.runtime.jsonrpc;
+
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.ID;
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.JSONRPC;
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.METHOD;
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.PARAMS;
+
+import java.util.Map;
+
+import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
+import io.vertx.core.json.JsonObject;
+
+public class JsonRpcRequestCreator {
+    private final JsonMapper jsonMapper;
+
+    JsonRpcRequestCreator(JsonMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
+    }
+
+    public JsonRpcRequest create(JsonObject jsonObject) {
+        JsonRpcRequest jsonRpcRequest = new JsonRpcRequest();
+        jsonRpcRequest.setId(jsonObject.getInteger(ID));
+        if (jsonObject.containsKey(JSONRPC)) {
+            jsonRpcRequest.setJsonrpc(jsonObject.getString(JSONRPC));
+        }
+        jsonRpcRequest.setMethod(jsonObject.getString(METHOD));
+        if (jsonObject.containsKey(PARAMS)) {
+            jsonRpcRequest.setParams(jsonObject.getJsonObject(PARAMS).getMap());
+        }
+
+        return jsonRpcRequest;
+    }
+
+    // TODO: Repeat of above
+    public JsonRpcRequest mcpCreate(JsonObject jsonObject) {
+        JsonRpcRequest jsonRpcRequest = new JsonRpcRequest();
+        if (jsonObject.containsKey(ID)) {
+            jsonRpcRequest.setId(jsonObject.getInteger(ID));
+        }
+        if (jsonObject.containsKey(JSONRPC)) {
+            jsonRpcRequest.setJsonrpc(jsonObject.getString(JSONRPC));
+        }
+
+        jsonRpcRequest.setMethod(jsonObject.getString(METHOD));
+        if (jsonObject.containsKey(PARAMS)) {
+
+            Map map = jsonObject.getJsonObject(PARAMS).getMap();
+            map.remove("_meta");
+            map.remove("cursor");
+            jsonRpcRequest.setParams(map);
+        }
+
+        return remap(jsonRpcRequest);
+    }
+
+    public JsonRpcRequest remap(JsonRpcRequest jsonRpcRequest) {
+        if (jsonRpcRequest.getMethod().equalsIgnoreCase(TOOLS_SLASH_CALL)) {
+
+            Map params = jsonRpcRequest.getParams();
+            String mappedName = (String) params.remove("name");
+            Map mappedParams = (Map) params.remove("arguments");
+
+            JsonRpcRequest mapped = new JsonRpcRequest();
+            mapped.setId(jsonRpcRequest.getId());
+            mapped.setJsonrpc(jsonRpcRequest.getJsonrpc());
+            mapped.setMethod(mappedName);
+            mapped.setParams(mappedParams);
+
+            return mapped;
+        }
+        return jsonRpcRequest;
+    }
+
+    public String toJson(JsonRpcRequest jsonRpcRequest) {
+        return jsonMapper.toString(jsonRpcRequest, true);
+    }
+
+    private static final String TOOLS_SLASH_CALL = "tools/call";
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcResponse.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcResponse.java
@@ -6,14 +6,20 @@ public final class JsonRpcResponse {
 
     // Public for serialization
     public final int id;
-    public final Result result;
+    public final Object result;
     public final Error error;
 
-    public JsonRpcResponse(int id, Result result) {
+    public JsonRpcResponse(int id, Object result) {
         this.id = id;
         this.result = result;
         this.error = null;
     }
+
+    //    public JsonRpcResponse(int id, Result result) {
+    //        this.id = id;
+    //        this.result = result;
+    //        this.error = null;
+    //    }
 
     public JsonRpcResponse(int id, Error error) {
         this.id = id;
@@ -34,23 +40,15 @@ public final class JsonRpcResponse {
                 '}';
     }
 
-    public static final class Result {
-        public final String messageType;
-        public final Object object;
-
-        public Result(String messageType, Object object) {
-            this.messageType = messageType;
-            this.object = object;
-        }
-
-        @Override
-        public String toString() {
-            return "Result{" +
-                    "messageType='" + messageType + '\'' +
-                    ", object=" + object +
-                    '}';
-        }
-    }
+    //    public static final class Content {
+    //        public final Object content;
+    //        public final boolean isError;
+    //
+    //        public Content(boolean isError, Object objects) {
+    //            this.isError = isError;
+    //            this.content = objects;
+    //        }
+    //    }
 
     public static final class Error {
         public final int code;

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamJsonRPCService.java
@@ -10,6 +10,7 @@ import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.Logger;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.json.JsonObject;
@@ -26,18 +27,21 @@ public class LogStreamJsonRPCService {
     }
 
     @NonBlocking
+    @JsonRpcDescription("Get a short Quarkus application log file history (last 60 lines)")
     public List<JsonObject> history() {
         LogStreamBroadcaster logStreamBroadcaster = Arc.container().instance(LogStreamBroadcaster.class).get();
         LinkedBlockingQueue<JsonObject> history = logStreamBroadcaster.getHistory();
         return new ArrayList<>(history);
     }
 
+    @JsonRpcDescription("Stream the Quarkus application log file")
     public Multi<JsonObject> streamLog() {
         LogStreamBroadcaster logStreamBroadcaster = Arc.container().instance(LogStreamBroadcaster.class).get();
         return logStreamBroadcaster.getLogStream();
     }
 
     @NonBlocking
+    @JsonRpcDescription("Get all the available loggers in this Quarkus application")
     public List<JsonObject> getLoggers() {
         LogContext logContext = LogContext.getLogContext();
         List<JsonObject> values = new ArrayList<>();
@@ -53,6 +57,7 @@ public class LogStreamJsonRPCService {
     }
 
     @NonBlocking
+    @JsonRpcDescription("Get a specific logger in this Quarkus application")
     public JsonObject getLogger(String loggerName) {
         LogContext logContext = LogContext.getLogContext();
         if (loggerName != null && !loggerName.isEmpty()) {
@@ -66,6 +71,7 @@ public class LogStreamJsonRPCService {
     }
 
     @NonBlocking
+    @JsonRpcDescription("Update a specific logger's log level in this Quarkus application")
     public JsonObject updateLogLevel(String loggerName, String levelValue) {
         LogContext logContext = LogContext.getLogContext();
         Logger logger = logContext.getLogger(loggerName);

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/DevMcpJsonRpcService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/DevMcpJsonRpcService.java
@@ -1,0 +1,39 @@
+package io.quarkus.devui.runtime.mcp;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+
+/**
+ * Normal Dev UI Json RPC Service for the Dev MPC Screen
+ */
+@ApplicationScoped
+public class DevMcpJsonRpcService {
+
+    private final BroadcastProcessor<McpClientInfo> connectedClientStream = BroadcastProcessor.create();
+
+    // TODO: We need to be able to deregister a client if the connection drops. Mayby ping it ?
+
+    private final Set<McpClientInfo> connectedClients = new HashSet<>();
+
+    public Set<McpClientInfo> getConnectedClients() {
+        if (!this.connectedClients.isEmpty()) {
+            return this.connectedClients;
+        }
+        return null;
+    }
+
+    public Multi<McpClientInfo> getConnectedClientStream() {
+        return connectedClientStream;
+    }
+
+    public void addClientInfo(McpClientInfo clientInfo) {
+        this.connectedClients.add(clientInfo);
+        this.connectedClientStream.onNext(clientInfo);
+    }
+
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpBuiltinMethods.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpBuiltinMethods.java
@@ -1,0 +1,11 @@
+package io.quarkus.devui.runtime.mcp;
+
+public interface McpBuiltinMethods {
+    public static final String INITIALIZE = "initialize";
+    public static final String NOTIFICATION = "notification";
+    public static final String TOOLS_LIST = "tools/list";
+    public static final String TOOLS_CALL = "tools/call";
+
+    public static final String RESOURCES_LIST = "resources/list";
+    public static final String RESOURCES_READ = "resources/read";
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpClientInfo.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpClientInfo.java
@@ -1,0 +1,80 @@
+package io.quarkus.devui.runtime.mcp;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class McpClientInfo {
+
+    private String name;
+    private String version;
+
+    public McpClientInfo() {
+    }
+
+    public McpClientInfo(String name, String version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 73 * hash + Objects.hashCode(this.name);
+        hash = 73 * hash + Objects.hashCode(this.version);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final McpClientInfo other = (McpClientInfo) obj;
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        return Objects.equals(this.version, other.version);
+    }
+
+    @Override
+    public String toString() {
+        return "McpClientInfo{" + "name=" + name + ", version=" + version + '}';
+    }
+
+    static McpClientInfo fromMap(Map map) {
+        if (map != null) {
+            McpClientInfo ci = new McpClientInfo();
+            ci.setName((String) map.getOrDefault(NAME, UNKNOWN));
+            ci.setVersion((String) map.getOrDefault(VERSION, ZERO));
+            return ci;
+        }
+        return null;
+    }
+
+    private static final String NAME = "name";
+    private static final String VERSION = "version";
+    private static final String UNKNOWN = "Unknown MCP Client";
+    private static final String ZERO = "0";
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
@@ -1,0 +1,134 @@
+package io.quarkus.devui.runtime.mcp;
+
+import java.util.Map;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.devui.runtime.comms.JsonRpcRouter;
+import io.quarkus.devui.runtime.comms.MessageType;
+import io.quarkus.devui.runtime.jsonrpc.JsonRpcCodec;
+import io.quarkus.devui.runtime.jsonrpc.JsonRpcRequest;
+import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
+import io.quarkus.devui.runtime.mcp.model.InitializeResponse;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Alternative Json RPC communication using Streamable HTTP for MCP
+ */
+public class McpHttpHandler implements Handler<RoutingContext> {
+    private static final Logger LOG = Logger.getLogger(McpHttpHandler.class.getName());
+    private final String quarkusVersion;
+    private final JsonMapper jsonMapper;
+    private JsonRpcCodec codec;
+
+    public McpHttpHandler(String quarkusVersion, JsonMapper jsonMapper) {
+        this.quarkusVersion = quarkusVersion;
+        this.jsonMapper = jsonMapper;
+        this.codec = new JsonRpcCodec(jsonMapper);
+    }
+
+    @Override
+    public void handle(RoutingContext ctx) {
+        // TODO:
+        // Servers MUST validate the Origin header on all incoming connections to prevent DNS rebinding attacks
+        // When running locally, servers SHOULD bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
+        // Servers SHOULD implement proper authentication for all connections
+
+        //The client MUST use HTTP POST to send JSON-RPC messages to the MCP endpoint.
+        //The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
+        // The body of the POST request MUST be a single JSON-RPC request, notification, or response.
+        if (ctx.request().method().equals(HttpMethod.GET)) { // TODO: Also check Accept header
+            handleSSEInitRequest(ctx);
+        } else if (ctx.request().method().equals(HttpMethod.POST)) { // TODO: Also check Accept header
+            handleMCPJsonRPCRequest(ctx);
+        }
+
+    }
+
+    private void handleSSEInitRequest(RoutingContext ctx) {
+        // TODO: Add SSE Support
+        // The client MAY issue an HTTP GET to the MCP endpoint.
+        // This can be used to open an SSE stream, allowing the server to communicate to the client,
+        // without the client first sending data via HTTP POST.
+        // The client MUST include an Accept header, listing text/event-stream as a supported content type.
+
+        //        ctx.response()
+        //                .putHeader("Content-Type", "text/event-stream; charset=utf-8")
+        //                .putHeader("Cache-Control", "no-cache")
+        //                .putHeader("Connection", "keep-alive")
+        //                .setChunked(true);
+        //
+        //        try {
+        //            JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
+        //            jsonRpcRouter.addSseSession(ctx);
+        //        } catch (IllegalStateException e) {
+        //            LOG.debug("Failed to connect to dev sse server", e);
+        //            ctx.response().end();
+        //        }
+
+        // The server MUST either return Content-Type: text/event-stream in response to this HTTP GET,
+        // or else return HTTP 405 Method Not Allowed, indicating that the server does not offer an SSE stream at this endpoint.
+
+        ctx.response()
+                .setStatusCode(405)
+                .putHeader("Allow", "POST")
+                .putHeader("Content-Type", "text/plain")
+                .end("Method Not Allowed");
+
+    }
+
+    private void handleMCPJsonRPCRequest(RoutingContext ctx) {
+        ctx.request().handler(buffer -> {
+            JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
+            String input = buffer.toString();
+
+            JsonRpcRequest jsonRpcRequest = codec.readMCPRequest(input);
+
+            String methodName = jsonRpcRequest.getMethod();
+            McpResponseWriter writer = new McpResponseWriter(ctx.response(), this.jsonMapper, methodName);
+            // First see if this a protocol specific method
+
+            if (methodName.equalsIgnoreCase(McpBuiltinMethods.INITIALIZE)) {
+                // This is a MCP server that initialize
+                this.routeToMCPInitialize(jsonRpcRequest, codec, writer);
+            } else if (methodName.startsWith(McpBuiltinMethods.NOTIFICATION)) {
+                // This is a MCP notification
+                this.routeToMCPNotification(jsonRpcRequest, codec, writer);
+            } else if (methodName.equalsIgnoreCase(McpBuiltinMethods.TOOLS_LIST) ||
+                    methodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_LIST) ||
+                    methodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_READ)) {
+                jsonRpcRequest.setMethod(methodName.replace(SLASH, UNDERSCORE));
+                jsonRpcRouter.route(jsonRpcRequest, writer);
+            } else {
+                // This is a normal extension method
+                jsonRpcRouter.route(jsonRpcRequest, writer);
+            }
+        });
+    }
+
+    private void routeToMCPInitialize(JsonRpcRequest jsonRpcRequest, JsonRpcCodec codec, McpResponseWriter writer) {
+        if (jsonRpcRequest.hasParam(CLIENT_INFO)) {
+            Map map = jsonRpcRequest.getParam(CLIENT_INFO, Map.class);
+            DevMcpJsonRpcService devMcpJsonRpcService = CDI.current().select(DevMcpJsonRpcService.class).get();
+            devMcpJsonRpcService.addClientInfo(McpClientInfo.fromMap(map));
+        }
+        String input = jsonMapper.toString(jsonRpcRequest, true);
+        codec.writeResponse(writer, jsonRpcRequest.getId(), new InitializeResponse(this.quarkusVersion), MessageType.Void);
+    }
+
+    private void routeToMCPNotification(JsonRpcRequest jsonRpcRequest, JsonRpcCodec codec, McpResponseWriter writer) {
+        String jsonRpcMethodName = jsonRpcRequest.getMethod();
+        String notification = jsonRpcMethodName.substring(McpBuiltinMethods.NOTIFICATION.length() + 2);
+        // TODO: Do something with the notification ?
+
+        writer.getResponse().setStatusCode(202).end();
+    }
+
+    private static final String SLASH = "/";
+    private static final String UNDERSCORE = "_";
+    private static final String CLIENT_INFO = "clientInfo";
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
@@ -1,0 +1,222 @@
+package io.quarkus.devui.runtime.mcp;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.devui.runtime.DevUIBuildTimeStaticService;
+import io.quarkus.devui.runtime.comms.JsonRpcRouter;
+import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
+import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
+import io.quarkus.devui.runtime.mcp.model.resource.Content;
+import io.quarkus.devui.runtime.mcp.model.resource.Resource;
+import io.quarkus.runtime.annotations.JsonRpcDescription;
+import io.quarkus.runtime.annotations.Usage;
+
+/**
+ * This expose all Dev UI BuildTimeData and Recorded values as MCP Resources
+ *
+ * @see https://modelcontextprotocol.io/specification/2024-11-05/server/resources#listing-resources
+ * @see https://modelcontextprotocol.io/specification/2024-11-05/server/resources#reading-resources
+ *
+ *      TODO: We can also expose the WorkItems here using resourceTemplates. See
+ *      https://modelcontextprotocol.io/specification/2024-11-05/server/resources#resource-templates
+ *      TODO: We can also send a changed notification on hot reload. See
+ *      https://modelcontextprotocol.io/specification/2024-11-05/server/resources#list-changed-notification
+ */
+@ApplicationScoped
+public class McpResourcesService {
+
+    @Inject
+    JsonRpcRouter jsonRpcRouter;
+
+    @Inject
+    DevUIBuildTimeStaticService buildTimeStaticService;
+
+    private Map<String, String> buildTimeData = null; // TODO: Find a way to set the description here.
+    private Map<String, JsonRpcMethod> recordedMethods = null;
+    // TODO: Add support for subscriptions
+
+    @JsonRpcDescription("This list all resources available for MCP")
+    public Map<String, List<Resource>> list() {
+
+        if (this.buildTimeData == null)
+            fetchBuildTimeData();
+        if (this.recordedMethods == null)
+            fecthRecordedData();
+
+        List<Resource> resources = new ArrayList<>();
+
+        // Add all buildtime data
+        resources.addAll(toBuildTimeDataResourceList());
+        // Add all recorded values as methods
+        resources.addAll(toRecordedResourceList());
+
+        return Map.of("resources", resources);
+    }
+
+    @JsonRpcDescription("This reads a certain resource given the uri as provided by resources/list")
+    public Map<String, List<Content>> read(String uri) {
+        String subUri = uri.substring(URI_SCHEME.length());
+        if (subUri.startsWith(SUB_SCHEME_BUILD_TIME)) {
+            return readBuildTimeData(uri);
+        } else if (subUri.startsWith(SUB_SCHEME_RECORDED)) {
+            return readRecordedData(uri);
+        } else {
+            throw new UncheckedIOException(uri + " not found", new IOException());
+        }
+    }
+
+    private List<Resource> toRecordedResourceList() {
+        List<Resource> resources = new ArrayList<>();
+
+        for (JsonRpcMethod recordedJsonRpcMethod : this.recordedMethods.values()) {
+            if (recordedJsonRpcMethod.getUsage().contains(Usage.DEV_MCP)) {
+                Resource resource = new Resource();
+                resource.uri = URI_SCHEME + SUB_SCHEME_RECORDED + recordedJsonRpcMethod.getMethodName();
+                resource.name = recordedJsonRpcMethod.getMethodName();
+
+                if (recordedJsonRpcMethod.getDescription() != null && !recordedJsonRpcMethod.getDescription().isBlank()) {
+                    resource.description = recordedJsonRpcMethod.getDescription();
+                }
+                resources.add(resource);
+            }
+        }
+
+        return resources;
+    }
+
+    private List<Resource> toBuildTimeDataResourceList() {
+        List<Resource> resources = new ArrayList<>();
+
+        for (Map.Entry<String, String> method : this.buildTimeData.entrySet()) {
+            Resource resource = new Resource();
+            resource.uri = URI_SCHEME + SUB_SCHEME_BUILD_TIME + method.getKey();
+            resource.name = method.getKey();
+            resource.description = method.getValue();
+            resources.add(resource);
+        }
+
+        return resources;
+    }
+
+    private Set<String> extractBuildTimeDataMethods(String ns, String jsContent) {
+        Set<String> result = new LinkedHashSet<>();
+
+        Matcher matcher = BTD_PATTERN.matcher(jsContent);
+
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            String jsonValue = matcher.group(2).trim();
+            if (!isEmptyValue(jsonValue)) { // No worth in adding empty resources
+                result.add(ns + SLASH + name);
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isEmptyValue(String value) {
+        return value == null ||
+                value.trim().isEmpty() ||
+                value.trim().matches("^\\[\\s*]$");
+    }
+
+    private Map<String, List<Content>> readBuildTimeData(String uri) {
+        JsonMapper jsonMapper = jsonRpcRouter.getJsonMapper();
+
+        String method = uri.substring((URI_SCHEME + SUB_SCHEME_BUILD_TIME).length());
+        String[] split = method.split(SLASH);
+        String ns = split[0];
+        String constt = split[1];
+        String filename = ns + DASH_DATA_DOT_JS;
+        String path = buildTimeStaticService.getUrlAndPath().get(filename);
+        try {
+            String jsContent = Files.readString(Paths.get(path));
+            Content content = new Content();
+            content.uri = uri;
+            content.text = jsonMapper.toString(getBuildTimeDataConstValue(jsContent, constt), true);
+            return Map.of("contents", List.of(content));
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Could not read " + path, ex);
+        }
+
+    }
+
+    private Map<String, List<Content>> readRecordedData(String uri) {
+        JsonMapper jsonMapper = jsonRpcRouter.getJsonMapper();
+
+        String method = uri.substring((URI_SCHEME + SUB_SCHEME_RECORDED).length());
+        Content content = new Content();
+        content.uri = uri;
+        content.text = jsonMapper.toString(recordedMethods.get(method).getRuntimeValue().getValue(), true);
+        // TODO: Handle Futures Unis and Multies
+
+        return Map.of("contents", List.of(content));
+    }
+
+    private void fetchBuildTimeData() {
+        this.buildTimeData = new LinkedHashMap<>();
+
+        Map<String, String> descriptions = buildTimeStaticService.getDescriptions();
+
+        Map<String, String> urlAndPath = buildTimeStaticService.getUrlAndPath();
+        for (Map.Entry<String, String> kv : urlAndPath.entrySet()) {
+            if (kv.getKey().endsWith(DASH_DATA_DOT_JS)) {
+                try {
+                    String key = kv.getKey().substring(0, kv.getKey().length() - DASH_DATA_DOT_JS.length());
+
+                    if (!key.equalsIgnoreCase("devui-jsonrpc")) { // We ignore this namespace, as this is the same as tools/list
+                        String content = Files.readString(Paths.get(kv.getValue()));
+                        Set<String> methodNames = extractBuildTimeDataMethods(key, content);
+                        for (String methodName : methodNames) {
+                            if (descriptions.containsKey(methodName)) {
+                                this.buildTimeData.put(methodName, descriptions.get(methodName)); // Only if a description exist
+                            }
+                        }
+                    }
+                } catch (IOException ex) {
+                    // Ignore ?
+                    ex.printStackTrace();
+                }
+            }
+        }
+    }
+
+    // TODO: Find a simpler way.
+    private String getBuildTimeDataConstValue(String jsContent, String constName) {
+        String patternString = "export const " + Pattern.quote(constName) + "\\s*=\\s*([^;]+);";
+        Pattern pattern = Pattern.compile(patternString, Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(jsContent);
+
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+
+        return "Error: Data not found for " + constName;
+    }
+
+    private void fecthRecordedData() {
+        this.recordedMethods = jsonRpcRouter.getRecordedMethodsMap();
+    }
+
+    private static final Pattern BTD_PATTERN = Pattern.compile("export const (\\w+)\\s*=\\s*([^;]+);", Pattern.DOTALL);
+
+    private static final String URI_SCHEME = "quarkus://resource/";
+    private static final String SUB_SCHEME_BUILD_TIME = "build-time/";
+    private static final String SUB_SCHEME_RECORDED = "recorded/";
+    private static final String SLASH = "/";
+    private static final String DASH_DATA_DOT_JS = "-data.js";
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResponseWriter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResponseWriter.java
@@ -1,0 +1,69 @@
+package io.quarkus.devui.runtime.mcp;
+
+import java.nio.charset.StandardCharsets;
+
+import io.quarkus.devui.runtime.comms.JsonRpcResponseWriter;
+import io.quarkus.devui.runtime.comms.MessageType;
+import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
+import io.quarkus.devui.runtime.mcp.model.tool.CallToolResult;
+import io.vertx.core.http.HttpServerResponse;
+
+/**
+ * Write the response for MCP Call. Depending on the original method request, we might need to wrap this into an expected output
+ */
+public class McpResponseWriter implements JsonRpcResponseWriter {
+    private final HttpServerResponse response;
+    private final String requestMethodName;
+    private final JsonMapper jsonMapper;
+
+    public McpResponseWriter(HttpServerResponse response, JsonMapper jsonMapper, String requestMethodName) {
+        this.response = response;
+        this.jsonMapper = jsonMapper;
+        this.requestMethodName = requestMethodName;
+    }
+
+    @Override
+    public void write(String message) {
+        String output = message + "\n\n";
+        int length = output.getBytes(StandardCharsets.UTF_8).length;
+
+        if (!response.closed()) {
+            response.putHeader("Content-Type", "application/json")
+                    .putHeader("Content-Length", String.valueOf(length))
+                    .end(output);
+        }
+    }
+
+    @Override
+    public void close() {
+        response.end();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !response.closed();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return response.closed();
+    }
+
+    public HttpServerResponse getResponse() {
+        return this.response;
+    }
+
+    @Override
+    public Object decorateObject(Object object, MessageType messageType) {
+        if (requestMethodName.equalsIgnoreCase(McpBuiltinMethods.INITIALIZE) ||
+                requestMethodName.equalsIgnoreCase(McpBuiltinMethods.NOTIFICATION) ||
+                requestMethodName.equalsIgnoreCase(McpBuiltinMethods.TOOLS_LIST) ||
+                requestMethodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_LIST) ||
+                requestMethodName.equalsIgnoreCase(McpBuiltinMethods.RESOURCES_READ)) {
+            return object;
+        } else { // Anyting else is a Tools call that we need to wrap in a call result objectc
+            String text = jsonMapper.toString(object, true);
+            return new CallToolResult(text);
+        }
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
@@ -1,0 +1,117 @@
+package io.quarkus.devui.runtime.mcp;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.devui.runtime.comms.JsonRpcRouter;
+import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
+import io.quarkus.devui.runtime.mcp.model.tool.Tool;
+import io.quarkus.runtime.annotations.JsonRpcDescription;
+import io.quarkus.runtime.annotations.Usage;
+
+/**
+ * This exposes all Dev UI Runtime and Deployment JsonRPC Methods as MCP Tools
+ *
+ * @see https://modelcontextprotocol.io/specification/2024-11-05/server/tools
+ */
+@ApplicationScoped
+public class McpToolsService {
+
+    @Inject
+    JsonRpcRouter jsonRpcRouter;
+
+    @JsonRpcDescription("This list all tools available for MCP")
+    public Map<String, List<Tool>> list() {
+        List<Tool> tools = toToolList(jsonRpcRouter.getRuntimeMethodsMap().values(),
+                jsonRpcRouter.getDeploymentMethodsMap().values());
+        // TODO: Add support for subscriptions
+        return Map.of("tools", tools);
+    }
+
+    private List<Tool> toToolList(Collection<JsonRpcMethod> runtimeMethods,
+            Collection<JsonRpcMethod> deploymentMethods) {
+        List<Tool> tools = new ArrayList<>();
+        for (JsonRpcMethod runtimeJsonRpcMethod : runtimeMethods) {
+            addTool(tools, runtimeJsonRpcMethod);
+        }
+        for (JsonRpcMethod deploymentJsonRpcMethod : deploymentMethods) {
+            addTool(tools, deploymentJsonRpcMethod);
+        }
+        return tools;
+    }
+
+    private void addTool(List<Tool> tools, JsonRpcMethod method) {
+        Tool tool = toTool(method);
+        if (tool != null) {
+            tools.add(tool);
+        }
+    }
+
+    private Tool toTool(JsonRpcMethod jsonRpcMethod) {
+
+        if (!jsonRpcMethod.getUsage().contains(Usage.DEV_MCP)) {
+            return null;
+        }
+
+        Tool tool = new Tool();
+        tool.name = jsonRpcMethod.getMethodName();
+        if (jsonRpcMethod.getDescription() != null && !jsonRpcMethod.getDescription().isBlank()) {
+            tool.description = jsonRpcMethod.getDescription();
+        }
+
+        Map<String, Object> props = new LinkedHashMap<>();
+        List<String> required = new ArrayList<>();
+
+        if (jsonRpcMethod.hasParameters()) {
+            for (Map.Entry<String, JsonRpcMethod.Parameter> parameter : jsonRpcMethod.getParameters().entrySet()) {
+                Map<String, Object> prop = new HashMap<>();
+                JsonRpcMethod.Parameter p = parameter.getValue();
+                prop.put("type", mapJavaTypeToJsonType(p.getType()));
+                if (p.getDescription() != null && !p.getDescription().isBlank()) {
+                    prop.put("description", p.getDescription());
+                }
+                required.add(parameter.getKey()); // TODO: Check for optional here
+                props.put(parameter.getKey(), prop);
+
+            }
+        }
+
+        tool.inputSchema = Map.of(
+                "type", "object",
+                "properties", props,
+                "required", required);
+
+        return tool;
+    }
+
+    private String mapJavaTypeToJsonType(Class<?> clazz) {
+        if (clazz == null)
+            return "string"; // fallback
+
+        if (clazz == String.class)
+            return "string";
+        if (clazz == Boolean.class || clazz == boolean.class)
+            return "boolean";
+        if (clazz == Integer.class || clazz == int.class
+                || clazz == Long.class || clazz == long.class
+                || clazz == Short.class || clazz == short.class
+                || clazz == Byte.class || clazz == byte.class)
+            return "integer";
+        if (clazz == Double.class || clazz == double.class
+                || clazz == Float.class || clazz == float.class)
+            return "number";
+        if (clazz.isArray() || List.class.isAssignableFrom(clazz))
+            return "array";
+        if (Map.class.isAssignableFrom(clazz))
+            return "object";
+
+        return "string"; // fallback for enums, complex types, etc.
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/InitializeResponse.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/InitializeResponse.java
@@ -1,0 +1,39 @@
+package io.quarkus.devui.runtime.mcp.model;
+
+/**
+ * The Initialize response as per MCP Spec (2025-03-26)
+ */
+public class InitializeResponse {
+    public String protocolVersion = "2025-03-26";
+    public Capabilities capabilities = new Capabilities();
+    public ServerInfo serverInfo;
+    public String instructions = "This MCP Server expose internals of a Running (Dev Mode) Quarkus application";
+
+    public InitializeResponse(String quarkusVersion) {
+        this.serverInfo = new ServerInfo(quarkusVersion);
+    }
+
+    public class Capabilities {
+        public Resources resources = new Resources();
+        public Tools tools = new Tools();
+    }
+
+    public class Resources {
+        public boolean subscribe = false;
+        public boolean listChanged = false;
+    }
+
+    public class Tools {
+        public boolean subscribe = false;
+        public boolean listChanged = false;
+    }
+
+    public class ServerInfo {
+        public String name = "Quarkus Dev MCP";
+        public String version;
+
+        ServerInfo(String version) {
+            this.version = version;
+        }
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/resource/Content.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/resource/Content.java
@@ -1,0 +1,14 @@
+package io.quarkus.devui.runtime.mcp.model.resource;
+
+/**
+ * Defines a MCP Content
+ *
+ * @see https://modelcontextprotocol.io/docs/concepts/resources
+ */
+public class Content {
+    private static final String MIME_TYPE_JSON = "application/json";
+
+    public String uri;
+    public String text;
+    public String mimeType = MIME_TYPE_JSON; // default
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/resource/Resource.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/resource/Resource.java
@@ -1,0 +1,15 @@
+package io.quarkus.devui.runtime.mcp.model.resource;
+
+/**
+ * Defines a MCP Resource
+ *
+ * @see https://modelcontextprotocol.io/docs/concepts/resources
+ */
+public class Resource {
+    private static final String MIME_TYPE_JSON = "application/json";
+
+    public String uri;
+    public String name;
+    public String description;
+    public String mimeType = MIME_TYPE_JSON; // default
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/tool/CallToolResult.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/tool/CallToolResult.java
@@ -1,0 +1,32 @@
+package io.quarkus.devui.runtime.mcp.model.tool;
+
+import java.util.List;
+
+public class CallToolResult {
+    private List<TextContent> content;
+    private Boolean isError = false;
+
+    public CallToolResult() {
+
+    }
+
+    public CallToolResult(String text) {
+        this.content = List.of(new TextContent(text));
+    }
+
+    public List<TextContent> getContent() {
+        return content;
+    }
+
+    public void setContent(List<TextContent> content) {
+        this.content = content;
+    }
+
+    public Boolean getIsError() {
+        return isError;
+    }
+
+    public void setIsError(Boolean isError) {
+        this.isError = isError;
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/tool/TextContent.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/tool/TextContent.java
@@ -1,0 +1,30 @@
+package io.quarkus.devui.runtime.mcp.model.tool;
+
+public class TextContent {
+    private String type = "text";
+    private String text;
+
+    public TextContent() {
+
+    }
+
+    public TextContent(String text) {
+        this.text = text;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/tool/Tool.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/model/tool/Tool.java
@@ -1,0 +1,14 @@
+package io.quarkus.devui.runtime.mcp.model.tool;
+
+import java.util.Map;
+
+/**
+ * Defines a MCP Tool
+ */
+public class Tool {
+    public String name;
+    public String description;
+    public Map<String, Object> inputSchema;
+    public Map<String, Object> annotations;
+
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/reportissues/ReportIssuesJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/reportissues/ReportIssuesJsonRPCService.java
@@ -18,6 +18,7 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.smallrye.common.os.OS;
 import io.vertx.core.json.JsonObject;
 
@@ -30,6 +31,7 @@ public class ReportIssuesJsonRPCService {
     @ConfigProperty(name = "quarkus.devui.report-issues.url", defaultValue = "https://github.com/quarkusio/quarkus/issues/new?labels=kind%2Fbug&template=bug_report.yml")
     String reportURL;
 
+    @JsonRpcDescription("Creates a url that if opened, will go to issue report for the Quarkus project with some of the value pre-filled")
     public JsonObject reportBug() {
         URLBuilder urlBuilder = new URLBuilder(reportURL);
         gatherInfo(urlBuilder);

--- a/extensions/devui/test-spi/src/main/java/io/quarkus/devui/tests/DevUIJsonRPCTest.java
+++ b/extensions/devui/test-spi/src/main/java/io/quarkus/devui/tests/DevUIJsonRPCTest.java
@@ -178,7 +178,7 @@ public class DevUIJsonRPCTest {
 
         request.put("jsonrpc", "2.0");
         request.put("id", id);
-        request.put("method", this.namespace + "." + methodName);
+        request.put("method", this.namespace + "_" + methodName);
         ObjectNode jsonParams = mapper.createObjectNode();
         if (params != null && !params.isEmpty()) {
             for (Map.Entry<String, Object> p : params.entrySet()) {

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
@@ -37,7 +37,6 @@ public class InfoDevUIProcessor {
                 .isJsonContent();
 
         CardPageBuildItem cardBuildItem = new CardPageBuildItem();
-        cardBuildItem.addBuildTimeData("infoUrl", path);
         cardBuildItem.addPage(infoPage);
         cardBuildItem.addPage(rawPage);
         cardPageProducer.produce(cardBuildItem);

--- a/extensions/info/deployment/src/main/resources/dev-ui/qwc-info.js
+++ b/extensions/info/deployment/src/main/resources/dev-ui/qwc-info.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css} from 'lit';
-import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import { infoUrl } from 'build-time-data';
+import { JsonRpc } from 'jsonrpc';
 import '@vaadin/progress-bar';
 import '@qomponent/qui-card';
 import '@vaadin/icon';
@@ -10,6 +10,8 @@ import '@vaadin/icon';
  * This component shows the Info Screen
  */
 export class QwcInfo extends LitElement {
+
+    jsonRpc = new JsonRpc(this);
 
     static styles = css`
         :host {
@@ -46,19 +48,14 @@ export class QwcInfo extends LitElement {
 
     constructor() {
         super();
-        this._infoUrl = infoUrl;
         this._info = null;
     }
 
     async connectedCallback() {
         super.connectedCallback();
-        await this.load();
-    }
-
-    async load() {
-        const response = await fetch(this._infoUrl);
-        const data = await response.json();
-        this._info = data;
+        this.jsonRpc.getApplicationAndEnvironmentInfo().then(jsonRpcResponse => { 
+            this._info = jsonRpcResponse.result;
+        });
     }
 
     render() {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.TemplateHtmlBuilder;
+import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.smallrye.common.annotation.NonBlocking;
 import io.vertx.core.json.JsonArray;
@@ -136,6 +137,7 @@ public class ResourceNotFoundData {
     }
 
     @NonBlocking
+    @JsonRpcDescription("Information on endpoints exposed by this application in Dev Mode. This includes Quarkus endpoints and application endpoints")
     public JsonObject getJsonContent() {
         List<RouteDescription> combinedRoutes = getCombinedRoutes();
         JsonObject infoMap = new JsonObject();


### PR DESCRIPTION
The PR introduces the ability to expose capabilities of the DevUI as MCP tools (and others), essentially making
a Quarkus application running in Dev Mode an MCP server.


https://github.com/user-attachments/assets/d60bef00-ce95-4217-a5b1-676865156494

https://github.com/user-attachments/assets/b7f4df15-549d-4a88-9fad-6d6bbbd34c9d




![image](https://github.com/user-attachments/assets/720ac2f2-2e5e-4f05-89f5-c585c28966f2)

TODO:

- [x] Making sure the Streamable Endpoint is handling all requests expected from Goose or similar.
- [x] Implement the resources from build time data 
- [x] Implement the resources from recorded values
- [ ] Implement the resourcesTemplates from Workspace Items
- [x] Add the parameters to the runtime tools
- [x] Add the parameters to the deployment tools
- [x] If the auto description is not enough, find a way to add descriptions.
- [x] Maybe have a filter to filter out some methods to not be used in MCP ?
- [x] Populate the Dev UI MCP Server page with info on how to use this.
