### PR TITLE
Always consider @RegisterRestClient interface as REST Clients

### DIFF
--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/basic/ClientWithImplementationsInvalidTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/basic/ClientWithImplementationsInvalidTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.restclient.basic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClientWithImplementationsInvalidTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyClient.class, MyImplementation.class))
+            .withConfigurationResource("client-with-implementations.properties")
+            .assertException(t -> {
+                assertThat(t).hasCauseInstanceOf(UnsatisfiedResolutionException.class);
+            });
+
+    @RestClient
+    MyClient client;
+
+    @Test
+    public void testClientBeanHasBeenCreated() {
+        Assertions.assertEquals("hello", client.get());
+    }
+
+    @Path("/client")
+    public interface MyClient {
+
+        @GET
+        @Path("/")
+        String get();
+    }
+
+    public static class MyImplementation implements MyClient {
+
+        @GET
+        @Path("/")
+        @Override
+        public String get() {
+            return "hello";
+        }
+    }
+}

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/basic/ClientWithImplementationsTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/basic/ClientWithImplementationsTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.restclient.basic;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClientWithImplementationsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyClient.class, MyImplementation.class))
+            .withConfigurationResource("client-with-implementations.properties");
+
+    @RestClient
+    MyClient client;
+
+    @Test
+    public void testClientBeanHasBeenCreated() {
+        Assertions.assertEquals("hello", client.get());
+    }
+
+    @Path("/client")
+    @RegisterRestClient(configKey = "my-client")
+    public interface MyClient {
+
+        @GET
+        @Path("/")
+        String get();
+    }
+
+    public static class MyImplementation implements MyClient {
+
+        @GET
+        @Path("/")
+        @Override
+        public String get() {
+            return "hello";
+        }
+    }
+}

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/resources/client-with-implementations.properties
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/resources/client-with-implementations.properties
@@ -1,0 +1,1 @@
+quarkus.rest-client.my-client.url=http://localhost:${quarkus.http.test-port:8081}


### PR DESCRIPTION
In RESTEasy Classic, even when an interface is annotated with @RegisterRestClient, the interface is not considered a REST Client if it has implementations.
It is not consistent with Quarkus REST and is annoying when you have both the client and the server parts in the same application.

It was reported by a user here: https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Synthetic.20bean.20generation.20for.20.40RestClient/with/513892718 .

And I think the intention is pretty clear when you have an explicit `@RegisterRestClient` annotation.