### PR TITLE
DevUI DatabaseView improve JDBC host resolution

### DIFF
--- a/extensions/agroal/deployment/src/main/resources/dev-ui/qwc-agroal-datasource.js
+++ b/extensions/agroal/deployment/src/main/resources/dev-ui/qwc-agroal-datasource.js
@@ -730,11 +730,12 @@ export class QwcAgroalDatasource extends QwcHotReloadElement {
                 }
             }
 
-            const urlPattern = /^jdbc:[^:]+:\/\/([^:/]+)(:\d+)?/;
+            const urlPattern = /\/\/([^:/?#]+)|@([^:/?#]+)/;
             const match = jdbcUrl.match(urlPattern);
 
             if (match) {
-                const host = match[1];
+                // match[1] is for //host, match[2] is for @host
+                const host = match[1] || match[2];
                 if(host === "localhost" || host === "127.0.0.1" || host === "::1"){
                     return true;
                 }


### PR DESCRIPTION
@phillip-kruger Fixes my issue of #47684 

The current regex was not correctly discovering for all JDBC URLS.  Here is a JS tester of my fix so it resolves Oracle URLS as well.

```js
const hostPattern = /\/\/([^:/?#]+)|@([^:/?#]+)/;

const urls = [
  'jdbc:postgresql://localhost:49679/postgres?stringtype=unspecified',
  'jdbc:mysql://127.0.0.1:3306/dbname',
  'jdbc:oracle:thin:@localhost:1521/freepdb1',
  'jdbc:sqlserver://my-host.example.com:1433;databaseName=test'
];

urls.forEach(url => {
  const match = url.match(hostPattern);
  if (match) {
    // match[1] is for //host, match[2] is for @host
    console.log('Host:', match[1] || match[2]);
  } else {
    console.log('No host match:', url);
  }
});
```


![image](https://github.com/user-attachments/assets/a24d1a3c-6478-4797-93ba-780e4b1136f1)
