### PR TITLE
Move version management of forbiddenapis plugin to the root pom

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -136,9 +136,6 @@
         <!-- The message that is appended to the end of the plugin error output when the API problems fail the build -->
         <revapi.buildFailureMessage>Run "jbang revapi-update" to update api-changes.xml file and also add the justification for those changes in that file.</revapi.buildFailureMessage>
 
-        <!-- Forbidden API checks -->
-        <forbiddenapis-maven-plugin.version>3.4</forbiddenapis-maven-plugin.version>
-
         <!-- platform properties - this is a floating tag -->
         <platform.quarkus.native.builder-image>mandrel</platform.quarkus.native.builder-image>
 
@@ -622,7 +619,6 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>${forbiddenapis-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>verify-forbidden-apis</id>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -43,6 +43,8 @@
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.versions.plugin>2.18.0</version.versions.plugin>
         <version.yaml-properties.plugin>1.1.3</version.yaml-properties.plugin>
+        <!-- Forbidden API checks -->
+        <version.forbiddenapis-maven-plugin>3.4</version.forbiddenapis-maven-plugin>
 
         <!-- Code format -->
         <format.skip>false</format.skip>
@@ -432,6 +434,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${version.versions.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>de.thetaphi</groupId>
+                    <artifactId>forbiddenapis</artifactId>
+                    <version>${version.forbiddenapis-maven-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -71,9 +71,6 @@
         <mockito.version>5.18.0</mockito.version>
         <wiremock.version>3.13.0</wiremock.version>
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
-
-        <!-- Forbidden API checks -->
-        <forbiddenapis-maven-plugin.version>3.4</forbiddenapis-maven-plugin.version>
     </properties>
 
     <modules>
@@ -502,7 +499,6 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>${forbiddenapis-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>verify-forbidden-apis</id>


### PR DESCRIPTION
I kept getting this warning:

```java
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.quarkus.arc:arc-processor:jar:999-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for de.thetaphi:forbiddenapis is missing. @ line 68, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

This should allow independent projects to also use the plugin when/if necessary... (and also align the version with the other  part of the build)