### PR TITLE
Remove "default" formatter mappers and let ORM build them itself

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -6,6 +6,7 @@ import java.util.TreeMap;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.config.DatabaseOrmCompatibilityVersion;
+import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -52,6 +53,12 @@ public interface HibernateOrmConfig {
      */
     @ConfigDocSection
     HibernateOrmConfigDatabase database();
+
+    /**
+     * JSON/XML mapping related configuration.
+     */
+    @ConfigDocSection
+    HibernateOrmConfigMapping mapping();
 
     /**
      * Configuration for persistence units.
@@ -209,5 +216,26 @@ public interface HibernateOrmConfig {
          */
         @WithDefault("false")
         boolean allowHql();
+    }
+
+    @ConfigGroup
+    interface HibernateOrmConfigMapping {
+
+        /**
+         * Mapping format.
+         */
+        HibernateOrmConfigMappingFormat format();
+
+        @ConfigGroup
+        interface HibernateOrmConfigMappingFormat {
+            /**
+             * How the default JSON/XML format mappers are configured.
+             *
+             * Only available to mitigate migration from the current Quarkus-preconfigured format mappers (that will be removed
+             * in the future version).
+             */
+            @WithDefault("warn")
+            BuiltinFormatMapperBehaviour global();
+        }
     }
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -324,8 +324,9 @@ public final class HibernateOrmProcessor {
                     .filter(i -> i.isDefault())
                     .findFirst();
             collectDialectConfigForPersistenceXml(puName, xmlDescriptor);
-            Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities);
-            Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities);
+            Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities,
+                    hibernateOrmConfig.mapping().format().global());
+            Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
             jsonMapper.flatMap(FormatMapperKind::requiredBeanType)
                     .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
             xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
@@ -341,7 +342,8 @@ public final class HibernateOrmProcessor {
                                     getMultiTenancyStrategy(
                                             Optional.ofNullable(persistenceXmlDescriptorBuildItem.getDescriptor()
                                                     .getProperties().getProperty("hibernate.multiTenancy"))), //FIXME this property is meaningless in Hibernate ORM 6
-                                    hibernateOrmConfig.database().ormCompatibilityVersion(), Collections.emptyMap()),
+                                    hibernateOrmConfig.database().ormCompatibilityVersion(),
+                                    hibernateOrmConfig.mapping().format().global(), Collections.emptyMap()),
                             null,
                             jpaModel.getXmlMappings(persistenceXmlDescriptorBuildItem.getDescriptor().getName()),
                             true, isHibernateValidatorPresent(capabilities), jsonMapper, xmlMapper));
@@ -948,8 +950,8 @@ public final class HibernateOrmProcessor {
         configureSqlLoadScript(persistenceUnitName, persistenceUnitConfig, applicationArchivesBuildItem, launchMode,
                 nativeImageResources, hotDeploymentWatchedFiles, descriptor);
 
-        Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities);
-        Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities);
+        Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
+        Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
         jsonMapper.flatMap(FormatMapperKind::requiredBeanType)
                 .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
         xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
@@ -963,6 +965,7 @@ public final class HibernateOrmProcessor {
                                 persistenceUnitConfig.dialect().dialect(),
                                 multiTenancyStrategy,
                                 hibernateOrmConfig.database().ormCompatibilityVersion(),
+                                hibernateOrmConfig.mapping().format().global(),
                                 persistenceUnitConfig.unsupportedProperties()),
                         persistenceUnitConfig.multitenantSchemaDatasource().orElse(null),
                         xmlMappings,

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
@@ -39,6 +39,7 @@ import io.quarkus.hibernate.orm.deployment.JpaModelBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
+import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
 import io.quarkus.hibernate.orm.runtime.customized.FormatMapperKind;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -58,7 +59,10 @@ public final class HibernateProcessorUtil {
         return !jpaModel.getEntityClassNames().isEmpty();
     }
 
