### PR TITLE
Clarify documentation for usage of TLS registry in Quarkus clients

### DIFF
--- a/adr/0004-using-the-tls-registry-for-clients.adoc
+++ b/adr/0004-using-the-tls-registry-for-clients.adoc
@@ -26,7 +26,7 @@ The TLS registry is an extension processing the `quarkus.tls` configuration and 
 Note that the configuration and the runtime API are different.
 The configuration is used to define the TLS settings, while the runtime API is used to access these pre-processed settings.
 
-hen using the options directly under `quarkus.tls.`, one configures the default (_unamed_) configuration, while using options under `quarkus.tls.<name>.` configures a _named_ configuration.
+When using the options directly under `quarkus.tls.`, one configures the default (_unnamed_) configuration, while using options under `quarkus.tls.<name>.` configures a _named_ configuration.
 For each configuration, trust stores and key stores can be defined, as well as the default protocol, cipher suites, etc.
 More details can be found in the https://quarkus.io/version/main/guides/tls-registry-reference[documentation] and in the https://github.com/quarkusio/quarkus/blob/main/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java[code].
 

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -55,6 +55,12 @@ Each named TLS configuration, or "TLS bucket," must provide its own properties.
 For instance, `quarkus.tls.reload-period` will only be applied to the default TLS configuration.
 ====
 
+[IMPORTANT]
+====
+As described in detail  link:https://github.com/quarkusio/quarkus/blob/main/adr/0004-using-the-tls-registry-for-clients.adoc#configuring-clients-with-the-tls-registry[here], Quarkus client extensions (REST, GRPC, etc) ignore properties, defined in default (ie unnamed) TLS configuration.
+The only exception is `quarkus.tls.trust-all` property.
+====
+
 === Configuring HTTPS for a HTTP server
 
 To ensure secure client-server communication, the client is often required to verify the server's authenticity.

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -262,10 +262,9 @@ public interface RestClientsConfig {
      * <p>
      * If a name is configured, it uses the configuration from {@code quarkus.tls.<name>.*}
      * If a name is configured, but no TLS configuration is found with that name then an error will be thrown.
+     * The default TLS configuration will be ignored.
      * <p>
-     * If no TLS configuration is set, then the keys-tore, trust-store, etc. properties will be used.
-     * <p>
-     * The default TLS configuration is <strong>not</strong> used by default.
+     * If no named TLS configuration is set, then the key-store, trust-store, etc. properties will be used.
      * <p>
      * This property is not applicable to the RESTEasy Client.
      */
@@ -546,10 +545,9 @@ public interface RestClientsConfig {
          * <p>
          * If a name is configured, it uses the configuration from {@code quarkus.tls.<name>.*}
          * If a name is configured, but no TLS configuration is found with that name then an error will be thrown.
+         * The default TLS configuration will be ignored.
          * <p>
-         * If no TLS configuration is set, then the keys-tore, trust-store, etc. properties will be used.
-         * <p>
-         * The default TLS configuration is <strong>not</strong> used by default.
+         * If no named TLS configuration is set, then the key-store, trust-store, etc. properties will be used.
          * <p>
          * This property is not applicable to the RESTEasy Client.
          */


### PR DESCRIPTION
Quarkus clients do not use default TLS registry, but there is no way or user to know about that.
This PR fixes that and contains three commits:
1. Changes javadoc for Rest Client
2. Adds a warning into TLS registry guide
3. Fixes a typo in ADR, which is the source of truth for this behavior