### PR TITLE
Disable analytics for the remote-dev tests

### DIFF
--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckWithAgentMojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckWithAgentMojoTestBase.java
@@ -75,7 +75,8 @@ public class RunAndCheckWithAgentMojoTestBase extends MojoTestBase {
                     .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/", 200));
 
             runningAgent = new RunningInvoker(agentDir, false);
-            runningAgent.execute(Arrays.asList("compile", "quarkus:remote-dev"), Collections.emptyMap());
+            runningAgent.execute(Arrays.asList("compile", "quarkus:remote-dev", "-Dquarkus.analytics.disabled=true"),
+                    Collections.emptyMap());
 
             Thread.sleep(1000);
             await().pollDelay(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Apparently, we've been waiting for 10 sec in remote-dev Maven tests before the launch.