### PR TITLE
Remove instances of BytecodeTransformerBuildItem.Builder().setEager()

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeTransformerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeTransformerBuildItem.java
@@ -113,7 +113,7 @@ public final class BytecodeTransformerBuildItem extends MultiBuildItem {
         return requireConstPoolEntry;
     }
 
-    @Deprecated
+    @Deprecated(since = "3.11", forRemoval = true)
     public boolean isEager() {
         return false;
     }
@@ -191,7 +191,7 @@ public final class BytecodeTransformerBuildItem extends MultiBuildItem {
             return this;
         }
 
-        @Deprecated
+        @Deprecated(since = "3.11", forRemoval = true)
         public Builder setEager(boolean eager) {
             return this;
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -125,7 +125,7 @@ public class TestTracingProcessor {
         for (ClassInfo clazz : combinedIndexBuildItem.getIndex().getKnownClasses()) {
             String theClassName = clazz.name().toString();
             if (isAppClass(theClassName)) {
-                transformerProducer.produce(new BytecodeTransformerBuildItem.Builder().setEager(false)
+                transformerProducer.produce(new BytecodeTransformerBuildItem.Builder()
                         .setClassToTransform(theClassName)
                         .setVisitorFunction(
                                 new BiFunction<String, ClassVisitor, ClassVisitor>() {

--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -80,7 +80,6 @@ public class JacocoProcessor {
                 transformers.produce(
                         new BytecodeTransformerBuildItem.Builder().setClassToTransform(className)
                                 .setCacheable(true)
-                                .setEager(true)
                                 .setInputTransformer(new BiFunction<String, byte[], byte[]>() {
                                     @Override
                                     public byte[] apply(String className, byte[] bytes) {


### PR DESCRIPTION
The method has been deprecated so let's not use them anymore