### PR TITLE
Use JDK 21 for build reporting

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1556,11 +1556,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: build-reports-artifacts
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Produce report and add it as job summary
         uses: quarkusio/action-build-reporter@main
         with:


### PR DESCRIPTION
This is what we enforce in the action so it will feed JBang with the correct JDK and avoid having JBang downloading the JDK (and potential errors doing it...).