### PR TITLE
Handle empty bearer token file in ClientAssertionProvider

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/ClientAssertionProvider.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/ClientAssertionProvider.java
@@ -75,6 +75,11 @@ public final class ClientAssertionProvider implements Closeable {
         if (Files.exists(bearerTokenPath)) {
             try {
                 String bearerToken = Files.readString(bearerTokenPath).trim();
+                if (bearerToken.isEmpty()) {
+                    LOG.error(String.format("Bearer token file at path %s is empty or contains only whitespace",
+                            bearerTokenPath));
+                    return null;
+                }
                 Long expiresAt = getExpiresAtFromExpClaim(bearerToken);
                 if (expiresAt != null) {
                     return new ClientAssertion(bearerToken, expiresAt, scheduleRefresh(expiresAt));


### PR DESCRIPTION
An empty bearer token file stops quarkus from starting due to `StringTokenizer.nextToken` used on `""`

- Fixes: #47630