### PR TITLE
Virtual thread support for smallrye-graphql

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.11</smallrye-open-api.version>
-        <smallrye-graphql.version>2.13.0</smallrye-graphql.version>
+        <smallrye-graphql.version>2.14.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.9.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.2</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>

--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -503,6 +503,22 @@ You can mix Blocking and Non-blocking in one request,
 
 Above will fetch the film on the event-loop threads, but switch to the worker thread to fetch the heroes.
 
+=== RunOnVirtualThread
+
+Queries can be run on a virtual thread by adding `@RunOnVirtualThread` to the method:
+
+[source,java]
+----
+    @Query
+    @Description("Get a Films from a galaxy far far away")
+    @RunOnVirtualThread
+    public Film getFilm(int filmId) {
+        // ...
+    }
+----
+
+Please note the general guidelines for using xref:./virtual-threads.adoc[virtual threads]
+
 == Abstract Types
 
 The current schema is simple with only two concrete types, `Hero` and `Film`.

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
@@ -1,7 +1,9 @@
 package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.graphql.schema.model.Execute;
 import io.smallrye.graphql.schema.model.Operation;
 import io.vertx.core.Context;
@@ -22,9 +24,27 @@ public final class BlockingHelper {
         return operation.getExecute().equals(Execute.BLOCKING) && vc.isEventLoopContext();
     }
 
+    public static boolean shouldUseVirtualThread(Operation operation, Context vc) {
+        // Use virtual threads if the operation is marked as run on virtual thread
+        return operation.getExecute().equals(Execute.RUN_ON_VIRTUAL_THREAD);
+    }
+
     @SuppressWarnings("unchecked")
