### PR TITLE
Health OpenAPI ensure repeatable builds

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/HealthOpenAPIFilter.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/HealthOpenAPIFilter.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.health.deployment;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -25,8 +26,7 @@ public class HealthOpenAPIFilter implements OASFilter {
 
     private static final Schema healthResponseSchemaDefinition = OASFactory.createSchema()
             .type(Collections.singletonList(Schema.SchemaType.OBJECT))
-            .properties(Map.ofEntries(
-
+            .properties(new TreeMap<>(Map.ofEntries(
                     Map.entry("status",
                             OASFactory.createSchema()
                                     .type(Collections.singletonList(Schema.SchemaType.STRING))
@@ -36,12 +36,11 @@ public class HealthOpenAPIFilter implements OASFilter {
                             OASFactory.createSchema()
                                     .type(Collections.singletonList(Schema.SchemaType.ARRAY))
                                     .items(OASFactory.createSchema()
-                                            .ref("#/components/schemas/" + HEALTH_CHECK_SCHEMA_NAME)))));
+                                            .ref("#/components/schemas/" + HEALTH_CHECK_SCHEMA_NAME))))));
 
     private static final Schema healthCheckSchemaDefinition = OASFactory.createSchema()
             .type(Collections.singletonList(Schema.SchemaType.OBJECT))
-            .properties(Map.ofEntries(
-
+            .properties(new TreeMap<>(Map.ofEntries(
                     Map.entry("name",
                             OASFactory.createSchema()
                                     .type(Collections.singletonList(Schema.SchemaType.STRING))),
@@ -53,7 +52,7 @@ public class HealthOpenAPIFilter implements OASFilter {
 
                     Map.entry("data",
                             OASFactory.createSchema()
-                                    .type(List.of(Schema.SchemaType.OBJECT, Schema.SchemaType.NULL)))));
+                                    .type(List.of(Schema.SchemaType.OBJECT, Schema.SchemaType.NULL))))));
 
     private final String rootPath;
     private final String livenessPath;


### PR DESCRIPTION
When using `quarkus.smallrye-health.openapi.included=true`

Every other build changes the `openapi.yml` unnecessarily and causes constant flip flop of the properties because its using a HashMap.  This uses a TreeMap to esnure the same order on every build.

Example below is with no code changes just running `mvn quarkus:dev` twice in a row

![image](https://github.com/user-attachments/assets/e50bc056-8915-4743-9788-6bbb9ef39def)
