### PR TITLE
Bump kubernetes-client-bom from 7.2.0 to 7.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Properties below are set in this file because they are used
              in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.13</jacoco.version>
-        <kubernetes-client.version>7.2.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>7.3.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.2</rest-assured.version>
         <hibernate-orm.version>6.6.15.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
Kubernetes Client 7.3.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v7.3.0

Requires #47558 (or should include the Jackson version bump)

### Breaking changes (sort of)

This release bumps the dependency of Jackson to v2.19.0 and is not backwards-compatible with any earlier version (hence the need for #47558)

/cc @metacosm