-    public static void runBlocking(Context vc, Callable<Object> contextualCallable, Promise result) {
-        // Here call blocking with context
-        vc.executeBlocking(contextualCallable).onComplete(result);
+    public static void runBlocking(Context vc, Callable<Object> contextualCallable, Promise result, Operation operation) {
+        // Check if we should use virtual threads
+        if (shouldUseVirtualThread(operation, vc)) {
+            ExecutorService virtualThreadsExecutor = VirtualThreadsRecorder.getCurrent();
+            virtualThreadsExecutor.submit(() -> {
+                try {
+                    Object value = contextualCallable.call();
+                    result.complete(value);
+                } catch (Throwable t) {
+                    result.fail(t);
+                }
+            });
+        } else {
+            // use regular blocking execution
+            vc.executeBlocking(contextualCallable).onComplete(result);
+        }
     }
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
@@ -61,7 +61,7 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(vc, contextualCallable, result, operation);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 
@@ -86,7 +86,7 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(vc, contextualCallable, result, operation);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDefaultDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDefaultDataFetcher.java
@@ -103,7 +103,7 @@ public class QuarkusDefaultDataFetcher<K, T> extends DefaultDataFetcher<K, T> {
             }
         });
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(vc, contextualCallable, result, operation);
 
         return (T) Uni.createFrom().completionStage(result.future().toCompletionStage()).onItemOrFailure()
                 .invoke((item, error) -> {
@@ -134,7 +134,7 @@ public class QuarkusDefaultDataFetcher<K, T> extends DefaultDataFetcher<K, T> {
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(vc, contextualCallable, result, operation);
         return result.future().toCompletionStage()
                 .whenComplete((resultList, error) -> {
                     if (error != null) {

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
@@ -58,7 +58,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(vc, contextualCallable, result, operation);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 
@@ -83,7 +83,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(vc, contextualCallable, result, operation);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 

--- a/integration-tests/virtual-threads/graphql-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-virtual-threads-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-virtual-threads-graphql</artifactId>
+    <name>Quarkus - Integration Tests - Virtual Threads - Graphql</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-graphql</artifactId>
+        </dependency>
+        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.junit5</groupId>
+            <artifactId>junit5-virtual-threads</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-graphql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/AbstractGraphQLTest.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/AbstractGraphQLTest.java
@@ -1,0 +1,183 @@
+package io.quarkus.virtual.graphql;
+
+import static io.quarkus.jsonp.JsonProviderHolder.jsonProvider;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.Properties;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonReader;
+
+import org.hamcrest.CoreMatchers;
+
+import io.restassured.RestAssured;
+import io.restassured.parsing.Parser;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Some shared methods
+ */
+public abstract class AbstractGraphQLTest {
+
+    static {
+        RestAssured.registerParser("application/graphql+json", Parser.JSON);
+    }
+
+    protected void pingTest() {
+        pingPongTest("ping", "pong");
+    }
+
+    protected void pongTest() {
+        pingPongTest("pong", "ping");
+    }
+
+    private void pingPongTest(String operationName, String message) {
+        String pingRequest = getPayload("{\n" +
+                "  " + operationName + " {\n" +
+                "    message\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(pingRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString("{\"data\":{\"" + operationName + "\":{\"message\":\"" + message + "\"}}}"));
+    }
+
+    protected String getPayload(String query) {
+        return getPayload(query, null);
+    }
+
+    protected String getPayload(String query, String variables) {
+        JsonObject jsonObject = createRequestBody(query, variables);
+        return jsonObject.toString();
+    }
+
+    protected JsonObject createRequestBody(String graphQL, String variables) {
+        // Create the request
+        JsonObject vjo = jsonProvider().createObjectBuilder().build();
+        if (variables != null && !variables.isEmpty()) {
+            try (JsonReader jsonReader = jsonProvider().createReader(new StringReader(variables))) {
+                vjo = jsonReader.readObject();
+            }
+        }
+
+        JsonObjectBuilder job = jsonProvider().createObjectBuilder();
+        if (graphQL != null && !graphQL.isEmpty()) {
+            job.add(QUERY, graphQL);
+        }
+
+        return job.add(VARIABLES, vjo).build();
+    }
+
+    protected static String getPropertyAsString() {
+        return getPropertyAsString(null);
+    }
+
+    protected static String getPropertyAsString(Map<String, String> otherProperties) {
+        try {
+            Properties p = new Properties();
+            p.putAll(PROPERTIES);
+            StringWriter writer = new StringWriter();
+            if (otherProperties != null) {
+                p.putAll(otherProperties);
+            }
+            p.store(writer, "Test Properties");
+            return writer.toString();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    protected static final String MEDIATYPE_JSON = "application/json";
+    protected static final String MEDIATYPE_TEXT = "text/plain";
+    protected static final String QUERY = "query";
+    protected static final String VARIABLES = "variables";
+
+    protected static final Properties PROPERTIES = new Properties();
+    static {
+        PROPERTIES.put("smallrye.graphql.allowGet", "true");
+        PROPERTIES.put("smallrye.graphql.printDataFetcherException", "true");
+        PROPERTIES.put("smallrye.graphql.events.enabled", "true");
+    }
+
+    /**
+     * Hold info about a thread
+     */
+    public static class TestThread {
+
+        private long id;
+        private String name;
+        private int priority;
+        private String state;
+        private String group;
+
+        public TestThread() {
+            super();
+        }
+
+        public TestThread(long id, String name, int priority, String state, String group) {
+            this.id = id;
+            this.name = name;
+            this.priority = priority;
+            this.state = state;
+            this.group = group;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public void setState(String state) {
+            this.state = state;
+        }
+
+        public String getGroup() {
+            return group;
+        }
+
+        public void setGroup(String group) {
+            this.group = group;
+        }
+
+        public String getVertxContextClassName() {
+            Context vc = Vertx.currentContext();
+            return vc.getClass().getName();
+        }
+    }
+}

--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/GraphQLThreadTest.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/GraphQLThreadTest.java
@@ -1,0 +1,403 @@
+package io.quarkus.virtual.graphql;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+
+/**
+ * Testing the thread used.
+ * Copied from graphql extension to make sure threading without @RunOnVirtualThread runs the same.
+ */
+@QuarkusTest
+public class GraphQLThreadTest extends AbstractGraphQLTest {
+
+    @Test
+    public void testOnlyObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyObject.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.onlyObject.vertxContextClassName", Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingObject.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.annotatedNonBlockingObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedBlockingObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingObject.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testOnlyReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyReactiveUni.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.onlyReactiveUni.vertxContextClassName", Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testOnlyReactiveUniWithDelay() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyReactiveUniWithDelay {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyReactiveUniWithDelay.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.onlyReactiveUniWithDelay.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedBlockingReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingReactiveUni.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingReactiveUni.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingReactiveUni.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.annotatedNonBlockingReactiveUni.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testOnlyCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyCompletionStage.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.onlyCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedBlockingCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingCompletionStage.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingCompletionStage.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.annotatedNonBlockingCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @GraphQLApi
+    public static class TestThreadResource {
+
+        @Inject
+        Vertx vertx;
+
+        // Return type Object
+        @Query
+        public TestThread onlyObject() {
+            return getTestThread();
+        }
+
+        // Return type Object, Annotated with @NonBlocking
+        @Query
+        @NonBlocking
+        public TestThread annotatedNonBlockingObject() {
+            return getTestThread();
+        }
+
+        // Return type Object with @Blocking (default)
+        @Query
+        @Blocking
+        public TestThread annotatedBlockingObject() {
+            return getTestThread();
+        }
+
+        // Return type Uni
+        @Query
+        public Uni<TestThread> onlyReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        // Return type Uni With Delay
+        @Query
+        public Uni<TestThread> onlyReactiveUniWithDelay() {
+            return Uni.createFrom().emitter(
+                    emitter -> {
+                        vertx.setTimer(1000, x -> emitter.complete(getTestThread()));
+                    });
+        }
+
+        // Return type Reactive with @Blocking
+        @Query
+        @Blocking
+        public Uni<TestThread> annotatedBlockingReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        // Return type Reactive with @NonBlocking (default)
+        @Query
+        @NonBlocking
+        public Uni<TestThread> annotatedNonBlockingReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        @Query
+        public CompletionStage<TestThread> onlyCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        // Return type CompletionStage with @Blocking
+        @Query
+        @Blocking
+        public CompletionStage<TestThread> annotatedBlockingCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        // Return type CompletionStage with @NonBlocking (default)
+        @Query
+        @NonBlocking
+        public CompletionStage<TestThread> annotatedNonBlockingCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        private TestThread getTestThread() {
+            Thread t = Thread.currentThread();
+            long id = t.getId();
+            String name = t.getName();
+            int priority = t.getPriority();
+            String state = t.getState().name();
+            String group = t.getThreadGroup().getName();
+            return new TestThread(id, name, priority, state, group);
+        }
+    }
+}

--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/RunOnVirtualThreadIT.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/RunOnVirtualThreadIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.virtual.graphql;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class RunOnVirtualThreadIT extends RunOnVirtualThreadTest {
+
+}

--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/RunOnVirtualThreadTest.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/RunOnVirtualThreadTest.java
@@ -1,0 +1,155 @@
+package io.quarkus.virtual.graphql;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit5.virtual.ShouldNotPin;
+import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+@QuarkusTest
+@VirtualThreadUnit
+@ShouldNotPin
+class RunOnVirtualThreadTest extends AbstractGraphQLTest {
+
+    @Test
+    public void testAnnotatedBlockingObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedRunOnVirtualThreadObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.annotatedRunOnVirtualThreadObject.name", Matchers.startsWith("quarkus-virtual-thread"))
+                .and()
+                .body("data.annotatedRunOnVirtualThreadObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedBlockingMutationObject() {
+
+        String fooRequest = getPayload("mutation{\n" +
+                "  annotatedRunOnVirtualThreadMutationObject(test:\"test\") {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.annotatedRunOnVirtualThreadMutationObject.name", Matchers.startsWith("quarkus-virtual-thread"))
+                .and()
+                .body("data.annotatedRunOnVirtualThreadMutationObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    @Disabled
+    public void testPiningThread() {
+
+        String fooRequest = getPayload("{\n" +
+                "  pinThread {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.pinThread.name", Matchers.startsWith("quarkus-virtual-thread"))
+                .and()
+                .body("data.pinThread.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @GraphQLApi
+    public static class RunOnVirtualThreadObjectTestThreadResource {
+
+        // Return type Object with @RunOnVirtualThread
+        @Query
+        @RunOnVirtualThread
+        public TestThread annotatedRunOnVirtualThreadObject() {
+            sleep();
+            return getTestThread();
+        }
+
+        // Return type Object with @RunOnVirtualThread
+        @Mutation
+        @RunOnVirtualThread
+        public TestThread annotatedRunOnVirtualThreadMutationObject(String test) {
+            sleep();
+            return getTestThread();
+        }
+
+        @Query
+        @RunOnVirtualThread
+        public TestThread pinThread() {
+            // Synchronize on an object to cause thread pinning
+            Object lock = new Object();
+            synchronized (lock) {
+                sleep();
+            }
+            return getTestThread();
+        }
+
+        private void sleep() {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        private TestThread getTestThread() {
+            Thread t = Thread.currentThread();
+            long id = t.getId();
+            String name = t.getName();
+            int priority = t.getPriority();
+            String state = t.getState().name();
+            String group = t.getThreadGroup().getName();
+            return new TestThread(id, name, priority, state, group);
+        }
+    }
+}

--- a/integration-tests/virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/pom.xml
@@ -38,6 +38,7 @@
         <module>reactive-routes-virtual-threads</module>
         <module>security-webauthn-virtual-threads</module>
         <module>metrics-virtual-threads</module>
+        <module>graphql-virtual-threads</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/35605
~~Needs a branch from smallrye grapgql https://github.com/smallrye/smallrye-graphql/pull/2287~~


Some questions:

1. Is there really no context handling needed? As stated here:io.quarkus.virtual.threads.ContextPreservingExecutorService
2. ~~How to prevent the virtual thread executor from being removed?~~

Probably we will need more tests, but at least io.quarkus.virtual.graphql.RunOnVirtualThreadTest#testAnnotatedBlockingObject tests for virtual thread and works.