### PR TITLE
Add OIDC GitHub wiremock credential provider test

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -992,8 +992,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             try {
                 json = OidcUtils.decryptJson(parsedStateCookieValue[1], configContext.getStateCookieEncryptionKey());
             } catch (Exception ex) {
-                LOG.errorf("State cookie value can not be decrypted for the %s tenant",
-                        configContext.oidcConfig().tenantId().get());
+                LOG.errorf("State cookie value for the %s tenant can not be decrypted: %s",
+                        configContext.oidcConfig().tenantId().get(), ex.getMessage());
                 throw new AuthenticationCompletionException(ex);
             }
             bean.setRestorePath(json.getString(OidcUtils.STATE_COOKIE_RESTORE_PATH));
@@ -1234,7 +1234,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             try {
                 return OidcUtils.encryptJson(json, configContext.getStateCookieEncryptionKey());
             } catch (Exception ex) {
-                LOG.errorf("State containing the code verifier can not be encrypted: %s", ex.getMessage());
+                LOG.errorf("State cookie value for the %s tenant can not be encrypted: %s",
+                        configContext.oidcConfig().tenantId().get(), ex.getMessage());
                 throw new AuthenticationCompletionException(ex);
             }
         } else {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SecretProvider.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SecretProvider.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Collections;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+import io.quarkus.credentials.CredentialsProvider;
+
+@ApplicationScoped
+@Named("vault-secret-provider")
+public class SecretProvider implements CredentialsProvider {
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        return Collections.singletonMap("secret-from-vault",
+                "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -126,7 +126,8 @@ quarkus.oidc.code-flow-user-info-github-cache-disabled.user-info-path=protocol/o
 quarkus.oidc.code-flow-user-info-github-cache-disabled.code-grant.extra-params.extra-param=extra-param-value
 quarkus.oidc.code-flow-user-info-github-cache-disabled.code-grant.headers.X-Custom=XCustomHeaderValue
 quarkus.oidc.code-flow-user-info-github-cache-disabled.client-id=quarkus-web-app
-quarkus.oidc.code-flow-user-info-github-cache-disabled.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.oidc.code-flow-user-info-github-cache-disabled.credentials.client-secret.provider.name=vault-secret-provider
+quarkus.oidc.code-flow-user-info-github-cache-disabled.credentials.client-secret.provider.key=secret-from-vault
 quarkus.oidc.code-flow-user-info-github-cache-disabled.cache-user-info-in-idtoken=false
 quarkus.oidc.code-flow-user-info-github-cache-disabled.allow-user-info-cache=false
 


### PR DESCRIPTION
Fixes #48218

After a few rounds of trying to find the cause of the problem for #48218, it proved to be a configuration property typo.

The expanded config talks about it [here](https://quarkus.io/guides/security-oidc-expanded-configuration#client-secret).

I added a test to confirm that `quarkus.oidc.provider=` blocks work with the Credential Provider, and updated the log messages related to the state cookie encryption/decryption be consistent, with both the tenant id and error message now reported in both cases.
