### PR TITLE
OpenAPI: enable merging of schema examples by default

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -234,12 +234,12 @@ public interface SmallRyeOpenApiConfig {
     Optional<OperationIdStrategy> operationIdStrategy();
 
     /**
-     * Set this boolean value to enable the merging of the deprecated `@Schema`
+     * Set this boolean value to enable or disable the merging of the deprecated `@Schema`
      * `example` property into the `examples` array introduced in OAS 3.1.0. If
-     * not set, it will default to `false` and the deprecated `example` will be
-     * kept as a separate annotation on the schema in the OpenAPI model.
+     * set to `false`, the deprecated `example` will be kept as a separate
+     * annotation on the schema in the OpenAPI model.
      */
-    @WithDefault("false")
+    @WithDefault("true")
     boolean mergeSchemaExamples();
 
     public enum SecurityScheme {

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
@@ -264,7 +264,7 @@ class SecurityConfigFilterTest {
 
         @Override
         public boolean mergeSchemaExamples() {
-            return false;
+            return true;
         }
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MergeSchemaExamplesTestCases.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MergeSchemaExamplesTestCases.java
@@ -68,34 +68,33 @@ abstract class MergeSchemaExamplesTestCases {
                         .addClasses(Resource.class, Bean.class));
 
         MergeSchemaExamplesDefaultTestCase() {
+            super(null, new String[] { "New example 1", "New example 2", "Deprecated example" });
+        }
+    }
+
+    static class MergeSchemaExamplesQuarkusFalseTestCase extends MergeSchemaExamplesTestCases {
+        @RegisterExtension
+        static QuarkusUnitTest runner = new QuarkusUnitTest()
+                .withApplicationRoot((jar) -> jar
+                        .addClasses(Resource.class, Bean.class)
+                        .addAsResource(new StringAsset("quarkus.smallrye-openapi.merge-schema-examples=false\n"),
+                                "application.properties"));
+
+        MergeSchemaExamplesQuarkusFalseTestCase() {
             super("Deprecated example", new String[] { "New example 1", "New example 2" });
         }
     }
 
-    static class MergeSchemaExamplesQuarkusTrueTestCase extends MergeSchemaExamplesTestCases {
+    static class MergeSchemaExamplesSmallRyeFalseTestCase extends MergeSchemaExamplesTestCases {
         @RegisterExtension
         static QuarkusUnitTest runner = new QuarkusUnitTest()
                 .withApplicationRoot((jar) -> jar
                         .addClasses(Resource.class, Bean.class)
-                        .addAsResource(new StringAsset("quarkus.smallrye-openapi.merge-schema-examples=true\n"),
+                        .addAsResource(new StringAsset(SmallRyeOASConfig.SMALLRYE_MERGE_SCHEMA_EXAMPLES + "=false\n"),
                                 "application.properties"));
 
-        MergeSchemaExamplesQuarkusTrueTestCase() {
-            super(null, new String[] { "New example 1", "New example 2", "Deprecated example" });
+        MergeSchemaExamplesSmallRyeFalseTestCase() {
+            super("Deprecated example", new String[] { "New example 1", "New example 2" });
         }
     }
-
-    static class MergeSchemaExamplesSmallRyeTrueTestCase extends MergeSchemaExamplesTestCases {
-        @RegisterExtension
-        static QuarkusUnitTest runner = new QuarkusUnitTest()
-                .withApplicationRoot((jar) -> jar
-                        .addClasses(Resource.class, Bean.class)
-                        .addAsResource(new StringAsset(SmallRyeOASConfig.SMALLRYE_MERGE_SCHEMA_EXAMPLES + "=true\n"),
-                                "application.properties"));
-
-        MergeSchemaExamplesSmallRyeTrueTestCase() {
-            super(null, new String[] { "New example 1", "New example 2", "Deprecated example" });
-        }
-    }
-
 }

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -31,7 +31,6 @@
                         <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
                         <quarkus.smallrye-openapi.auto-add-tags>false</quarkus.smallrye-openapi.auto-add-tags>
                         <quarkus.smallrye-openapi.auto-add-bad-request-response>false</quarkus.smallrye-openapi.auto-add-bad-request-response>
-                        <quarkus.smallrye-openapi.merge-schema-examples>true</quarkus.smallrye-openapi.merge-schema-examples>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->


### PR DESCRIPTION
As of the bump to smallrye-open-api 4.0.9 in #47124, Swagger UI will now properly display the schema `examples` array. Change #46956 introduced a new property to proxy to the smallrye property that allows disabling the merging of the singleton `example` to the `examples` array due to lack of support in earlier Swagger UI versions. 

This change flips the default value of the new property to `true`, which is also the default in smallrye-openapi. The benefit of keeping the property in Quarkus is to expose documentation for those using other tools that cannot tolerate the `examples` array in OAS 3.1.0.

![image](https://github.com/user-attachments/assets/2b24717e-950d-42c5-91a9-778e012cdf06)
