### PR TITLE
Fixed configuration sample for kotlin live reload:

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -389,7 +389,7 @@ If you need to customize the compiler flags used by `kotlinc` in development mod
 ----
 quarkusDev {
     compilerOptions {
-        compiler("kotlin").args(['-Werror'])
+        compiler("kotlinc").args(['-Werror'])
     }
 }
 ----
@@ -399,7 +399,7 @@ quarkusDev {
 ----
 tasks.quarkusDev {
      compilerOptions {
-        compiler("kotlin").args(["-Werror"])
+        compiler("kotlinc").args(listOf("-Werror"))
     }
 }
 ----


### PR DESCRIPTION
- compiler should be `kotlinc` instead of `kotlin`
- for Kotlin DSL `compiler("kotlinc").args()` paramert should be instance of class List instead of Array