### PR TITLE
Add missing `@PathParam` in injection example (getting started guide)

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -252,6 +252,7 @@ package org.acme;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
@@ -264,7 +265,7 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/greeting/{name}")
-    public String greeting(String name) {
+    public String greeting(@PathParam("name") String name) {
         return service.greeting(name);
     }
 


### PR DESCRIPTION
Currently example at https://quarkus.io/guides/getting-started#using-injection doesn't work as expected due to missing `@PathParam`/`@RestPath`