### PR TITLE
Adding scheme and authority to absoluteUri

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -462,12 +462,13 @@ public abstract class ResteasyReactiveRequestContext
 
     public String getAbsoluteURI() {
         // if we never changed the path we can use the vert.x URI
-        if (path == null)
+        if (path == null) {
             return serverRequest().getRequestAbsoluteUri();
+        }
         // Note: we could store our cache as normalised, but I'm not sure if the vertx one is normalised
         if (absoluteUri == null) {
             try {
-                absoluteUri = new URI(scheme, authority, path, null, null).toASCIIString();
+                absoluteUri = new URI(getScheme(), getAuthority(), path, null, null).toASCIIString();
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }
@@ -476,14 +477,16 @@ public abstract class ResteasyReactiveRequestContext
     }
 
     public String getScheme() {
-        if (scheme == null)
+        if (scheme == null) {
             return serverRequest().getRequestScheme();
+        }
         return scheme;
     }
 
     public String getAuthority() {
-        if (authority == null)
+        if (authority == null) {
             return serverRequest().getRequestHost();
+        }
         return authority;
     }
 
@@ -1012,7 +1015,7 @@ public abstract class ResteasyReactiveRequestContext
                         select.destroy(instance);
                     }
                 });
-                return (T) instance;
+                return instance;
             }
         }
         throw new IllegalStateException("Unsupported bean param type: " + type);

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
@@ -1,0 +1,62 @@
+package org.jboss.resteasy.reactive.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.concurrent.Executor;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.ServerHttpRequest;
+import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ResteasyReactiveRequestContextTest {
+
+    @Test
+    void testAbsoluteUriWithOverrides() {
+        var request = Mockito.mock(ServerHttpRequest.class);
+        var context = new ResteasyReactiveRequestContext(null, null, null, null) {
+
+            @Override
+            public ServerHttpResponse serverResponse() {
+                return null;
+            }
+
+            @Override
+            public ServerHttpRequest serverRequest() {
+                return request;
+            }
+
+            @Override
+            public boolean resumeExternalProcessing() {
+                return false;
+            }
+
+            @Override
+            public Runnable registerTimer(long millis, Runnable task) {
+                return null;
+            }
+
+            @Override
+            protected Executor getEventLoop() {
+                return null;
+            }
+
+            @Override
+            protected void setQueryParamsFrom(String uri) {
+
+            }
+        };
+        Mockito.when(request.getRequestNormalisedPath()).thenReturn("/path;a");
+        Mockito.when(request.getRequestScheme()).thenReturn("http");
+        Mockito.when(request.getRequestHost()).thenReturn("host:port");
+
+        context.initPathSegments();
+        assertEquals("http://host:port/path", context.getAbsoluteURI());
+
+        context.setRequestUri(URI.create("https://host1:port1/path1"));
+        assertEquals("https://host1:port1/path1", context.getAbsoluteURI());
+    }
+
+}


### PR DESCRIPTION
The query and fragment will still be left off of the returned absolute uri.

- Closes: #47785