### PR TITLE
Fix Kotlin compilation

### DIFF
--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
@@ -77,6 +77,8 @@ public class KotlinCompilationProvider implements CompilationProvider {
         context.getReloadableClasspath().forEach(file -> classpathJoiner.add(file.getAbsolutePath()));
 
         compilerArguments.setClasspath(classpathJoiner.toString());
+        compilerArguments.setFriendPaths(new String[] { context.getOutputDirectory().getAbsolutePath() });
+
         compilerArguments.setDestination(context.getOutputDirectory().getAbsolutePath());
         compilerArguments.setFreeArgs(filesToCompile.stream().map(File::getAbsolutePath).collect(Collectors.toList()));
 


### PR DESCRIPTION
Marking the output dir as a friend dir means that the compiler treats already compiled classes as part of the same module. Without this some features such as smart casts will fail after the initial compilation.

I was seeing errors like `Reason: Smart cast to 'SomeClass' is impossible, because 'someProperty' is a public API property declared in different module.` because the property was on an existing class not currently being compiled.