### PR TITLE
mvnw - Fix sha256 check on macOS

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -227,7 +227,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then


### PR DESCRIPTION
I simply applied:
https://github.com/apache/maven-wrapper/commit/b2ff9cdfa2d4a1f2bc0d4f039c0efc297b0c5875 which is not included in what mvn wrapper:wrapper installs for whatever reason.