### PR TITLE
Health OpenAPI add missing Tag description

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/HealthOpenAPIFilter.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/HealthOpenAPIFilter.java
@@ -14,6 +14,7 @@ import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.media.Content;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.responses.APIResponses;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
 
 /**
  * Create OpenAPI entries (if configured)
@@ -78,6 +79,11 @@ public class HealthOpenAPIFilter implements OASFilter {
         if (openAPI.getPaths() == null) {
             openAPI.setPaths(OASFactory.createPaths());
         }
+
+        Tag tag = OASFactory.createTag();
+        tag.setName(MICROPROFILE_HEALTH_TAG.get(0));
+        tag.setDescription("Check the health of the application");
+        openAPI.addTag(tag);
 
         final Paths paths = openAPI.getPaths();
 


### PR DESCRIPTION
The Health OpenAPI is missing its tag description see this screenshot.

![image](https://github.com/user-attachments/assets/3cd92d62-43b6-4fef-a928-222fbe50413e)
