### PR TITLE
Upload more reports for TCKs testing

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1334,6 +1334,7 @@ jobs:
         run: |
           7z a -tzip build-reports.zip -r \
               '**/target/*-reports/TEST-*.xml' \
+              '**/target/*-reports-*/TEST-*.xml' \
               'target/build-report.json' \
               'target/gradle-build-scan-url.txt' \
               LICENSE


### PR DESCRIPTION
This is going to be useful for `tcks/microprofile-opentelemetry` as some reports are generated in `target/surefire-reports-tracing`.

(I'm also making some changes to the bot to be more permissive)