### PR TITLE
Sync Kotlin protobuf version with Java protobuf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <grpc-jprotoc.version>1.2.2</grpc-jprotoc.version>
         <protoc.version>3.25.5</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
-        <protobuf-kotlin.version>4.29.3</protobuf-kotlin.version>
+        <protobuf-kotlin.version>${protoc.version}</protobuf-kotlin.version>
         <proto-google-common-protos.version>2.56.0</proto-google-common-protos.version>
         <perfmark.version>0.27.0</perfmark.version><!-- dependency of io.grpc:grpc-core not managed in io.grpc:grpc-bom -->
 


### PR DESCRIPTION
Quarkus 3.21 added support for the Kotlin extension of Java gRPC. With this support however, protobuf-kotlin was given a protobuf V4 version. The Java protobuf version published by Quarkus is however a protobuf V3 version. V4 has a breaking change around a class rename of `GeneratedMessageV3` to `GeneratedMessage`, which is one of the reasons Quarkus is still on V3.

Publishing a V4 version of Kotlin but a V3 version of Java causes incompatibility exactly due to this breaking change. So the project I work on which is using Quarkus is getting the following error:

```
Reason:
  Type 'com/google/protobuf/GeneratedMessageV3$FieldAccessorTable' (current frame, stack[0]) is not assignable to 'com/google/protobuf/GeneratedMessage$FieldAccessorTable' (from method signature)
```

This is fixed by giving protobuf-kotlin a V3 version. I think it makes sense for both Java and Kotlin to always be synced up, so I simply change the hardcoded protobuf-kotlin version to the protoc version that Java is using too, which changes Kotlin to a V3 version.

Note that theoretically, the versions of different languages of protobuf may diverge. While the minor and patch version will always be the same, the major version may change if one language has a breaking change but another does not. So theoretically Kotlin may at some point get a version like 6.80.1 while Java would be 7.80.1, however, I would say this is unlikely since Kotlin extends the Java implementation, whereas something like C# and Java diverting I would say would be an actual possibility.