### PR TITLE
Redis dev services: Add disabled tests for case where multiple profiles share a port

### DIFF
--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceITest.java
@@ -1,0 +1,24 @@
+package io.quarkus.redis.devservices.it;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.devservices.it.profiles.DevServicesCustomPortReusableServiceProfile;
+import io.quarkus.redis.devservices.it.utils.SocketKit;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@Disabled("Tracked by https://github.com/quarkusio/quarkus/issues/45785")
+@QuarkusTest
+@TestProfile(DevServicesCustomPortReusableServiceProfile.class)
+public class DevServicesRedisCustomPortReusableServiceITest {
+
+    @Test
+    @DisplayName("should start redis container with the given custom port")
+    public void shouldStartRedisContainer() {
+        Assertions.assertTrue(SocketKit.isPortAlreadyUsed(6371));
+    }
+
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisNonUniquePortITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisNonUniquePortITest.java
@@ -1,0 +1,47 @@
+package io.quarkus.redis.devservices.it;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.devservices.it.profiles.DevServicesNonUniquePortProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@Disabled("Tracked by https://github.com/quarkusio/quarkus/issues/45785")
+@QuarkusTest
+@TestProfile(DevServicesNonUniquePortProfile.class)
+public class DevServicesRedisNonUniquePortITest {
+
+    @Inject
+    RedisDataSource redisClient;
+
+    @BeforeEach
+    public void setUp() {
+        redisClient.value(String.class).set("anykey", "anyvalue");
+    }
+
+    @Test
+    @DisplayName("given redis container must communicate with it and return value by key")
+    public void shouldReturnAllKeys() {
+        Assertions.assertEquals("anyvalue", redisClient.value(String.class).get("anykey").toString());
+    }
+
+    @Test
+    public void shouldHaveStack() {
+        // The entertainingly named lolwut command gives a version number but doesn't say if stack is available, so try using some of the commands
+        try {
+            redisClient.bloom(String.class).bfadd("key", "whatever");
+        } catch (Exception e) {
+            fail("Redis stack should be available on the connected back end (underlying error was  " + e + ")");
+        }
+    }
+
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisRandomPortITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisRandomPortITest.java
@@ -1,0 +1,33 @@
+package io.quarkus.redis.devservices.it;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.devservices.it.profiles.DevServicesRandomPortProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DevServicesRandomPortProfile.class)
+public class DevServicesRedisRandomPortITest {
+
+    @Inject
+    RedisDataSource redisClient;
+
+    @BeforeEach
+    public void setUp() {
+        redisClient.value(String.class).set("anykey", "anyvalue");
+    }
+
+    @Test
+    @DisplayName("given redis container must communicate with it and return value by key")
+    public void shouldReturnAllKeys() {
+        Assertions.assertEquals("anyvalue", redisClient.value(String.class).get("anykey").toString());
+    }
+
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesCustomPortProfile.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesCustomPortProfile.java
@@ -7,9 +7,11 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 
 public class DevServicesCustomPortProfile implements QuarkusTestProfile {
 
+    public static final String PORT = "6371";
+
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Collections.singletonMap("quarkus.redis.devservices.port", "6371");
+        return Collections.singletonMap("quarkus.redis.devservices.port", PORT);
     }
 
     @Override

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesCustomPortReusableServiceProfile.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesCustomPortReusableServiceProfile.java
@@ -1,0 +1,15 @@
+package io.quarkus.redis.devservices.it.profiles;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesCustomPortReusableServiceProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        // This is a distinct profile, but its config should be identical to the custom port profile, so the dev service can be the same
+        return Collections.singletonMap("quarkus.redis.devservices.port", DevServicesCustomPortProfile.PORT);
+    }
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesNonUniquePortProfile.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesNonUniquePortProfile.java
@@ -1,0 +1,19 @@
+package io.quarkus.redis.devservices.it.profiles;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesNonUniquePortProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        // Set an image, both for coverage, and so we know we're connecting to the right service
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put("quarkus.redis.devservices.port", "6371");
+        // Choose an image which includes redis stack, so we can identify we're running on it
+        overrides.put("quarkus.redis.devservices.image-name", "redis/redis-stack:latest");
+        return overrides;
+    }
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesRandomPortProfile.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/profiles/DevServicesRandomPortProfile.java
@@ -1,0 +1,15 @@
+package io.quarkus.redis.devservices.it.profiles;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesRandomPortProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        // Don't set a port, to exercise the random port path
+        return Collections.emptyMap();
+    }
+}


### PR DESCRIPTION
I'm working on a fix for the Redis part of https://github.com/quarkusio/quarkus/issues/45785, and spotted that the only coverage we have of the scenario where multiple profiles try to use the same port is in the opentelemetry-redis-instrumentation integration test. (This is better than most dev services, which don't cover the case at all). 

To bring the problem scenario closer to the relevant dev service, I've added some new tests. They're disabled for the moment, since the multiple-profiles-attempting-to-use-the-same-port scenario stopped working with #34681. 

PR for a fix incoming soon. 