### PR TITLE
Properly drop preview status for WebSockets.next

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="websockets-next-reference-guide"]
 = WebSockets Next reference guide
-:extension-status: preview
 include::_attributes.adoc[]
 :numbered:
 :sectnums:
@@ -13,8 +12,6 @@ include::_attributes.adoc[]
 :categories: web
 :topics: web,websockets
 :extensions: io.quarkus:quarkus-websockets-next
-
-include::{includes}/extension-status.adoc[]
 
 The `quarkus-websockets-next` extension provides a modern declarative API to define WebSocket server and client endpoints.
 

--- a/docs/src/main/asciidoc/websockets-next-tutorial.adoc
+++ b/docs/src/main/asciidoc/websockets-next-tutorial.adoc
@@ -14,9 +14,6 @@ include::_attributes.adoc[]
 This guide explains how your Quarkus application can utilize web sockets to create interactive web applications.
 In this guide, we will develop a very simple chat application using web sockets to receive and send messages to the other connected users.
 
-include::{includes}/extension-status.adoc[]
-
-
 == Prerequisites
 
 include::{includes}/prerequisites.adoc[]

--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -3,14 +3,22 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using WebSockets
+= Using WebSockets with Undertow
 include::_attributes.adoc[]
 :categories: web
 :summary: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications. Because it’s the canonical web socket application, we are going to create a simple chat application.
 :topics: web,websockets
 :extensions: io.quarkus:quarkus-websockets,io.quarkus:quarkus-websockets-client
 
-This guide explains how your Quarkus application can utilize web sockets to create interactive web applications.
+This guide explains how your Quarkus application can utilize web sockets to create interactive web applications,
+in the context of an Undertow-based Quarkus application, or if you rely on https://jakarta.ee/specifications/websocket/[Jakarta WebSocket].
+
+[TIP]
+====
+If you don't use Undertow or https://jakarta.ee/specifications/websocket/[Jakarta WebSocket],
+it is recommended to use the more modern xref:websockets-next-tutorial.adoc[WebSockets Next extensions].
+====
+
 Because it's the _canonical_ web socket application, we are going to create a simple chat application.
 
 == Prerequisites


### PR DESCRIPTION
@mkouba I also wonder if we should add a note/tip/whatever at the top of https://quarkus.io/guides/websockets to point people to WebSockets.next as our preferred way to use WebSockets nowadays?

Also maybe the guide should be renamed to `Using WebSockets with Undertow`?

I will let you judge of that.

Per gripe from @tqvarnst 