### PR TITLE
Add Javadoc for ArchiveRootBuildItem class

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ArchiveRootBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ArchiveRootBuildItem.java
@@ -16,8 +16,20 @@ import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathList;
 
+/**
+ * Represents a build item for an archive root, typically used in Quarkus build steps to
+ * reference application classes directories or archives (like JARs) for indexing and processing.
+ *
+ * <p>
+ * This class contains the paths of directories or archives to be used as archive roots,
+ * as well as paths that should be excluded from indexing.
+ * </p>
+ */
 public final class ArchiveRootBuildItem extends SimpleBuildItem {
 
+    /**
+     * Builder for constructing {@link ArchiveRootBuildItem} instances.
+     */
     public static class Builder {
 
         private List<Path> archiveRoots = new ArrayList<>();
@@ -26,21 +38,46 @@ public final class ArchiveRootBuildItem extends SimpleBuildItem {
         private Builder() {
         }
 
+        /**
+         * Adds a single archive root path to the builder.
+         *
+         * @param root the archive root path to add
+         * @return this builder instance
+         */
         public Builder addArchiveRoot(Path root) {
             this.archiveRoots.add(root);
             return this;
         }
 
+        /**
+         * Adds multiple archive root paths to the builder.
+         *
+         * @param paths a {@link PathCollection} of archive root paths to add
+         * @return this builder instance
+         */
         public Builder addArchiveRoots(PathCollection paths) {
             paths.forEach(archiveRoots::add);
             return this;
         }
 
+        /**
+         * Sets the collection of paths to exclude from indexing.
+         *
+         * @param excludedFromIndexing a collection of paths to be excluded
+         * @return this builder instance
+         */
         public Builder setExcludedFromIndexing(Collection<Path> excludedFromIndexing) {
             this.excludedFromIndexing = excludedFromIndexing;
             return this;
         }
 
+        /**
+         * @deprecated Use {@link #addArchiveRoot(Path)} instead to add archive roots.
+         *             This method clears previous archive roots before setting the new one.
+         *
+         * @param archiveLocation the archive location to set
+         * @return this builder instance
+         */
         @Deprecated
         public Builder setArchiveLocation(Path archiveLocation) {
             this.archiveRoots.clear();
@@ -48,11 +85,23 @@ public final class ArchiveRootBuildItem extends SimpleBuildItem {
             return this;
         }
 
+        /**
+         * Builds the {@link ArchiveRootBuildItem} using the configured properties.
+         *
+         * @param buildCloseables a {@link QuarkusBuildCloseablesBuildItem} to manage opened resources (e.g., zip file systems)
+         * @return a new {@link ArchiveRootBuildItem} instance
+         * @throws IOException if an I/O error occurs when accessing the archive roots
+         */
         public ArchiveRootBuildItem build(QuarkusBuildCloseablesBuildItem buildCloseables) throws IOException {
             return new ArchiveRootBuildItem(this, buildCloseables);
         }
     }
 
+    /**
+     * Creates a new {@link Builder} instance for building an {@link ArchiveRootBuildItem}.
+     *
+     * @return a new {@link Builder} instance
+     */
     public static Builder builder() {
         return new Builder();
     }
@@ -62,10 +111,22 @@ public final class ArchiveRootBuildItem extends SimpleBuildItem {
     private final PathCollection rootDirs;
     private final PathCollection paths;
 
+    /**
+     * Constructs an {@link ArchiveRootBuildItem} with a single application classes directory.
+     *
+     * @param appClassesDir the path to the application classes directory
+     */
     public ArchiveRootBuildItem(Path appClassesDir) {
         this(appClassesDir, appClassesDir);
     }
 
+    /**
+     * @deprecated Use {@link Builder} instead.
+     *             Constructs an {@link ArchiveRootBuildItem} with a given archive location and root directory.
+     *
+     * @param archiveLocation the archive location (e.g., JAR file path)
+     * @param archiveRoot the root directory of the archive
+     */
     @Deprecated
     public ArchiveRootBuildItem(Path archiveLocation, Path archiveRoot) {
         this(archiveLocation, archiveRoot, Collections.emptySet());


### PR DESCRIPTION
This PR adds comprehensive JavaDoc comments to the ArchiveRootBuildItem class and its inner Builder class in order to improve code readability, maintainability, and developer experience when working with Quarkus build items.