### PR TITLE
Add ID attribute to a button for starting continuous testing so that DEV UI tests select the button and start testing using DEV UI

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
@@ -289,7 +289,7 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
 
     _renderPlayButton(){
         if(!this._busy && !this._testsEnabled){
-            return html`<vaadin-button theme="tertiary" @click=${this._start}>
+            return html`<vaadin-button theme="tertiary" id="start-continuous-testing-btn" @click=${this._start}>
                         <vaadin-icon icon="font-awesome-solid:play"></vaadin-icon>
                         Start
                     </vaadin-button>`;


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/47952 starting continuous testing using the start button in the `qwc-continuous-testing-menu-action.js` component became less reliable (during testing where millis matter) as clicking on button as soon as the menu was rendered didn't result in starting the tests. Waiting tiny little bit helped, but I'd like to be able to refer to the `Start` button as suggested here https://github.com/quarkusio/quarkus/pull/47952#discussion_r2103630167, which could help determine the right time when to click on the button.