### PR TITLE
Docs update security-customization.adoc to remove invalid comment

### DIFF
--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -163,9 +163,6 @@ public class RolesAugmentor implements SecurityIdentityAugmentor {
     @Override
     public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
         return Uni.createFrom().item(build(identity));
-
-        // Do 'return context.runBlocking(build(identity));'
-        // if a blocking call is required to customize the identity
     }
 
     private Supplier<SecurityIdentity> build(SecurityIdentity identity) {


### PR DESCRIPTION
cc @sberyozkin

This comment is actually incorrect and threw me off when the example below using Hibernate is actually correct.