### PR TITLE
Perf(panache - kotlin): Nullable parameters are standardized and others

### DIFF
--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
@@ -68,7 +68,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun find(query: String, vararg params: Any): PanacheQuery<Entity> =
+    fun find(query: String, vararg params: Any?): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -82,7 +82,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, vararg params: Any): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, vararg params: Any?): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -95,7 +95,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun find(query: String, params: Map<String, Any>): PanacheQuery<Entity> =
+    fun find(query: String, params: Map<String, Any?>): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -109,7 +109,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, params: Map<String, Any>): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, params: Map<String, Any?>): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -170,7 +170,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun list(query: String, vararg params: Any): List<Entity> =
+    fun list(query: String, vararg params: Any?): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -185,7 +185,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun list(query: String, sort: Sort, vararg params: Any): List<Entity> =
+    fun list(query: String, sort: Sort, vararg params: Any?): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -199,7 +199,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun list(query: String, params: Map<String, Any>): List<Entity> =
+    fun list(query: String, params: Map<String, Any?>): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -214,7 +214,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
-    fun list(query: String, sort: Sort, params: Map<String, Any>): List<Entity> =
+    fun list(query: String, sort: Sort, params: Map<String, Any?>): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -278,7 +278,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.list]
      */
     @GenerateBridge
-    fun stream(query: String, vararg params: Any): Stream<Entity> =
+    fun stream(query: String, vararg params: Any?): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -295,7 +295,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.list]
      */
     @GenerateBridge
-    fun stream(query: String, sort: Sort, vararg params: Any): Stream<Entity> =
+    fun stream(query: String, sort: Sort, vararg params: Any?): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -310,7 +310,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.list]
      */
     @GenerateBridge
-    fun stream(query: String, params: Map<String, Any>): Stream<Entity> =
+    fun stream(query: String, params: Map<String, Any?>): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -326,7 +326,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.list]
      */
     @GenerateBridge
-    fun stream(query: String, sort: Sort, params: Map<String, Any>): Stream<Entity> =
+    fun stream(query: String, sort: Sort, params: Map<String, Any?>): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -400,7 +400,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @return the number of entities counted.
      */
     @GenerateBridge
-    fun count(query: String, vararg params: Any): Long = throw implementationInjectionMissing()
+    fun count(query: String, vararg params: Any?): Long = throw implementationInjectionMissing()
 
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
@@ -410,7 +410,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @return the number of entities counted.
      */
     @GenerateBridge
-    fun count(query: String, params: Map<String, Any>): Long =
+    fun count(query: String, params: Map<String, Any?>): Long =
         throw implementationInjectionMissing()
 
     /**
@@ -446,7 +446,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.deleteAll]
      */
     @GenerateBridge
-    fun delete(query: String, vararg params: Any): Long = throw implementationInjectionMissing()
+    fun delete(query: String, vararg params: Any?): Long = throw implementationInjectionMissing()
 
     /**
      * Delete all entities of this type matching the given query, with named parameters.
@@ -460,7 +460,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [PanacheCompanion.deleteAll]
      */
     @GenerateBridge
-    fun delete(query: String, params: Map<String, Any>): Long =
+    fun delete(query: String, params: Map<String, Any?>): Long =
         throw implementationInjectionMissing()
 
     /**
@@ -520,7 +520,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @return the number of entities updated.
      */
     @GenerateBridge
-    fun update(query: String, vararg params: Any): Int = throw implementationInjectionMissing()
+    fun update(query: String, vararg params: Any?): Int = throw implementationInjectionMissing()
 
     /**
      * Update all entities of this type matching the given query, with named parameters.
@@ -530,7 +530,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @return the number of entities updated.
      */
     @GenerateBridge
-    fun update(query: String, params: Map<String, Any>): Int =
+    fun update(query: String, params: Map<String, Any?>): Int =
         throw implementationInjectionMissing()
 
     /**

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheCompanion.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheCompanion.kt
@@ -24,7 +24,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      *
      * @return the current [Mutiny.Session]
      */
-    fun getSession() = AbstractJpaOperations.getSession()
+    @CheckReturnValue fun getSession(): Uni<Mutiny.Session> = AbstractJpaOperations.getSession()
 
     /**
      * Find an entity of this type by ID.
@@ -32,7 +32,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @param id the ID of the entity to find.
      * @return the entity found, or `null` if not found.
      */
