### PR TITLE
Correctly identify nested QuarkusTests in continuous testing

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
@@ -73,7 +73,6 @@ public class QuarkusTestIT extends RunAndCheckMojoTestBase {
 
     }
 
-    @Disabled("See https://github.com/quarkusio/quarkus/issues/47671")
     @Test
     public void testNestedQuarkusTestMixedWithNormalTestsContinuousTesting()
             throws MavenInvocationException, FileNotFoundException {
@@ -88,7 +87,8 @@ public class QuarkusTestIT extends RunAndCheckMojoTestBase {
         // This is a bit brittle when we add tests, but failures are often so catastrophic they're not even reported as failures,
         // so we need to check the pass count explicitly
         Assertions.assertEquals(0, results.getTestsFailed());
-        Assertions.assertEquals(3, results.getTestsPassed());
+        Assertions.assertEquals(2, results.getTestsPassed());
+        Assertions.assertEquals(1, results.getTestsSkipped());
     }
 
     /**

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-nested-tests-mixed-with-normal-tests/src/test/java/org/acme/VanillaTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-nested-tests-mixed-with-normal-tests/src/test/java/org/acme/VanillaTest.java
@@ -3,6 +3,9 @@ package org.acme;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+import io.quarkus.runtime.LaunchMode;
 
 public class VanillaTest {
 
@@ -11,9 +14,15 @@ public class VanillaTest {
         assertEquals(new HelloResource().hello(), "Hello from Quarkus REST via config");
     }
 
+    @DisabledIf("isContinuousTesting")
     @Test
     public void testTCCL() {
         // This test is looking at internals, not externals, but I think it's a fair enough expectation
+        // In continuous testing mode the normal tests get loaded with the deployment classloader, so we should not make assertions
         assertEquals(ClassLoader.getSystemClassLoader(), Thread.currentThread().getContextClassLoader());
+    }
+
+    public boolean isContinuousTesting() {
+        return LaunchMode.current().isDevOrTest();
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -613,6 +613,11 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                         .getCuratedApplication()
                 : null;
         boolean isSameCuratedApplication = cl.getCuratedApplication() == curatedApplication;
+
+        if (cl.getCuratedApplication() == null) {
+            throw new IllegalStateException(
+                    "Internal error: ClassLoader " + cl + " does not have a linked curated application.");
+        }
         cl.getCuratedApplication().setEligibleForReuse(isSameCuratedApplication);
 
         // TODO if classes are misordered, say because someone overrode the ordering, and there are profiles or resources,


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/47671. 

The problem here turned out to not be anything to do with the TCCL setting; it was just that `FacadeClassLoade`r was not recognising the nested subclasses as Quarkus Tests, because `JUnitRunner` wasn't including those tests in the list of quarkus tests it passed over.