### PR TITLE
PoC: integrate `Eclipse Formatter Profile` into `Maven Spotless Plugin`

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -677,8 +677,48 @@
                     <artifactId>smallrye-certificate-generator-maven-plugin</artifactId>
                     <version>${smallrye-certificate-generator.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>2.44.4</version>
+                    <configuration>
+                        <java>
+                            <removeUnusedImports />
+                            <formatAnnotations />
+                            <eclipse>
+                                <file>${maven.multiModuleProjectDirectory}/independent-projects/ide-config/src/main/resources/eclipse-format.xml</file>
+                            </eclipse>
+                            <importOrder>
+                                <file>${maven.multiModuleProjectDirectory}/independent-projects/ide-config/src/main/resources/eclipse.importorder</file>
+                            </importOrder>
+                        </java>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>spotless-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <phase>verify</phase>
+                        </execution>
+                        <execution>
+                            <id>spotless-apply</id>
+                            <goals>
+                                <!-- <goal>apply</goal> -->
+                                <goal>check</goal>
+                            </goals>
+                            <phase>verify</phase>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>
@@ -779,7 +819,6 @@
                     <plugin>
                         <groupId>com.diffplug.spotless</groupId>
                         <artifactId>spotless-maven-plugin</artifactId>
-                        <version>2.35.0</version>
                         <executions>
                             <execution>
                                 <id>format-kotlin</id>


### PR DESCRIPTION
good idea to use `Eclipse Formatter Profile` as this seamless integrates with spotless.

Working with maven is very easy as the build fixes the code. This could be done here just the same. The config is already there.

- https://www.baeldung.com/java-maven-spotless-plugin#custom-formatting-rules
- https://github.com/apache/maven-parent/blob/237aabdc41f90c7de15ebaafa27643ed80e5f4da/pom.xml#L1208
- https://github.com/quarkusio/quarkus/pull/45599
- https://github.com/quarkusio/quarkus/pull/45651
- https://github.com/quarkusio/quarkus/pull/45372

```console
[INFO] Index file corresponds to a different configuration of the plugin. Either the plugin version or its configuration has changed. Fallback to an empty index
[INFO] Spotless.Java is keeping 45 files clean - 1 needs changes to be clean, 44 were already clean, 0 were skipped because caching determined they were already clean
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.858 s
[INFO] Finished at: 2025-05-24T21:00:40+02:00
[INFO] ------------------------------------------------------------------------
[INFO] 1 goals, 1 executed
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.44.4:check (default-cli) on project quarkus-builder: The following files had format violations:
[ERROR]     src/main/java/io/quarkus/builder/diag/Diagnostic.java
[ERROR]         @@ -8,11 +8,11 @@
[ERROR]          import·io.quarkus.builder.location.Location;
[ERROR]          import·io.smallrye.common.constraint.Assert;
[ERROR]          
[ERROR]         -public·final·class··Diagnostic·{
[ERROR]         -····private·final·Level·level··;
[ERROR]         +public·final·class·Diagnostic·{
[ERROR]         +····private·final·Level·level;
[ERROR]          ····private·final·Location·location;
[ERROR]         -····private·final···················String·format;
[ERROR]         -private·final·Object[]·args;
[ERROR]         +····private·final·String·format;
[ERROR]         +····private·final·Object[]·args;
[ERROR]          ····private·final·Throwable·thrown;
[ERROR]          
[ERROR]          ····public·Diagnostic(final·Level·level,·final·Location·location,·final·String·format,·final·Object...·args)·{
[ERROR] Run 'mvn spotless:apply' to fix these violations.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

check:
<img width="1731" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/59603902-734f-479c-8f59-93895f05599e" />

apply:
<img width="1691" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/56e3ae9b-ec13-4d42-ad2d-fbe1bdedac73" />


unused:

<img width="1887" alt="image" src="https://github.com/user-attachments/assets/e7b92395-17dd-4d62-9d1c-f9dc154dd946" />


```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.44.4:check (spotless-check) on project quarkus-smallrye-context-propagation: The following files had format violations:
[ERROR]     src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
[ERROR]         @@ -12,7 +12,6 @@
[ERROR]          
[ERROR]          import·org.eclipse.microprofile.context.ManagedExecutor;
[ERROR]          import·org.eclipse.microprofile.context.ThreadContext;
[ERROR]         -import·org.eclipse.microprofile.context.spi.ContextManager.Builder;
[ERROR]          import·org.eclipse.microprofile.context.spi.ContextManagerExtension;
[ERROR]          import·org.eclipse.microprofile.context.spi.ContextManagerProvider;
[ERROR]          import·org.eclipse.microprofile.context.spi.ThreadContextProvider;
[ERROR] Run 'mvn spotless:apply' to fix these violations.
[ERROR] -> [Help 1]
```