### PR TITLE
Enable --install-exit-handlers in native mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -849,6 +849,14 @@ public class NativeImageBuildStep {
                 }
 
                 /*
+                 * Always install exit handlers, it will become the default and the flag will be deprecated
+                 * in GraalVM for JDK 25 see https://github.com/quarkusio/quarkus/issues/47799
+                 */
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_25_0_0) < 0) {
+                    nativeImageArgs.add("--install-exit-handlers");
+                }
+
+                /*
                  * Any parameters following this call are forced over the user provided parameters in
                  * quarkus.native.additional-build-args or quarkus.native.additional-build-args-append. So if you need
                  * a parameter to be overridable through quarkus.native.additional-build-args or

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -287,28 +287,17 @@ public class ApplicationLifecycleManager {
     }
 
     private static void registerSignalHandlers(final BiConsumer<Integer, Throwable> exitCodeHandler) {
-        final SignalHandler exitHandler = new SignalHandler() {
-            @Override
-            public void handle(Signal signal) {
-                Logger applicationLogger = Logger.getLogger(Application.class);
-                applicationLogger.debugf("Received signed %s, shutting down", signal.getNumber());
-                exitCodeHandler.accept(signal.getNumber() + 0x80, null);
-            }
-        };
         final SignalHandler diagnosticsHandler = new SignalHandler() {
             @Override
             public void handle(Signal signal) {
                 DiagnosticPrinter.printDiagnostics(System.out);
             }
         };
-        handleSignal("INT", exitHandler);
-        handleSignal("TERM", exitHandler);
         // the HUP and QUIT signals are not defined for the Windows OpenJDK implementation:
         // https://hg.openjdk.java.net/jdk8u/jdk8u-dev/hotspot/file/7d5c800dae75/src/os/windows/vm/jvm_windows.cpp
         if (IS_WINDOWS) {
             handleSignal("BREAK", diagnosticsHandler);
         } else {
-            handleSignal("HUP", exitHandler);
             handleSignal("QUIT", diagnosticsHandler);
         }
     }


### PR DESCRIPTION
1. `--install-exit-handlers` doesn't interfere with Quarkus'
   handlers. It sets up the handlers before Quarkus, so the latter can
   then override them.

2. `--install-exit-handlers` impact on image size and reachability is
   negligible:

   ```
   ❯ rg -A 3 'compilation units' vanilla-build.txt exit-handlers-build.txt
   vanilla-build.txt
   81:  24.50MB (45.75%) for code area:    39,827 compilation units
   82-  28.65MB (53.50%) for image heap:  330,561 objects and 63 resources
   83- 411.84kB ( 0.75%) for other data
   84-  53.56MB in total

   exit-handlers-build.txt
   80:  24.50MB (45.75%) for code area:    39,829 compilation units
   81-  28.66MB (53.50%) for image heap:  330,576 objects and 63 resources
   82- 410.29kB ( 0.75%) for other data
   83-  53.56MB in total
   ```

Closes: https://github.com/quarkusio/quarkus/issues/47799
