### PR TITLE
Prevent LogManager logging issue with Amazon Lambda ITs

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -175,6 +175,7 @@ public final class IntegrationTestUtil {
 
     static ArtifactLauncher.InitContext.DevServicesLaunchResult handleDevServices(ExtensionContext context,
             boolean isDockerAppLaunch) throws Exception {
+        System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
         Class<?> requiredTestClass = context.getRequiredTestClass();
         Path testClassLocation = getTestClassesLocation(requiredTestClass);
         final Path appClassLocation = getAppClassLocationForTestLocation(testClassLocation);


### PR DESCRIPTION
Meant to prevent this sort of issue:

```
May 27, 2025 1:50:55 PM org.jboss.logmanager.JBossLoggerFinder getLogger
ERROR: The LogManager accessed before the "java.util.logging.manager" system property was set to "org.jboss.logmanager.LogManager". Results may be unexpected.
```

which can occur from this stacktrace:

```
	at org.jboss.logmanager.JBossLoggerFinder.getLogger(JBossLoggerFinder.java:73)
	at jdk.internal.logger.LazyLoggers.getLoggerFromFinder(LazyLoggers.java:410)
	at jdk.internal.logger.LazyLoggers$1.apply(LazyLoggers.java:369)
	at jdk.internal.logger.LazyLoggers$1.apply(LazyLoggers.java:366)
	at jdk.internal.logger.LazyLoggers$LazyLoggerAccessor.createLogger(LazyLoggers.java:292)
	at jdk.internal.logger.BootstrapLogger.getLogger(BootstrapLogger.java:980)
	at jdk.internal.logger.LazyLoggers$LazyLoggerAccessor.wrapped(LazyLoggers.java:179)
	at jdk.internal.logger.LazyLoggers$LazyLoggerWrapper.wrapped(LazyLoggers.java:332)
	at jdk.internal.logger.AbstractLoggerWrapper.log(AbstractLoggerWrapper.java:101)
	at java.io.ObjectInputFilter$Config.traceFilter(ObjectInputFilter.java:709)
	at java.io.ObjectInputFilter$Config$BuiltinFilterFactory.apply(ObjectInputFilter.java:1444)
	at java.io.ObjectInputFilter$Config$BuiltinFilterFactory.apply(ObjectInputFilter.java:1423)
	at java.io.ObjectInputStream.<init>(ObjectInputStream.java:414)
	at io.quarkus.bootstrap.util.BootstrapUtils.readAppModelWithWorkspaceId(BootstrapUtils.java:156)
	at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModelForWorkspace(BootstrapAppModelFactory.java:255)
	at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModel(BootstrapAppModelFactory.java:216)
	at io.quarkus.bootstrap.app.QuarkusBootstrap.bootstrap(QuarkusBootstrap.java:138)
	at io.quarkus.test.junit.IntegrationTestUtil.handleDevServices(IntegrationTestUtil.java:248)
	at io.quarkus.test.junit.QuarkusIntegrationTestExtension.doProcessStart(QuarkusIntegrationTestExtension.java:200)
	at io.quarkus.test.junit.QuarkusIntegrationTestExtension.ensureStarted(QuarkusIntegrationTestExtension.java:167)
	at io.quarkus.test.junit.QuarkusIntegrationTestExtension.beforeAll(QuarkusIntegrationTestExtension.java:127)
```