### PR TITLE
Avoid class cast exception when reading Vert.x Remote User attribute if Vert.x UserImpl is available

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteUserAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteUserAttribute.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -11,6 +12,7 @@ public class RemoteUserAttribute implements ExchangeAttribute {
 
     public static final String REMOTE_USER_SHORT = "%u";
     public static final String REMOTE_USER = "%{REMOTE_USER}";
+    public static final String VERTX_USER_NAME = "username";
 
     public static final ExchangeAttribute INSTANCE = new RemoteUserAttribute();
 
@@ -20,11 +22,15 @@ public class RemoteUserAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        QuarkusHttpUser sc = (QuarkusHttpUser) exchange.user();
-        if (sc == null) {
+        User user = exchange.user();
+        if (user == null) {
             return null;
         }
-        return sc.getSecurityIdentity().getPrincipal().getName();
+        if (user instanceof QuarkusHttpUser quarkusUser) {
+            return quarkusUser.getSecurityIdentity().getPrincipal().getName();
+        } else {
+            return user.principal().getString(VERTX_USER_NAME);
+        }
     }
 
     @Override


### PR DESCRIPTION
I'm experimenting with running https://how-to.vertx.io/web-and-oauth2-oidc/ with `quarkus-reactive-routes`, as the first step in the migration, where Vert.x OIDC users may want to start moving to Quarkus (and use Quarkus Config, Qute) but choose to retain Vert.x OIDC code.

While I will also work on preparing a migration to Quarkus OIDC, I think we should make it easy for existing Vert.x OIDC users to continue using their existing code.

It all works fine except for the class cast exception in dev mode, where `Vert.x UserImpl` is cast to `QuarkusHttpUser`, the demo still works though.

So this PR does a minor tweak to avoid the exception - at this point, no Quarkus Security is even operational, so makes sense to allow accepting `Vert.x UserImpl` in this code