### PR TITLE
Strip the classpath scheme from SmallrRye JWT native resources

### DIFF
--- a/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
+++ b/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
@@ -19,6 +19,7 @@ import io.smallrye.jwt.build.impl.JwtProviderImpl;
 class SmallRyeJwtBuildProcessor {
 
     private static final Logger log = Logger.getLogger(SmallRyeJwtBuildProcessor.class.getName());
+    private static final String CLASSPATH_SCHEME = "classpath:";
 
     @BuildStep
     void addClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
@@ -45,9 +46,20 @@ class SmallRyeJwtBuildProcessor {
             BuildProducer<NativeImageResourceBuildItem> nativeImageResource) {
         Optional<String> keyLocation = config.getOptionalValue(propertyName, String.class);
         if (keyLocation.isPresent() && keyLocation.get().length() > 1
-                && (keyLocation.get().indexOf(':') < 0 || keyLocation.get().startsWith("classpath:"))) {
+                && (keyLocation.get().indexOf(':') < 0 || (keyLocation.get().startsWith(CLASSPATH_SCHEME)
+                        && keyLocation.get().length() > CLASSPATH_SCHEME.length()))) {
             log.infof("Adding %s to native image", keyLocation.get());
-            String location = keyLocation.get().startsWith("/") ? keyLocation.get().substring(1) : keyLocation.get();
+
+            String location = keyLocation.get();
+
+            // It can only be `classpath:` at this point
+            if (location.startsWith(CLASSPATH_SCHEME)) {
+                location = location.substring(CLASSPATH_SCHEME.length());
+            }
+            if (location.startsWith("/")) {
+                location = location.substring(1);
+            }
+
             nativeImageResource.produce(new NativeImageResourceBuildItem(location));
         }
     }

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
@@ -7,7 +7,7 @@ io.quarkus.it.keycloak.JwtTokenPropagationService/mp-rest/uri=http://localhost:8
 io.quarkus.it.keycloak.AccessTokenPropagationService/mp-rest/uri=http://localhost:8081/protected
 
 quarkus.resteasy-client-oidc-token-propagation.secure-json-web-token=true
-smallrye.jwt.sign.key.location=/privateKey.pem
+smallrye.jwt.sign.key.location=classpath:/privateKey.pem
 smallrye.jwt.new-token.issuer=http://frontend-resource
 smallrye.jwt.new-token.audience=http://jwt-resigned-protected-resource
 smallrye.jwt.new-token.override-matching-claims=true


### PR DESCRIPTION
Fixes #47701.

I confirmed the fix with the Quickstart.

I could've tried to escape `:` in the `classpath:key_location` to prevent the native image generation errors, but, given that smallrye-jwt always considers a classpath, it is simpler to strip the scheme off