### PR TITLE
Make Stork optional for REST Client

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -127,6 +127,7 @@ public interface Capability {
     String SMALLRYE_OPENAPI = QUARKUS_PREFIX + ".smallrye.openapi";
     String SMALLRYE_GRAPHQL = QUARKUS_PREFIX + ".smallrye.graphql";
     String SMALLRYE_FAULT_TOLERANCE = QUARKUS_PREFIX + ".smallrye.faulttolerance";
+    String SMALLRYE_STORK = QUARKUS_PREFIX + ".smallrye.stork";
 
     String SPRING_WEB = QUARKUS_PREFIX + ".spring.web";
 

--- a/docs/src/main/asciidoc/stork-kubernetes.adoc
+++ b/docs/src/main/asciidoc/stork-kubernetes.adoc
@@ -61,10 +61,10 @@ The various integrations in Quarkus extract the location of the service from tha
 
 == Bootstrapping the project
 
-Create a Quarkus project importing the quarkus-rest-client and quarkus-rest extensions using your favorite approach:
+Create a Quarkus project importing the quarkus-rest-client, quarkus-rest, and quarkus-smallrye-stork extensions using your favorite approach:
 
 :create-app-artifact-id: stork-kubernetes-quickstart
-:create-app-extensions: quarkus-rest-client,quarkus-rest
+:create-app-extensions: quarkus-rest-client,quarkus-rest,quarkus-smallrye-stork
 include::{includes}/devtools/create-app.adoc[]
 
 In the generated project, also add the following dependencies:

--- a/docs/src/main/asciidoc/stork.adoc
+++ b/docs/src/main/asciidoc/stork.adoc
@@ -70,10 +70,10 @@ image::stork-process.png[Discovery and Selection of services,width=50%, align=ce
 
 == Bootstrapping the project
 
-Create a Quarkus project importing the quarkus-rest-client and quarkus-rest extensions using your favorite approach:
+Create a Quarkus project importing the quarkus-rest-client, quarkus-rest, and quarkus-smallrye-stork extensions using your favorite approach:
 
 :create-app-artifact-id: stork-quickstart
-:create-app-extensions: quarkus-rest-client,quarkus-rest
+:create-app-extensions: quarkus-rest-client,quarkus-rest,quarkus-smallrye-stork
 include::{includes}/devtools/create-app.adoc[]
 
 In the generated project, also add the following dependencies:

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -93,6 +93,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -259,9 +259,14 @@ public class JaxrsClientReactiveProcessor {
     }
 
     @BuildStep
-    void initializeStorkFilter(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+    void initializeStorkFilter(Capabilities capabilities,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
+        if (!capabilities.isPresent(Capability.SMALLRYE_STORK)) {
+            return;
+        }
+
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(StorkClientRequestFilter.class));
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(StorkClientRequestFilter.class.getName()));

--- a/extensions/resteasy-reactive/rest-client/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client/deployment/pom.xml
@@ -26,10 +26,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-config-deployment</artifactId>
         </dependency>
         <dependency>
@@ -99,6 +95,11 @@
         <dependency>
             <groupId>io.smallrye.stork</groupId>
             <artifactId>stork-load-balancer-least-response-time</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/resteasy-reactive/rest-client/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client/runtime/pom.xml
@@ -20,23 +20,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-stork</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-config</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-tls-registry</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.stork</groupId>
-            <artifactId>stork-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.stork</groupId>
-            <artifactId>stork-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>

--- a/extensions/smallrye-stork/runtime/pom.xml
+++ b/extensions/smallrye-stork/runtime/pom.xml
@@ -41,6 +41,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.smallrye.stork</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/independent-projects/resteasy-reactive/client/runtime/pom.xml
+++ b/independent-projects/resteasy-reactive/client/runtime/pom.xml
@@ -17,6 +17,11 @@
         <dependency>
             <groupId>io.smallrye.stork</groupId>
             <artifactId>stork-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.resteasy.reactive</groupId>

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/StorkClientRequestFilter.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/StorkClientRequestFilter.java
@@ -20,7 +20,24 @@ import io.smallrye.stork.Stork;
 @Priority(Priorities.AUTHENTICATION)
 @Provider
 public class StorkClientRequestFilter implements ResteasyReactiveClientRequestFilter {
+
     private static final Logger log = Logger.getLogger(StorkClientRequestFilter.class);
+
+    private final Stork stork;
+
+    public StorkClientRequestFilter() {
+        try {
+            stork = Stork.getInstance();
+
+            if (stork == null) {
+                throw new IllegalStateException(
+                        "Trying to use a StorkClientRequestFilter but the quarkus-smallrye-stork extension is missing, please add the extension.");
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Trying to use a StorkClientRequestFilter but the quarkus-smallrye-stork extension is missing, please add the extension.");
+        }
+    }
 
     @Override
     public void filter(ResteasyReactiveClientRequestContext requestContext) {
@@ -34,8 +51,7 @@ public class StorkClientRequestFilter implements ResteasyReactiveClientRequestFi
             requestContext.suspend();
             boolean measureTime = shouldMeasureTime(requestContext.getResponseType());
             try {
-                Stork.getInstance()
-                        .getService(serviceName)
+                stork.getService(serviceName)
                         .selectInstanceAndRecordStart(measureTime)
                         .subscribe()
                         .with(instance -> {

--- a/integration-tests/rest-client-reactive-stork/pom.xml
+++ b/integration-tests/rest-client-reactive-stork/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
@@ -83,6 +87,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/smallrye-stork-registration/pom.xml
+++ b/integration-tests/smallrye-stork-registration/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
+            <artifactId>quarkus-smallrye-stork</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.stork</groupId>
@@ -50,6 +50,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
If you want to use Stork, you now have to add the quarkus-smallrye-stork extension, which IMHO makes perfect sense.

This avoids initializing Stork for every application using the REST Client.

I tested several ITs both in JVM and native and it looked fine. Let's hope CI will agree.

Fixes #47337