### PR TITLE
Change MSSQL username from `SA` to `sa`

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -217,7 +217,7 @@ Login credentials are the same for most databases, except when the database requ
 |`quarkus` for the default datasource or name of the datasource
 
 |Microsoft SQL Server
-|`SA`
+|`sa`
 |`Quarkus123`
 |
 


### PR DESCRIPTION
If `MSSQL_COLLATION` is set to a collation with case-sensetive (`_CS` not `_CI`), the username `SA` will fail to login to DB, as `sa` is the correct username.

```
quarkus.datasource.devservices.container-env.MSSQL_COLLATION=Arabic_100_CS_AS_KS_WS_SC_UTF8
```