### PR TITLE
Remove regex from hot path in micrometer

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/RequestMetricInfo.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/RequestMetricInfo.java
@@ -11,8 +11,6 @@ import io.micrometer.core.instrument.Timer;
 public class RequestMetricInfo {
     static final Logger log = Logger.getLogger(RequestMetricInfo.class);
 
-    public static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
-    public static final Pattern MULTIPLE_SLASH_PATTERN = Pattern.compile("//+");
     public static final String ROOT = "/";
 
     public static final String HTTP_REQUEST_PATH = "HTTP_REQUEST_PATH";
@@ -85,12 +83,30 @@ public class RequestMetricInfo {
         if (uri == null || uri.isEmpty() || ROOT.equals(uri)) {
             return ROOT;
         }
-        // Label value consistency: result should begin with a '/' and should not end with one
-        String workingPath = MULTIPLE_SLASH_PATTERN.matcher('/' + uri).replaceAll("/");
-        workingPath = TRAILING_SLASH_PATTERN.matcher(workingPath).replaceAll("");
-        if (workingPath.isEmpty()) {
-            return ROOT;
+
+        String workingPath = new String(uri);
+
+        // Remove all leading slashes
+        // detect
+        int start = 0;
+        while (start < workingPath.length() && workingPath.charAt(start) == '/') {
+            start++;
         }
+        // Add missing / and remove multiple leading
+        if (start != 1) {
+            workingPath = "/" + workingPath.substring(start);
+        }
+
+        // Collapse multiple trailing slashes
+        int end = workingPath.length();
+        while (end > 1 && workingPath.charAt(end - 1) == '/') {
+            end--;
+        }
+
+        if (end != workingPath.length()) {
+            workingPath = workingPath.substring(0, end);
+        }
+
         return workingPath;
     }
 }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/RequestMetricInfoTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/RequestMetricInfoTest.java
@@ -33,8 +33,20 @@ public class RequestMetricInfoTest {
     }
 
     @Test
+    public void testParsePathSingleSlash() {
+        String path = requestMetric.getNormalizedUriPath(NO_MATCH_PATTERNS, NO_IGNORE_PATTERNS, "/");
+        Assertions.assertEquals("/", path);
+    }
+
+    @Test
     public void testParsePathDoubleSlash() {
         String path = requestMetric.getNormalizedUriPath(NO_MATCH_PATTERNS, NO_IGNORE_PATTERNS, "//");
+        Assertions.assertEquals("/", path);
+    }
+
+    @Test
+    public void testParsePathMultipleSlash() {
+        String path = requestMetric.getNormalizedUriPath(NO_MATCH_PATTERNS, NO_IGNORE_PATTERNS, "/////");
         Assertions.assertEquals("/", path);
     }
 
@@ -45,10 +57,30 @@ public class RequestMetricInfoTest {
     }
 
     @Test
+    public void testParseNullPath() {
+        String path = requestMetric.getNormalizedUriPath(NO_MATCH_PATTERNS, NO_IGNORE_PATTERNS, null);
+        Assertions.assertEquals("/", path);
+    }
+
+    @Test
     public void testParsePathNoLeadingSlash() {
         String path = requestMetric.getNormalizedUriPath(NO_MATCH_PATTERNS, NO_IGNORE_PATTERNS,
                 "path/with/no/leading/slash");
         Assertions.assertEquals("/path/with/no/leading/slash", path);
+    }
+
+    @Test
+    public void testParsePathNoEndSlash() {
+        String path = requestMetric.getNormalizedUriPath(NO_MATCH_PATTERNS, NO_IGNORE_PATTERNS,
+                "/path/with/no/end/slash/");
+        Assertions.assertEquals("/path/with/no/end/slash", path);
+    }
+
+    @Test
+    public void testParsePathNoEndDoubleSlash() {
+        String path = requestMetric.getNormalizedUriPath(NO_MATCH_PATTERNS, NO_IGNORE_PATTERNS,
+                "/path/with/no/end/double/slash///////");
+        Assertions.assertEquals("/path/with/no/end/double/slash", path);
     }
 
     @Test


### PR DESCRIPTION
During the OTel performance work, which now includes Micrometer, some inefficiencies were detected on the hot path. This affects all requests and uses ~5% of the samples in the test run.