### PR TITLE
Document quarkusIntTest task no longer depends on test task

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -584,7 +584,7 @@ Run the native tests using:
 ./gradlew testNative
 ----
 
-This task depends on `quarkusBuild`, so it will generate the native image before running the tests.
+This task depends on `quarkusBuild`, so it will generate the native image before running the native tests.
 
 [NOTE]
 ====
@@ -628,7 +628,7 @@ Those tests can be placed in a `src/integrationTest/java` directory and executed
 ./gradlew quarkusIntTest
 ----
 
-This task depends on both `test` and `quarkusBuild` tasks. The final artifact will be produced before running tests.
+This task depends on `quarkusBuild`, so it will generate the artifact before running the integration tests.
 
 == Using fast-jar
 


### PR DESCRIPTION
Resolves #48048

Since #46676 the gradle task `quarkusIntTest` no longer depends on the `test` task and thus only executes integration tests. Before also regular tests were executed.

If desired, I can also try to prepare a MR for the wiki, so this change in behaviour will be mentioned in the migration guide for 3.22