### PR TITLE
Disable test which fails on non-AWS-runner CIs

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
@@ -76,6 +76,7 @@ public class QuarkusTestIT extends RunAndCheckMojoTestBase {
     }
 
     @DisabledOnOs(OS.WINDOWS) // Tracked by https://github.com/quarkusio/quarkus/issues/47913
+    @Disabled("See https://github.com/quarkusio/quarkus/issues/48004")
     @Test
     public void testNestedQuarkusTestMixedWithNormalTestsContinuousTesting()
             throws MavenInvocationException, FileNotFoundException {


### PR DESCRIPTION

See https://github.com/quarkusio/quarkus/issues/48004. This doesn't fix the problem, but it makes it less annoying, since if you don't test for a problem, it doesn't exist!