### PR TITLE
Forward subscription cancellation from client to server

### DIFF
--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/MultiStreamObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/MultiStreamObserver.java
@@ -1,28 +1,62 @@
 package io.quarkus.grpc.stubs;
 
-import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 
-public class MultiStreamObserver<T> implements StreamObserver<T> {
+public class MultiStreamObserver<I, O> implements ClientResponseObserver<I, O> {
+    private final MultiEmitter<? super O> emitter;
 
-    private final MultiEmitter<? super T> emitter;
+    // If this is set, the Multi was terminated by completion or failure, not by cancellation.
+    private final AtomicBoolean terminated = new AtomicBoolean();
 
-    public MultiStreamObserver(MultiEmitter<? super T> emitter) {
-        this.emitter = emitter;
+    private AtomicReference<ClientCallStreamObserver<I>> requestStreamObserver = new AtomicReference<>();
+
+    public MultiStreamObserver(MultiEmitter<? super O> emitter, Runnable onTermination) {
+        this.emitter = emitter.onTermination(() -> {
+            // This is called when the reply Multi (the return value of the RPC method) is cancelled or the gRPC server completes the request.
+            if (terminated.compareAndSet(false, true)) {
+                // Cancel the gRPC stream on reply Multi cancellation only (not on completion, this would unnecessarily reset the HTTP/2 stream)
+                ClientCallStreamObserver<I> observer = requestStreamObserver.getAndSet(null);
+                if (observer != null) {
+                    observer.cancel("Cancelled by Multi!", null);
+                }
+            }
+
+            if (onTermination != null) {
+                onTermination.run();
+            }
+        });
     }
 
     @Override
-    public void onNext(T item) {
+    public void beforeStart(ClientCallStreamObserver<I> requestStreamObserver) {
+        this.requestStreamObserver.set(requestStreamObserver);
+    }
+
+    @Override
+    public void onNext(O item) {
         emitter.emit(item);
     }
 
     @Override
     public void onError(Throwable failure) {
-        emitter.fail(failure);
+        if (terminated.compareAndSet(false, true)) {
+            emitter.fail(failure);
+        } else {
+            // If the reply Multi is cancelled, the ClientCallStreamObserver will be cancelled (see constructor).
+            // ClientCallStreamObserver.cancel causes onError to be called with an io.grpc.StatusRuntimeException.
+            // We are not interested in this exception and we do not want the emitter to fail because this exception
+            // cannot be handled by Mutiny because the Multi has already been terminated.
+        }
     }
 
     @Override
     public void onCompleted() {
+        terminated.set(true);
         emitter.complete();
     }
 }

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ServerCalls.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ServerCalls.java
@@ -35,12 +35,12 @@ public class ServerCalls {
                 onError(response, Status.fromCode(Status.Code.INTERNAL).asException());
                 return;
             }
-            uni.subscribe().with(
+            handleSubscription(uni.subscribe().with(
                     item -> {
                         response.onNext(item);
                         onCompleted(response);
                     },
-                    failure -> onError(response, failure));
+                    failure -> onError(response, failure)), response);
         } catch (Throwable t) {
             onError(response, t);
         }
@@ -82,12 +82,12 @@ public class ServerCalls {
                 onError(response, Status.fromCode(Status.Code.INTERNAL).asException());
                 return null;
             }
-            uni.subscribe().with(
+            handleSubscription(uni.subscribe().with(
                     item -> {
                         response.onNext(item);
                         onCompleted(response);
                     },
-                    failure -> onError(response, failure));
+                    failure -> onError(response, failure)), response);
             return pump;
         } catch (Throwable throwable) {
             onError(response, throwable);

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/UniStreamObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/UniStreamObserver.java
@@ -1,28 +1,62 @@
 package io.quarkus.grpc.stubs;
 
-import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.smallrye.mutiny.subscription.UniEmitter;
 
-public class UniStreamObserver<T> implements StreamObserver<T> {
+public class UniStreamObserver<I, O> implements ClientResponseObserver<I, O> {
+    private final UniEmitter<? super O> emitter;
 
-    private final UniEmitter<? super T> emitter;
+    // If this is set, the Uni was terminated by item or failure, not by cancellation.
+    private final AtomicBoolean terminated = new AtomicBoolean();
 
-    public UniStreamObserver(UniEmitter<? super T> emitter) {
-        this.emitter = emitter;
+    private AtomicReference<ClientCallStreamObserver<I>> requestStreamObserver = new AtomicReference<>();
+
+    public UniStreamObserver(UniEmitter<? super O> emitter, Runnable onTermination) {
+        this.emitter = emitter.onTermination(() -> {
+            // This is called when the reply Uni (the return value of the RPC method) is cancelled or the gRPC server completes the request.
+            if (terminated.compareAndSet(false, true)) {
+                // Cancel the gRPC stream on reply Uni cancellation only (not on completion, this would unnecessarily reset the HTTP/2 stream)
+                ClientCallStreamObserver<I> observer = requestStreamObserver.getAndSet(null);
+                if (observer != null) {
+                    observer.cancel("Cancelled by Uni!", null);
+                }
+            }
+
+            if (onTermination != null) {
+                onTermination.run();
+            }
+        });
     }
 
     @Override
-    public void onNext(T item) {
+    public void beforeStart(ClientCallStreamObserver<I> requestStreamObserver) {
+        this.requestStreamObserver.set(requestStreamObserver);
+    }
+
+    @Override
+    public void onNext(O item) {
+        terminated.set(true);
         emitter.complete(item);
     }
 
     @Override
     public void onError(Throwable failure) {
-        emitter.fail(failure);
+        if (terminated.compareAndSet(false, true)) {
+            emitter.fail(failure);
+        } else {
+            // If the reply Uni is cancelled, the ClientCallStreamObserver will be cancelled (see constructor).
+            // ClientCallStreamObserver.cancel causes onError to be called with an io.grpc.StatusRuntimeException.
+            // We are not interested in this exception and we do not want the emitter to fail because this exception
+            // cannot be handled by Mutiny because the Uni has already been terminated.
+        }
     }
 
     @Override
     public void onCompleted() {
-        // Do nothing.
+        // do not handle on Uni (onNext is called for items)
     }
 }

--- a/integration-tests/grpc-mutiny-cancellation/pom.xml
+++ b/integration-tests/grpc-mutiny-cancellation/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-mutiny-cancellation</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Cancellation with Mutiny</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-grpc</artifactId>
+            <version>${project.version}</version> <!--kept here to not pollute the BOM-->
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/grpc-mutiny-cancellation/src/main/java/io/quarkus/grpc/examples/cancellation/TestServiceImpl.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/main/java/io/quarkus/grpc/examples/cancellation/TestServiceImpl.java
@@ -1,0 +1,102 @@
+package io.quarkus.grpc.examples.cancellation;
+
+import java.time.Duration;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.protobuf.Empty;
+
+import examples.Item;
+import examples.StatusResponse;
+import examples.TestService;
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.logging.Log;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+
+@GrpcService
+public class TestServiceImpl implements TestService {
+    AtomicReference<MultiEmitter<? super StatusResponse>> emitter = new AtomicReference<>();
+
+    @Override
+    public Uni<Item> oneToOne(Empty request) {
+        return Uni.createFrom().item(15)
+                .onItem().delayIt().by(Duration.ofSeconds(3))
+                .map(i -> Item.newBuilder().setValue(i).build())
+                .onTermination().invoke(this::emitTermination)
+                .onCancellation().invoke(this::emitCancellation)
+                .onCancellation().invoke(() -> Log.info("oneToOne cancelled on server"))
+                .onSubscription().invoke(this::emitSubscription);
+    }
+
+    @Override
+    public Multi<Item> oneToMany(Empty request) {
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+                .select().first(3)
+                .map(Long::intValue)
+                .map(i -> Item.newBuilder().setValue(i).build())
+                .onTermination().invoke(this::emitTermination)
+                .onCancellation().invoke(this::emitCancellation)
+                .onCancellation().invoke(() -> Log.info("oneToMany cancelled on server"))
+                .onSubscription().invoke(this::emitSubscription);
+    }
+
+    @Override
+    public Uni<Item> manyToOne(Multi<Item> request) {
+        return request
+                .map(Item::getValue)
+                .collect().last()
+                .map(i -> Item.newBuilder().setValue(i).build())
+                .onTermination().invoke(this::emitTermination)
+                .onCancellation().invoke(this::emitCancellation)
+                .onCancellation().invoke(() -> Log.info("manyToOne cancelled on server"))
+                .onSubscription().invoke(this::emitSubscription);
+    }
+
+    @Override
+    public Multi<Item> manyToMany(Multi<Item> request) {
+        return request
+                .map(Item::getValue)
+                .onItem().scan(Integer::sum)
+                .map(i -> Item.newBuilder().setValue(i).build())
+                .onTermination().invoke(this::emitTermination)
+                .onCancellation().invoke(this::emitCancellation)
+                .onCancellation().invoke(() -> Log.info("manyToMany cancelled on server"))
+                .onSubscription().invoke(this::emitSubscription);
+    }
+
+    @Override
+    public Multi<StatusResponse> readStatus(Empty request) {
+        return Multi.createFrom().emitter(e -> {
+            emitter.set(e);
+            emitReady();
+        });
+    }
+
+    private void emitReady() {
+        emitStatus(StatusResponse.Status.READY);
+    }
+
+    private void emitSubscription(Subscription subscription) {
+        emitStatus(StatusResponse.Status.SUBSCRIBED);
+    }
+
+    private void emitCancellation() {
+        emitStatus(StatusResponse.Status.CANCELLED);
+    }
+
+    private void emitTermination() {
+        MultiEmitter<? super StatusResponse> e = emitter.get();
+        if (e != null) {
+            e.complete();
+        }
+    }
+
+    private void emitStatus(StatusResponse.Status status) {
+        MultiEmitter<? super StatusResponse> e = emitter.get();
+        if (e != null) {
+            e.emit(StatusResponse.newBuilder().setStatus(status).build());
+        }
+    }
+}

--- a/integration-tests/grpc-mutiny-cancellation/src/main/proto/cancellation.proto
+++ b/integration-tests/grpc-mutiny-cancellation/src/main/proto/cancellation.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+option java_multiple_files = true;
+option java_package = "examples";
+
+package cancellation;
+
+service TestService {
+  rpc OneToOne (google.protobuf.Empty) returns (Item) {}
+  rpc OneToMany (google.protobuf.Empty) returns (stream Item) {}
+  rpc ManyToOne (stream Item) returns (Item) {}
+  rpc ManyToMany (stream Item) returns (stream Item) {}
+
+  // used to report request status events from the server to the client
+  rpc readStatus(google.protobuf.Empty) returns (stream StatusResponse) {}
+}
+
+message Item {
+  int32 value = 1;
+}
+
+message StatusResponse {
+  enum Status {
+    UNSPECIFIED = 0;
+    READY = 1;
+    SUBSCRIBED = 2;
+    CANCELLED = 3;
+  }
+  Status status = 1;
+}

--- a/integration-tests/grpc-mutiny-cancellation/src/main/resources/application.properties
+++ b/integration-tests/grpc-mutiny-cancellation/src/main/resources/application.properties
@@ -1,0 +1,21 @@
+## --- servers
+
+quarkus.grpc.server.use-separate-server=true
+%vertx.quarkus.grpc.server.use-separate-server=false
+%n2o.quarkus.grpc.server.use-separate-server=true
+%o2n.quarkus.grpc.server.use-separate-server=false
+
+## --- clients
+
+quarkus.grpc.clients.testService.host=localhost
+quarkus.grpc.clients.testService.port=9001
+quarkus.grpc.clients.testService.use-quarkus-grpc-client=false
+
+%vertx.quarkus.grpc.clients.testService.port=8081
+%vertx.quarkus.grpc.clients.testService.use-quarkus-grpc-client=true
+
+%n2o.quarkus.grpc.clients.testService.port=9001
+%n2o.quarkus.grpc.clients.testService.use-quarkus-grpc-client=true
+
+%o2n.quarkus.grpc.clients.testService.port=8081
+%o2n.quarkus.grpc.clients.testService.use-quarkus-grpc-client=false

--- a/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/CancellationTest.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/CancellationTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.grpc.examples.cancellation;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import com.google.protobuf.Empty;
+
+import examples.Item;
+import examples.TestService;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.examples.cancellation.helper.CancellationTestRunner;
+import io.quarkus.logging.Log;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Multi;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CancellationTest {
+    @GrpcClient
+    TestService testService;
+
+    private CancellationTestRunner testRunner;
+
+    private static final Consumer<Item> NOOP = item -> {
+    };
+
+    @BeforeEach
+    void setUp() {
+        testRunner = new CancellationTestRunner(testService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        testRunner = null;
+    }
+
+    @Test
+    @Order(1)
+    void oneToOne() {
+        Log.info("Starting oneToOne request...");
+        testRunner.start(() -> testService.oneToOne(Empty.getDefaultInstance())
+                .onCancellation().invoke(() -> Log.info("oneToOne cancelled"))
+                .subscribe().with(NOOP));
+        testRunner.awaitTermination();
+    }
+
+    @Test
+    @Order(2)
+    void oneToMany() {
+        Log.info("Starting oneToMany request...");
+        testRunner.start(() -> testService.oneToMany(Empty.getDefaultInstance())
+                .onCancellation().invoke(() -> Log.info("oneToMany cancelled"))
+                .subscribe().with(NOOP));
+        testRunner.awaitTermination();
+    }
+
+    @Test
+    @Order(3)
+    void manyToOne() {
+        Log.info("Starting manyToOne request...");
+        Multi<Item> request = createMultiRequest()
+                .onCancellation().invoke(() -> Log.info("manyToOne request cancelled"));
+
+        testRunner.start(() -> testService.manyToOne(request)
+                .onCancellation().invoke(() -> Log.info("manyToOne cancelled"))
+                .subscribe().with(NOOP));
+        testRunner.awaitTermination();
+    }
+
+    @Test
+    @Order(4)
+    void manyToMany() {
+        Log.info("Starting manyToMany request...");
+        Multi<Item> request = createMultiRequest()
+                .onCancellation().invoke(() -> Log.info("manyToMany request cancelled"));
+
+        testRunner.start(() -> testService.manyToMany(request)
+                .onCancellation().invoke(() -> Log.info("manyToMany cancelled"))
+                .subscribe().with(NOOP));
+        testRunner.awaitTermination();
+    }
+
+    private Multi<Item> createMultiRequest() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(500))
+                .select().first(10)
+                .map(Long::intValue)
+                .map(i -> Item.newBuilder().setValue(i).build());
+    }
+}

--- a/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/N2OCancellationTest.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/N2OCancellationTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.grpc.examples.cancellation;
+
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(N2OGRPCTestProfile.class)
+public class N2OCancellationTest extends CancellationTest {
+}

--- a/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/O2NCancellationTest.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/O2NCancellationTest.java
@@ -1,0 +1,13 @@
+package io.quarkus.grpc.examples.cancellation;
+
+import org.junit.jupiter.api.Disabled;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@Disabled
+@QuarkusTest
+@TestProfile(O2NGRPCTestProfile.class)
+public class O2NCancellationTest extends CancellationTest {
+}

--- a/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/O2NCancellationTest.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/O2NCancellationTest.java
@@ -1,12 +1,9 @@
 package io.quarkus.grpc.examples.cancellation;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
-@Disabled
 @QuarkusTest
 @TestProfile(O2NGRPCTestProfile.class)
 public class O2NCancellationTest extends CancellationTest {

--- a/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/VertxCancellationTest.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/VertxCancellationTest.java
@@ -1,0 +1,13 @@
+package io.quarkus.grpc.examples.cancellation;
+
+import org.junit.jupiter.api.Disabled;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@Disabled
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+public class VertxCancellationTest extends CancellationTest {
+}

--- a/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/VertxCancellationTest.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/VertxCancellationTest.java
@@ -1,12 +1,9 @@
 package io.quarkus.grpc.examples.cancellation;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
-@Disabled
 @QuarkusTest
 @TestProfile(VertxGRPCTestProfile.class)
 public class VertxCancellationTest extends CancellationTest {

--- a/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/helper/CancellationTestRunner.java
+++ b/integration-tests/grpc-mutiny-cancellation/src/test/java/io/quarkus/grpc/examples/cancellation/helper/CancellationTestRunner.java
@@ -1,0 +1,64 @@
+package io.quarkus.grpc.examples.cancellation.helper;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import com.google.protobuf.Empty;
+
+import examples.StatusResponse;
+import examples.TestService;
+import io.quarkus.logging.Log;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.subscription.Cancellable;
+
+public class CancellationTestRunner {
+    private final TestService testService;
+    private final AtomicReference<Cancellable> cancellableSubscriber = new AtomicReference<>();
+
+    private AssertSubscriber<Object> statusSubscriber;
+
+    public CancellationTestRunner(TestService testService) {
+        this.testService = testService;
+    }
+
+    public void start(Supplier<Cancellable> requestToTest) {
+        statusSubscriber = testService.readStatus(Empty.getDefaultInstance())
+                .map(StatusResponse::getStatus)
+                .onItem().invoke(s -> {
+                    switch (s) {
+                        case READY:
+                            // Run request as soon as the status reader is ready.
+                            cancellableSubscriber.set(requestToTest.get());
+                            break;
+                        case SUBSCRIBED:
+                            // Do not cancel until the request has reached the server. This is to ensure that the server call must be cancelled.
+                            cancelRequest();
+                            break;
+                        default:
+                            break;
+                    }
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+    }
+
+    public void awaitTermination() {
+        try {
+            statusSubscriber
+                    .awaitCompletion(Duration.ofSeconds(5))
+                    .assertItems(StatusResponse.Status.READY, StatusResponse.Status.SUBSCRIBED,
+                            StatusResponse.Status.CANCELLED);
+        } catch (AssertionError e) {
+            Log.error("cancellation failed");
+            cancelRequest();
+            throw e;
+        }
+    }
+
+    private void cancelRequest() {
+        Cancellable cancellable = cancellableSubscriber.get();
+        if (cancellable != null) {
+            cancellable.cancel();
+        }
+    }
+}


### PR DESCRIPTION
This PR forwards the cancellation events from response `Uni` and `Multi` to the server by cancelling the gRPC stream.

- Fixes: #41776 
- Fixes: #46986.