### PR TITLE
Expose SSLSession from connection in WebSockets Next

### DIFF
--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/Connection.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/Connection.java
@@ -2,6 +2,8 @@ package io.quarkus.websockets.next;
 
 import java.time.Instant;
 
+import javax.net.ssl.SSLSession;
+
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.mutiny.Uni;
 
@@ -31,6 +33,12 @@ public interface Connection extends Sender {
      * @return {@code true} if the HTTP connection is encrypted via SSL/TLS
      */
     boolean isSecure();
+
+    /**
+     * @return {@link SSLSession} associated with the underlying socket, or {@code null} if connection is not secure.
+     * @see #isSecure()
+     */
+    SSLSession sslSession();
 
     /**
      * @return {@code true} if the WebSocket is closed

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
@@ -4,6 +4,8 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
+import javax.net.ssl.SSLSession;
+
 import org.jboss.logging.Logger;
 
 import io.quarkus.vertx.utils.NoBoundChecksBuffer;
@@ -135,6 +137,11 @@ public abstract class WebSocketConnectionBase implements Connection {
     @Override
     public boolean isSecure() {
         return webSocket().isSsl();
+    }
+
+    @Override
+    public SSLSession sslSession() {
+        return webSocket().sslSession();
     }
 
     @Override


### PR DESCRIPTION
This PR adds a `sslSession()` method to the common interface and base implementation for server and client sockets. This is necessary for server or client implementations that need to enforce specific rules for TLS communications beyond the standard handshake process.

While implementing test coverage, I noticed that the existing MTLS test case was flawed due to a missing `quarkus.http.ssl.client-auth=required` configuration. This has been corrected.