### PR TITLE
Exceptions thrown by resteasy reactive itself do not need to be wrapped

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientMultipleBodyParamLogMessageTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientMultipleBodyParamLogMessageTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class ClientMultipleBodyParamLogMessageTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(Client.class));
+
+    @Test
+    void basicTest() {
+        try {
+            QuarkusRestClientBuilder.newBuilder().baseUri(URI.create("http://localhost:8081"))
+                    .build(Client.class);
+        } catch (Exception e) {
+            assertThat(e.getMessage()).endsWith(
+                    "Failed to generate client for class interface io.quarkus.rest.client.reactive.ClientMultipleBodyParamLogMessageTest$Client : Resource method 'io.quarkus.rest.client.reactive.ClientMultipleBodyParamLogMessageTest$Client#java.lang.String getMessagesForTopic(int param1, int param2)' can only have a single body parameter, but has at least 2. A body parameter is a method parameter without any annotations. Last discovered body parameter is 'param2'.");
+            return;
+        }
+        Assertions.fail("Should have thrown an exception");
+    }
+
+    public interface Client {
+        @GET
+        @Path("/messages")
+        String getMessagesForTopic(int param1, int param2);
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
@@ -142,7 +142,7 @@ public class ClientEndpointIndexer
     protected InjectableBean scanInjectableBean(ClassInfo currentClassInfo, ClassInfo actualEndpointInfo,
             Map<String, String> existingConverters, AdditionalReaders additionalReaders,
             Map<String, InjectableBean> injectableBeans, boolean hasRuntimeConverters) {
-        throw new RuntimeException("Injectable beans not supported in client");
+        throw new RuntimeException("Injectable beans are not supported in client");
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -641,11 +641,12 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 String defaultValue = parameterResult.getDefaultValue();
                 ParameterType type = parameterResult.getType();
                 if (type == ParameterType.BODY) {
-                    if (bodyParamType != null)
-                        throw new RuntimeException(String.format(
-                                "Resource method '%s#%s' can only have a single body parameter: '%s'",
+                    if (bodyParamType != null) {
+                        throw new DeploymentException(String.format(
+                                "Resource method '%s#%s' can only have a single body parameter, but has at least 2. A body parameter is a method parameter without any annotations. Last discovered body parameter is '%s'.",
                                 currentMethodInfo.declaringClass().name(), currentMethodInfo,
                                 currentMethodInfo.parameterName(i)));
+                    }
                     bodyParamType = paramType;
                     if (GET.equals(httpMethod) || HEAD.equals(httpMethod) || OPTIONS.equals(httpMethod)) {
                         warnAboutMissUsedBodyParameter(httpMethod, currentMethodInfo);
@@ -673,7 +674,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 if (bodyParamType != null
                         && !bodyParamType.name().equals(ResteasyReactiveDotNames.MULTI_VALUED_MAP)
                         && !bodyParamType.name().equals(ResteasyReactiveDotNames.STRING)) {
-                    throw new RuntimeException(String.format(
+                    throw new DeploymentException(String.format(
                             "'@FormParam' and '@RestForm' cannot be used in a resource method that contains a body parameter. Offending method is "
                                     + "'%s#%s'",
                             currentMethodInfo.declaringClass().name(), currentMethodInfo));
@@ -689,7 +690,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                     }
                     // TODO: does it make sense to default to MediaType.MULTIPART_FORM_DATA when no consumes is set?
                     if (!validConsumes) {
-                        throw new RuntimeException(String.format(
+                        throw new DeploymentException(String.format(
                                 "'@FormParam' and '@RestForm' can only be used on methods annotated with '@Consumes(MediaType.MULTIPART_FORM_DATA)' '@Consumes(MediaType.APPLICATION_FORM_URLENCODED)'. Offending method is "
                                         + "'%s#%s'",
                                 currentMethodInfo.declaringClass().name(), currentMethodInfo));
@@ -811,9 +812,11 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                                 method));
             }
             return method;
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("Failed to process method '%s#%s'",
-                    currentMethodInfo.declaringClass().name(), currentMethodInfo), e);
+        } catch (DeploymentException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new RuntimeException(String.format("Failed to process method '%s#%s'. Reason: %s",
+                    currentMethodInfo.declaringClass().name(), currentMethodInfo, e.getMessage()), e);
         }
     }
 
@@ -1288,9 +1291,9 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             return builder;
         } else if (moreThanOne(pathParam, queryParam, headerParam, formParam, cookieParam, contextParam, beanParam,
                 restPathParam, restQueryParam, restHeaderParam, restFormParam, restCookieParam)) {
-            throw new RuntimeException(
+            throw new DeploymentException(
                     "Cannot have more than one of @PathParam, @QueryParam, @HeaderParam, @FormParam, @CookieParam, @BeanParam, @Context on "
-                            + errorLocation);
+                            + builder.getErrorLocation());
         } else if (pathParam != null) {
             builder.setName(pathParam.value().asString());
             builder.setType(ParameterType.PATH);
@@ -1513,10 +1516,12 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             }
         }
         if (suspendedAnnotation != null && !elementType.equals(AsyncResponse.class.getName())) {
-            throw new RuntimeException("Can only inject AsyncResponse on methods marked @Suspended");
+            throw new DeploymentException(
+                    "Can only inject AsyncResponse on methods marked @Suspended on " + builder.getErrorLocation());
         }
         if (builder.isSingle() && builder.getSeparator() != null) {
-            throw new DeploymentException("Single parameters should not be marked with @Separator");
+            throw new DeploymentException(
+                    "Single parameters should not be marked with @Separator on " + builder.getErrorLocation());
         }
         builder.setElementType(elementType);
         return builder;


### PR DESCRIPTION
Explicitly throw DeploymentException when resteasy reactive encounters a problem, instead of the generic runtimeexception. This allows not to wrap the DE.
For all other exceptions, still wrap them, but include the original message in the wrapper.
Also try to improve some of the other existing exception messages.

quarkus-rest-client only uses the message from the original exception (and not of any of its causes) to display to the user.

closes #38562