### PR TITLE
Fail early if the access token is not returned from GitHub

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -864,10 +864,15 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                             if (isIdTokenRequired(configContext)) {
                                 LOG.errorf("ID token is not available in the authorization code grant response");
                                 return Uni.createFrom().failure(new AuthenticationCompletionException());
-                            } else {
+                            } else if (tokens.getAccessToken() != null) {
                                 tokens.setIdToken(generateInternalIdToken(configContext, null, null,
                                         tokens.getAccessTokenExpiresIn()));
                                 internalIdToken = true;
+                            } else {
+                                LOG.errorf(
+                                        "Neither ID token nor access tokens are available in the authorization code grant response."
+                                                + " Please check logs for more details, enable debug log level if no details are visible.");
+                                return Uni.createFrom().failure(new AuthenticationCompletionException());
                             }
                         } else {
                             if (!prepareNonceForVerification(context, configContext.oidcConfig(), stateBean)) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -802,6 +802,10 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
         LOG.debug("Requesting UserInfo");
         String contextAccessToken = (String) requestData.get(OidcConstants.ACCESS_TOKEN_VALUE);
+        if (contextAccessToken == null && isIdToken(request)) {
+            throw new AuthenticationCompletionException(
+                    "Authorization code flow access token which is required to get UserInfo is missing");
+        }
         final String accessToken = contextAccessToken != null ? contextAccessToken : request.getToken().getToken();
 
         UserInfoCache userInfoCache = tenantResolver.getUserInfoCache();


### PR DESCRIPTION
If GitHub provider fails to complete the authorization code flow, it will reply with 200, without the actual access token, causing a confusing error when Quarkus OIDC attempts to verify this non-existent token via the UserInfo injection...

This PR adds a couple of checks to fail early and an extra check to check the confusing error