### PR TITLE
Retry when `CL.definePackage()` throws an IAE

### DIFF
--- a/core/launcher/src/main/java/io/quarkus/launcher/RuntimeLaunchClassLoader.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/RuntimeLaunchClassLoader.java
@@ -35,14 +35,22 @@ public class RuntimeLaunchClassLoader extends ClassLoader {
     }
 
     private void definePackage(String name) {
-        final String pkgName = getPackageNameFromClassName(name);
-        if ((pkgName != null) && getPackage(pkgName) == null) {
-            synchronized (getClassLoadingLock(pkgName)) {
-                if (getPackage(pkgName) == null) {
-                    // this could certainly be improved to use the actual manifest
-                    definePackage(pkgName, null, null, null, null, null, null, null);
-                }
+        var pkgName = getPackageNameFromClassName(name);
+        if (pkgName == null) {
+            return;
+        }
+        if (getDefinedPackage(pkgName) != null) {
+            return;
+        }
+        try {
+            // this could certainly be improved to use the actual manifest
+            definePackage(pkgName, null, null, null, null, null, null, null);
+        } catch (IllegalArgumentException e) {
+            // retry, thrown by definePackage(), if a package for the same name is already defines by this class loader.
+            if (getDefinedPackage(pkgName) != null) {
+                return;
             }
+            throw e;
         }
     }
 

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloading/ConcurrentDefinePackageTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloading/ConcurrentDefinePackageTestCase.java
@@ -1,0 +1,48 @@
+package io.quarkus.bootstrap.classloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+public class ConcurrentDefinePackageTestCase {
+
+    /**
+     * Validates that {@link QuarkusClassLoader} can safely do concurrent class loading against "new" packages,
+     * backed by {@link ClassLoader#definePackage(String, String, String, String, String, String, String, URL)}, which throws an
+     * {@link IllegalArgumentException} if the package is already defined.
+     */
+    @Test
+    public void concurrentDefinePackage() throws Exception {
+        var threads = Math.max(8, Runtime.getRuntime().availableProcessors() * 2);
+        var pool = Executors.newFixedThreadPool(threads);
+        try (var quarkusClassLoader = QuarkusClassLoader.builder("test", Thread.currentThread().getContextClassLoader(), false)
+                .build()) {
+            for (var pkg = 0; pkg < 200; pkg++) {
+                var readyLatch = new CountDownLatch(threads);
+                var startLatch = new CountDownLatch(1);
+                var pkgName = "my.package" + pkg;
+                var futures = IntStream.range(0, threads).mapToObj(i -> CompletableFuture.runAsync(() -> {
+                    readyLatch.countDown();
+                    try {
+                        assertThat(startLatch.await(5, TimeUnit.MINUTES)).isTrue();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    quarkusClassLoader.definePackage(pkgName, ClassPathElement.EMPTY);
+                }, pool)).toArray(CompletableFuture[]::new);
+                assertThat(readyLatch.await(5, TimeUnit.MINUTES)).isTrue();
+                startLatch.countDown();
+                CompletableFuture.allOf(futures).get(5, TimeUnit.MINUTES);
+            }
+        } finally {
+            pool.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
`java.lang.ClassLoader.definePackage()` succeeeds if, and only if, the package was not already defined. This is problematic when packages are defined concurrently, for example when classes are loaded concurrently. `j.l.ClassLoader` does not offer something like `definePackageIfNotExists()`.

The proposed fix here is to change the implementations of `definePackage` in in `io.quarkus.bootstrap.classloading.QuarkusClassLoader#definePackage` and also `io.quarkus.launcher.RuntimeLaunchClassLoader#definePackage`, the same change was applied by #42139 to `io.quarkus.bootstrap.runner.RunnerClassLoader#definePackage`:
1. check if the package is already defined via `CL.getDefinedPackage()`
2. if it is, then return
2. if not, then call `CL.definePackage()`
3. if the former fails with an `IllegalArgumentException`, then check once against `getDefinedPackage()`, rethrow the IAE, if the pacakge's not defined

I could not find another `ClassLoader` implementation in Quarkus, which could be prone to IAEs via `CL.definePackage()`'s behavior.

Fixes #37363