### PR TITLE
Add JSpecify annotations to improve null-safety

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -190,6 +190,7 @@
         <commons-compress.version>1.27.1</commons-compress.version> <!-- Please check with Java Operator SDK / Fabric8 team before updating -->
         <commons-text.version>1.13.1</commons-text.version>
         <gson.version>2.13.1</gson.version>
+        <jspecify.version>1.0.0</jspecify.version>
         <log4j2-jboss-logmanager.version>2.0.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.24.3</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.3.1.Final</log4j-jboss-logmanager.version>
@@ -6653,6 +6654,12 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-jfr-deployment</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
             </dependency>
 
             <!-- WebAuthn4J -->

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -84,6 +84,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
@@ -16,6 +16,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.quarkus.fs.util.ZipUtils;
+import org.jspecify.annotations.Nullable;
 
 public class ClassPathUtils {
 
@@ -29,7 +30,8 @@ public class ClassPathUtils {
      * @param path file system path
      * @return Java classpath resource name
      */
-    public static String toResourceName(Path path) {
+    @Nullable
+    public static String toResourceName(@Nullable Path path) {
         if (path == null) {
             return null;
         }

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
@@ -1,5 +1,7 @@
 package io.quarkus.runtime.util;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -17,7 +19,8 @@ public class ExceptionUtil {
      * @param exception
      * @return
      */
-    public static String generateStackTrace(final Throwable exception) {
+    @Nullable
+    public static String generateStackTrace(final @Nullable Throwable exception) {
         if (exception == null) {
             return null;
         }
@@ -35,9 +38,10 @@ public class ExceptionUtil {
      * usage of this method is necessary.
      *
      * @param exception The exception
-     * @return
+     * @return root cause or null
      */
-    public static String rootCauseFirstStackTrace(final Throwable exception) {
+    @Nullable
+    public static String rootCauseFirstStackTrace(final @Nullable Throwable exception) {
         if (exception == null) {
             return null;
         }
@@ -76,6 +80,7 @@ public class ExceptionUtil {
         return generateStackTrace(modifiedRoot).replace("Caused by:", "Resulted in:");
     }
 
+    @Nullable
     public static Throwable getRootCause(Throwable exception) {
         final List<Throwable> chain = new ArrayList<>();
         Throwable curr = exception;

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
@@ -1,5 +1,7 @@
 package io.quarkus.runtime.util;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -26,7 +28,7 @@ public final class StringUtil {
     }
 
     public static Iterator<String> camelHumpsIterator(String str) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             int idx;
 
             public boolean hasNext() {
@@ -100,7 +102,7 @@ public final class StringUtil {
     }
 
     public static Iterator<String> lowerCase(Iterator<String> orig) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             public boolean hasNext() {
                 return orig.hasNext();
             }
@@ -142,7 +144,7 @@ public final class StringUtil {
     }
 
     public static Iterator<String> lowerCaseFirst(Iterator<String> orig) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             boolean first = true;
 
             public boolean hasNext() {
@@ -162,7 +164,7 @@ public final class StringUtil {
     }
 
     public static Iterator<String> withoutSuffix(Iterator<String> orig, String... suffixes) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             String next = null;
 
             public boolean hasNext() {
@@ -229,7 +231,7 @@ public final class StringUtil {
         return join("-", lowerCase(camelHumpsIterator(orig)));
     }
 
-    public static boolean isNullOrEmpty(String s) {
+    public static boolean isNullOrEmpty(@Nullable String s) {
         return s == null || s.isEmpty();
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/package-info.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package io.quarkus.runtime.util;


### PR DESCRIPTION
- Introduced the JSpecify library and applied its annotations to enhance null-safety in runtime utilities.
- Updated method signatures, added package-level null annotations
- Modified the pom files to include JSpecify as a dependency.