### PR TITLE
Attempt to address flakiness of VertxConnectionMetricsTest

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -154,20 +154,27 @@ public final class VertxHttpSender implements HttpSender {
             return shutdownResult;
         }
 
-        client.close()
-                .onSuccess(
-                        new Handler<>() {
-                            @Override
-                            public void handle(Void event) {
-                                shutdownResult.succeed();
-                            }
-                        })
-                .onFailure(new Handler<>() {
-                    @Override
-                    public void handle(Throwable event) {
-                        shutdownResult.fail();
-                    }
-                });
+        try {
+            client.close()
+                    .onSuccess(
+                            new Handler<>() {
+                                @Override
+                                public void handle(Void event) {
+                                    shutdownResult.succeed();
+                                }
+                            })
+                    .onFailure(new Handler<>() {
+                        @Override
+                        public void handle(Throwable event) {
+                            shutdownResult.fail();
+                        }
+                    });
+        } catch (RejectedExecutionException e) {
+            internalLogger.log(Level.FINE, "Unable to complete shutdown", e);
+            // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException
+            // which we need to handle
+            shutdownResult.fail();
+        }
         return shutdownResult;
     }
 


### PR DESCRIPTION
The exception we are guarding against here is:

```posh
at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:934)	
	at io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:353)	
	at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:346)	
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:836)	
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute0(SingleThreadEventExecutor.java:827)	
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:817)	
	at io.vertx.core.impl.EventLoopExecutor.execute(EventLoopExecutor.java:35)	
	at io.vertx.core.impl.ContextImpl.execute(ContextImpl.java:314)	
	at io.vertx.core.impl.ContextImpl.execute(ContextImpl.java:302)	
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:57)	
	at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:231)	
	at io.vertx.core.impl.future.FutureImpl.onSuccess(FutureImpl.java:87)	
	at io.quarkus.opentelemetry.runtime.exporter.otlp.sender.VertxGrpcSender.shutdown(VertxGrpcSender.java:117)	
	at io.opentelemetry.exporter.internal.grpc.GrpcExporter.shutdown(GrpcExporter.java:131)	
	at io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.VertxGrpcSpanExporter.shutdown(VertxGrpcSpanExporter.java:32)	
	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.lambda$shutdown$3(BatchSpanProcessor.java:307)	
	at io.opentelemetry.sdk.common.CompletableResultCode.succeed(CompletableResultCode.java:107)	
	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.flush(BatchSpanProcessor.java:291)	
	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.run(BatchSpanProcessor.java:252)	
	at java.lang.Thread.run(Thread.java:1583)
```

See [this](https://github.com/quarkusio/quarkus/pull/47909#issuecomment-2886859624) for an example of ^ occurring in CI