### PR TITLE
HQL console transaction fix for panache entities

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
@@ -402,19 +402,22 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
     }
 
     _cellRenderer(value) {
-        if (value) {
-            if (value === 'true') {
-                return html`
-                    <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
-                                 icon="font-awesome-regular:square-check"></vaadin-icon>`;
-            } else if (value === 'false') {
-                return html`
-                    <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
-                                 icon="font-awesome-regular:square"></vaadin-icon>`;
-            } else if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+        if ( value === true ) {
+            return html`
+                <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
+                             icon="font-awesome-regular:square-check"></vaadin-icon>`;
+        }
+        else if ( value === false ) {
+            return html`
+                <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
+                             icon="font-awesome-regular:square"></vaadin-icon>`;
+        }
+        else if ( value ) {
+            if ( typeof value === 'string' && (value.startsWith( 'http://' ) || value.startsWith( 'https://' )) ) {
                 return html`<a href="${value}" target="_blank">${value}</a>`;
-            } else {
-                const s = typeof value === 'object' ? JSON.stringify(value) : value;
+            }
+            else {
+                const s = typeof value === 'object' ? JSON.stringify( value ) : value;
                 return html`<span>${s}</span>`;
             }
         }


### PR DESCRIPTION
Fixes #47663.

This partially addresses the issue by ensuring `PanacheEntityBase#isPersistent()` can retrieve the active session by wrapping query execution and result seralization within a transaction. This ensures we can retrieve the currently active session and prevents errors.

As a temporary side-effect, any entity extending `PanacheEntity` will be serialized including a boolean `persistent` property value which will then be rendered in the console. This will be improved when the custom Hibernate-specific serialization will be available (hopefully very soon).