### PR TITLE
Avoid NPE in TenantIdentityProvider

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkus.oidc.runtime;
 
-import static io.quarkus.oidc.runtime.OidcConfig.getDefaultTenant;
-import static io.quarkus.oidc.runtime.OidcUtils.DEFAULT_TENANT_ID;
 import static io.quarkus.runtime.configuration.DurationConverter.parseDuration;
 import static io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.getRoutingContextAttribute;
 
@@ -186,12 +184,7 @@ public class OidcRecorder {
             super(Arc.container().instance(DefaultTenantConfigResolver.class).get(),
                     Arc.container().instance(BlockingSecurityExecutor.class).get());
             this.blockingExecutor = Arc.container().instance(BlockingSecurityExecutor.class).get();
-            if (tenantId.equals(DEFAULT_TENANT_ID)) {
-                OidcConfig config = Arc.container().instance(OidcConfig.class).get();
-                this.tenantId = getDefaultTenant(config).tenantId().orElse(OidcUtils.DEFAULT_TENANT_ID);
-            } else {
-                this.tenantId = tenantId;
-            }
+            this.tenantId = tenantId;
         }
 
         @Override


### PR DESCRIPTION
Fixes #47568

It only impacts the case where the user code attempts to verify token manually, and only when the default tenant is used.

The current code is OK in principle, because a default tenant may actually set its own tenant id - but `quarkus-oidc` currently expects in different places that it is always going to be `Default`, and we should improve it with a dedicated PR, there is no strong practical reason for users to customize a default tenant id.