### PR TITLE
Get the user name as principal name with OAuth2 code flow

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -463,7 +463,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                     String errorMessage = "Token and UserInfo do not have matching `sub` claims";
                     return Uni.createFrom().failure(new AuthenticationCompletionException(errorMessage));
                 }
-
+                final String principalClaim = resolvedContext.oidcConfig().token().principalClaim().orElse(null);
+                if (principalClaim != null && !tokenJson.containsKey(principalClaim) && userInfo != null
+                        && userInfo.contains(principalClaim)) {
+                    tokenJson.put(principalClaim, userInfo.getString(principalClaim));
+                }
                 JsonObject rolesJson = getRolesJson(requestData, resolvedContext, tokenCred, tokenJson,
                         userInfo);
                 SecurityIdentity securityIdentity = validateAndCreateIdentity(requestData, tokenCred,

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -43,7 +43,6 @@ public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmento
         RoutingContext routingContext = identity.getAttribute(RoutingContext.class.getName());
         if (routingContext != null &&
                 (routingContext.normalizedPath().endsWith("code-flow-user-info-only")
-                        || routingContext.normalizedPath().endsWith("code-flow-user-info-github")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github")
                         || routingContext.normalizedPath().endsWith("code-flow-token-introspection")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github-cached-in-idtoken")

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -103,6 +103,8 @@ quarkus.oidc.code-flow-user-info-only.credentials.secret=AyM1SysPpbyDfgZld3umj1q
 quarkus.oidc.code-flow-user-info-only.application-type=web-app
 
 quarkus.oidc.code-flow-user-info-github.provider=github
+# Specifies which UserInfo field is used as the OAuth2 principal name.
+quarkus.oidc.code-flow-user-info-github.token.principal-claim=preferred_username
 quarkus.oidc.code-flow-user-info-github.authentication.internal-id-token-lifespan=7H
 quarkus.oidc.code-flow-user-info-github.authentication.verify-access-token=false
 quarkus.oidc.code-flow-user-info-github.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/


### PR DESCRIPTION
This is a minor update to make it possible to get the user name using the same code with both authorization code and bearer token flows, when dealing with social provider tokens. I noticed it had to be tuned when working on the latest demo.

For example, given a GitHub token, if it is an authorization code flow login, then the user name can only be acquired from `quarkus.oidc.UserInfo`, as shown [here](https://github.com/quarkiverse/quarkus-langchain4j/blob/main/samples/secure-mcp-sse-client-server/secure-mcp-client/src/main/java/io/quarkiverse/langchain4j/sample/LoginResource.java), getting it from `SecurityIdentity` does not work.

But if it is a bearer access token, then using either `UserInfo` or `SecurityIdentity` (as shown [here](https://github.com/quarkiverse/quarkus-langchain4j/blob/main/samples/secure-mcp-sse-client-server/secure-mcp-server/src/main/java/io/quarkiverse/langchain4j/sample/UserNameProvider.java)) works.

Ideally, the `securityIdentity.getPrincipal().getName()` option should also work for tokens acquired from OAuth2 social providers during the authorization code flow too.

The reason it currently does not is that in case of the code flow, an internal ID token is generated which is then used as a source for a principal name, while it is only available for OAuth2 providers in the `UserInfo` json.

So I did a minor update to fix it.

The updated test confirms it - note, that before, the augmentor was manually updating the principal to pick up the UserInfo property, for a test GitHub provider. It is no longer necessary if `UserInfo` contains the configured principal claim