### PR TITLE
Deprecate quarkus.log.console.async and add enable to it

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
@@ -495,9 +495,15 @@ public interface LogRuntimeConfig {
         /**
          * Indicates whether to log asynchronously
          */
-        @WithParentName
         @WithDefault("false")
         boolean enable();
+
+        /**
+         * Indicates whether to log asynchronously
+         */
+        @WithParentName
+        @Deprecated(forRemoval = true, since = "3.24")
+        Optional<Boolean> legacyEnable();
 
         /**
          * The queue length to use before flushing writing

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -613,7 +613,8 @@ public class LoggingSetupRecorder {
         consoleHandler.setErrorManager(defaultErrorManager);
         applyFilter(includeFilters, defaultErrorManager, cleanupFilter, config.filter(), namedFilters, consoleHandler);
 
-        Handler handler = config.async().enable() ? createAsyncHandler(config.async(), config.level(), consoleHandler)
+        Handler handler = config.async().legacyEnable().orElse(config.async().enable())
+                ? createAsyncHandler(config.async(), config.level(), consoleHandler)
                 : consoleHandler;
 
         if (color && launchMode.isDevOrTest() && !config.async().enable()) {
@@ -708,7 +709,7 @@ public class LoggingSetupRecorder {
             handler.getErrorManager().error("Multiple file formatters were activated", null, ErrorManager.GENERIC_FAILURE);
         }
 
-        if (config.async().enable()) {
+        if (config.async().legacyEnable().orElse(config.async().enable())) {
             return createAsyncHandler(config.async(), config.level(), handler);
         }
         return handler;
@@ -790,7 +791,7 @@ public class LoggingSetupRecorder {
                         ErrorManager.GENERIC_FAILURE);
             }
 
-            if (config.async().enable()) {
+            if (config.async().legacyEnable().orElse(config.async().enable())) {
                 return createAsyncHandler(config.async(), config.level(), handler);
             }
             return handler;
@@ -837,7 +838,7 @@ public class LoggingSetupRecorder {
                         ErrorManager.GENERIC_FAILURE);
             }
 
-            if (config.async().enable()) {
+            if (config.async().legacyEnable().orElse(config.async().enable())) {
                 return createAsyncHandler(config.async(), config.level(), handler);
             }
             return handler;


### PR DESCRIPTION
I went for `enable` for now as it's what is used in all the logging config but at some point, we will switch to use `enabled` everywhere.

Related to #47889 and part of a larger effort to remove the requirement for using ~ in YAML.