### PR TITLE
Fallback `quarkus.test.integration-test-profile` to `quarkus.profile`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -160,7 +160,7 @@ public interface TestConfig {
     /**
      * The profile to use when testing using {@code @QuarkusIntegrationTest}
      */
-    @WithDefault("${quarkus.profile:prod}")
+    @WithDefault("prod")
     String integrationTestProfile();
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfigCustomizer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfigCustomizer.java
@@ -1,0 +1,44 @@
+package io.quarkus.deployment.dev.testing;
+
+import java.util.function.Function;
+
+import io.quarkus.runtime.LaunchMode;
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigSourceInterceptorFactory;
+import io.smallrye.config.FallbackConfigSourceInterceptor;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+public class TestConfigCustomizer implements SmallRyeConfigBuilderCustomizer {
+    private final LaunchMode launchMode;
+
+    public TestConfigCustomizer(final LaunchMode launchMode) {
+        this.launchMode = launchMode;
+    }
+
+    @Override
+    public void configBuilder(final SmallRyeConfigBuilder builder) {
+        builder.withDefaultValue("quarkus.profile", launchMode.getDefaultProfile());
+        builder.withMapping(TestConfig.class);
+        builder.withInterceptorFactories(new ConfigSourceInterceptorFactory() {
+            @Override
+            public ConfigSourceInterceptor getInterceptor(final ConfigSourceInterceptorContext context) {
+                return new FallbackConfigSourceInterceptor(new Function<String, String>() {
+                    @Override
+                    public String apply(final String name) {
+                        if (name.equals("quarkus.test.integration-test-profile")) {
+                            return "quarkus.profile";
+                        }
+                        return name;
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public int priority() {
+        return SmallRyeConfigBuilderCustomizer.super.priority();
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/QuarkusTestConfigProviderResolver.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/QuarkusTestConfigProviderResolver.java
@@ -1,6 +1,6 @@
 package io.quarkus.test.junit.classloading;
 
-import io.quarkus.deployment.dev.testing.TestConfig;
+import io.quarkus.deployment.dev.testing.TestConfigCustomizer;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.smallrye.config.SmallRyeConfig;
@@ -17,9 +17,8 @@ public class QuarkusTestConfigProviderResolver extends SmallRyeConfigProviderRes
         try {
             Thread.currentThread().setContextClassLoader(classLoader);
             SmallRyeConfig config = ConfigUtils.configBuilder(false, true, LaunchMode.TEST)
-                    .withProfile(LaunchMode.TEST.getDefaultProfile())
-                    .withMapping(TestConfig.class, "quarkus.test")
                     .forClassLoader(classLoader)
+                    .withCustomizers(new TestConfigCustomizer(LaunchMode.TEST))
                     .build();
 
             // See comments on AbstractJVMTestExtension#evaluateExecutionCondition for why this is the system classloader


### PR DESCRIPTION
- Fixes #47853

There was a clash between #47759 and #47807. Before #47807 the JUnit config would always use the `test` profile to set the config. For Quarkus, this is not a big issue, but it prevented users from setting a profile when running plain JUnit tests #47755. To fix it, the JUnit config now reads `quarkus.profile` and sets it as a default.

With #47759, it unifies how integration tests profile and the main profile are used, by adding a fallback in the form of `${quarkus.profile:prod}` to `quarkus.test.integration-test-profile`. While this works most of the times, it does have a limitation. In the case where both values are set in the same config source ordinal (like defaults), it is the expression that has priority and not the original value, which ends up now working as an intended fallback. For that reason, an actual `FallbackConfigSourceInterceptor` checks each value ordinal and uses the one coming from a higher source, or in the case of a tie, uses the property's original value before being fallbacked.

Because of #47807 which now sets `quarkus.profile` as a default and `quarkus.test.integration-test-profile` pointing to `${quarkus.profile:prod}`, it would end up using `test`. With this change, it now correctly uses `prod`, but allows users to override if they set `quarkus.profile`.