### PR TITLE
Only display the extension status note if attribute is defined

### DIFF
--- a/docs/src/main/asciidoc/_includes/extension-status.adoc
+++ b/docs/src/main/asciidoc/_includes/extension-status.adoc
@@ -1,3 +1,4 @@
+ifdef::extension-status[]
 [NOTE]
 ====
 This technology is considered {extension-status}.
@@ -21,3 +22,4 @@ endif::[]
 
 For a full list of possible statuses, check our https://quarkus.io/faq/#what-are-the-extension-statuses[FAQ entry].
 ====
+endif::[]


### PR DESCRIPTION
At the moment, if you drop the attribute but keep the note, the note is displayed with `{extension-status}` in the text which is not ideal.

Let's display the note only if the status is defined.