### PR TITLE
Runtime init `io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils`

### DIFF
--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -797,7 +797,7 @@ dependencies {
 In JVM mode, any version of `io.confluent:kafka-avro-serializer` can be used.
 In native mode, Quarkus supports the following versions: `6.2.x`, `7.0.x`, `7.1.x`, `7.2.x`, `7.3.x`.
 
-For version `7.4.x` and `7.5.x`, due to an issue with the Confluent Schema Serializer, you need to add another dependency:
+For versions `7.4.x` and later, due to an issue with the Confluent Schema Serializer, you need to add another dependency:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml

--- a/extensions/schema-registry/confluent/avro/deployment/src/main/java/io/quarkus/confluent/registry/avro/ConfluentRegistryAvroProcessor.java
+++ b/extensions/schema-registry/confluent/avro/deployment/src/main/java/io/quarkus/confluent/registry/avro/ConfluentRegistryAvroProcessor.java
@@ -50,11 +50,14 @@ public class ConfluentRegistryAvroProcessor {
         Optional<ResolvedDependency> serde = findConfluentSerde(cp.getApplicationModel().getDependencies());
         if (serde.isPresent()) {
             String version = serde.get().getVersion();
+            NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder();
             if (version.startsWith("7.1") || version.startsWith("7.2")) {
                 // Only required for Confluent Serde 7.1.x and 7.2.x
-                config.produce(NativeImageConfigBuildItem.builder()
-                        .addRuntimeInitializedClass("io.confluent.kafka.schemaregistry.client.rest.utils.UrlList").build());
+                builder.addRuntimeInitializedClass("io.confluent.kafka.schemaregistry.client.rest.utils.UrlList");
             }
+            // Depends on org.apache.avro.reflect.ReflectData$AllowNull since v7.4.5
+            builder.addRuntimeInitializedClass("io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils");
+            config.produce(builder.build());
         }
     }
 


### PR DESCRIPTION
Depends on org.apache.avro.reflect.ReflectData$AllowNull since `io.confluent:kafka-avro-serializer` v7.4.5
which is runtime initialized resulting in:

```
Error: An object of type
'org.apache.avro.reflect.ReflectData$AllowNull' was found in the image
heap. This type, however, is marked for initialization at image run time
for the following reason: classes are initialized at run time by
default.
```

Tested with `io.confluent:kafka-avro-serializer` 7.8.0

Closes: https://github.com/quarkusio/quarkus/issues/45742
