### PR TITLE
Add a note about client secret to GitHub provider docs

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -230,6 +230,21 @@ quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Secret>
 ----
 
+[NOTE]
+====
+By default, Quarkus GitHub provider submits the client id and secret in the HTTP Authorization header.
+However, GitHub may require that both client id and secret are submitted as form parameters instead.
+When you get HTTP 401 error after logging in to GitHub and being redirected back to Quarkus MCP server,
+replace the `quarkus.oidc.credentials.secret=<Secret>` property
+with the following two properties instead:
+
+[source,properties]
+----
+quarkus.oidc.credentials.client-secret.method=post
+quarkus.oidc.credentials.client-secret.value=<Secret>
+----
+====
+
 `quarkus.oidc.provider=github` will request GitHub to add a `user:email` scope to issued access tokens. For information about overriding this scope or requesting more scopes, see the  <<provider-scope>> section.
 
 TIP: You can also send access tokens issued by GitHub to `quarkus.oidc.application-type=service` or `quarkus.oidc.application-type=hybrid` Quarkus applications.


### PR DESCRIPTION
It was confirmed when @sabre1041 was testing the secure MCP server demo. So I'm adding this note to different sources.

At the Quarkus level, it is too early to consider making it a default option, as it is not obvious if the default way of submitting GitHiub client id and secret is being deprecated or if it is a case of the legacy GitHub OAuth2 deployment...

