### PR TITLE
Quarkus REST - Be more forgiving when adding headers

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/AbstractResponseBuilder.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/AbstractResponseBuilder.java
@@ -277,9 +277,14 @@ public abstract class AbstractResponseBuilder extends Response.ResponseBuilder {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Response.ResponseBuilder header(String name, Object value) {
         if (value == null) {
             metadata.remove(name);
+            return this;
+        }
+        if (value instanceof List values) {
+            metadata.addAll(name, values);
             return this;
         }
         metadata.add(name, value);


### PR DESCRIPTION
The JAX-RS API is very loose and allows adding Object and in some cases we actually add a List to the headers and we need to take this into account.

While I'm usually not for handling things this way, the API is not enforcing things properly so I think we really need to handle this ourself and be more forgiving if a list is added.

- Fixes: #47507