### PR TITLE
Improve diagnostic output for null system properties

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestorableSystemProperties.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestorableSystemProperties.java
@@ -20,6 +20,16 @@ public class RestorableSystemProperties implements Closeable {
             sysPropRestore.put(i.getKey(), System.getProperty(i.getKey()));
         }
         for (Map.Entry<String, String> i : props.entrySet()) {
+            if (i.getKey() == null) {
+                throw new IllegalArgumentException(
+                        String.format("Internal error: Cannot set null key as a system property (value is %s)",
+                                i.getValue()));
+            }
+            if (i.getValue() == null) {
+                throw new IllegalArgumentException(
+                        String.format("Internal error: Cannot use null value as a system property (key is %s)",
+                                i.getKey()));
+            }
             System.setProperty(i.getKey(), i.getValue());
         }
         return new RestorableSystemProperties(sysPropRestore);


### PR DESCRIPTION
I can't reproduce https://github.com/quarkusio/quarkus/issues/47475 locally, so need some diagnostics in CI. More generally, it's also useful to have diagnostics if this scenario happens, so I think the change is worth keeping. 