### PR TITLE
Add support for passing user data through client connectors in WebSockets Next

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -1398,6 +1398,49 @@ class MyEndpoint {
 <1> `CoolService#isCool()` returns `Boolean` that is associated with the current connection.
 <2> The `TypedKey.forBoolean("isCool")` is the key used to obtain the data stored when the connection was created.
 
+===== Specify in connector
+
+In some scenarios you may wish to associate user data with a connection to be created by a <<client-connectors,connector>>. In this case, you can set values on the connector instance prior to obtaining the connection. This is particularly useful if you need to do something when the connection is opened and the necessary context cannot be otherwise inferred.
+
+.Connector
+[source, java]
+----
+@Singleton
+public class MyBean {
+
+    @Inject
+    MyService service;
+
+    @Inject
+    Instance<WebSocketConnector<MyEndpoint>> connectorInstance;
+
+    public void openAndSendMessage(String internalId, String message) {
+        var externalId = service.getExternalId(internalId);
+        var connection = connectorInstance.get()
+            .pathParam("externalId", externalId)
+            .userData(TypedKey.forString("internalId"), internalId)
+            .connectAndAwait();
+        connection.sendTextAndAwait(message);
+    }
+}
+----
+
+.Endpoint
+[source,java]
+----
+@WebSocketClient(path = "/endpoint/{externalId}")
+class MyEndpoint {
+
+    @Inject
+    MyService service;
+
+    @OnOpen
+    void open(WebSocketClientConnection connection) {
+        var internalId = connection.userData().get(TypedKey.forString("internalId"));
+        service.doSomething(internalId);
+    }
+}
+----
 
 [[client-cdi-events]]
 ==== CDI events

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/programmatic/ClientEndpointProgrammaticTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/programmatic/ClientEndpointProgrammaticTest.java
@@ -1,9 +1,13 @@
 package io.quarkus.websockets.next.test.client.programmatic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -20,6 +24,8 @@ import io.quarkus.websockets.next.HandshakeRequest;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.UserData;
+import io.quarkus.websockets.next.UserData.TypedKey;
 import io.quarkus.websockets.next.WebSocket;
 import io.quarkus.websockets.next.WebSocketClient;
 import io.quarkus.websockets.next.WebSocketClientConnection;
@@ -45,15 +51,42 @@ public class ClientEndpointProgrammaticTest {
                 .get()
                 .baseUri(uri)
                 .addHeader("Foo", "Lu")
+                .userData(TypedKey.forBoolean("boolean"), true)
+                .userData(TypedKey.forInt("int"), Integer.MAX_VALUE)
+                .userData(TypedKey.forLong("long"), Long.MAX_VALUE)
+                .userData(TypedKey.forString("string"), "Lu")
                 .connectAndAwait();
+        assertTrue(connection1.userData().get(TypedKey.forBoolean("boolean")));
+        assertEquals(Integer.MAX_VALUE, connection1.userData().get(TypedKey.forInt("int")));
+        assertEquals(Long.MAX_VALUE, connection1.userData().get(TypedKey.forLong("long")));
+        assertEquals("Lu", connection1.userData().get(TypedKey.forString("string")));
         connection1.sendTextAndAwait("Hi!");
 
         WebSocketClientConnection connection2 = connector
                 .get()
                 .baseUri(uri)
                 .addHeader("Foo", "Ma")
+                .userData(TypedKey.forBoolean("boolean"), false)
+                .userData(TypedKey.forInt("int"), Integer.MIN_VALUE)
+                .userData(TypedKey.forLong("long"), Long.MIN_VALUE)
+                .userData(TypedKey.forString("string"), "Ma")
                 .connectAndAwait();
+        assertFalse(connection2.userData().get(TypedKey.forBoolean("boolean")));
+        assertEquals(Integer.MIN_VALUE, connection2.userData().get(TypedKey.forInt("int")));
+        assertEquals(Long.MIN_VALUE, connection2.userData().get(TypedKey.forLong("long")));
+        assertEquals("Ma", connection2.userData().get(TypedKey.forString("string")));
         connection2.sendTextAndAwait("Hi!");
+
+        assertTrue(ClientEndpoint.OPEN_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(ClientEndpoint.CONNECTION_USER_DATA.containsKey(connection1.id()));
+        assertTrue(ClientEndpoint.CONNECTION_USER_DATA.get(connection1.id()).get(TypedKey.forBoolean("boolean")));
+        assertEquals(Integer.MAX_VALUE, ClientEndpoint.CONNECTION_USER_DATA.get(connection1.id()).get(TypedKey.forInt("int")));
+        assertEquals(Long.MAX_VALUE, ClientEndpoint.CONNECTION_USER_DATA.get(connection1.id()).get(TypedKey.forLong("long")));
+        assertEquals("Lu", ClientEndpoint.CONNECTION_USER_DATA.get(connection1.id()).get(TypedKey.forString("string")));
+        assertFalse(ClientEndpoint.CONNECTION_USER_DATA.get(connection2.id()).get(TypedKey.forBoolean("boolean")));
+        assertEquals(Integer.MIN_VALUE, ClientEndpoint.CONNECTION_USER_DATA.get(connection2.id()).get(TypedKey.forInt("int")));
+        assertEquals(Long.MIN_VALUE, ClientEndpoint.CONNECTION_USER_DATA.get(connection2.id()).get(TypedKey.forLong("long")));
+        assertEquals("Ma", ClientEndpoint.CONNECTION_USER_DATA.get(connection2.id()).get(TypedKey.forString("string")));
 
         assertTrue(ClientEndpoint.MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
         assertTrue(ClientEndpoint.MESSAGES.contains("Lu:Hello Lu!"));
@@ -92,11 +125,21 @@ public class ClientEndpointProgrammaticTest {
     @WebSocketClient(path = "/endpoint")
     public static class ClientEndpoint {
 
+        static final CountDownLatch OPEN_LATCH = new CountDownLatch(2);
+
+        static final Map<String, UserData> CONNECTION_USER_DATA = new ConcurrentHashMap<>();
+
         static final CountDownLatch MESSAGE_LATCH = new CountDownLatch(4);
 
         static final List<String> MESSAGES = new CopyOnWriteArrayList<>();
 
         static final CountDownLatch CLOSED_LATCH = new CountDownLatch(2);
+
+        @OnOpen
+        void onOpen(WebSocketClientConnection connection) {
+            CONNECTION_USER_DATA.put(connection.id(), connection.userData());
+            OPEN_LATCH.countDown();
+        }
 
         @OnTextMessage
         void onMessage(String message, HandshakeRequest handshakeRequest) {

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.websockets.next.UserData.TypedKey;
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.buffer.Buffer;
@@ -113,6 +114,18 @@ public interface BasicWebSocketConnector {
      * @return self
      */
     BasicWebSocketConnector addSubprotocol(String value);
+
+    /**
+     * Add a value to the connection user data.
+     *
+     * @param key
+     * @param value
+     * @param <VALUE>
+     * @return self
+     * @see UserData#put(TypedKey, Object)
+     * @see WebSocketClientConnection#userData()
+     */
+    <VALUE> BasicWebSocketConnector userData(TypedKey<VALUE> key, VALUE value);
 
     /**
      * Set the execution model for callback handlers.

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
@@ -6,6 +6,7 @@ import java.net.URLEncoder;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 
+import io.quarkus.websockets.next.UserData.TypedKey;
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.mutiny.Uni;
 
@@ -93,6 +94,18 @@ public interface WebSocketConnector<CLIENT> {
      * @return self
      */
     WebSocketConnector<CLIENT> addSubprotocol(String value);
+
+    /**
+     * Add a value to the connection user data.
+     *
+     * @param key
+     * @param value
+     * @param <VALUE>
+     * @return self
+     * @see UserData#put(TypedKey, Object)
+     * @see WebSocketClientConnection#userData()
+     */
+    <VALUE> WebSocketConnector<CLIENT> userData(TypedKey<VALUE> key, VALUE value);
 
     /**
      *

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
@@ -186,7 +186,7 @@ public class BasicWebSocketConnectorImpl extends WebSocketConnectorBase<BasicWeb
                     codecs,
                     pathParams,
                     serverEndpointUri,
-                    headers, trafficLogger, null);
+                    headers, trafficLogger, userData, null);
             if (trafficLogger != null) {
                 trafficLogger.connectionOpened(connection);
             }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/UserDataImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/UserDataImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.websockets.next.runtime;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -11,6 +12,10 @@ final class UserDataImpl implements UserData {
 
     UserDataImpl() {
         this.data = new ConcurrentHashMap<>();
+    }
+
+    UserDataImpl(Map<String, Object> data) {
+        this.data = new ConcurrentHashMap<>(data);
     }
 
     @SuppressWarnings("unchecked")

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientConnectionImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientConnectionImpl.java
@@ -21,9 +21,9 @@ class WebSocketClientConnectionImpl extends WebSocketConnectionBase implements W
 
     WebSocketClientConnectionImpl(String clientId, WebSocket webSocket, Codecs codecs,
             Map<String, String> pathParams, URI serverEndpointUri, Map<String, List<String>> headers,
-            TrafficLogger trafficLogger, SendingInterceptor sendingInterceptor) {
+            TrafficLogger trafficLogger, Map<String, Object> userData, SendingInterceptor sendingInterceptor) {
         super(Map.copyOf(pathParams), codecs, new ClientHandshakeRequestImpl(serverEndpointUri, headers), trafficLogger,
-                sendingInterceptor);
+                new UserDataImpl(userData), sendingInterceptor);
         this.clientId = clientId;
         this.webSocket = Objects.requireNonNull(webSocket);
     }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
@@ -36,19 +36,19 @@ public abstract class WebSocketConnectionBase implements Connection {
 
     protected final TrafficLogger trafficLogger;
 
-    private final UserData data;
+    private final UserData userData;
 
     private final SendingInterceptor sendingInterceptor;
 
     WebSocketConnectionBase(Map<String, String> pathParams, Codecs codecs, HandshakeRequest handshakeRequest,
-            TrafficLogger trafficLogger, SendingInterceptor sendingInterceptor) {
+            TrafficLogger trafficLogger, UserData userData, SendingInterceptor sendingInterceptor) {
         this.identifier = UUID.randomUUID().toString();
         this.pathParams = pathParams;
         this.codecs = codecs;
         this.handshakeRequest = handshakeRequest;
         this.creationTime = Instant.now();
         this.trafficLogger = trafficLogger;
-        this.data = new UserDataImpl();
+        this.userData = userData;
         this.sendingInterceptor = sendingInterceptor;
     }
 
@@ -172,7 +172,7 @@ public abstract class WebSocketConnectionBase implements Connection {
 
     @Override
     public UserData userData() {
-        return data;
+        return userData;
     }
 
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
@@ -36,7 +36,7 @@ class WebSocketConnectionImpl extends WebSocketConnectionBase implements WebSock
             ConnectionManager connectionManager, Codecs codecs, RoutingContext ctx,
             TrafficLogger trafficLogger, SendingInterceptor sendingInterceptor) {
         super(Map.copyOf(ctx.pathParams()), codecs, new HandshakeRequestImpl(webSocket, ctx), trafficLogger,
-                sendingInterceptor);
+                new UserDataImpl(), sendingInterceptor);
         this.generatedEndpointClass = generatedEndpointClass;
         this.endpointId = endpointClass;
         this.webSocket = Objects.requireNonNull(webSocket);

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.quarkus.tls.runtime.config.TlsConfigUtils;
+import io.quarkus.websockets.next.UserData.TypedKey;
 import io.quarkus.websockets.next.WebSocketClientException;
 import io.quarkus.websockets.next.runtime.config.WebSocketsClientRuntimeConfig;
 import io.vertx.core.Vertx;
@@ -40,6 +41,8 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
     protected String path;
 
     protected Set<String> pathParamNames;
+
+    protected final Map<String, Object> userData;
 
     // injected dependencies
 
@@ -66,6 +69,7 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
         this.tlsConfigurationRegistry = tlsConfigurationRegistry;
         this.path = "";
         this.pathParamNames = Set.of();
+        this.userData = new HashMap<>();
     }
 
     public THIS baseUri(URI baseUri) {
@@ -98,6 +102,11 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
 
     public THIS addSubprotocol(String value) {
         subprotocols.add(Objects.requireNonNull(value));
+        return self();
+    }
+
+    public <VALUE> THIS userData(TypedKey<VALUE> key, VALUE value) {
+        userData.put(key.value(), value);
         return self();
     }
 

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
@@ -138,7 +138,7 @@ public class WebSocketConnectorImpl<CLIENT> extends WebSocketConnectorBase<WebSo
             WebSocketClientConnectionImpl connection = new WebSocketClientConnectionImpl(clientEndpoint.clientId, ws,
                     codecs,
                     pathParams,
-                    serverEndpointUri, headers, trafficLogger, sendingInterceptor);
+                    serverEndpointUri, headers, trafficLogger, userData, sendingInterceptor);
             if (trafficLogger != null) {
                 trafficLogger.connectionOpened(connection);
             }


### PR DESCRIPTION
This PR adds a `userData(TypedKey<V> key, V value)` method to the client connector interfaces to enable the ability to associate user data to a connect before it is established.