### PR TITLE
Record access token scope in the grant response

### DIFF
--- a/extensions/oidc-db-token-state-manager/deployment/src/main/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerProcessor.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/main/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerProcessor.java
@@ -44,29 +44,31 @@ public class OidcDbTokenStateManagerProcessor {
         final String[] queryParamPlaceholders;
         switch (sqlClientBuildItem.reactiveClient) {
             case REACTIVE_PG_CLIENT:
-                queryParamPlaceholders = new String[] { "$1", "$2", "$3", "$4", "$5", "$6" };
+                queryParamPlaceholders = new String[] { "$1", "$2", "$3", "$4", "$5", "$6", "$7" };
                 break;
             case REACTIVE_MSSQL_CLIENT:
-                queryParamPlaceholders = new String[] { "@p1", "@p2", "@p3", "@p4", "@p5", "@p6" };
+                queryParamPlaceholders = new String[] { "@p1", "@p2", "@p3", "@p4", "@p5", "@p6", "@p7" };
                 break;
             case REACTIVE_MYSQL_CLIENT:
             case REACTIVE_DB2_CLIENT:
             case REACTIVE_ORACLE_CLIENT:
-                queryParamPlaceholders = new String[] { "?", "?", "?", "?", "?", "?" };
+                queryParamPlaceholders = new String[] { "?", "?", "?", "?", "?", "?", "?" };
                 break;
             default:
                 throw new RuntimeException("Unknown Reactive Sql Client " + sqlClientBuildItem.reactiveClient);
         }
         String deleteStatement = format("DELETE FROM oidc_db_token_state_manager WHERE id = %s", queryParamPlaceholders[0]);
         String getQuery = format(
-                "SELECT id_token, access_token, refresh_token, access_token_expires_in FROM oidc_db_token_state_manager WHERE "
+                "SELECT id_token, access_token, refresh_token, access_token_expires_in, access_token_scope FROM oidc_db_token_state_manager WHERE "
                         +
                         "id = %s",
                 queryParamPlaceholders[0]);
         String insertStatement = format("INSERT INTO oidc_db_token_state_manager (id_token, access_token, refresh_token," +
-                " access_token_expires_in, expires_in, id) VALUES (%s, %s, %s, %s, %s, %s)", queryParamPlaceholders[0],
+                " access_token_expires_in, access_token_scope, expires_in, id) VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                queryParamPlaceholders[0],
                 queryParamPlaceholders[1],
-                queryParamPlaceholders[2], queryParamPlaceholders[3], queryParamPlaceholders[4], queryParamPlaceholders[5]);
+                queryParamPlaceholders[2], queryParamPlaceholders[3], queryParamPlaceholders[4], queryParamPlaceholders[5],
+                queryParamPlaceholders[6]);
         return SyntheticBeanBuildItem
                 .configure(OidcDbTokenStateManager.class)
                 .alternative(true)
