### PR TITLE
Ignore false reflection hierarchy warning for Kotlin serialization

### DIFF
--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
@@ -2,6 +2,8 @@ package io.quarkus.kotlin.deployment;
 
 import static io.quarkus.deployment.builditem.nativeimage.NativeImageResourcePatternsBuildItem.builder;
 
+import org.jboss.jandex.DotName;
+
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -10,6 +12,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourcePatternsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassFinalFieldsWritablePredicateBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
 import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 
 public class KotlinProcessor {
@@ -49,7 +52,8 @@ public class KotlinProcessor {
      */
     @BuildStep
     void registerKotlinReflection(final BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<NativeImageResourcePatternsBuildItem> nativeResourcePatterns) {
+            BuildProducer<NativeImageResourcePatternsBuildItem> nativeResourcePatterns,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> reflectiveHierarchyIgnoreWarning) {
 
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("kotlin.reflect.jvm.internal.ReflectionFactoryImpl")
                 .build());
@@ -71,5 +75,10 @@ public class KotlinProcessor {
                 "META-INF/services/kotlin.reflect.*",
                 ".*.kotlin_builtins")
                 .build());
+
+        reflectiveHierarchyIgnoreWarning.produce(
+                new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("kotlinx.serialization.KSerializer")));
+        reflectiveHierarchyIgnoreWarning.produce(new ReflectiveHierarchyIgnoreWarningBuildItem(
+                DotName.createSimple("kotlinx.serialization.descriptors.SerialDescriptor")));
     }
 }


### PR DESCRIPTION
Originally mentioned in https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/.E2.9C.94.20Quarkus.20LangChain4J/near/517459374