### PR TITLE
Add tests for redis dev services behaviour in devmode

### DIFF
--- a/integration-tests/redis-devservices/pom.xml
+++ b/integration-tests/redis-devservices/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
@@ -32,6 +36,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
@@ -51,6 +60,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/redis-devservices/pom.xml
+++ b/integration-tests/redis-devservices/pom.xml
@@ -24,6 +24,16 @@
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -103,6 +113,30 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <exclude>**/continuoustesting/**/*.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>devmode-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>**/continuoustesting/**/*.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>

--- a/integration-tests/redis-devservices/src/main/java/io/quarkus/test/devservices/redis/TestResource.java
+++ b/integration-tests/redis-devservices/src/main/java/io/quarkus/test/devservices/redis/TestResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.test.devservices.redis;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+
+@Path("/")
+public class TestResource {
+
+    @Inject
+    RedisDataSource redis;
+
+    @GET
+    @Path("/ping")
+    public String ping() {
+        return redis.execute("ping").toString();
+    }
+
+    @GET
+    @Path("/set/{key}/{value}")
+    public String set(@PathParam("key") String key, @PathParam("value") String value) {
+        redis.value(String.class).set(key, value);
+        return "OK";
+    }
+
+    @GET
+    @Path("/get/{key}")
+    public String get(@PathParam("key") String key) {
+        return redis.value(String.class).get(key);
+    }
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
@@ -1,0 +1,159 @@
+package io.quarkus.redis.devservices.continuoustesting.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
+
+import io.quarkus.redis.devservices.it.PlainQuarkusTest;
+import io.quarkus.test.ContinuousTestingTestUtils;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class DevServicesRedisContinuousTestingTest {
+
+    static final String DEVSERVICES_DISABLED_PROPERTIES = ContinuousTestingTestUtils.appProperties(
+            "quarkus.devservices.enabled=false");
+
+    static final String FIXED_PORT_PROPERTIES = ContinuousTestingTestUtils.appProperties(
+            "quarkus.redis.devservices.port=6377");
+
+    static final String UPDATED_FIXED_PORT_PROPERTIES = ContinuousTestingTestUtils.appProperties(
+            "quarkus.redis.devservices.port=6342");
+
+    @RegisterExtension
+    public static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses()
+                    .addAsResource(new StringAsset(ContinuousTestingTestUtils.appProperties("")),
+                            "application.properties"))
+            .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(PlainQuarkusTest.class));
+
+    @Disabled("Not currently working")
+    @Test
+    public void testContinuousTestingDisablesDevServicesWhenPropertiesChange() {
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        var result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+
+        // Now let's disable dev services globally ... BOOOOOM! Splat!
+        test.modifyResourceFile("application.properties", s -> DEVSERVICES_DISABLED_PROPERTIES);
+        result = utils.waitForNextCompletion();
+        assertEquals(0, result.getTotalTestsPassed());
+        assertEquals(1, result.getTotalTestsFailed());
+
+        // We could check the container goes away, but we'd have to check slowly, because ryuk can be slow
+    }
+
+    @Test
+    public void testContinuousTestingReusesInstanceWhenPropertiesAreNotChanged() {
+
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        var result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+        List<Container> redisContainers = getRedisContainers();
+
+        // Make a change that shouldn't affect dev services
+        test.modifyTestSourceFile(PlainQuarkusTest.class, s -> s.replaceAll("redisClient", "updatedRedisClient"));
+
+        result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTestsPassed());
+        assertEquals(0, result.getTestsFailed());
+
+        // Some containers could have disappeared, because ryuk cleaned them up, but no new containers should have appeared
+        List<Container> newContainers = getRedisContainersExcludingExisting(redisContainers);
+        assertEquals(0, newContainers.size(),
+                "New containers: " + newContainers + "\n Old containers: " + redisContainers + "\n All containers: "
+                        + getAllContainers());
+    }
+
+    @Test
+    public void testContinuousTestingCreatesANewInstanceWhenPropertiesAreChanged() {
+
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        var result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+        List<Container> existingContainers = new ArrayList<>();
+        existingContainers.addAll(getRedisContainers());
+
+        test.modifyResourceFile("application.properties", s -> FIXED_PORT_PROPERTIES);
+
+        result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTestsPassed());
+        assertEquals(0, result.getTestsFailed());
+
+        // A new container should have appeared
+        {
+            List<Container> newContainers = getRedisContainersExcludingExisting(existingContainers);
+            existingContainers.addAll(newContainers);
+            assertEquals(1, newContainers.size(),
+                    "New containers: " + newContainers + "\n Old containers: " + existingContainers + "\n All containers: "
+                            + getAllContainers());
+
+            // The new container should be on the new port
+            List<Integer> ports = Arrays.stream(newContainers.get(0).getPorts())
+                    .map(ContainerPort::getPublicPort)
+                    .toList();
+
+            // Oh good, it's one port, so it should be the expected one
+            assertTrue(ports.contains(6377), "Container ports: " + ports);
+        }
+        test.modifyResourceFile("application.properties", s -> UPDATED_FIXED_PORT_PROPERTIES);
+
+        result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTestsPassed());
+        assertEquals(0, result.getTestsFailed());
+
+        // Another new container should have appeared
+
+        {
+            List<Container> newContainers = getRedisContainersExcludingExisting(existingContainers);
+            assertEquals(1, newContainers.size(),
+                    "New containers: " + newContainers + "\n Old containers: " + existingContainers + "\n All containers: "
+                            + getAllContainers());
+
+            // The new container should be on the new port
+            List<Integer> ports = Arrays.stream(newContainers.get(0).getPorts())
+                    .map(ContainerPort::getPublicPort)
+                    .toList();
+            assertTrue(ports.contains(6342), "Container ports: " + ports);
+
+        }
+    }
+
+    private static List<Container> getAllContainers() {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(container -> isRedisContainer(container)).toList();
+    }
+
+    private static List<Container> getRedisContainers() {
+        return getAllContainers();
+    }
+
+    private static List<Container> getRedisContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getRedisContainers().stream().filter(
+                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    private static boolean isRedisContainer(Container container) {
+        // The output of getCommand() seems to vary by host OS (it's different on CI and mac), but the image name should be reliable
+        return container.getImage().contains("redis");
+    }
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
@@ -63,19 +63,22 @@ public class DevServicesRedisContinuousTestingTest {
         // We could check the container goes away, but we'd have to check slowly, because ryuk can be slow
     }
 
+    // This tests behaviour in dev mode proper (rather than continuous testing)
     @Test
     public void testDevModeServiceConfigRefresh() {
         List<Container> started = getRedisContainers();
+        // Interacting with the app will force a refresh
         ping();
 
         assertFalse(started.isEmpty());
         Container container = started.get(0);
         assertTrue(Arrays.stream(container.getPorts()).noneMatch(p -> p.getPublicPort() == 6377),
-                "Expected random port 6377, but got: " + Arrays.toString(container.getPorts()));
+                "Expected random port, but got: " + Arrays.toString(container.getPorts()));
 
         test.modifyResourceFile("application.properties",
-                s -> ContinuousTestingTestUtils.appProperties("quarkus.redis.devservices.port=6377"));
+                s -> ContinuousTestingTestUtils.appProperties(FIXED_PORT_PROPERTIES));
 
+        // Force another refresh
         ping();
         List<Container> newContainers = getRedisContainersExcludingExisting(started);
         assertEquals(1, newContainers.size()); // this can be wrong

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/PlainQuarkusTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/PlainQuarkusTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.redis.devservices.it;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PlainQuarkusTest {
+
+    @Inject
+    RedisDataSource redisClient;
+
+    @Test
+    public void shouldStartRedisContainer() {
+        assertNotNull(redisClient);
+    }
+}


### PR DESCRIPTION
While working on #47610, I realised we didn't have much coverage of continuous testing and the redis dev services. 

I've added tests to make sure that dev services work, and that containers are (a) updated or (b) reused when the app changes. I expected that disabling dev services would make the dev service go away, but that's not currently working, so I've disabled that test.