### PR TITLE
Document known Flyway issues and configuration examples

### DIFF
--- a/docs/src/main/asciidoc/flyway.adoc
+++ b/docs/src/main/asciidoc/flyway.adoc
@@ -448,3 +448,27 @@ quarkus.openshift.init-task-defaults.wait-for-container.image=my/wait-for-image:
 ----
 
 **Note**: In this context globally means `for all extensions that support init task externalization`.
+
+== Known Issues in Flyway
+
+=== Oracle: Multiple schemas in Dev Services
+
+When having multiple schemas in Oracle, you can use the `quarkus.flyway.schemas` property to specify the schemas that Flyway should manage.
+However, because this is executed in the DB as the `quarkus` user, you need to either give DBA privileges to the user that is executing the migration (`quarkus`) or perform the necessary DDLs before the Dev Service starts. This is done with the `quarkus.datasource.devservices.init-script-path` configuration.
+
+==== Giving DBA privileges to the user
+
+- In your application, create a SQL file named `001-devservice-init.sql` (for ordering purposes, it can be any name really) in your `src/main/resources` with the following content:
+
+[source,sql]
+----
+ALTER SESSION SET CONTAINER=quarkus;
+GRANT DBA TO quarkus;
+----
+
+- Add the following configuration to your `application.properties`:
+
+[source,properties]
+----
+quarkus.datasource.devservices.init-script-path=001-devservice-init.sql
+----


### PR DESCRIPTION
- Document known issues with Oracle and multiple schemas in Flyway's DevServices.
- Provide guidance on granting DBA privileges and configuring schema management.
- Include example configuration for schema initialization using `application.properties`.
- Follow-up from https://github.com/quarkusio/quarkus/pull/47753