### PR TITLE
Avoid a duplicate OIDC add cookie call

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -1263,7 +1263,6 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         if (sessionCookie) {
             cookie.setSameSite(CookieSameSite.valueOf(oidcConfig.authentication().cookieSameSite().name()));
         }
-        context.response().addCookie(cookie);
         return cookie;
     }
 

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -14,7 +14,9 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -1707,7 +1709,19 @@ public class CodeFlowTest {
     }
 
     private Cookie getSessionCookie(WebClient webClient, String tenantId) {
-        return webClient.getCookieManager().getCookie("q_session" + (tenantId == null ? "_Default_test" : "_" + tenantId));
+        String cookieName = "q_session" + (tenantId == null ? "_Default_test" : "_" + tenantId);
+        List<Cookie> sessionCookies = new ArrayList<>();
+        for (Cookie c : webClient.getCookieManager().getCookies()) {
+            if (c.getName().equals(cookieName)) {
+                sessionCookies.add(c);
+            }
+        }
+        if (sessionCookies.isEmpty()) {
+            return null;
+        } else {
+            assertEquals(1, sessionCookies.size());
+            return sessionCookies.get(0);
+        }
     }
 
     private Cookie getSessionAtCookie(WebClient webClient, String tenantId) {


### PR DESCRIPTION
I found out today there was a duplicate call to add OIDC cookies, in `CodeAuthenticationMechanism#createCookie` which delegates to `OidcUtils#createCookie` which also does an `addCookie` call. Good news it was not actually leading to having several cookies created, as I wrote the test to confirm it first. But in any case, worth removing a duplicate call