### PR TITLE
Add OIDC Health Check

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -1067,6 +1067,20 @@ You can observe an https://quarkus.io/guides/security-openid-connect-multitenanc
 
 You can register xref:security-openid-connect-multitenancy.adoc#tenant-config-resolver[TenantConfigResolver] and build the configuration dynamically, using `OicTenantConfig` builder API, using the request properties such as request path and headers for additional hints or retrieve the matching configuration from the external sources.
 
+.OIDC Health Check
+[options="header"]
+|====
+|Property name |Default |Description
+
+|quarkus.oidc.health.enabled |false|If the OIDC Health Readiness Check must be registered.
+|====
+
+This build-time property can be used to register an `OIDC Provider Health Readiness Check` when the `quarkus-smallrye-health` dependency is included. When the health check is registered, it uses HTTP HEAD to ping the well-known OIDC provider configuration endpoint for every configured OIDC tenant.
+
+Individual OIDC tenant statuses are `OK`, `Not Ready`, `Disabled`, `Unknown` and `Error`.
+
+The OIDC Health check status is `UP` if at least one of the OIDC tenants has an `OK` status and `DOWN` otherwise.
+
 [[typical-property-combinations]]
 == Typical property combinations
 

--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -46,6 +46,15 @@
             <artifactId>quarkus-jsonp-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-activation</artifactId>
         </dependency>

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -99,6 +99,7 @@ import io.quarkus.oidc.runtime.OidcTenantDefaultIdConfigBuilder;
 import io.quarkus.oidc.runtime.OidcTokenCredentialProducer;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.oidc.runtime.TenantConfigBean;
+import io.quarkus.oidc.runtime.health.OidcTenantHealthCheck;
 import io.quarkus.oidc.runtime.providers.AzureAccessTokenCustomizer;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.Authenticated;
@@ -106,6 +107,7 @@ import io.quarkus.security.runtime.SecurityConfig;
 import io.quarkus.security.spi.AdditionalSecuredMethodsBuildItem;
 import io.quarkus.security.spi.ClassSecurityAnnotationBuildItem;
 import io.quarkus.security.spi.RegisterClassSecurityCheckBuildItem;