@@ -119,6 +121,7 @@ public class OidcDbTokenStateManagerProcessor {
                         "access_token VARCHAR, " +
                         "refresh_token VARCHAR, " +
                         "access_token_expires_in BIGINT, " +
+                        "access_token_scope VARCHAR, " +
                         "expires_in BIGINT NOT NULL)";
                 supportsIfTableNotExists = true;
                 break;
@@ -129,6 +132,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "access_token VARCHAR(5000) NULL, "
                         + "refresh_token VARCHAR(5000) NULL, "
                         + "access_token_expires_in BIGINT NULL, "
+                        + "access_token_scope VARCHAR(100) NULL, "
                         + "expires_in BIGINT NOT NULL, "
                         + "PRIMARY KEY (id))";
                 supportsIfTableNotExists = true;
@@ -140,6 +144,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "access_token NVARCHAR(MAX), "
                         + "refresh_token NVARCHAR(MAX), "
                         + "access_token_expires_in BIGINT, "
+                        + "access_token_scope NVARCHAR(100), "
                         + "expires_in BIGINT NOT NULL)";
                 supportsIfTableNotExists = false;
                 break;
@@ -150,6 +155,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "access_token VARCHAR(4000), "
                         + "refresh_token VARCHAR(4000), "
                         + "access_token_expires_in BIGINT, "
+                        + "access_token_scope VARCHAR(100), "
                         + "expires_in BIGINT NOT NULL)";
                 supportsIfTableNotExists = false;
                 break;
@@ -160,6 +166,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "access_token VARCHAR2(4000), "
                         + "refresh_token VARCHAR2(4000), "
                         + "access_token_expires_in NUMBER, "
+                        + "access_token_scope VARCHAR2(100), "
                         + "expires_in NUMBER NOT NULL, "
                         + "PRIMARY KEY (id))";
                 supportsIfTableNotExists = true;

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
@@ -70,7 +70,8 @@ public abstract class AbstractDbTokenStateManagerTest {
 
             textPage = loginForm.getButtonByName("login").click();
 
-            assertEquals("alice, access token: true, access_token_expires_in: true, refresh_token: true",
+            assertEquals(
+                    "alice, access token: true, access_token_expires_in: true, access_token_scope: true, refresh_token: true",
                     textPage.getContent());
 
             assertTokenStateCount(1);

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerEntity.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerEntity.java
@@ -24,6 +24,9 @@ public class OidcDbTokenStateManagerEntity {
     @Column(name = "access_token_expires_in")
     Long accessTokenExpiresIn;
 
+    @Column(name = "access_token_scope", length = 100)
+    String accessTokenScope;
+
     @Column(name = "expires_in")
     Long expiresIn;
 }

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/ProtectedResource.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/ProtectedResource.java
@@ -28,6 +28,7 @@ public class ProtectedResource {
         return idToken.getName()
                 + ", access token: " + (tokens.getAccessToken() != null)
                 + ", access_token_expires_in: " + (tokens.getAccessTokenExpiresIn() != null)
+                + ", access_token_scope: " + (tokens.getAccessTokenScope() != null)
                 + ", refresh_token: " + (tokens.getRefreshToken() != null);
 
     }

--- a/extensions/oidc-db-token-state-manager/runtime/src/main/java/io/quarkus/oidc/db/token/state/manager/runtime/OidcDbTokenStateManager.java
+++ b/extensions/oidc-db-token-state-manager/runtime/src/main/java/io/quarkus/oidc/db/token/state/manager/runtime/OidcDbTokenStateManager.java
@@ -31,6 +31,7 @@ public class OidcDbTokenStateManager implements TokenStateManager {
     private static final String ID_TOKEN_COLUMN = "id_token";
     private static final String ACCESS_TOKEN_COLUMN = "access_token";
     private static final String ACCESS_TOKEN_EXPIRES_IN_COLUMN = "access_token_expires_in";
+    private static final String ACCESS_TOKEN_SCOPE_COLUMN = "access_token_scope";
     private static final String REFRESH_TOKEN_COLUMN = "refresh_token";
 
     private final String insertStatement;
@@ -61,6 +62,7 @@ public class OidcDbTokenStateManager implements TokenStateManager {
                                         .execute(
                                                 Tuple.of(tokens.getIdToken(), tokens.getAccessToken(),
                                                         tokens.getRefreshToken(), tokens.getAccessTokenExpiresIn(),
+                                                        tokens.getAccessTokenScope(),
                                                         expiresIn(event), id)))
                                 .toCompletionStage())
                 .onFailure().transform(new Function<Throwable, Throwable>() {
@@ -110,7 +112,8 @@ public class OidcDbTokenStateManager implements TokenStateManager {
                                                 firstRow.getString(ID_TOKEN_COLUMN),
                                                 firstRow.getString(ACCESS_TOKEN_COLUMN),
                                                 firstRow.getString(REFRESH_TOKEN_COLUMN),
-                                                firstRow.getLong(ACCESS_TOKEN_EXPIRES_IN_COLUMN)));
+                                                firstRow.getLong(ACCESS_TOKEN_EXPIRES_IN_COLUMN),
+                                                firstRow.getString(ACCESS_TOKEN_SCOPE_COLUMN)));
                             }
                         }
                         return Uni.createFrom().failure(new AuthenticationCompletionException(FAILED_TO_ACQUIRE_TOKEN));

