### PR TITLE
Sort dot names when identifying quarkus tests in continuous testing so nested tests are always identified

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -644,7 +645,9 @@ public class JunitTestRunner {
         }
 
         Set<DotName> allTestAnnotations = collectTestAnnotations(index);
-        Set<DotName> allTestClasses = new HashSet<>();
+        // Order matters here for nested tests
+        // We assume we have evaluated the parent of a class before evaluating it
+        Set<DotName> allTestClasses = new TreeSet<>();
         Map<DotName, DotName> enclosingClasses = new HashMap<>();
         for (DotName annotation : allTestAnnotations) {
             for (AnnotationInstance instance : index.getAnnotations(annotation)) {
@@ -680,7 +683,7 @@ public class JunitTestRunner {
             }
             var enclosing = enclosingClasses.get(testClass);
             if (enclosing != null) {
-                String enclosingString = enclosing.toString();
+                final String enclosingString = enclosing.toString();
                 if (quarkusTestClassesForFacadeClassLoader.contains(enclosingString)) {
                     quarkusTestClassesForFacadeClassLoader.add(name);
                 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusTestIT.java
@@ -12,8 +12,6 @@ import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
 import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
@@ -75,8 +73,6 @@ public class QuarkusTestIT extends RunAndCheckMojoTestBase {
 
     }
 
-    @DisabledOnOs(OS.WINDOWS) // Tracked by https://github.com/quarkusio/quarkus/issues/47913
-    @Disabled("See https://github.com/quarkusio/quarkus/issues/48004")
     @Test
     public void testNestedQuarkusTestMixedWithNormalTestsContinuousTesting()
             throws MavenInvocationException, FileNotFoundException {

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-nested-tests-mixed-with-normal-tests/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-nested-tests-mixed-with-normal-tests/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.test.continuous-testing=enabled
+quarkus.test.display-test-output=true
 greeting.message=Hello from Quarkus REST via config


### PR DESCRIPTION
Resolves #47913
Resolves https://github.com/quarkusio/quarkus/issues/47671 (again)
Resolves https://github.com/quarkusio/quarkus/issues/48004 (the right way)

This was a good one. The way we decide a nested test is a `QuarkusTest` is by checking to see if we know its enclosing class is a `QuarkusTest`. That only works if we process the tests in the right order. It happened that for lightly nested tests, we usually do them in the right order, but as the nesting gets deeper (for example, in the tests added in https://github.com/quarkusio/quarkus/pull/47890), there’s more chance of a child being processed before its parent. 

So the solution is actually just a four character fix, to use a sorted set. We care about the order, so in hindsight it’s obvious it should be a sorted set. The default sorting of `DotName` should be good enough, since the more deeply nested tests will have the enclosing class in the name and should be sorted after.   

The problem fixed by this test does not show up on the main Quarkus CI, because its JVMs have a different hashmap order. However, the relevant tests are clean in https://github.com/holly-cummins/quarkus/actions/runs/15281007407. That build has other problems but they seem to be I/O-related.