### PR TITLE
Revert "Bump netty.version to 4.1.121.Final"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -133,7 +133,7 @@
         <infinispan.version>15.0.14.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.2.0</caffeine.version>
-        <netty.version>4.1.121.Final</netty.version>
+        <netty.version>4.1.119.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>


### PR DESCRIPTION
- Reverts: quarkusio/quarkus#47618

- Fixes: #https://github.com/quarkusio/quarkus/issues/47903