--- a/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
+++ b/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
@@ -59,7 +59,8 @@ public abstract class AbstractRedisTokenStateManagerTest {
 
             textPage = loginForm.getButtonByName("login").click();
 
-            assertEquals("alice, access token: true, access_token_expires_in: true, refresh_token: true",
+            assertEquals(
+                    "alice, access token: true, access_token_expires_in: true, access_token_scope: true, refresh_token: true",
                     textPage.getContent());
 
             assertTokenStateCount(1);

--- a/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/ProtectedResource.java
+++ b/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/ProtectedResource.java
@@ -28,6 +28,7 @@ public class ProtectedResource {
         return idToken.getName()
                 + ", access token: " + (tokens.getAccessToken() != null)
                 + ", access_token_expires_in: " + (tokens.getAccessTokenExpiresIn() != null)
+                + ", access_token_scope: " + (tokens.getAccessTokenScope() != null)
                 + ", refresh_token: " + (tokens.getRefreshToken() != null);
     }
 

--- a/extensions/oidc-redis-token-state-manager/runtime/src/main/java/io/quarkus/oidc/redis/token/state/manager/runtime/OidcRedisTokenStateManager.java
+++ b/extensions/oidc-redis-token-state-manager/runtime/src/main/java/io/quarkus/oidc/redis/token/state/manager/runtime/OidcRedisTokenStateManager.java
@@ -81,15 +81,16 @@ final class OidcRedisTokenStateManager implements TokenStateManager {
         return Instant.now().plusSeconds(event.<Long> get(SESSION_MAX_AGE_PARAM));
     }
 
-    record AuthorizationCodeTokensRecord(String idToken, String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+    record AuthorizationCodeTokensRecord(String idToken, String accessToken, String refreshToken, Long accessTokenExpiresIn,
+            String accessTokenScope) {
 
         private static AuthorizationCodeTokensRecord of(AuthorizationCodeTokens tokens) {
             return new AuthorizationCodeTokensRecord(tokens.getIdToken(), tokens.getAccessToken(), tokens.getRefreshToken(),
-                    tokens.getAccessTokenExpiresIn());
+                    tokens.getAccessTokenExpiresIn(), tokens.getAccessTokenScope());
         }
 
         private AuthorizationCodeTokens toTokens() {
-            return new AuthorizationCodeTokens(idToken, accessToken, refreshToken, accessTokenExpiresIn);
+            return new AuthorizationCodeTokens(idToken, accessToken, refreshToken, accessTokenExpiresIn, accessTokenScope);
         }
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
@@ -9,6 +9,7 @@ public class AuthorizationCodeTokens {
     private String accessToken;
     private String refreshToken;
     private Long accessTokenExpiresIn;
+    private String accessTokenScope;
 
     public AuthorizationCodeTokens() {
     }
@@ -18,10 +19,16 @@ public class AuthorizationCodeTokens {
     }
 
     public AuthorizationCodeTokens(String idToken, String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+        this(idToken, accessToken, refreshToken, accessTokenExpiresIn, null);
+    }
+
+    public AuthorizationCodeTokens(String idToken, String accessToken, String refreshToken, Long accessTokenExpiresIn,
+            String accessTokenScope) {
         this.idToken = idToken;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.accessTokenExpiresIn = accessTokenExpiresIn;
+        this.accessTokenScope = accessTokenScope;
     }
 
     /**
@@ -96,5 +103,23 @@ public class AuthorizationCodeTokens {
      */
     public void setAccessTokenExpiresIn(Long accessTokenExpiresIn) {
         this.accessTokenExpiresIn = accessTokenExpiresIn;
+    }
+
+    /**
+     * Get the access token scope.
+     *
+     * @return access token scope.
+     */
+    public String getAccessTokenScope() {
+        return accessTokenScope;
+    }
+
+    /**
+     * Set the access token scope.
+     *
+     * @param accessTokenScope access token scope.
+     */
+    public void setAccessTokenScope(String accessTokenScope) {
+        this.accessTokenScope = accessTokenScope;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -6,7 +6,6 @@ import static io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.getRoutin
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -516,12 +515,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                     principalName = result.introspectionResult.getSubject();
                 }
                 userName = principalName != null ? principalName : "";
-
-                Set<String> scopes = result.introspectionResult.getScopes();
-                if (scopes != null) {
-                    builder.addRoles(scopes);
-                    OidcUtils.addTokenScopesAsPermissions(builder, scopes);
-                }
+                OidcUtils.setIntrospectionScopes(builder, result.introspectionResult);
             }
             builder.setPrincipal(new Principal() {
                 @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -364,8 +364,9 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
             tokenExpiresIn = tokenExpiresInObj instanceof Number ? ((Number) tokenExpiresInObj).longValue()
                     : Long.parseLong(tokenExpiresInObj.toString());
         }
+        final String accessTokenScope = json.getString(OidcConstants.TOKEN_SCOPE);
 
-        return new AuthorizationCodeTokens(idToken, accessToken, refreshToken, tokenExpiresIn);
+        return new AuthorizationCodeTokens(idToken, accessToken, refreshToken, tokenExpiresIn, accessTokenScope);
     }
 
     private UserInfoResponse getUserInfo(OidcRequestContextProperties requestProps, HttpResponse<Buffer> resp) {

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -180,6 +180,7 @@ quarkus.oidc.tenant-split-tokens.token-state-manager.split-tokens=true
 quarkus.oidc.tenant-split-tokens.token-state-manager.encryption-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-split-tokens.application-type=web-app
 quarkus.oidc.tenant-split-tokens.authentication.cookie-same-site=strict
+quarkus.oidc.tenant-split-tokens.authentication.scopes=phone
 
 quarkus.http.auth.permission.roles1.paths=/index.html,/index.html;/checktterer
 quarkus.http.auth.permission.roles1.policy=authenticated

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowOpaqueAccessTokenResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowOpaqueAccessTokenResource.java
@@ -8,9 +8,9 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionsAllowed;
 
 @Path("/code-flow-opaque-access-token")
-@Authenticated
 public class CodeFlowOpaqueAccessTokenResource {
 
     @Inject
@@ -20,12 +20,14 @@ public class CodeFlowOpaqueAccessTokenResource {
     AccessTokenCredential accessTokenCredential;
 
     @GET
+    @PermissionsAllowed("phone")
     public String getAccessTokenCredential() {
         return accessTokenCredential.getToken();
     }
 
     @GET
     @Path("/jwt-access-token")
+    @Authenticated
     public String getJwtAccessToken() {
         return jwtAccessToken.getRawToken();
     }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
@@ -7,11 +7,11 @@ import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.oidc.TokenIntrospection;
-import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/code-flow-token-introspection")
-@Authenticated
+@PermissionsAllowed("email")
 public class CodeFlowTokenIntrospectionResource {
 
     @Inject

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -45,6 +45,7 @@ quarkus.oidc.code-flow-opaque-access-token.user-info-path=protocol/openid-connec
 quarkus.oidc.code-flow-opaque-access-token.client-id=quarkus-web-app
 quarkus.oidc.code-flow-opaque-access-token.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-opaque-access-token.tenant-paths=/code-flow-opaque-access-token/*
+quarkus.oidc.code-flow-opaque-access-token.roles.source=accesstoken
 
 quarkus.oidc.code-flow-encrypted-id-token-jwk.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-jwk.client-id=quarkus-web-app
@@ -166,7 +167,7 @@ quarkus.oidc.code-flow-token-introspection.authorization-path=/
 quarkus.oidc.code-flow-token-introspection.user-info-path=protocol/openid-connect/userinfo
 quarkus.oidc.code-flow-token-introspection.introspection-path=protocol/openid-connect/token/introspect
 quarkus.oidc.code-flow-token-introspection.token.refresh-token-time-skew=298
-quarkus.oidc.code-flow-token-introspection.authentication.verify-access-token=true
+quarkus.oidc.code-flow-token-introspection.roles.source=accesstoken
 quarkus.oidc.code-flow-token-introspection.client-id=quarkus-web-app
 quarkus.oidc.code-flow-token-introspection.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-token-introspection.code-grant.headers.X-Custom=XTokenIntrospection

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -528,6 +528,9 @@ public class CodeFlowAuthorizationTest {
 
             assertEquals("alice:alice", textPage.getContent());
 
+            textPage = webClient.getPage("http://localhost:8081/code-flow-token-introspection");
+            assertEquals("alice:alice", textPage.getContent());
+
             // Refresh
             // The internal ID token lifespan is 5 mins
             // Configured refresh token skew is 298 secs = 5 mins - 2 secs
@@ -770,6 +773,7 @@ public class CodeFlowAuthorizationTest {
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +
                                         "  \"access_token\": \"alice\","
+                                        + "  \"scope\": \"laptop phone\","
                                         + "\"expires_in\": 299}")));
     }
 
@@ -786,6 +790,7 @@ public class CodeFlowAuthorizationTest {
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +
                                         "  \"access_token\": \"alice\","
+                                        + "  \"scope\": \"email\","
                                         + "  \"refresh_token\": \"refresh5678\""
                                         + "}")));
 
@@ -795,7 +800,8 @@ public class CodeFlowAuthorizationTest {
                         .willReturn(WireMock.aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +
-                                        "  \"access_token\": \"admin\""
+                                        "  \"access_token\": \"admin\","
+                                        + "  \"scope\": \"email\""
                                         + "}")));
     }
 


### PR DESCRIPTION
Fixes #48152

The main update is [here](https://github.com/quarkusio/quarkus/compare/main...sberyozkin:access_token_scope?expand=1#diff-8af2ccae2405932ff99db333a8b3932c5df400268993c83c38210a1e18fd762eR366) - if it is authorization code flow token, check the scope from the authorization code flow response as well. This update is really relevant with social providers like GitHub when the token is binary, if it is JWT then JSON with roles/permissions is checked a few lines earlier - which is where I had to fix NPE - until now, we have only enforced `@Authenticated` at the point of login with social providers.

Updated tests, confirmed I can use for example, `@PermissionsAllowed("user:email")` with the GitHub login.