### PR TITLE
Add tests for gradle case where a package private class is in a test fixture

### DIFF
--- a/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'java'
+    id 'java-test-fixtures'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'my-groupId'
+version 'my-version'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/gradle.properties
@@ -1,0 +1,4 @@
+#Quarkus Gradle TS
+#Sat May 23 23:11:14 CEST 2020
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/settings.gradle
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name='io.quarkus.reproducer'
+

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/src/main/java/org/acme/GreetingResource.java
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Quarkus REST";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/src/test/java/org/acme/ChildTest.java
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/src/test/java/org/acme/ChildTest.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class ChildTest extends ParentTest {
+    @Test
+    void testHelloEndpoint() {
+        given()
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("Hello from Quarkus REST"));
+    }
+
+}

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/src/testFixtures/java/org/acme/ParentTest.java
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/src/testFixtures/java/org/acme/ParentTest.java
@@ -1,0 +1,5 @@
+package org.acme;
+
+class ParentTest {
+
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleWithPackagePrivateParentTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleWithPackagePrivateParentTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class TestFixtureModuleWithPackagePrivateParentTest extends QuarkusGradleWrapperTestBase {
+
+    @Disabled("See https://github.com/quarkusio/quarkus/issues/47760")
+    @Test
+    public void testTaskShouldUseTestFixtures() throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir("test-fixtures-module-with-package-private-parent");
+
+        final BuildResult result = runGradleWrapper(projectDir, "clean", "test");
+
+        assertThat(BuildResult.isSuccessful(result.getTasks().get(":test"))).isTrue();
+    }
+}


### PR DESCRIPTION
Reproducer for https://github.com/quarkusio/quarkus/issues/47760. 

The key condition is that a package is split between a normal test source and a test fixture source. 

The QuarkusClassLoader loads the test source with the runtime classloader, but the test fixture gets loaded with the base runtime classloader, because it can't be found using the normal lookup in runtime classloader, so the runtime classloader delegates to its parent, the base runtime classloader. Different classloaders and package private access is a bad combination, so things explode. 

I haven't investigated to confirm whether in 3.21 we always managed to load test fixtures with the runtime classloader, but it seems likely. So I wonder if some of the new code is initialising the app with the wrong classpath? 

@aloubyansky I'm sending this to you for review, but I'm also hoping you might have some ideas about where things are going wrong with the loading of the `testFixture` classes in the runtime classloader.

This is probably also closely related to https://github.com/quarkusio/quarkus/issues/47692.