### PR TITLE
Correct MDC context propagation in SmallRye Health

### DIFF
--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/QuarkusAsyncHealthCheckFactory.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/QuarkusAsyncHealthCheckFactory.java
@@ -50,6 +50,7 @@ public class QuarkusAsyncHealthCheckFactory extends AsyncHealthCheckFactory {
     @Override
     public Uni<HealthCheckResponse> callAsync(AsyncHealthCheck asyncHealthCheck) {
         Uni<HealthCheckResponse> healthCheckResponseUni = super.callAsync(asyncHealthCheck);
-        return healthCheckResponseUni.runSubscriptionOn(MutinyHelper.executor(vertx));
+        return healthCheckResponseUni.runSubscriptionOn(MutinyHelper.executor(
+                VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext())));
     }
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
@@ -314,7 +314,7 @@ public enum VertxMDC implements MDCProvider {
         }
 
         ConcurrentMap<Object, Object> lcd = Objects.requireNonNull((ContextInternal) ctx).localContextData();
-        return (ConcurrentMap<String, Object>) lcd.computeIfAbsent(VertxMDC.class.getName(),
+        return (ConcurrentMap<String, Object>) lcd.computeIfAbsent(VertxMDC.class.getName() + ctx.hashCode(),
                 k -> new ConcurrentHashMap<String, Object>());
     }
 }


### PR DESCRIPTION
This should fix the issue described in https://github.com/quarkusio/quarkus/discussions/47481. I don't know if the change to VertxMDC is OK or not, but I want to try to run the tests.

I will port the test for this if the current tests pass.