### PR TITLE
Fully disable Dev Services in oidc-wiremock-providers

### DIFF
--- a/integration-tests/oidc-wiremock-providers/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock-providers/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.http.auth.proactive=false
 quarkus.log.category."org.htmlunit".level=ERROR
 quarkus.log.category."com.github".level=ERROR
-quarkus.keycloak.devservices.enabled=false
+quarkus.devservices.enabled=false
 
 quarkus.oidc.slack.provider=slack
 quarkus.oidc.slack.auth-server-url=${keycloak.url}/slack


### PR DESCRIPTION
This makes things better on Windows and speeds up the build as starting a Keycloak container is not necessary for this test.