### PR TITLE
Do not register the Hot Reload Handler into the Management Interface router

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/management/LiveReloadManagementTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/management/LiveReloadManagementTest.java
@@ -6,12 +6,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@Disabled("See https://github.com/quarkusio/quarkus/pull/48171")
 public class LiveReloadManagementTest {
 
     private static final String APP_PROPS = """

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -563,7 +563,7 @@ public class VertxHttpRecorder {
             var mr = managementRouter.getValue();
             boolean hasManagementRoutes = !mr.getRoutes().isEmpty();
 
-            addHotReplacementHandlerIfNeeded(mr);
+            // We do not add the hotreload handler on the management interface
 
             mr.route().last().failureHandler(
                     new QuarkusErrorHandler(launchMode.isDevOrTest(), decorateStacktrace(launchMode, logBuildTimeConfig),


### PR DESCRIPTION
This commit removes the registration of the hot reload handler from the management interface router. The handler is associated with the main router, can potentially block processing tasks.

Fix #48151 and quarkiverse/quarkus-logging-manager#359.
