### PR TITLE
Deprecations scheduled for removal in Gradle 9:  Detached Configurations should not use extendsFrom

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -681,8 +681,8 @@ public class QuarkusPlugin implements Plugin<Project> {
     protected void visitProjectDependencies(Project project, Project dep, Set<String> visited) {
         final Configuration compileConfig = dep.getConfigurations().findByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
         if (compileConfig != null) {
-            final Configuration compilePlusRuntimeConfig = dep.getConfigurations().detachedConfiguration()
-                    .extendsFrom(compileConfig);
+            final Configuration compilePlusRuntimeConfig = dep.getConfigurations().create("compilePlusRuntime");
+            compilePlusRuntimeConfig.extendsFrom(compileConfig);
             final Configuration runtimeOnlyConfig = dep.getConfigurations()
                     .findByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME);
             if (runtimeOnlyConfig != null) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -681,7 +681,7 @@ public class QuarkusPlugin implements Plugin<Project> {
     protected void visitProjectDependencies(Project project, Project dep, Set<String> visited) {
         final Configuration compileConfig = dep.getConfigurations().findByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
         if (compileConfig != null) {
-            final Configuration compilePlusRuntimeConfig = dep.getConfigurations().create("compilePlusRuntime");
+            final Configuration compilePlusRuntimeConfig = dep.getConfigurations().maybeCreate("compilePlusRuntime");
             compilePlusRuntimeConfig.extendsFrom(compileConfig);
             final Configuration runtimeOnlyConfig = dep.getConfigurations()
                     .findByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME);


### PR DESCRIPTION
Detached Configurations should not use extendsFrom: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#detached_configurations_cannot_extend

@aloubyansky, I pinged the BT team to verify whether this could be the correct fix for the deprecation that will become an error in Gradle 9.0

