### PR TITLE
Make placing JPA listener annotations a little safer

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -429,24 +429,13 @@ public final class JpaJandexScavenger {
 
         for (AnnotationInstance annotation : jpaAnnotations) {
             AnnotationTarget target = annotation.target();
-            ClassInfo beanType;
-            switch (target.kind()) {
-                case CLASS:
-                    beanType = target.asClass();
-                    break;
-                case FIELD:
-                    beanType = target.asField().declaringClass();
-                    break;
-                case METHOD:
-                    beanType = target.asMethod().declaringClass();
-                    break;
-                case METHOD_PARAMETER:
-                case TYPE:
-                case RECORD_COMPONENT:
-                default:
-                    throw new IllegalArgumentException(
-                            "Annotation " + dotName + " was not expected on a target of kind " + target.kind());
-            }
+            ClassInfo beanType = switch (target.kind()) {
+                case CLASS -> target.asClass();
+                case FIELD -> target.asField().declaringClass();
+                case METHOD -> target.asMethod().declaringClass();
+                default -> throw new IllegalArgumentException(
+                        "Annotation " + dotName + " was not expected on a target of kind " + target.kind());
+            };
             DotName beanTypeDotName = beanType.name();
             collector.potentialCdiBeanTypes.add(beanTypeDotName);
         }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/JpaListenerOnPrivateMethodOfApplicationScopedCdiBeanTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/JpaListenerOnPrivateMethodOfApplicationScopedCdiBeanTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.hibernate.orm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PostPersist;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JpaListenerOnPrivateMethodOfApplicationScopedCdiBeanTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application.properties"))
+            .assertException(e -> {
+                assertThat(e).isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("SomeEntityListener#postPersist");
+            });
+
+    @Test
+    @Transactional
+    public void test() {
+        fail("should never be called");
+    }
+
+    @Entity
+    @EntityListeners(SomeEntityListener.class)
+    public static class SomeEntity {
+        private long id;
+        private String name;
+
+        public SomeEntity() {
+        }
+
+        public SomeEntity(String name) {
+            this.name = name;
+        }
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "myEntitySeq")
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return "SomeEntity:" + name;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SomeEntityListener {
+
+        @PostPersist
+        private void postPersist(SomeEntity someEntity) {
+            fail("should not reach here");
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/JpaListenerOnPrivateMethodOfSingletonCdiBeanTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/JpaListenerOnPrivateMethodOfSingletonCdiBeanTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.hibernate.orm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PrePersist;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JpaListenerOnPrivateMethodOfSingletonCdiBeanTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application.properties"));
+
+    @Inject
+    EventStore eventStore;
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    @Transactional
+    public void test() {
+        Arc.container().requestContext().activate();
+        try {
+            SomeEntity entity = new SomeEntity("test");
+            em.persist(entity);
+            em.flush();
+        } finally {
+            Arc.container().requestContext().terminate();
+        }
+
+        assertThat(eventStore.getEvents()).containsExactly("prePersist", "postPersist");
+    }
+
+    @Entity
+    @EntityListeners(SomeEntityListener.class)
+    public static class SomeEntity {
+        private long id;
+        private String name;
+
+        public SomeEntity() {
+        }
+
+        public SomeEntity(String name) {
+            this.name = name;
+        }
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "myEntitySeq")
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return "SomeEntity:" + name;
+        }
+    }
+
+    @Singleton
+    public static class SomeEntityListener {
+
+        private final EventStore eventStore;
+
+        public SomeEntityListener(EventStore eventStore) {
+            this.eventStore = eventStore;
+        }
+
+        @PrePersist
+        void prePersist(SomeEntity someEntity) {
+            eventStore.addEvent("prePersist");
+        }
+
+        @PostPersist
+        private void postPersist(SomeEntity someEntity) {
+            eventStore.addEvent("postPersist");
+        }
+    }
+
+    @ApplicationScoped
+    public static class EventStore {
+        private final List<String> events = new CopyOnWriteArrayList<>();
+
+        public void addEvent(String event) {
+            events.add(event);
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+    }
+}


### PR DESCRIPTION
This essentially handles the case where such a listener
is added on private method of a CDI EntityListener class.
When the listener is a `@Singleton` we can safely transform
the private method to package private, but when it's
`@ApplicationScoped` there is nothing we can do
(as any transformation we apply is invisible to Arc
when it creates the Client Proxy class), so we
therefore fail the build (with an actionable error
message).

- Closes: https://github.com/quarkusio/quarkus/issues/24340