### PR TITLE
Restore loading of all JDBC drivers on datasource creation

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -62,6 +62,7 @@ import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.narayana.jta.deployment.NarayanaInitBuildItem;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -89,6 +90,7 @@ class AgroalProcessor {
             List<JdbcDriverBuildItem> jdbcDriverBuildItems,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBuildItem> resource,
+            BuildProducer<ServiceProviderBuildItem> service,
             Capabilities capabilities,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
             BuildProducer<AggregatedDataSourceBuildTimeConfigBuildItem> aggregatedConfig,
@@ -138,6 +140,9 @@ class AgroalProcessor {
         // resolve them at build time and push them to Agroal soon.
         resource.produce(new NativeImageResourceBuildItem(
                 "META-INF/services/" + io.agroal.api.security.AgroalSecurityProvider.class.getName()));
+
+        // accessed through io.quarkus.agroal.runtime.DataSources.loadDriversInTCCL
+        service.produce(ServiceProviderBuildItem.allProvidersFromClassPath(Driver.class.getName()));
 
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(io.agroal.pool.ConnectionHandler[].class.getName(),
                 io.agroal.pool.ConnectionHandler.class.getName(),

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -1,9 +1,12 @@
 package io.quarkus.agroal.runtime;
 
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.Statement;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -153,6 +156,9 @@ public class DataSources {
             throw new IllegalArgumentException(
                     "Datasource " + dataSourceName + " does not have a JDBC URL and should not be created");
         }
+
+        // we first make sure that all available JDBC drivers are loaded in the current TCCL
+        loadDriversInTCCL();
 
         AgroalDataSourceSupport.Entry matchingSupportEntry = agroalDataSourceSupport.entries.get(dataSourceName);
         String resolvedDriverClass = matchingSupportEntry.resolvedDriverClass;
@@ -359,4 +365,21 @@ public class DataSources {
         poolConfiguration.recoveryEnable(dataSourceJdbcRuntimeConfig.enableRecovery());
     }
 
+    /**
+     * Uses the {@link ServiceLoader#load(Class) ServiceLoader to load the JDBC drivers} in context
+     * of the current {@link Thread#getContextClassLoader() TCCL}
+     */
+    private static void loadDriversInTCCL() {
+        // load JDBC drivers in the current TCCL
+        final ServiceLoader<Driver> drivers = ServiceLoader.load(Driver.class);
+        final Iterator<Driver> iterator = drivers.iterator();
+        while (iterator.hasNext()) {
+            try {
+                // load the driver
+                iterator.next();
+            } catch (Throwable t) {
+                // ignore
+            }
+        }
+    }
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -367,7 +367,13 @@ public class DataSources {
 
     /**
      * Uses the {@link ServiceLoader#load(Class) ServiceLoader to load the JDBC drivers} in context
-     * of the current {@link Thread#getContextClassLoader() TCCL}
+     * of the current {@link Thread#getContextClassLoader() TCCL}.
+     * <p>
+     * This is necessary to have JDBC URLs work properly, in particular when using custom drivers,
+     * and in particular when the app gets "restarted" in a single system (?) classloader,
+     * because DriverManager's list of available drivers would get cleared on shutdown.
+     * <p>
+     * See also https://github.com/quarkusio/quarkus/issues/46324#issuecomment-2687615191
      */
     private static void loadDriversInTCCL() {
         // load JDBC drivers in the current TCCL


### PR DESCRIPTION
Fixes #46324

Reverts #45540 and applies #45533 instead, adding a few comments.

I checked manually against the reproducer, but I don't see an easy way to add a non-regression test in the codebase, due to the weird classloader setup this requires (which probably requires Gradle, with a weird setup at that?).
