### PR TITLE
Use config.getOptionValue checking quarkus.security.auth.enabled-in-dev-mode

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -346,9 +346,10 @@ public class SmallRyeOpenApiProcessor {
 
         if (launchMode.getLaunchMode().equals(LaunchMode.DEVELOPMENT)) {
             Config config = ConfigProvider.getConfig();
-            boolean authEnabled = config.getValue("quarkus.security.auth.enabled-in-dev-mode", Boolean.class);
-            if (authEnabled)
+            Optional<Boolean> authEnabled = config.getOptionalValue("quarkus.security.auth.enabled-in-dev-mode", Boolean.class);
+            if (authEnabled.isPresent() && authEnabled.get()) {
                 return securitySetting.get();
+            }
             return false;
         } else {
             return securitySetting.get();


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/47933

This fixes a regression in the Dev mode tests.

FYI @phillip-kruger @gsmet 