### PR TITLE
[3.15] RunnerClassLoader - Return URL with an ending / if resource ending with /

### DIFF
--- a/independent-projects/bootstrap/runner/pom.xml
+++ b/independent-projects/bootstrap/runner/pom.xml
@@ -69,6 +69,11 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/RunnerClassLoaderTest.java
+++ b/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/RunnerClassLoaderTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.bootstrap.runner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
@@ -67,6 +69,27 @@ public class RunnerClassLoaderTest {
             executor.shutdown();
             executor.awaitTermination(1, TimeUnit.SECONDS);
         }
+    }
+
+    @Test
+    public void testUrlWithTrailingSlash() {
+        ClassLoadingResource[] classLoadingResources = new ClassLoadingResource[] {
+                createProjectJarResource("simple-project-1.0.jar") };
+
+        Map<String, ClassLoadingResource[]> resourceDirectoryMap = Map.of(
+                "org", classLoadingResources,
+                "org/simple", classLoadingResources);
+
+        RunnerClassLoader runnerClassLoader = new RunnerClassLoader(ClassLoader.getSystemClassLoader(), resourceDirectoryMap,
+                Collections.emptySet(), Collections.emptySet(),
+                Collections.emptyList(), Collections.emptyMap());
+
+        assertThat(runnerClassLoader.findResource("org").toString()).endsWith("/org");
+        assertThat(runnerClassLoader.findResource("org/").toString()).endsWith("/org/");
+        assertThat(runnerClassLoader.findResource("org/simple").toString()).endsWith("/org/simple");
+        assertThat(runnerClassLoader.findResource("org/simple/").toString()).endsWith("/org/simple/");
+        assertThat(runnerClassLoader.findResource("org/simple/SimplePojo1.class").toString())
+                .endsWith("/org/simple/SimplePojo1.class");
     }
 
     private static JarResource createProjectJarResource(String jarName) {


### PR DESCRIPTION
While QuarkusClassLoader already has this behavior, RunnerClassLoader was forcibly removing the ending / even when the requested resource had one.

This shouldn't be the case.

Fixes #46563
Fixes #46998

(cherry picked from commit 3a8db483dabbdd9b1143285260301a076618e915)