### PR TITLE
Ensure that `@RequestScoped` beans can be mocked

### DIFF
--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/RequestScopedFooFromProducer.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/RequestScopedFooFromProducer.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.mockbean;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.annotation.PostConstruct;
+
+public class RequestScopedFooFromProducer {
+
+    static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+
+    public String ping() {
+        return "bar";
+    }
+
+    @PostConstruct
+    void init() {
+        CONSTRUCTED.set(true);
+    }
+
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/RequestScopedProducer.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/RequestScopedProducer.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.mockbean;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.quarkus.arc.Unremovable;
+
+public class RequestScopedProducer {
+
+    @Produces
+    @RequestScoped
+    @Unremovable
+    public RequestScopedFooFromProducer produce() {
+        return new RequestScopedFooFromProducer();
+    }
+
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/RequestScopedFooMockTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/RequestScopedFooMockTest.java
@@ -15,11 +15,17 @@ class RequestScopedFooMockTest {
     @InjectMock
     RequestScopedFoo foo;
 
+    @InjectMock
+    RequestScopedFooFromProducer foo2;
+
     @Test
     void testMock() {
         when(foo.ping()).thenReturn("pong");
+        when(foo2.ping()).thenReturn("pong2");
         assertEquals("pong", foo.ping());
+        assertEquals("pong2", foo2.ping());
         assertFalse(RequestScopedFoo.CONSTRUCTED.get());
+        assertFalse(RequestScopedFooFromProducer.CONSTRUCTED.get());
     }
 
 }

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
@@ -48,6 +48,17 @@ final class MockitoMocksTracker {
         return Optional.empty();
     }
 
-    record Mocked(Object mock, Object beanInstance) {
+    // don't use a Record because we don't want the auto-generated methods which delegate to the components
+    // see https://github.com/quarkusio/quarkus/issues/47739
+    @SuppressWarnings("ClassCanBeRecord")
+    final static class Mocked {
+
+        final Object mock;
+        final Object beanInstance;
+
+        Mocked(Object mock, Object beanInstance) {
+            this.mock = mock;
+            this.beanInstance = beanInstance;
+        }
     }
 }

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
@@ -18,9 +18,9 @@ public class SetMockitoMockAsBeanMockCallback implements QuarkusTestBeforeEachCa
 
     private void installMock(MockitoMocksTracker.Mocked mocked) {
         try {
-            QuarkusMock.installMockForInstance(mocked.mock(), mocked.beanInstance());
+            QuarkusMock.installMockForInstance(mocked.mock, mocked.beanInstance);
         } catch (Exception e) {
-            throw new RuntimeException(mocked.beanInstance()
+            throw new RuntimeException(mocked.beanInstance
                     + " is not a normal scoped CDI bean, make sure the bean is a normal scope like @ApplicationScoped or @RequestScoped."
                     + " Alternatively you can use '@MockitoConfig(convertScopes = true)' in addition to '@InjectMock' if you would like"
                     + " Quarkus to automatically make that conversion (you should only use this if you understand the implications).");


### PR DESCRIPTION
- Fixes: #47739