### PR TITLE
Add CDI support for additional JPA/Hibernate components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,9 @@ lib
 bin
 !devtools/cli/distribution/java-binary/bin
 dependency-reduced-pom.xml
-derby.log
-hotspot.log
 .directory
 .java-version
 .graal-install
-hs_err_pid*.log
 dumps
 *.orig
 *.rej
@@ -31,9 +28,8 @@ ObjectStore
 .gradle
 docker/distroless/bazel-*
 /.apt_generated_tests/
-quarkus.log
-quarkus.log*
-replay_*.logß
+*.log
+*.log*
 nbactions.xml
 nb-configuration.xml
 .cache

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -498,6 +498,47 @@ You can inject the `EntityManagerFactory` of a named persistence unit using the 
 EntityManagerFactory entityManagerFactory;
 ----
 
+In addition to `EntityManager` and `EntityManagerFactory`, Quarkus also supports injecting the following JPA/Hibernate components:
+
+[source,java]
+----
+@Inject
+CriteriaBuilder criteriaBuilder;
+
+@Inject
+HibernateCriteriaBuilder hibernateCriteriaBuilder;
+
+@Inject
+Metamodel metamodel;
+
+@Inject
+org.hibernate.Metamodel metamodel;
+
+@Inject
+JpaMetamodel jpaMetamodel;
+
+@Inject
+Cache cache;
+
+@Inject
+org.hibernate.Cache cache;
+
+@Inject
+jakarta.persistence.PersistenceUnitUtil persistenceUnitUtil;
+
+@Inject
+org.hibernate.relational.SchemaManager schemaManager;
+----
+
+These components can also be injected with a specific persistence unit qualifier:
+
+[source,java]
+----
+@Inject
+@PersistenceUnit("users")
+CriteriaBuilder criteriaBuilder;
+----
+
 [[persistence-unit-active]]
 === Activate/deactivate persistence units
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -53,6 +53,16 @@ public final class ClassNames {
     public static final DotName ENTITY_MANAGER = createConstant("jakarta.persistence.EntityManager");
     public static final DotName SESSION = createConstant("org.hibernate.Session");
     public static final DotName STATELESS_SESSION = createConstant("org.hibernate.StatelessSession");
+    public static final DotName CRITERIA_BUILDER = createConstant("jakarta.persistence.criteria.CriteriaBuilder");
+    public static final DotName HIBERNATE_CRITERIA_BUILDER = createConstant(
+            "org.hibernate.query.criteria.HibernateCriteriaBuilder");
+    public static final DotName METAMODEL = createConstant("jakarta.persistence.metamodel.Metamodel");
+    public static final DotName HIBERNATE_METAMODEL = createConstant("org.hibernate.Metamodel");
+    public static final DotName JPA_METAMODEL = createConstant("org.hibernate.metamodel.model.domain.JpaMetamodel");
+    public static final DotName SCHEMA_MANAGER = createConstant("org.hibernate.relational.SchemaManager");
+    public static final DotName CACHE = createConstant("jakarta.persistence.Cache");
+    public static final DotName HIBERNATE_CACHE = createConstant("org.hibernate.Cache");
+    public static final DotName PERSISTENCE_UNIT_UTIL = createConstant("jakarta.persistence.PersistenceUnitUtil");
 
     public static final DotName INTERCEPTOR = createConstant("org.hibernate.Interceptor");
     public static final DotName STATEMENT_INSPECTOR = createConstant("org.hibernate.resource.jdbc.spi.StatementInspector");

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiCriteriaBuilderTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiCriteriaBuilderTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.hibernate.orm.multiplepersistenceunits;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.DefaultEntity;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user.User;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultiplePersistenceUnitsCdiCriteriaBuilderTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addClass(User.class)
+                    .addClass(Plane.class)
+                    .addAsResource("application-multiple-persistence-units.properties", "application.properties"));
+
+    @Inject
+    CriteriaBuilder defaultCriteriaBuilder;
+
+    @Inject
+    @PersistenceUnit("users")
+    HibernateCriteriaBuilder usersHibernateCriteriaBuilder;
+
+    @Inject
+    @PersistenceUnit("users")
+    CriteriaBuilder usersCriteriaBuilder;
+
+    @Inject
+    @PersistenceUnit("inventory")
+    CriteriaBuilder inventoryCriteriaBuilder;
+
+    @Test
+    public void defaultCriteriaBuilder() {
+        assertNotNull(defaultCriteriaBuilder);
+
+        CriteriaQuery<DefaultEntity> query = defaultCriteriaBuilder.createQuery(DefaultEntity.class);
+        Root<DefaultEntity> root = query.from(DefaultEntity.class);
+        query.select(root);
+
+        assertNotNull(defaultCriteriaBuilder.count(root));
+        assertNotNull(defaultCriteriaBuilder.equal(root.get("name"), "test"));
+    }
+
+    @Test
+    public void usersCriteriaBuilder() {
+        assertNotNull(usersCriteriaBuilder);
+
+        CriteriaQuery<User> query = usersCriteriaBuilder.createQuery(User.class);
+        Root<User> root = query.from(User.class);
+        query.select(root);
+
+        assertNotNull(usersCriteriaBuilder.count(root));
+        assertNotNull(usersCriteriaBuilder.equal(root.get("name"), "test"));
+    }
+
+    @Test
+    public void usersHibernateCriteriaBuilder() {
+        assertNotNull(usersHibernateCriteriaBuilder);
+
+        CriteriaQuery<User> query = usersHibernateCriteriaBuilder.createQuery(User.class);
+        Root<User> root = query.from(User.class);
+        query.select(root);
+
+        assertNotNull(usersHibernateCriteriaBuilder.count(root));
+        assertNotNull(usersHibernateCriteriaBuilder.equal(root.get("name"), "test"));
+    }
+
+    @Test
+    public void inventoryCriteriaBuilder() {
+        assertNotNull(inventoryCriteriaBuilder);
+
+        CriteriaQuery<Plane> query = inventoryCriteriaBuilder.createQuery(Plane.class);
+        Root<Plane> root = query.from(Plane.class);
+        query.select(root);
+
+        assertNotNull(inventoryCriteriaBuilder.count(root));
+        assertNotNull(inventoryCriteriaBuilder.equal(root.get("name"), "test"));
+    }
+
+    @Test
+    public void testUserInInventoryCriteriaBuilder() {
+        assertThatThrownBy(() -> {
+            CriteriaQuery<User> query = inventoryCriteriaBuilder.createQuery(User.class);
+            query.from(User.class);
+        }).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not an entity");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiMetamodelTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiMetamodelTest.java
@@ -1,0 +1,116 @@
+package io.quarkus.hibernate.orm.multiplepersistenceunits;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
+
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.DefaultEntity;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user.User;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultiplePersistenceUnitsCdiMetamodelTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addClass(User.class)
+                    .addClass(Plane.class)
+                    .addAsResource("application-multiple-persistence-units.properties", "application.properties"));
+
+    @Inject
+    Metamodel defaultMetamodel;
+
+    @Inject
+    @PersistenceUnit("users")
+    Metamodel usersMetamodel;
+
+    @Inject
+    @PersistenceUnit("users")
+    JpaMetamodel usersJpaMetamodel;
+
+    @Inject
+    @PersistenceUnit("inventory")
+    Metamodel inventoryMetamodel;
+
+    @Inject
+    @PersistenceUnit("inventory")
+    org.hibernate.Metamodel hibernateInventoryMetamodel;
+
+    @Test
+    public void defaultMetamodel() {
+        assertNotNull(defaultMetamodel);
+
+        EntityType<DefaultEntity> entityType = defaultMetamodel.entity(DefaultEntity.class);
+        assertNotNull(entityType);
+
+        assertNotNull(entityType.getName());
+        assertEquals(DefaultEntity.class.getSimpleName(), entityType.getName());
+    }
+
+    @Test
+    public void usersMetamodel() {
+        assertNotNull(usersMetamodel);
+
+        EntityType<User> entityType = usersMetamodel.entity(User.class);
+        assertNotNull(entityType);
+
+        assertEquals(User.class.getSimpleName(), entityType.getName());
+    }
+
+    @Test
+    public void usersJpaMetamodel() {
+        assertNotNull(usersJpaMetamodel);
+
+        EntityType<User> entityType = usersJpaMetamodel.entity(User.class);
+        assertNotNull(entityType);
+
+        assertEquals(User.class.getSimpleName(), entityType.getName());
+    }
+
+    @Test
+    public void inventoryMetamodel() {
+        assertNotNull(inventoryMetamodel);
+
+        EntityType<Plane> entityType = inventoryMetamodel.entity(Plane.class);
+        assertNotNull(entityType);
+
+        assertEquals(Plane.class.getSimpleName(), entityType.getName());
+    }
+
+    @Test
+    public void hibernateInventoryMetamodel() {
+        assertNotNull(hibernateInventoryMetamodel);
+
+        EntityType<Plane> entityType = hibernateInventoryMetamodel.entity(Plane.class);
+        assertNotNull(entityType);
+
+        assertEquals(Plane.class.getSimpleName(), entityType.getName());
+    }
+
+    @Test
+    public void testUserInInventoryMetamodel() {
+        assertThatThrownBy(() -> {
+            inventoryMetamodel.entity(User.class);
+        }).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not an entity");
+    }
+
+    @Test
+    public void testUserInHibernateInventoryMetamodel() {
+        assertThatThrownBy(() -> {
+            hibernateInventoryMetamodel.entity(User.class);
+        }).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not an entity");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiPersistenceUnitUtilTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiPersistenceUnitUtilTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.hibernate.orm.multiplepersistenceunits;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.DefaultEntity;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user.User;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultiplePersistenceUnitsCdiPersistenceUnitUtilTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addClass(User.class)
+                    .addClass(Plane.class)
+                    .addAsResource("application-multiple-persistence-units.properties", "application.properties"));
+
+    @Inject
+    PersistenceUnitUtil defaultPersistenceUnitUtil;
+
+    @Inject
+    EntityManager defaultEntityManager;
+
+    @Inject
+    @PersistenceUnit("users")
+    PersistenceUnitUtil usersPersistenceUnitUtil;
+
+    @Inject
+    @PersistenceUnit("users")
+    EntityManager usersEntityManager;
+
+    @Inject
+    @PersistenceUnit("inventory")
+    PersistenceUnitUtil inventoryPersistenceUnitUtil;
+
+    @Inject
+    @PersistenceUnit("inventory")
+    EntityManager inventoryEntityManager;
+
+    @Test
+    @Transactional
+    public void testDefaultPersistenceUnitUtil() {
+        assertNotNull(defaultPersistenceUnitUtil);
+
+        DefaultEntity entity = new DefaultEntity("test");
+        defaultEntityManager.persist(entity);
+
+        assertTrue(defaultPersistenceUnitUtil.isLoaded(entity, "name"));
+    }
+
+    @Test
+    @Transactional
+    public void testUsersPersistenceUnitUtil() {
+        assertNotNull(usersPersistenceUnitUtil);
+
+        User entity = new User("test");
+        usersEntityManager.persist(entity);
+
+        assertTrue(usersPersistenceUnitUtil.isLoaded(entity, "name"));
+    }
+
+    @Test
+    @Transactional
+    public void testInventoryPersistenceUnitUtil() {
+        assertNotNull(inventoryPersistenceUnitUtil);
+
+        Plane entity = new Plane("test");
+        inventoryEntityManager.persist(entity);
+
+        assertTrue(inventoryPersistenceUnitUtil.isLoaded(entity, "name"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsSchemaManagerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsSchemaManagerTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.hibernate.orm.multiplepersistenceunits;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.relational.SchemaManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.DefaultEntity;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user.User;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultiplePersistenceUnitsSchemaManagerTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addClass(User.class)
+                    .addClass(Plane.class)
+                    .addAsResource("application-multiple-persistence-units.properties", "application.properties"));
+
+    @Inject
+    SchemaManager defaultSchemaManager;
+
+    @Inject
+    @PersistenceUnit("users")
+    SchemaManager usersSchemaManager;
+
+    @Inject
+    @PersistenceUnit("inventory")
+    SchemaManager inventorySchemaManager;
+
+    @Test
+    public void testDefaultSchemaManager() {
+        assertNotNull(defaultSchemaManager);
+    }
+
+    @Test
+    public void testUsersSchemaManager() {
+        assertNotNull(usersSchemaManager);
+    }
+
+    @Test
+    public void testInventorySchemaManager() {
+        assertNotNull(inventorySchemaManager);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/DefaultEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/DefaultEntity.java
@@ -1,11 +1,13 @@
 package io.quarkus.hibernate.orm.singlepersistenceunit;
 
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
+@Cacheable
 public class DefaultEntity {
 
     private long id;

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiCacheTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiCacheTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.hibernate.orm.singlepersistenceunit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.Cache;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.TransactionTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SinglePersistenceUnitCdiCacheTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addClass(TransactionTestUtils.class)
+                    .addAsResource("application.properties"))
+            .overrideRuntimeConfigKey("quarkus.hibernate-orm.second-level-caching-enabled", "true");
+
+    @Inject
+    Cache jakartaCache;
+
+    @Inject
+    org.hibernate.Cache hibernateCache;
+    @Inject
+    EntityManager em;
+
+    @Inject
+    UserTransaction tx;
+
+    @Test
+    public void testJakartaCacheOperations() {
+        DefaultEntity entity = new DefaultEntity("test");
+        TransactionTestUtils.inTransaction(tx, () -> {
+            em.persist(entity);
+            em.flush();
+        });
+
+        TransactionTestUtils.inTransaction(tx, () -> {
+            DefaultEntity loaded = em.find(DefaultEntity.class, entity.getId());
+            assertNotNull(loaded, "Entity should be loaded");
+
+            // Verify entity is in cache
+            assertTrue(jakartaCache.contains(DefaultEntity.class, entity.getId()),
+                    "Entity should be in cache after load");
+
+            // Test cache operations
+            DefaultEntity fromCache = em.find(DefaultEntity.class, entity.getId());
+            assertNotNull(fromCache, "Entity should be retrieved from cache");
+            assertEquals("test", fromCache.getName(), "Entity data should match");
+
+            jakartaCache.evict(DefaultEntity.class, entity.getId());
+            assertFalse(jakartaCache.contains(DefaultEntity.class, entity.getId()),
+                    "Entity should not be in cache after eviction");
+
+            DefaultEntity fromDatabase = em.find(DefaultEntity.class, entity.getId());
+            assertNotNull(fromDatabase, "Entity should be retrievable from database after cache eviction");
+        });
+    }
+
+    @Test
+    public void testHibernateCacheOperations() {
+        DefaultEntity entity = new DefaultEntity("test");
+        TransactionTestUtils.inTransaction(tx, () -> {
+            em.persist(entity);
+            em.flush();
+        });
+
+        TransactionTestUtils.inTransaction(tx, () -> {
+            DefaultEntity loaded = em.find(DefaultEntity.class, entity.getId());
+            assertNotNull(loaded, "Entity should be loaded");
+
+            // Verify entity is in cache
+            assertTrue(hibernateCache.contains(DefaultEntity.class, entity.getId()),
+                    "Entity should be in cache after load");
+
+            // Test cache operations
+            DefaultEntity fromCache = em.find(DefaultEntity.class, entity.getId());
+            assertNotNull(fromCache, "Entity should be retrieved from cache");
+            assertEquals("test", fromCache.getName(), "Entity data should match");
+
+            hibernateCache.evict(DefaultEntity.class, entity.getId());
+            assertFalse(hibernateCache.contains(DefaultEntity.class, entity.getId()),
+                    "Entity should not be in cache after eviction");
+
+            DefaultEntity fromDatabase = em.find(DefaultEntity.class, entity.getId());
+            assertNotNull(fromDatabase, "Entity should be retrievable from database after cache eviction");
+        });
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiCriteriaBuilderTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiCriteriaBuilderTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.orm.singlepersistenceunit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SinglePersistenceUnitCdiCriteriaBuilderTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    CriteriaBuilder criteriaBuilder;
+    @Inject
+    HibernateCriteriaBuilder hibernateCriteriaBuilder;
+
+    @Test
+    public void testCriteriaBuilder() {
+        assertNotNull(criteriaBuilder);
+
+        CriteriaQuery<DefaultEntity> equalQuery = criteriaBuilder.createQuery(DefaultEntity.class);
+        Root<DefaultEntity> root = equalQuery.from(DefaultEntity.class);
+        equalQuery.select(root)
+                .where(criteriaBuilder.equal(root.get("name"), "test"));
+        assertNotNull(equalQuery);
+    }
+
+    @Test
+    public void testHibernateCriteriaBuilder() {
+        assertNotNull(hibernateCriteriaBuilder);
+
+        CriteriaQuery<DefaultEntity> equalQuery = hibernateCriteriaBuilder.createQuery(DefaultEntity.class);
+        Root<DefaultEntity> root = equalQuery.from(DefaultEntity.class);
+        equalQuery.select(root)
+                .where(hibernateCriteriaBuilder.equal(root.get("name"), "test"));
+        assertNotNull(equalQuery);
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiMetamodelTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiMetamodelTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.hibernate.orm.singlepersistenceunit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
+
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SinglePersistenceUnitCdiMetamodelTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    Metamodel metamodel;
+    @Inject
+    org.hibernate.Metamodel hibernateMetamodel;
+    @Inject
+    JpaMetamodel jpaMetamodel;
+
+    @Test
+    public void testMetamodel() {
+        assertNotNull(metamodel);
+        EntityType<DefaultEntity> entityType = metamodel.entity(DefaultEntity.class);
+        assertNotNull(entityType);
+        assertTrue(
+                metamodel.getEntities().stream()
+                        .anyMatch(et -> et.getJavaType().equals(DefaultEntity.class)),
+                "Metamodel should contain DefaultEntity");
+        assertEquals(DefaultEntity.class.getSimpleName(), entityType.getName());
+    }
+
+    @Test
+    public void testHibernateMetamodel() {
+        assertNotNull(hibernateMetamodel);
+        EntityType<DefaultEntity> entityType = hibernateMetamodel.entity(DefaultEntity.class);
+        assertNotNull(entityType);
+        assertTrue(
+                hibernateMetamodel.getEntities().stream()
+                        .anyMatch(et -> et.getJavaType().equals(DefaultEntity.class)),
+                "Hibernate Metamodel should contain DefaultEntity");
+        assertEquals(DefaultEntity.class.getSimpleName(), entityType.getName());
+    }
+
+    @Test
+    public void testJpaMetamodel() {
+        assertNotNull(jpaMetamodel);
+        EntityType<DefaultEntity> entityType = jpaMetamodel.entity(DefaultEntity.class);
+        assertNotNull(entityType);
+        assertTrue(
+                jpaMetamodel.getEntities().stream()
+                        .anyMatch(et -> et.getJavaType().equals(DefaultEntity.class)),
+                "Hibernate Metamodel should contain DefaultEntity");
+        assertEquals(DefaultEntity.class.getSimpleName(), entityType.getName());
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiPersistenceUnitUtilTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiPersistenceUnitUtilTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.hibernate.orm.singlepersistenceunit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SinglePersistenceUnitCdiPersistenceUnitUtilTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    PersistenceUnitUtil persistenceUnitUtil;
+
+    @Inject
+    EntityManager entityManager;
+
+    @Test
+    @Transactional
+    public void testPersistenceUtil() {
+        assertNotNull(persistenceUnitUtil);
+        DefaultEntity entity = new DefaultEntity("test");
+        entityManager.persist(entity);
+        assertTrue(persistenceUnitUtil.isLoaded(entity, "name"));
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitSchemaManagerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitSchemaManagerTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.hibernate.orm.singlepersistenceunit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.relational.SchemaManager;
+import org.hibernate.tool.schema.spi.SchemaManagementException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SinglePersistenceUnitSchemaManagerTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultEntity.class)
+                    .addAsResource("application.properties"))
+            .overrideConfigKey("quarkus.hibernate-orm.database.generation", "none");
+    @Inject
+    SchemaManager schemaManager;
+
+    @Inject
+    EntityManager entityManager;
+
+    @Test
+    @Transactional
+    public void testSchemaManager() {
+        assertNotNull(schemaManager);
+        assertThrows(SchemaManagementException.class,
+                () -> schemaManager.validateMappedObjects(),
+                "Validation should fail if table is missing.");
+
+        schemaManager.exportMappedObjects(true);
+
+        assertDoesNotThrow(() -> schemaManager.validateMappedObjects(),
+                "Validation should pass after exporting objects.");
+
+        entityManager.createNativeQuery("DROP TABLE IF EXISTS DefaultEntity").executeUpdate();
+
+        SchemaManagementException ex = assertThrows(SchemaManagementException.class,
+                () -> schemaManager.validateMappedObjects(),
+                "Validation should fail if table is missing.");
+        assertTrue(ex.getMessage().toLowerCase(Locale.ROOT).contains("missing table"),
+                "Exception message should indicate missing table.");
+
+    }
+}


### PR DESCRIPTION
Adding CDI support for the following JPA/hibernate components:

- CriteriaBuilder
- Metamodel
- Cache
- PersistenceUnitUtil
- SchemaManager

**Testing**

In addition to unit tests, I verified my changes in a quarkus project using local build to ensure proper injection and runtime behavior 
![{F2BB58DD-8CEB-432C-9C2D-33566A56E488}](https://github.com/user-attachments/assets/f99c9615-b75f-4ae0-9c9d-a30c7c391238)


**q/arc/beans**
```
  {
    "id": "4skIeF8wp4Wg4D6tne7GHU-9epc",
    "kind": "SYNTHETIC",
    "generatedClass": "org.hibernate.query.criteria.HibernateCriteriaBuilder_4skIeF8wp4Wg4D6tne7GHU-9epc_Synthetic_Bean",
    "beanClass": "org.hibernate.query.criteria.HibernateCriteriaBuilder",
    "types": [
      "jakarta.persistence.criteria.CriteriaBuilder",
      "org.hibernate.query.criteria.HibernateCriteriaBuilder",
      "java.lang.Object"
    ],
    "qualifiers": [
      "@Default",
      "@Any"
    ],
    "scope": "jakarta.enterprise.context.ApplicationScoped"
  }
```

Please let me know if you'd like any refinements or further adjustments. 
Thanks!

- Resolves: #46843 

FYI : @yrodiere @gsmet 


