### PR TITLE
Add Add-Opens for java.base/java.lang (JDKSpecifics)

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -448,8 +448,11 @@
                         </systemPropertyVariables>
                         <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
-                        <!-- the add-opens is here to allow to clear the propertiesCache in com.sun.naming.internal.ResourceManager -->
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED</argLine>
+                        <!-- the add-opens java.naming/com.sun.naming.internal is here to allow to clear
+                             the propertiesCache in com.sun.naming.internal.ResourceManager -->
+                        <!-- the add-opens java.base/java.lang=ALL-UNNAMED is here for
+                             org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals() -->
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1358,6 +1358,8 @@ public class JarResultBuildStep {
         Files.createDirectories(manifestPath.getParent());
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        // JDK 24+ needs --add-opens=java.base/java.lang=ALL-UNNAMED for org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals()
+        attributes.put(new Attributes.Name("Add-Opens"), "java.base/java.lang");
 
         for (Map.Entry<String, String> attribute : config.jar().manifest().attributes().entrySet()) {
             attributes.putValue(attribute.getKey(), attribute.getValue());


### PR DESCRIPTION
Add the equivalent of --add-opens=java.base/java.lang=ALL-UNNAMED to the quarkus runner jars' MANIFEST.MF.

The 3.9 update of JBoss Threads removes some Unsafe usages and replaces that by supported JDK APIs. The new code, however, uses field.setAccessible(true), requiring the Add-Opens manifest entry.

For the quarkus tests we add the option via the argLine parameter.

Closes: #47566 (together with the 3.9.1 jboss-threads update)