### PR TITLE
Bump smallrye-reactive-messaging from 4.27.0 to 4.28.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -58,7 +58,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.19.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.27.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.28.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
https://github.com/smallrye/smallrye-reactive-messaging/milestone/112