### PR TITLE
Trivial: Do not wrap runtime exception

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainBuilderConsumer.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainBuilderConsumer.java
@@ -12,7 +12,7 @@ import io.quarkus.builder.BuildStep;
 import io.quarkus.builder.BuildStepBuilder;
 import io.quarkus.builder.item.BuildItem;
 
-// needs to be in a class of it's own in order to avoid java.lang.IncompatibleClassChangeError
+// needs to be in a class of its own in order to avoid java.lang.IncompatibleClassChangeError
 public class ProdModeTestBuildChainBuilderConsumer implements Consumer<BuildChainBuilder> {
     private final String buildStepClassName;
     private final List<String> producesClassNames;

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainCustomizerProducer.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildChainCustomizerProducer.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 
 import io.quarkus.builder.BuildChainBuilder;
 
-// needs to be in a class of it's own in order to avoid java.lang.IncompatibleClassChangeError
+// needs to be in a class of its own in order to avoid java.lang.IncompatibleClassChangeError
 public class ProdModeTestBuildChainCustomizerProducer
         implements Function<Map<String, Object>, List<Consumer<BuildChainBuilder>>> {
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
@@ -480,9 +480,12 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
             runtimeClassLoaders.put(key, startupAction);
 
             return startupAction.getClassLoader();
+        } catch (RuntimeException e) {
+            // Exceptions here get swallowed by the JUnit framework and we don't get any debug information unless we print it ourself
+            e.printStackTrace();
+            throw e;
         } catch (Exception e) {
             // Exceptions here get swallowed by the JUnit framework and we don't get any debug information unless we print it ourself
-            // TODO what's the best way to do this?
             e.printStackTrace();
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
I spotted a case where I sometimes wrapped runtime exceptions unnecessarily, so I've fixed that. I've also fixed some typos in comments. 