### PR TITLE
Set path of client subinterfaces 2+ levels deep

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/InterfacePathInheritanceTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/InterfacePathInheritanceTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.hamcrest.MatcherAssert;
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.resteasy.reactive.common.deployment.ResourceScanningResultBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InterfacePathInheritanceTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(Z.class)
+                    .addClass(Y.class)
+                    .addClass(InheritanceTestClient.class))
+            .addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            ResourceScanningResultBuildItem consumed = context.consume(ResourceScanningResultBuildItem.class);
+                            context.produce(new FeatureBuildItem("just-here-to-invoke-buildstep"));
+
+                            Map<DotName, String> clientInterfaces = consumed.getResult().getClientInterfaces();
+                            MatcherAssert.assertThat(clientInterfaces.size(), is(3));
+                            clientInterfaces.forEach((k, v) -> {
+                                MatcherAssert.assertThat("Path of %s needs to match".formatted(k), v, is("hello"));
+                            });
+                        }
+                    }).consumes(ResourceScanningResultBuildItem.class).produces(FeatureBuildItem.class).build();
+                }
+            });
+
+    @Test
+    void basicTest() {
+        // see addBuildChainCustomizer of RegisterExtension for the test logic
+    }
+
+    @Path("hello")
+    public interface Z {
+        @GET
+        @Path("something")
+        String get();
+    }
+
+    public interface Y extends Z {
+
+    }
+
+    @RegisterRestClient
+    public interface InheritanceTestClient extends Y {
+
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -302,11 +302,9 @@ public class ResteasyReactiveScanner {
             }
         }
 
-        Map<DotName, String> clientInterfaceSubtypes = new HashMap<>();
-        for (DotName interfaceName : clientInterfaces.keySet()) {
-            addClientSubInterfaces(interfaceName, index, clientInterfaceSubtypes, clientInterfaces);
+        for (DotName interfaceName : new ArrayList<>(clientInterfaces.keySet())) {
+            addClientSubInterfaces(interfaceName, index, clientInterfaces);
         }
-        clientInterfaces.putAll(clientInterfaceSubtypes);
 
         for (Map.Entry<DotName, String> i : pathInterfaces.entrySet()) {
             for (ClassInfo clazz : index.getAllKnownImplementors(i.getKey())) {
@@ -402,13 +400,13 @@ public class ResteasyReactiveScanner {
     }
 
     private static void addClientSubInterfaces(DotName interfaceName, IndexView index,
-            Map<DotName, String> clientInterfaceSubtypes, Map<DotName, String> clientInterfaces) {
+            Map<DotName, String> clientInterfaces) {
+
         Collection<ClassInfo> subclasses = index.getKnownDirectImplementors(interfaceName);
         for (ClassInfo subclass : subclasses) {
-            if (!clientInterfaces.containsKey(subclass.name()) && Modifier.isInterface(subclass.flags())
-                    && !clientInterfaceSubtypes.containsKey(subclass.name())) {
-                clientInterfaceSubtypes.put(subclass.name(), clientInterfaces.get(interfaceName));
-                addClientSubInterfaces(subclass.name(), index, clientInterfaceSubtypes, clientInterfaces);
+            if (!clientInterfaces.containsKey(subclass.name()) && Modifier.isInterface(subclass.flags())) {
+                clientInterfaces.put(subclass.name(), clientInterfaces.get(interfaceName));
+                addClientSubInterfaces(subclass.name(), index, clientInterfaces);
             }
         }
 


### PR DESCRIPTION
The path of client interfaces, which do not have a Path annotation of their own, needs to be set to the path of its direct parent. Now this also works if a parent interface is inerhited 2 or more levels deep, without another Path annotation on any of the sub interfaces.

This prevents an NPE I discovered while working on #43011