### PR TITLE
Add support for disabling automatic key generation in JWT extension via new properties

### DIFF
--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -876,12 +876,16 @@ You can disable automatic key generation by setting at least one of the followin
 
 * `mp.jwt.verify.publickey.location`
 * `mp.jwt.verify.publickey`
+* `mp.jwt.decrypt.key.location`
+* `smallrye.jwt.encrypt.key.location`
 * `smallrye.jwt.sign.key.location`
 * `smallrye.jwt.sign.key`
 
 [NOTE]
 ====
-Additionally, if you do not specify the issuer information (using the `mp.jwt.verify.issuer` property), the {extension-name} extension will set a default issuer as `https://quarkus.io/issuer`.
+In *dev* mode, if you do not explicitly configure the issuer using the `mp.jwt.verify.issuer` property, the {extension-name} extension will set a default issuer of `https://quarkus.io/issuer`.
+
+If you prefer to configure the issuer programmatically, set `mp.jwt.verify.issuer` to `NONE` to prevent the default value from being applied.
 ====
 
 [[integration-testing-wiremock]]

--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
@@ -28,10 +28,12 @@ public class SmallryeJwtDevModeProcessor {
 
     private static final String MP_JWT_VERIFY_PUBLIC_KEY = "mp.jwt.verify.publickey";
     private static final String MP_JWT_VERIFY_ISSUER = "mp.jwt.verify.issuer";
+    private static final String MP_JWT_DECRYPT_KEY_LOCATION = "mp.jwt.decrypt.key.location";
 
     private static final String SMALLRYE_JWT_NEW_TOKEN_ISSUER = "smallrye.jwt.new-token.issuer";
     private static final String SMALLRYE_JWT_SIGN_KEY_LOCATION = "smallrye.jwt.sign.key.location";
     private static final String SMALLRYE_JWT_SIGN_KEY = "smallrye.jwt.sign.key";
+    private static final String SMALLRYE_JWT_ENCRYPT_KEY_LOCATION = "smallrye.jwt.encrypt.key.location";
 
     private static final String NONE = "NONE";
     private static final String DEFAULT_ISSUER = "https://quarkus.io/issuer";
@@ -41,8 +43,10 @@ public class SmallryeJwtDevModeProcessor {
     private static final Set<String> JWT_SIGN_KEY_PROPERTIES = Set.of(
             MP_JWT_VERIFY_KEY_LOCATION,
             MP_JWT_VERIFY_PUBLIC_KEY,
+            MP_JWT_DECRYPT_KEY_LOCATION,
             SMALLRYE_JWT_SIGN_KEY_LOCATION,
-            SMALLRYE_JWT_SIGN_KEY);
+            SMALLRYE_JWT_SIGN_KEY,
+            SMALLRYE_JWT_ENCRYPT_KEY_LOCATION);
 
     /**
      * This build step generates an RSA-256 key pair for development and test modes.

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtLocationDevModeTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtLocationDevModeTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.jwt.test.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SmallryeJwtLocationDevModeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            """
+                                    smallrye.jwt.encrypt.key.location=/publicKey.pem
+                                    mp.jwt.decrypt.key.location=/privateKey.pem
+                                    """), "application.properties")
+                    .addAsResource("publicKey.pem")
+                    .addAsResource("privateKey.pem"))
+            .addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
+                @Override
+                public void accept(BuildChainBuilder chain) {
+                    chain.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            List<DevServicesResultBuildItem> buildItems = context
+                                    .consumeMulti(DevServicesResultBuildItem.class);
+                            assertThat(buildItems).filteredOn(item -> item.getName().equals("SMALLRYE_JWT"))
+                                    .first()
+                                    .satisfies(item -> {
+                                        assertThat(item.getConfig())
+                                                .containsEntry("mp.jwt.verify.publickey", "NONE")
+                                                .containsEntry("smallrye.jwt.sign.key", "NONE");
+                                    });
+                            context.produce(new FeatureBuildItem("dummy"));
+                        }
+                    })
+                            .consumes(DevServicesResultBuildItem.class)
+                            .produces(FeatureBuildItem.class)
+                            .build();
+                }
+            });
+
+    @Test
+    void shouldNotConfigureAutomatically() {
+        assertThat(true).isTrue();
+    }
+
+}


### PR DESCRIPTION
This pull request checks two new properties for disabling the automatic key generation for JWT on dev mode and update the documentation about the issue.

Closes #47751 #47749 #47723 

