### PR TITLE
OpenAPI Filters ensure consistent ordering

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -906,7 +906,10 @@ public class SmallRyeOpenApiProcessor {
                 .withOperationHandler(this::handleOperation)
                 .enableUnannotatedPathParameters(capabilities.isPresent(Capability.RESTEASY_REACTIVE))
                 .enableStandardFilter(false)
-                .withFilters(openAPIBuildItems.stream().map(AddToOpenAPIDefinitionBuildItem::getOASFilter).toList());
+                .withFilters(openAPIBuildItems.stream()
+                        .map(AddToOpenAPIDefinitionBuildItem::getOASFilter)
+                        .sorted(Comparator.comparing(filter -> filter.getClass().getName()))
+                        .toList());
 
         getUserDefinedBuildtimeFilters(index).forEach(builder::addFilterName);
 


### PR DESCRIPTION
Based on Zulip: [#dev > OpenAPI Filter enforce order with priority in extensions @ 💬](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/OpenAPI.20Filter.20enforce.20order.20with.20priority.20in.20extensions/near/517138727)

And open Quarkus Logging manager ticket: https://github.com/quarkiverse/quarkus-logging-manager/pull/373

this uses the classnames to always ensure the same order when generating from OASFilters like SmallRye Health, RestEasyProblem, and Logging Manager