### PR TITLE
Fix case in which normal tests would trash the TCCL and cause NPEs

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ExecutionListener.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ExecutionListener.java
@@ -19,7 +19,7 @@ import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
  */
 public class ExecutionListener implements TestExecutionListener {
 
-    private Deque<ClassLoader> origCl = new ArrayDeque<>();
+    private final Deque<ClassLoader> origCl = new ArrayDeque<>();
 
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
@@ -34,8 +34,6 @@ public class ExecutionListener implements TestExecutionListener {
                 if (isQuarkusTest(classLoader)) {
                     origCl.push(Thread.currentThread().getContextClassLoader());
                     Thread.currentThread().setContextClassLoader(classLoader);
-                } else {
-                    origCl = null;
                 }
             }
         }


### PR DESCRIPTION
Follow-on to https://github.com/quarkusio/quarkus/issues/47657. I was staring at this code debugging something else and noticed a serious problem. Some code from an earlier, non-stack, version of the code hadn't been deleted but really should have been. 