### PR TITLE
Handle method parameter type annotations in ClassComparisonUtil

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/ClassComparisonUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/ClassComparisonUtilTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.deployment.dev;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.MethodParameterInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ClassComparisonUtilTest {
+
+    @Nested
+    class CompareMethodAnnotations {
+
+        @Test
+        public void annotationsEqual() {
+            AnnotationInstance instance1 = methodParameterAnnotation(AnnotationForTest1.class);
+            AnnotationInstance instance2 = methodParameterAnnotation(AnnotationForTest1.class);
+
+            List<AnnotationInstance> instances1 = List.of(instance1);
+            List<AnnotationInstance> instances2 = List.of(instance2);
+
+            Assertions.assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        }
+
+        @Test
+        public void annotationsNotEqual() {
+            AnnotationInstance instance1 = methodParameterAnnotation(AnnotationForTest1.class);
+            AnnotationInstance instance2 = methodParameterAnnotation(AnnotationForTest2.class);
+
+            List<AnnotationInstance> instances1 = List.of(instance1);
+            List<AnnotationInstance> instances2 = List.of(instance2);
+
+            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        }
+
+        @Test
+        public void compareMethodAnnotationsSizeDiffer() {
+            AnnotationInstance instance = methodParameterAnnotation(AnnotationForTest1.class);
+
+            List<AnnotationInstance> instances = List.of(instance);
+
+            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances, List.of()));
+            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(List.of(), instances));
+        }
+
+        @Test
+        public void multipleAnnotationsAtSamePosition() {
+            List<AnnotationInstance> instances1 = List.of(
+                    methodParameterAnnotation(AnnotationForTest1.class),
+                    methodParameterAnnotation(AnnotationForTest2.class));
+            List<AnnotationInstance> instances2 = List.of(
+                    methodParameterAnnotation(AnnotationForTest2.class),
+                    methodParameterAnnotation(AnnotationForTest1.class));
+
+            Assertions.assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        }
+
+        @Test
+        public void multipleAnnotations() {
+            List<AnnotationInstance> instances1 = List.of(
+                    methodParameterAnnotation(AnnotationForTest1.class, 1),
+                    methodParameterAnnotation(AnnotationForTest2.class, 2));
+
+            List<AnnotationInstance> instances2 = List.of(
+                    methodParameterAnnotation(AnnotationForTest1.class, 2),
+                    methodParameterAnnotation(AnnotationForTest2.class, 1));
+
+            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        }
+
+        private static AnnotationInstance methodParameterAnnotation(
+                Class<? extends Annotation> annotation) {
+            return methodParameterAnnotation(annotation, 1);
+        }
+
+        private static AnnotationInstance methodParameterAnnotation(
+                Class<? extends Annotation> annotation, int position) {
+            MethodParameterInfo target = MethodParameterInfo.create(null, (short) position);
+            return AnnotationInstance.builder(annotation).buildWithTarget(target);
+        }
+
+        @Target({ ElementType.PARAMETER, ElementType.TYPE_USE })
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        private @interface AnnotationForTest1 {
+        }
+
+        @Target({ ElementType.PARAMETER, ElementType.TYPE_USE })
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        private @interface AnnotationForTest2 {
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes live-Reload with instrumentation, if the class uses annotations with target "TYPE_USE" (e.g. jakarta.validation.Valid). 
Such annotations are reported 2 times by jandex (once as method parameter annotation and once as method parameter type annotation).


Example: 
```java
package io.quarkus;

import jakarta.validation.Valid;
import jakarta.ws.rs.*;
import jakarta.ws.rs.core.MediaType;

@Path("/hello")
public class ExampleResource {

    @GET
    @Produces(MediaType.TEXT_PLAIN)
    public String hello(@Valid @QueryParam("to") String to )
    {
        int x = 1;
        return "Hello from Quarkus REST to1 " + to + x;
    }
}
```

Changing the local variable "x" in the example and sending a HTTP-Request would log an exception and restart the server.

Exception: 
````
ERROR [io.qua.dep.dev.RuntimeUpdatesProcessor] (vert.x-worker-thread-1) Failed to replace classes via instrumentation: java.lang.IllegalArgumentException: Not a method parameter
	at org.jboss.jandex.TypeTarget.asMethodParameter(TypeTarget.java:201)
	at io.quarkus.deployment.dev.ClassComparisonUtil.methodMap(ClassComparisonUtil.java:158)
	at io.quarkus.deployment.dev.ClassComparisonUtil.compareMethodAnnotations(ClassComparisonUtil.java:133)
	at io.quarkus.deployment.dev.ClassComparisonUtil.isSameStructure(ClassComparisonUtil.java:95)
	at io.quarkus.deployment.dev.RuntimeUpdatesProcessor.doScan(RuntimeUpdatesProcessor.java:516)
	at io.quarkus.deployment.dev.RuntimeUpdatesProcessor.doScan(RuntimeUpdatesProcessor.java:455)
```
