### PR TITLE
Fully disable max-parallel to see if it causes Spring native issue

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1361,7 +1361,8 @@ jobs:
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:
-      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
+      # fully disable for now as we have issues with RunsOn and it might come from the value being defined (even if set to 999)
+      #max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
       fail-fast: false
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
     steps:


### PR DESCRIPTION
For whatever reason, the Spring native job is sometimes pending forever and it seemed to happen quite a lot lately.

Let's see if it could be related to max-parallel being set (even if we set it to 999 when using RunsOn so it shouldn't be in the way...).