-    public static Optional<FormatMapperKind> jsonMapperKind(Capabilities capabilities) {
+    public static Optional<FormatMapperKind> jsonMapperKind(Capabilities capabilities, BuiltinFormatMapperBehaviour behaviour) {
+        if (BuiltinFormatMapperBehaviour.IGNORE.equals(behaviour)) {
+            return Optional.empty();
+        }
         if (capabilities.isPresent(Capability.JACKSON)) {
             return Optional.of(FormatMapperKind.JACKSON);
         } else if (capabilities.isPresent(Capability.JSONB)) {
@@ -68,7 +72,10 @@ public final class HibernateProcessorUtil {
         }
     }
 
-    public static Optional<FormatMapperKind> xmlMapperKind(Capabilities capabilities) {
+    public static Optional<FormatMapperKind> xmlMapperKind(Capabilities capabilities, BuiltinFormatMapperBehaviour behaviour) {
+        if (BuiltinFormatMapperBehaviour.IGNORE.equals(behaviour)) {
+            return Optional.empty();
+        }
         return capabilities.isPresent(Capability.JAXB)
                 ? Optional.of(FormatMapperKind.JAXB)
                 : Optional.empty();

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -205,7 +205,8 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                     standardServiceRegistry /* Mostly ignored! (yet needs to match) */,
                     runtimeSettings,
                     validatorFactory, cdiBeanManager, recordedState.getMultiTenancyStrategy(),
-                    true);
+                    true,
+                    recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour());
         }
 
         log.debug("Found no matching persistence units");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -46,7 +46,7 @@ public class JPAConfig {
 
     void startAll() {
         List<CompletableFuture<?>> start = new ArrayList<>();
-        //by using a dedicated thread for starting up the PR,
+        //by using a dedicated thread for starting up the PU,
         //we work around https://github.com/quarkusio/quarkus/issues/17304 to some extent
         //as the main thread is now no longer polluted with ThreadLocals by default
         //this is not a complete fix, but will help as long as the test methods

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
@@ -35,6 +35,7 @@ import io.quarkus.hibernate.orm.JsonFormat;
 import io.quarkus.hibernate.orm.XmlFormat;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.RuntimeSettings;
+import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.observers.QuarkusSessionFactoryObserverForDbVersionCheck;
 import io.quarkus.hibernate.orm.runtime.observers.SessionFactoryObserverForNamedQueryValidation;
@@ -50,6 +51,7 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
     private final RuntimeSettings runtimeSettings;
     private final Object validatorFactory;
     private final Object cdiBeanManager;
+    private final BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour;
 
     protected final MultiTenancyStrategy multiTenancyStrategy;
     protected final boolean shouldApplySchemaMigration;
@@ -58,7 +60,8 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
             QuarkusPersistenceUnitDescriptor puDescriptor,
             PrevalidatedQuarkusMetadata metadata,
             StandardServiceRegistry standardServiceRegistry, RuntimeSettings runtimeSettings, Object validatorFactory,
-            Object cdiBeanManager, MultiTenancyStrategy multiTenancyStrategy, boolean shouldApplySchemaMigration) {
+            Object cdiBeanManager, MultiTenancyStrategy multiTenancyStrategy, boolean shouldApplySchemaMigration,
+            BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour) {
         this.puDescriptor = puDescriptor;
         this.metadata = metadata;
         this.standardServiceRegistry = standardServiceRegistry;
@@ -67,6 +70,7 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
         this.cdiBeanManager = cdiBeanManager;
         this.multiTenancyStrategy = multiTenancyStrategy;
         this.shouldApplySchemaMigration = shouldApplySchemaMigration;
+        this.builtinFormatMapperBehaviour = builtinFormatMapperBehaviour;
     }
 
     @Override
@@ -211,11 +215,15 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
                 FormatMapper.class, persistenceUnitName, JsonFormat.Literal.INSTANCE);
         if (!jsonFormatMapper.isUnsatisfied()) {
             options.applyJsonFormatMapper(jsonFormatMapper.get());
+        } else {
+            builtinFormatMapperBehaviour.jsonApply(metadata(), persistenceUnitName);
         }
         InjectableInstance<FormatMapper> xmlFormatMapper = PersistenceUnitUtil.singleExtensionInstanceForPersistenceUnit(
                 FormatMapper.class, persistenceUnitName, XmlFormat.Literal.INSTANCE);
         if (!xmlFormatMapper.isUnsatisfied()) {
             options.applyXmlFormatMapper(xmlFormatMapper.get());
+        } else {
+            builtinFormatMapperBehaviour.xmlApply(metadata(), persistenceUnitName);
         }
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BuiltinFormatMapperBehaviour.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BuiltinFormatMapperBehaviour.java
@@ -1,0 +1,108 @@
+package io.quarkus.hibernate.orm.runtime.customized;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.mapping.Collection;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.type.SqlTypes;
+import org.jboss.logging.Logger;
+
+import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
+
+public enum BuiltinFormatMapperBehaviour {
+    /**
+     * The Quarkus preconfigured mappers are ignored and if there is no user provided one,
+     * Hibernate ORM will create a mapper according to its own rules.
+     */
+    IGNORE {
+        @Override
+        protected void action(String puName, String type) {
+        }
+    },
+    /**
+     * Currently the default one, uses a Quarkus preconfigured format mappers. If a format mapper operation is invoked a
+     * warning is logged.
+     */
+    WARN {
+        @Override
+        protected void action(String puName, String type) {
+            LOGGER.warn(message(puName, type));
+        }
+    },
+    /**
+     * If there is no user provided format mapper, a Quarkus preconfigured one will fail at runtime.
+     * Will become the default in the future versions of Quarkus.
+     */
+    FAIL {
+        @Override
+        protected void action(String puName, String type) {
+            throw new IllegalStateException(message(puName, type));
+        }
+    };
+
+    private static final Logger LOGGER = Logger.getLogger(BuiltinFormatMapperBehaviour.class);
+    private static final String TYPE_JSON = "JSON";
+    private static final String TYPE_XML = "XML";
+
+    private static String message(String puName, String type) {
+        return String.format(Locale.ROOT,
+                "Persistence unit [%1$s] uses Quarkus' main formatting facilities for %2$s columns in the database. "
+                        + "\nAs these facilities are primarily meant for REST endpoints, and they might have been customized for such use, "
+                        + "this may lead to undesired behavior, up to and including data loss. "
+                        + "\nTo address this:"
+                        + "\n\t- If the application does not customize the %2$s serialization/deserialization, set \"quarkus.hibernate-orm.mapping.format.global=ignore\". This will be the default in future versions of Quarkus. "
+                        + "\n\t- Otherwise, define a custom `FormatMapper` bean annotated with "
+                        + (TYPE_JSON.equals(type) ? "@JsonFormat" : "@XmlFormat")
+                        + " and @PersistenceUnitExtension"
+                        + (PersistenceUnitUtil.isDefaultPersistenceUnit(puName) ? "" : "(\"%1$s\")")
+                        + "to address your database serialization/deserialization needs."
+                        + "\nSee the migration guide for more details and how to proceed.",
+                puName, type);
+    }
+
+    public static boolean hasJsonProperties(MetadataImplementor metadata) {
+        return hasXxxProperties(metadata, Set.of(SqlTypes.JSON, SqlTypes.JSON_ARRAY));
+    }
+
+    public static boolean hasXmlProperties(MetadataImplementor metadata) {
+        return hasXxxProperties(metadata, Set.of(SqlTypes.SQLXML, SqlTypes.XML_ARRAY));
+    }
+
+    private static boolean hasXxxProperties(MetadataImplementor metadata, Set<Integer> sqlTypeCodes) {
+        for (PersistentClass persistentClass : metadata.getEntityBindings()) {
+            for (Property property : persistentClass.getProperties()) {
+                List<Column> columns = property.getColumns();
+                if (columns.isEmpty()) {
+                    if (property.getValue() instanceof Collection c) {
+                        columns = c.getElement().getColumns();
+                    }
+                }
+                for (Column column : columns) {
+                    if (sqlTypeCodes.contains(column.getSqlTypeCode(metadata))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    public void jsonApply(MetadataImplementor metadata, String puName) {
+        if (hasJsonProperties(metadata)) {
+            action(puName, TYPE_JSON);
+        }
+    }
+
+    public void xmlApply(MetadataImplementor metadata, String puName) {
+        if (hasXmlProperties(metadata)) {
+            action(puName, TYPE_XML);
+        }
+    }
+
+    protected abstract void action(String puName, String type);
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.quarkus.hibernate.orm.runtime.config.DatabaseOrmCompatibilityVersion;
+import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.runtime.annotations.RecordableConstructor;
 
@@ -19,12 +20,14 @@ public class RecordedConfig {
     private final MultiTenancyStrategy multiTenancyStrategy;
     private final Map<String, String> quarkusConfigUnsupportedProperties;
     private final DatabaseOrmCompatibilityVersion databaseOrmCompatibilityVersion;
+    private final BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour;
 
     @RecordableConstructor
     public RecordedConfig(Optional<String> dataSource, Optional<String> dbKind,
             Optional<String> dbVersion, Optional<String> explicitDialect,
             MultiTenancyStrategy multiTenancyStrategy,
             DatabaseOrmCompatibilityVersion databaseOrmCompatibilityVersion,
+            BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour,
             Map<String, String> quarkusConfigUnsupportedProperties) {
         Objects.requireNonNull(dataSource);
         Objects.requireNonNull(dbKind);
@@ -35,8 +38,9 @@ public class RecordedConfig {
         this.dbVersion = dbVersion;
         this.explicitDialect = explicitDialect;
         this.multiTenancyStrategy = multiTenancyStrategy;
-        this.quarkusConfigUnsupportedProperties = quarkusConfigUnsupportedProperties;
         this.databaseOrmCompatibilityVersion = databaseOrmCompatibilityVersion;
+        this.builtinFormatMapperBehaviour = builtinFormatMapperBehaviour;
+        this.quarkusConfigUnsupportedProperties = quarkusConfigUnsupportedProperties;
     }
 
     public Optional<String> getDataSource() {
@@ -59,11 +63,15 @@ public class RecordedConfig {
         return multiTenancyStrategy;
     }
 
-    public Map<String, String> getQuarkusConfigUnsupportedProperties() {
-        return quarkusConfigUnsupportedProperties;
-    }
-
     public DatabaseOrmCompatibilityVersion getDatabaseOrmCompatibilityVersion() {
         return databaseOrmCompatibilityVersion;
+    }
+
+    public BuiltinFormatMapperBehaviour getBuiltinFormatMapperBehaviour() {
+        return builtinFormatMapperBehaviour;
+    }
+
+    public Map<String, String> getQuarkusConfigUnsupportedProperties() {
+        return quarkusConfigUnsupportedProperties;
     }
 }

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -183,8 +183,8 @@ public final class HibernateReactiveProcessor {
                 launchMode.getLaunchMode(),
                 systemProperties, nativeImageResources, hotDeploymentWatchedFiles, dbKindDialectBuildItems);
 
-        Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities);
-        Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities);
+        Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
+        Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
         jsonMapper.flatMap(FormatMapperKind::requiredBeanType)
                 .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
         xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
@@ -202,6 +202,7 @@ public final class HibernateReactiveProcessor {
                         persistenceUnitConfig.dialect().dialect(),
                         io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy.NONE,
                         hibernateOrmConfig.database().ormCompatibilityVersion(),
+                        hibernateOrmConfig.mapping().format().global(),
                         persistenceUnitConfig.unsupportedProperties()),
                 null,
                 jpaModel.getXmlMappings(reactivePU.getName()),

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -231,7 +231,8 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
                     standardServiceRegistry /* Mostly ignored! (yet needs to match) */,
                     runtimeSettings,
                     validatorFactory, cdiBeanManager, recordedState.getMultiTenancyStrategy(),
-                    PersistenceUnitsHolder.getPersistenceUnitDescriptors().size() == 1);
+                    PersistenceUnitsHolder.getPersistenceUnitDescriptors().size() == 1,
+                    recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour());
         }
 
         log.debug("Found no matching persistence units");

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
@@ -11,6 +11,7 @@ import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.RuntimeSettings;
 import io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
+import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.recording.PrevalidatedQuarkusMetadata;
 
@@ -20,9 +21,10 @@ public final class FastBootReactiveEntityManagerFactoryBuilder extends FastBootE
             PrevalidatedQuarkusMetadata metadata,
             StandardServiceRegistry standardServiceRegistry, RuntimeSettings runtimeSettings, Object validatorFactory,
             Object cdiBeanManager, MultiTenancyStrategy strategy,
-            boolean shouldApplySchemaMigration) {
+            boolean shouldApplySchemaMigration,
+            BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour) {
         super(puDescriptor, metadata, standardServiceRegistry, runtimeSettings, validatorFactory,
-                cdiBeanManager, strategy, shouldApplySchemaMigration);
+                cdiBeanManager, strategy, shouldApplySchemaMigration, builtinFormatMapperBehaviour);
     }
 
     @Override

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
@@ -20,6 +20,7 @@ import io.quarkus.it.jpa.postgresql.defaultpu.EntityWithJson;
 import io.quarkus.it.jpa.postgresql.defaultpu.MyUUIDEntity;
 import io.quarkus.it.jpa.postgresql.defaultpu.Person;
 import io.quarkus.it.jpa.postgresql.defaultpu.SequencedAddress;
+import io.quarkus.it.jpa.postgresql.defaultpu.SomeEmbeddable;
 import io.quarkus.it.jpa.postgresql.otherpu.EntityWithJsonOtherPU;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 
@@ -133,7 +134,8 @@ public class JPAFunctionalityTestEndpoint {
     public String json() {
         QuarkusTransaction.requiringNew().run(() -> {
             EntityWithJson entity = new EntityWithJson(
-                    new EntityWithJson.ToBeSerializedWithDateTime(LocalDate.of(2023, 7, 28)));
+                    new EntityWithJson.ToBeSerializedWithDateTime(LocalDate.of(2023, 7, 28)),
+                    new SomeEmbeddable(100, LocalDate.of(2023, 7, 29)));
             em.persist(entity);
         });
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/EntityWithJson.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/EntityWithJson.java
@@ -1,7 +1,10 @@
 package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import java.time.LocalDate;
+import java.util.Set;
 
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -22,11 +25,20 @@ public class EntityWithJson {
     @JdbcTypeCode(SqlTypes.JSON)
     ToBeSerializedWithDateTime json;
 
+    @Embedded
+    SomeEmbeddable someEmbeddable;
+
+    @ElementCollection
+    Set<SomeEmbeddable> collection;
+
     public EntityWithJson() {
     }
 
-    public EntityWithJson(ToBeSerializedWithDateTime data) {
+    public EntityWithJson(ToBeSerializedWithDateTime data,
+            SomeEmbeddable someEmbeddable) {
         this.json = data;
+        this.someEmbeddable = someEmbeddable;
+        this.collection = Set.of(someEmbeddable);
     }
 
     @Override

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/SomeEmbeddable.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/SomeEmbeddable.java
@@ -1,0 +1,53 @@
+package io.quarkus.it.jpa.postgresql.defaultpu;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Embeddable;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@Embeddable
+public class SomeEmbeddable {
+
+    public int someNumber;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    public ToBeSerializedWithDateTime someOtherJson;
+
+    public SomeEmbeddable() {
+    }
+
+    public SomeEmbeddable(int someNumber, LocalDate date) {
+        this.someNumber = someNumber;
+        this.someOtherJson = new ToBeSerializedWithDateTime(date);
+    }
+
+    @RegisterForReflection
+    public static class ToBeSerializedWithDateTime {
+        @JsonProperty
+        LocalDate date;
+
+        @JsonProperty
+        int year;
+
+        public ToBeSerializedWithDateTime() {
+        }
+
+        public ToBeSerializedWithDateTime(LocalDate date) {
+            this.date = date;
+            this.year = date.getYear();
+        }
+
+        @Override
+        public String toString() {
+            return "ToBeSerializedWithDateTime{" +
+                    "date=" + date +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/47588 (in a way 😄)

- there is some ongoing work in Hibernate ORM that will preconfigure the Jackson `ObjectMapper` in a specific way if the Oracle DB is in use. This will probably be part of 7.1 or so, and once it's out, we'd need to adapt and "copy" that logic here 
- this has been causing other problems in the past
- we don't want to let the global mapper configuration affect the db serialisation/deserialisation 

so with that ^ let's just drop the "default" mappers and let Hibernate ORM do its thing and configure it in a way it wants by default. If users want more control over it they could (and should) use the `@io.quarkus.hibernate.orm.JsonFormat` + `@io.quarkus.hibernate.orm.PersistenceUnitExtension` : https://quarkus.io/guides/hibernate-orm#json_xml_serialization_deserialization

As this is a breaking change ... for migration purposes... we'd suggest that users define a `FormatMapper` like:
```java
@JsonFormat
@PersistenceUnitExtension
public class OrmJsonFormatMapper implements FormatMapper {

    private final JacksonJsonFormatMapper mapper;

    @Inject
    public OrmJsonFormatMapper(ObjectMapper objectMapper) {
        this.mapper = new JacksonJsonFormatMapper(objectMapper);
    }

    @Override
    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
        return mapper.fromString(charSequence, javaType, wrapperOptions);
    }

    @Override
    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
        return mapper.toString(value, javaType, wrapperOptions);
    }
}
```
to get the same behaviour as right now, and hint them to reconsider using the injected object mapper, but built one themselves for persistence purposes ?

I'm opening this as a draft to discuss this approach. If we agree on it, I will prepare and test examples for each mapper type and write the migration note. 😃 