### PR TITLE
Add HTTP server and client active network connection gauge metrics

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxHttpClientMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxHttpClientMetricsTest.java
@@ -89,6 +89,7 @@ public class VertxHttpClientMetricsTest {
             Assertions.assertEquals("HELLO", client.post("hello"));
 
             Assertions.assertNotNull(getMeter("http.client.connections").longTaskTimer());
+            Assertions.assertNotNull(getMeter("http.client.active.connections").gauge());
 
             // Body sizes
             double expectedBytesWritten = sizeBefore + 5;
@@ -105,6 +106,7 @@ public class VertxHttpClientMetricsTest {
                 // Because of the different tag, the timer got called a single time
                 return getMeter("http.client.requests").timer().count() == 1;
             });
+            await().until(() -> getMeter("http.client.active.connections").gauge().value() == 1);
 
             Assertions.assertEquals(1, registry.find("http.client.requests")
                     .tag("uri", "root")

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpClientMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpClientMetrics.java
@@ -9,7 +9,8 @@ public class VertxTcpClientMetrics extends NetworkMetrics {
         super(registry, tags, prefix,
                 "Number of bytes received by the client",
                 "Number of bytes sent by the client",
-                "The duration of the connections");
+                "The duration of the connections",
+                "Number of connections to the remote host currently opened");
     }
 
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpServerMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpServerMetrics.java
@@ -9,7 +9,8 @@ public class VertxTcpServerMetrics extends NetworkMetrics {
         super(registry, tags, prefix,
                 "Number of bytes received by the server",
                 "Number of bytes sent by the server",
-                "The duration of the connections");
+                "The duration of the connections",
+                "Number of opened connections to the HTTP Server");
     }
 
 }


### PR DESCRIPTION
Add new HTTP Server `http_server_active_connections` and Client `http_client_active_connections` gauge metrics.

The client metric will be available (just like many other such client metrics) only when the client is registered with metrics name programmatically as below:
```java
var httpClientOptions = new HttpClientOptions().setMetricsName("|localhost"); // IMPORTANT!
        
externalService = QuarkusRestClientBuilder.newBuilder()
    .baseUri(URI.create("http://localhost:8081"))
    .httpClientOptions(httpClientOptions) // IMPORTANT!
    .build(ExternalService.class);
```
where ExternalService is a Rest Client interface.

Another approach: I couldn't find a way to register the metrics name through annotations, so using `@RestClient` annotation will not register this metric along with some other metrics which fall into the same category unless ContextResolver for HttpClientOptions is registered as given [here](https://quarkus.io/guides/rest-client#use-custom-http-options) .