### PR TITLE
[3.15] Use the version of Quarkus platform recommended for the current project for recipe filtering instead of the latest version recommended by the registry

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
@@ -80,6 +80,13 @@ public class UpdateProject {
         return this;
     }
 
+    /**
+     * This method is not used since currently the version passed in here might not be the final target platform version
+     * but the latest recommended w/o taking into account extensions found in the current project.
+     *
+     * @param targetPlatformVersion latest recommended Quarkus platform version
+     * @return this instance
+     */
     public UpdateProject targetPlatformVersion(String targetPlatformVersion) {
         invocation.setValue(TARGET_PLATFORM_VERSION, targetPlatformVersion);
         return this;

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
@@ -215,18 +215,16 @@ public final class ProjectUpdateInfos {
     private static void addOrigins(final List<ExtensionOrigins> extOrigins, Extension e) {
         ExtensionOrigins.Builder eoBuilder = null;
         for (ExtensionOrigin o : e.getOrigins()) {
-            if (!(o instanceof ExtensionCatalog)) {
-                continue;
+            if (o instanceof ExtensionCatalog c) {
+                final OriginPreference op = (OriginPreference) c.getMetadata().get("origin-preference");
+                if (op == null) {
+                    continue;
+                }
+                if (eoBuilder == null) {
+                    eoBuilder = ExtensionOrigins.builder(e.getArtifact().getKey());
+                }
+                eoBuilder.addOrigin(c, op);
             }
-            final ExtensionCatalog c = (ExtensionCatalog) o;
-            final OriginPreference op = (OriginPreference) c.getMetadata().get("origin-preference");
-            if (op == null) {
-                continue;
-            }
-            if (eoBuilder == null) {
-                eoBuilder = ExtensionOrigins.builder(e.getArtifact().getKey());
-            }
-            eoBuilder.addOrigin(c, op);
         }
         if (eoBuilder != null) {
             extOrigins.add(eoBuilder.build());


### PR DESCRIPTION
A backport of https://github.com/quarkusio/quarkus/pull/46612

@jmartisk @gsmet @rsvoboda The original change was applied on top of Andy's refactoring, which is why it resulted in lots of conflicts. Here is my attempt to clean it up for 3.15. If you think it's too risky, I won't insist on including it.

The change is essentially about calculating the recommended target platform version based on the current state (extensions present in the project) instead of simply trusting the version from the "merged by the registry client" extension catalog.

Thanks.