### PR TITLE
ArC: optimize the generated dependency graphs for the Dev UI

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcDevModeConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcDevModeConfig.java
@@ -15,9 +15,17 @@ public interface ArcDevModeConfig {
     boolean monitoringEnabled();
 
     /**
-     * If set to true then the dependency graphs are generated and available in the Dev UI.
+     * If set to {@code true} then the dependency graphs are generated and available in the Dev UI. If set to {@code auto}
+     * then the dependency graphs are generated if there's less than 1000 beans in the application. If set to {@code false} the
+     * dependency graphs are not generated.
      */
-    @WithDefault("true")
-    boolean generateDependencyGraphs();
+    @WithDefault("auto")
+    GenerateDependencyGraphs generateDependencyGraphs();
+
+    public enum GenerateDependencyGraphs {
+        TRUE,
+        FALSE,
+        AUTO
+    }
 
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevModeApiProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevModeApiProcessor.java
@@ -89,7 +89,7 @@ public class ArcDevModeApiProcessor {
                 // id -> [dep1Id, dep2Id]
                 beanDependenciesMap.put(bean.getIdentifier(),
                         dependencyGraph.filterLinks(link -> link.type.equals("directDependency")).nodes.stream()
-                                .map(DevBeanInfo::getId).filter(id -> !id.equals(bean.getIdentifier()))
+                                .map(Node::getId).filter(id -> !id.equals(bean.getIdentifier()))
                                 .collect(Collectors.toList()));
             }
         }
@@ -111,7 +111,7 @@ public class ArcDevModeApiProcessor {
         addNodesDependencies(0, bean, nodes, links, bean, devBeanInfos);
         addNodesDependents(0, bean, nodes, links, bean, allInjectionPoints, declaringToProducers, resolver, devBeanInfos,
                 directDependents);
-        return new DependencyGraph(nodes, links);
+        return new DependencyGraph(nodes.stream().map(Node::from).collect(Collectors.toSet()), links);
     }
 
     private void addNodesDependencies(int level, BeanInfo root, Set<DevBeanInfo> nodes, Set<Link> links, BeanInfo bean,

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/DependencyGraph.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/DependencyGraph.java
@@ -8,11 +8,11 @@ public class DependencyGraph {
 
     static final DependencyGraph EMPTY = new DependencyGraph(Set.of(), Set.of());
 
-    public final Set<DevBeanInfo> nodes;
+    public final Set<Node> nodes;
     public final Set<Link> links;
     public final int maxLevel;
 
-    public DependencyGraph(Set<DevBeanInfo> nodes, Set<Link> links) {
+    public DependencyGraph(Set<Node> nodes, Set<Link> links) {
         this.nodes = nodes;
         this.links = links;
         this.maxLevel = links.stream().mapToInt(l -> l.level).max().orElse(0);
@@ -25,7 +25,7 @@ public class DependencyGraph {
     DependencyGraph filterLinks(Predicate<Link> predicate) {
         // Filter out links first
         Set<Link> newLinks = new HashSet<>();
-        Set<DevBeanInfo> newNodes = new HashSet<>();
+        Set<Node> newNodes = new HashSet<>();
         Set<String> usedIds = new HashSet<>();
         for (Link link : links) {
             if (predicate.test(link)) {
@@ -35,7 +35,7 @@ public class DependencyGraph {
             }
         }
         // Now keep only nodes for which a link exists...
-        for (DevBeanInfo node : nodes) {
+        for (Node node : nodes) {
             if (usedIds.contains(node.getId())) {
                 newNodes.add(node);
             }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/DevBeanInfos.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/DevBeanInfos.java
@@ -90,6 +90,7 @@ public class DevBeanInfos {
     }
 
     public DependencyGraph getDependencyGraph(String beanId) {
+        // Note that MAX_DEPENDENCY_LEVEL is not implemented in UI yet
         Integer maxLevel = DevConsoleManager.getGlobal(MAX_DEPENDENCY_LEVEL);
         if (maxLevel == null) {
             maxLevel = DEFAULT_MAX_DEPENDENCY_LEVEL;

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/Node.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/Node.java
@@ -1,0 +1,31 @@
+package io.quarkus.arc.deployment.devui;
+
+public class Node {
+
+    static Node from(DevBeanInfo beanInfo) {
+        return new Node(beanInfo.getId(), beanInfo.getDescription(), beanInfo.getSimpleDescription());
+    }
+
+    private final String id;
+    private final String description;
+    private final String simpleDescription;
+
+    Node(String id, String description, String simpleDescription) {
+        this.id = id;
+        this.description = description;
+        this.simpleDescription = simpleDescription;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getSimpleDescription() {
+        return simpleDescription;
+    }
+
+}

--- a/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-bean-graph.js
+++ b/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-bean-graph.js
@@ -92,7 +92,6 @@ export class QwcArcBeanGraph extends LitElement {
             }else {
                 newNode.category = catindex;
             }
-            //console.log('Adding node: ' + newNode.name);
             return this._nodes.push(newNode) - 1;
         }
         return index;


### PR DESCRIPTION
- introduce a simplified node structure; in a simple app with 65 beans (and 33 removed components) the size of the generated `io.quarkus.quarkus-arc-data.js` file goes from 719 KB to 271 KB (~ 62%)
- do not render the graph icon if no links exist
- if a dependency graph exceeds the limit of 30 nodes then we apply the
`DevBeanInfos#MAX_DEPENDENCY_LEVEL` and if still exceeds the limit it's
skipped completely, i.e. dependency graph is not available
- introduce `quarkus.arc.dev-mode.generate-dependency-graphs=auto` and use it as a default value; i.e. dependency graphs are only generated for apps with less than 1000 beans