### PR TITLE
More informative/encouraging grpc warning about legacy compatibility

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -142,8 +142,11 @@ public class GrpcServerRecorder {
         if (configuration.useSeparateServer()) {
             if (provider == null) {
                 LOGGER.warn(
-                        "Using legacy gRPC support, with separate new HTTP server instance. " +
-                                "Switch to single HTTP server instance usage with quarkus.grpc.server.use-separate-server=false property");
+                        """
+                                Using legacy gRPC support with a separate HTTP server instance. This is the current default to maintain compatibility.
+                                You can switch to the new unified HTTP server by setting quarkus.grpc.server.use-separate-server=false
+                                This change is recommended for new applications and will become the default in future versions.
+                                """);
             }
 
             if (launchMode == LaunchMode.DEVELOPMENT) {


### PR DESCRIPTION
discussed in https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/GRPC.20legacy.20warning/near/515484148 as warning was leaving a bit too much uncertainty.

@cescoffier explained the technical diff between legacy/non-legacy:

legacy: use gRPC Java using Netty in a very weird way. Requires its own server (on port 9000)
Vert.x: use Vert.x directly, we have more control on everything, reuse the HTTP server (port 8080)
