### PR TITLE
Use 'greater than or equal to' comparison in the OIDC client token expiry check

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
@@ -85,7 +85,7 @@ public class Tokens {
             return false;
         }
         final long nowSecs = System.currentTimeMillis() / 1000;
-        final boolean expired = nowSecs > expiresAt;
+        final boolean expired = nowSecs >= expiresAt;
 
         if (expired) {
             if (accessToken) {


### PR DESCRIPTION
Fixes #48103

This PR makes an expiry check just a tiny bit stricter as proposed in #48103, by catching those cases where the token expires on the current second. It is unlikely to make much difference on the slower networks where the refresh token skew should be used to enable the proactive refresh, but perhaps it may indeed help in some cases