### PR TITLE
Qute: rename doFilter to filter and make it public

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/tag/UserTagArgumentsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/tag/UserTagArgumentsTest.java
@@ -2,13 +2,22 @@ package io.quarkus.qute.deployment.tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.RawString;
 import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateExtension;
+import io.quarkus.qute.UserTagSectionHelper;
+import io.quarkus.qute.UserTagSectionHelper.Arguments;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class UserTagArgumentsTest {
@@ -19,14 +28,37 @@ public class UserTagArgumentsTest {
                     .addAsResource(new StringAsset(
                             "{_args.size}::{_args.empty}::{_args.get('name')}::{_args.asHtmlAttributes}::{_args.skip('foo','baz').size}::{#each _args.filter('name')}{it.value}{/each}"),
                             "templates/tags/hello.txt")
-                    .addAsResource(new StringAsset("{#hello name=val /}"), "templates/foo.txt"));
+                    .addAsResource(new StringAsset("{#hello name=val /}"), "templates/foo.txt")
+                    .addAsResource(new StringAsset("{_args.startsWith('hx-','x-')}"),
+                            "templates/tags/startsWith.txt"));
 
     @Inject
     Template foo;
 
+    @Inject
+    Engine engine;
+
     @Test
     public void testInjection() {
         assertEquals("1::false::Lu::name=\"Lu\"::1::Lu", foo.data("val", "Lu").render());
+    }
+
+    @Test
+    public void testNotBuiltInTemplateExtension() {
+        assertEquals("hx-get=\"/endpoint\" x-data=\"{}\"",
+                engine.parse("{#startsWith hx-get='/endpoint' x-data='{}' ignored-arg='ignored' /}").render());
+    }
+
+    @TemplateExtension
+    public static class Extensions {
+
+        public static RawString startsWith(UserTagSectionHelper.Arguments obj, String... startsWithPrefix) {
+            Set<String> startsWithSet = Set.of(startsWithPrefix);
+            Predicate<Map.Entry<String, Object>> predicate = e -> startsWithSet.stream()
+                    .anyMatch(k -> e.getKey().startsWith(k));
+            return obj.filter(predicate).asHtmlAttributes();
+        }
+
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
@@ -208,27 +208,27 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
 
         public Arguments skip(String... keys) {
             Set<String> keySet = Set.of(keys);
-            return doFilter(e -> !keySet.contains(e.getKey()));
+            return filter(e -> !keySet.contains(e.getKey()));
         }
 
         public Arguments skipIdenticalKeyValue() {
-            return doFilter(e -> !e.getKey().equals(e.getValue()));
+            return filter(e -> !e.getKey().equals(e.getValue()));
         }
 
         /**
          * Skip the first argument if it does not define a name.
          */
         public Arguments skipIt() {
-            return doFilter(e -> !e.getKey().equals(itKey));
+            return filter(e -> !e.getKey().equals(itKey));
         }
 
         public Arguments filter(String... keys) {
             Set<String> keySet = Set.of(keys);
-            return doFilter(e -> keySet.contains(e.getKey()));
+            return filter(e -> keySet.contains(e.getKey()));
         }
 
         public Arguments filterIdenticalKeyValue() {
-            return doFilter(e -> e.getKey().equals(e.getValue()));
+            return filter(e -> e.getKey().equals(e.getValue()));
         }
 
         // foo="1" bar="true" readonly="readonly"
@@ -247,7 +247,7 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
             return new RawString(builder.toString());
         }
 
-        private Arguments doFilter(Predicate<Entry<String, Object>> predicate) {
+        public Arguments filter(Predicate<Entry<String, Object>> predicate) {
             List<Entry<String, Object>> newArgs = new ArrayList<>(args.size());
             for (Entry<String, Object> e : args) {
                 if (predicate.test(e)) {


### PR DESCRIPTION
By making the `doFilter` method public we can create our own `@TemplateExtension` filter methods which are not built-in like the `startsWith`.

```java
    public static RawString startsWith(UserTagSectionHelper.Arguments obj, String... startsWithPrefix) {
        Set<String> startsWithSet = Set.of(startsWithPrefix);
        Predicate<Map.Entry<String, String>> predicate = e -> startsWithSet.stream().anyMatch(k -> e.getKey().startsWith(k));
        return obj.doFilter(predicate).asHtmlAttributes();
    }
``` 