### PR TITLE
Try and give more helpful error message for bad surefire version

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -321,6 +321,17 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                         + requiredTestClass.getClassLoader()
                         + " This should not happen, but changing directory names or class layout may help work around the issue.");
             } else {
+                boolean isSurefire = System.getProperty("surefire.real.class.path") != null;
+                if (isSurefire) {
+                    boolean isSurefire3 = System.getProperty("surefire.real.class.path").contains("_3.jar");
+                    if (!isSurefire3) {
+                        throw new RuntimeException("The test class " + requiredTestClass
+                                + " should have been loaded with a QuarkusClassLoader, but instead it was loaded with "
+                                + requiredTestClass.getClassLoader()
+                                + ". Is the version of the Surefire plugin at least 3.x?");
+                    }
+                }
+
                 throw new RuntimeException("Internal error. The test class " + requiredTestClass
                         + " should have been loaded with a QuarkusClassLoader, but instead it was loaded with "
                         + requiredTestClass.getClassLoader()


### PR DESCRIPTION
See discussion around https://github.com/quarkusio/quarkus/pull/34681#issuecomment-2816743071

Detecting surefire is relatively easy, but I couldn't find a great way to detect the version. The best I could do was look at the name of the surefire booter. For Surefire 3.x it ends in `_3`, such as 

```
surefire.real.class.path:/Users/holly/Code/quarkus/quarkus/integration-tests/gradle/target/surefire/surefirebooter-20250422184338999_3.jar
```

For Surefire 2 it's a random number, such as 

```
surefire.real.class.path:/Users/holly/Downloads/code-with-quarkus/target/surefire/surefirebooter3233894128258247821.jar
```

I wouldn't want to do such fragile detection for something important, but since it's just enhancing an error message it should be ok.

Example (from a local test) output with new message:

```
java.lang.RuntimeException: The test class class org.acme.GreetingResourceTest should have been loaded with a QuarkusClassLoader, but instead it was loaded with jdk.internal.loader.ClassLoaders$AppClassLoader@2c854dc5. Is the version of the Surefire plugin at least 3.x?
```