### PR TITLE
Fix gRPC enum registration in native

### DIFF
--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
@@ -29,7 +29,7 @@ public class GrpcCommonProcessor {
 
         // We also need to include enums.
         Collection<ClassInfo> enums = combinedIndex.getIndex()
-                .getAllKnownSubclasses(GrpcDotNames.PROTOCOL_MESSAGE_ENUM);
+                .getAllKnownImplementations(GrpcDotNames.PROTOCOL_MESSAGE_ENUM);
         for (ClassInfo en : enums) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(en.name().toString()).methods()
                     .fields().build());


### PR DESCRIPTION
Properly register gRPC enum into the native image.
