### PR TITLE
Introduce new assistant module

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -605,7 +605,26 @@
             </dependency>
 
             <!-- Quarkus libraries -->
-
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-assistant</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-assistant-dev</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-assistant-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-assistant-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-caffeine</artifactId>
@@ -1917,6 +1936,7 @@
                 <artifactId>quarkus-smallrye-graphql</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-graphql-deployment</artifactId>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -13,6 +13,11 @@ public interface Capability {
     String AGROAL = QUARKUS_PREFIX + ".agroal";
 
     /**
+     * An assistant implementation
+     */
+    String ASSISTANT = QUARKUS_PREFIX + ".assistant";
+
+    /**
      * JSR 365 compatible contexts and dependency injection
      */
     String CDI = QUARKUS_PREFIX + ".cdi";

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/DevConsoleManager.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/DevConsoleManager.java
@@ -5,13 +5,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.quarkus.dev.spi.HotReplacementContext;
 
 public class DevConsoleManager {
-
+    public static volatile String DEV_MANAGER_GLOBALS_ASSISTANT = "_assistant";
     private static volatile Consumer<DevConsoleRequest> handler;
     private static volatile Map<String, Map<String, Object>> templateInfo;
     private static volatile HotReplacementContext hotReplacementContext;
@@ -25,18 +26,18 @@ public class DevConsoleManager {
      * <p>
      * As the class loaders are different these objects will generally need to implement some kind of common interface
      */
-    private static Map<String, Object> globals = new ConcurrentHashMap<>();
+    private static final Map<String, Object> globals = new ConcurrentHashMap<>();
 
     public static void registerHandler(Consumer<DevConsoleRequest> requestHandler) {
         handler = requestHandler;
     }
 
     public static void sentRequest(DevConsoleRequest request) {
-        Consumer<DevConsoleRequest> handler = DevConsoleManager.handler;
-        if (handler == null) {
+        Consumer<DevConsoleRequest> h = DevConsoleManager.handler;
+        if (h == null) {
             request.getResponse().complete(new DevConsoleResponse(503, Collections.emptyMap(), new byte[0])); //service unavailable
         } else {
-            handler.accept(request);
+            h.accept(request);
         }
     }
 
@@ -98,6 +99,7 @@ public class DevConsoleManager {
         hotReplacementContext = null;
         quarkusBootstrap = null;
         actions.clear();
+        assistantActions.clear();
         globals.clear();
     }
 
@@ -106,6 +108,7 @@ public class DevConsoleManager {
      * The action registered here should be used with the Dev UI / JSON RPC services.
      */
     private static final Map<String, Function<Map<String, String>, ?>> actions = new HashMap<>();
+    private static final Map<String, BiFunction<Object, Map<String, String>, ?>> assistantActions = new HashMap<>();
 
     /**
      * Registers an action that will be called by a JSON RPC service at runtime
@@ -117,6 +120,19 @@ public class DevConsoleManager {
      */
     public static <T> void register(String name, Function<Map<String, String>, T> action) {
         actions.put(name, action);
+    }
+
+    /**
+     * Registers an action that will be called by a JSON RPC service at runtime, this action will include the assistant if
+     * available
+     *
+     * @param name the name of the action, should be namespaced to avoid conflicts
+     * @param action the action. The function receives a Map as parameters (named parameters) and returns an object of type
+     *        {@code T}.
+     *        Note that the type {@code T} must be a class shared by both the deployment and the runtime.
+     */
+    public static <T> void register(String name, BiFunction<Object, Map<String, String>, T> action) {
+        assistantActions.put(name, action);
     }
 
     /**
@@ -141,7 +157,18 @@ public class DevConsoleManager {
     public static <T> T invoke(String name, Map<String, String> params) {
         var function = actions.get(name);
         if (function == null) {
-            throw new NoSuchElementException(name);
+            // Try assistant actions
+            var bifunction = assistantActions.get(name);
+            if (bifunction != null) {
+                Object assistant = DevConsoleManager.getGlobal(DEV_MANAGER_GLOBALS_ASSISTANT);
+                if (assistant != null) {
+                    return (T) bifunction.apply(assistant, params);
+                } else {
+                    throw new RuntimeException("Assistant not available");
+                }
+            } else {
+                throw new NoSuchElementException(name);
+            }
         } else {
             return (T) function.apply(params);
         }

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -228,6 +228,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-assistant</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-avro</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -237,6 +237,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-avro-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/assistant/deployment-spi/pom.xml
+++ b/extensions/assistant/deployment-spi/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-assistant-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-assistant-deployment-spi</artifactId>
+    <name>Quarkus - Assistant - Deployment SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant-dev</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
+        </dependency>
+        
+        
+    </dependencies>
+
+</project>

--- a/extensions/assistant/deployment-spi/src/main/java/io/quarkus/assistant/deployment/spi/AssistantConsoleBuildItem.java
+++ b/extensions/assistant/deployment-spi/src/main/java/io/quarkus/assistant/deployment/spi/AssistantConsoleBuildItem.java
@@ -1,0 +1,168 @@
+package io.quarkus.assistant.deployment.spi;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.quarkus.assistant.runtime.dev.Assistant;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.console.ConsoleCommand;
+import io.quarkus.deployment.dev.testing.MessageFormat;
+
+/**
+ * Add a menu item in the Assistant console menu
+ *
+ * Extensions can produce this to add a item under the Assistant heading in the console
+ * This will only appear in the console if the assistant is available
+ */
+public final class AssistantConsoleBuildItem extends MultiBuildItem {
+    private final ConsoleCommand consoleCommand;
+
+    private final String description;
+    private final char key;
+    private final Optional<String> systemMessage;
+    private final String userMessage;
+    private final Supplier<String> colorSupplier;
+    private final Supplier<String> stateSupplier;
+    private final Map<String, String> variables;
+    private final Optional<Function<Assistant, CompletionStage<?>>> function;
+
+    public AssistantConsoleBuildItem(ConsoleCommand consoleCommand) {
+        this.consoleCommand = consoleCommand;
+        this.function = Optional.empty();
+        this.description = consoleCommand.getDescription();
+        this.key = consoleCommand.getKey();
+        this.systemMessage = Optional.empty();
+        this.userMessage = null;
+        this.colorSupplier = consoleCommand.getHelpState().getColorSupplier();
+        this.stateSupplier = consoleCommand.getHelpState().getStateSupplier();
+        this.variables = Map.of();
+    }
+
+    private AssistantConsoleBuildItem(Builder builder) {
+        this.description = builder.description;
+        this.key = builder.key;
+        this.systemMessage = builder.systemMessage;
+        this.userMessage = builder.userMessage;
+        this.colorSupplier = builder.colorSupplier;
+        this.stateSupplier = builder.stateSupplier;
+        this.variables = builder.variables;
+        this.consoleCommand = null;
+        this.function = builder.function;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String description;
+        private char key = Character.MIN_VALUE;
+        private Optional<String> systemMessage = Optional.empty();
+        private String userMessage;
+        private Supplier<String> colorSupplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                return MessageFormat.RESET;
+            }
+        };
+        private Supplier<String> stateSupplier = null;
+        private Map<String, String> variables = Map.of();
+        private Optional<Function<Assistant, CompletionStage<?>>> function = Optional.empty();
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder key(char key) {
+            this.key = key;
+            return this;
+        }
+
+        public Builder systemMessage(String systemMessage) {
+            this.systemMessage = Optional.of(systemMessage);
+            return this;
+        }
+
+        public Builder userMessage(String userMessage) {
+            this.userMessage = userMessage;
+            return this;
+        }
+
+        public Builder colorSupplier(Supplier<String> colorSupplier) {
+            this.colorSupplier = colorSupplier;
+            return this;
+        }
+
+        public Builder stateSupplier(Supplier<String> stateSupplier) {
+            this.stateSupplier = stateSupplier;
+            return this;
+        }
+
+        public Builder variables(Map<String, String> variables) {
+            this.variables = variables;
+            return this;
+        }
+
+        public Builder function(Function<Assistant, CompletionStage<?>> function) {
+            this.function = Optional.of(function);
+            return this;
+        }
+
+        public AssistantConsoleBuildItem build() {
+            if (key == Character.MIN_VALUE) {
+                throw new IllegalStateException(
+                        "You have to specify a key. This is the key the user will press to get to your function");
+            }
+            if (description == null || description.isBlank()) {
+                throw new IllegalStateException(
+                        "You have to specify a description. This is what the user will see in the console menu");
+            }
+            if (userMessage == null && !function.isPresent()) {
+                throw new IllegalStateException(
+                        "You have to specify userMessage that will be send to AI, or implement your own using the function");
+            }
+
+            return new AssistantConsoleBuildItem(this);
+        }
+    }
+
+    public ConsoleCommand getConsoleCommand() {
+        return consoleCommand;
+    }
+
+    public String getDescription() {
+        return consoleCommand != null ? consoleCommand.getDescription() : description;
+    }
+
+    public char getKey() {
+        return key;
+    }
+
+    public Optional<String> getSystemMessage() {
+        return systemMessage;
+    }
+
+    public String getUserMessage() {
+        return userMessage;
+    }
+
+    public Supplier<String> getColorSupplier() {
+        return consoleCommand != null ? consoleCommand.getHelpState().getColorSupplier() : colorSupplier;
+    }
+
+    public Supplier<String> getStateSupplier() {
+        return consoleCommand != null ? consoleCommand.getHelpState().getStateSupplier() : stateSupplier;
+    }
+
+    public Map<String, String> getVariables() {
+        return variables;
+    }
+
+    public Optional<Function<Assistant, CompletionStage<?>>> getFunction() {
+        return function;
+    }
+}

--- a/extensions/assistant/deployment-spi/src/main/java/io/quarkus/assistant/deployment/spi/AssistantPageBuildItem.java
+++ b/extensions/assistant/deployment-spi/src/main/java/io/quarkus/assistant/deployment/spi/AssistantPageBuildItem.java
@@ -1,0 +1,26 @@
+package io.quarkus.assistant.deployment.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.devui.spi.page.PageBuilder;
+
+public final class AssistantPageBuildItem extends MultiBuildItem {
+    private final PageBuilder pageBuilder;
+    private final boolean alwaysVisible;
+
+    public AssistantPageBuildItem(PageBuilder pageBuilder) {
+        this(pageBuilder, false);
+    }
+
+    public AssistantPageBuildItem(PageBuilder pageBuilder, boolean alwaysVisible) {
+        this.pageBuilder = pageBuilder;
+        this.alwaysVisible = alwaysVisible;
+    }
+
+    public PageBuilder getPageBuilder() {
+        return pageBuilder;
+    }
+
+    public boolean isAlwaysVisible() {
+        return alwaysVisible;
+    }
+}

--- a/extensions/assistant/deployment/pom.xml
+++ b/extensions/assistant/deployment/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-assistant-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-assistant-deployment</artifactId>
+    <name>Quarkus - Assistant - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant-deployment-spi</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        
+        <!-- Test -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/assistant/pom.xml
+++ b/extensions/assistant/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-assistant-parent</artifactId>
+    <name>Quarkus - Assistant</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+        <module>deployment-spi</module>
+        <module>runtime-dev</module>
+    </modules>
+
+</project>

--- a/extensions/assistant/runtime-dev/pom.xml
+++ b/extensions/assistant/runtime-dev/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-assistant-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-assistant-dev</artifactId>
+    <name>Quarkus - Assistant - Runtime Dev mode</name>
+    <description>Assistant for Quarkus - Dev mode only</description>
+
+</project>

--- a/extensions/assistant/runtime-dev/src/main/java/io/quarkus/assistant/runtime/dev/Assistant.java
+++ b/extensions/assistant/runtime-dev/src/main/java/io/quarkus/assistant/runtime/dev/Assistant.java
@@ -1,0 +1,158 @@
+package io.quarkus.assistant.runtime.dev;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * This is the Assistant for Quarkus Dev Mode. The actual implementation will be provided by another extension (eg. Chappie)
+ */
+public interface Assistant {
+
+    /**
+     * Check if the assistant is available
+     *
+     * @return true id there is an implementation that is configured and connected
+     */
+    public boolean isAvailable();
+
+    /**
+     * Explain and suggest a fix for an exception in the user code
+     *
+     * @param <T>
+     * @param systemMessage System wide context
+     * @param userMessage User specific context
+     * @param stacktrace The exception stacktrace
+     * @param path The path to the effective class causing this exception
+     * @return
+     */
+    <T> CompletionStage<T> exception(Optional<String> systemMessage, String userMessage, String stacktrace,
+            Path path);
+
+    /**
+     * Assist the developer with something
+     *
+     * @param <T> The response
+     * @param systemMessageTemplate System wide context
+     * @param userMessageTemplate User specific context
+     * @param variables variables that can be used in the templates
+     * @param paths Paths to workspace files (optional)
+     * @return
+     */
+    <T> CompletionStage<T> assist(Optional<String> systemMessageTemplate,
+            String userMessageTemplate,
+            Map<String, String> variables, List<Path> paths);
+
+    default ExceptionBuilder exceptionBuilder() {
+        return new ExceptionBuilder(this);
+    }
+
+    default AssistBuilder assistBuilder() {
+        return new AssistBuilder(this);
+    }
+
+    // Builder class
+    class AssistBuilder {
+        private final Assistant assistant;
+        private Optional<String> systemMessage = Optional.empty();
+        private String userMessage;
+        private final Map<String, String> variables = new LinkedHashMap<>();
+        private final List<Path> paths = new ArrayList<>();
+
+        AssistBuilder(Assistant assistant) {
+            this.assistant = assistant;
+        }
+
+        public AssistBuilder systemMessage(String systemMessage) {
+            this.systemMessage = Optional.ofNullable(systemMessage);
+            return this;
+        }
+
+        public AssistBuilder userMessage(String userMessage) {
+            this.userMessage = userMessage;
+            return this;
+        }
+
+        public AssistBuilder variables(Map<String, String> variables) {
+            if (variables != null) {
+                this.variables.putAll(variables);
+            }
+            return this;
+        }
+
+        public AssistBuilder addVariable(String key, String value) {
+            if (key != null && value != null) {
+                this.variables.put(key, value);
+            }
+            return this;
+        }
+
+        public AssistBuilder paths(List<Path> paths) {
+            if (paths != null) {
+                this.paths.addAll(paths);
+            }
+            return this;
+        }
+
+        public AssistBuilder addPath(Path path) {
+            if (path != null) {
+                this.paths.add(path);
+            }
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> CompletionStage<T> assist() {
+            if (userMessage == null || userMessage.isBlank()) {
+                throw new IllegalStateException("User message is required");
+            }
+            return (CompletionStage<T>) assistant.assist(systemMessage, userMessage, variables, paths);
+        }
+    }
+
+    class ExceptionBuilder {
+        private final Assistant assistant;
+
+        private Optional<String> systemMessage = Optional.empty();
+        private String userMessage;
+        private String stacktrace;
+        private Path path;
+
+        ExceptionBuilder(Assistant assistant) {
+            this.assistant = assistant;
+        }
+
+        public ExceptionBuilder systemMessage(String systemMessage) {
+            this.systemMessage = Optional.ofNullable(systemMessage);
+            return this;
+        }
+
+        public ExceptionBuilder userMessage(String userMessage) {
+            this.userMessage = userMessage;
+            return this;
+        }
+
+        public ExceptionBuilder stacktrace(String stacktrace) {
+            this.stacktrace = stacktrace;
+            return this;
+        }
+
+        public ExceptionBuilder path(Path path) {
+            this.path = path;
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> CompletionStage<T> explain() {
+            if (userMessage == null || stacktrace == null || path == null) {
+                throw new IllegalStateException("userMessage, stacktrace, and path must be provided");
+            }
+            return (CompletionStage<T>) assistant.exception(systemMessage, userMessage, stacktrace, path);
+        }
+    }
+
+}

--- a/extensions/assistant/runtime/pom.xml
+++ b/extensions/assistant/runtime/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-assistant-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-assistant</artifactId>
+    <name>Quarkus - Assistant - Runtime</name>
+    <description>AI Assistant for Quarkus Dev mode</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <conditionalDevDependencies>
+                        <artifact>${project.groupId}:${project.artifactId}-dev:${project.version}</artifact>
+                    </conditionalDevDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -225,7 +225,7 @@
 
         <!-- JMS -->
         <module>jms-spi</module>
-
+        <module>assistant</module>
     </modules>
 
     <build>

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -53,7 +53,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-spi</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant-deployment-spi</artifactId>
+        </dependency>
         <!-- Dev UI -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -113,6 +113,8 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("qwc-extension-link", contextRoot + "qwc/qwc-extension-link.js");
         // Quarkus UI
         internalImportMapBuildItem.add("qui-ide-link", contextRoot + "qui/qui-ide-link.js");
+        internalImportMapBuildItem.add("qui-assistant-warning", contextRoot + "qui/qui-assistant-warning.js");
+        internalImportMapBuildItem.add("qui-assistant-button", contextRoot + "qui/qui-assistant-button.js");
 
         // Echarts
         internalImportMapBuildItem.add("echarts/", contextRoot + "echarts/");
@@ -138,6 +140,7 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("state/", contextRoot + "state/");
         internalImportMapBuildItem.add("theme-state", contextRoot + "state/theme-state.js");
         internalImportMapBuildItem.add("connection-state", contextRoot + "state/connection-state.js");
+        internalImportMapBuildItem.add("assistant-state", contextRoot + "state/assistant-state.js");
         internalImportMapBuildItem.add("devui-state", contextRoot + "state/devui-state.js");
 
         return internalImportMapBuildItem;
@@ -218,8 +221,10 @@ public class BuildTimeContentProcessor {
                 String fullName = extensionPathName + "." + bta.getMethodName();
                 if (bta.hasRuntimeValue()) {
                     recordedValues.put(fullName, bta.getRuntimeValue());
-                } else {
+                } else if (bta.hasAction()) {
                     DevConsoleManager.register(fullName, bta.getAction());
+                } else if (bta.hasAssistantAction()) {
+                    DevConsoleManager.register(fullName, bta.getAssistantAction());
                 }
                 methodNames.add(fullName);
             }
@@ -227,8 +232,10 @@ public class BuildTimeContentProcessor {
                 String fullName = extensionPathName + "." + bts.getMethodName();
                 if (bts.hasRuntimeValue()) {
                     recordedValues.put(fullName, bts.getRuntimeValue());
-                } else {
+                } else if (bts.hasAction()) {
                     DevConsoleManager.register(fullName, bts.getAction());
+                } else if (bts.hasAssistantAction()) {
+                    DevConsoleManager.register(fullName, bts.getAssistantAction());
                 }
                 subscriptionNames.add(fullName);
             }
@@ -450,7 +457,7 @@ public class BuildTimeContentProcessor {
         addThemeBuildTimeData(internalBuildTimeData, devUIConfig, themeVarsProducer);
         addMenuSectionBuildTimeData(internalBuildTimeData, internalPages, extensionsBuildItem);
         addFooterTabBuildTimeData(internalBuildTimeData, extensionsBuildItem, devUIConfig);
-        addVersionInfoBuildTimeData(internalBuildTimeData, curateOutcomeBuildItem, nonApplicationRootPathBuildItem);
+        addApplicationInfoBuildTimeData(internalBuildTimeData, curateOutcomeBuildItem, nonApplicationRootPathBuildItem);
         addIdeBuildTimeData(internalBuildTimeData, effectiveIdeBuildItem, launchModeBuildItem);
         buildTimeConstProducer.produce(internalBuildTimeData);
     }
@@ -558,7 +565,7 @@ public class BuildTimeContentProcessor {
         internalBuildTimeData.addBuildTimeData("loggerLevels", LEVELS);
     }
 
-    private void addVersionInfoBuildTimeData(BuildTimeConstBuildItem internalBuildTimeData,
+    private void addApplicationInfoBuildTimeData(BuildTimeConstBuildItem internalBuildTimeData,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
 
@@ -710,6 +717,9 @@ public class BuildTimeContentProcessor {
 
         light.put("--quarkus-center", QUARKUS_DARK.toString());
         dark.put("--quarkus-center", QUARKUS_LIGHT.toString());
+
+        light.put("--quarkus-assistant", QUARKUS_ASSISTANT.toString());
+        dark.put("--quarkus-assistant", QUARKUS_ASSISTANT.toString());
     }
 
     /**
@@ -1171,6 +1181,7 @@ public class BuildTimeContentProcessor {
     private static final Color QUARKUS_RED = Color.from(4, 90, 58);
     private static final Color QUARKUS_DARK = Color.from(0, 0, 13);
     private static final Color QUARKUS_LIGHT = Color.from(0, 0, 100);
+    private static final Color QUARKUS_ASSISTANT = Color.from(320, 100, 71);
 
     private static String getThemeSettingOrDefault(Optional<DevUIConfig.Theme> theme,
             Function<DevUIConfig.Theme, Optional<DevUIConfig.ThemeMode>> themeModeExtractor,

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/router-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/router-controller.js
@@ -163,6 +163,10 @@ export class RouterController {
         Router.go({pathname: pageRef});
     }
 
+    navigate(pageRef){
+        Router.go(pageRef);
+    }
+
     getFirstPageUrl(){
         for (let entry of RouterController.pageMap) {
             let value = entry[1];

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qui/qui-assistant-button.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qui/qui-assistant-button.js
@@ -1,0 +1,52 @@
+import {LitElement, html, css} from 'lit';
+import '@vaadin/button';
+import '@vaadin/icon';
+
+export class QuiAssistantButton extends LitElement {
+
+    static styles = css`
+        vaadin-button {
+            color: var(--quarkus-assistant);
+            --lumo-button-size: var(--lumo-size-s);
+            background: var(--vaadin-button-tertiary-background);
+            --vaadin-button-min-width: 0;
+        }
+    `;
+
+    static properties = {
+        disabled: { type: Boolean, reflect: true },
+        title: { type: String }
+    };
+
+    constructor() {
+        super();
+        this.disabled = false;
+        this.title = '';
+    }
+    
+    connectedCallback() {
+        super.connectedCallback();
+    }
+
+    render() {
+        return html`
+            <vaadin-button
+                ?disabled=${this.disabled}
+                title=${this.title}
+                @click=${(e) => this._handleClick(e)}>
+                    <vaadin-icon icon="font-awesome-solid:brain"></vaadin-icon>
+                    <slot></slot>
+            </vaadin-button>
+          `;
+    }
+    
+    _handleClick(e) {
+        this.dispatchEvent(new CustomEvent('click', {
+            detail: e,
+            bubbles: true,
+            composed: true
+        }));
+    }
+}
+
+customElements.define('qui-assistant-button', QuiAssistantButton);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qui/qui-assistant-warning.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qui/qui-assistant-warning.js
@@ -1,0 +1,28 @@
+import {LitElement, html, css} from 'lit';
+import '@qomponent/qui-badge';
+
+export class QuiAssistantWarning extends LitElement {
+
+    static styles = css``;
+
+    static properties = {
+        warning: {type: String}
+    };
+
+    constructor() {
+        super();
+        this.warning = "Quarkus assistant can make mistakes. Check responses.";
+    }
+    
+    connectedCallback() {
+        super.connectedCallback();
+    }
+
+    render() {
+        return html`<qui-badge style="padding-left: 20px;" text="Warning" level="contrast" color="var(--quarkus-assistant)" icon="brain" tiny>
+                            <span>${this.warning}</span>
+                        </qui-badge>`;
+    }
+}
+
+customElements.define('qui-assistant-warning', QuiAssistantWarning);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension-link.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension-link.js
@@ -44,7 +44,6 @@ export class QwcExtensionLink extends QwcHotReloadElement {
             flex-direction: row;
             justify-content: flex-start;
             align-items: center;
-            color: var(--lumo-contrast-80pct);
         }
     `;
 
@@ -52,6 +51,8 @@ export class QwcExtensionLink extends QwcHotReloadElement {
         namespace: {type: String},
         extensionName: {type: String},
         iconName: {type: String},
+        colorName: {type: String},
+        tooltipContent: {type: String},
         displayName: {type: String},
         staticLabel: {type: String},
         dynamicLabel: {type: String},
@@ -190,8 +191,8 @@ export class QwcExtensionLink extends QwcHotReloadElement {
     renderLink(linkRef, routerIgnore, target){
         if(linkRef){
             return html`
-                <a class="extensionLink" href="${linkRef}" ?router-ignore=${routerIgnore} target="${target}">
-                    <span class="iconAndName">
+                <a class="extensionLink" href="${linkRef}" ?router-ignore=${routerIgnore} target="${target}" title="${this.tooltipContent}">
+                    <span class="iconAndName" style="color:${this.colorName};">
                         <vaadin-icon class="icon" icon="${this.iconName}"></vaadin-icon>
                         ${this.displayName}
                     </span>

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -301,6 +301,8 @@ export class QwcExtensions extends observeState(LitElement) {
                                 namespace="${extension.namespace}"
                                 extensionName="${extension.name}"
                                 iconName="${page.icon}"
+                                tooltipContent="${page.tooltip}"
+                                colorName="${page.color}"
                                 displayName="${page.title}"
                                 staticLabel="${page.staticLabel}"
                                 dynamicLabel="${page.dynamicLabel}"

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
@@ -9,6 +9,7 @@ import '@vaadin/tabs';
 import '@vaadin/confirm-dialog';
 import '@vaadin/popover';
 import '@vaadin/vertical-layout';
+import 'qui-assistant-warning';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
 import 'qwc/qwc-extension-link.js';
 import './qwc-theme-switch.js';
@@ -102,6 +103,7 @@ export class QwcHeader extends observeState(LitElement) {
     static properties = {
         _title: {state: true},
         _subTitle: {state: true},
+        _showWarning: {state: true},
         _rightSideNav: {state: true},
         _dialogOpened: {state: true},
     };
@@ -111,6 +113,7 @@ export class QwcHeader extends observeState(LitElement) {
         this._dialogOpened = false;
         this._title = "Extensions";
         this._subTitle = null;
+        this._showWarning = false;
         this._rightSideNav = "";
         
         window.addEventListener('vaadin-router-location-changed', (event) => {
@@ -180,9 +183,15 @@ export class QwcHeader extends observeState(LitElement) {
     _renderTitle(){
         let dot = "\u00B7";
         if(this._subTitle){
-            return html`<span class="title">${this._title}</span><span class="subtitle">${dot} ${this._subTitle}</span>`;
+            return html`<span class="title">${this._title}</span><span class="subtitle">${dot} ${this._subTitle} ${this._renderWarning()}</span>`;
         }else{
             return html`<span class="title">${this._title}</span>`;
+        }
+    }
+
+    _renderWarning(){
+        if(this._showWarning){
+            return html`<qui-assistant-warning></qui-assistant-warning>`;
         }
     }
 
@@ -223,9 +232,16 @@ export class QwcHeader extends observeState(LitElement) {
 
     _updateHeader(event){
         let currentPage = this.routerController.getCurrentPage();
+        
         this._selectedPageIsMax = !currentPage.includeInMenu; // TODO: introduce new property called isMaxView ?
         this._title = this.routerController.getCurrentTitle();
         this._subTitle = this.routerController.getCurrentSubTitle();
+        if(currentPage.assistantPage) {
+            this._showWarning = true;
+        }else{
+            this._showWarning = false;
+        }
+        
         var subMenu = this.routerController.getCurrentSubMenu();
         if(subMenu){
             this._rightSideNav = html`<vaadin-tabs selected="${subMenu.index}">
@@ -268,6 +284,8 @@ export class QwcHeader extends observeState(LitElement) {
             namespace="${link.page.namespace}"
             extensionName="${link.page.extensionId}"
             iconName="${link.page.icon}"
+            tooltipContent="${link.page.tooltip}"
+            colorName="${link.page.color}"
             displayName="${link.page.title}"
             staticLabel="${link.page.staticLabel}"
             dynamicLabel="${link.page.dynamicLabel}"

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/state/assistant-state.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/state/assistant-state.js
@@ -1,0 +1,47 @@
+import { LitState } from 'lit-element-state';
+
+/**
+ * This keeps state of the Assistant
+ */
+class AssistantState extends LitState {
+    
+    constructor() {
+        super();
+        this.notAvailable();
+    }
+
+    static get stateVars() {
+        return {
+            current: {}
+        };
+    }
+    
+    notAvailable(){
+        const newState = new Object();
+        newState.name = "notAvailable";
+        newState.message = "No assistant is available";
+        newState.isAvailable = false;
+        newState.isConfigured = false;
+        this.current = newState;
+    }
+    
+    available(){
+        const newState = new Object();
+        newState.name = "available";
+        newState.message = "Assistant is available, but not configured";
+        newState.isAvailable = true;
+        newState.isConfigured = false;
+        this.current = newState;
+    }
+    
+    ready(){
+        const newState = new Object();
+        newState.name = "ready";
+        newState.message = "Assistant is available, and configured";
+        newState.isAvailable = true;
+        newState.isConfigured = true;
+        this.current = newState;
+    }
+}
+
+export const assistantState = new AssistantState();

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeAction.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeAction.java
@@ -1,6 +1,7 @@
 package io.quarkus.devui.spi.buildtime;
 
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import io.quarkus.runtime.RuntimeValue;
@@ -13,6 +14,7 @@ public class BuildTimeAction {
 
     private final String methodName;
     private final Function<Map<String, String>, ?> action;
+    private final BiFunction<Object, Map<String, String>, ?> assistantAction;
     private final RuntimeValue runtimeValue;
 
     protected <T> BuildTimeAction(String methodName,
@@ -20,6 +22,16 @@ public class BuildTimeAction {
 
         this.methodName = methodName;
         this.action = action;
+        this.assistantAction = null;
+        this.runtimeValue = null;
+    }
+
+    protected <T> BuildTimeAction(String methodName,
+            BiFunction<Object, Map<String, String>, T> assistantAction) {
+
+        this.methodName = methodName;
+        this.action = null;
+        this.assistantAction = assistantAction;
         this.runtimeValue = null;
     }
 
@@ -28,6 +40,7 @@ public class BuildTimeAction {
 
         this.methodName = methodName;
         this.action = null;
+        this.assistantAction = null;
         this.runtimeValue = runtimeValue;
     }
 
@@ -37,6 +50,18 @@ public class BuildTimeAction {
 
     public Function<Map<String, String>, ?> getAction() {
         return action;
+    }
+
+    public boolean hasAction() {
+        return this.action != null;
+    }
+
+    public BiFunction<Object, Map<String, String>, ?> getAssistantAction() {
+        return assistantAction;
+    }
+
+    public boolean hasAssistantAction() {
+        return this.assistantAction != null;
     }
 
     public RuntimeValue getRuntimeValue() {

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkus.devui.spi.buildtime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import io.quarkus.devui.spi.AbstractDevUIBuildItem;
@@ -24,12 +25,17 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
         super(customIdentifier);
     }
 
-    public void addAction(BuildTimeAction buildTimeAction) {
+    private void addAction(BuildTimeAction buildTimeAction) {
         this.actions.add(buildTimeAction);
     }
 
     public <T> void addAction(String methodName,
             Function<Map<String, String>, T> action) {
+        this.addAction(new BuildTimeAction(methodName, action));
+    }
+
+    public <T> void addAssistantAction(String methodName,
+            BiFunction<Object, Map<String, String>, T> action) {
         this.addAction(new BuildTimeAction(methodName, action));
     }
 

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
@@ -1,8 +1,10 @@
 package io.quarkus.devui.spi.page;
 
-import io.quarkus.logging.Log;
+import org.jboss.logging.Logger;
 
 public class ExternalPageBuilder extends PageBuilder<ExternalPageBuilder> {
+    private static final Logger log = Logger.getLogger(ExternalPageBuilder.class);
+
     private static final String QWC_EXTERNAL_PAGE_JS = "qwc-external-page.js";
     private static final String EXTERNAL_URL = "externalUrl";
     private static final String DYNAMIC_URL = "dynamicUrlMethodName";
@@ -66,7 +68,7 @@ public class ExternalPageBuilder extends PageBuilder<ExternalPageBuilder> {
             throw new RuntimeException("Invalid mimeType, can not be empty");
         }
         if (super.metadata.containsKey(MIME_TYPE)) {
-            Log.warn("MimeType already set to " + super.metadata.get(MIME_TYPE) + ", overriding with new value");
+            log.warn("MimeType already set to " + super.metadata.get(MIME_TYPE) + ", overriding with new value");
         }
         super.metadata.put(MIME_TYPE, mimeType);
         return this;

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
@@ -14,6 +14,8 @@ import java.util.Map;
  */
 public class Page {
     private final String icon; // Any font awesome icon
+    private final String color; // The color of the link and icon
+    private final String tooltip; // Add a tooltip to the link
     private final String title; // This is the display name and link title for the page
     private final String staticLabel; // This is optional extra info that might be displayed next to the link
     private final String dynamicLabel; // This is optional extra info that might be displayed next to the link. This will override above static label. This expects a jsonRPC method name
@@ -34,6 +36,8 @@ public class Page {
     private String menuActionComponent = null; // Internal pages can set this
 
     protected Page(String icon,
+            String color,
+            String tooltip,
             String title,
             String staticLabel,
             String dynamicLabel,
@@ -49,6 +53,8 @@ public class Page {
             String extensionId) {
 
         this.icon = icon;
+        this.color = color;
+        this.tooltip = tooltip;
         this.title = title;
         this.staticLabel = staticLabel;
         this.dynamicLabel = dynamicLabel;
@@ -111,6 +117,19 @@ public class Page {
         return icon;
     }
 
+    public String getColor() {
+        return color;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public boolean isAssistantPage() {
+        return this.metadata != null && this.metadata.containsKey("isAssistantPage")
+                && this.metadata.get("isAssistantPage").equalsIgnoreCase("true");
+    }
+
     public String getTitle() {
         return title;
     }
@@ -167,6 +186,8 @@ public class Page {
     public String toString() {
         return "Page {\n\tid=" + getId()
                 + ", \n\ticon=" + icon
+                + ", \n\tcolor=" + color
+                + ", \n\ttooltip=" + tooltip
                 + ", \n\ttitle=" + title
                 + ", \n\tstaticLabel=" + staticLabel
                 + ", \n\tdynamicLabel=" + dynamicLabel
@@ -185,6 +206,15 @@ public class Page {
      */
     public static WebComponentPageBuilder webComponentPageBuilder() {
         return new WebComponentPageBuilder();
+    }
+
+    /**
+     * Here you provide the Web Component that should be rendered. You have full control over the page.
+     * You can use build time data if you made it available
+     */
+    public static WebComponentPageBuilder assistantPageBuilder() {
+        return new WebComponentPageBuilder("font-awesome-solid:brain", "var(--lumo-warning-color)",
+                "This uses the Quarkus Assistant feature");
     }
 
     /**

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
@@ -3,7 +3,11 @@ package io.quarkus.devui.spi.page;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.logging.Logger;
+
 public abstract class PageBuilder<T> {
+    private static final Logger log = Logger.getLogger(PageBuilder.class);
+
     protected static final String EMPTY = "";
     protected static final String SPACE = " ";
     protected static final String DASH = "-";
@@ -12,7 +16,9 @@ public abstract class PageBuilder<T> {
     protected static final String QWC_DASH = "qwc-";
     protected static final String DOT_JS = DOT + JS;
 
-    protected String icon = "font-awesome-solid:arrow-right";
+    protected String icon = null;
+    protected String color = null;
+    protected String tooltip = null;
     protected String title = null;
     protected String staticLabel = null;
     protected String dynamicLabel = null;
@@ -28,9 +34,44 @@ public abstract class PageBuilder<T> {
     protected String extensionId = null;
     protected Class preprocessor = null;
 
+    protected PageBuilder() {
+        this("font-awesome-solid:arrow-right", "var(--lumo-contrast-80pct)", null, false);
+    }
+
+    protected PageBuilder(String icon, String color, String tooltip, boolean assistantPage) {
+        this.icon = icon;
+        this.color = color;
+        this.tooltip = tooltip;
+        if (assistantPage) {
+            metadata("isAssistantPage", "true");
+        }
+    }
+
     @SuppressWarnings("unchecked")
     public T icon(String icon) {
-        this.icon = icon;
+        if (this.icon != null) {
+            this.icon = icon;
+        } else {
+            log.warn("Icon already set, ignoring " + icon);
+        }
+        return (T) this;
+    }
+
+    public T color(String color) {
+        if (this.color != null) {
+            this.color = color;
+        } else {
+            log.warn("Color already set, ignoring " + color);
+        }
+        return (T) this;
+    }
+
+    public T tooltip(String tooltip) {
+        if (this.tooltip != null) {
+            this.tooltip = tooltip;
+        } else {
+            log.warn("Tooltip already set, ignoring " + tooltip);
+        }
         return (T) this;
     }
 
@@ -129,6 +170,8 @@ public abstract class PageBuilder<T> {
         }
 
         Page page = new Page(icon,
+                color,
+                tooltip,
                 title,
                 staticLabel,
                 dynamicLabel,

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/WebComponentPageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/WebComponentPageBuilder.java
@@ -6,6 +6,10 @@ public class WebComponentPageBuilder extends PageBuilder<WebComponentPageBuilder
         super();
     }
 
+    protected WebComponentPageBuilder(String icon, String color, String tooltip) {
+        super(icon, color, tooltip, true);
+    }
+
     public WebComponentPageBuilder componentName(String componentName) {
         if (componentName == null || componentName.isEmpty()) {
             throw new RuntimeException("Invalid component [" + componentName + "]");

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/workspace/Action.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/workspace/Action.java
@@ -5,6 +5,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -18,6 +19,7 @@ public class Action<T, R> {
     private final String label; // This is the label in the dropdown
     private final String namespace; // The namespace of the extension
     private final Function<T, R> function; // The function to call when the user select it
+    private final BiFunction<Object, T, R> assistantFunction; // The assistant function to call when the user select it
     private final Optional<Pattern> filter; // Filter to only apply on certain files
     private final Display display; // Response display for the UI
     private final DisplayType displayType; // Response display type
@@ -27,6 +29,7 @@ public class Action<T, R> {
             String label,
             String namespace,
             Function<T, R> function,
+            BiFunction<Object, T, R> assistantFunction,
             Optional<Pattern> filter,
             Display display,
             DisplayType displayType,
@@ -35,6 +38,7 @@ public class Action<T, R> {
         this.label = label;
         this.namespace = namespace;
         this.function = function;
+        this.assistantFunction = assistantFunction;
         this.filter = filter;
         this.display = display;
         this.displayType = displayType;
@@ -67,6 +71,10 @@ public class Action<T, R> {
         return this.function;
     }
 
+    public BiFunction<Object, T, R> getAssistantFunction() {
+        return this.assistantFunction;
+    }
+
     public Optional<Pattern> getFilter() {
         return this.filter;
     }
@@ -81,6 +89,10 @@ public class Action<T, R> {
 
     public Function<Path, Path> getPathConverter() {
         return this.pathConverter;
+    }
+
+    public boolean isAssistant() {
+        return this.assistantFunction != null;
     }
 
     @Override

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/workspace/ActionBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/workspace/ActionBuilder.java
@@ -2,6 +2,7 @@ package io.quarkus.devui.spi.workspace;
 
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -10,6 +11,7 @@ public class ActionBuilder<T, R> {
     private String label = null;
     private String namespace = null;
     private Function<T, R> function;
+    private BiFunction<Object, T, R> assistantFunction;
     private Optional<Pattern> filter = Optional.empty();
     private Display display = Display.dialog;
     private DisplayType displayType = DisplayType.code;
@@ -36,6 +38,11 @@ public class ActionBuilder<T, R> {
         return this;
     }
 
+    public ActionBuilder assistantFunction(BiFunction<Object, T, R> assistantFunction) {
+        this.assistantFunction = assistantFunction;
+        return this;
+    }
+
     public ActionBuilder filter(Pattern filter) {
         this.filter = Optional.of(filter);
         return this;
@@ -57,10 +64,10 @@ public class ActionBuilder<T, R> {
     }
 
     public Action build() {
-        if (this.label == null || this.function == null) {
+        if (this.label == null || (this.function == null && this.assistantFunction == null)) {
             throw new RuntimeException(
-                    "Not enough information to build the action. Set at least label and function");
+                    "Not enough information to build the action. Set at least label and function/assistantFunction");
         }
-        return new Action(label, namespace, function, filter, display, displayType, pathConverter);
+        return new Action(label, namespace, function, assistantFunction, filter, display, displayType, pathConverter);
     }
 }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/workspace/Patterns.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/workspace/Patterns.java
@@ -6,28 +6,29 @@ import java.util.regex.Pattern;
  * Common patterns for filters
  */
 public interface Patterns {
-    public static Pattern JAVA_ANY = Pattern.compile(".*\\.java$");
-    public static Pattern JAVA_SRC = Pattern.compile("^((?!test).)*\\.java$");
-    public static Pattern JAVA_TEST = Pattern.compile("^.*test.*\\.java$");
+    public static final Pattern JAVA_ANY = Pattern.compile(".*\\.java$");
+    public static final Pattern JAVA_SRC = Pattern.compile("^((?!test).)*\\.java$");
+    public static final Pattern JAVA_TEST = Pattern.compile("^.*test.*\\.java$");
 
-    public static Pattern README_MD = Pattern.compile(".*README\\.md$");
-    public static Pattern POM_XML = Pattern.compile("^pom\\.xml$");
-    public static Pattern APPLICATION_PROPERTIES = Pattern.compile("^.*application\\.properties$");
+    public static final Pattern README_MD = Pattern.compile(".*README\\.md$");
+    public static final Pattern ANY_MD = Pattern.compile(".*\\.md$");
+    public static final Pattern POM_XML = Pattern.compile("^pom\\.xml$");
+    public static final Pattern APPLICATION_PROPERTIES = Pattern.compile("^.*application\\.properties$");
 
-    public static Pattern DOCKER_FILE = Pattern.compile("^.*Dockerfile(\\..*)?$");
+    public static final Pattern DOCKER_FILE = Pattern.compile("^.*Dockerfile(\\..*)?$");
 
-    public static Pattern SHELL_SCRIPT = Pattern.compile(".*\\.(sh|bash|zsh|ksh)$");
+    public static final Pattern SHELL_SCRIPT = Pattern.compile(".*\\.(sh|bash|zsh|ksh)$");
 
-    public static Pattern HTML = Pattern.compile(".*\\.(html|htm)$");
-    public static Pattern CSS = Pattern.compile(".*\\.css$");
-    public static Pattern JS = Pattern.compile(".*\\.js$");
-    public static Pattern JSON = Pattern.compile(".*\\.json$");
-    public static Pattern XML = Pattern.compile(".*\\.xml$");
-    public static Pattern WSDL = Pattern.compile(".*\\.wsdl$");
-    public static Pattern PROPERTIES = Pattern.compile(".*\\.properties$");
-    public static Pattern YAML = Pattern.compile(".*\\.(yaml|yml)$");
+    public static final Pattern HTML = Pattern.compile(".*\\.(html|htm)$");
+    public static final Pattern CSS = Pattern.compile(".*\\.css$");
+    public static final Pattern JS = Pattern.compile(".*\\.js$");
+    public static final Pattern JSON = Pattern.compile(".*\\.json$");
+    public static final Pattern XML = Pattern.compile(".*\\.xml$");
+    public static final Pattern WSDL = Pattern.compile(".*\\.wsdl$");
+    public static final Pattern PROPERTIES = Pattern.compile(".*\\.properties$");
+    public static final Pattern YAML = Pattern.compile(".*\\.(yaml|yml)$");
 
-    public static Pattern ANY_KNOWN_TEXT = Pattern.compile(
+    public static final Pattern ANY_KNOWN_TEXT = Pattern.compile(
             ".*(" +
                     "README\\.md" + "|" +
                     "pom\\.xml" + "|" +

--- a/extensions/vertx-http/runtime-dev/pom.xml
+++ b/extensions/vertx-http/runtime-dev/pom.xml
@@ -17,5 +17,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant-dev</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/vertx-http/runtime-dev/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
+++ b/extensions/vertx-http/runtime-dev/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
@@ -56,6 +56,7 @@ public class DevUIRecorder {
         if (recordedValues != null && !recordedValues.isEmpty()) {
             jsonRpcRouter.setRecordedValues(recordedValues);
         }
+
         jsonRpcRouter.initializeCodec(createJsonMapper());
     }
 

--- a/extensions/vertx-http/runtime-dev/src/main/java/io/quarkus/devui/runtime/comms/ReflectionInfo.java
+++ b/extensions/vertx-http/runtime-dev/src/main/java/io/quarkus/devui/runtime/comms/ReflectionInfo.java
@@ -2,6 +2,8 @@ package io.quarkus.devui.runtime.comms;
 
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -46,5 +48,10 @@ public class ReflectionInfo {
 
     public boolean isReturningUni() {
         return method.getReturnType().getName().equals(Uni.class.getName());
+    }
+
+    public boolean isReturningCompletionStage() {
+        return method.getReturnType().getName().equals(CompletionStage.class.getName()) ||
+                method.getReturnType().getName().equals(CompletableFuture.class.getName());
     }
 }


### PR DESCRIPTION
This PR introduce a new module in Quarkus called assistant, that allows extensions to talk to an assistant (if any is added)

For now this can work with Chappie (we need to wait for this to be released and then release a new Chappie version)

Once this PR is in, extensions can start making use of the assistant feature, example OpenAPI (#47872) :

![chappie_openapi](https://github.com/user-attachments/assets/bd2bc47c-dfd3-4276-afee-26c1e22aeb71)

TODO:
- [x] Confirm the naming. Should this be named Assistant ?
- [x] Confirm the "branding". Currently using "warn" colors. Maybe it should be something else ? Quarkus Blue ? Pink ?
- [x] Confirm if Chappie extension in Quarkiverse should be merged with this ? (There is only a deployment)
