### PR TITLE
Runtime initialize classes to preserve Netty's assumptions

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -246,7 +246,11 @@ class NettyProcessor {
                 // - io.netty.tryUnsafe
                 // - org.jboss.netty.tryUnsafe
                 // - io.netty.tryReflectionSetAccessible
-                .addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent0");
+                .addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent0")
+                // Runtime initialize classes to allow netty to use the field offset for testing if unsafe is available or not
+                // See https://github.com/quarkusio/quarkus/issues/47903#issuecomment-2890924970
+                .addRuntimeReinitializedClass("io.netty.util.AbstractReferenceCounted")
+                .addRuntimeReinitializedClass("io.netty.buffer.AbstractReferenceCountedByteBuf");
 
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.buffer.UnpooledByteBufAllocator")) {
             // Runtime initialize due to the use of the io.netty.util.internal.PlatformDependent class

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -407,22 +407,6 @@ final class Target_io_netty_channel_nio_NioEventLoop {
     }
 }
 
-@TargetClass(className = "io.netty.buffer.AbstractReferenceCountedByteBuf")
-final class Target_io_netty_buffer_AbstractReferenceCountedByteBuf {
-
-    @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, name = "refCnt")
-    private static long REFCNT_FIELD_OFFSET;
-}
-
-@TargetClass(className = "io.netty.util.AbstractReferenceCounted")
-final class Target_io_netty_util_AbstractReferenceCounted {
-
-    @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, name = "refCnt")
-    private static long REFCNT_FIELD_OFFSET;
-}
-
 // This class is runtime-initialized by NettyProcessor
 final class Holder_io_netty_util_concurrent_ScheduledFutureTask {
     static final long START_TIME = System.nanoTime();


### PR DESCRIPTION
Runtime initialize classes to allow netty to use the field offset for testing if unsafe is available or not.

In java 24 and higher, unsafe is not available resulting in `UNSAFE` being set to `null`.

In NettySubstitutions Quarkus substitutes the value of `REFCNT_FIELD_OFFSET` which is done without the need of unsafe being present. This results in `unsafeOffset` not returning -1 which netty expects when unsafe is not available. As a result Quarkus native builds with this substitution fail with unsafe is not available.

- Closes: https://github.com/quarkusio/quarkus/issues/47903

Being tested with Mandrel for JDK 25 EA: https://github.com/graalvm/mandrel/actions/runs/15115110093