### PR TITLE
SmallRye Fault Tolerance: add missing reflection registration

### DIFF
--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -315,6 +315,8 @@ public class SmallRyeFaultToleranceProcessor {
                     if (ftMethod.isLegitimate()) {
                         ftMethods.add(ftMethod);
 
+                        reflectiveMethod.produce(new ReflectiveMethodBuildItem("fault tolerance method", method));
+
                         if (annotationStore.hasAnnotation(method, DotNames.ASYNCHRONOUS)
                                 && annotationStore.hasAnnotation(method, DotNames.ASYNCHRONOUS_NON_BLOCKING)) {
                             exceptions.add(new DefinitionException(


### PR DESCRIPTION
All fault tolerance methods are reflected upon at runtime, so they need to be registered. That's what this commit does.

- Fixes #47895