### PR TITLE
Do not expose Hibernate-specific metamodels through CDI

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -515,12 +515,6 @@ HibernateCriteriaBuilder hibernateCriteriaBuilder;
 Metamodel metamodel;
 
 @Inject
-org.hibernate.Metamodel metamodel;
-
-@Inject
-JpaMetamodel jpaMetamodel;
-
-@Inject
 Cache cache;
 
 @Inject

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -57,8 +57,6 @@ public final class ClassNames {
     public static final DotName HIBERNATE_CRITERIA_BUILDER = createConstant(
             "org.hibernate.query.criteria.HibernateCriteriaBuilder");
     public static final DotName METAMODEL = createConstant("jakarta.persistence.metamodel.Metamodel");
-    public static final DotName HIBERNATE_METAMODEL = createConstant("org.hibernate.Metamodel");
-    public static final DotName JPA_METAMODEL = createConstant("org.hibernate.metamodel.model.domain.JpaMetamodel");
     public static final DotName SCHEMA_MANAGER = createConstant("org.hibernate.relational.SchemaManager");
     public static final DotName CACHE = createConstant("jakarta.persistence.Cache");
     public static final DotName HIBERNATE_CACHE = createConstant("org.hibernate.Cache");

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
@@ -72,8 +72,7 @@ public class HibernateOrmCdiProcessor {
     private static final List<DotName> STATELESS_SESSION_EXPOSED_TYPES = List.of(ClassNames.STATELESS_SESSION);
     private static final List<DotName> CRITERIA_BUILDER_EXPOSED_TYPES = List.of(ClassNames.CRITERIA_BUILDER,
             ClassNames.HIBERNATE_CRITERIA_BUILDER);
-    private static final List<DotName> METAMODEL_EXPOSED_TYPES = List.of(ClassNames.METAMODEL, ClassNames.JPA_METAMODEL,
-            ClassNames.HIBERNATE_METAMODEL);
+    private static final List<DotName> METAMODEL_EXPOSED_TYPES = List.of(ClassNames.METAMODEL);
     private static final List<DotName> SCHEMA_MANAGER_EXPOSED_TYPES = List.of(ClassNames.SCHEMA_MANAGER);
     private static final List<DotName> CACHE_EXPOSED_TYPES = List.of(ClassNames.CACHE, ClassNames.HIBERNATE_CACHE);
     private static final List<DotName> PERSISTENCE_UNIT_UTIL_EXPOSED_TYPES = List.of(ClassNames.PERSISTENCE_UNIT_UTIL);
@@ -401,7 +400,7 @@ public class HibernateOrmCdiProcessor {
         // Create Metamodel bean
         producer.produce(createSyntheticBean(persistenceUnitName,
                 isDefaultPU, isNamedPU,
-                org.hibernate.Metamodel.class, METAMODEL_EXPOSED_TYPES, false)
+                jakarta.persistence.metamodel.Metamodel.class, METAMODEL_EXPOSED_TYPES, false)
                 .createWith(recorder.metamodelSupplier(persistenceUnitName))
                 .addInjectionPoint(ClassType.create(DotName.createSimple(SessionFactory.class)),
                         sessionFactoryQualifier)

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiMetamodelTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiMetamodelTest.java
@@ -8,7 +8,6 @@ import jakarta.inject.Inject;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
 
-import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -36,16 +35,8 @@ public class MultiplePersistenceUnitsCdiMetamodelTest {
     Metamodel usersMetamodel;
 
     @Inject
-    @PersistenceUnit("users")
-    JpaMetamodel usersJpaMetamodel;
-
-    @Inject
     @PersistenceUnit("inventory")
     Metamodel inventoryMetamodel;
-
-    @Inject
-    @PersistenceUnit("inventory")
-    org.hibernate.Metamodel hibernateInventoryMetamodel;
 
     @Test
     public void defaultMetamodel() {
@@ -69,30 +60,10 @@ public class MultiplePersistenceUnitsCdiMetamodelTest {
     }
 
     @Test
-    public void usersJpaMetamodel() {
-        assertNotNull(usersJpaMetamodel);
-
-        EntityType<User> entityType = usersJpaMetamodel.entity(User.class);
-        assertNotNull(entityType);
-
-        assertEquals(User.class.getSimpleName(), entityType.getName());
-    }
-
-    @Test
     public void inventoryMetamodel() {
         assertNotNull(inventoryMetamodel);
 
         EntityType<Plane> entityType = inventoryMetamodel.entity(Plane.class);
-        assertNotNull(entityType);
-
-        assertEquals(Plane.class.getSimpleName(), entityType.getName());
-    }
-
-    @Test
-    public void hibernateInventoryMetamodel() {
-        assertNotNull(hibernateInventoryMetamodel);
-
-        EntityType<Plane> entityType = hibernateInventoryMetamodel.entity(Plane.class);
         assertNotNull(entityType);
 
         assertEquals(Plane.class.getSimpleName(), entityType.getName());
@@ -106,11 +77,4 @@ public class MultiplePersistenceUnitsCdiMetamodelTest {
                 .hasMessageContaining("Not an entity");
     }
 
-    @Test
-    public void testUserInHibernateInventoryMetamodel() {
-        assertThatThrownBy(() -> {
-            hibernateInventoryMetamodel.entity(User.class);
-        }).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Not an entity");
-    }
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiMetamodelTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitCdiMetamodelTest.java
@@ -8,7 +8,6 @@ import jakarta.inject.Inject;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
 
-import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -24,10 +23,6 @@ public class SinglePersistenceUnitCdiMetamodelTest {
 
     @Inject
     Metamodel metamodel;
-    @Inject
-    org.hibernate.Metamodel hibernateMetamodel;
-    @Inject
-    JpaMetamodel jpaMetamodel;
 
     @Test
     public void testMetamodel() {
@@ -41,27 +36,4 @@ public class SinglePersistenceUnitCdiMetamodelTest {
         assertEquals(DefaultEntity.class.getSimpleName(), entityType.getName());
     }
 
-    @Test
-    public void testHibernateMetamodel() {
-        assertNotNull(hibernateMetamodel);
-        EntityType<DefaultEntity> entityType = hibernateMetamodel.entity(DefaultEntity.class);
-        assertNotNull(entityType);
-        assertTrue(
-                hibernateMetamodel.getEntities().stream()
-                        .anyMatch(et -> et.getJavaType().equals(DefaultEntity.class)),
-                "Hibernate Metamodel should contain DefaultEntity");
-        assertEquals(DefaultEntity.class.getSimpleName(), entityType.getName());
-    }
-
-    @Test
-    public void testJpaMetamodel() {
-        assertNotNull(jpaMetamodel);
-        EntityType<DefaultEntity> entityType = jpaMetamodel.entity(DefaultEntity.class);
-        assertNotNull(entityType);
-        assertTrue(
-                jpaMetamodel.getEntities().stream()
-                        .anyMatch(et -> et.getJavaType().equals(DefaultEntity.class)),
-                "Hibernate Metamodel should contain DefaultEntity");
-        assertEquals(DefaultEntity.class.getSimpleName(), entityType.getName());
-    }
 }


### PR DESCRIPTION
They are deprecated or incubating, and changes are coming in Hibernate ORM 7.0, so it's best not to rely on them for now.

See https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/MappingMetamodel.20and.20JpaMetamodel/with/518018057

Follows up on #47792 .

Should probably be backported to 3.23.0.Final to avoid this (now removed) feature being actually used in the real world. It was introduced in 3.23.0.CR1.