### PR TITLE
Added support for dynamic discovery of Config Server instances

### DIFF
--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/ConfigServerBaseUrlProvider.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/ConfigServerBaseUrlProvider.java
@@ -1,0 +1,7 @@
+package io.quarkus.spring.cloud.config.client.runtime;
+
+import java.net.URI;
+
+public interface ConfigServerBaseUrlProvider {
+    URI get();
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/ConfigServerUrl.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/ConfigServerUrl.java
@@ -1,0 +1,7 @@
+package io.quarkus.spring.cloud.config.client.runtime;
+
+import java.net.URI;
+
+public record ConfigServerUrl(URI baseURI, int port, String host, String completeURLString) {
+
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/DirectConfigServerBaseUrlProvider.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/DirectConfigServerBaseUrlProvider.java
@@ -1,0 +1,38 @@
+package io.quarkus.spring.cloud.config.client.runtime;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.spring.cloud.config.client.runtime.util.UrlUtility;
+
+public class DirectConfigServerBaseUrlProvider implements ConfigServerBaseUrlProvider {
+
+    private static final Logger log = Logger.getLogger(DirectConfigServerBaseUrlProvider.class);
+    private final SpringCloudConfigClientConfig config;
+
+    public DirectConfigServerBaseUrlProvider(SpringCloudConfigClientConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public URI get() {
+        log.info("Getting config server URL with Direct ConfigServer BaseUrl");
+        String url = config.url();
+        validate(url);
+        try {
+            return UrlUtility.toURI(url);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Value: '" + config.url()
+                    + "' of property 'quarkus.spring-cloud-config.url' is invalid", e);
+        }
+    }
+
+    private void validate(String url) {
+        if (null == url || url.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "The 'quarkus.spring-cloud-config.url' property cannot be empty");
+        }
+    }
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/DiscoveryConfigServerBaseUrlProvider.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/DiscoveryConfigServerBaseUrlProvider.java
@@ -1,0 +1,32 @@
+package io.quarkus.spring.cloud.config.client.runtime;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.spring.cloud.config.client.runtime.eureka.DiscoveryService;
+import io.quarkus.spring.cloud.config.client.runtime.util.UrlUtility;
+
+public class DiscoveryConfigServerBaseUrlProvider implements ConfigServerBaseUrlProvider {
+
+    private static final Logger log = Logger.getLogger(DiscoveryConfigServerBaseUrlProvider.class);
+    private final DiscoveryService discoveryService;
+    private final SpringCloudConfigClientConfig config;
+
+    public DiscoveryConfigServerBaseUrlProvider(DiscoveryService discoveryService, SpringCloudConfigClientConfig config) {
+        this.discoveryService = discoveryService;
+        this.config = config;
+    }
+
+    @Override
+    public URI get() {
+        log.info("Getting config server URL with Discovery ConfigServer");
+        try {
+            return UrlUtility.toURI(discoveryService.discover(config));
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientConfig.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientConfig.java
@@ -129,6 +129,43 @@ public interface SpringCloudConfigClientConfig {
     @WithDefault("450")
     int ordinal();
 
+    /**
+     * Configuration for Config Server discovery.
+     */
+    Optional<DiscoveryConfig> discovery();
+
+    interface DiscoveryConfig {
+        /**
+         * Enable discovery of the Spring Cloud Config Server
+         */
+        @WithDefault("false")
+        boolean enabled();
+
+        /**
+         * The service ID to use when discovering the Spring Cloud Config Server
+         */
+        Optional<String> serviceId();
+
+        /**
+         * Eureka server configuration
+         */
+        Optional<EurekaConfig> eurekaConfig();
+
+        interface EurekaConfig {
+            /**
+             * The service URL to use to specify Eureka server
+             */
+            Map<String, String> serviceUrl();
+
+            /**
+             * Indicates how often(in seconds) to fetch the registry information from the eureka server.
+             */
+            @WithDefault("30S")
+            @WithConverter(DurationConverter.class)
+            Duration registryFetchIntervalSeconds();
+        }
+    }
+
     /** */
     default boolean usernameAndPasswordSet() {
         return username().isPresent() && password().isPresent();

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/DiscoveryService.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/DiscoveryService.java
@@ -1,0 +1,75 @@
+package io.quarkus.spring.cloud.config.client.runtime.eureka;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.spring.cloud.config.client.runtime.SpringCloudConfigClientConfig;
+import io.vertx.core.json.JsonObject;
+
+public class DiscoveryService {
+
+    private static final Logger log = Logger.getLogger(DiscoveryService.class);
+    private static final String DEFAULT_ZONE = "defaultZone";
+
+    private final EurekaClient eurekaClient;
+
+    public DiscoveryService(EurekaClient eurekaClient) {
+        this.eurekaClient = eurekaClient;
+    }
+
+    public String discover(SpringCloudConfigClientConfig config) {
+        SpringCloudConfigClientConfig.DiscoveryConfig discoveryConfig = config.discovery().get();
+        validate(discoveryConfig);
+
+        String serviceId = discoveryConfig.serviceId().get();
+        SpringCloudConfigClientConfig.DiscoveryConfig.EurekaConfig eurekaConfig = discoveryConfig.eurekaConfig().get();
+        String defaultServiceUrl = eurekaConfig.serviceUrl().get(DEFAULT_ZONE);
+
+        Map<String, String> serviceUrlMap = eurekaConfig
+                .serviceUrl()
+                .entrySet()
+                .stream().filter(entry -> !DEFAULT_ZONE.equals(entry.getKey()))
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        log.debug("Attempting to discover Spring Cloud Config Server URL for service '" + serviceId
+                + "' using the following URLs: " + serviceUrlMap.values());
+        for (Map.Entry<String, String> entry : serviceUrlMap.entrySet()) {
+            try {
+                return getHomeUrl(entry.getValue(), serviceId);
+            } catch (Exception e) {
+                log.debug("Timed out while waiting for Spring Cloud Config Server URL for service '" + serviceId + "'", e);
+            }
+        }
+
+        log.debug("Fallback Attempting to discover Spring Cloud Config Server URL for service '" + serviceId
+                + "' using the default URL: " + defaultServiceUrl);
+        try {
+            return getHomeUrl(defaultServiceUrl, serviceId);
+        } catch (Exception e) {
+            log.debug("Timed out while waiting for Spring Cloud Config Server URL for service '" + serviceId + "'", e);
+        }
+
+        throw new RuntimeException("Unable to discover Spring Cloud Config Server URL for service '" + serviceId + "'");
+    }
+
+    private void validate(SpringCloudConfigClientConfig.DiscoveryConfig discoveryConfig) {
+        if (discoveryConfig.eurekaConfig().isEmpty()) {
+            throw new IllegalArgumentException("No Eureka configuration has been provided");
+        }
+        if (discoveryConfig.eurekaConfig().get().serviceUrl().isEmpty()) {
+            throw new IllegalArgumentException("No service URLs have been configured for service");
+        }
+        if (discoveryConfig.serviceId().isEmpty()) {
+            throw new IllegalArgumentException("No service ID has been configured for service");
+        }
+    }
+
+    private String getHomeUrl(String defaultServiceUrl, String serviceId) {
+        JsonObject instance = eurekaClient.fetchInstances(defaultServiceUrl, serviceId);
+        return instance.getString("homePageUrl");
+    }
+
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/EurekaClient.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/EurekaClient.java
@@ -1,0 +1,68 @@
+package io.quarkus.spring.cloud.config.client.runtime.eureka;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.spring.cloud.config.client.runtime.util.UrlUtility;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+public class EurekaClient {
+
+    public static final String UP = "UP";
+    public static final String STATUS = "status";
+    private static final Logger log = Logger.getLogger(EurekaClient.class);
+    private final WebClient webClient;
+    private final Duration timeout;
+    private final EurekaResponseMapper eurekaResponseMapper;
+    private final RandomEurekaInstanceSelector randomEurekaInstanceSelector;
+
+    public EurekaClient(WebClient webClient, Duration timeout, EurekaResponseMapper eurekaResponseMapper,
+            RandomEurekaInstanceSelector randomEurekaInstanceSelector) {
+        this.webClient = webClient;
+        this.timeout = timeout;
+        this.eurekaResponseMapper = eurekaResponseMapper;
+        this.randomEurekaInstanceSelector = randomEurekaInstanceSelector;
+    }
+
+    public JsonObject fetchInstances(String eurekaUrl, String appId) {
+        String serviceUrl = UrlUtility.sanitize(eurekaUrl);
+        URI serviceURI;
+        try {
+            serviceURI = new URI(serviceUrl);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Value: '" + serviceUrl, e);
+        }
+        log.debug("Attempting to discover Spring Cloud Config Server URL for service '" + appId + "' using URL '" + eurekaUrl
+                + "'");
+        String requestURI = serviceURI.getPath() + "/apps/" + appId;
+        log.debug("Attempting to read configuration from '" + requestURI + "'.");
+        Uni<JsonObject> uni = webClient
+                .get(UrlUtility.getPort(serviceURI), serviceURI.getHost(), requestURI)
+                .putHeader("Accept", "application/json")
+                .send()
+                .map(r -> {
+                    if (r.statusCode() != 200) {
+                        throw new RuntimeException(
+                                "Got unexpected HTTP response code " + r.statusCode() + " from " + requestURI);
+                    }
+                    String bodyAsString = r.bodyAsString();
+                    log.debug("Received response from Spring Cloud Config Server: "
+                            + new JsonObject(bodyAsString).encodePrettily());
+                    List<JsonObject> upInstances = eurekaResponseMapper.instances(r.bodyAsString())
+                            .stream()
+                            .filter(i -> UP.equals(i.getString(STATUS)))
+                            .toList();
+
+                    return randomEurekaInstanceSelector.select(upInstances);
+                });
+
+        return uni.await().atMost(timeout);
+    }
+
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/EurekaInstanceSelector.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/EurekaInstanceSelector.java
@@ -1,0 +1,10 @@
+package io.quarkus.spring.cloud.config.client.runtime.eureka;
+
+import java.util.List;
+
+import io.vertx.core.json.JsonObject;
+
+@FunctionalInterface
+public interface EurekaInstanceSelector {
+    JsonObject select(List<JsonObject> instances);
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/EurekaResponseMapper.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/EurekaResponseMapper.java
@@ -1,0 +1,22 @@
+package io.quarkus.spring.cloud.config.client.runtime.eureka;
+
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class EurekaResponseMapper {
+
+    private static final Logger log = Logger.getLogger(EurekaResponseMapper.class);
+
+    public List<JsonObject> instances(String jsonString) {
+        JsonObject json = new JsonObject(jsonString);
+        log.debug("Received response from Spring Cloud Config Server: " + json.encodePrettily());
+        JsonArray jsonArray = json.getJsonObject("application").getJsonArray("instance");
+        return jsonArray.stream()
+                .map(o -> (JsonObject) o)
+                .toList();
+    }
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/RandomEurekaInstanceSelector.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/eureka/RandomEurekaInstanceSelector.java
@@ -1,0 +1,16 @@
+package io.quarkus.spring.cloud.config.client.runtime.eureka;
+
+import java.util.List;
+import java.util.Random;
+
+import io.vertx.core.json.JsonObject;
+
+public class RandomEurekaInstanceSelector implements EurekaInstanceSelector {
+
+    private final Random random = new Random();
+
+    @Override
+    public JsonObject select(List<JsonObject> instances) {
+        return instances.get(random.nextInt(instances.size()));
+    }
+}

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/util/UrlUtility.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/util/UrlUtility.java
@@ -1,0 +1,27 @@
+package io.quarkus.spring.cloud.config.client.runtime.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public final class UrlUtility {
+
+    public static int getPort(URI uri) {
+        return uri.getPort() != -1 ? uri.getPort() : (isHttps(uri) ? 443 : 80);
+    }
+
+    public static boolean isHttps(URI uri) {
+        return uri.getScheme().contains("https");
+    }
+
+    public static URI toURI(String url) throws URISyntaxException {
+        return new URI(sanitize(url));
+    }
+
+    public static String sanitize(String url) {
+        if (url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
+
+}

--- a/extensions/spring-cloud-config-client/runtime/src/test/resources/eureka-response.json
+++ b/extensions/spring-cloud-config-client/runtime/src/test/resources/eureka-response.json
@@ -1,0 +1,25 @@
+{
+  "application": {
+    "name": "config-server-id",
+    "instance": [
+      {
+        "instanceId": "my-service:9300",
+        "hostName": "localhost",
+        "app": "config-server-id",
+        "ipAddr": "192.168.1.10",
+        "status": "UP",
+        "port": {
+          "$": 9300,
+          "@enabled": true
+        },
+        "healthCheckUrl": "http://localhost:9300/actuator/health",
+        "statusPageUrl": "http://localhost:9300/info",
+        "homePageUrl": "http://localhost:9300/",
+        "dataCenterInfo": {
+          "@class": "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo",
+          "name": "MyOwn"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This development adds configuration to enable discovery of Config Server instance using Eureka Server. It exploits lazy url provider to get actual config server url from up instance during exchange.

The  implemented discovery strategy is random pick with defaultZone fallback

- Closes: #47989