### PR TITLE
Add comments and lightly refactor to improve clarity

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -111,7 +111,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
 
         var result = AppMakerHelper.prepare(requiredTestClass, curatedApplication, profile);
         if (result.profileInstance() != null) {
-            shutdownTasks.add(AppMakerHelper.setExtraProperties(profile, result.profileInstance()));
+            Runnable configCleaner = AppMakerHelper.setExtraPropertiesRestorably(profile, result.profileInstance());
+            shutdownTasks.add(configCleaner);
         }
         return result;
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -195,7 +195,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             System.clearProperty("test.url");
             QuarkusTestProfile profileInstance = AppMakerHelper.getQuarkusTestProfile(profile);
             if (profileInstance != null) {
-                shutdownTasks.add(AppMakerHelper.setExtraProperties(profile, profileInstance));
+                Runnable configCleaner = AppMakerHelper.setExtraPropertiesRestorably(profile, profileInstance);
+                shutdownTasks.add(configCleaner);
             }
             StartupAction startupAction = getClassLoaderFromTestClass(requiredTestClass).getStartupAction();
 


### PR DESCRIPTION
See (painful) discussion on https://github.com/quarkusio/quarkus/pull/47892#issue-3067297430. Having invested the brainpower in figuring out what's going on, I decided I should add some comments to help future developers (most likely future me), and rename a few things to maybe make things slightly clearer. 

In general, the `shutdownTasks.add(doTheAction)` pattern confuses me every time I hit it, because I assume `doTheAction` is producing something which happens at shutdown. That's sort of true, but it misses the massive side effect of `doTheAction` happening now. So the `doTheAction` method name is referring to what's happening now, not what's happening at shutdown, even though it's wrapped in `shutdownTasks.add`. The names and structure all just end up being a bit misleading. I don't see an alternative to the pattern, though. I guess you could pass the shutdownTasks in to the method, and then it would be self-cleaning. That's no good for the case where we do cleanup in a `finally` block, though.