### PR TITLE
Deprecations scheduled for removal in Gradle 9: getDependencyProject and BuildIdentifier.getBuildPath

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -693,7 +693,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                         Project depProject = null;
 
                         if (d instanceof ProjectDependency) {
-                            depProject = project.project(((ProjectDependency) d).getPath());
+                            depProject = dep.project(((ProjectDependency) d).getPath());
                         } else if (d instanceof ExternalModuleDependency) {
                             depProject = ToolingUtils.findIncludedProject(project, (ExternalModuleDependency) d);
                         }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -693,7 +693,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                         Project depProject = null;
 
                         if (d instanceof ProjectDependency) {
-                            depProject = ((ProjectDependency) d).getDependencyProject();
+                            depProject = project.project(((ProjectDependency) d).getPath());
                         } else if (d instanceof ExternalModuleDependency) {
                             depProject = ToolingUtils.findIncludedProject(project, (ExternalModuleDependency) d);
                         }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
@@ -96,7 +96,7 @@ public class DependencyUtils {
             projectDependency = getProjectExtensionDependencyOrNull(
                     project,
                     componentId.getProjectPath(),
-                    componentId.getBuild().getName());
+                    componentId.getBuild().getBuildPath());
 
             if (projectDependency != null)
                 return projectDependency;


### PR DESCRIPTION
This PR addresses several deprecations scheduled for removal in Gradle 9:

Deprecated ProjectDependency#getDependencyProject():
https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#deprecate_get_dependency_project

BuildIdentifier and ProjectComponentSelector method deprecations:
https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation