### PR TITLE
Add Maven 4 resolver support with backward compatibility

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/pom.xml
@@ -76,6 +76,17 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-maven4-resolver</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
         </dependency>

--- a/independent-projects/bootstrap/maven4-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven4-resolver/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-bootstrap-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-bootstrap-maven4-resolver</artifactId>
+    <name>Quarkus - Bootstrap - Maven 4 Resolver</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.inject</artifactId>
+            <version>0.9.0.M3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>4.0.0-rc-3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/independent-projects/bootstrap/maven4-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapArtifactTransformer.java
+++ b/independent-projects/bootstrap/maven4-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapArtifactTransformer.java
@@ -1,0 +1,13 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.aether.spi.artifact.transformer.ArtifactTransformer;
+import org.eclipse.sisu.Priority;
+
+@Singleton
+@Named
+@Priority(100)
+public class BootstrapArtifactTransformer implements ArtifactTransformer {
+}

--- a/independent-projects/bootstrap/maven4-resolver/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/independent-projects/bootstrap/maven4-resolver/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,13 @@
+org.apache.maven.repository.internal.DefaultArtifactDescriptorReader
+org.apache.maven.repository.internal.DefaultModelCacheFactory
+org.apache.maven.repository.internal.DefaultModelVersionParser
+org.apache.maven.repository.internal.DefaultVersionRangeResolver
+org.apache.maven.repository.internal.DefaultVersionResolver
+org.apache.maven.repository.internal.DefaultVersionSchemeProvider
+org.apache.maven.repository.internal.PluginsMetadataGeneratorFactory
+org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory
+org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory
+org.apache.maven.repository.internal.relocation.DistributionManagementArtifactRelocationSource
+org.apache.maven.repository.internal.relocation.UserPropertiesArtifactRelocationSource
+org.apache.maven.repository.internal.type.DefaultTypeProvider
+io.quarkus.bootstrap.resolver.maven.BootstrapArtifactTransformer

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -79,6 +79,7 @@
         <module>bom</module>
         <module>bom-test</module>
         <module>app-model</module>
+        <module>maven4-resolver</module>
         <module>maven-resolver</module>
         <module>core</module>
         <module>runner</module>


### PR DESCRIPTION
This commit introduces a Maven 4 resolver implementation that:

- Creates a separate maven4-resolver module that depends on Maven 4
- Implements BootstrapArtifactTransformer for Maven Resolver 2.x compatibility
- Uses Sisu component discovery to handle missing interfaces gracefully
- Maintains Maven 3.x behavior unchanged (uses Resolver 1.x)
- Provides explicit Sisu component registration via META-INF/sisu/javax.inject.Named
  to replace the deprecated Sisu index in Maven 4

The resolver will automatically ignore components that cannot be loaded due to
missing interfaces (like ArtifactTransformer), ensuring compatibility across
different Maven versions without affecting existing Maven 3.x functionality.

- Closes: #37627