### PR TITLE
Enable named data sources for Hibernate Reactive

### DIFF
--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -354,6 +354,28 @@ public class SomeTest {
 ----
 ====
 
+[[hr-named-datasource]]
+==== Named data sources
+
+Hibernate Reactive supports having named data sources
+
+[source,properties]
+.Example `{config-file}`
+----
+# datasource configuration
+quarkus.hibernate-orm.datasource = named-datasource
+quarkus.datasource."named-datasource".db-kind" = postgresql
+
+# drop and create the database at startup (use `update` to only update the schema)
+%prod.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%prod.quarkus.datasource."named-datasource".reactive" = true
+%prod.quarkus.datasource."named-datasource".username" = quarkus_test
+%prod.quarkus.datasource."named-datasource".password" = quarkus_test
+%prod.quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost/quarkus_test <1>
+----
+
+When using a named data source, you need to set the `quarkus.hibernate-orm.datasource` property to the name of the data source.
+
 [[hr-limitations]]
 == Limitations and other things you should know
 

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceNamedPersistenceUnitBothUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceNamedPersistenceUnitBothUnitTest.java
@@ -35,9 +35,10 @@ public class ORMReactiveCompatbilityNamedDataSourceNamedPersistenceUnitBothUnitT
             .assertException(t -> assertThat(t)
                     .isInstanceOf(ConfigurationException.class)
                     .hasMessageContainingAll(
-                            // Hibernate Reactive doesn't support explicitly setting the datasource (yet),
-                            // so it will just notice the default datasource is not configured!
-                            "The default datasource must be configured for Hibernate Reactive",
+                            // Hibernate Reactive doesn't support named persistence unit
+                            // so it will just notice the datasource is not configured!
+                            // We probably need a better error message when named persistence unit is supported
+                            "The datasource must be configured for Hibernate Reactive",
                             "Refer to https://quarkus.io/guides/datasource for guidance."));
 
     @Test

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceReactiveUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceReactiveUnitTest.java
@@ -1,28 +1,27 @@
 package io.quarkus.hibernate.reactive.compatibility;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.builder.Version;
 import io.quarkus.hibernate.reactive.entities.Hero;
-import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;
+import io.vertx.sqlclient.Pool;
 
-public class ORMReactiveCompatbilityNamedDataSourceBothUnitTest extends CompatibilityUnitTestBase {
+public class ORMReactiveCompatbilityNamedDataSourceReactiveUnitTest extends CompatibilityUnitTestBase {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(Hero.class)
                     .addAsResource("complexMultilineImports.sql", "import.sql"))
-            .setForcedDependencies(List.of(
-                    Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
-            ))
-            .withConfigurationResource("application-unittest-both-named.properties")
+            .withConfigurationResource("application-unittest-onlyreactive-named.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.hibernate-orm.datasource", "named-datasource")
             .overrideConfigKey("quarkus.datasource.\"named-datasource\".reactive", "true")
@@ -30,14 +29,15 @@ public class ORMReactiveCompatbilityNamedDataSourceBothUnitTest extends Compatib
             .overrideConfigKey("quarkus.datasource.\"named-datasource\".username", USERNAME_PWD)
             .overrideConfigKey("quarkus.datasource.\"named-datasource\".password", USERNAME_PWD);
 
+    @Inject
+    @ReactiveDataSource("named-datasource")
+    Pool pool;
+
     @Test
     @RunOnVertxContext
     public void test(UniAsserter uniAsserter) {
         testReactiveWorks(uniAsserter);
+        assertThat(pool).isNotNull();
     }
 
-    @Test
-    public void testBlocking() {
-        testBlockingWorks();
-    }
 }

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithExplicitDatasourceConfigActiveFalseTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithExplicitDatasourceConfigActiveFalseTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.reactive.config.datasource;
 
+import static io.quarkus.datasource.common.runtime.DatabaseKind.POSTGRESQL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Assertions;
@@ -21,13 +22,11 @@ public class EntitiesInDefaultPUWithExplicitDatasourceConfigActiveFalseTest {
             .overrideConfigKey("quarkus.datasource.\"ds-1\".active", "false")
             // We need at least one build-time property for the datasource,
             // otherwise it's considered unconfigured at build time...
-            .overrideConfigKey("quarkus.datasource.\"ds-1\".db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".db-kind", POSTGRESQL)
             .assertException(t -> assertThat(t)
                     .isInstanceOf(ConfigurationException.class)
                     .hasMessageContainingAll(
-                            // Hibernate Reactive doesn't support explicitly setting the datasource (yet),
-                            // so it will just notice the default datasource is not configured!
-                            "The default datasource must be configured for Hibernate Reactive",
+                            "Datasource 'ds-1' was deactivated through configuration properties. To activate the datasource, set configuration property 'quarkus.datasource.\"ds-1\".active' to 'true' and configure datasource 'ds-1'",
                             "Refer to https://quarkus.io/guides/datasource for guidance."));
 
     @Test

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithExplicitDatasourceConfigUrlMissingTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithExplicitDatasourceConfigUrlMissingTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.reactive.config.datasource;
 
+import static io.quarkus.datasource.common.runtime.DatabaseKind.POSTGRESQL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Assertions;
@@ -22,13 +23,13 @@ public class EntitiesInDefaultPUWithExplicitDatasourceConfigUrlMissingTest {
             .overrideConfigKey("quarkus.devservices.enabled", "false")
             // We need at least one build-time property for the datasource,
             // otherwise it's considered unconfigured at build time...
-            .overrideConfigKey("quarkus.datasource.ds-1.db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.ds-1.db-kind", POSTGRESQL)
             .assertException(t -> assertThat(t)
                     .isInstanceOf(ConfigurationException.class)
                     .hasMessageContainingAll(
                             // Hibernate Reactive doesn't support explicitly setting the datasource (yet),
-                            // so it will just notice the default datasource is not configured!
-                            "The default datasource must be configured for Hibernate Reactive",
+                            // so it will just notice the datasource is not configured!
+                            "Datasource 'ds-1' was deactivated automatically because its URL is not set. To activate the datasource, set configuration property 'quarkus.datasource.\"ds-1\".reactive.url'",
                             "Refer to https://quarkus.io/guides/datasource for guidance."));
 
     @Test

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithExplicitDatasourceMissingTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithExplicitDatasourceMissingTest.java
@@ -31,8 +31,8 @@ public class EntitiesInDefaultPUWithExplicitDatasourceMissingTest {
                     .isInstanceOf(ConfigurationException.class)
                     .hasMessageContainingAll(
                             // Hibernate Reactive doesn't support explicitly setting the datasource (yet),
-                            // so it will just notice the default datasource is not configured!
-                            "The default datasource must be configured for Hibernate Reactive",
+                            // so it will just notice the datasource is not configured!
+                            "The datasource must be configured for Hibernate Reactive",
                             "Refer to https://quarkus.io/guides/datasource for guidance."));
 
     @Test

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithImplicitDatasourceConfigUrlMissingTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/EntitiesInDefaultPUWithImplicitDatasourceConfigUrlMissingTest.java
@@ -30,7 +30,7 @@ public class EntitiesInDefaultPUWithImplicitDatasourceConfigUrlMissingTest {
             .assertException(t -> assertThat(t)
                     .isInstanceOf(ConfigurationException.class)
                     .hasMessageContainingAll(
-                            "The default datasource must be configured for Hibernate Reactive",
+                            "The datasource must be configured for Hibernate Reactive",
                             "Refer to https://quarkus.io/guides/datasource for guidance."));
 
     @Test

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyreactive-named.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyreactive-named.properties
@@ -1,0 +1,1 @@
+quarkus.datasource."named-datasource".reactive.url=${postgres.reactive.url}


### PR DESCRIPTION
The named data source part for https://github.com/quarkusio/quarkus/issues/46727

I know we [discussed doing named PU together](https://github.com/quarkusio/quarkus/issues/46727#issuecomment-2765814753), but this works already and the changes seems easy to understand so I wanted to try create the smaller one first. 

[this one was supposed to be done together as well](https://github.com/quarkusio/quarkus/issues/47034) but it doesn't seem to be related to named-datasource so I assume it's related to named persistent units.  
