### PR TITLE
Qute: fix type-safe fragments defined as top-level records

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -2061,9 +2061,13 @@ public class ItemResource {
 [[type_safe_fragments]]
 ==== Type-safe Fragments
 
-You can also define a type-safe <<fragments,fragment>> in your Java code.
-A _native static_ method with the name that contains a dollar sign `$` denotes a method that represents a fragment of a type-safe template.
-The name of the fragment is derived from the annotated method name.
+You can also define a type-safe <<fragments,fragment>> of a type-safe template in your Java code.
+There are two ways to define a type-safe fragment:
+
+1. A _native static_ method annotated with `@CheckedTemplate`, with a name that contains a dollar sign `$`.
+2. A Java record that implements `io.quarkus.qute.TemplateInstance` and its name contains a dollar sign `$`.
+
+The name of the fragment is derived from the annotated member name.
 The part before the last occurrence of a dollar sign `$` is the method name of the related type-safe template.
 The part after the last occurrence of a dollar sign is the fragment identifier.
 The strategy defined by the relevant `CheckedTemplate#defaultName()` is honored when constructing the defaulted names.
@@ -2082,6 +2086,9 @@ class Templates {
 
   // defines a fragment of Templates#items() with identifier "item"
   static native TemplateInstance items$item(Item item); <1>
+  
+  // type-safe fragment as a Java record - functionally equivalent to the items$item() method above
+  record items$item(Item item) implements TemplateInstance {}
 }
 ----
 <1> Quarkus validates at build time that each template that corresponds to the `Templates#items()` contains a fragment with identifier `item`. Moreover, the parameters of the fragment method are validated too. In general, all type-safe expressions that are found in the fragment and that reference some data from the original/outer template require a specific parameter to be present.

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -543,7 +543,7 @@ public class QuteProcessor {
         } else {
             defaultName = nameValue.asString();
         }
-        String name = target.kind() == Kind.METHOD ? target.asMethod().name() : target.asClass().simpleName();
+        String name = getTargetName(target);
         if (checkedFragment) {
             // the name is the part before the last occurence of a dollar sign
             name = name.substring(0, name.lastIndexOf('$'));
@@ -558,7 +558,7 @@ public class QuteProcessor {
         if (ignoreFragmentsValue != null && ignoreFragmentsValue.asBoolean()) {
             return null;
         }
-        String name = target.kind() == Kind.METHOD ? target.asMethod().name() : target.asClass().simpleName();
+        String name = getTargetName(target);
         // the id is the part after the last occurence of a dollar sign
         int idx = name.lastIndexOf('$');
         if (idx == -1 || idx == name.length()) {
@@ -574,6 +574,15 @@ public class QuteProcessor {
             defaultName = nameValue.asString();
         }
         return defaultedName(defaultName, name.substring(idx + 1, name.length()));
+    }
+
+    private String getTargetName(AnnotationTarget target) {
+        if (target.kind() == Kind.METHOD) {
+            return target.asMethod().name();
+        }
+        ClassInfo targetClass = target.asClass();
+        return targetClass.nestingType() == NestingType.TOP_LEVEL ? targetClass.name().withoutPackagePrefix()
+                : targetClass.simpleName();
     }
 
     private String defaultedName(String defaultNameStrategy, String value) {

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/records/TemplateRecordTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/records/TemplateRecordTest.java
@@ -29,12 +29,14 @@ public class TemplateRecordTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(HelloInt.class, helloWorld.class)
+                    .addClasses(HelloInt.class, helloWorld.class, hello.class, hello$name.class, hello$top.class)
                     .addAsResource(new StringAsset("Hello {val}!"),
                             "templates/TemplateRecordTest/HelloInt.txt")
                     .addAsResource(new StringAsset("Hello {name}!"),
                             "templates/hello_world.txt")
-                    .addAsResource(new StringAsset("Hello {#fragment name}{name}{/fragment} and {foo}!"),
+                    .addAsResource(
+                            new StringAsset(
+                                    "Hello {#fragment name}{name}{/fragment}::{#fragment top}{index}{/fragment} and {foo}!"),
                             "templates/hello.txt")
                     .addAsResource(new StringAsset("{alpha}:{bravo}:{charlie}"),
                             "templates/TemplateRecordTest/multiParams.txt"));
@@ -72,13 +74,17 @@ public class TemplateRecordTest {
 
         assertEquals("Hello Lu!", new helloWorld("Lu").render());
 
-        hello hello = new hello("Ma", "bar");
+        hello hello = new hello("Ma", "bar", 1);
         assertFalse(hello.getTemplate().isFragment());
-        assertEquals("Hello Ma and bar!", hello.render());
+        assertEquals("Hello Ma::1 and bar!", hello.render());
 
-        hello$name hello$name = new hello$name("Lu");
+        hello$name hello$name = new hello$name("Lu", 1);
         assertTrue(hello$name.getTemplate().isFragment());
         assertEquals("Lu", hello$name.render());
+
+        hello$top hello$top = new hello$top("Lu", 1);
+        assertTrue(hello$top.getTemplate().isFragment());
+        assertEquals("1", hello$top.render());
 
         assertEquals("15:true:foo", new multiParams(true, 15, "foo").render());
         assertThrows(IllegalArgumentException.class, () -> new multiParams(false, 50, null));
@@ -92,11 +98,11 @@ public class TemplateRecordTest {
     }
 
     @CheckedTemplate(basePath = "")
-    record hello(String name, String foo) implements TemplateInstance {
+    record hello(String name, String foo, int index) implements TemplateInstance {
     }
 
     @CheckedTemplate(basePath = "")
-    record hello$name(String name) implements TemplateInstance {
+    record hello$name(String name, int index) implements TemplateInstance {
     }
 
     record multiParams(boolean bravo, int alpha, String charlie) implements TemplateInstance {

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/records/hello$top.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/records/hello$top.java
@@ -1,0 +1,7 @@
+package io.quarkus.qute.deployment.records;
+
+import io.quarkus.qute.TemplateInstance;
+
+public record hello$top(String name, int index) implements TemplateInstance {
+
+}


### PR DESCRIPTION
- this workarounds the inconsistency in ClassInfo#simpleName() from Jandex: https://github.com/smallrye/jandex/issues/526
- also fixes #47804