### PR TITLE
Speed up reload test and update lgtm image

### DIFF
--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
@@ -4,7 +4,7 @@ public final class ContainerConstants {
 
     // Images
 
-    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.9.0";
+    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.11.0";
 
     // Ports
 

--- a/integration-tests/observability-lgtm/src/main/resources/application.properties
+++ b/integration-tests/observability-lgtm/src/main/resources/application.properties
@@ -4,12 +4,13 @@ quarkus.log.category."io.quarkus.devservices".level=DEBUG
 #micrometer
 quarkus.micrometer.export.otlp.enabled=true
 quarkus.micrometer.export.otlp.publish=true
-quarkus.micrometer.export.otlp.step=PT5S
+quarkus.micrometer.export.otlp.step=PT1S
 quarkus.micrometer.export.otlp.default-registry=true
 %prod.quarkus.micrometer.export.otlp.url=http://localhost:4318/v1/metrics
 
 #opentelemetry
 %prod.quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4318
+quarkus.otel.metric.export.interval=1s
 
 #quarkus.observability.lgtm.image-name=grafana/otel-lgtm
 #quarkus.observability.lgtm.logging=ALL

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
@@ -20,15 +20,15 @@ public abstract class LgtmTestHelper {
         log.info("Response: " + response);
         GrafanaClient client = new GrafanaClient(grafanaEndpoint(), "admin", "admin");
 
-        Awaitility.setDefaultPollInterval(1, TimeUnit.SECONDS); // reduce load on the server. Default is .1s
+        Awaitility.setDefaultPollInterval(5, TimeUnit.SECONDS); // reduce load on the server. Default is .1s
 
-        Awaitility.given().ignoreException(UncheckedIOException.class).await().atMost(61, TimeUnit.SECONDS).until(
+        Awaitility.given().ignoreException(UncheckedIOException.class).await().atMost(90, TimeUnit.SECONDS).until(
                 client::user,
                 u -> "admin".equals(u.login));
-        Awaitility.given().ignoreException(UncheckedIOException.class).await().atMost(61, TimeUnit.SECONDS).until(
+        Awaitility.given().ignoreException(UncheckedIOException.class).await().atMost(90, TimeUnit.SECONDS).until(
                 () -> client.query("xvalue_X"),
                 result -> !result.data.result.isEmpty());
-        Awaitility.given().ignoreException(UncheckedIOException.class).await().atMost(61, TimeUnit.SECONDS).until(
+        Awaitility.given().ignoreException(UncheckedIOException.class).await().atMost(90, TimeUnit.SECONDS).until(
                 () -> client.traces("quarkus-integration-test-observability-lgtm", 20, 3),
                 result -> !result.traces.isEmpty());
     }

--- a/integration-tests/observability-lgtm/src/test/resources/application.properties
+++ b/integration-tests/observability-lgtm/src/test/resources/application.properties
@@ -7,6 +7,6 @@ quarkus.log.category."io.quarkus.devservices".level=DEBUG
 #micrometer
 quarkus.micrometer.export.otlp.enabled=true
 quarkus.micrometer.export.otlp.publish=true
-quarkus.micrometer.export.otlp.step=PT5S
+quarkus.micrometer.export.otlp.step=PT1S
 
 quarkus.observability.lgtm.timeout=PT3M


### PR DESCRIPTION
Tweaking timeouts and confs.
The new Grafana-lgtm image also starts quicker.
On my machine the tests run on 1/3 of the time, now.