### PR TITLE
Extract Kafka Streams topics to check from the topology

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
@@ -4,7 +4,6 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -48,6 +47,13 @@ public interface KafkaStreamsRuntimeConfig {
     Optional<List<String>> topics();
 
     /**
+     * A comma-separated list of topic name patterns.
+     * The pipeline will only be started once all these topics are present in the Kafka cluster
+     * and {@code ignore.topics} is set to false.
+     */
+    Optional<List<String>> topicPatterns();
+
+    /**
      * Timeout to wait for topic names to be returned from admin client.
      * If set to 0 (or negative), {@code topics} check is ignored.
      */
@@ -88,8 +94,4 @@ public interface KafkaStreamsRuntimeConfig {
      */
     SslConfig ssl();
 
-    default List<String> getTrimmedTopics() {
-        return topics().orElseThrow(() -> new IllegalArgumentException("Missing list of topics"))
-                .stream().map(String::trim).collect(Collectors.toList());
-    }
 }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
@@ -1,16 +1,21 @@
 package io.quarkus.kafka.streams.runtime;
 
 import java.time.Duration;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
 import org.jboss.logging.Logger;
 
 public class KafkaStreamsTopologyManager {
@@ -18,31 +23,146 @@ public class KafkaStreamsTopologyManager {
     private static final Logger LOGGER = Logger.getLogger(KafkaStreamsTopologyManager.class.getName());
 
     private final Admin adminClient;
+    private final List<String> sourceTopics;
+    private final List<Pattern> sourcePatterns;
+    private final Duration topicsTimeout;
 
-    public KafkaStreamsTopologyManager(Admin adminClient) {
+    private volatile boolean closed = false;
+
+    public KafkaStreamsTopologyManager(Admin adminClient, Topology topology, KafkaStreamsRuntimeConfig runtimeConfig) {
         this.adminClient = adminClient;
+        this.topicsTimeout = runtimeConfig.topicsTimeout();
+        if (isTopicsCheckEnabled()) {
+            if (runtimeConfig.topics().isEmpty() && runtimeConfig.topicPatterns().isEmpty()) {
+                Set<String> topics = new HashSet<>();
+                Set<Pattern> patterns = new HashSet<>();
+                extractSources(topology, topics, patterns);
+                this.sourceTopics = new ArrayList<>(topics);
+                this.sourcePatterns = new ArrayList<>(patterns);
+                LOGGER.infof("Kafka Streams will wait for topics: %s and topics matching patterns: %s to be created",
+                        sourceTopics, sourcePatterns);
+            } else {
+                this.sourceTopics = runtimeConfig.topics().orElse(Collections.emptyList());
+                this.sourcePatterns = runtimeConfig.topicPatterns().orElse(Collections.emptyList()).stream()
+                        .map(Pattern::compile)
+                        .toList();
+            }
+            if (sourceTopics.isEmpty() && sourcePatterns.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "No topics or topic patterns specified; cannot wait for topics to be created, " +
+                                "in order to disable topics creation check set `quarkus.kafka-streams.topics-check-timeout=0`");
+            }
+        } else {
+            LOGGER.infof("Kafka Streams will not wait for topics to be created");
+            this.sourceTopics = Collections.emptyList();
+            this.sourcePatterns = Collections.emptyList();
+        }
     }
 
-    public Set<String> getMissingTopics(Collection<String> topicsToCheck) throws InterruptedException {
-        return getMissingTopics(topicsToCheck, Duration.ofSeconds(10)); // keep defaults
+    public boolean isTopicsCheckEnabled() {
+        return topicsTimeout.compareTo(Duration.ZERO) > 0;
     }
 
-    public Set<String> getMissingTopics(Collection<String> topicsToCheck, Duration timeout) throws InterruptedException {
-        Set<String> missing = new LinkedHashSet<>(topicsToCheck);
+    void close() {
+        this.closed = true;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    // visible for testing
+    public static void extractSources(Topology topo, Set<String> topics, Set<Pattern> patterns) {
+        Set<String> sinkTopics = new HashSet<>();
+        TopologyDescription topologyDescription = topo.describe();
+        for (TopologyDescription.GlobalStore globalStore : topologyDescription.globalStores()) {
+            TopologyDescription.Source source = globalStore.source();
+            if (source.topicPattern() != null) {
+                patterns.add(source.topicPattern());
+            }
+            if (source.topicSet() != null) {
+                topics.addAll(source.topicSet());
+            }
+        }
+        for (TopologyDescription.Subtopology subtopology : topologyDescription.subtopologies()) {
+            for (TopologyDescription.Node node : subtopology.nodes()) {
+                if (node instanceof TopologyDescription.Sink sink) {
+                    if (sink.topic() != null) {
+                        sinkTopics.add(sink.topic());
+                    }
+                } else if (node instanceof TopologyDescription.Source source) {
+                    if (source.topicPattern() != null) {
+                        patterns.add(source.topicPattern());
+                    }
+                    if (source.topicSet() != null) {
+                        topics.addAll(source.topicSet());
+                    }
+                }
+            }
+        }
+        // remove topics used both in sinks ans sources
+        topics.removeAll(sinkTopics);
+    }
+
+    public List<String> getSourceTopics() {
+        return sourceTopics;
+    }
+
+    public List<Pattern> getSourcePatterns() {
+        return sourcePatterns;
+    }
+
+    public Set<String> getMissingTopics() throws InterruptedException {
+        if (!isTopicsCheckEnabled()) {
+            return Collections.emptySet();
+        }
+
+        Set<String> missing = new LinkedHashSet<>(sourceTopics);
 
         try {
             ListTopicsResult topics = adminClient.listTopics();
-            Set<String> topicNames = topics.names().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            Set<String> existingTopics = topics.names().get(topicsTimeout.toMillis(), TimeUnit.MILLISECONDS);
 
-            if (topicNames.containsAll(topicsToCheck)) {
-                return Collections.emptySet();
-            } else {
-                missing.removeAll(topicNames);
-            }
+            missing.removeAll(existingTopics);
+            missing.addAll(sourcePatterns.stream()
+                    .filter(p -> existingTopics.stream().noneMatch(p.asPredicate()))
+                    .map(Pattern::pattern)
+                    .toList());
         } catch (ExecutionException | TimeoutException e) {
             LOGGER.error("Failed to get topic names from broker", e);
         }
 
         return missing;
+    }
+
+    public void waitForTopicsToBeCreated() throws InterruptedException {
+        Set<String> lastMissingTopics = null;
+        while (!closed) {
+            try {
+                ListTopicsResult topics = adminClient.listTopics();
+                Set<String> existingTopics = topics.names().get(topicsTimeout.toMillis(), TimeUnit.MILLISECONDS);
+
+                if (existingTopics.containsAll(sourceTopics)
+                        && sourcePatterns.stream().allMatch(p -> existingTopics.stream().anyMatch(p.asPredicate()))) {
+                    LOGGER.debugf("All expected topics %s and topics matching patterns %s ", sourceTopics, sourcePatterns);
+                    return;
+                } else {
+                    Set<String> missingTopics = new HashSet<>(sourceTopics);
+                    missingTopics.removeAll(existingTopics);
+
+                    // Do not spam warnings - topics may take time to be created by an operator like Strimzi
+                    if (missingTopics.equals(lastMissingTopics)) {
+                        LOGGER.debug("Waiting for topic(s) to be created: " + missingTopics);
+                    } else {
+                        LOGGER.warn("Waiting for topic(s) to be created: " + missingTopics);
+                        lastMissingTopics = missingTopics;
+                    }
+                }
+            } catch (ExecutionException | TimeoutException e) {
+                LOGGER.error("Failed to get topic names from broker", e);
+            } finally {
+                Thread.sleep(1_000);
+            }
+        }
     }
 }

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
@@ -4,30 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.kafka.streams.KafkaStreams;
 import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
-
+@ExtendWith(MockitoExtension.class)
 public class KafkaStreamsHealthCheckTest {
 
     @InjectMocks
-    KafkaStreamsStateHealthCheck healthCheck = new KafkaStreamsStateHealthCheck();
-
-    @Mock
-    private KafkaStreamsTopologyManager manager;
+    KafkaStreamsStateHealthCheck healthCheck;
 
     @Mock
     private KafkaStreams streams;
-
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
-    }
 
     @Test
     public void shouldBeUpIfStateRunning() {

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
@@ -1,57 +1,40 @@
 package io.quarkus.kafka.streams.runtime.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 
-import java.time.Duration;
 import java.util.Collections;
-import java.util.Optional;
 
 import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
 
+@ExtendWith(MockitoExtension.class)
 public class KafkaStreamsTopicsHealthCheckTest {
 
     @InjectMocks
-    KafkaStreamsTopicsHealthCheck healthCheck = new KafkaStreamsTopicsHealthCheck();
+    KafkaStreamsTopicsHealthCheck healthCheck;
 
     @Mock
     private KafkaStreamsTopologyManager manager;
 
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
-
-        KafkaStreamsRuntimeConfig configMock = Mockito.mock(KafkaStreamsRuntimeConfig.class);
-        Mockito.doReturn(Optional.of(Collections.singletonList("topic")))
-                .when(configMock).topics();
-
-        Mockito.doReturn(Duration.ofSeconds(10))
-                .when(configMock).topicsTimeout();
-        healthCheck.kafkaStreamsRuntimeConfig = configMock;
-
-        healthCheck.init();
-    }
-
     @Test
     public void shouldBeUpIfNoMissingTopic() throws InterruptedException {
-        Mockito.when(manager.getMissingTopics(anyList(), any())).thenReturn(Collections.emptySet());
+        Mockito.when(manager.isTopicsCheckEnabled()).thenReturn(true);
+        Mockito.when(manager.getMissingTopics()).thenReturn(Collections.emptySet());
         HealthCheckResponse response = healthCheck.call();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
     }
 
     @Test
     public void shouldBeDownIfMissingTopic() throws InterruptedException {
-        Mockito.when(manager.getMissingTopics(anyList(), any())).thenReturn(Collections.singleton("topic"));
+        Mockito.when(manager.isTopicsCheckEnabled()).thenReturn(true);
+        Mockito.when(manager.getMissingTopics()).thenReturn(Collections.singleton("topic"));
         HealthCheckResponse response = healthCheck.call();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
     }

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/TopologyTopicsExtractTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/TopologyTopicsExtractTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.kafka.streams.runtime.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import jakarta.enterprise.inject.Produces;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
+
+public class TopologyTopicsExtractTest {
+
+    @Test
+    void testTopologyWithStateStore() {
+        Set<String> topics = new HashSet<>();
+        Set<Pattern> patterns = new HashSet<>();
+        KafkaStreamsTopologyManager.extractSources(topologyWithStateStore(), topics, patterns);
+        assertThat(topics).containsExactlyInAnyOrder("WEATHER_STATIONS_TOPIC", "TEMPERATURE_VALUES_TOPIC");
+    }
+
+    @Test
+    void testTopologyWithSelectKey() {
+        Set<String> topics = new HashSet<>();
+        Set<Pattern> patterns = new HashSet<>();
+        KafkaStreamsTopologyManager.extractSources(buildTopology(), topics, patterns);
+        assertThat(topics).containsExactlyInAnyOrder("streams-test-customers", "streams-test-categories");
+    }
+
+    public Topology topologyWithStateStore() {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        KeyValueBytesStoreSupplier storeSupplier = Stores.persistentKeyValueStore(
+                "WEATHER_STATIONS_STORE");
+
+        GlobalKTable<Integer, String> stations = builder.globalTable( // <1>
+                "WEATHER_STATIONS_TOPIC",
+                Consumed.with(Serdes.Integer(), Serdes.String()));
+
+        builder.stream( // <2>
+                "TEMPERATURE_VALUES_TOPIC",
+                Consumed.with(Serdes.Integer(), Serdes.String()))
+                .join( // <3>
+                        stations,
+                        (stationId, timestampAndValue) -> stationId,
+                        (timestampAndValue, station) -> {
+                            String[] parts = timestampAndValue.split(";");
+                            return parts[0] + "," + parts[1] + "," + station;
+                        })
+                .groupByKey() // <4>
+                .aggregate( // <5>
+                        String::new,
+                        (stationId, value, aggregation) -> aggregation + value,
+                        Materialized.<Integer, String> as(storeSupplier)
+                                .withKeySerde(Serdes.Integer())
+                                .withValueSerde(Serdes.String()))
+                .toStream()
+                .to( // <6>
+                        "TEMPERATURES_AGGREGATED_TOPIC",
+                        Produced.with(Serdes.Integer(), Serdes.String()));
+
+        return builder.build();
+    }
+
+    @Produces
+    public Topology buildTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        KTable<Integer, String> categories = builder.table(
+                "streams-test-categories",
+                Consumed.with(Serdes.Integer(), Serdes.String()));
+
+        KStream<Integer, String> customers = builder
+                .stream("streams-test-customers", Consumed.with(Serdes.Integer(), Serdes.String()))
+                .selectKey((id, customer) -> customer.length())
+                .join(categories,
+                        (customer, category) -> "" + customer.length() + category.length(),
+                        Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
+
+        KeyValueBytesStoreSupplier storeSupplier = Stores.inMemoryKeyValueStore("countstore");
+        customers.groupByKey()
+                .count(Materialized.as(storeSupplier));
+
+        customers.selectKey((categoryId, customer) -> customer)
+                .to("streams-test-customers-processed", Produced.with(Serdes.String(), Serdes.String()));
+
+        return builder.build();
+    }
+}

--- a/integration-tests/kafka-streams/src/main/resources/application.properties
+++ b/integration-tests/kafka-streams/src/main/resources/application.properties
@@ -2,8 +2,6 @@ quarkus.log.category.kafka.level=WARN
 quarkus.log.category.\"org.apache.kafka\".level=WARN
 quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 
-quarkus.kafka-streams.topics=streams-test-categories,streams-test-customers
-
 quarkus.kafka-streams.schema-registry-key=apicurio.registry.url
 quarkus.kafka-streams.schema-registry-url=http://localhost:8080
 

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsListedTopicsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsListedTopicsTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.kafka.streams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTestResource(KafkaSSLTestResource.class)
+@TestProfile(KafkaStreamsListedTopicsTest.ListedTopicsProfile.class)
+@QuarkusTest
+public class KafkaStreamsListedTopicsTest extends KafkaStreamsTest {
+
+    public static class ListedTopicsProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> conf = new HashMap<>();
+            conf.put("quarkus.kafka-streams.topics", "streams-test-categories,streams-test-customers");
+            return conf;
+        }
+    }
+}

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTopicsPatternTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTopicsPatternTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.kafka.streams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTestResource(KafkaSSLTestResource.class)
+@TestProfile(KafkaStreamsTopicsPatternTest.TopicsPatternProfile.class)
+@QuarkusTest
+public class KafkaStreamsTopicsPatternTest extends KafkaStreamsTest {
+
+    @Override
+    Matcher<String> topicsMatcher() {
+        return CoreMatchers.containsString("streams-test-.*");
+    }
+
+    public static class TopicsPatternProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> conf = new HashMap<>();
+            conf.put("quarkus.kafka-streams.topic-patterns", "streams-test-.*");
+            return conf;
+        }
+    }
+}


### PR DESCRIPTION
The list of topics is used for waiting before starting the KafkaStreams instance and readiness health check.

Added config for waiting on patterns of topics.

