### PR TITLE
Update quarkus-http, create test coverage for Undertow session context events

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -31,7 +31,7 @@
         <resteasy.version>6.2.12.Final</resteasy.version>
         <opentelemetry-instrumentation.version>2.10.0-alpha</opentelemetry-instrumentation.version>
         <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
-        <quarkus-http.version>5.3.4</quarkus-http.version>
+        <quarkus-http.version>5.3.5</quarkus-http.version>
         <micrometer.version>1.14.7</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->
         <hdrhistogram.version>2.2.2</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/sessioncontext/SessionScopedObserver.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/sessioncontext/SessionScopedObserver.java
@@ -1,0 +1,26 @@
+package io.quarkus.undertow.test.sessioncontext;
+
+import jakarta.enterprise.context.BeforeDestroyed;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.event.Observes;
+
+@SessionScoped
+public class SessionScopedObserver {
+
+    static int timesInitObserved = 0;
+    static int timesBeforeDestroyedObserved = 0;
+
+    public void observeInit(@Observes @Initialized(SessionScoped.class) Object event) {
+        timesInitObserved++;
+    }
+
+    public void observeBeforeDestroyed(@Observes @BeforeDestroyed(SessionScoped.class) Object event) {
+        timesBeforeDestroyedObserved++;
+    }
+
+    public static void resetState() {
+        timesInitObserved = 0;
+        timesBeforeDestroyedObserved = 0;
+    }
+}


### PR DESCRIPTION
The idea is to enable `@SessionScoped` beans to observe its own `@Initialized` and `@BeforeDestroyed` events (which they should be able to according to the specification).

The fix itself is in `quarkus-http`, see https://github.com/quarkusio/quarkus-http/pull/174

Fixes #46363