### PR TITLE
Do not start redis dev services in augmentation (plus supporting framework)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInstanceIdBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInstanceIdBuildItem.java
@@ -1,0 +1,25 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.UUID;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A unique identifier for an instance of an application.
+ * Development and test modes will have different IDs.
+ * The application ID will persist across continuous test restarts and dev mode restarts.
+ * It mirrors the lifecycle of a curated application.
+ *
+ */
+public final class ApplicationInstanceIdBuildItem extends SimpleBuildItem {
+
+    final UUID UUID;
+
+    public ApplicationInstanceIdBuildItem(UUID uuid) {
+        this.UUID = uuid;
+    }
+
+    public UUID getUUID() {
+        return UUID;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/CuratedApplicationShutdownBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/CuratedApplicationShutdownBuildItem.java
@@ -13,7 +13,7 @@ import io.quarkus.builder.item.SimpleBuildItem;
  * <p>
  * For production applications, this will be at the end of the Maven/Gradle build. For dev mode applications, this will be
  * when dev mode shuts down. For tests, it will generally be at the end of the test run. However, for continuous testing this
- * will be when the outer dev mode process shuts down. For unit style tests, this will usually be the end of the test.
+ * will be when the outer dev mode process shuts down. For extension unit tests, this will usually be the end of the test.
  */
 public final class CuratedApplicationShutdownBuildItem extends SimpleBuildItem {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -1,0 +1,61 @@
+package io.quarkus.deployment.builditem;
+
+import java.io.Closeable;
+import java.util.Set;
+import java.util.UUID;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.devservices.crossclassloader.runtime.ComparableDevServicesConfig;
+import io.quarkus.devservices.crossclassloader.runtime.DevServiceOwner;
+import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
+import io.quarkus.runtime.LaunchMode;
+
+// Ideally we would have a unique build item for each processor/feature, but that would need a new KeyedBuildItem or FeatureBuildItem type
+// Needs to be in core because DevServicesResultBuildItem is in core
+public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
+
+    // This is a fairly thin wrapper around the tracker, so the tracker can be loaded with the system classloader
+    // The QuarkusClassLoader takes care of loading the tracker with the right classloader
+    private final RunningDevServicesRegistry tracker;
+    private final UUID uuid;
+    private final DevServicesConfig globalConfig;
+    private final LaunchMode launchMode;
+
+    public DevServicesRegistryBuildItem(UUID uuid, DevServicesConfig globalDevServicesConfig, LaunchMode launchMode) {
+        this.launchMode = launchMode;
+        this.tracker = new RunningDevServicesRegistry();
+        this.uuid = uuid;
+        this.globalConfig = globalDevServicesConfig;
+    }
+
+    public Set<Closeable> getRunningServices(String featureName, String configName, Object identifyingConfig) {
+        DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
+        ComparableDevServicesConfig key = new ComparableDevServicesConfig(uuid, owner, globalConfig, identifyingConfig);
+        return tracker.getRunningServices(key);
+    }
+
+    public Set<Closeable> getAllRunningServices(String featureName, String configName) {
+        DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
+        return tracker.getAllRunningServices(owner);
+    }
+
+    public void addRunningService(String featureName, String configName, Object identifyingConfig,
+            DevServicesResultBuildItem.RunnableDevService service) {
+        DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
+        ComparableDevServicesConfig key = new ComparableDevServicesConfig(uuid, owner, globalConfig, identifyingConfig);
+        tracker.addRunningService(key, service);
+    }
+
+    public void removeRunningService(String featureName, String configName, Object identifyingConfig,
+            DevServicesResultBuildItem.RunnableDevService service) {
+        DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
+        ComparableDevServicesConfig key = new ComparableDevServicesConfig(uuid, owner, globalConfig, identifyingConfig);
+        tracker.removeRunningService(key, service);
+    }
+
+    public void closeAllRunningServices() {
+        tracker.closeAllRunningServices(launchMode.name());
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
@@ -2,27 +2,35 @@ package io.quarkus.deployment.builditem;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * BuildItem for running dev services.
  * Combines injected configs to the application with container id (if it exists).
- *
+ * <p>
  * Processors are expected to return this build item not only when the dev service first starts,
  * but also if a running dev service already exists.
- *
+ * <p>
  * {@link RunningDevService} helps to manage the lifecycle of the running dev service.
  */
 public final class DevServicesResultBuildItem extends MultiBuildItem {
 
+    private static final Logger log = Logger.getLogger(DevServicesResultBuildItem.class);
+
     private final String name;
     private final String description;
+    // Will be null if there is a runnable dev service
     private final String containerId;
-    private final Map<String, String> config;
+    protected final Map<String, String> config;
+    protected RunnableDevService runnableDevService;
 
     public DevServicesResultBuildItem(String name, String containerId, Map<String, String> config) {
         this(name, null, containerId, config);
@@ -35,6 +43,12 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
         this.config = config;
     }
 
+    public DevServicesResultBuildItem(String name, String description, Map<String, String> config,
+            RunnableDevService runnableDevService) {
+        this(name, description, null, config);
+        this.runnableDevService = runnableDevService;
+    }
+
     public String getName() {
         return name;
     }
@@ -44,20 +58,42 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
     }
 
     public String getContainerId() {
-        return containerId;
+        if (runnableDevService != null) {
+            return runnableDevService.getContainerId();
+        } else {
+            return containerId;
+        }
     }
 
     public Map<String, String> getConfig() {
         return config;
     }
 
+    public void start() {
+        if (runnableDevService != null) {
+            runnableDevService.start();
+        } else {
+            log.debugf("Not starting %s because runnable dev service is null (it is probably a running dev service.", name);
+        }
+    }
+
+    // Ideally everyone would use the config source, but if people need to ask for config directly, make it possible
+    public Map<String, String> getDynamicConfig() {
+        if (runnableDevService != null && runnableDevService.isRunning()) {
+            return runnableDevService.get();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
     public static class RunningDevService implements Closeable {
 
-        private final String name;
-        private final String description;
-        private final String containerId;
-        private final Map<String, String> config;
-        private final Closeable closeable;
+        protected final String name;
+        protected final String description;
+        protected final String containerId;
+        protected final Map<String, String> config;
+        protected final Closeable closeable;
+        protected volatile boolean isRunning = true;
 
         private static Map<String, String> mapOf(String key, String value) {
             Map<String, String> map = new HashMap<>();
@@ -109,6 +145,9 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
             return closeable;
         }
 
+        // This method should be on RunningDevService, but not on RunnableDevService, where we use different logic to
+        // decide when it's time to close a container. For now, leave it where it is and hope it doesn't get called when it shouldn't.
+        // We can either make a common parent class or throw unsupported when this is called from Runnable.
         public boolean isOwner() {
             return closeable != null;
         }
@@ -117,11 +156,135 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
         public void close() throws IOException {
             if (this.closeable != null) {
                 this.closeable.close();
+                isRunning = false;
             }
         }
 
         public DevServicesResultBuildItem toBuildItem() {
             return new DevServicesResultBuildItem(name, description, containerId, config);
         }
+    }
+
+    public static class RunnableDevService extends RunningDevService implements Supplier<Map<String, String>> {
+
+        private final DevServicesRegistryBuildItem tracker;
+        private final Startable container;
+        private final Object identifyingConfig;
+        private final String featureName;
+        private final String configName;
+        private final Map<String, Supplier<String>> lazyConfig;
+
+        /**
+         * There are several configs in this argument, but there's a reason! (For now, at least.)
+         * The identifying config object is the user-defined config, and are what we use to establish ownership and reusability.
+         * The config name is used to identify sub-configuration.
+         * The first feature name is generated by the processor.
+         */
+        public RunnableDevService(String featureName, String configName, Startable container,
+                Map lazyConfig,
+                Object identifyingConfig,
+                DevServicesRegistryBuildItem tracker) {
+            super(featureName, null, container::close, Collections.emptyMap());
+
+            this.featureName = featureName;
+            this.configName = configName;
+            this.container = container;
+            this.tracker = tracker;
+            isRunning = false;
+            this.lazyConfig = lazyConfig;
+            this.identifyingConfig = identifyingConfig;
+        }
+
+        public boolean isRunning() {
+            return isRunning;
+        }
+
+        @Override
+        public String getContainerId() {
+            return container != null ? container.getContainerId() : null;
+        }
+
+        /**
+         * Starts the service, after first checking for a compatible service in the tracker.
+         * Calling classes may wish to do their own checks for compatible services before calling start().
+         */
+        public void start() {
+            // We want to do two things; find things with the same config as us to reuse them, and find things with different config to close them
+            // We figure out if we need to shut down existing redis containers that might have been started in previous profiles or restarts
+
+            // These RunnableDevService classes could be from another classloader, so don't make assumptions about the class
+            Collection<?> matchedDevServices = tracker.getRunningServices(featureName, configName, identifyingConfig);
+            // if the redis containers have already started we just return; if we wanted to be very cautious we could check the entries for an isRunningStatus, but they might be in the wrong classloader, so that's hard work
+            if (matchedDevServices == null || matchedDevServices.isEmpty()) {
+                // There isn't a running container that has the right config, we need to do work
+                // Let's get all the running dev services associated with this feature (+ launch mode plus named section), so we can close them
+                closeOwnedServices();
+
+                reallyStart();
+            }
+        }
+
+        private void closeOwnedServices() {
+            Collection<Closeable> unusableDevServices = tracker.getAllRunningServices(featureName, configName);
+            if (unusableDevServices != null) {
+                for (Closeable closeable : unusableDevServices) {
+                    try {
+                        closeable.close();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Starts, without doing any duplicate checking, and without doing any cleanup.
+         * The duplicate checking is optional, the cleanup is not.
+         */
+        private void reallyStart() {
+            if (container != null) {
+                synchronized (this) {
+                    container.start();
+
+                    //  tell the tracker that we started
+                    isRunning = true;
+                    tracker.addRunningService(featureName, configName, identifyingConfig, this);
+                }
+                // Ideally we'd print out a port number here, but we can only do that if we add a dependency on GenericContainer (or update startable to add a method)
+
+                log.infof("The %s dev service is ready to accept connections on %s", name, container.getConnectionInfo());
+            } else {
+                throw new IllegalStateException("Internal error: attempted to start a null container.");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            tracker.removeRunningService(featureName, configName, identifyingConfig, this);
+            super.close();
+        }
+
+        public DevServicesResultBuildItem toBuildItem() {
+            return new DevServicesResultBuildItem(name, description, config, this);
+        }
+
+        /**
+         * This is a supplier interface to maintain type-compatibility across classloaders.
+         * What this is actually giving is an aggregate of the hardcoded and lazy (dynamic at runtime) config.
+         *
+         */
+        @Override
+        public Map<String, String> get() {
+            // printlns show this gets called super often, so want to be as efficient as we can in this code
+            Map<String, String> newConfig = new HashMap<>(getConfig());
+            // We don't want to be returning config while the container is in the process of starting, so synchronize
+            synchronized (this) {
+                for (Map.Entry<String, Supplier<String>> entry : lazyConfig.entrySet()) {
+                    newConfig.put(entry.getKey(), entry.getValue().get());
+                }
+            }
+            return newConfig;
+        }
+
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/Startable.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/Startable.java
@@ -1,0 +1,13 @@
+package io.quarkus.deployment.builditem;
+
+import java.io.Closeable;
+
+public interface Startable extends Closeable {
+    void start();
+
+    String getConnectionInfo();
+
+    // This starts to couple to containers, so we could move it to sub-interface and use that in dev services
+    String getContainerId();
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServicesConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServicesConfig.java
@@ -23,7 +23,7 @@ public interface DevServicesConfig {
     boolean enabled();
 
     /**
-     * Global flag that can be used to force the attachmment of Dev Services to shared network. Default is false.
+     * Global flag that can be used to force the attachment of Dev Services to shared network. Default is false.
      */
     @WithDefault("false")
     boolean launchOnSharedNetwork();

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ApplicationInstanceIdBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ApplicationInstanceIdBuildStep.java
@@ -1,0 +1,24 @@
+package io.quarkus.deployment.steps;
+
+import java.util.UUID;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ApplicationInstanceIdBuildItem;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+
+public class ApplicationInstanceIdBuildStep {
+
+    private static volatile UUID uuid = null;
+
+    @BuildStep
+    public ApplicationInstanceIdBuildItem create(CuratedApplicationShutdownBuildItem buildItem) {
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+        buildItem.addCloseTask(() -> {
+            uuid = null;
+
+        }, true);
+        return new ApplicationInstanceIdBuildItem(uuid);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigBuilder.java
@@ -1,0 +1,24 @@
+package io.quarkus.devservice.runtime.config;
+
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+// This should live in the devservices/runtime module, but that module doesn't exist, and adding it is a breaking change
+public class DevServicesConfigBuilder implements ConfigBuilder {
+
+    @Override
+    public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
+        return builder.withSources(new DevServicesConfigSource(LaunchMode.current()));
+    }
+
+    @Override
+    public int priority() {
+        // What's the right priority? This is a cheeky dynamic override, so a high priority seems correct, but dev services are supposed to fill in gaps in existing information.
+        // Dev services should be looking at those sources and not doing anything if there's existing config,
+        // so a very low priority is also arguably correct.
+        // In principle the priority actually shouldn't matter much, but in practice it needs to not be higher than Arquillian config overrides or some tests fail
+
+        return 10;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigSource.java
+++ b/core/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigSource.java
@@ -1,0 +1,64 @@
+package io.quarkus.devservice.runtime.config;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
+import io.quarkus.runtime.LaunchMode;
+
+// This should live in the devservices/runtime module, but that module doesn't exist, and adding it is a breaking change
+public class DevServicesConfigSource implements ConfigSource {
+
+    RunningDevServicesRegistry tracker = new RunningDevServicesRegistry();
+
+    private final LaunchMode launchMode;
+
+    public DevServicesConfigSource(LaunchMode launchMode) {
+        this.launchMode = launchMode;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        // We could make this more efficient by not invoking the supplier on the other end, but it would need a more complex interface
+        Set<String> names = new HashSet<>();
+
+        Set<Supplier<Map>> allConfig = tracker.getConfigForAllRunningServices(launchMode.name());
+        if (allConfig != null) {
+            for (Supplier<Map> o : allConfig) {
+                Map config = o.get();
+                names.addAll(config.keySet());
+            }
+        }
+        return names;
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        Set<Supplier<Map>> allConfig = tracker.getConfigForAllRunningServices(launchMode.name());
+        if (allConfig != null) {
+            for (Supplier<Map> o : allConfig) {
+                Map config = o.get();
+                String answer = (String) config.get(propertyName);
+                if (answer != null) {
+                    return answer;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return "DevServicesConfigSource";
+    }
+
+    @Override
+    public int getOrdinal() {
+        // See discussion on DevServicesConfigBuilder about what the right value here is
+        return 10;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/ComparableDevServicesConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/ComparableDevServicesConfig.java
@@ -1,0 +1,122 @@
+package io.quarkus.devservices.crossclassloader.runtime;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.ConfigMapping;
+
+/**
+ * @param globalConfig should be a io.quarkus.deployment.dev.devservices.DevServicesConfig, but is not that type to avoid
+ *        the dependency on the devservices module
+ * @param identifyingConfig a config object specific to the extension's dev services configuration
+ */
+public record ComparableDevServicesConfig(UUID applicationInstanceId,
+        DevServiceOwner owner,
+        Object globalConfig,
+        Object identifyingConfig) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ComparableDevServicesConfig that))
+            return false;
+        return Objects.equals(owner, that.owner)
+                && reflectiveEquals(globalConfig, that.globalConfig)
+                && reflectiveEquals(identifyingConfig, that.identifyingConfig)
+                && Objects.equals(applicationInstanceId, that.applicationInstanceId);
+    }
+
+    private static boolean reflectiveEquals(Object config, Object otherConfig) {
+
+        // This could be expensive, so we might wish to shove everything into a map, reflectively, and just compare that
+        // The externals won't change if we do that, so we can do it later if we want to
+        // We can assume config mapping is immutable
+        // We need to compare across classloaders, so we cannot use equals()
+
+        if (config == null || otherConfig == null) {
+            // If they're both null, they're equal
+            return config == otherConfig;
+        }
+
+        Class<?> clazz = config.getClass();
+        Class<?> otherClazz = otherConfig.getClass();
+
+        // We can't compare classes because of multiple classloaders, but we can compare class names
+        if (!clazz.getName().equals(otherClazz.getName())) {
+            return false;
+        }
+
+        try {
+            while (clazz != null) {
+                // Get all interfaces implemented by the class
+                for (Class<?> iface : clazz.getInterfaces()) {
+                    // Check if the interface is a config one
+
+                    if (isConfigInterface(iface)) {
+                        // For each method in the interface
+                        // In the future, if we wanted some methods to be ignored, we could use a marker annotation in the config object
+                        for (Method method : iface.getMethods()) {
+
+                            int modifiers = method.getModifiers();
+                            if (isInvokableMethod(method, modifiers)) {
+                                Method otherMethod = clazz == otherClazz ? method : otherClazz.getMethod(method.getName());
+                                otherMethod.setAccessible(true);
+
+                                Object thisValue = method.invoke(config);
+                                Object otherValue = otherMethod.invoke(otherConfig);
+
+                                // Assume the objects in the config use types from the parent classloader, or we just declare them non-equal if they're not in the same classloader
+
+                                if (!Objects.deepEquals(thisValue, otherValue)) {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+                clazz = clazz.getSuperclass();
+                otherClazz = otherClazz.getSuperclass();
+
+            }
+            return true;
+        } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * We can't just use clazz.isAnnotationPresent(), because the annotation itself is likely to be proxied
+     */
+    private static boolean containsAnnotation(Class<?> iface, Class<? extends Annotation> configAnnotation) {
+        return Arrays.stream(iface.getAnnotations())
+                .anyMatch(a -> a.annotationType().getName().equals(configAnnotation.getName()));
+    }
+
+    private static boolean isInvokableMethod(Method method, int modifiers) {
+        if (Modifier.isStatic(modifiers) ||
+                Modifier.isTransient(modifiers)) {
+            return false;
+        }
+
+        if (Modifier.isPrivate(modifiers)) {
+            return false;
+        }
+
+        if (method.getParameterCount() > 0) {
+            return false;
+        }
+
+        method.setAccessible(true);
+        return true;
+    }
+
+    private static boolean isConfigInterface(Class<?> iface) {
+        return containsAnnotation(iface, ConfigMapping.class) || containsAnnotation(iface, ConfigGroup.class);
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/DevServiceOwner.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/DevServiceOwner.java
@@ -1,0 +1,14 @@
+package io.quarkus.devservices.crossclassloader.runtime;
+
+/**
+ * We store the launch mode as a string to make cross-classloader comparisons easier
+ *
+ * @param featureName the name of the feature, e.g. "redis-client" or "kafka-client"
+ * @param launchMode use launchMode.name()
+ * @param configName the name of the config, e.g. "redis"
+ */
+
+public record DevServiceOwner(String featureName, String launchMode, String configName) {
+
+    //   Ideally we'd have a constructor that takes in a LaunchMode and calls launchMode.name(), but because this loads parent-first, we can't pass in Quarkus classes
+}

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
@@ -1,0 +1,128 @@
+package io.quarkus.devservices.crossclassloader.runtime;
+
+import static java.util.UUID.randomUUID;
+
+import java.io.Closeable;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Note: This class should only use language-level classes and classes defined in this same package.
+ * Other Quarkus classes might be in a different classloader.
+ *
+ * Warning: The methods in this class should *not* be called directly from an extension processor, in the augmentation phase.
+ * Tracker-aware running dev services will only be registered post-augmentation, at runtime.
+ */
+public class RunningDevServicesRegistry {
+
+    // A useful uniqueness marker which will persist across profiles and application restarts, since this class lives in the system classloader. The value will be the same between dev and test mode.
+    public static final String APPLICATION_UUID = randomUUID().toString();
+
+    private static final Map<String, Set<Supplier<Map>>> configTracker = new ConcurrentHashMap<>();
+
+    // A dev service owner is a combination of an extension (feature) and the app type (dev or test) which identifies which dev services
+    // an extension processor can safely close.
+    private static final Map<DevServiceOwner, Set<Closeable>> servicesIndexedByOwner = new ConcurrentHashMap<>();
+    private static final Map<ComparableDevServicesConfig, Set<Closeable>> servicesIndexedByConfig = new ConcurrentHashMap<>();
+
+    public void closeAllRunningServices() {
+        // This is called when the application is shutting down, so we can close all running services
+        servicesIndexedByOwner.forEach((owner, services) -> {
+            for (Closeable service : services) {
+                try {
+                    service.close();
+                } catch (Exception e) {
+                    // We don't want to fail the shutdown hook if a service fails to close
+                    e.printStackTrace();
+                }
+            }
+        });
+        servicesIndexedByOwner.clear();
+        servicesIndexedByConfig.clear();
+        configTracker.clear();
+    }
+
+    public void closeAllRunningServices(String launchMode) {
+        Iterator<Map.Entry<ComparableDevServicesConfig, Set<Closeable>>> it = servicesIndexedByConfig.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<ComparableDevServicesConfig, Set<Closeable>> next = it.next();
+            DevServiceOwner owner = next.getKey().owner();
+            if (owner.launchMode().equals(launchMode)) {
+                it.remove();
+                servicesIndexedByOwner.remove(owner);
+                for (Closeable service : next.getValue()) {
+                    try {
+                        service.close();
+                    } catch (Exception e) {
+                        // We don't want to fail the shutdown hook if a service fails to close
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+        configTracker.remove(launchMode);
+    }
+
+    /**
+     *
+     * @return may return null
+     */
+    public Set<Supplier<Map>> getConfigForAllRunningServices(String launchMode) {
+        // This gets called an awful lot. Should we cache it? If we did, we'd need to deal with cache invalidation, so maybe not.
+        return configTracker.get(launchMode);
+    }
+
+    public Set<Closeable> getRunningServices(ComparableDevServicesConfig identifyingConfig) {
+        return servicesIndexedByConfig.get(identifyingConfig);
+    }
+
+    public Set<Closeable> getAllRunningServices(DevServiceOwner owner) {
+        return servicesIndexedByOwner.get(owner);
+    }
+
+    public void addRunningService(ComparableDevServicesConfig key, Closeable service) {
+        addServiceToIndex(servicesIndexedByOwner, key.owner(), service);
+        addServiceToIndex(servicesIndexedByConfig, key, service);
+        addServiceToConfig(key.owner().launchMode(), (Supplier<Map>) service);
+    }
+
+    // The service passed in here might be from a different classloader
+    public void removeRunningService(ComparableDevServicesConfig key, Closeable service) {
+        DevServiceOwner owner = key.owner();
+        removeServiceFromIndex(servicesIndexedByConfig, key, service);
+        removeServiceFromIndex(servicesIndexedByOwner, owner, service);
+        removeServiceFromConfig(owner.launchMode(), (Supplier<Map>) service);
+    }
+
+    static <T, K> void addServiceToIndex(Map<K, Set<T>> servicesIndexed, K key, T value) {
+        servicesIndexed.computeIfAbsent(key, k -> new HashSet<>()).add(value);
+    }
+
+    static <T, K> void removeServiceFromIndex(Map<K, Set<T>> servicesIndexed, K key, T value) {
+        Set<T> servicesForOwner = servicesIndexed.get(key);
+        if (servicesForOwner != null) {
+            servicesForOwner.remove(value);
+            if (servicesForOwner.isEmpty()) {
+                servicesIndexed.remove(key);
+            }
+        }
+    }
+
+    void addServiceToConfig(String launchMode, Supplier<Map> configSupplier) {
+        configTracker.computeIfAbsent(launchMode, k -> new HashSet<>()).add(configSupplier);
+    }
+
+    void removeServiceFromConfig(String launchMode, Supplier<Map> configSupplier) {
+        Set<Supplier<Map>> configs = configTracker.get(launchMode);
+        if (configs != null) {
+            configs.remove(configSupplier);
+            if (configs.isEmpty()) {
+                configTracker.remove(launchMode);
+            }
+        }
+    }
+}

--- a/core/runtime/src/test/java/io/quarkus/devservices/crossclassloader/runtime/ComparableDevServicesConfigTest.java
+++ b/core/runtime/src/test/java/io/quarkus/devservices/crossclassloader/runtime/ComparableDevServicesConfigTest.java
@@ -1,0 +1,135 @@
+package io.quarkus.devservices.crossclassloader.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+// Be aware that many challenges with ComparableDevServicesConfigTest come from operating across classloaders, and this test does not exercise that
+// The other challenges come from working with proxied annotations, and this test also doesn't exercise that. :)
+public class ComparableDevServicesConfigTest {
+
+    String configName = "prefix";
+    UUID uuid = UUID.randomUUID();
+
+    @Test
+    public void identicalWrappersShouldBeEqual() {
+        DevServiceOwner owner = new DevServiceOwner("someextension", LaunchMode.TEST.name(), configName);
+        DummyDevServicesConfig globalConfig = new DummyDevServicesConfig("b", 3);
+        DummyExtensionConfig config = new DummyExtensionConfig("a", 1);
+        ComparableDevServicesConfig wrapped = new ComparableDevServicesConfig(uuid, owner, globalConfig, config);
+        assertEquals(wrapped, wrapped);
+    }
+
+    @Test
+    public void wrappersWrappingIdenticalObjectsShouldBeEqual() {
+        DevServiceOwner owner = new DevServiceOwner("someextension", LaunchMode.TEST.name(), configName);
+        DummyDevServicesConfig globalConfig = new DummyDevServicesConfig("b", 3);
+        DummyExtensionConfig config = new DummyExtensionConfig("a", 1);
+        assertEquals(new ComparableDevServicesConfig(uuid, owner, globalConfig, config),
+                new ComparableDevServicesConfig(uuid, owner, globalConfig, config));
+    }
+
+    @Test
+    public void wrappersWrappingEquivalentObjectsShouldBeEqual() {
+        DevServiceOwner owner = new DevServiceOwner("someextension", LaunchMode.TEST.name(), configName);
+        DummyDevServicesConfig globalConfig1 = new DummyDevServicesConfig("b", 3);
+        DummyExtensionConfig config1 = new DummyExtensionConfig("a", 1);
+        DummyDevServicesConfig globalConfig2 = new DummyDevServicesConfig("b", 3);
+        DummyExtensionConfig config2 = new DummyExtensionConfig("a", 1);
+        assertEquals(new ComparableDevServicesConfig(uuid, owner, globalConfig1, config1),
+                new ComparableDevServicesConfig(uuid, owner, globalConfig2, config2));
+    }
+
+    @Test
+    public void wrappersWrappingIdenticalObjectsShouldBeHaveTheSameHashCode() {
+        DevServiceOwner owner = new DevServiceOwner("someextension", LaunchMode.TEST.name(), configName);
+        DummyDevServicesConfig globalConfig = new DummyDevServicesConfig("b", 3);
+        DummyExtensionConfig config = new DummyExtensionConfig("a", 1);
+        assertEquals(new ComparableDevServicesConfig(uuid, owner, globalConfig, config).hashCode(),
+                new ComparableDevServicesConfig(uuid, owner, globalConfig, config).hashCode());
+    }
+
+    @Test
+    public void wrappersWrappingDifferentOwnerExtensionsShouldNotBeEqual() {
+        DevServiceOwner owner1 = new DevServiceOwner("someextension", LaunchMode.TEST.name(), configName);
+        DevServiceOwner owner2 = new DevServiceOwner("anotherextension", LaunchMode.TEST.name(), configName);
+        assertNotEquals(new ComparableDevServicesConfig(uuid, owner1, null, null),
+                new ComparableDevServicesConfig(uuid, owner2, null, null));
+    }
+
+    @Test
+    public void wrappersWrappingDifferentOwnerLaunchModesShouldNotBeEqual() {
+        DevServiceOwner owner1 = new DevServiceOwner("someextension", LaunchMode.TEST.name(), configName);
+        DevServiceOwner owner2 = new DevServiceOwner("someextension", LaunchMode.DEVELOPMENT.name(), configName);
+        assertNotEquals(new ComparableDevServicesConfig(uuid, owner1, null, null),
+                new ComparableDevServicesConfig(uuid, owner2, null, null));
+    }
+
+    @Test
+    public void wrappersWrappingDifferentIdentifyingConfigShouldNotBeEqual() {
+        DummyExtensionConfig config1 = new DummyExtensionConfig("a", 1);
+        DummyExtensionConfig config2 = new DummyExtensionConfig("a", 2);
+        assertNotEquals(new ComparableDevServicesConfig(uuid, null, null, config1),
+                new ComparableDevServicesConfig(uuid, null, null, config2));
+    }
+
+    @Test
+    public void wrappersWrappingDifferentIdentifyingConfigHaveDifferentHashCodes() {
+        DummyExtensionConfig config1 = new DummyExtensionConfig("a", 1);
+        DummyExtensionConfig config2 = new DummyExtensionConfig("a", 2);
+        assertNotEquals(new ComparableDevServicesConfig(uuid, null, null, config1).hashCode(),
+                new ComparableDevServicesConfig(uuid, null, null, config2).hashCode());
+    }
+
+    @Test
+    public void nullUuidIsHandled() {
+        DummyExtensionConfig config = new DummyExtensionConfig("a", 1);
+        assertNotNull(new ComparableDevServicesConfig(null, null, null, config).hashCode());
+        assertEquals(new ComparableDevServicesConfig(null, null, null, config).hashCode(),
+                new ComparableDevServicesConfig(null, null, null, config).hashCode());
+    }
+
+    @ConfigGroup
+    interface CI {
+
+        int a();
+
+    }
+
+    private class DummyDevServicesConfig implements CI {
+        String s;
+        int i;
+
+        public DummyDevServicesConfig(String a, int i) {
+            this.s = a;
+            this.i = i;
+        }
+
+        @Override
+        public int a() {
+            return i;
+        }
+    }
+
+    private class DummyExtensionConfig implements CI {
+        String s;
+        int i;
+
+        public DummyExtensionConfig(String a, int i) {
+            this.s = a;
+            this.i = i;
+        }
+
+        @Override
+        public int a() {
+            return i;
+        }
+    }
+}

--- a/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/BasicRedisCacheTest.java
+++ b/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/BasicRedisCacheTest.java
@@ -56,7 +56,7 @@ public class BasicRedisCacheTest {
         // Verified by: STEP 2.
         String value1 = simpleCachedService.cachedMethod(KEY_1);
         List<String> newKeys = TestUtil.allRedisKeys(redisDataSource);
-        assertEquals(allKeysAtStart.size() + 1, newKeys.size());
+        assertEquals(allKeysAtStart.size() + 1, newKeys.size(), "Compared " + allKeysAtStart + " and " + newKeys);
         Assertions.assertThat(newKeys).contains(expectedCacheKey(KEY_1));
 
         // STEP 2
@@ -121,7 +121,7 @@ public class BasicRedisCacheTest {
         // Verified by: comparison with previous number of keys, STEPS 9 and 10.
         simpleCachedService.invalidateAll();
         newKeys = TestUtil.allRedisKeys(redisDataSource);
-        assertEquals(allKeysAtStart.size(), newKeys.size());
+        assertEquals(allKeysAtStart.size(), newKeys.size(), "Compared " + allKeysAtStart + " and " + newKeys);
         Assertions.assertThat(newKeys).doesNotContain(expectedCacheKey(KEY_1), expectedCacheKey(KEY_2));
 
         // STEP 9

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
@@ -180,6 +180,7 @@ public class ConfigurationProcessor {
                 .replace("\n", "<br>");
     }
 
+    // TODO does this need updating to the config source? Or just deleting? Or consolidating?
     private static boolean isSetByDevServices(Optional<DevServicesLauncherConfigResultBuildItem> devServicesLauncherConfig,
             String propertyName) {
         if (devServicesLauncherConfig.isPresent()) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -24,7 +24,7 @@ public interface StartupAction {
     /**
      * Runs the application by running the main method of the main class. As this is a blocking method a new
      * thread is created to run this task.
-     *
+     * <p>
      * Before this method is called an appropriate exit handler will likely need to
      * be set in {@link io.quarkus.runtime.ApplicationLifecycleManager#setDefaultExitCodeHandler(Consumer)}
      * of the JVM will exit when the app stops.

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -222,7 +222,8 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     }
 
     private boolean parentFirst(String name, ClassPathResourceIndex classPathResourceIndex) {
-        return parentFirst || classPathResourceIndex.isParentFirst(name);
+        return parentFirst || name.startsWith("io/quarkus/devservices/crossclassloader")
+                || classPathResourceIndex.isParentFirst(name);
     }
 
     public void reset(Map<String, byte[]> generatedResources, Map<String, byte[]> transformedClasses) {

--- a/integration-tests/opentelemetry-redis-instrumentation/src/test/java/io/quarkus/it/opentelemetry/profile/RedisInstrumentationDisabledProfile.java
+++ b/integration-tests/opentelemetry-redis-instrumentation/src/test/java/io/quarkus/it/opentelemetry/profile/RedisInstrumentationDisabledProfile.java
@@ -9,9 +9,8 @@ public class RedisInstrumentationDisabledProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        Map overrides = new HashMap();
+        Map<String, String> overrides = new HashMap();
         overrides.put("quarkus.otel.instrument.vertx-redis-client", "false");
-        overrides.put("quarkus.redis.devservices.port", "4001"); // Workaround for #45785; the dev services for distinct dev services cannot share a port
         return overrides;
 
     }

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
@@ -132,8 +132,8 @@ public class DevServicesRedisContinuousTestingTest {
 
     private static String prettyPrintContainerList(List<Container> newContainers) {
         return newContainers.stream()
-                .map(c -> Arrays.toString(c.getPorts()) + "--" + Arrays.toString(c.getNames()))
-                .collect(Collectors.joining(", "));
+                .map(c -> Arrays.toString(c.getPorts()) + " -- " + Arrays.toString(c.getNames()) + " -- " + c.getLabels())
+                .collect(Collectors.joining(", \n"));
     }
 
     private static boolean hasPublicPort(Container newContainer, int newPort) {
@@ -242,6 +242,12 @@ public class DevServicesRedisContinuousTestingTest {
 
     private static List<Container> getRedisContainersExcludingExisting(Collection<Container> existingContainers) {
         return getRedisContainers().stream().filter(
+                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    private static List<Container> getAllContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getAllContainers().stream().filter(
                 container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
                 .toList();
     }

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceITest.java
@@ -1,7 +1,6 @@
 package io.quarkus.redis.devservices.it;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +9,6 @@ import io.quarkus.redis.devservices.it.utils.SocketKit;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
-@Disabled("Tracked by https://github.com/quarkusio/quarkus/issues/45785")
 @QuarkusTest
 @TestProfile(DevServicesCustomPortReusableServiceProfile.class)
 public class DevServicesRedisCustomPortReusableServiceITest {
@@ -18,6 +16,7 @@ public class DevServicesRedisCustomPortReusableServiceITest {
     @Test
     @DisplayName("should start redis container with the given custom port")
     public void shouldStartRedisContainer() {
+        // We could strengthen this test to make sure the container is the same as seen by other tests, but it's hard since we won't know the order
         Assertions.assertTrue(SocketKit.isPortAlreadyUsed(6371));
     }
 

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisNonUniquePortITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisNonUniquePortITest.java
@@ -6,7 +6,6 @@ import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +14,6 @@ import io.quarkus.redis.devservices.it.profiles.DevServicesNonUniquePortProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
-@Disabled("Tracked by https://github.com/quarkusio/quarkus/issues/45785")
 @QuarkusTest
 @TestProfile(DevServicesNonUniquePortProfile.class)
 public class DevServicesRedisNonUniquePortITest {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -1,10 +1,13 @@
 package io.quarkus.test.junit;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 import io.quarkus.builder.BuildResult;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 
 public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult> {
     @Override
@@ -19,6 +22,19 @@ public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult>
         }
         if (compose != null && compose.getNetworkId() != null) {
             propertyConsumer.accept("quarkus.test.container.network", compose.getNetworkId());
+        }
+
+        List<DevServicesResultBuildItem> devServicesResultBuildItems = buildResult
+                .consumeMulti(DevServicesResultBuildItem.class);
+        for (DevServicesResultBuildItem devServicesResultBuildItem : devServicesResultBuildItems) {
+            devServicesResultBuildItem.start();
+
+            // It would be nice to use the config source, but since we have the build item right there and this is a one-shot operation, just ask it instead
+            Map<String, String> dynamicConfig = devServicesResultBuildItem.getDynamicConfig();
+            for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+                propertyConsumer.accept(entry.getKey(), entry.getValue());
+
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/47602

See also https://github.com/quarkusio/quarkus/issues/45785. This is the first of an incremental rollout of a new model, to resolve a problem created by #34681. Doing the change incrementally keeps PRs small and allows feedback on the approach. This also has the advantage of validating that existing ecosystem extensions will continue to work. “Work” needs qualification, since they only work if ports are distinct, which brings us back to #45785. In the existing dev services, assumption that the order of the processors running correlates to the order of the dev services being used (like `first` static variables) is problematic. 

 ### The design

There are two elements to the design:

- Do not start dev services in the build step
- Start them at application start
- Use a runtime`ConfigSource` to lazily share about ephemeral ports, etc

Most dev service processors check to see if a service is already running, but using static variables, so the check only finds services within the same profile. This isn’t enough post-#34681, because another profile might have started dev services on the same port. Those dev services would ideally be re-used, and if they’re not re-used, they need to be closed. This means we need to track dev services between augmentation classloaders. To do this, I’ve created a tracker build item which tracks across classloaders. I would have liked to inject unique instances into processors but doing that would need a `KeyedBuildItem` or `FeatureBuildItem` or some other basic type which got created with state about what it’s getting injected into. 

#### Re-use semantics

The logic for starting dev services is a bit more involved than it used to be, but it’s centralised. It's also more capable. There's better ability to shut down dev services from other profiles without relying on tracking owners, and better ability (but ultimately controlled by dev service processor) to reuse dev services.

When start gets called on a dev services build item, it first checks to see if there’s a running dev service with the right properties. (This could be from a previous continuous testing restart, or another profile. If there’s a match, no further action is needed. If there’s not a match, we need to stop other dev services of the same kind. The tracker helps us find them, because we can’t assume that dev services are started in the same order that augmentation was run. Once all the other containers are stopped, the new container is started and submitted for tracking.
 
![image](https://github.com/user-attachments/assets/d527870e-546d-4985-8da1-62f08ea157be)
(https://excalidraw.com/#json=VvSzzPO1nVD_XdPElaHsF,EHrqqwDzb5H5g5lXFYUk6A)

In the old model, the Redis processor would store state in a static variable and attempt to re-use compatible `RunningDevServices`, with a `boolean restartRequired = !currentDevServicesConfiguration.equals(capturedDevServicesConfiguration);` check. In the new model it does a similar check, but also checks across profile boundaries. This check is now non-optional because any extant containers/RDSes that don't get re-used need to get stopped. The `ContainerLocator` logic isn't changed. 

A nice benefit of this approach is that the code in the processors is shorter, which gets us a bit closer to the dream of low-boilerplate dev services. The one icky boilerplate that’s new is the key-value pairs for the uniqueness/re-use criteria for the dev services. This is maybe something to think about for a follow-up PR. I think this approach might also avoid a few restarts we used to see between profiles, which could speed up tests.

#### Could be better (areas for discussion)

- The processors identify uniqueness/re-use criteria, based on config. For redis, the port number is automatically considered, and I added code to also look at the image name. I didn’t look at things like timeout, but maybe all config should be included in the key.
- I made `RunnableDevService` extend `RunningDevService`. That seems most logical in terms of the methods (runnable dev services has more classes and methods), but it’s least logical in terms of the names. A third common superclass would solve the naming problem, but make for a lot of classes. 
- @ozangunalp points out that starting dev services sequentially is a performance disaster (although he used nicer words). This is true, but I'd like to fix it in a follow-on item, since at the moment only one devservice uses the new model, and parellising a queue of one is a no-op.


### Other approaches considered

I was originally hoping to do a less invasive approach where I just filtered out dev service build items during augmentation, and then ran a custom build with a new build chain including those items. This sort of worked, but getting the right config to the right place wouldn’t have been straightforward, and the second augmentation would have made classloader problems. The current approach means every dev service needs updating, but it does improve the processor code for the adjusted dev services, I think. 