### PR TITLE
Only reset the test TCCL in cases where we had changed it

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MethodSourceTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MethodSourceTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +29,9 @@ public class MethodSourceTest {
     public void testParameterResolver(UnusedBean.DummyInput dummyInput, Matcher<String> matcher) {
         UnusedBean.DummyResult dummyResult = unusedBean.dummy(dummyInput);
         assertThat(dummyResult.getResult(), matcher);
+
+        // Can we get config?
+        ConfigProvider.getConfig();
     }
 
     private static Collection<Arguments> provideDummyInput() {

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -74,6 +74,14 @@
             <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- This one is used by the tested projects so we need to create a dependency
+        to make sure GIB triggers the testing. --> 
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-project-core-extension-codestarts</artifactId>


### PR DESCRIPTION
... as well as class sources. 

Fixes https://github.com/quarkusio/quarkus/issues/47419.

Note that I've added a test, but the test I added does *not* reproduce the camel problem. I decided to fix first and create local reproducers second. :) 