### PR TITLE
Disable Quarkus - Integration Tests - Bouncy Castle FIPS JSSE module in native mode

### DIFF
--- a/integration-tests/bouncycastle-fips-jsse/disable-native-profile
+++ b/integration-tests/bouncycastle-fips-jsse/disable-native-profile
@@ -1,0 +1,1 @@
+This file disables the native profile in the parent pom.xml of this module.


### PR DESCRIPTION
Running this module in native mode fails and I have a pipeline that needs to be able to determine what can be run and what cannot be run in native, so if it is all the same to you, let's exclude this officially.

See also https://github.com/quarkusio/quarkus/blob/edb449b25a862edfe19445f4320dd4716a2e9447/integration-tests/pom.xml#L447