### PR TITLE
Limit Dependabot Expressly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -223,6 +223,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: co.elastic.clients:elasticsearch-java
         update-types: ["version-update:semver-major"]
+      # Expressly, as an EL implementation is tightly coupled with the Jakarta Validation and Hibernate Validator versions in use
+      # Hence we update major/minor Expressly versions manually.
+      - dependency-name: org.glassfish.expressly:expressly
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     rebase-strategy: disabled
   - package-ecosystem: gradle
     directory: "/devtools/gradle"


### PR DESCRIPTION
So that we do not accidentally update it, and to make sure we keep it more aligned with Jakarta Validation/Hibernate Validator needs.