### PR TITLE
Panache and Hibernate Reactive use different Vert.x local contexts

### DIFF
--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Counter.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Counter.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.panache.reactive;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+
+@Entity
+public class Counter extends PanacheEntityBase {
+
+    @Id
+    private Long id;
+    private int count = 0;
+
+    public Counter() {
+    }
+
+    public Counter(long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(count);
+    }
+
+    public void increase() {
+        this.count++;
+    }
+}

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/WithTransactionCounterBean.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/WithTransactionCounterBean.java
@@ -1,0 +1,64 @@
+package io.quarkus.it.panache.reactive;
+
+import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * The goal if this class is to test the usage of {@link WithTransaction},
+ * you should not use {@link io.quarkus.hibernate.reactive.panache.Panache#withTransaction(Supplier)}
+ * nor {@link org.hibernate.reactive.mutiny.Mutiny.SessionFactory#withTransaction(Function)}
+ */
+@ApplicationScoped
+@WithTransaction
+public class WithTransactionCounterBean {
+
+    private static final Long ID_COUNTER = 42L;
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    public Uni<Counter> createOrResetCounter() {
+        final Counter counter = new Counter(ID_COUNTER);
+        return sessionFactory.withStatelessSession(session -> session
+                .upsert(counter)
+                .replaceWith(counter));
+    }
+
+    public Uni<Counter> increaseCounterWithHR() {
+        return sessionFactory.withSession(session -> session
+                .find(Counter.class, ID_COUNTER, PESSIMISTIC_WRITE)
+                .invoke(Counter::increase));
+    }
+
+    public Uni<Counter> increaseCounterWithPanache() {
+        return Counter
+                .<Counter> findById(ID_COUNTER, PESSIMISTIC_WRITE)
+                .invoke(Counter::increase);
+    }
+
+    public Uni<Void> assertThatSessionsAreEqual() {
+        return sessionFactory.withSession(hrSession -> Panache
+                .getSession().chain(panacheSession -> {
+                    if (panacheSession != hrSession) {
+                        return Uni.createFrom().failure(new AssertionError("Sessions are different!"));
+                    }
+                    return Uni.createFrom().voidItem();
+                }));
+    }
+
+    public Uni<Counter> findCounter() {
+        return sessionFactory.withSession(session -> session
+                .find(Counter.class, ID_COUNTER));
+    }
+}

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/WithTransactionTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/WithTransactionTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.it.panache.reactive;
+
+import static io.quarkus.vertx.VertxContextSupport.subscribeAndAwait;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Hibernate Reactive and Panache store the created sessions in a local Vert.x context,
+ * and we need to make sure that they won't get lost.
+ * See issue <a href="https://github.com/quarkusio/quarkus/issues/47314">47314</a>
+ *
+ * @see io.quarkus.hibernate.reactive.panache.common.runtime.SessionOperations
+ * @see io.quarkus.hibernate.reactive.panache.common.WithTransaction
+ */
+@QuarkusTest
+public class WithTransactionTest {
+    // How many times we want to increase the counter
+    private static final int INCREASES_NUM = 10;
+
+    @Inject
+    WithTransactionCounterBean counterBean;
+
+    @BeforeEach
+    public void createOrResetCounter() throws Throwable {
+        subscribeAndAwait(counterBean::createOrResetCounter);
+    }
+
+    @Test
+    void increaseCounterWithHibernateReactive() throws Throwable {
+        subscribeAndAwait(counterBean::increaseCounterWithHR);
+        Counter counter = subscribeAndAwait(counterBean::findCounter);
+
+        assertThat(counter.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void increaseCounterWithPanache() throws Throwable {
+        subscribeAndAwait(counterBean::increaseCounterWithPanache);
+        Counter counter = subscribeAndAwait(counterBean::findCounter);
+
+        assertThat(counter.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldReuseExistingSessions() throws Throwable {
+        subscribeAndAwait(counterBean::assertThatSessionsAreEqual);
+    }
+
+    @Test
+    void increaseCounter() throws Throwable {
+        List<Supplier<Uni<Counter>>> suppliers = new ArrayList<>();
+        for (int i = 0; i < INCREASES_NUM; i++) {
+            suppliers.add(() -> counterBean.increaseCounterWithHR());
+        }
+
+        final List<Counter> results = new ArrayList<>();
+        suppliers.stream()
+                .parallel()
+                .forEach(uni -> increaseCounter(uni, results));
+
+        final Counter dbCounter = subscribeAndAwait(() -> counterBean.findCounter());
+        assertThat(dbCounter.getCount()).isEqualTo(INCREASES_NUM);
+    }
+
+    private static void increaseCounter(Supplier<Uni<Counter>> func, List<Counter> counters) {
+        try {
+            final var counter = subscribeAndAwait(func);
+            counters.add(counter);
+        } catch (final Throwable e) {
+            fail(e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>2.4.6.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>2.4.7.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
         <hibernate-search.version>7.2.3.Final</hibernate-search.version>
 


### PR DESCRIPTION
Possible fix for https://github.com/quarkusio/quarkus/issues/47314

Draft because it needs [these changes](https://github.com/hibernate/hibernate-reactive/pull/2208) in Hibernate Reactive (next release).
@tsegismont, or @vietj,  Do these changes make sense?

Thanks
