### PR TITLE
Dev UI: new feature - menu actions

### DIFF
--- a/bom/dev-ui/pom.xml
+++ b/bom/dev-ui/pom.xml
@@ -32,6 +32,7 @@
         <path-to-regexp.version>2.4.0</path-to-regexp.version>
         <codeblock.version>1.1.1</codeblock.version>
         <qomponent.version>1.0.4</qomponent.version>
+        <ldrs.version>1.1.7</ldrs.version>
         <directory-tree.version>1.0.3</directory-tree.version>
         <hpcc-js-wasm.version>2.15.3</hpcc-js-wasm.version>
         <yargs.version>17.7.2</yargs.version>
@@ -328,6 +329,14 @@
                 <scope>runtime</scope>
             </dependency>
             
+            <!-- Loading indicators -->
+            <dependency>
+                <groupId>org.mvnpm</groupId>
+                <artifactId>ldrs</artifactId>
+                <version>${ldrs.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+
             <!-- Polyfill for importmaps -->
             <dependency>
                 <groupId>org.mvnpm</groupId>

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -503,6 +503,9 @@ public class BuildTimeContentProcessor {
         for (InternalPageBuildItem internalPageBuildItem : internalPages) {
             List<Page> pages = internalPageBuildItem.getPages();
             for (Page page : pages) {
+                if (internalPageBuildItem.getMenuActionComponent() != null) {
+                    page.setMenuActionComponent(internalPageBuildItem.getMenuActionComponent());
+                }
                 sectionMenu.add(page);
             }
             internalBuildTimeData.addAllBuildTimeData(internalPageBuildItem.getBuildTimeData());

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
@@ -18,10 +18,16 @@ public final class InternalPageBuildItem extends MultiBuildItem {
     private final int position;
     private final List<Page> pages = new ArrayList<>();
     private final Map<String, Object> buildTimeData = new HashMap<>();
+    private final String menuActionComponent;
 
     public InternalPageBuildItem(String namespaceLabel, int position) {
+        this(namespaceLabel, position, null);
+    }
+
+    public InternalPageBuildItem(String namespaceLabel, int position, String menuActionComponent) {
         this.namespaceLabel = namespaceLabel;
         this.position = position;
+        this.menuActionComponent = menuActionComponent;
     }
 
     public void addPage(PageBuilder page) {
@@ -35,6 +41,10 @@ public final class InternalPageBuildItem extends MultiBuildItem {
 
     public List<Page> getPages() {
         return pages;
+    }
+
+    public String getMenuActionComponent() {
+        return menuActionComponent;
     }
 
     public int getPosition() {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -52,7 +52,8 @@ public class ContinuousTestingProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     InternalPageBuildItem createContinuousTestingPages() {
 
-        InternalPageBuildItem continuousTestingPages = new InternalPageBuildItem("Continuous Testing", 30);
+        InternalPageBuildItem continuousTestingPages = new InternalPageBuildItem("Continuous Testing", 30,
+                "qwc-continuous-testing-menu-action");
 
         continuousTestingPages.addPage(Page.webComponentPageBuilder()
                 .namespace(NAMESPACE)

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -36,7 +36,7 @@ public class ExtensionsProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     InternalPageBuildItem createExtensionsPages(ExtensionsBuildItem extensionsBuildItem) {
 
-        InternalPageBuildItem extensionsPages = new InternalPageBuildItem("Extensions", 10);
+        InternalPageBuildItem extensionsPages = new InternalPageBuildItem("Extensions", 10, "qwc-extensions-menu-action");
 
         // Extensions
         Map<ExtensionGroup, List<Extension>> response = Map.of(

--- a/extensions/vertx-http/dev-ui-resources/pom.xml
+++ b/extensions/vertx-http/dev-ui-resources/pom.xml
@@ -117,6 +117,13 @@
             <scope>runtime</scope>
         </dependency>
         
+        <!-- Loading indicators -->
+        <dependency>
+            <groupId>org.mvnpm</groupId>
+            <artifactId>ldrs</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        
         <!-- Markdown it -->
         <dependency>
             <groupId>org.mvnpm</groupId>

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/router-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/router-controller.js
@@ -158,6 +158,11 @@ export class RouterController {
         Router.go({pathname: firstPage});
     }
 
+    go(page){
+        let pageRef = this.getPageUrlFor(page);
+        Router.go({pathname: pageRef});
+    }
+
     getFirstPageUrl(){
         for (let entry of RouterController.pageMap) {
             let value = entry[1];

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing-menu-action.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing-menu-action.js
@@ -1,0 +1,75 @@
+import { LitElement, html, css} from 'lit';
+import {ring} from 'ldrs';
+
+ring.register();
+
+/**
+ * This is the menu action on the Continuous Testing menu
+ */
+export class QwcContinuousTestingMenuAction extends LitElement {
+    
+    static styles = css`
+            .actionBtn{
+                color: var(--lumo-contrast-25pct);
+            }
+            .ring {
+                padding-right: 5px;
+                padding-top: 5px;
+            }
+       `;
+
+    static properties = {
+        _ctState: {state : true}
+    }
+
+    constructor() {
+        super();
+        this._ctState = "stopped";
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        window.addEventListener('continuous-testing-state-change', this._onStateChanged);   
+    }
+    
+    disconnectedCallback() {
+        window.removeEventListener('continuous-testing-state-change', this._onStateChanged);
+        super.disconnectedCallback();
+    }
+
+    _onStateChanged = (event) => {
+        this._ctState = event.detail.state;
+    }
+
+    render(){
+        let icon = "stop";
+        let title = "Stop";
+        if(this._ctState === "stopped"){
+            icon = "play";
+            title = "Start";
+        }
+
+        if(this._ctState === "stopped" || this._ctState === "started"){
+            return html`<vaadin-button 
+                            title="${title} Continuous Testing " class="actionBtn"
+                            id="start-cnt-testing-btn" 
+                            theme="icon tertiary small" 
+                            @click="${this._startStopClicked}">
+                        <vaadin-icon icon="font-awesome-solid:${icon}"></vaadin-icon>
+                    </vaadin-button>`;
+        }else{
+            return html`<l-ring size="26" stroke="2" color="var(--lumo-contrast-25pct)" class="ring"></l-ring>`;
+        }
+    }
+    
+    _startStopClicked(e){
+        this.dispatchEvent(new CustomEvent('continuous-testing-start-stop', {
+            detail: { requested: "start/stop" },
+            bubbles: true,
+            composed: true
+        }));
+    }
+    
+    
+}
+customElements.define('qwc-continuous-testing-menu-action', QwcContinuousTestingMenuAction);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions-menu-action.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions-menu-action.js
@@ -1,0 +1,91 @@
+import { LitElement, html, css} from 'lit';
+import { StorageController } from 'storage-controller';
+import '@vaadin/popover';
+import '@vaadin/vertical-layout';
+import { popoverRenderer } from '@vaadin/popover/lit.js';
+
+
+/**
+ * This is the menu action on the Extensions menu
+ */
+export class QwcExtensionsMenuAction extends LitElement {
+    
+    storageController = new StorageController(this);
+    
+    static styles = css`
+            .actionBtn{
+                color: var(--lumo-contrast-25pct);
+            }
+       `;
+
+    static properties = {
+        _selectedFilters: {state: true, type: Array}
+    }
+
+    constructor() {
+        super();
+        this._filteritems = ["Favorites","Active","Inactive"];
+        
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._selectedFilters = this._getStoredFilters();
+    }
+
+    render(){
+        return html`<vaadin-button id="filterButton" theme="icon tertiary small" aria-label="Filter" title="Filter extension cards" class="actionBtn">
+                        <vaadin-icon icon="font-awesome-solid:filter"></vaadin-icon>
+                    </vaadin-button>
+                    <vaadin-popover
+                        for="filterButton"
+                        .position="bottom-start"
+                        .position="${this.position}"
+                        ${popoverRenderer(this._renderFilters)}
+                    ></vaadin-popover>`;
+    }
+
+    _renderFilters = () => {
+    return html`
+            <vaadin-list-box multiple
+                .selectedValues="${this._selectedFilters}"
+                @selected-values-changed="${this._onFilterChange}">
+                    ${this._filteritems.map(filter => this._renderFilter(filter))}
+            </vaadin-list-box>
+        `;
+    }
+
+    _renderFilter(filter){
+        return html`<vaadin-item>${filter}</vaadin-item>`;
+    }
+
+    _getStoredFilters(){
+        const storedFilters = JSON.parse(this.storageController.get?.('selectedFilters'));
+        const selectedFilters = Array.isArray(storedFilters) && storedFilters.length > 0 ? storedFilters : this._filteritems;
+        const selectedIndexes = selectedFilters.map(option => this._filteritems.indexOf(option));
+        return selectedIndexes;
+    }
+
+    _setStoredFilters(selectedFilters){
+        this.storageController.set('selectedFilters', JSON.stringify(selectedFilters));
+    }
+    
+    _onFilterChange(event) {
+        const selectedIndexes = event.detail.value;
+        this._selectedFilters = selectedIndexes;
+
+        const selectedFilters = selectedIndexes.map(i => this._filteritems[i]);
+
+        // Save to storage
+        this._setStoredFilters(selectedFilters);
+
+        // Fire custom event
+        this.dispatchEvent(new CustomEvent('extensions-filters-changed', {
+            detail: { filters: selectedFilters },
+            bubbles: true,
+            composed: true
+        }));
+    }
+    
+}
+customElements.define('qwc-extensions-menu-action', QwcExtensionsMenuAction);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-menu.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-menu.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css} from 'lit';
+import { html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { devuiState } from 'devui-state';
 import { observeState } from 'lit-element-state';
 import { RouterController } from 'router-controller';
@@ -29,12 +30,8 @@ export class QwcMenu extends observeState(LitElement) {
             }
             
             .menuSizeControl {
-                align-self: flex-end;
                 cursor: pointer;
                 color: var(--lumo-contrast-10pct);
-                height: 60px;
-                width: 30px;
-                padding-top:30px;
             }
             
             .menuSizeControl:hover {
@@ -67,6 +64,7 @@ export class QwcMenu extends observeState(LitElement) {
                 color: var(--lumo-contrast-90pct);
                 height:30px;
                 text-decoration: none;
+                justify-content: space-between;
             }
             
             .item:hover{
@@ -80,13 +78,23 @@ export class QwcMenu extends observeState(LitElement) {
                 background-color: var(--lumo-primary-color-10pct);
             }
 
+            .itemref{
+                color: var(--lumo-contrast-90pct);
+                text-decoration: none;
+            }
+
             .hidden {
                 display:none;
             }
 
+            .bottom {
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+            }
+
             .quarkusVersion {
-                padding-bottom: 10px;
-                padding-left: 15px;
+                padding-left: 5px;
                 width: 100%;
             }
     
@@ -156,11 +164,9 @@ export class QwcMenu extends observeState(LitElement) {
                     ${this._dynamicMenuNamespaces.map((page) =>
                         html`${this._renderCustomItem(page, -1)}`
                     )}
-                    ${this._renderIcon("chevron-left", "smaller")}
-                    ${this._renderIcon("chevron-right", "larger")}
                 </div>
 
-                ${this._renderVersion()}
+                ${this._renderBottom()}
             </div>`;
     }
 
@@ -200,7 +206,15 @@ export class QwcMenu extends observeState(LitElement) {
         this.storageControl.set('customPageLinks', JSON.stringify(menu));
     }
 
-    _renderVersion(){
+    _renderBottom(){
+        return html`<div class="bottom">
+                        ${this._renderVersion()}
+                        ${this._renderIcon("chevron-left", "smaller")}
+                        ${this._renderIcon("chevron-right", "larger")}
+                    </div>`;
+    }
+    
+    _renderVersion(){    
         if(this._show){
             return html`<div class="quarkusVersion">
                             <span @click="${this._quarkus}">Quarkus ${devuiState.applicationInfo.quarkusVersion}</span>
@@ -260,15 +274,23 @@ export class QwcMenu extends observeState(LitElement) {
                 }
             }
             
-            let pageRef = this.routerController.getPageUrlFor(page);
-            
             let classnames = this._getClassNamesForMenuItem(page, index);
-            return html`
-                <a class="${classnames}" href="${pageRef}">
-                    <vaadin-icon icon="${page.icon}"></vaadin-icon>
-                    <span class="item-text" data-page="${page.componentName}">${displayName}</span>
-                </a>
-                `;
+            return html`<div class="${classnames}" @click=${() => this.routerController.go(page)}>
+                    <div>
+                        <vaadin-icon icon="${page.icon}"></vaadin-icon>
+                        <span class="item-text" data-page="${page.componentName}">${displayName}</span>
+                    </div>
+                    ${this._renderMenuAction(page, classnames)}
+                </div>`;
+        }
+    }
+
+    _renderMenuAction(page, classnames){
+        if(page.menuActionComponent && this._show && classnames.includes("selected")){
+            import(`./${page.menuActionComponent}.js`);
+            
+            const tagName = unsafeStatic(page.menuActionComponent);
+            return staticHtml`<${tagName}></${tagName}>`;
         }
     }
 
@@ -312,7 +334,7 @@ export class QwcMenu extends observeState(LitElement) {
     _renderIcon(icon, action){
         if(action == "smaller" && this._show){
             return html`
-                <vaadin-icon class="menuSizeControl" icon="font-awesome-solid:${icon}" @click="${this._changeMenuSize}" data-action="${action}" style="position: absolute;top: 45%;"></vaadin-icon>
+                <vaadin-icon class="menuSizeControl" icon="font-awesome-solid:${icon}" @click="${this._changeMenuSize}" data-action="${action}"></vaadin-icon>
             `;
         }else if(action == "larger" && !this._show){
             return html`

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-no-data.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-no-data.js
@@ -35,10 +35,12 @@ export class QwcNoData extends LitElement {
     }
 
     render() {
-        return html`<p class="nodata">
+        return html`
+            <div class="nodata">
                 <span>${this.message}</span>
                 ${this._renderLink()}
-            </p>
+                <slot></slot>
+            </div>
         `;
     }
     

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
@@ -31,6 +31,8 @@ public class Page {
     private String namespaceLabel = null; // When more than one page belongs to the same namespace, we use the namespace as a title sometimes
     private String extensionId = null; // If this originates from an extension, then id. For internal this will be null;
 
+    private String menuActionComponent = null; // Internal pages can set this
+
     protected Page(String icon,
             String title,
             String staticLabel,
@@ -151,6 +153,14 @@ public class Page {
 
     public Map<String, String> getMetadata() {
         return metadata;
+    }
+
+    public void setMenuActionComponent(String menuActionComponent) {
+        this.menuActionComponent = menuActionComponent;
+    }
+
+    public String getMenuActionComponent() {
+        return this.menuActionComponent;
     }
 
     @Override


### PR DESCRIPTION
This is a small cosmetic change for Dev UI to "fix" a pedantic layout issue :)

With this PR a new feature is added to Menu Items - they can now define a Menu Item (sub) action. So the main action will still be selecting that page, if you can now add a sub-action. This is just a component you define and in the component you can implement the action.

As an example, this PR also now move the extension filter (that was placed awkwardly at the top of the extension page) to the menu as a sub action. Another example is the Continuous Testing start/stop that moves here with a better "not-running" page (mimic the "no dev services" page.

 

https://github.com/user-attachments/assets/712c0c79-6b50-4c82-829e-312b39053b80

