### PR TITLE
Better handle registry referencing non-existing codestarts

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateJBangMojo.java
@@ -113,7 +113,7 @@ public class CreateJBangMojo extends AbstractMojo {
             throw new MojoExecutionException("Failed to resolve Quarkus extension catalog", e);
         }
 
-        final List<ResourceLoader> codestartsResourceLoader = codestartLoadersBuilder()
+        final List<ResourceLoader> codestartsResourceLoader = codestartLoadersBuilder(log)
                 .catalog(catalog)
                 .artifactResolver(mvn)
                 .build();

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -296,7 +296,7 @@ public class CreateProjectMojo extends AbstractMojo {
             catalog = CreateProjectHelper.completeCatalog(catalog, extensions, mvn);
             sanitizeOptions();
 
-            final List<ResourceLoader> codestartsResourceLoader = codestartLoadersBuilder()
+            final List<ResourceLoader> codestartsResourceLoader = codestartLoadersBuilder(log)
                     .catalog(catalog)
                     .artifactResolver(mvn)
                     .build();

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -103,7 +103,7 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
         } else {
             final ExtensionCatalog extensionCatalog = resolveExtensionCatalog();
             final List<ResourceLoader> codestartsResourceLoader = CodestartResourceLoadersBuilder
-                    .codestartLoadersBuilder()
+                    .codestartLoadersBuilder(log)
                     .artifactResolver(artifactResolver())
                     .catalog(extensionCatalog)
                     .build();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartCatalog.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import io.quarkus.devtools.codestarts.Codestart;
 import io.quarkus.devtools.codestarts.DataKey;
 import io.quarkus.devtools.codestarts.core.GenericCodestartCatalog;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 
 public final class QuarkusExtensionCodestartCatalog extends GenericCodestartCatalog<QuarkusExtensionCodestartProjectInput> {
 
@@ -78,9 +79,9 @@ public final class QuarkusExtensionCodestartCatalog extends GenericCodestartCata
         GIT
     }
 
-    public static QuarkusExtensionCodestartCatalog fromBaseCodestartsResources()
+    public static QuarkusExtensionCodestartCatalog fromBaseCodestartsResources(MessageWriter log)
             throws IOException {
-        final Map<String, Codestart> codestarts = loadCodestartsFromResources(getCodestartResourceLoaders(),
+        final Map<String, Codestart> codestarts = loadCodestartsFromResources(getCodestartResourceLoaders(log),
                 QUARKUS_EXTENSION_CODESTARTS_DIR);
         return new QuarkusExtensionCodestartCatalog(codestarts.values());
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartCatalog.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import io.quarkus.devtools.codestarts.Codestart;
 import io.quarkus.devtools.codestarts.DataKey;
 import io.quarkus.devtools.codestarts.core.GenericCodestartCatalog;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
 
 public final class QuarkusJBangCodestartCatalog extends GenericCodestartCatalog<QuarkusJBangCodestartProjectInput> {
@@ -48,9 +49,9 @@ public final class QuarkusJBangCodestartCatalog extends GenericCodestartCatalog<
         super(codestarts);
     }
 
-    public static QuarkusJBangCodestartCatalog fromBaseCodestartsResources()
+    public static QuarkusJBangCodestartCatalog fromBaseCodestartsResources(MessageWriter log)
             throws IOException {
-        final Map<String, Codestart> codestarts = loadCodestartsFromResources(getCodestartResourceLoaders(),
+        final Map<String, Codestart> codestarts = loadCodestartsFromResources(getCodestartResourceLoaders(log),
                 QUARKUS_JBANG_CODESTARTS_DIR);
         return new QuarkusJBangCodestartCatalog(codestarts.values());
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +27,7 @@ import io.quarkus.devtools.codestarts.CodestartStructureException;
 import io.quarkus.devtools.codestarts.CodestartType;
 import io.quarkus.devtools.codestarts.DataKey;
 import io.quarkus.devtools.codestarts.core.GenericCodestartCatalog;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.extensions.Extensions;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.platform.catalog.processor.ExtensionProcessor;
@@ -86,22 +86,23 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
         this.extensionsMapping = extensionsMapping;
     }
 
-    public static QuarkusCodestartCatalog fromBaseCodestartsResources(Map<String, Extension> extensionsMapping)
+    public static QuarkusCodestartCatalog fromBaseCodestartsResources(MessageWriter log,
+            Map<String, Extension> extensionsMapping)
             throws IOException {
-        final Map<String, Codestart> codestarts = loadCodestartsFromResources(getCodestartResourceLoaders(),
+        final Map<String, Codestart> codestarts = loadCodestartsFromResources(getCodestartResourceLoaders(log),
                 QUARKUS_CODESTARTS_DIR);
         return new QuarkusCodestartCatalog(codestarts.values(), extensionsMapping);
     }
 
-    public static QuarkusCodestartCatalog fromBaseCodestartsResources()
+    public static QuarkusCodestartCatalog fromBaseCodestartsResources(MessageWriter log)
             throws IOException {
-        return fromBaseCodestartsResources(Collections.emptyMap());
+        return fromBaseCodestartsResources(log, Map.of());
     }
 
     public static QuarkusCodestartCatalog fromExtensionsCatalogAndDirectories(
-            ExtensionCatalog catalog, Collection<Path> directories)
+            MessageWriter log, ExtensionCatalog catalog, Collection<Path> directories)
             throws IOException {
-        final List<ResourceLoader> loaders = getCodestartResourceLoaders(catalog);
+        final List<ResourceLoader> loaders = getCodestartResourceLoaders(log, catalog);
         final Map<String, Codestart> codestarts = loadCodestartsFromResources(loaders,
                 QUARKUS_CODESTARTS_DIR);
         for (Path directory : directories) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateExtensionCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateExtensionCommandHandler.java
@@ -63,7 +63,7 @@ public class CreateExtensionCommandHandler {
             throws QuarkusCommandException {
         try {
             final QuarkusExtensionCodestartCatalog catalog = QuarkusExtensionCodestartCatalog
-                    .fromBaseCodestartsResources();
+                    .fromBaseCodestartsResources(log);
             catalog.createProject(input).generate(newExtensionDir);
 
             final String extensionDirName = newExtensionDir.getFileName().toString();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
@@ -146,7 +146,7 @@ public class QuarkusProjectHelper {
     public static QuarkusProject getProject(Path projectDir, ExtensionCatalog catalog, BuildTool buildTool,
             JavaVersion javaVersion,
             MessageWriter log) {
-        return QuarkusProject.of(projectDir, catalog, getCodestartResourceLoaders(catalog),
+        return QuarkusProject.of(projectDir, catalog, getCodestartResourceLoaders(log, catalog),
                 log, buildTool, javaVersion);
     }
 
@@ -161,7 +161,7 @@ public class QuarkusProjectHelper {
     public static QuarkusProject getProject(Path projectDir, ExtensionCatalog catalog, ExtensionManager extManager,
             JavaVersion javaVersion,
             MessageWriter log) {
-        return QuarkusProject.of(projectDir, catalog, getCodestartResourceLoaders(catalog),
+        return QuarkusProject.of(projectDir, catalog, getCodestartResourceLoaders(log, catalog),
                 log, extManager, javaVersion);
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -121,7 +121,7 @@ public class MavenProjectBuildFile extends BuildFile {
         }
         final MavenProjectBuildFile extensionManager = new MavenProjectBuildFile(projectDir, extensionCatalog,
                 projectModel, deps, managedDeps, projectProps, projectPom == null ? null : artifactResolver);
-        final List<ResourceLoader> codestartResourceLoaders = codestartLoadersBuilder().catalog(extensionCatalog)
+        final List<ResourceLoader> codestartResourceLoaders = codestartLoadersBuilder(log).catalog(extensionCatalog)
                 .artifactResolver(artifactResolver).build();
         final JavaVersion javaVersion = resolveJavaVersion(projectProps);
         return QuarkusProject.of(projectDir, extensionCatalog,

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/FakeExtensionCatalog.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/FakeExtensionCatalog.java
@@ -6,6 +6,7 @@ import java.io.UncheckedIOException;
 import java.util.Map;
 
 import io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
 public final class FakeExtensionCatalog {
@@ -20,6 +21,7 @@ public final class FakeExtensionCatalog {
     private static QuarkusCodestartCatalog getQuarkusCodestartCatalog() {
         try {
             return QuarkusCodestartCatalog.fromBaseCodestartsResources(
+                    MessageWriter.info(),
                     QuarkusCodestartCatalog.buildExtensionsMapping(FAKE_EXTENSION_CATALOG.getExtensions()));
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/PlatformAwareTestBase.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/PlatformAwareTestBase.java
@@ -7,6 +7,7 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
 import io.quarkus.platform.tools.ToolsUtils;
@@ -21,7 +22,7 @@ public class PlatformAwareTestBase {
     private Properties quarkusProps;
 
     protected List<ResourceLoader> getCodestartsResourceLoaders() {
-        return getCodestartResourceLoaders(getExtensionsCatalog());
+        return getCodestartResourceLoaders(MessageWriter.info(), getExtensionsCatalog());
     }
 
     protected ExtensionCatalog getExtensionsCatalog() {

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog;
 import io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog.Language;
 import io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartProjectInput;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.testing.SnapshotTesting;
@@ -354,7 +355,7 @@ public class QuarkusCodestartTest implements BeforeAllCallback, AfterAllCallback
     }
 
     protected List<ResourceLoader> getCodestartsResourceLoaders() {
-        return codestartLoadersBuilder()
+        return codestartLoadersBuilder(MessageWriter.info())
                 .catalog(getExtensionsCatalog())
                 .addExtraCodestartsArtifactCoords(artifacts)
                 .build();

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartGenerationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.testing.SnapshotTesting;
 
 class QuarkusExtensionCodestartGenerationTest {
@@ -57,7 +58,7 @@ class QuarkusExtensionCodestartGenerationTest {
     }
 
     private QuarkusExtensionCodestartCatalog getCatalog() throws IOException {
-        return QuarkusExtensionCodestartCatalog.fromBaseCodestartsResources();
+        return QuarkusExtensionCodestartCatalog.fromBaseCodestartsResources(MessageWriter.info());
     }
 
 }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/jbang/QuarkusJBangCodestartGenerationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import io.quarkus.devtools.codestarts.utils.NestedMaps;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.testing.SnapshotTesting;
 
 class QuarkusJBangCodestartGenerationTest {
@@ -61,7 +62,7 @@ class QuarkusJBangCodestartGenerationTest {
     }
 
     private QuarkusJBangCodestartCatalog getCatalog() throws IOException {
-        return QuarkusJBangCodestartCatalog.fromBaseCodestartsResources();
+        return QuarkusJBangCodestartCatalog.fromBaseCodestartsResources(MessageWriter.info());
     }
 
 }

--- a/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/CatalogCompatibilityTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/CatalogCompatibilityTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.CodestartResourceLoadersBuilder;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.testing.PlatformAwareTestBase;
@@ -65,7 +66,7 @@ public class CatalogCompatibilityTest extends PlatformAwareTestBase {
 
     private static void checkCodestarts(ExtensionCatalog extensionCatalog, CatalogProcessor processed) throws IOException {
         final List<ResourceLoader> codestartResourceLoaders = CodestartResourceLoadersBuilder
-                .getCodestartResourceLoaders(extensionCatalog);
+                .getCodestartResourceLoaders(MessageWriter.info(), extensionCatalog);
         final QuarkusCodestartCatalog quarkusCodestartCatalog = QuarkusCodestartCatalog
                 .fromExtensionsCatalog(extensionCatalog, codestartResourceLoaders);
         assertThat(quarkusCodestartCatalog.getCodestarts()).isNotNull();


### PR DESCRIPTION
We need to be a lot more solid when the registry is referencing non-existing codestarts.
Which can happen if an extension is pointing to a non-existing codestart.

The patch is extremely small but we have to push the logger there thus why patch is larger than expected.

Related to
https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/.60quarkus.20create.20cli.60.20is.20possibly.20broken.3F/with/517462042

Fixes #47783