### PR TITLE
Make protected constructors callable again for resteasy reactive

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -560,7 +560,8 @@ public class ResteasyReactiveProcessor {
                                         initConverters.getMethodParam(0));
                             }))
                     .setConverterSupplierIndexerExtension(new GeneratedConverterIndexerExtension(
-                            (name) -> new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer, true)))
+                            (name) -> new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer,
+                                    applicationClassPredicate.test(name))))
                     .setHasRuntimeConverters(!paramConverterProviders.getParamConverterProviders().isEmpty())
                     .setClassLevelExceptionMappers(
                             classLevelExceptionMappers.isPresent() ? classLevelExceptionMappers.get().getMappers()

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -1684,6 +1684,26 @@ public class DevMojoIT extends LaunchMojoTestBase {
     }
 
     @Test
+    public void testResteasyReactiveExternalArtifact() throws Exception {
+        final String rootProjectPath = "projects/rr-external-artifacts";
+
+        // Set up the external project
+        final File externalJarDir = initProject(rootProjectPath + "/external-lib");
+
+        // Clean and install the external JAR in local repository (.m2)
+        install(externalJarDir, true);
+
+        // Set up the main project that uses the external dependency
+        this.testDir = initProject(rootProjectPath + "/app");
+
+        // Run quarkus:dev process
+        run(true);
+
+        Assertions.assertEquals("Quarkus", devModeClient.getHttpResponse("/hello/Quarkus"));
+        Assertions.assertEquals("OK", devModeClient.getHttpResponse("/hello/parameterized-type-external"));
+    }
+
+    @Test
     public void testThatAptInClasspathWorks() throws MavenInvocationException, IOException {
         testDir = initProject("projects/apt-in-classpath", "projects/project-apt-in-classpath");
         run(true);

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/app/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/app/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme</groupId>
+    <artifactId>acme</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>\${quarkus.platform.group-id}</groupId>
+                <artifactId>\${quarkus.platform.artifact-id}</artifactId>
+                <version>\${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.acme.lib</groupId>
+            <artifactId>acme-lib</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>\${compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>\${quarkus-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/app/src/main/java/org/acme/GreetingListSortAttribute.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/app/src/main/java/org/acme/GreetingListSortAttribute.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import org.acme.lib.SortAttribute;
+
+public enum GreetingListSortAttribute implements SortAttribute{
+    FORMALITY_FACTOR,
+    LANGUAGE;
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/app/src/main/java/org/acme/ParametersResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/app/src/main/java/org/acme/ParametersResource.java
@@ -1,0 +1,24 @@
+package org.acme;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.acme.lib.StringTypeProtectedConstructor;
+import org.acme.lib.GreetingListFilter;
+
+@Path("/hello")
+public class ParametersResource {
+
+    @Path("{stringValue}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String stringTypePath(@PathParam("stringValue") final StringTypeProtectedConstructor stringValue) {
+        return stringValue.getValue();
+    }
+
+    @Path("parameterized-type-external")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello(@BeanParam GreetingListFilter<GreetingListSortAttribute> listFilter) {
+        return "OK";
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme.lib</groupId>
+    <artifactId>acme-lib</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.jar.plugin.version>${version.jar.plugin}</maven.jar.plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>\${quarkus.platform.group-id}</groupId>
+                <artifactId>\${quarkus.platform.artifact-id}</artifactId>
+                <version>\${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>\${compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>\${maven.jar.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/src/main/java/org/acme/lib/GreetingListFilter.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/src/main/java/org/acme/lib/GreetingListFilter.java
@@ -1,0 +1,9 @@
+package org.acme.lib;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.QueryParam;
+
+public class GreetingListFilter<T extends SortAttribute> {
+    @QueryParam("sortAttribute")
+    public T sortAttribute;
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/src/main/java/org/acme/lib/SortAttribute.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/src/main/java/org/acme/lib/SortAttribute.java
@@ -1,0 +1,4 @@
+package org.acme.lib;
+
+public interface SortAttribute {
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/src/main/java/org/acme/lib/StringTypeProtectedConstructor.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-external-artifacts/external-lib/src/main/java/org/acme/lib/StringTypeProtectedConstructor.java
@@ -1,0 +1,26 @@
+package org.acme.lib;
+
+public class StringTypeProtectedConstructor {
+
+    private String value;
+
+    protected StringTypeProtectedConstructor(final String value) {
+        this.value = value;
+    }
+
+
+    public String getValue() {
+        return value;
+    }
+
+
+    public static StringTypeProtectedConstructor fromString(final String s) {
+        return new StringTypeProtectedConstructor(s);
+    }
+
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}


### PR DESCRIPTION
The resteasy reactive param converter, which gets automatically generated, calls the fromString/valueOf/constructor of the wrapper class directly. This fails if the paramconveter and the wrapper class is housed in different class loader. We can ensure that the TCCL is the same CL as the wrapper class, by not considering the wrapper an application class anymore if it is in an external jar.

related to #47471

This reverts #39691 (but also adds tests)
Follows up on #39823