### PR TITLE
Introduce `quarkus.datasource.devservices.init-privileged-script-path`

### DIFF
--- a/docs/src/main/asciidoc/flyway.adoc
+++ b/docs/src/main/asciidoc/flyway.adoc
@@ -454,7 +454,7 @@ quarkus.openshift.init-task-defaults.wait-for-container.image=my/wait-for-image:
 === Oracle: Multiple schemas in Dev Services
 
 When having multiple schemas in Oracle, you can use the `quarkus.flyway.schemas` property to specify the schemas that Flyway should manage.
-However, because this is executed in the DB as the `quarkus` user, you need to either give DBA privileges to the user that is executing the migration (`quarkus`) or perform the necessary DDLs before the Dev Service starts. This is done with the `quarkus.datasource.devservices.init-script-path` configuration.
+However, because this is executed in the DB as the `quarkus` user, you need to either give DBA privileges to the user that is executing the migration (`quarkus`) or perform the necessary DDLs before the Dev Service starts. This is done with the `quarkus.datasource.devservices.init-privileged-script-path` configuration.
 
 ==== Giving DBA privileges to the user
 
@@ -470,5 +470,5 @@ GRANT DBA TO quarkus;
 
 [source,properties]
 ----
-quarkus.datasource.devservices.init-script-path=001-devservice-init.sql
+quarkus.datasource.devservices.init-privileged-script-path=001-devservice-init.sql
 ----

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -17,6 +17,7 @@ public class DevServicesDatasourceContainerConfig {
     private final Optional<String> username;
     private final Optional<String> password;
     private final Optional<List<String>> initScriptPath;
+    private final Optional<List<String>> initPrivilegedScriptPath;
     private final Map<String, String> volumes;
     private final boolean reuse;
     private final boolean showLogs;
@@ -31,6 +32,7 @@ public class DevServicesDatasourceContainerConfig {
             Optional<String> username,
             Optional<String> password,
             Optional<List<String>> initScriptPath,
+            Optional<List<String>> initPrivilegedScriptPath,
             Map<String, String> volumes,
             boolean reuse,
             boolean showLogs) {
@@ -44,6 +46,7 @@ public class DevServicesDatasourceContainerConfig {
         this.username = username;
         this.password = password;
         this.initScriptPath = initScriptPath;
+        this.initPrivilegedScriptPath = initPrivilegedScriptPath;
         this.volumes = volumes;
         this.reuse = reuse;
         this.showLogs = showLogs;
@@ -87,6 +90,10 @@ public class DevServicesDatasourceContainerConfig {
 
     public Optional<List<String>> getInitScriptPath() {
         return initScriptPath;
+    }
+
+    public Optional<List<String>> getInitPrivilegedScriptPath() {
+        return initPrivilegedScriptPath;
     }
 
     public boolean isShowLogs() {

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -189,6 +189,7 @@ public class DevServicesDatasourceProcessor {
             res.put(name + ".devservices.db-name", config.devservices().dbName());
             res.put(name + ".devservices.image-name", config.devservices().imageName());
             res.put(name + ".devservices.init-script-path", config.devservices().initScriptPath());
+            res.put(name + ".devservices.init-privileged-script-path", config.devservices().initPrivilegedScriptPath());
             res.put(name + ".devservices.password", config.devservices().password());
             res.put(name + ".devservices.port", config.devservices().port());
             res.put(name + ".devservices.properties", config.devservices().properties());
@@ -301,6 +302,7 @@ public class DevServicesDatasourceProcessor {
                     dataSourceBuildTimeConfig.devservices().username(),
                     dataSourceBuildTimeConfig.devservices().password(),
                     dataSourceBuildTimeConfig.devservices().initScriptPath(),
+                    dataSourceBuildTimeConfig.devservices().initPrivilegedScriptPath(),
                     dataSourceBuildTimeConfig.devservices().volumes(),
                     dataSourceBuildTimeConfig.devservices().reuse(),
                     dataSourceBuildTimeConfig.devservices().showLogs());

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -89,6 +89,14 @@ public interface DevServicesBuildTimeConfig {
     Optional<List<@WithConverter(TrimmedStringConverter.class) String>> initScriptPath();
 
     /**
+     * The paths to SQL scripts to be loaded from the classpath and applied to the Dev Service database using the SYS privileged
+     * user.
+     * Not all databases provide a privileged user. In these cases, the property is ignored.
+     * This has no effect if the provider is not a container-based database, such as H2 or Derby.
+     */
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> initPrivilegedScriptPath();
+
+    /**
      * The volumes to be mapped to the container.
      * <p>
      * The map key corresponds to the host location; the map value is the container location.

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -90,8 +90,9 @@ public class OracleDevServicesProcessor {
 
                     containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                     containerConfig.getCommand().ifPresent(container::setCommand);
-                    if (containerConfig.getInitScriptPath().isPresent()) {
-                        for (String initScript : containerConfig.getInitScriptPath().get()) {
+                    containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
+                    if (containerConfig.getInitPrivilegedScriptPath().isPresent()) {
+                        for (String initScript : containerConfig.getInitPrivilegedScriptPath().get()) {
                             container.withCopyFileToContainer(MountableFile.forClasspathResource(initScript),
                                     "/container-entrypoint-startdb.d/" + initScript);
                         }


### PR DESCRIPTION
This is to separate scripts run as a privileged user from the app user

- Fixes #47905