### PR TITLE
Copy `init-script-path` files to Oracle DevService volume

### DIFF
--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
@@ -89,7 +90,12 @@ public class OracleDevServicesProcessor {
 
                     containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                     containerConfig.getCommand().ifPresent(container::setCommand);
-                    containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
+                    if (containerConfig.getInitScriptPath().isPresent()) {
+                        for (String initScript : containerConfig.getInitScriptPath().get()) {
+                            container.withCopyFileToContainer(MountableFile.forClasspathResource(initScript),
+                                    "/container-entrypoint-startdb.d/" + initScript);
+                        }
+                    }
                     if (containerConfig.isShowLogs()) {
                         container.withLogConsumer(new JBossLoggingConsumer(LOG));
                     }


### PR DESCRIPTION
This is reported in https://github.com/testcontainers/testcontainers-java/issues/4615.

See https://github.com/gvenzl/oci-oracle-free#initialization-scripts

This is necessary so you can introduce scripts that are executed using the SYSTEM user (see below for an example).

## Instructions for giving DBA access to the Quarkus user 

1. In your application, create a SQL file named `001-init.sql` in your `src/main/resources` with the following content:
 
```sql
ALTER SESSION SET CONTAINER=quarkus;
GRANT DBA TO quarkus;
```
2. Add the following configuration to your `application.properties`: 

```properties
quarkus.datasource.devservices.init-script-path=001-init.sql
```

- Fixes #47743 