### PR TITLE
Update profile configuration for integration tests

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -158,15 +158,9 @@ public interface TestConfig {
     boolean flatClassPath();
 
     /**
-     * The profile to use when testing the native image
-     */
-    @WithDefault("prod")
-    String nativeImageProfile();
-
-    /**
      * The profile to use when testing using {@code @QuarkusIntegrationTest}
      */
-    @WithDefault("prod")
+    @WithDefault("${quarkus.profile:prod}")
     String integrationTestProfile();
 
     /**

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -232,7 +232,10 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             // propagate Quarkus properties set from the build tool
             Properties existingSysProps = System.getProperties();
             for (String name : existingSysProps.stringPropertyNames()) {
-                if (name.startsWith("quarkus.")) {
+                if (name.startsWith("quarkus.")
+                        // don't include 'quarkus.profile' as that has already been taken into account when determining the launch profile
+                        // so we don't want this to end up in multiple launch arguments
+                        && !name.equals("quarkus.profile")) {
                     additionalProperties.put(name, existingSysProps.getProperty(name));
                 }
             }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -144,7 +144,10 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                 // propagate Quarkus properties set from the build tool
                 Properties existingSysProps = System.getProperties();
                 for (String name : existingSysProps.stringPropertyNames()) {
-                    if (name.startsWith("quarkus.")) {
+                    if (name.startsWith("quarkus.")
+                            // don't include 'quarkus.profile' as that has already been taken into account when determining the launch profile
+                            // so we don't want this to end up in multiple launch arguments
+                            && !name.equals("quarkus.profile")) {
                         additionalProperties.put(name, existingSysProps.getProperty(name));
                     }
                 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -155,8 +155,8 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
         private final Map<Integer, Integer> additionalExposedPorts;
         private final Optional<String> entryPoint;
         private final List<String> programArgs;
-        private Map<String, String> labels;
-        private Map<String, String> volumeMounts;
+        private final Map<String, String> labels;
+        private final Map<String, String> volumeMounts;
 
         public DefaultDockerInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
                 List<String> argLine, Map<String, String> env,

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
@@ -45,7 +45,7 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                     testConfig.waitTime(),
-                    testConfig.nativeImageProfile(),
+                    testConfig.integrationTestProfile(),
                     TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                     testConfig.env(),
                     context.devServicesLaunchResult(),


### PR DESCRIPTION
All integration test launchers now first consult
`quarkus.test.integration-test-profile` and use
`quarkus.profile` as the fallback when determining
which profile the application should be run with.
We also make sure that the application is not
launched with multiple options specifying
what profile should be used.

- Fixes: https://github.com/quarkusio/quarkus/issues/47400