### PR TITLE
Add support for setting the TLS configuration name from client connectors in WebSockets Next

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -1465,15 +1465,40 @@ class MyBean {
 
 === Configuring SSL/TLS
 
-To establish a TLS connection, you need to configure a _named_ configuration using the xref:./tls-registry-reference.adoc[TLS registry]:
+To establish a TLS connection, you need to configure a _named_ configuration using the xref:./tls-registry-reference.adoc[TLS registry]. This is typically done via configuration:
 
 [source, properties]
 ----
 quarkus.tls.my-ws-client.trust-store.p12.path=server-truststore.p12
 quarkus.tls.my-ws-client.trust-store.p12.password=secret
-
-quarkus.websockets-next.client.tls-configuration-name=my-ws-client # Reference the named configuration
 ----
+
+With a _named_ TLS configuration established, you can then configure the client to use it:
+
+[source, properties]
+----
+quarkus.websockets-next.client.tls-configuration-name=my-ws-client
+----
+
+Alternatively, you can supply the configuration name using the <<client-connectors,connector>>:
+
+[source, java]
+----
+@Singleton
+public class MyBean {
+
+    @Inject
+    WebSocketConnector<MyEndpoint> connector;
+
+    public void connect() {
+        connector
+            .tlsConfigurationName("my-ws-client")
+            .connectAndAwait();
+    }
+}
+----
+
+A name supplied to the connector will override any statically configured name. This can be useful for establishing a default configuration which can be overridden at runtime as necessary.
 
 WARNING: When using the WebSocket client, using a _named_ configuration is required to avoid conflicts with other TLS configurations.
 The client will not use the default TLS configuration.

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsBasicConnectorMissingTlsConfigurationTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsBasicConnectorMissingTlsConfigurationTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class TlsBasicConnectorMissingTlsConfigurationTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(ServerEndpoint.class)
+                    .addAsResource(new File("target/certs/ssl-test-keystore.jks"), "keystore.jks")
+                    .addAsResource(new File("target/certs/ssl-test-truststore.jks"), "truststore.jks"))
+            .overrideConfigKey("quarkus.tls.key-store.jks.path", "keystore.jks")
+            .overrideConfigKey("quarkus.tls.key-store.jks.password", "secret")
+            .overrideConfigKey("quarkus.websockets-next.client.tls-configuration-name", "ws-client");
+
+    @Inject
+    BasicWebSocketConnector connector;
+
+    @TestHTTPResource(value = "/end", tls = true)
+    URI uri;
+
+    @Test
+    void testClient() {
+        assertThrows(IllegalStateException.class, () -> connector
+                .baseUri(uri)
+                .path("/{name}")
+                .pathParam("name", "Lu")
+                .connectAndAwait());
+    }
+
+    @WebSocket(path = "/end/{name}")
+    public static class ServerEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsBasicConnectorRuntimeTlsConfigurationTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsBasicConnectorRuntimeTlsConfigurationTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.tls.BaseTlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.TrustOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class TlsBasicConnectorRuntimeTlsConfigurationTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(ServerEndpoint.class)
+                    .addAsResource(new File("target/certs/ssl-test-keystore.jks"), "keystore.jks")
+                    .addAsResource(new File("target/certs/ssl-test-truststore.jks"), "truststore.jks"))
+            .overrideConfigKey("quarkus.tls.key-store.jks.path", "keystore.jks")
+            .overrideConfigKey("quarkus.tls.key-store.jks.password", "secret");
+
+    @Inject
+    BasicWebSocketConnector connector;
+
+    @Inject
+    TlsConfigurationRegistry tlsRegistry;
+
+    @TestHTTPResource(value = "/end", tls = true)
+    URI uri;
+
+    @Test
+    void testClient() {
+        tlsRegistry.register("ws-client", new BaseTlsConfiguration() {
+            @Override
+            public TrustOptions getTrustStoreOptions() {
+                return new JksOptions().setPath("truststore.jks").setPassword("secret");
+            }
+        });
+        WebSocketClientConnection connection = connector
+                .tlsConfigurationName("ws-client")
+                .baseUri(uri)
+                .path("/{name}")
+                .pathParam("name", "Lu")
+                .connectAndAwait();
+        assertTrue(connection.isOpen());
+        assertTrue(connection.isSecure());
+        connection.closeAndAwait();
+    }
+
+    @WebSocket(path = "/end/{name}")
+    public static class ServerEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsBasicConnectorTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsBasicConnectorTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class TlsBasicConnectorTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(ServerEndpoint.class)
+                    .addAsResource(new File("target/certs/ssl-test-keystore.jks"), "keystore.jks")
+                    .addAsResource(new File("target/certs/ssl-test-truststore.jks"), "truststore.jks"))
+            .overrideConfigKey("quarkus.tls.key-store.jks.path", "keystore.jks")
+            .overrideConfigKey("quarkus.tls.key-store.jks.password", "secret")
+            .overrideConfigKey("quarkus.tls.ws-client.trust-store.jks.path", "truststore.jks")
+            .overrideConfigKey("quarkus.tls.ws-client.trust-store.jks.password", "secret")
+            .overrideConfigKey("quarkus.websockets-next.client.tls-configuration-name", "ws-client");
+
+    @Inject
+    BasicWebSocketConnector connector;
+
+    @TestHTTPResource(value = "/end", tls = true)
+    URI uri;
+
+    @Test
+    void testClient() throws URISyntaxException {
+        assertClient(uri);
+        URI wssUri = new URI("wss", uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(),
+                uri.getFragment());
+        assertClient(wssUri);
+    }
+
+    void assertClient(URI uri) {
+        WebSocketClientConnection connection = connector
+                .baseUri(uri)
+                .path("/{name}")
+                .pathParam("name", "Lu")
+                .connectAndAwait();
+        assertTrue(connection.isOpen());
+        assertTrue(connection.isSecure());
+        connection.closeAndAwait();
+    }
+
+    @WebSocket(path = "/end/{name}")
+    public static class ServerEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsClientEndpointMissingTlsConfigurationTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsClientEndpointMissingTlsConfigurationTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketConnector;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class TlsClientEndpointMissingTlsConfigurationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ServerEndpoint.class, ClientEndpoint.class)
+                    .addAsResource(new File("target/certs/ssl-test-keystore.jks"), "keystore.jks")
+                    .addAsResource(new File("target/certs/ssl-test-truststore.jks"), "truststore.jks"))
+            .overrideConfigKey("quarkus.tls.key-store.jks.path", "keystore.jks")
+            .overrideConfigKey("quarkus.tls.key-store.jks.password", "secret")
+            .overrideConfigKey("quarkus.websockets-next.client.tls-configuration-name", "ws-client");
+
+    @Inject
+    WebSocketConnector<ClientEndpoint> connector;
+
+    @TestHTTPResource(value = "/", tls = true)
+    URI uri;
+
+    @Test
+    void testClient() {
+        assertThrows(IllegalStateException.class, () -> connector
+                .baseUri(uri)
+                .pathParam("name", "Lu=")
+                .connectAndAwait());
+    }
+
+    @WebSocket(path = "/endpoint/{name}")
+    public static class ServerEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+
+    @WebSocketClient(path = "/endpoint/{name}")
+    public static class ClientEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsClientEndpointRuntimeTlsConfigurationTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/TlsClientEndpointRuntimeTlsConfigurationTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.tls.BaseTlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.TrustOptions;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class TlsClientEndpointRuntimeTlsConfigurationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ServerEndpoint.class, ClientEndpoint.class)
+                    .addAsResource(new File("target/certs/ssl-test-keystore.jks"), "keystore.jks")
+                    .addAsResource(new File("target/certs/ssl-test-truststore.jks"), "truststore.jks"))
+            .overrideConfigKey("quarkus.tls.key-store.jks.path", "keystore.jks")
+            .overrideConfigKey("quarkus.tls.key-store.jks.password", "secret");
+
+    @Inject
+    WebSocketConnector<ClientEndpoint> connector;
+
+    @TestHTTPResource(value = "/", tls = true)
+    URI uri;
+
+    @Inject
+    TlsConfigurationRegistry tlsRegistry;
+
+    @Test
+    void testClient() {
+        tlsRegistry.register("ws-client", new BaseTlsConfiguration() {
+            @Override
+            public TrustOptions getTrustStoreOptions() {
+                return new JksOptions().setPath("truststore.jks").setPassword("secret");
+            }
+        });
+        WebSocketClientConnection connection = connector
+                .tlsConfigurationName("ws-client")
+                .baseUri(uri)
+                .pathParam("name", "Lu=")
+                .connectAndAwait();
+        assertTrue(connection.isOpen());
+        assertTrue(connection.isSecure());
+        connection.closeAndAwait();
+    }
+
+    @WebSocket(path = "/endpoint/{name}")
+    public static class ServerEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+
+    @WebSocketClient(path = "/endpoint/{name}")
+    public static class ClientEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.websockets.next.UserData.TypedKey;
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.mutiny.Uni;
@@ -70,6 +71,15 @@ public interface BasicWebSocketConnector {
     default BasicWebSocketConnector baseUri(String baseUri) {
         return baseUri(URI.create(baseUri));
     }
+
+    /**
+     * Set the name of the {@link TlsConfiguration}.
+     *
+     * @param tlsConfigurationName
+     * @return self
+     * @see io.quarkus.tls.TlsConfigurationRegistry#get(String)
+     */
+    BasicWebSocketConnector tlsConfigurationName(String tlsConfigurationName);
 
     /**
      * Set the path that should be appended to the path of the URI set by {@link #baseUri(URI)}.

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
@@ -6,6 +6,7 @@ import java.net.URLEncoder;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 
+import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.websockets.next.UserData.TypedKey;
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.mutiny.Uni;
@@ -61,6 +62,15 @@ public interface WebSocketConnector<CLIENT> {
     default WebSocketConnector<CLIENT> baseUri(String baseUri) {
         return baseUri(URI.create(baseUri));
     }
+
+    /**
+     * Set the name of the {@link TlsConfiguration}.
+     *
+     * @param tlsConfigurationName
+     * @return self
+     * @see io.quarkus.tls.TlsConfigurationRegistry#get(String)
+     */
+    WebSocketConnector<CLIENT> tlsConfigurationName(String tlsConfigurationName);
 
     /**
      * Set the path param.

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
@@ -164,18 +164,22 @@ public class BasicWebSocketConnectorImpl extends WebSocketConnectorBase<BasicWeb
             context.dispatch(new Handler<Void>() {
                 @Override
                 public void handle(Void event) {
-                    WebSocketClient c = vertx.createWebSocketClient(populateClientOptions());
-                    client.setPlain(c);
-                    c.connect(connectOptions, new Handler<AsyncResult<WebSocket>>() {
-                        @Override
-                        public void handle(AsyncResult<WebSocket> r) {
-                            if (r.succeeded()) {
-                                e.complete(r.result());
-                            } else {
-                                e.fail(r.cause());
+                    try {
+                        WebSocketClient c = vertx.createWebSocketClient(populateClientOptions());
+                        client.setPlain(c);
+                        c.connect(connectOptions, new Handler<AsyncResult<WebSocket>>() {
+                            @Override
+                            public void handle(AsyncResult<WebSocket> r) {
+                                if (r.succeeded()) {
+                                    e.complete(r.result());
+                                } else {
+                                    e.fail(r.cause());
+                                }
                             }
-                        }
-                    });
+                        });
+                    } catch (RuntimeException re) {
+                        e.fail(re);
+                    }
                 }
             });
         });

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
@@ -44,6 +44,8 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
 
     protected final Map<String, Object> userData;
 
+    protected String tlsConfigurationName;
+
     // injected dependencies
 
     protected final Vertx vertx;
@@ -74,6 +76,11 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
 
     public THIS baseUri(URI baseUri) {
         this.baseUri = Objects.requireNonNull(baseUri);
+        return self();
+    }
+
+    public THIS tlsConfigurationName(String tlsConfigurationName) {
+        this.tlsConfigurationName = Objects.requireNonNull(tlsConfigurationName);
         return self();
     }
 
@@ -167,7 +174,11 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
         }
 
         Optional<TlsConfiguration> maybeTlsConfiguration = TlsConfiguration.from(tlsConfigurationRegistry,
-                config.tlsConfigurationName());
+                Optional.ofNullable(tlsConfigurationName));
+        if (maybeTlsConfiguration.isEmpty()) {
+            maybeTlsConfiguration = TlsConfiguration.from(tlsConfigurationRegistry,
+                    config.tlsConfigurationName());
+        }
         if (maybeTlsConfiguration.isPresent()) {
             TlsConfigUtils.configure(clientOptions, maybeTlsConfiguration.get());
         }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
@@ -111,24 +111,28 @@ public class WebSocketConnectorImpl<CLIENT> extends WebSocketConnectorBase<WebSo
             context.dispatch(new Handler<Void>() {
                 @Override
                 public void handle(Void event) {
-                    WebSocketClient c = vertx.createWebSocketClient(populateClientOptions());
-                    client.setPlain(c);
-                    if (telemetrySupport != null && telemetrySupport.interceptConnection()) {
-                        telemetrySupport.connectionOpened();
-                    }
-                    c.connect(connectOptions, new Handler<AsyncResult<WebSocket>>() {
-                        @Override
-                        public void handle(AsyncResult<WebSocket> r) {
-                            if (r.succeeded()) {
-                                e.complete(r.result());
-                            } else {
-                                if (telemetrySupport != null && telemetrySupport.interceptConnection()) {
-                                    telemetrySupport.connectionOpeningFailed(r.cause());
-                                }
-                                e.fail(r.cause());
-                            }
+                    try {
+                        WebSocketClient c = vertx.createWebSocketClient(populateClientOptions());
+                        client.setPlain(c);
+                        if (telemetrySupport != null && telemetrySupport.interceptConnection()) {
+                            telemetrySupport.connectionOpened();
                         }
-                    });
+                        c.connect(connectOptions, new Handler<AsyncResult<WebSocket>>() {
+                            @Override
+                            public void handle(AsyncResult<WebSocket> r) {
+                                if (r.succeeded()) {
+                                    e.complete(r.result());
+                                } else {
+                                    if (telemetrySupport != null && telemetrySupport.interceptConnection()) {
+                                        telemetrySupport.connectionOpeningFailed(r.cause());
+                                    }
+                                    e.fail(r.cause());
+                                }
+                            }
+                        });
+                    } catch (RuntimeException re) {
+                        e.fail(re);
+                    }
                 }
             });
         });


### PR DESCRIPTION
This PR adds a `tlsConfigurationName(String)` method to the client connector interfaces, making it possible to specify the TLS configuration at runtime.

While writing the tests, I also discovered a bug causing the connector to hang indefinitely on `connectAndAwait()` when a TLS configuration cannot be found. I added appropriate error handling to ensure the underlying exception gets emitted instead of being swallowed by Vert.x, and some test coverage.