-    @GenerateBridge fun findById(id: Id): Uni<Entity?> = injectionMissing()
+    @CheckReturnValue @GenerateBridge fun findById(id: Id): Uni<Entity?> = injectionMissing()
 
     /**
      * Find an entity of this type by ID and lock it.
@@ -43,7 +43,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun findById(id: Id, lockModeType: LockModeType): Uni<Entity> = injectionMissing()
+    fun findById(id: Id, lockModeType: LockModeType): Uni<Entity?> = injectionMissing()
 
     /**
      * Find entities using a query, with optional indexed parameters.
@@ -54,7 +54,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, vararg params: Any): PanacheQuery<Entity> = injectionMissing()
+    fun find(query: String, vararg params: Any?): PanacheQuery<Entity> = injectionMissing()
 
     /**
      * Find entities using a query and the given sort options, with optional indexed parameters.
@@ -66,7 +66,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, vararg params: Any): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, vararg params: Any?): PanacheQuery<Entity> =
         injectionMissing()
 
     /**
@@ -78,7 +78,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, params: Map<String, Any>): PanacheQuery<Entity> = injectionMissing()
+    fun find(query: String, params: Map<String, Any?>): PanacheQuery<Entity> = injectionMissing()
 
     /**
      * Find entities using a query and the given sort options, with named parameters.
@@ -90,7 +90,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, params: Map<String, Any>): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, params: Map<String, Any?>): PanacheQuery<Entity> =
         injectionMissing()
 
     /**
@@ -145,7 +145,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, vararg params: Any): Uni<List<Entity>> = injectionMissing()
+    fun list(query: String, vararg params: Any?): Uni<List<Entity>> = injectionMissing()
 
     /**
      * Find entities matching a query and the given sort options, with optional indexed parameters.
@@ -159,7 +159,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, sort: Sort, vararg params: Any): Uni<List<Entity>> = injectionMissing()
+    fun list(query: String, sort: Sort, vararg params: Any?): Uni<List<Entity>> = injectionMissing()
 
     /**
      * Find entities matching a query, with named parameters. This method is a shortcut for
@@ -172,7 +172,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, params: Map<String, Any>): Uni<List<Entity>> = injectionMissing()
+    fun list(query: String, params: Map<String, Any?>): Uni<List<Entity>> = injectionMissing()
 
     /**
      * Find entities matching a query and the given sort options, with named parameters. This method
@@ -186,7 +186,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, sort: Sort, params: Map<String, Any>): Uni<List<Entity>> =
+    fun list(query: String, sort: Sort, params: Map<String, Any?>): Uni<List<Entity>> =
         injectionMissing()
 
     /**
@@ -253,7 +253,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun count(query: String, vararg params: Any): Uni<Long> = injectionMissing()
+    fun count(query: String, vararg params: Any?): Uni<Long> = injectionMissing()
 
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
@@ -264,7 +264,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun count(query: String, params: Map<String, Any>): Uni<Long> = injectionMissing()
+    fun count(query: String, params: Map<String, Any?>): Uni<Long> = injectionMissing()
 
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
@@ -309,7 +309,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun delete(query: String, vararg params: Any): Uni<Long> = injectionMissing()
+    fun delete(query: String, vararg params: Any?): Uni<Long> = injectionMissing()
 
     /**
      * Delete all entities of this type matching the given query, with named parameters.
@@ -324,7 +324,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun delete(query: String, params: Map<String, Any>): Uni<Long> = injectionMissing()
+    fun delete(query: String, params: Map<String, Any?>): Uni<Long> = injectionMissing()
 
     /**
      * Delete all entities of this type matching the given query, with named parameters.
@@ -347,7 +347,8 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @param entities the entities to persist
      * @return
      */
-    @CheckReturnValue fun persist(entities: Iterable<Entity>) = INSTANCE.persist(entities)
+    @CheckReturnValue
+    fun persist(entities: Iterable<Entity>): Uni<Void> = INSTANCE.persist(entities)
 
     /**
      * Persist all given entities.
@@ -355,7 +356,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @param entities the entities to persist
      * @return
      */
-    @CheckReturnValue fun persist(entities: Stream<Entity>) = INSTANCE.persist(entities)
+    @CheckReturnValue fun persist(entities: Stream<Entity>): Uni<Void> = INSTANCE.persist(entities)
 
     /**
      * Persist all given entities.
@@ -364,8 +365,8 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @return
      */
     @CheckReturnValue
-    fun persist(firstEntity: Entity, vararg entities: Entity) =
-        INSTANCE.persist(listOf(firstEntity) + listOf(*entities))
+    fun persist(firstEntity: Entity, vararg entities: Entity): Uni<Void> =
+        INSTANCE.persist(listOf(firstEntity, *entities))
 
     /**
      * Update all entities of this type matching the given query, with optional indexed parameters.
@@ -376,7 +377,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun update(query: String, vararg params: Any): Uni<Int> = injectionMissing()
+    fun update(query: String, vararg params: Any?): Uni<Int> = injectionMissing()
 
     /**
      * Update all entities of this type matching the given query, with named parameters.
@@ -387,7 +388,7 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun update(query: String, params: Map<String, Any>): Uni<Int> = injectionMissing()
+    fun update(query: String, params: Map<String, Any?>): Uni<Int> = injectionMissing()
 
     /**
      * Update all entities of this type matching the given query, with named parameters.

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheEntityBase.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheEntityBase.kt
@@ -16,20 +16,16 @@ interface PanacheEntityBase {
     @JsonbTransient @JsonIgnore fun isPersistent(): Boolean = INSTANCE.isPersistent(this)
 
     /** Persist this entity in the database. This will set its ID field if not already set. */
