### PR TITLE
Use case-insensitive DPoP scheme check

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -60,7 +60,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
     }
 
     private static void setDPopProof(RoutingContext context, OidcTenantConfig oidcTenantConfig, String token) {
-        if (OidcConstants.DPOP_SCHEME.equals(oidcTenantConfig.token().authorizationScheme())) {
+        if (OidcUtils.isDPoPScheme(oidcTenantConfig.token().authorizationScheme())) {
 
             List<String> proofs = context.request().headers().getAll(OidcConstants.DPOP_SCHEME);
             if (proofs == null || proofs.isEmpty()) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -916,4 +916,8 @@ public final class OidcUtils {
         }
         return token;
     }
+
+    public static boolean isDPoPScheme(String authorizationScheme) {
+        return OidcConstants.DPOP_SCHEME.equalsIgnoreCase(authorizationScheme);
+    }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -34,6 +34,15 @@ import io.vertx.core.json.JsonObject;
 public class OidcUtilsTest {
 
     @Test
+    public void testDpopScheme() throws Exception {
+
+        assertTrue(OidcUtils.isDPoPScheme("DPoP"));
+        assertTrue(OidcUtils.isDPoPScheme("dpop"));
+        assertFalse(OidcUtils.isDPoPScheme("pop"));
+
+    }
+
+    @Test
     public void testGetSingleSessionCookie() throws Exception {
 
         OidcTenantConfig oidcConfig = new OidcTenantConfig();


### PR DESCRIPTION
Fixes #48085 

We already have an integration test with the `DPoP` value, so I just moved the check to `OidcUtils` to test a few more variations