### PR TITLE
Avoid setting null system properties in Mojos

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -114,6 +114,10 @@ public class BuildMojo extends QuarkusBootstrapMojo {
             // Add the system properties of the plugin to the system properties
             // if and only if they are not already set.
             for (Map.Entry<String, String> entry : systemProperties.entrySet()) {
+                if (entry.getValue() == null) {
+                    continue;
+                }
+
                 String key = entry.getKey();
                 if (System.getProperty(key) == null) {
                     System.setProperty(key, entry.getValue());

--- a/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
@@ -43,6 +43,10 @@ public class RunMojo extends QuarkusBootstrapMojo {
         // Add the system properties of the plugin to the system properties
         // if and only if they are not already set.
         for (Map.Entry<String, String> entry : systemProperties.entrySet()) {
+            if (entry.getValue() == null) {
+                continue;
+            }
+
             String key = entry.getKey();
             if (System.getProperty(key) == null) {
                 System.setProperty(key, entry.getValue());


### PR DESCRIPTION
Empty values injected by @Parameter in a Map are going to be null. We should avoid trying to push these values to the system properties as they are ultimately backed by a CHM, which doesn't support null values.

Fixes #47446