### PR TITLE
Fix Platform overriding of codestart dockerfile data

### DIFF
--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -146,10 +146,10 @@
     "project": {
       "default-codestart": "rest",
       "codestart-data": {
-        "dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21",
-        "dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.21",
-        "dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.5",
-        "dockerfile.native-micro": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
+        "tooling-dockerfiles.dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21",
+        "tooling-dockerfiles.dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.21",
+        "tooling-dockerfiles.dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.5",
+        "tooling-dockerfiles.dockerfile.native-micro.from": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
       },
       "properties": {
         "doc-root": "https://quarkus.io",

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
@@ -8,7 +8,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.aether.artifact.Artifact;
@@ -235,7 +237,25 @@ public class ToolsUtils {
     @SuppressWarnings("unchecked")
     public static Map<String, Object> readProjectData(ExtensionCatalog catalog) {
         Map<Object, Object> map = (Map<Object, Object>) catalog.getMetadata().getOrDefault("project", Map.of());
-        return (Map<String, Object>) map.getOrDefault("codestart-data", Map.of());
+        Map<String, Object> projectData = (Map<String, Object>) map.getOrDefault("codestart-data", Map.of());
+
+        // fix the dockerfile entries for Platform < 3.23.1
+        projectData = projectData.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> {
+                            if (!e.getKey().startsWith("dockerfile.")) {
+                                return e.getKey();
+                            }
+                            String key = e.getKey();
+                            if ("dockerfile.native-micro".equals(key)) {
+                                key += ".from";
+                            }
+
+                            return "tooling-dockerfiles." + key;
+                        },
+                        Entry::getValue));
+
+        return projectData;
     }
 
     public static String requireProperty(Properties props, String name) {


### PR DESCRIPTION
We need the Platform to override the values in the codestart data, and for that, they need to be prefixed by the codestart name. TBH, my first inclination was to always override properties in the codestarts with what comes from the data... but it breaks a test so let's not go there for now.

Also fix the native-micro entry as it was missing a `.from`.

And make sure the data coming from previous platforms is properly fixed when extracted.

Fixes #48102

Problem is due to the `tooling-dockerfiles` `codestart.yml` containing the default values for `native` and `native-micro` so we need to make sure they are properly overridden:

```yaml
    data:
      dockerfile:
        native:
          from: registry.access.redhat.com/ubi8/ubi-minimal:8.10
        native-micro:
          from: quay.io/quarkus/quarkus-micro-image:2.0
```