### PR TITLE
Allow "unsupported properties" set in the Hibernate ORM/Reactive extension to override Quarkus' own values

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -205,10 +205,9 @@ public class FastBootMetadataBuilder {
                 .getQuarkusConfigUnsupportedProperties();
         Map<String, Object> allSettings = new HashMap<>(quarkusConfigSettings);
 
-        // Ignore properties that were already set by Quarkus;
-        // we'll log a warning about those on startup.
+        // We'll log warnings about unsupported properties and overrides on startup.
         // (see io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.buildRuntimeSettings)
-        quarkusConfigUnsupportedProperties.forEach(allSettings::putIfAbsent);
+        allSettings.putAll(quarkusConfigUnsupportedProperties);
 
         var databaseOrmCompatibilityVersion = puDefinition.getConfig().getDatabaseOrmCompatibilityVersion();
         Map<String, String> appliedDatabaseOrmCompatibilitySettings = new HashMap<>();

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application.properties
@@ -3,7 +3,6 @@ quarkus.datasource.username=hibernate_orm_test
 quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.reactive=true
 quarkus.datasource.reactive.url=${postgres.reactive.url}
-quarkus.postgres_blvertx-reactive:postgresql://localhost:5431/hibernate_orm_test"
 
 # Hibernate config
 #quarkus.hibernate-orm.log.sql=true

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -189,18 +189,22 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
                         persistenceUnitName,
                         puConfig.unsupportedProperties().keySet());
             }
+            Set<String> overriddenProperties = new HashSet<>();
             for (Map.Entry<String, String> entry : puConfig.unsupportedProperties().entrySet()) {
                 var key = entry.getKey();
-                if (runtimeSettingsBuilder.get(key) != null) {
-                    log.warnf("Persistence-unit [%s] sets property '%s' to a custom value through '%s',"
-                            + " but Quarkus already set that property independently."
-                            + " The custom value will be ignored.",
-                            persistenceUnitName, key,
-                            HibernateOrmRuntimeConfig.puPropertyKey(persistenceUnit.getConfigurationName(),
-                                    "unsupported-properties.\"" + key + "\""));
-                    continue;
+                var value = runtimeSettingsBuilder.get(key);
+                if (value != null && !(value instanceof String stringValue && stringValue.isBlank())) {
+                    overriddenProperties.add(key);
                 }
                 runtimeSettingsBuilder.put(entry.getKey(), entry.getValue());
+            }
+            if (!overriddenProperties.isEmpty()) {
+                log.warnf("Persistence-unit [%s] sets unsupported properties that override Quarkus' own settings."
+                        + " These properties may break assumptions in Quarkus code and cause malfunctions."
+                        + " If this override is absolutely necessary, make sure to file a feature request or bug report so that a solution can be implemented in Quarkus."
+                        + " Unsupported properties that override Quarkus' own settings: %s",
+                        persistenceUnitName,
+                        overriddenProperties);
             }
 
             RuntimeSettings runtimeSettings = runtimeSettingsBuilder.build();


### PR DESCRIPTION
It can be useful to work around bugs from time to time, such as #47353

This is dangerous and thus will multiple warnings.
First, the pre-existing one about unsupported properties being, well,
unsupported:

> 2025-05-16 15:50:35,316 WARN  [io.qua.hib.rea.run.FastBootHibernateReactivePersistenceProvider] (JPA Startup Thread) Persistence-unit [default-reactive] sets unsupported properties. These properties may not work correctly, and even if they do, that may change when upgrading to a newer version of Quarkus (even just a micro/patch version). Consider using a supported configuration property before falling back to unsupported ones. If there is no supported equivalent, make sure to file a feature request so that a supported configuration property can be added to Quarkus, and more importantly so that the configuration property is tested regularly. Unsupported properties being set: [hibernate.some.unknown.key.static-and-runtime, jakarta.persistence.schema-generation.database.action, hibernate.order_updates, hibernate.some.unknown.key.runtime-only, hibernate.order_inserts]

Then, if overriding values set by Quarkus, an additional warning about
that, because it's even worse:

> 2025-05-16 15:50:35,317 WARN  [io.qua.hib.rea.run.FastBootHibernateReactivePersistenceProvider] (JPA Startup Thread) Persistence-unit [default-reactive] sets unsupported properties that override Quarkus' own settings. These properties may break assumptions in Quarkus code and cause malfunctions. If this override is absolutely necessary, make sure to file a feature request or bug report so that a solution can be implemented in Quarkus. Unsupported properties that override Quarkus' own settings: [jakarta.persistence.schema-generation.database.action, hibernate.order_updates]