### PR TITLE
Bump elasticsearch-opensource-components.version from 8.17.4 to 8.18.1 / Prevent dependabot from updating major versions of any Elasticsearch components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -216,6 +216,13 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: org.apache.kafka:*
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Elasticsearch - major updates usually require more work and synchronization, we do them manually.
+      - dependency-name: org.elasticsearch.client:elasticsearch-rest-client
+        update-types: ["version-update:semver-major"]
+      - dependency-name: org.elasticsearch.client:elasticsearch-rest-client-sniffer
+        update-types: ["version-update:semver-major"]
+      - dependency-name: co.elastic.clients:elasticsearch-java
+        update-types: ["version-update:semver-major"]
     rebase-strategy: disabled
   - package-ecosystem: gradle
     directory: "/devtools/gradle"

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,7 +100,7 @@
         <narayana-lra.version>1.0.0.Final</narayana-lra.version>
         <agroal.version>2.6</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-opensource-components.version>8.17.4</elasticsearch-opensource-components.version>
+        <elasticsearch-opensource-components.version>8.18.1</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl-java.version>2.2.5.Final</wildfly.openssl-java.version>
         <wildfly.openssl-linux.version>2.2.2.SP01</wildfly.openssl-linux.version>


### PR DESCRIPTION
this one is instead of https://github.com/quarkusio/quarkus/pull/47727

Bumping to the next major version breaks the elasticsearch-java-client tests: https://github.com/quarkusio/quarkus/pull/47391#issuecomment-2808678129

My assumption here is that we'd want to bump to the next major when there's a Hibernate Search version that can work with that major, hence I've also added the ignore rules to dependabot config. 

Let me know if this makes sense, or if instead I should just bump the container version (so the tests for elasticsearch-java-client can pass).