### PR TITLE
Add Javadoc for various build items

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ContextHandlerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ContextHandlerBuildItem.java
@@ -4,6 +4,9 @@ import org.jboss.threads.ContextHandler;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Holds a context handler used to propagate context when executing tasks.
+ */
 public final class ContextHandlerBuildItem extends SimpleBuildItem {
     private final ContextHandler<Object> contextHandler;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ExtensionSslNativeSupportBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ExtensionSslNativeSupportBuildItem.java
@@ -3,6 +3,14 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.Feature;
 
+/**
+ * A build item indicating that a specific Quarkus extension requires SSL support in native mode.
+ * <p>
+ * This is a {@link MultiBuildItem}. Each instance signifies that the extension named in the
+ * {@link #extension} field needs the necessary native SSL configuration (like certificates)
+ * included in the native image build. It can be instantiated using either a {@link Feature}
+ * enum constant or directly with the extension's name string.
+ */
 public final class ExtensionSslNativeSupportBuildItem extends MultiBuildItem {
 
     private String extension;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedClassBuildItem.java
@@ -2,6 +2,19 @@ package io.quarkus.deployment.builditem;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * A build item representing a Java class file generated during the build process.
+ * <p>
+ * This is a {@link MultiBuildItem}. Each instance holds information about a single generated class:
+ * <ul>
+ * <li>Whether it's considered an application class ({@link #isApplicationClass()}).</li>
+ * <li>The class name in binary format (e.g., {@code com.example.MyClass}) via {@link #binaryName()}.</li>
+ * <li>The class name in internal format (e.g., {@code com/example/MyClass}) via {@link #internalName()}.</li>
+ * <li>The raw bytecode of the class via {@link #getClassData()}.</li>
+ * <li>Optional source file information for debugging via {@link #getSource()}.</li>
+ * </ul>
+ * These generated classes are typically added to the application's class path or packaged into the final artifact.
+ */
 public final class GeneratedClassBuildItem extends MultiBuildItem {
 
     final boolean applicationClass;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
@@ -2,6 +2,9 @@ package io.quarkus.deployment.builditem;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Representing a resource file generated during the build
+ */
 public final class GeneratedResourceBuildItem extends MultiBuildItem {
     final String name;
     final byte[] data;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/JavaLibraryPathAdditionalPathBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/JavaLibraryPathAdditionalPathBuildItem.java
@@ -2,6 +2,9 @@ package io.quarkus.deployment.builditem;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * A build item representing an additional path to be added to the Java library path (`java.library.path`).
+ */
 public final class JavaLibraryPathAdditionalPathBuildItem extends MultiBuildItem {
 
     private final String path;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogCategoryMinLevelDefaultsBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogCategoryMinLevelDefaultsBuildItem.java
@@ -6,6 +6,10 @@ import java.util.Map;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.runtime.logging.InheritableLevel;
 
+/**
+ * A build item containing the default minimum log levels for specific log categories.
+ * Minimum log levels ({@link io.quarkus.runtime.logging.InheritableLevel}).
+ */
 public final class LogCategoryMinLevelDefaultsBuildItem extends SimpleBuildItem {
 
     public final Map<String, InheritableLevel> content;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/MainBytecodeRecorderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/MainBytecodeRecorderBuildItem.java
@@ -3,6 +3,15 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.recording.BytecodeRecorderImpl;
 
+/**
+ * A build item holding bytecode recording information relevant to the main application startup.
+ * <p>
+ * Instances of this item can hold either:
+ * <ul>
+ * <li>A direct {@link io.quarkus.deployment.recording.BytecodeRecorderImpl} instance via {@link #bytecodeRecorder}.</li>
+ * <li>The name of a generated startup context class via {@link #generatedStartupContextClassName}.</li>
+ * </ul>
+ */
 public final class MainBytecodeRecorderBuildItem extends MultiBuildItem {
 
     private final BytecodeRecorderImpl bytecodeRecorder;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/MainClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/MainClassBuildItem.java
@@ -2,6 +2,9 @@ package io.quarkus.deployment.builditem;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Holds the name of the main class for the application.
+ */
 public final class MainClassBuildItem extends SimpleBuildItem {
 
     public final String className;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/NativeImageEnableAllCharsetsBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/NativeImageEnableAllCharsetsBuildItem.java
@@ -2,6 +2,9 @@ package io.quarkus.deployment.builditem;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Indicates that all charsets should be enabled in native image.
+ */
 public final class NativeImageEnableAllCharsetsBuildItem extends MultiBuildItem {
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/QuarkusApplicationClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/QuarkusApplicationClassBuildItem.java
@@ -3,6 +3,12 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.runtime.QuarkusApplication;
 
+/**
+ * Holds the name of the class implementing {@link io.quarkus.runtime.QuarkusApplication}.
+ * <p>
+ * This allows other build steps to identify the main application class
+ * It stores the fully qualified class name as a {@code String}.
+ */
 public final class QuarkusApplicationClassBuildItem extends SimpleBuildItem {
     private final String className;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/QuarkusBuildCloseablesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/QuarkusBuildCloseablesBuildItem.java
@@ -9,6 +9,14 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Represents a build item for managing {@link Closeable} resources during the build
+ * <p>
+ * This build item collects {@link Closeable} resources that need to be closed
+ * <p>
+ * It provides a central place to register closeable resources (like file systems)
+ * and ensures they are all closed at the end of the build.
+ */
 public final class QuarkusBuildCloseablesBuildItem extends SimpleBuildItem implements Closeable {
 
     private static final Logger log = Logger.getLogger(QuarkusBuildCloseablesBuildItem.class);

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ShutdownListenerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ShutdownListenerBuildItem.java
@@ -3,6 +3,11 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.runtime.shutdown.ShutdownListener;
 
+/**
+ * A build item that holds a {@link ShutdownListener} instance.
+ * <p>
+ * Allows registration of listeners to be notified during application shutdown.
+ */
 public final class ShutdownListenerBuildItem extends MultiBuildItem {
 
     final ShutdownListener shutdownListener;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/SslNativeConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/SslNativeConfigBuildItem.java
@@ -4,6 +4,13 @@ import java.util.Optional;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Represents the configuration for SSL native support.
+ * <p>
+ * This build item allows specifying whether SSL native support is enabled,
+ * disabled, or left unspecified during the build process.
+ * </p>
+ */
 public final class SslNativeConfigBuildItem extends SimpleBuildItem {
 
     private Optional<Boolean> enableSslNativeConfig;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/StaticBytecodeRecorderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/StaticBytecodeRecorderBuildItem.java
@@ -3,6 +3,9 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.recording.BytecodeRecorderImpl;
 
+/**
+ * A build item holding a {@link BytecodeRecorderImpl} instance used for generating static initializer bytecode.
+ */
 public final class StaticBytecodeRecorderBuildItem extends MultiBuildItem {
 
     private final BytecodeRecorderImpl bytecodeRecorder;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ThreadFactoryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ThreadFactoryBuildItem.java
@@ -4,6 +4,9 @@ import java.util.concurrent.ThreadFactory;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * holds a {@link ThreadFactory} instance, used to configure thread creation for the main executor
+ */
 public final class ThreadFactoryBuildItem extends SimpleBuildItem {
     private final ThreadFactory threadFactory;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageConfigBuildItem.java
@@ -10,6 +10,22 @@ import java.util.Set;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * A build item used to aggregate configuration settings for the GraalVM native image build.
+ * <p>
+ * This is a {@code MultiBuildItem}, meaning multiple instances can be produced by different extensions
+ * during the build process.
+ * It collects information such as:
+ * <ul>
+ * <li>Classes to be initialized at runtime ({@link #runtimeInitializedClasses})</li>
+ * <li>Classes to be re-initialized at runtime ({@link #runtimeReinitializedClasses})</li>
+ * <li>Resource bundles to include ({@link #resourceBundles})</li>
+ * <li>Dynamic proxy definitions ({@link #proxyDefinitions})</li>
+ * <li>System properties to be set within the native image ({@link #nativeImageSystemProperties})</li>
+ * </ul>
+ * The final native image configuration is assembled by combining all produced instances of this build item.
+ * Use the {@link #builder()} method to construct instances.
+ */
 public final class NativeImageConfigBuildItem extends MultiBuildItem {
 
     private final Set<String> runtimeInitializedClasses;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveFieldBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveFieldBuildItem.java
@@ -6,6 +6,9 @@ import org.jboss.jandex.FieldInfo;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Registering fields for reflective access during the build
+ */
 public final class ReflectiveFieldBuildItem extends MultiBuildItem {
 
     final String declaringClass;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
@@ -8,6 +8,9 @@ import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Registering methods for reflective access during the build
+ */
 public final class ReflectiveMethodBuildItem extends MultiBuildItem {
 
     final String declaringClass;

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsafeAccessedFieldBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsafeAccessedFieldBuildItem.java
@@ -2,6 +2,11 @@ package io.quarkus.deployment.builditem.nativeimage;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Represents fields that are accessed using unsafe operations.
+ * This build item provides information about the class and field names
+ * that require special handling during the build process.
+ */
 public final class UnsafeAccessedFieldBuildItem extends MultiBuildItem {
 
     final String declaringClass;

--- a/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandActionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandActionBuildItem.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Represents an action to run a specific command during the build process.
+ */
 public final class RunCommandActionBuildItem extends MultiBuildItem {
     private final String commandName;
     private final List<String> args;

--- a/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandActionResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandActionResultBuildItem.java
@@ -4,6 +4,10 @@ import java.util.List;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Represents the result of executing multiple command actions during the build process.
+ * It contains a list of {@link RunCommandActionBuildItem} for completed commands.
+ */
 public final class RunCommandActionResultBuildItem extends SimpleBuildItem {
     private final List<RunCommandActionBuildItem> commands;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
@@ -7,6 +7,19 @@ import java.util.function.Supplier;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * A build item describing a Dev Service that has been started by Quarkus.
+ * <p>
+ * Each instance provides details about a specific Dev Service, including:
+ * <ul>
+ * <li>Its {@link #name}.</li>
+ * <li>An optional {@link #description}.</li>
+ * <li>Information about the container running the service (if applicable) via {@link #containerInfo}.</li>
+ * <li>Configuration properties associated with the service via {@link #configs}.</li>
+ * </ul>
+ * This information is often used for display, for example, in the Dev UI or console logs,
+ * to inform the developer about the running Dev Services and their configurations.
+ */
 public final class DevServiceDescriptionBuildItem extends MultiBuildItem {
     private final String name;
     private final String description;

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestListenerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestListenerBuildItem.java
@@ -2,6 +2,10 @@ package io.quarkus.deployment.dev.testing;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * A build item that holds a {@link TestListener} instance.
+ * These listeners are notified of test events during development mode continuous testing.
+ */
 public final class TestListenerBuildItem extends MultiBuildItem {
 
     final TestListener listener;

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LogStreamBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LogStreamBuildItem.java
@@ -2,5 +2,9 @@ package io.quarkus.deployment.logging;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Signal indicating that a log stream should be enabled.
+ * Should ensure a log stream handler is active, often used for dev mode
+ */
 public final class LogStreamBuildItem extends MultiBuildItem {
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/metrics/MetricsCapabilityBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/metrics/MetricsCapabilityBuildItem.java
@@ -2,6 +2,22 @@ package io.quarkus.deployment.metrics;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * A build item indicating the presence and capabilities of a metrics system in the application.
+ * <p>
+ * This build item provides:
+ * <ul>
+ * <li>A {@link MetricsCapability} instance via {@link #metricsCapability} to check if specific metrics backends (like
+ * Micrometer or MP Metrics) are supported. This is typically used by extensions to conditionally register metrics. See
+ * {@link #metricsSupported(String)}.</li>
+ * <li>The configured path for the metrics endpoint via {@link #path}, if one is enabled. See {@link #metricsEndpoint()}.</li>
+ * </ul>
+ * It extends {@link io.quarkus.builder.item.SimpleBuildItem}.
+ * The inner functional interface {@link MetricsCapability} defines the contract for checking backend support.
+ *
+ * @see io.quarkus.runtime.metrics.MetricsFactory#MICROMETER
+ * @see io.quarkus.runtime.metrics.MetricsFactory#MP_METRICS
+ */
 public final class MetricsCapabilityBuildItem extends SimpleBuildItem {
     @FunctionalInterface
     public interface MetricsCapability<String> {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
@@ -2,6 +2,11 @@ package io.quarkus.deployment.pkg.builditem;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Represents the Java version used during compilation based on the first Class file's version
+ * You can use this during the build process to adapt your logic based on the
+ * {@link JavaVersion.Known} or {@link JavaVersion.Unknown} Java version
+ */
 public final class CompiledJavaVersionBuildItem extends SimpleBuildItem {
 
     private final JavaVersion javaVersion;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JarBuildItem.java
@@ -11,6 +11,9 @@ import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.sbom.ApplicationManifestConfig;
 
+/**
+ * Provides information about the primary JAR artifact generated
+ */
 public final class JarBuildItem extends SimpleBuildItem {
 
     private final Path path;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
@@ -6,6 +6,17 @@ import java.util.Map;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * A build item representing the successfully built native image.
+ * <p>
+ * This item is produced after the native image build process completes. It contains:
+ * <ul>
+ * <li>The {@link #path} to the generated native executable.</li>
+ * <li>Information about the GraalVM instance used via {@link #graalVMVersion}.</li>
+ * <li>A flag {@link #reused} indicating if an existing image was reused instead of performing a full build.</li>
+ * </ul>
+ * The {@link GraalVMVersion} inner class provides details about the GraalVM distribution, version, and Java version.
+ */
 public final class NativeImageBuildItem extends SimpleBuildItem {
 
     private final Path path;


### PR DESCRIPTION
This PR adds Javadoc to several BuildItem classes displayed [guides](https://quarkus.io/guides/all-builditems) #47523
Let me know if any modification, such as any missing information or additional formatting is required, I will be happy to adjust based on feedback