### PR TITLE
Otel optimizations I

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
@@ -3,8 +3,6 @@ package io.quarkus.opentelemetry.runtime;
 import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
 import static io.smallrye.common.vertx.VertxContext.isDuplicatedContext;
 
-import java.util.Map;
-
 import org.jboss.logging.Logger;
 
 import io.opentelemetry.context.Context;
@@ -66,8 +64,7 @@ public enum QuarkusContextStorage implements ContextStorage {
             return Scope.noop();
         }
         vertxContext.putLocal(OTEL_CONTEXT, toAttach);
-        final Map<String, String> spanDataToAttach = OpenTelemetryUtil.getSpanData(toAttach);
-        OpenTelemetryUtil.setMDCData(spanDataToAttach, vertxContext);
+        OpenTelemetryUtil.setMDCData(toAttach, vertxContext);
 
         return new Scope() {
 
@@ -77,7 +74,7 @@ public enum QuarkusContextStorage implements ContextStorage {
                 if (before != toAttach) {
                     log.info("Context in storage not the expected context, Scope.close was not called correctly. Details:" +
                             " OTel context before: " + OpenTelemetryUtil.getSpanData(before) +
-                            ". OTel context toAttach: " + spanDataToAttach);
+                            ". OTel context toAttach: " + OpenTelemetryUtil.getSpanData(toAttach));
                 }
 
                 if (beforeAttach == null) {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSampler.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSampler.java
@@ -37,9 +37,8 @@ public class DropTargetsSampler implements Sampler {
 
         if (spanKind.equals(SpanKind.SERVER)) {
             // HTTP_TARGET was split into url.path and url.query
-            String path = attributes.get(URL_PATH);
             String query = attributes.get(URL_QUERY);
-            String target = path + (query == null ? "" : "?" + query);
+            String target = attributes.get(URL_PATH) + (query == null ? "" : "?" + query);
 
             if (shouldDrop(target)) {
                 return SamplingResult.drop();

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtil.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtil.java
@@ -9,7 +9,7 @@ public final class VertxUtil {
     private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?");
     private static final String FORWARDED = "Forwarded";
     private static final String COMMA_SPLITTER = ",";
-    private static final String COLON_SPLITTER = ":";
+    private static final char COLON_SPLITTER = ':';
     private static final int SPLIT_LIMIT = -1;
 
     private VertxUtil() {
@@ -35,23 +35,6 @@ public final class VertxUtil {
         return xForwardedForHeader.split(COMMA_SPLITTER, SPLIT_LIMIT)[0];
     }
 
-    private static String getHostHeader(HttpServerRequest httpRequest) {
-        String header = httpRequest.getHeader("host");
-        if (header == null) {
-            return null;
-        }
-        return header.split(COLON_SPLITTER, SPLIT_LIMIT)[0];
-    }
-
-    private static String getHostPortHeader(HttpServerRequest httpRequest) {
-        String header = httpRequest.getHeader("host");
-        if (header == null) {
-            return null;
-        }
-        String[] headerValues = header.split(COLON_SPLITTER, SPLIT_LIMIT);
-        return headerValues.length > 1 ? headerValues[1] : null;
-    }
-
     public static String extractClientIP(HttpServerRequest httpServerRequest) {
         // Tries to fetch Forwarded first since X-Forwarded can be lost by a proxy
         // If Forwarded is not there tries to fetch the X-Forwarded-For header
@@ -69,7 +52,14 @@ public final class VertxUtil {
     }
 
     public static String extractRemoteHostname(HttpServerRequest httpRequest) {
-        String hostname = getHostHeader(httpRequest);
+        String header = httpRequest.getHeader("host");
+        if (header == null) {
+            return null;
+        }
+
+        // localhost:8808, hostname localhost
+        String hostname = beforeDelimiter(header, COLON_SPLITTER);
+
         if (hostname != null) {
             return hostname;
         }
@@ -77,7 +67,14 @@ public final class VertxUtil {
     }
 
     public static Long extractRemoteHostPort(HttpServerRequest httpRequest) {
-        String portString = getHostPortHeader(httpRequest);
+        String header = httpRequest.getHeader("host");
+        if (header == null) {
+            return null;
+        }
+
+        // localhost:8808, port 8080
+        String portString = afterDelimiter(header, COLON_SPLITTER);
+
         if (portString != null) {
             try {
                 return Long.parseLong(portString);
@@ -89,5 +86,28 @@ public final class VertxUtil {
             return Integer.toUnsignedLong(httpRequest.remoteAddress().port());
         }
         return null;
+    }
+
+    private static String beforeDelimiter(String str, char delimiter) {
+        if (str == null || str.isEmpty()) {
+            return "";
+        }
+        int index = str.indexOf(delimiter);
+        return (index >= 0) ? str.substring(0, index) : str;
+    }
+
+    private static String afterDelimiter(String str, char delimiter) {
+        if (str == null || str.isEmpty()) {
+            return "";
+        }
+
+        int index = str.indexOf(delimiter);
+        if (index < 0) {
+            return null;
+        } else if (index >= 0 && index + 1 < str.length()) {
+            return str.substring(index + 1);
+        } else {
+            return "";
+        }
     }
 }

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtilTest.java
@@ -1,0 +1,258 @@
+package io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.handler.codec.DecoderResult;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+
+class VertxUtilTest {
+
+    @Test
+    void extractRemoteHostnameTest() {
+        assertEquals("localhost", VertxUtil.extractRemoteHostname(createDummyRequest("localhost:8080")));
+        assertEquals("127.0.0.1", VertxUtil.extractRemoteHostname(createDummyRequest("127.0.0.1:111")));
+        assertEquals("localhost", VertxUtil.extractRemoteHostname(createDummyRequest("localhost")));
+        assertEquals("localhost", VertxUtil.extractRemoteHostname(createDummyRequest("localhost:")));
+        assertEquals("", VertxUtil.extractRemoteHostname(createDummyRequest(":1111")));
+        assertEquals("", VertxUtil.extractRemoteHostname(createDummyRequest(":")));
+        assertEquals("", VertxUtil.extractRemoteHostname(createDummyRequest("")));
+    }
+
+    @Test
+    void extractRemoteHostPortTest() {
+        assertEquals(8080, VertxUtil.extractRemoteHostPort(createDummyRequest("localhost:8080")));
+        assertEquals(111, VertxUtil.extractRemoteHostPort(createDummyRequest("127.0.0.1:111")));
+        assertEquals(1010, VertxUtil.extractRemoteHostPort(createDummyRequest("localhost")));
+        assertEquals(1010, VertxUtil.extractRemoteHostPort(createDummyRequest("localhost:")));
+        assertEquals(1111, VertxUtil.extractRemoteHostPort(createDummyRequest(":1111")));
+        assertEquals(1010, VertxUtil.extractRemoteHostPort(createDummyRequest(":")));
+        assertEquals(1010, VertxUtil.extractRemoteHostPort(createDummyRequest("")));
+    }
+
+    private HttpServerRequest createDummyRequest(String hostHeader) {
+        return new HttpServerRequest() {
+            @Override
+            public HttpServerRequest exceptionHandler(Handler<Throwable> handler) {
+                return null;
+            }
+
+            @Override
+            public HttpServerRequest handler(Handler<Buffer> handler) {
+                return null;
+            }
+
+            @Override
+            public HttpServerRequest pause() {
+                return null;
+            }
+
+            @Override
+            public HttpServerRequest resume() {
+                return null;
+            }
+
+            @Override
+            public HttpServerRequest fetch(long amount) {
+                return null;
+            }
+
+            @Override
+            public HttpServerRequest endHandler(Handler<Void> endHandler) {
+                return null;
+            }
+
+            @Override
+            public HttpVersion version() {
+                return null;
+            }
+
+            @Override
+            public HttpMethod method() {
+                return null;
+            }
+
+            @Override
+            public @Nullable String scheme() {
+                return "";
+            }
+
+            @Override
+            public String uri() {
+                return "";
+            }
+
+            @Override
+            public @Nullable String path() {
+                return "";
+            }
+
+            @Override
+            public @Nullable String query() {
+                return "";
+            }
+
+            @Override
+            public @Nullable HostAndPort authority() {
+                return null;
+            }
+
+            @Override
+            public @Nullable String host() {
+                return "";
+            }
+
+            @Override
+            public long bytesRead() {
+                return 0;
+            }
+
+            @Override
+            public HttpServerResponse response() {
+                return null;
+            }
+
+            @Override
+            public MultiMap headers() {
+                HeadersMultiMap entries = new HeadersMultiMap();
+                entries.add("host", hostHeader);
+                return entries;
+            }
+
+            @Override
+            public HttpServerRequest setParamsCharset(String charset) {
+                return null;
+            }
+
+            @Override
+            public String getParamsCharset() {
+                return "";
+            }
+
+            @Override
+            public MultiMap params(boolean semicolonIsNormalChar) {
+                return null;
+            }
+
+            @Override
+            public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+                return new X509Certificate[0];
+            }
+
+            @Override
+            public String absoluteURI() {
+                return "";
+            }
+
+            @Override
+            public Future<Buffer> body() {
+                return null;
+            }
+
+            @Override
+            public Future<Void> end() {
+                return null;
+            }
+
+            @Override
+            public Future<NetSocket> toNetSocket() {
+                return null;
+            }
+
+            @Override
+            public HttpServerRequest setExpectMultipart(boolean expect) {
+                return null;
+            }
+
+            @Override
+            public boolean isExpectMultipart() {
+                return false;
+            }
+
+            @Override
+            public HttpServerRequest uploadHandler(@Nullable Handler<HttpServerFileUpload> uploadHandler) {
+                return null;
+            }
+
+            @Override
+            public MultiMap formAttributes() {
+                return null;
+            }
+
+            @Override
+            public @Nullable String getFormAttribute(String attributeName) {
+                return "";
+            }
+
+            @Override
+            public Future<ServerWebSocket> toWebSocket() {
+                return null;
+            }
+
+            @Override
+            public boolean isEnded() {
+                return false;
+            }
+
+            @Override
+            public HttpServerRequest customFrameHandler(Handler<HttpFrame> handler) {
+                return null;
+            }
+
+            @Override
+            public HttpConnection connection() {
+                return null;
+            }
+
+            @Override
+            public HttpServerRequest streamPriorityHandler(Handler<StreamPriority> handler) {
+                return null;
+            }
+
+            @Override
+            public DecoderResult decoderResult() {
+                return null;
+            }
+
+            @Override
+            public @Nullable Cookie getCookie(String name) {
+                return null;
+            }
+
+            @Override
+            public @Nullable Cookie getCookie(String name, String domain, String path) {
+                return null;
+            }
+
+            @Override
+            public Set<Cookie> cookies(String name) {
+                return Set.of();
+            }
+
+            @Override
+            public Set<Cookie> cookies() {
+                return Set.of();
+            }
+
+            @Override
+            public SocketAddress remoteAddress() {
+                return SocketAddress.inetSocketAddress(1010, "localhost");
+            }
+        };
+    }
+}


### PR DESCRIPTION
During the otel performance work some inefficiencies were detected on the hot path, the one affecting the creation of all spans:
1. We were placing MDC trace data in a HashMap that was resizing. Code was re-written in order to not use the HashMap at all.
2. When calculating host and port we where using `String.split()` which uses a regex and was costing many cycles. Re-wrote that part and added tests to make sure behaviour is compatible. 
