### PR TITLE
Disable Dev Services fully in oidc-wiremock-logout IT

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -155,8 +155,8 @@ public class KeycloakDevServicesProcessor {
         }
 
         if (devSvcRequiredMarkerItems.isEmpty()
-                || linuxContainersNotAvailable(dockerStatusBuildItem, devSvcRequiredMarkerItems)
-                || oidcDevServicesEnabled()) {
+                || oidcDevServicesEnabled()
+                || linuxContainersNotAvailable(dockerStatusBuildItem, devSvcRequiredMarkerItems)) {
             if (devService != null) {
                 closeDevService();
             }

--- a/integration-tests/oidc-wiremock-logout/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock-logout/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.keycloak.devservices.enabled=false
+quarkus.devservices.enabled=false
 
 quarkus.oidc.code-flow-form-post.auth-server-url=${keycloak.url}/realms/quarkus-form-post/
 quarkus.oidc.code-flow-form-post.client-id=quarkus-web-app


### PR DESCRIPTION
They are not required and it's failing on Windows as Docker is not available.