### PR TITLE
Tweaks for permission checkers for WebSockets Next

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -1029,6 +1029,8 @@ public class ProductEndpoint {
 <1> The `getProduct` callback method can only be invoked if the current security identity has an `admin` role or the user is allowed to get the product detail.
 <2> The error handler is invoked in case of the authorization failure.
 
+More information about permission checkers can be found on the JavaDoc of link:https://javadoc.io/doc/io.quarkus.security/quarkus-security/latest/io.quarkus.security.api/io/quarkus/security/PermissionChecker.html[`@PermissionChecker`].
+
 ==== Bearer token authentication
 
 The xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication] expects that the bearer token is passed in the `Authorization` header during the initial HTTP handshake.

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/HttpUpgradePermissionCheckerTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/HttpUpgradePermissionCheckerTest.java
@@ -33,6 +33,7 @@ import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
 import io.quarkus.websockets.next.test.utils.WSClient;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.UpgradeRejectedException;
 
 public class HttpUpgradePermissionCheckerTest extends SecurityTestBase {
@@ -138,8 +139,8 @@ public class HttpUpgradePermissionCheckerTest extends SecurityTestBase {
     public static class AdminEndpoint {
 
         @OnOpen
-        String open() {
-            return "ready";
+        Uni<String> open() {
+            return Uni.createFrom().item("ready");
         }
 
         @OnTextMessage

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/PayloadPermissionCheckerTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/PayloadPermissionCheckerTest.java
@@ -25,6 +25,7 @@ import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
 import io.quarkus.websockets.next.test.utils.WSClient;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.WebSocketConnectOptions;
@@ -70,7 +71,8 @@ public class PayloadPermissionCheckerTest {
             // shouldn't close as user declared @OnError
             client.waitForMessages(2);
             // can't see product 1
-            assertEquals("forbidden:user", client.getMessages().get(1).toString());
+            assertEquals("forbidden:user,endpointId:io.quarkus.websockets.next.test.security.ProductEndpoint",
+                    client.getMessages().get(1).toString());
             // can see product 2
             client.sendAndAwait("2");
             client.waitForMessages(3);
@@ -236,9 +238,9 @@ public class PayloadPermissionCheckerTest {
         }
 
         @PermissionChecker("perm2")
-        boolean hasPerm2(SecurityIdentity securityIdentity) {
+        Uni<Boolean> hasPerm2(SecurityIdentity securityIdentity) {
             String principalName = securityIdentity.getPrincipal().getName();
-            return principalName.equals("user") || principalName.equals("almighty");
+            return Uni.createFrom().item(Boolean.valueOf(principalName.equals("user") || principalName.equals("almighty")));
         }
 
     }

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/ProductEndpoint.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/ProductEndpoint.java
@@ -10,6 +10,7 @@ import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
 
 @WebSocket(path = "/product")
 public class ProductEndpoint {
@@ -32,8 +33,8 @@ public class ProductEndpoint {
     }
 
     @OnError
-    String error(ForbiddenException t) {
-        return "forbidden:" + currentIdentity.getPrincipal().getName();
+    String error(ForbiddenException t, WebSocketConnection conn) {
+        return "forbidden:" + currentIdentity.getPrincipal().getName() + ",endpointId:" + conn.endpointId();
     }
 
     @PermissionChecker("product:get")


### PR DESCRIPTION
Tweaks for permission checkers for WebSockets Next

Part of work on QUARKUS-5859 Support permission checkers for WebSockets Next

 * PermissionChecker JavaDoc link
 * Uni usage in PermissionChecker and WS endpoint, OnError with WebSocketConnection