### PR TITLE
Update datasource observability configs docs and setup

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -194,24 +194,9 @@ Hit `CTRL+C` or type `q` to stop the application.
 
 === JDBC
 
-The https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jdbc/library[JDBC instrumentation] will add a span for each JDBC queries done by your application, to enable it, add the following dependency to your build file:
+The https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jdbc/library[JDBC instrumentation] bundled with this extension will add a span for each JDBC queries done by your application.
 
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
-.pom.xml
-----
-<dependency>
-    <groupId>io.opentelemetry.instrumentation</groupId>
-    <artifactId>opentelemetry-jdbc</artifactId>
-</dependency>
-----
-
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-implementation("io.opentelemetry.instrumentation:opentelemetry-jdbc")
-----
-
-As it uses a dedicated JDBC datasource wrapper, you must enable telemetry for your datasource:
+As it uses a dedicated JDBC datasource wrapper, you must enable telemetry for your datasource with the `quarkus.datasource.jdbc.telemetry` property, as in the following example:
 
 [source, properties]
 ----

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
@@ -34,7 +34,12 @@ public interface DataSourceJdbcBuildTimeConfig {
     /**
      * Enable datasource metrics collection. If unspecified, collecting metrics will be enabled by default if
      * a metrics extension is active.
+     * <p>
+     * Deprecated. This was used by the now deprecated quarkus-smallrye-metrics and will be removed soon.
+     * <p>
+     * Please use quarkus-micrometer and the quarkus.datasource.metrics.enabled property
      */
+    @Deprecated(forRemoval = true)
     Optional<Boolean> enableMetrics();
 
     /**

--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -131,11 +131,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2-deployment</artifactId>
             <scope>test</scope>

--- a/extensions/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/runtime/pom.xml
@@ -198,6 +198,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-jdbc</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
@@ -33,10 +33,6 @@
 
         <!-- JDBC instrumentation -->
         <dependency>
-            <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-jdbc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-oracle</artifactId>
         </dependency>


### PR DESCRIPTION
Relates with https://github.com/quarkusio/quarkus/issues/22556

The documentation for `quarkus.datasource.jdbc.enable-metrics` is outdated. Prop should be deprecated because it's related with `quarkus-smallrye-metrics` but we cannot remove it for now.

The PR also includes a setup simplification for tracing. 