### PR TITLE
Revert "ProjectDependency.getDependencyProject() and BuildIdentifier.getName() deprecations"

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
@@ -96,7 +96,7 @@ public class DependencyUtils {
             projectDependency = getProjectExtensionDependencyOrNull(
                     project,
                     componentId.getProjectPath(),
-                    componentId.getBuild().getBuildPath());
+                    componentId.getBuild().getName());
 
             if (projectDependency != null)
                 return projectDependency;


### PR DESCRIPTION
This reverts commit 539ab7c36ce8a40920fb095eff91db550f37fb1a.

@cdsap I have to revert this commit since the failures reported in https://github.com/quarkusio/quarkus/pull/47924 aren't flaky but caused by this change.