+    @Suppress("UNCHECKED_CAST")
     @CheckReturnValue
-    fun <T : PanacheEntityBase> persist(): Uni<T> {
-        return INSTANCE.persist(this).map { this as T }
-    }
+    fun <T : PanacheEntityBase> persist(): Uni<T> = INSTANCE.persist(this).map { this as T }
 
     /**
      * Flushes all pending changes to the database.
      *
      * @return
      */
-    @CheckReturnValue
-    fun flush(): Uni<Void> {
-        return INSTANCE.flush()
-    }
+    @CheckReturnValue fun flush(): Uni<Void> = INSTANCE.flush()
 
     /**
      * Persist this entity in the database, if not already persisted. This will set your ID field if
@@ -41,14 +37,9 @@ interface PanacheEntityBase {
      */
     @Suppress("UNCHECKED_CAST")
     @CheckReturnValue
-    fun <T : PanacheEntityBase> persistAndFlush(): Uni<T> {
-        return INSTANCE.persist(this).flatMap { INSTANCE.flush() }.map { this as T }
-    }
+    fun <T : PanacheEntityBase> persistAndFlush(): Uni<T> =
+        INSTANCE.persist(this).flatMap { INSTANCE.flush() }.map { this as T }
 
-    /**
-     * Delete this entity from the database if it is already persisted.
-     *
-     * @see [deleteAll]
-     */
-    fun delete(): Uni<Void> = INSTANCE.delete(this)
+    /** Delete this entity from the database if it is already persisted. */
+    @CheckReturnValue fun delete(): Uni<Void> = INSTANCE.delete(this)
 }

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheRepositoryBase.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheRepositoryBase.kt
@@ -27,7 +27,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      *
      * @return the current [Mutiny.Session]
      */
-    fun getSession(): Uni<Mutiny.Session> = AbstractJpaOperations.getSession()
+    @CheckReturnValue fun getSession(): Uni<Mutiny.Session> = AbstractJpaOperations.getSession()
 
     @CheckReturnValue
     fun persist(entity: Entity): Uni<Entity> = INSTANCE.persist(entity).map { entity }
@@ -81,7 +81,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun findById(id: Id): Uni<Entity> = throw INSTANCE.implementationInjectionMissing()
+    fun findById(id: Id): Uni<Entity?> = throw INSTANCE.implementationInjectionMissing()
 
     /**
      * Find an entity of this type by ID and lock it.
@@ -92,7 +92,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun findById(id: Id, lockModeType: LockModeType): Uni<Entity> =
+    fun findById(id: Id, lockModeType: LockModeType): Uni<Entity?> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -442,7 +442,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     fun persist(firstEntity: Entity, vararg entities: Entity): Uni<Void> =
-        INSTANCE.persist(listOf(firstEntity) + listOf(*entities))
+        INSTANCE.persist(listOf(firstEntity, *entities))
 
     /**
      * Update all entities of this type matching the given query, with optional indexed parameters.

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Address.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Address.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.Id
 @Entity
 open class Address : PanacheEntityBase {
     companion object : PanacheCompanionBase<Address, Int> {
-        override fun count(query: String, params: Map<String, Any>): Long {
+        override fun count(query: String, params: Map<String, Any?>): Long {
             AddressDao.shouldBeOverridden()
         }
     }

--- a/integration-tests/hibernate-reactive-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/reactive/kotlin/Person.kt
+++ b/integration-tests/hibernate-reactive-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/reactive/kotlin/Person.kt
@@ -65,7 +65,7 @@ class Person : PanacheEntity() {
 
         // For https://github.com/quarkusio/quarkus/issues/9635
         @Suppress("UNCHECKED_CAST")
-        override fun find(query: String, vararg params: Any): PanacheQuery<Person> {
+        override fun find(query: String, vararg params: Any?): PanacheQuery<Person> {
             return INSTANCE.find(Person::class.java, query, *params) as PanacheQuery<Person>
         }
 


### PR DESCRIPTION
Add annotations are added, explicit types are defined, and [single-expression functions](https://kotlinlang.org/docs/functions.html#single-expression-functions) are used.

In my opinion, the Panache repository had better signature and typing than the companion object, when they should be the same.
PR that adds the null parameters: https://github.com/quarkusio/quarkus/pull/45609
Without further ado, I hope you like it and that everything continues to work.

Pd. I recommend using [no-args plugin for kotlin with JPA.](https://kotlinlang.org/docs/no-arg-plugin.html#jpa-support) and add to [all-open ApplicationScoped and RequestScoped.](https://github.com/JetBrains/kotlin/blob/0bcd62b050402f624ef9675aae5d9a470fcc0c2c/plugins/allopen/allopen.common/src/org/jetbrains/kotlin/allopen/AllOpenPluginNames.kt#L18) in your pom.xml with kotlin files.

Pd2. `io/quarkus/hibernate/orm/panache/kotlin/PanacheEntityBase.kt` can have the `flush()` method with `INSTANCE.flush()`