### PR TITLE
Refresh deleted source file location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ nb-configuration.xml
 .mvn/.develocity
 .mvn/.gradle-enterprise/
 .quarkus
+
+.goosehints
+.goose


### PR DESCRIPTION
If a kotlin file is renamed a class that was previously provided by the old file will now be provided by the new one.

This fix reloads the class file location to make sure that it is a true delete, otherwise the first reload after a rename will fail.