### PR TITLE
Log just the error message instead of complete stacktraces from DevModeClient

### DIFF
--- a/test-framework/devmode-test-utils/src/main/java/io/quarkus/test/devmode/util/DevModeClient.java
+++ b/test-framework/devmode-test-utils/src/main/java/io/quarkus/test/devmode/util/DevModeClient.java
@@ -190,10 +190,16 @@ public class DevModeClient {
                         resp.set(content);
                         return true;
                     } catch (Exception e) {
-                        LOG.error(
-                                "An error occurred when DevModeClient accessed " + path
-                                        + ". It might be a normal testing behavior but logging the exception for information",
-                                e);
+                        var sb = new StringBuilder();
+                        sb.append("DevModeClient failed to accessed ").append(path)
+                                .append(". It might be a normal testing behavior but logging the messages for information: ")
+                                .append(e.getLocalizedMessage());
+                        var cause = e.getCause();
+                        while (cause != null) {
+                            sb.append(": ").append(cause.getLocalizedMessage());
+                            cause = cause.getCause();
+                        }
+                        LOG.error(sb);
                         return false;
                     }
                 });


### PR DESCRIPTION
@holly-cummins this is a follow up to your change enabling stacktraces.

This cleans up the log for dev mode tests. Instead of overwhelming stacktraces that are expected, log just a summary of the errors accessing a resource. It would look like

```
:quarkusDev (Thread[Execution worker,5,main]) started.
2025-06-03 09:21:49,757 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:49,859 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:49,967 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,069 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,171 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,273 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,374 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,475 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,576 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,677 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,778 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,879 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:50,980 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:51,081 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:51,182 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:51,283 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:51,384 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:51,485 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:51,587 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused
2025-06-03 09:21:51,688 ERROR [io.qua.tes.dev.uti.DevModeClient] (awaitility-thread) DevModeClient failed to accessed /hello. It might be a normal testing behavior but logging the messages for information: Connection refused

> Task :quarkusDev
```