+import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.tls.deployment.spi.TlsRegistryBuildItem;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.EagerSecurityInterceptorBindingBuildItem;
@@ -470,6 +472,14 @@ public class OidcBuildStep {
                 .forEach(c -> registerClassSecurityCheckProducer.produce(
                         new RegisterClassSecurityCheckBuildItem(c.name(), AnnotationInstance
                                 .builder(Authenticated.class).buildWithTarget(c))));
+    }
+
+    @BuildStep
+    public void registerHealthCheck(OidcBuildTimeConfig config, BuildProducer<HealthBuildItem> healthBuildItems,
+            Capabilities capabilities) {
+        if (config.healthEnabled() && capabilities.isPresent(Capability.SMALLRYE_HEALTH)) {
+            healthBuildItems.produce(new HealthBuildItem(OidcTenantHealthCheck.class.getName(), true));
+        }
     }
 
     private static boolean areEagerSecInterceptorsSupported(Capabilities capabilities,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
@@ -5,6 +5,7 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * Build time configuration for OIDC.
@@ -31,4 +32,12 @@ public interface OidcBuildTimeConfig {
      */
     @WithDefault("true")
     boolean defaultTokenCacheEnabled();
+
+    /**
+     * Whether the OIDC extension should automatically register a health check for OIDC tenants
+     * when a Health Check capability is present.
+     */
+    @WithName("health.enabled")
+    @WithDefault("false")
+    boolean healthEnabled();
 }

--- a/extensions/oidc/runtime/pom.xml
+++ b/extensions/oidc/runtime/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/health/OidcTenantHealthCheck.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/health/OidcTenantHealthCheck.java
@@ -1,0 +1,106 @@
+package io.quarkus.oidc.runtime.health;
+
+import java.util.Map.Entry;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+import io.quarkus.oidc.runtime.OidcProviderClientImpl;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.quarkus.oidc.runtime.TenantConfigBean;
+import io.quarkus.oidc.runtime.TenantConfigContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+
+@Readiness
+public class OidcTenantHealthCheck implements HealthCheck {
+    private static final String HEALTH_CHECK_NAME = "OIDC Provider Health Check";
+
+    private static final String OK_STATUS = "OK";
+    private static final String ERROR_STATUS = "Error";
+    private static final String DISABLED_STATUS = "Disabled";
+    private static final String UNKNOWN_STATUS = "Unknown";
+    private static final String NOT_READY_STATUS = "Not Ready";
+
+    @Inject
+    TenantConfigBean tenantConfigBean;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.builder()
+                .name(HEALTH_CHECK_NAME)
+                .up();
+
+        String status = checkTenant(builder, OidcUtils.DEFAULT_TENANT_ID, tenantConfigBean.getDefaultTenant());
+        boolean atLeastOneTenantIsReady = OK_STATUS.equals(status);
+
+        for (Entry<String, TenantConfigContext> entry : tenantConfigBean.getStaticTenantsConfig().entrySet()) {
+            status = checkTenant(builder, entry.getKey(), entry.getValue());
+            if (!atLeastOneTenantIsReady) {
+                atLeastOneTenantIsReady = OK_STATUS.equals(status);
+            }
+        }
+
+        if (!atLeastOneTenantIsReady) {
+            builder.down();
+        }
+        return builder.build();
+    }
+
+    private static String checkTenant(HealthCheckResponseBuilder builder, String tenantId,
+            TenantConfigContext tenantConfigContext) {
+
+        if (tenantConfigContext.oidcConfig() == null) {
+            return null;
+        }
+        String name = tenantConfigContext.oidcConfig().clientName().orElse(tenantId);
+
+        String status = null;
+        if (tenantConfigContext.getOidcProviderClient() == null) {
+            if (!tenantConfigContext.oidcConfig().tenantEnabled()) {
+                status = DISABLED_STATUS;
+            } else if (!tenantConfigContext.ready()) {
+                status = NOT_READY_STATUS;
+            }
+        } else if (tenantConfigContext.getOidcMetadata().getDiscoveryUri() == null) {
+            // We may introduce a metadata health property
+            status = UNKNOWN_STATUS;
+        } else {
+            try {
+                status = checkHealth(tenantConfigContext.getOidcProviderClient(),
+                        tenantConfigContext.getOidcMetadata().getDiscoveryUri()).await().indefinitely();
+            } catch (Exception e) {
+                status = ERROR_STATUS + ": " + e.getMessage();
+            }
+        }
+        if (status != null) {
+            builder.withData(name, status);
+        }
+        return status;
+    }
+
+    private static Uni<String> checkHealth(OidcProviderClientImpl oidcClient, String healthUri) {
+
+        HttpRequest<Buffer> request = oidcClient.getWebClient().headAbs(healthUri);
+        return request.send().onItem().transform(resp -> {
+            Buffer buffer = resp.body();
+            if (resp.statusCode() == 200) {
+                return OK_STATUS;
+            } else {
+                String errorMessage = buffer != null ? buffer.toString() : null;
+                if (errorMessage != null && !errorMessage.isEmpty()) {
+                    return ERROR_STATUS + ": " + errorMessage;
+                } else {
+                    return ERROR_STATUS;
+                }
+
+            }
+        });
+
+    }
+}

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
@@ -106,6 +110,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -1,7 +1,10 @@
+quarkus.oidc.health.enabled=true
+
 quarkus.keycloak.devservices.create-realm=false
 quarkus.keycloak.devservices.show-logs=true
 # Default tenant configuration
 quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.client-name=Quarkus Keycloak
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.authentication.scopes=profile,email
 quarkus.oidc.authentication.redirect-path=/web-app

--- a/integration-tests/oidc-dpop/pom.xml
+++ b/integration-tests/oidc-dpop/pom.xml
@@ -34,6 +34,23 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>

--- a/integration-tests/oidc-dpop/src/main/resources/application.properties
+++ b/integration-tests/oidc-dpop/src/main/resources/application.properties
@@ -1,10 +1,15 @@
+quarkus.oidc.health.enabled=true
+
 # Disable default tenant
 quarkus.oidc.tenant-enabled=false
