### PR TITLE
Respect annotation configuration values when comparing test resources

### DIFF
--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/WithListEndTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/WithListEndTest.java
@@ -8,16 +8,16 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @CustomResourceWithList
 @QuarkusTest
-public class StartTestWithList {
+public class WithListEndTest {
 
     @Test
     public void test1() {
-        assertTrue(Counter.startCounter.get() <= 1);
+        assertTrue(Counter.endCounter.get() <= 1);
     }
 
     @Test
     public void test2() {
-        assertTrue(Counter.startCounter.get() <= 1);
+        assertTrue(Counter.endCounter.get() <= 1);
     }
 
 }

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/WithListStartTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/WithListStartTest.java
@@ -8,16 +8,16 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @CustomResourceWithList
 @QuarkusTest
-public class EndTestWithList {
+public class WithListStartTest {
 
     @Test
     public void test1() {
-        assertTrue(Counter.endCounter.get() <= 1);
+        assertTrue(Counter.startCounter.get() <= 1);
     }
 
     @Test
     public void test2() {
-        assertTrue(Counter.endCounter.get() <= 1);
+        assertTrue(Counter.startCounter.get() <= 1);
     }
 
 }

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/ConfigurableLifecycleManager.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/ConfigurableLifecycleManager.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.extension.configurable;
+
+import java.util.Map;
+
+import io.quarkus.it.extension.Counter;
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+
+public class ConfigurableLifecycleManager
+        implements QuarkusTestResourceConfigurableLifecycleManager<CustomResourceWithAttribute> {
+
+    String attributeValue;
+
+    @Override
+    public void init(CustomResourceWithAttribute annotation) {
+        attributeValue = annotation.value();
+    }
+
+    @Override
+    public Map<String, String> start() {
+        Counter.startCounter.incrementAndGet();
+        return Map.of("attributeValue", attributeValue);
+    }
+
+    @Override
+    public void stop() {
+        Counter.endCounter.incrementAndGet();
+    }
+
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/CustomResourceWithAttribute.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/CustomResourceWithAttribute.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.extension.configurable;
+
+import java.lang.annotation.*;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import io.quarkus.test.common.QuarkusTestResource;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@QuarkusTestResource(ConfigurableLifecycleManager.class)
+@Stereotype
+public @interface CustomResourceWithAttribute {
+
+    String value();
+
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/WithAttributeEndTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/WithAttributeEndTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.extension.configurable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.extension.Counter;
+import io.quarkus.test.junit.QuarkusTest;
+
+@CustomResourceWithAttribute(value = "bar")
+@QuarkusTest
+public class WithAttributeEndTest {
+
+    @Test
+    public void test1() {
+        assertEquals("bar", ConfigProvider.getConfig().getValue("attributeValue", String.class));
+        assertTrue(Counter.endCounter.get() <= 1);
+    }
+
+    @Test
+    public void test2() {
+        assertTrue(Counter.endCounter.get() <= 1);
+    }
+
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/WithAttributeStartTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/configurable/WithAttributeStartTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.extension.configurable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.extension.Counter;
+import io.quarkus.test.junit.QuarkusTest;
+
+@CustomResourceWithAttribute(value = "foo")
+@QuarkusTest
+public class WithAttributeStartTest {
+
+    @Test
+    public void test1() {
+        assertEquals("foo", ConfigProvider.getConfig().getValue("attributeValue", String.class));
+        assertTrue(Counter.startCounter.get() <= 1);
+    }
+
+    @Test
+    public void test2() {
+        assertTrue(Counter.startCounter.get() <= 1);
+    }
+
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestResourceUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestResourceUtil.java
@@ -243,7 +243,7 @@ public final class TestResourceUtil {
                         testResourceScope = TestResourceScope.valueOf(originalTestResourceScope.toString());
                     }
                     Object originalArgs = entry.getClass().getMethod("args").invoke(entry);
-                    Map<String, String> args = (Map<String, String>) originalArgs;
+                    Map<String, Object> args = (Map<String, Object>) originalArgs;
                     result.add(new TestResourceManager.TestResourceComparisonInfo(testResourceLifecycleManagerClass,
                             testResourceScope, args));
                 }


### PR DESCRIPTION
Comparing custom test resources should take annotation attributes into account.
Relates to https://github.com/quarkusio/quarkus/issues/44129, https://github.com/quarkusio/quarkus/pull/44324 and https://github.com/quarkusio/quarkus/pull/44215

- Fixes: https://github.com/quarkusio/quarkus/issues/48238