### PR TITLE
Qute: fix build time validation and generated value resolver for getters

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/getters/TypesafeGettersValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/getters/TypesafeGettersValidationTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.qute.deployment.typesafe.getters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Template;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TypesafeGettersValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(SomeBean.class, SomeInterface.class)
+                    .addAsResource(new StringAsset("""
+                            {@io.quarkus.qute.deployment.typesafe.getters.TypesafeGettersValidationTest$SomeBean some}
+                            {some.image.length}::{some.hasImage}::{some.hasImage('bar')}::{some.png}::{some.hasPng('bar')}
+                            """), "templates/some.html"));
+
+    @Inject
+    Template some;
+
+    @Test
+    public void testValidation() {
+        assertEquals("3::true::true::ping::false", some.data("some", new SomeBean("bar")).render().strip());
+    }
+
+    public static class SomeBean implements SomeInterface {
+
+        private final String image;
+
+        SomeBean(String image) {
+            this.image = image;
+        }
+
+        public String image() {
+            return image;
+        }
+
+        public boolean hasImage() {
+            return image != null;
+        }
+
+        public boolean hasImage(String val) {
+            return image.equals(val);
+        }
+
+    }
+
+    public interface SomeInterface {
+
+        default String png() {
+            return "ping";
+        }
+
+        default boolean hasPng(String val) {
+            return png().equals(val);
+        }
+
+    }
+
+}

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -371,7 +371,10 @@ public class ValueResolverGenerator extends AbstractGenerator {
                     matchingNames.add(method.name());
                 }
                 String propertyName = isGetterName(method.name(), method.returnType()) ? getPropertyName(method.name()) : null;
-                if (propertyName != null && matchedNames.add(propertyName)) {
+                if (propertyName != null
+                        // No method with exact name match exists
+                        && noParamMethods.stream().noneMatch(mk -> mk.name.equals(propertyName))
+                        && matchedNames.add(propertyName)) {
                     matchingNames.add(propertyName);
                 }
                 if (matchingNames.isEmpty()) {
@@ -1107,7 +1110,7 @@ public class ValueResolverGenerator extends AbstractGenerator {
         return (mod & 0x00001000) != 0;
     }
 
-    static boolean isGetterName(String name, Type returnType) {
+    public static boolean isGetterName(String name, Type returnType) {
         if (name.startsWith(GET_PREFIX)) {
             return true;
         }

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SimpleGeneratorTest.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SimpleGeneratorTest.java
@@ -41,7 +41,7 @@ public class SimpleGeneratorTest {
     public static void init() throws IOException {
         TestClassOutput classOutput = new TestClassOutput();
         Index index = index(MyService.class, PublicMyService.class, BaseService.class, MyItem.class, String.class,
-                CompletionStage.class, List.class, MyEnum.class, StringBuilder.class);
+                CompletionStage.class, List.class, MyEnum.class, StringBuilder.class, SomeBean.class, SomeInterface.class);
         ClassInfo myServiceClazz = index.getClassByName(DotName.createSimple(MyService.class.getName()));
         ValueResolverGenerator generator = ValueResolverGenerator.builder().setIndex(index).setClassOutput(classOutput)
                 .addClass(myServiceClazz)
@@ -51,6 +51,7 @@ public class SimpleGeneratorTest {
                 .addClass(index.getClassByName(List.class))
                 .addClass(index.getClassByName(MyEnum.class))
                 .addClass(index.getClassByName(StringBuilder.class), stringBuilderTemplateData())
+                .addClass(index.getClassByName(SomeBean.class))
                 .build();
 
         generator.generate();
@@ -150,6 +151,11 @@ public class SimpleGeneratorTest {
         assertEquals("one", engine.parse("{MyEnum:valueOf('ONE').name}").render());
         assertEquals("10", engine.parse("{io_quarkus_qute_generator_MyService:getDummy(5)}").render());
         assertEquals("foo", engine.parse("{builder.append('foo')}").data("builder", new StringBuilder()).render());
+
+        // Exact match takes precedence over the getter
+        assertEquals("bar::true::true::ping::false",
+                engine.parse("{some.image}::{some.hasImage}::{some.hasImage('bar')}::{some.png}::{some.hasPng('bar')}")
+                        .data("some", new SomeBean("bar")).render());
     }
 
     @Test

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SomeBean.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SomeBean.java
@@ -1,0 +1,26 @@
+package io.quarkus.qute.generator;
+
+import io.quarkus.qute.TemplateData;
+
+@TemplateData
+public class SomeBean implements SomeInterface {
+
+    private final String image;
+
+    SomeBean(String image) {
+        this.image = image;
+    }
+
+    public String image() {
+        return image;
+    }
+
+    public boolean hasImage() {
+        return image != null;
+    }
+
+    public boolean hasImage(String val) {
+        return image.equals(val);
+    }
+
+}

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SomeInterface.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/SomeInterface.java
@@ -1,0 +1,13 @@
+package io.quarkus.qute.generator;
+
+public interface SomeInterface {
+
+    default String png() {
+        return "ping";
+    }
+
+    default boolean hasPng(String val) {
+        return png().equals(val);
+    }
+
+}


### PR DESCRIPTION
- the problem occurs when the getter syntax is mixed with "normal" syntax (Java record-style); e.g. Foo#image() and Foo#hasImage()