### PR TITLE
Implement fallback logic for Keycloak dev startup failure

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FailedDevServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FailedDevServiceBuildItem.java
@@ -1,0 +1,32 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.smallrye.common.constraint.NotNull;
+
+/**
+ * A build item indicating that a specific dev service, identified by a unique name,
+ * attempted to start but failed.
+ * This can be used by other extensions to implement fallback logic or any other action.
+ */
+public final class FailedDevServiceBuildItem extends MultiBuildItem {
+    private final String serviceName;
+    private final Throwable cause;
+
+    public FailedDevServiceBuildItem(@NotNull String serviceName) {
+        this.serviceName = serviceName;
+        this.cause = null;
+    }
+
+    public FailedDevServiceBuildItem(String serviceName, Throwable cause) {
+        this.serviceName = serviceName;
+        this.cause = cause;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+}

--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesConfig.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesConfig.java
@@ -8,6 +8,7 @@ import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 /**
  * OpenID Connect Dev Services configuration.
@@ -29,5 +30,15 @@ public interface OidcDevServicesConfig {
      */
     @ConfigDocMapKey("role-name")
     Map<String, List<String>> roles();
+
+    /**
+     * If true, and the Keycloak Dev Service is active but fails to start,
+     * this lightweight OIDC Dev Service will attempt to start as a fallback.
+     * This allows development to continue with a mock OIDC provider even if Keycloak encounters issues.
+     * <p>
+     * This fallback is only considered if {@code quarkus.oidc.devservices.enabled} is not explicitly set to {@code false}.
+     */
+    @WithDefault("false")
+    boolean keycloakFallback();
 
 }


### PR DESCRIPTION
Leightweight OIDC devservice to act as a fallback if the Keycloak Dev Service fails to start.
A new OIDC config property, `quarkus.oidc.devservices.keycloak-fallback` (boolean, default false), controls this behavior.

- Resolves : #47800
## Current Status:
This is a DRAFT PR. The core logic is implemented, but there are no integration tests
I'm looking for feedback on the approach and would appreciate any assistance or suggestions on the best way to test this interaction, especially concerning existing Keycloak test utilities.
Open to all changes and further discussions..
CC : @sberyozkin 