### PR TITLE
SmallRye Fault Tolerance: skip private methods

### DIFF
--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
@@ -1,6 +1,7 @@
 package io.quarkus.smallrye.faulttolerance.deployment;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -100,6 +101,10 @@ final class FaultToleranceScanner {
             }
             if (method.isSynthetic()) {
                 // synthetic methods can't be intercepted
+                continue;
+            }
+            if (Modifier.isPrivate(method.flags())) {
+                // private methods can't be intercepted
                 continue;
             }
             if (annotationStore.hasAnnotation(method, io.quarkus.arc.processor.DotNames.NO_CLASS_INTERCEPTORS)

--- a/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/FaultToleranceTestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/FaultToleranceTestResource.java
@@ -12,6 +12,9 @@ public class FaultToleranceTestResource {
     @Inject
     Service service;
 
+    @Inject
+    SecondService secondService;
+
     @GET
     public String getName() {
         AtomicInteger counter = new AtomicInteger();
@@ -33,5 +36,11 @@ public class FaultToleranceTestResource {
         AtomicInteger counter = new AtomicInteger();
         String name = service.fallbackMethod(counter);
         return counter + ":" + name;
+    }
+
+    @GET
+    @Path("/hello")
+    public String hello() {
+        return secondService.publicHello();
     }
 }

--- a/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/SecondService.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/SecondService.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.faulttolerance;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@ApplicationScoped
+@Retry
+public class SecondService {
+    public String publicHello() {
+        return "hello";
+    }
+
+    private String privateHello() {
+        return "hello";
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/FaultToleranceTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/FaultToleranceTestCase.java
@@ -35,5 +35,10 @@ public class FaultToleranceTestCase {
                 .given().baseUri(uri.toString() + "/fallback")
                 .when().get()
                 .then().body(is("1:fallback"));
+
+        RestAssured
+                .given().baseUri(uri.toString() + "/hello")
+                .when().get()
+                .then().body(is("hello"));
     }
 }


### PR DESCRIPTION
Private methods can never be intercepted, so it makes no sense to check if they are fault tolerance methods or to register them as such.

In fact, when compiling to native image, this used to cause a problem with reflection registration. ArC automatically registers intercepted methods for reflection, but it doesn't register `private` methods (because they cannot be intercepted). SmallRye Fault Tolerance tries to reflect on all fault tolerance methods, which used to fail on private methods. This commit fixes that.

Fixes #47509