### PR TITLE
Add test check for log messages about not being able to load class orderer

### DIFF
--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/ParameterDevModeIT.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/ParameterDevModeIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.maven.it.RunAndCheckMojoTestBase;
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
+import io.quarkus.test.config.QuarkusClassOrderer;
 
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
 public class ParameterDevModeIT extends RunAndCheckMojoTestBase {
@@ -46,6 +47,16 @@ public class ParameterDevModeIT extends RunAndCheckMojoTestBase {
         // so we need to check the pass count explicitly
         Assertions.assertEquals(0, results.getTestsFailed());
         Assertions.assertEquals(1, results.getTestsPassed());
+
+        // Also check stdout out for errors of the form
+        // 2025-05-12 15:58:46,729 WARNING [org.jun.jup.eng.con.InstantiatingConfigurationParameterConverter] (Test runner thread) Failed to load default class orderer class 'io.quarkus.test.config.QuarkusClassOrderer' set via the 'junit.jupiter.testclass.order.default' configuration parameter. Falling back to default behavior.: java.lang.ClassNotFoundException: io.quarkus.test.config.QuarkusClassOrderer
+        //	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
+        //	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
+        //	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
+        // These are hard to test directly for but are not wanted
+        String logs = running.log();
+        assertThat(logs).doesNotContainIgnoringCase("java.lang.ClassNotFoundException")
+                .doesNotContainIgnoringCase(QuarkusClassOrderer.class.getName());
     }
 
 }


### PR DESCRIPTION
Early versions of the fix for https://github.com/quarkusio/quarkus/pull/47365 introduced a stack trace into some continuous testing modes. Because the tests still passed, we might not have noticed it unless @gsmet hadn't been looking through the very long logs. The effect of the error was that profile tests might be mixed with non-profile tests in continuous testing, which would only show up in a complex test, and even then could be intermittent.

Since we can't test for this directly with complete confidence, and since stack traces are bad, and since it's quite possible further fixes in [this area](https://github.com/orgs/quarkusio/projects/30) could reintroduce the problem, I've added a test for the output. I've confirmed the test fails with commit 5f2493e032dc038f0306c5d237c132917e23a9bc. 

See discussion in https://github.com/quarkusio/quarkus/pull/47365#issuecomment-2828728068