### PR TITLE
Manage io.perfmark:perfmark-api to keep Quarkus, Camel Quarkus, Quarkus CXF and Quarkus Google Cloud Services in sync 

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -398,6 +398,12 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.perfmark</groupId>
+                <artifactId>perfmark-api</artifactId>
+                <version>${perfmark.version}</version>
+            </dependency>
+
 
             <!-- Micrometer Core and Registries, imported as BOM -->
             <dependency>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -48,6 +48,8 @@
 
         <!-- Default properties -->
         <maven.compiler.parameters>true</maven.compiler.parameters>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -48,8 +48,6 @@
 
         <!-- Default properties -->
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,15 @@
         <hibernate-search.version>7.2.3.Final</hibernate-search.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
-        <grpc.version>1.69.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <grpc.version>1.69.1</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->
+                                            <!-- com.google.auth -->
+                                            <!-- perfmark.version https://central.sonatype.com/artifact/io.grpc/grpc-core  -->
         <grpc-jprotoc.version>1.2.2</grpc-jprotoc.version>
         <protoc.version>3.25.5</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
         <protobuf-kotlin.version>4.29.3</protobuf-kotlin.version>
         <proto-google-common-protos.version>2.56.0</proto-google-common-protos.version>
+        <perfmark.version>0.27.0</perfmark.version><!-- dependency of io.grpc:grpc-core not managed in io.grpc:grpc-bom -->
 
         <!-- Used in the build parent and test BOM (for the junit 5 plugin) and in the BOM (for the API) -->
         <smallrye-certificate-generator.version>0.9.2</smallrye-certificate-generator.version>


### PR DESCRIPTION
- Fixes: #47877