### PR TITLE
Trigger Quarkus Deploy Snapshots in the middle of the night

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -2,7 +2,7 @@ name: Quarkus Deploy Snapshots
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
I have tests running against Quarkus daily snapshots and ideally I'd like to test whatever was merged yesterday so that I can detect & investigate & report issues early. I use `999-SNAPSHOT` artifacts deployed by https://github.com/quarkusio/quarkus/actions/workflows/deploy-snapshots.yml (currently the deployment is not working, but that's irrelevant). In theory, you can see that the deployment is scheduled for 2 AM and it runs roughly 30 minutes, plus it takes little while until the artifacts are available. However, if you look at the runs properly, they most often starts like 2:30 GMT+0. I suppose that is due to the fact that runners (busy running other jobs).

Due to the fact that me and my colleagues work in GMT+2, it means that on average we have artifacts available around 5 AM. Our tests are running roughly 8 hours and takes all the executors we could use for PR CIs.

TL;DR; I'd appreciate if the deployment could be scheduled at 0:00 so that the new snapshot is available little sooner. It kinda makes sense considering it is supposed to be a build for previous day, right?