### PR TITLE
OIDC : Improve DefaultStaticTenantResolver URL handling

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
@@ -84,7 +84,7 @@ final class StaticTenantResolver {
     }
 
     private static final class DefaultStaticTenantResolver implements TenantResolver {
-
+        private static final String PATH_SEPARATOR = "/";
         private final TenantConfigBean tenantConfigBean;
 
         private DefaultStaticTenantResolver(TenantConfigBean tenantConfigBean) {
@@ -93,13 +93,12 @@ final class StaticTenantResolver {
 
         @Override
         public String resolve(RoutingContext context) {
-            String[] pathSegments = context.request().path().split("/");
-            if (pathSegments.length > 0) {
-                String lastPathSegment = pathSegments[pathSegments.length - 1];
-                if (tenantConfigBean.getStaticTenant(lastPathSegment) != null) {
+            String[] pathSegments = context.request().path().split(PATH_SEPARATOR);
+            for (String segment : pathSegments) {
+                if (tenantConfigBean.getStaticTenant(segment) != null) {
                     LOG.debugf(
-                            "Tenant id '%s' is selected on the '%s' request path", lastPathSegment, context.normalizedPath());
-                    return lastPathSegment;
+                            "Tenant id '%s' is selected on the '%s' request path", segment, context.normalizedPath());
+                    return segment;
                 }
             }
             return null;

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/model/User.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/model/User.java
@@ -3,12 +3,23 @@ package io.quarkus.it.keycloak.model;
 public class User {
 
     private final String userName;
+    private final String tenantId;
 
     public User(String name) {
         this.userName = name;
+        this.tenantId = null;
+    }
+
+    public User(String userName, String tenantId) {
+        this.userName = userName;
+        this.tenantId = tenantId;
     }
 
     public String getUserName() {
         return userName;
+    }
+
+    public String getTenantId() {
+        return tenantId;
     }
 }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -59,6 +59,28 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testTenantIdFromRoutingContextDefaultTenantResolver() {
+        String username = "alice";
+        String tenantId = "bearer";
+        String accessToken = getAccessToken(username, Set.of("user"));
+
+        RestAssured.given().auth().oauth2(accessToken)
+                .queryParam("includeTenantId", Boolean.TRUE)
+                .when().get("/api/users/preferredUserName/bearer")
+                .then()
+                .statusCode(200)
+                .body("userName", equalTo(username))
+                .body("tenantId", equalTo(tenantId));
+
+        RestAssured.given().auth().oauth2(getAccessToken(username, Set.of("user", "admin")))
+                .when().get("/api/users/preferredUserName/bearer/token")
+                .then()
+                .statusCode(200)
+                .body("userName", equalTo(username))
+                .body("tenantId", equalTo(tenantId));
+    }
+
+    @Test
     public void testAccessResourceAzure() throws Exception {
         String azureToken = readFile("token.txt");
         String azureJwk = readFile("jwks.json");


### PR DESCRIPTION
Fixes #47562.
The current default tenant resolver checks for tenants in the last path segment,
this change is to check if all of the URL path contains a tenant id, as opposed to checking the last path segment only