### PR TITLE
Add config option to disable extension management in dev ui

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
@@ -53,6 +53,12 @@ public interface DevUIConfig {
     Cors cors();
 
     /**
+     * Enable/Disable the ability to add and remove extensions from Dev UI
+     */
+    @WithDefault("true")
+    boolean allowExtensionManagement();
+
+    /**
      * Fine tune the theme
      */
     Optional<Theme> theme();

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -21,6 +21,7 @@ import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.devui.deployment.DevUIConfig;
 import io.quarkus.devui.deployment.ExtensionsBuildItem;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.deployment.extension.Extension;
@@ -34,7 +35,7 @@ import io.quarkus.devui.spi.page.Page;
 public class ExtensionsProcessor {
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)
-    InternalPageBuildItem createExtensionsPages(ExtensionsBuildItem extensionsBuildItem) {
+    InternalPageBuildItem createExtensionsPages(ExtensionsBuildItem extensionsBuildItem, DevUIConfig config) {
 
         InternalPageBuildItem extensionsPages = new InternalPageBuildItem("Extensions", 10, "qwc-extensions-menu-action");
 
@@ -52,15 +53,18 @@ public class ExtensionsProcessor {
                 .icon("font-awesome-solid:puzzle-piece")
                 .componentLink("qwc-extensions.js"));
 
+        extensionsPages.addBuildTimeData("allowExtensionManagement", config.allowExtensionManagement());
+
         return extensionsPages;
     }
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     void createBuildTimeActions(BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
-            LaunchModeBuildItem launchModeBuildItem) {
+            LaunchModeBuildItem launchModeBuildItem, DevUIConfig config) {
 
         if (launchModeBuildItem.getDevModeType().isPresent()
-                && launchModeBuildItem.getDevModeType().get().equals(DevModeType.LOCAL)) {
+                && launchModeBuildItem.getDevModeType().get().equals(DevModeType.LOCAL)
+                && config.allowExtensionManagement()) {
 
             BuildTimeActionBuildItem buildTimeActions = new BuildTimeActionBuildItem(NAMESPACE);
             getCategories(buildTimeActions);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -3,6 +3,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { RouterController } from 'router-controller';
 import { devuiState } from 'devui-state';
 import { observeState } from 'lit-element-state';
+import { allowExtensionManagement } from 'devui-data';
 import 'qwc/qwc-extension.js';
 import 'qwc/qwc-extension-link.js';
 import 'qwc/qwc-extension-add.js';
@@ -96,14 +97,16 @@ export class QwcExtensions extends observeState(LitElement) {
     connectedCallback() {
         super.connectedCallback();
         window.addEventListener('extensions-filters-changed', this._onFiltersChanged);
-        this.jsonRpc.getInstalledNamespaces().then(jsonRpcResponse => {
-            if (jsonRpcResponse.result) {
-                this._installedExtensions = jsonRpcResponse.result;
-                this._addExtensionsEnabled = true;
-            }
-        }).catch(e => {
-            notifier.showErrorMessage("Could not list namespaces "+ e?.error?.message);
-        });
+        if (allowExtensionManagement) {
+            this.jsonRpc.getInstalledNamespaces().then(jsonRpcResponse => {
+                if (jsonRpcResponse.result) {
+                    this._installedExtensions = jsonRpcResponse.result;
+                    this._addExtensionsEnabled = true;
+                }
+            }).catch(e => {
+                notifier.showErrorMessage("Could not list namespaces "+ e?.error?.message);
+            });
+        }
     }
 
     disconnectedCallback() {


### PR DESCRIPTION
This config `quarkus.dev-ui.allow-extension-management=false` will disable the extension management feature in dev ui

- Closes: #47026