### PR TITLE
Restore previous behavior of QuarkusTransaction#isActive()

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/QuarkusTransaction.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/QuarkusTransaction.java
@@ -68,14 +68,17 @@ public interface QuarkusTransaction {
     }
 
     /**
-     * If a transaction is active.
-     * A transaction is considered active after it has been started and prior to a Coordinator issuing any prepares, unless the
-     * transaction has been marked for rollback
+     * Returns whether a transaction is associated to the current request scope. The name of this method is misleading. Don't
+     * use it.
      *
-     * @return {@code true} if the transaction is in the {@link Status#STATUS_ACTIVE} state.
+     * @return {@code true} if a transaction is associated to the current request scope.
+     *
+     * @deprecated the name of this method was misleading and it shouldn't be used anymore. Use {@link #getStatus()} for a
+     *             better semantic instead.
      */
+    @Deprecated(forRemoval = true, since = "3.22")
     static boolean isActive() {
-        return getStatus() == Status.STATUS_ACTIVE;
+        return getStatus() != Status.STATUS_NO_TRANSACTION;
     }
 
     /**


### PR DESCRIPTION
And mark is as deprecated.
It was causing issues with IronJacamar so we have a proof that this change is disruptive. And transactions are critical enough that we don't want to take any risks.

This is a follow-up of https://github.com/quarkusio/quarkus/pull/47212.

And related to
https://github.com/quarkiverse/quarkus-ironjacamar/issues/174.