### PR TITLE
Fix reflection-free for @JsonValue annotated classes

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -797,13 +797,43 @@ public abstract class AbstractSimpleJsonTest {
     }
 
     @Test
-    void testJsonValue() {
+    void testJsonValuePublicMethod() {
         RestAssured.given()
                 .queryParam("value", 240)
-                .post("/simple/json-value")
+                .post("/simple/json-value-public-method")
                 .then()
                 .statusCode(200)
-                .body(Matchers.equalTo('\"' + new ItemId(240).format() + '\"'));
+                .body(Matchers.equalTo("\"" + Integer.toString(240) + "\""));
+    }
+
+    @Test
+    void testJsonValuePublicField() {
+        RestAssured.given()
+                .queryParam("value", 368)
+                .post("/simple/json-value-public-field")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo(Integer.toString(368)));
+    }
+
+    @Test
+    void testJsonValuePrivateMethod() {
+        RestAssured.given()
+                .queryParam("value", 256)
+                .post("/simple/json-value-private-method")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("\"" + Integer.toString(256) + "\""));
+    }
+
+    @Test
+    void testJsonValuePrivateField() {
+        RestAssured.given()
+                .queryParam("value", 795)
+                .post("/simple/json-value-private-field")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo(Integer.toString(795)));
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePrivateField.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePrivateField.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class ItemJsonValuePrivateField {
+    @JsonValue
+    private final int value;
+
+    @JsonCreator
+    public ItemJsonValuePrivateField(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePrivateMethod.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePrivateMethod.java
@@ -3,11 +3,11 @@ package io.quarkus.resteasy.reactive.jackson.deployment.test;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public class ItemId {
-    final int value;
+public class ItemJsonValuePrivateMethod {
+    private final int value;
 
     @JsonCreator
-    public ItemId(int value) {
+    public ItemJsonValuePrivateMethod(int value) {
         this.value = value;
     }
 
@@ -16,7 +16,7 @@ public class ItemId {
     }
 
     @JsonValue
-    public String format() {
-        return "ItemId:" + value;
+    private String format() {
+        return Integer.toString(value);
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePublicField.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePublicField.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class ItemJsonValuePublicField {
+    @JsonValue
+    public final int value;
+
+    @JsonCreator
+    public ItemJsonValuePublicField(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePublicMethod.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemJsonValuePublicMethod.java
@@ -1,0 +1,22 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class ItemJsonValuePublicMethod {
+    private final int value;
+
+    @JsonCreator
+    public ItemJsonValuePublicMethod(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+
+    @JsonValue
+    public String format() {
+        return Integer.toString(value);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -510,10 +510,31 @@ public class SimpleJsonResource extends SuperClass<Person> {
     }
 
     @POST
-    @Path("/json-value")
+    @Path("/json-value-public-method")
     @Produces(MediaType.APPLICATION_JSON)
-    public ItemId generate(@RestQuery int value) {
-        return new ItemId(value);
+    public ItemJsonValuePublicMethod echoJsonValuePublicMethod(@RestQuery int value) {
+        return new ItemJsonValuePublicMethod(value);
+    }
+
+    @POST
+    @Path("/json-value-public-field")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ItemJsonValuePublicField echoJsonValuePublicField(@RestQuery int value) {
+        return new ItemJsonValuePublicField(value);
+    }
+
+    @POST
+    @Path("/json-value-private-method")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ItemJsonValuePrivateMethod echoJsonValuePrivateMethod(@RestQuery int value) {
+        return new ItemJsonValuePrivateMethod(value);
+    }
+
+    @POST
+    @Path("/json-value-private-field")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ItemJsonValuePrivateField echoJsonValuePrivateField(@RestQuery int value) {
+        return new ItemJsonValuePrivateField(value);
     }
 
     @POST

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -27,7 +27,9 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     Pond.class, FrogBodyParts.class, FrogBodyParts.BodyPart.class, ContainerDTO.class,
                                     NestedInterface.class, StateRecord.class, MapWrapper.class, GenericWrapper.class,
                                     Fruit.class, Price.class, DogRecord.class, ItemExtended.class, Book.class, LombokBook.class,
-                                    PrimitiveTypesBean.class, PrimitiveTypesRecord.class, TokenResponse.class, ItemId.class)
+                                    PrimitiveTypesBean.class, PrimitiveTypesRecord.class, TokenResponse.class,
+                                    ItemJsonValuePublicMethod.class, ItemJsonValuePublicField.class,
+                                    ItemJsonValuePrivateMethod.class, ItemJsonValuePrivateField.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n"), "application.properties");

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -29,7 +29,9 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     Pond.class, FrogBodyParts.class, FrogBodyParts.BodyPart.class, ContainerDTO.class,
                                     NestedInterface.class, StateRecord.class, MapWrapper.class, GenericWrapper.class,
                                     Fruit.class, Price.class, DogRecord.class, ItemExtended.class, Book.class, LombokBook.class,
-                                    PrimitiveTypesBean.class, PrimitiveTypesRecord.class, TokenResponse.class, ItemId.class)
+                                    PrimitiveTypesBean.class, PrimitiveTypesRecord.class, TokenResponse.class,
+                                    ItemJsonValuePublicMethod.class, ItemJsonValuePublicField.class,
+                                    ItemJsonValuePrivateMethod.class, ItemJsonValuePrivateField.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +


### PR DESCRIPTION
Fix a NPE for non public annotated field and skip generation of serializer for classes annotated with @JsonValue that doesn't meet requirements to generate a reflection-free serializer; for this classes standard Jackson serializer is used.

Additional modification to https://github.com/quarkusio/quarkus/pull/47719

/cc @mariofusco

If PR can't be used for any reason the related patch is attached

[issue-47719.patch](https://github.com/user-attachments/files/20079796/issue-47719.patch)