### PR TITLE
Cache DevUI give datatable more height

### DIFF
--- a/extensions/cache/deployment/src/main/resources/dev-ui/qwc-cache-caches.js
+++ b/extensions/cache/deployment/src/main/resources/dev-ui/qwc-cache-caches.js
@@ -18,6 +18,12 @@ export class QwcCacheCaches extends LitElement {
 
     // Component style
     static styles = css`
+        .datatable {
+            height: 100%;
+        }
+        .caches {
+            height: 100%;
+        }
         .button {
             background-color: transparent;
             cursor: pointer;
@@ -74,6 +80,7 @@ export class QwcCacheCaches extends LitElement {
     _renderCacheTable() {
         let caches = [...this._caches.values()];
         return html`
+            <div class="caches">
                 <vaadin-grid .items="${caches}" class="datatable" theme="no-border">
                     <vaadin-grid-column auto-width
                                         header="Name"
@@ -90,7 +97,8 @@ export class QwcCacheCaches extends LitElement {
                                         ${columnBodyRenderer(this._actionRenderer, [])}
                                         resizable>
                     </vaadin-grid-column>
-                </vaadin-grid>`;
+                </vaadin-grid>
+            </div>`;
     }
     
     _renderCacheKeys(){

--- a/extensions/cache/deployment/src/main/resources/dev-ui/qwc-cache-keys.js
+++ b/extensions/cache/deployment/src/main/resources/dev-ui/qwc-cache-keys.js
@@ -12,10 +12,14 @@ import '@vaadin/grid/vaadin-grid-sort-column.js';
 export class QwcCacheKeys extends LitElement {
     
      static styles = css`
+        .datatable {
+            height: 100%;
+        }
         .keys {
             padding-left: 20px;
             justify-content: space-between;
             padding-right: 20px;
+            height: 100%;
         }
     
         .keys h4 {


### PR DESCRIPTION
The datables had the CSS class `datatable` on them but no styling so they are cut off at 400px default which is sorta tight...

![image](https://github.com/user-attachments/assets/77f9a87e-ecc9-42f2-a983-77e0503b4761)


cc @phillip-kruger 