+quarkus.oidc.client-name=Default Tenant
+
 quarkus.keycloak.devservices.start-with-disabled-tenant=true
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 quarkus.keycloak.devservices.features=dpop
 
 quarkus.oidc.dpop-jwt.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.dpop-jwt.token.authorization-scheme=DPoP
+quarkus.oidc.dpop-jwt.client-name=DPoP Tenant
 
 quarkus.log.category."org.htmlunit".level=ERROR

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.oidc.health.enabled=true
+
 quarkus.keycloak.devservices.create-realm=false
 quarkus.keycloak.devservices.realm-name=quarkus-a
 

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -92,7 +92,13 @@ public class BearerTokenAuthorizationTest {
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app"));
 
             webClient.getCookieManager().clearCookies();
+
+            checkHealth();
         }
+    }
+
+    private static void checkHealth() {
+        RestAssured.when().get("http://localhost:8081/q/health/ready").then().statusCode(404);
     }
 
     @Test

--- a/integration-tests/oidc-wiremock/pom.xml
+++ b/integration-tests/oidc-wiremock/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc</artifactId>
         </dependency>
         <dependency>
@@ -80,6 +84,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.oidc.health.enabled=true
 
 # Configuration file
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus2/
@@ -68,7 +69,7 @@ quarkus.oidc.code-flow-encrypted-id-token-disabled.credentials.secret=secret
 quarkus.oidc.code-flow-encrypted-id-token-disabled.application-type=web-app
 quarkus.oidc.code-flow-encrypted-id-token-disabled.token-path=encrypted-id-token
 quarkus.oidc.code-flow-encrypted-id-token-disabled.token.decryption-key-location=privateKey.pem
-quarkus.oidc.code-flow-encrypted-id-token-disabled.token.decryption-id-token=false
+quarkus.oidc.code-flow-encrypted-id-token-disabled.token.decrypt-id-token=false
 quarkus.oidc.code-flow-encrypted-id-token-disabled.token.audience=any
 
 quarkus.oidc.code-flow-form-post.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus-form-post/

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -219,7 +219,7 @@ public class CodeFlowAuthorizationTest {
                 form.getInputByValue("login").click();
                 fail("ID token decryption is disabled");
             } catch (FailingHttpStatusCodeException ex) {
-                assertEquals(500, ex.getResponse().getStatusCode());
+                assertEquals(401, ex.getResponse().getStatusCode());
             }
 
             webClient.getCookieManager().clearCookies();

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.not;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -37,6 +38,10 @@ public class WiremockTestResource {
                 wireMockConfig()
                         .port(port));
         server.start();
+
+        server.stubFor(
+                head(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
+                        .willReturn(aResponse().withStatus(200)));
 
         server.stubFor(
                 get(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))


### PR DESCRIPTION
Fixes #47861.

This is a copy and paste of @jmartisk and @geoand work in Quarkus LangChain4j MCP Client, adapted to  Quarkus OIDC :-)

This PR is meant to offer a simple OIDC Provider Health Check for all OIDC and OAuth2 providers.

It pings the `discovery` endpoint, if it is available. Other endpoints, either MP Health compliant (to deal with ##47791) or other ones, for ex, some GitHub url, can be supported later as `quarkus.oidc.health-url`.

The JSON looks like this:

```json
{
    "checks": [
        {
            "name": "OIDC Provider Health Check",
            "status": "UP",
            "data": {
                "tenant-id-refresh-token": "OK",
                "tenant-https": "OK",
                "tenant-listener": "OK",
                "tenant-split-tokens": "OK"
            }
        }
    ]
}
```

Status will be `UP` if at least a single provider is `OK`, and `DOWN` otherwise.
Tenant statuses: `OK`, `Error`, `Disabled`, `Not Ready Yet`, `Unknown`.

This is only a start and it will definitely require some more tuning,but it is high time `quarkus-oidc` started supporting health checks, as well as telemetry.

I'll need to do a bit more testing and add more docs


