### PR TITLE
Update dev services docs to not use deprecated guard

### DIFF
--- a/docs/src/main/asciidoc/extension-writing-dev-service.adoc
+++ b/docs/src/main/asciidoc/extension-writing-dev-service.adoc
@@ -48,7 +48,7 @@ Here, the https://hub.docker.com/_/hello-world[`hello-world`] image is used, but
 
 [source,java]
 ----
-@BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+@BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
 public DevServicesResultBuildItem createContainer() {
     DockerImageName dockerImageName = DockerImageName.parse("hello-world");
     GenericContainer container = new GenericContainer<>(dockerImageName)


### PR DESCRIPTION
In 3.18 we switched from using `onlyIf = GlobalDevServicesConfig.Enabled.class` to `onlyIf = DevServicesConfig.Enabled.class`, but the docs missed being updated. 