### PR TITLE
JWT dev mode keys: add two build items to customise

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/GenerateEncryptedDevModeJwtKeysBuildItem.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/GenerateEncryptedDevModeJwtKeysBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.smallrye.jwt.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker build item to enable encrypted dev/test jwt keys.
+ */
+public final class GenerateEncryptedDevModeJwtKeysBuildItem extends SimpleBuildItem {
+}

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/GeneratePersistentDevModeJwtKeysBuildItem.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/GeneratePersistentDevModeJwtKeysBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.smallrye.jwt.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker build item to enable restart-persistent jwt keys.
+ */
+public final class GeneratePersistentDevModeJwtKeysBuildItem extends SimpleBuildItem {
+}

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
@@ -2,37 +2,49 @@ package io.quarkus.smallrye.jwt.deployment;
 
 import static io.quarkus.smallrye.jwt.deployment.SmallRyeJwtProcessor.MP_JWT_VERIFY_KEY_LOCATION;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
+import io.quarkus.bootstrap.workspace.ArtifactSources;
+import io.quarkus.bootstrap.workspace.SourceDir;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.smallrye.jwt.util.KeyUtils;
 
 public class SmallryeJwtDevModeProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(SmallryeJwtDevModeProcessor.class);
 
-    private static final String MP_JWT_VERIFY_PUBLIC_KEY = "mp.jwt.verify.publickey";
+    public static final String MP_JWT_VERIFY_PUBLIC_KEY = "mp.jwt.verify.publickey";
     private static final String MP_JWT_VERIFY_ISSUER = "mp.jwt.verify.issuer";
+    private static final String SMALLRYE_JWT_DECRYPT_KEY = "smallrye.jwt.decrypt.key"; // no MP equivalent
     private static final String MP_JWT_DECRYPT_KEY_LOCATION = "mp.jwt.decrypt.key.location";
 
     private static final String SMALLRYE_JWT_NEW_TOKEN_ISSUER = "smallrye.jwt.new-token.issuer";
     private static final String SMALLRYE_JWT_SIGN_KEY_LOCATION = "smallrye.jwt.sign.key.location";
-    private static final String SMALLRYE_JWT_SIGN_KEY = "smallrye.jwt.sign.key";
+    public static final String SMALLRYE_JWT_SIGN_KEY = "smallrye.jwt.sign.key";
+    private static final String SMALLRYE_JWT_ENCRYPT_KEY = "smallrye.jwt.encrypt.key";
     private static final String SMALLRYE_JWT_ENCRYPT_KEY_LOCATION = "smallrye.jwt.encrypt.key.location";
 
     private static final String NONE = "NONE";
@@ -43,10 +55,14 @@ public class SmallryeJwtDevModeProcessor {
     private static final Set<String> JWT_SIGN_KEY_PROPERTIES = Set.of(
             MP_JWT_VERIFY_KEY_LOCATION,
             MP_JWT_VERIFY_PUBLIC_KEY,
+            SMALLRYE_JWT_DECRYPT_KEY,
             MP_JWT_DECRYPT_KEY_LOCATION,
             SMALLRYE_JWT_SIGN_KEY_LOCATION,
             SMALLRYE_JWT_SIGN_KEY,
+            SMALLRYE_JWT_ENCRYPT_KEY,
             SMALLRYE_JWT_ENCRYPT_KEY_LOCATION);
+    public static final String DEV_PRIVATE_KEY_PEM = "dev.privateKey.pem";
+    public static final String DEV_PUBLIC_KEY_PEM = "dev.publicKey.pem";
 
     /**
      * This build step generates an RSA-256 key pair for development and test modes.
@@ -58,10 +74,15 @@ public class SmallryeJwtDevModeProcessor {
      * this build step will add a default issuer, regardless of the above condition.
      *
      * @throws NoSuchAlgorithmException if RSA-256 key generation fails.
+     * @throws IOException if persistent key storage fails
      */
     @BuildStep(onlyIfNot = { IsNormal.class })
     void generateSignKeys(BuildProducer<DevServicesResultBuildItem> devServices,
-            LiveReloadBuildItem liveReloadBuildItem) throws NoSuchAlgorithmException {
+            LiveReloadBuildItem liveReloadBuildItem,
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            Optional<GeneratePersistentDevModeJwtKeysBuildItem> generatePersistentDevModeJwtKeysBuildItem,
+            Optional<GenerateEncryptedDevModeJwtKeysBuildItem> generateEncryptedDevModeJwtKeysBuildItem)
+            throws GeneralSecurityException, IOException {
 
         Set<String> userProps = JWT_SIGN_KEY_PROPERTIES
                 .stream()
@@ -71,7 +92,8 @@ public class SmallryeJwtDevModeProcessor {
         if (!userProps.isEmpty()) {
             // If the user has set the property, we need to avoid adding or overriding it with the
             // smallrye default configuration
-            Map<String, String> devServiceProps = addDefaultSmallryePropertiesIfMissing(userProps);
+            Map<String, String> devServiceProps = addDefaultSmallryePropertiesIfMissing(userProps,
+                    generateEncryptedDevModeJwtKeysBuildItem);
 
             if (!isConfigPresent(MP_JWT_VERIFY_ISSUER) && !isConfigPresent(SMALLRYE_JWT_NEW_TOKEN_ISSUER)) {
                 devServiceProps.put(MP_JWT_VERIFY_ISSUER, DEFAULT_ISSUER);
@@ -88,11 +110,12 @@ public class SmallryeJwtDevModeProcessor {
                 "Please ensure the correct keys/locations are set in production to avoid potential issues.");
         if (ctx == null && !liveReloadBuildItem.isLiveReload()) {
             // first execution
-            KeyPair keyPair = KeyUtils.generateKeyPair(KEY_SIZE);
+            KeyPair keyPair = generateOrReloadKeyPair(curateOutcomeBuildItem, generatePersistentDevModeJwtKeysBuildItem);
             String publicKey = getStringKey(keyPair.getPublic());
             String privateKey = getStringKey(keyPair.getPrivate());
 
-            Map<String, String> devServiceProps = generateDevServiceProperties(publicKey, privateKey);
+            Map<String, String> devServiceProps = generateDevServiceProperties(publicKey, privateKey,
+                    generateEncryptedDevModeJwtKeysBuildItem);
 
             if (!isConfigPresent(MP_JWT_VERIFY_ISSUER) && !isConfigPresent(SMALLRYE_JWT_NEW_TOKEN_ISSUER)) {
                 devServiceProps.put(MP_JWT_VERIFY_ISSUER, DEFAULT_ISSUER);
@@ -110,7 +133,67 @@ public class SmallryeJwtDevModeProcessor {
         }
     }
 
-    private Map<String, String> addDefaultSmallryePropertiesIfMissing(Set<String> userConfigs) {
+    private KeyPair generateOrReloadKeyPair(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            Optional<GeneratePersistentDevModeJwtKeysBuildItem> generatePersistentDevModeJwtKeysBuildItem)
+            throws GeneralSecurityException, IOException {
+        if (generatePersistentDevModeJwtKeysBuildItem.isPresent()) {
+            File buildDir = getBuildDir(curateOutcomeBuildItem);
+
+            buildDir.mkdirs();
+            File privateKey = new File(buildDir, DEV_PRIVATE_KEY_PEM);
+            File publicKey = new File(buildDir, DEV_PUBLIC_KEY_PEM);
+            if (!privateKey.exists() || !publicKey.exists()) {
+                KeyPair keyPair = KeyUtils.generateKeyPair(KEY_SIZE);
+                LOGGER.infof("Generating private/public keys for DEV/TEST in %s and %s", privateKey, publicKey);
+                try (FileWriter fw = new FileWriter(privateKey)) {
+                    fw.append("-----BEGIN PRIVATE KEY-----\n");
+                    fw.append(Base64.getMimeEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
+                    fw.append("\n");
+                    fw.append("-----END PRIVATE KEY-----\n");
+                }
+                try (FileWriter fw = new FileWriter(publicKey)) {
+                    fw.append("-----BEGIN PUBLIC KEY-----\n");
+                    fw.append(Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+                    fw.append("\n");
+                    fw.append("-----END PUBLIC KEY-----\n");
+                }
+                return keyPair;
+            } else {
+                // read from disk
+                return new KeyPair(KeyUtils.readPublicKey(publicKey.getName()),
+                        KeyUtils.readPrivateKey(privateKey.getName()));
+            }
+        } else {
+            return KeyUtils.generateKeyPair(KEY_SIZE);
+        }
+    }
+
+    public static File getBuildDir(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        File buildDir = null;
+        ArtifactSources src = curateOutcomeBuildItem.getApplicationModel().getAppArtifact().getSources();
+        if (src != null) { // shouldn't be null in dev mode
+            Collection<SourceDir> srcDirs = src.getResourceDirs();
+            if (srcDirs.isEmpty()) {
+                // if the module has no resources dir?
+                srcDirs = src.getSourceDirs();
+            }
+            if (!srcDirs.isEmpty()) {
+                // pick the first resources output dir
+                Path resourcesOutputDir = srcDirs.iterator().next().getOutputDir();
+                buildDir = resourcesOutputDir.toFile();
+            }
+        }
+        if (buildDir == null) {
+            // the module doesn't have any sources nor resources, stick to the build dir
+            buildDir = new File(
+                    curateOutcomeBuildItem.getApplicationModel().getAppArtifact().getWorkspaceModule().getBuildDir(),
+                    "classes");
+        }
+        return buildDir;
+    }
+
+    private Map<String, String> addDefaultSmallryePropertiesIfMissing(Set<String> userConfigs,
+            Optional<GenerateEncryptedDevModeJwtKeysBuildItem> generateEncryptedDevModeJwtKeysBuildItem) {
         HashMap<String, String> devServiceConfigs = new HashMap<>();
         if (!userConfigs.contains(SMALLRYE_JWT_SIGN_KEY)) {
             devServiceConfigs.put(SMALLRYE_JWT_SIGN_KEY, NONE);
@@ -118,6 +201,16 @@ public class SmallryeJwtDevModeProcessor {
 
         if (!userConfigs.contains(MP_JWT_VERIFY_PUBLIC_KEY)) {
             devServiceConfigs.put(MP_JWT_VERIFY_PUBLIC_KEY, NONE);
+        }
+
+        if (generateEncryptedDevModeJwtKeysBuildItem.isPresent()) {
+            if (!userConfigs.contains(SMALLRYE_JWT_ENCRYPT_KEY) && !userConfigs.contains(SMALLRYE_JWT_ENCRYPT_KEY_LOCATION)) {
+                devServiceConfigs.put(SMALLRYE_JWT_ENCRYPT_KEY, NONE);
+            }
+
+            if (!userConfigs.contains(SMALLRYE_JWT_DECRYPT_KEY) && !userConfigs.contains(MP_JWT_DECRYPT_KEY_LOCATION)) {
+                devServiceConfigs.put(SMALLRYE_JWT_DECRYPT_KEY, NONE);
+            }
         }
 
         return devServiceConfigs;
@@ -133,10 +226,15 @@ public class SmallryeJwtDevModeProcessor {
                 Feature.SMALLRYE_JWT.name(), null, properties);
     }
 
-    private static Map<String, String> generateDevServiceProperties(String publicKey, String privateKey) {
+    private static Map<String, String> generateDevServiceProperties(String publicKey, String privateKey,
+            Optional<GenerateEncryptedDevModeJwtKeysBuildItem> generateEncryptedDevModeJwtKeysBuildItem) {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(MP_JWT_VERIFY_PUBLIC_KEY, publicKey);
         properties.put(SMALLRYE_JWT_SIGN_KEY, privateKey);
+        if (generateEncryptedDevModeJwtKeysBuildItem.isPresent()) {
+            properties.put(SMALLRYE_JWT_ENCRYPT_KEY, publicKey);
+            properties.put(SMALLRYE_JWT_DECRYPT_KEY, privateKey);
+        }
         return properties;
     }
 

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentColdStartupEncryptedTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentColdStartupEncryptedTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.jwt.test.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.jwt.test.GreetingResource;
+import io.quarkus.smallrye.jwt.deployment.GenerateEncryptedDevModeJwtKeysBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.smallrye.jwt.build.Jwt;
+
+public class SmallryeJwtPersistentColdStartupEncryptedTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(GreetingResource.class,
+                            SmallryeJwtPersistentColdStartupSignedTest.PersistentJwtColdStartupChainBuilder.class))
+            .addBuildChainCustomizer(new SmallryeJwtPersistentColdStartupSignedTest.PersistentJwtColdStartupChainBuilder() {
+                @Override
+                public void accept(BuildChainBuilder chain) {
+                    super.accept(chain);
+                    chain.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            context.produce(new GenerateEncryptedDevModeJwtKeysBuildItem());
+                        }
+                    })
+                            .produces(GenerateEncryptedDevModeJwtKeysBuildItem.class)
+                            .build();
+                }
+            });
+
+    @Test
+    void canBeEncrypted() {
+        // make sure we can sign JWT tokens recognised by the server, since they use the same config
+        String token = Jwt.upn("jdoe@quarkus.io")
+                .groups("User")
+                .innerSign().encrypt();
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200);
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentColdStartupSignedTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentColdStartupSignedTest.java
@@ -1,0 +1,140 @@
+package io.quarkus.jwt.test.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.jwt.test.GreetingResource;
+import io.quarkus.smallrye.jwt.deployment.GeneratePersistentDevModeJwtKeysBuildItem;
+import io.quarkus.smallrye.jwt.deployment.SmallryeJwtDevModeProcessor;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.smallrye.jwt.build.Jwt;
+import io.smallrye.jwt.util.ResourceUtils;
+
+public class SmallryeJwtPersistentColdStartupSignedTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreetingResource.class))
+            .addBuildChainCustomizer(new PersistentJwtColdStartupChainBuilder());
+
+    static class PersistentJwtColdStartupChainBuilder implements Consumer<BuildChainBuilder> {
+        @Override
+        public void accept(BuildChainBuilder chain) {
+            chain.addBuildStep(new BuildStep() {
+                @Override
+                public void execute(BuildContext context) {
+                    CurateOutcomeBuildItem curateOutcomeBuildItem = context.consume(CurateOutcomeBuildItem.class);
+                    File buildDir = SmallryeJwtDevModeProcessor.getBuildDir(curateOutcomeBuildItem);
+                    File privateKeyFile = new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PRIVATE_KEY_PEM);
+                    File publicKeyFile = new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PUBLIC_KEY_PEM);
+                    // make sure the files still exist
+                    assertThat(privateKeyFile).exists();
+                    assertThat(publicKeyFile).exists();
+                    try {
+                        // make sure they are the same as the original keys
+                        assertThat(Files.readString(privateKeyFile.toPath()))
+                                .isEqualTo(new String(
+                                        ResourceUtils
+                                                .readBytes(ResourceUtils.getAsClasspathResource("/jwtPrivateKey.pem")),
+                                        StandardCharsets.UTF_8));
+                        assertThat(Files.readString(publicKeyFile.toPath()))
+                                .isEqualTo(new String(
+                                        ResourceUtils
+                                                .readBytes(ResourceUtils.getAsClasspathResource("/jwtPublicKey.pem")),
+                                        StandardCharsets.UTF_8));
+                        // extract their keys
+                        String publicKey = Files.readAllLines(publicKeyFile.toPath())
+                                .stream().filter(l -> !l.startsWith("----"))
+                                .collect(Collectors.joining());
+                        String privateKey = Files.readAllLines(privateKeyFile.toPath())
+                                .stream().filter(l -> !l.startsWith("----"))
+                                .collect(Collectors.joining());
+                        List<RunTimeConfigurationDefaultBuildItem> buildItems = context
+                                .consumeMulti(RunTimeConfigurationDefaultBuildItem.class);
+                        // make sure we used them for configuration
+                        assertThat(buildItems)
+                                .filteredOn(
+                                        item -> item.getKey()
+                                                .equals(SmallryeJwtDevModeProcessor.MP_JWT_VERIFY_PUBLIC_KEY))
+                                .first()
+                                .extracting(s -> s.getValue())
+                                .isEqualTo(publicKey);
+                        assertThat(buildItems)
+                                .filteredOn(
+                                        item -> item.getKey().equals(SmallryeJwtDevModeProcessor.SMALLRYE_JWT_SIGN_KEY))
+                                .first()
+                                .extracting(s -> s.getValue())
+                                .isEqualTo(privateKey);
+                        context.produce(new FeatureBuildItem("dummy"));
+                    } catch (IOException x) {
+                        throw new UncheckedIOException(x);
+                    }
+                }
+            })
+                    .consumes(RunTimeConfigurationDefaultBuildItem.class)
+                    .consumes(CurateOutcomeBuildItem.class)
+                    .produces(FeatureBuildItem.class)
+                    .build();
+            chain.addBuildStep(new BuildStep() {
+                @Override
+                public void execute(BuildContext context) {
+                    // this is called before the JWT dev mode processor, so we can clean up here
+                    CurateOutcomeBuildItem curateOutcomeBuildItem = context.consume(CurateOutcomeBuildItem.class);
+                    File buildDir = SmallryeJwtDevModeProcessor.getBuildDir(curateOutcomeBuildItem);
+                    File privateKeyFile = new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PRIVATE_KEY_PEM);
+                    privateKeyFile.delete();
+                    File publicKeyFile = new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PUBLIC_KEY_PEM);
+                    publicKeyFile.delete();
+                    // re-create them with pre-existing keys
+                    try {
+                        Files.write(privateKeyFile.toPath(),
+                                ResourceUtils.readBytes(ResourceUtils.getAsClasspathResource("/jwtPrivateKey.pem")));
+                        Files.write(publicKeyFile.toPath(),
+                                ResourceUtils.readBytes(ResourceUtils.getAsClasspathResource("/jwtPublicKey.pem")));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    context.produce(new GeneratePersistentDevModeJwtKeysBuildItem());
+                }
+            })
+                    .produces(GeneratePersistentDevModeJwtKeysBuildItem.class)
+                    .consumes(CurateOutcomeBuildItem.class)
+                    .build();
+        }
+    }
+
+    @Test
+    void canBeSigned() {
+        // make sure we can sign JWT tokens recognised by the server, since they use the same config
+        String token = Jwt.upn("jdoe@quarkus.io")
+                .groups("User")
+                .sign();
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200);
+    }
+
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentDevModeEncryptedTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentDevModeEncryptedTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.jwt.test.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.jwt.test.GreetingResource;
+import io.quarkus.smallrye.jwt.deployment.GenerateEncryptedDevModeJwtKeysBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.smallrye.jwt.build.Jwt;
+
+public class SmallryeJwtPersistentDevModeEncryptedTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(GreetingResource.class, SmallryeJwtPersistentDevModeSignedTest.PersistentJwtChainBuilder.class))
+            .addBuildChainCustomizer(new SmallryeJwtPersistentDevModeSignedTest.PersistentJwtChainBuilder() {
+                @Override
+                public void accept(BuildChainBuilder chain) {
+                    super.accept(chain);
+                    chain.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            context.produce(new GenerateEncryptedDevModeJwtKeysBuildItem());
+                        }
+                    })
+                            .produces(GenerateEncryptedDevModeJwtKeysBuildItem.class)
+                            .build();
+                }
+            });
+
+    @Test
+    void canBeEncrypted() {
+        // make sure we can sign JWT tokens recognised by the server, since they use the same config
+        String token = Jwt.upn("jdoe@quarkus.io")
+                .groups("User")
+                .innerSign().encrypt();
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200);
+    }
+
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentDevModeSignedTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtPersistentDevModeSignedTest.java
@@ -1,0 +1,115 @@
+package io.quarkus.jwt.test.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.jwt.test.GreetingResource;
+import io.quarkus.smallrye.jwt.deployment.GeneratePersistentDevModeJwtKeysBuildItem;
+import io.quarkus.smallrye.jwt.deployment.SmallryeJwtDevModeProcessor;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.smallrye.jwt.build.Jwt;
+
+public class SmallryeJwtPersistentDevModeSignedTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(GreetingResource.class))
+            .addBuildChainCustomizer(new PersistentJwtChainBuilder());
+
+    static class PersistentJwtChainBuilder implements Consumer<BuildChainBuilder> {
+        @Override
+        public void accept(BuildChainBuilder chain) {
+            chain.addBuildStep(new BuildStep() {
+                @Override
+                public void execute(BuildContext context) {
+                    CurateOutcomeBuildItem curateOutcomeBuildItem = context.consume(CurateOutcomeBuildItem.class);
+                    File buildDir = SmallryeJwtDevModeProcessor.getBuildDir(curateOutcomeBuildItem);
+                    File privateKeyFile = new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PRIVATE_KEY_PEM);
+                    File publicKeyFile = new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PUBLIC_KEY_PEM);
+                    // make sure the files were created
+                    assertThat(privateKeyFile).exists();
+                    assertThat(publicKeyFile).exists();
+                    try {
+                        // extract their keys
+                        String publicKey = Files.readAllLines(publicKeyFile.toPath())
+                                .stream().filter(l -> !l.startsWith("----"))
+                                .collect(Collectors.joining());
+                        String privateKey = Files.readAllLines(privateKeyFile.toPath())
+                                .stream().filter(l -> !l.startsWith("----"))
+                                .collect(Collectors.joining());
+                        List<RunTimeConfigurationDefaultBuildItem> buildItems = context
+                                .consumeMulti(RunTimeConfigurationDefaultBuildItem.class);
+                        // make sure we used them for configuration
+                        assertThat(buildItems)
+                                .filteredOn(
+                                        item -> item.getKey()
+                                                .equals(SmallryeJwtDevModeProcessor.MP_JWT_VERIFY_PUBLIC_KEY))
+                                .first()
+                                .extracting(s -> s.getValue())
+                                .isEqualTo(publicKey);
+                        assertThat(buildItems)
+                                .filteredOn(
+                                        item -> item.getKey().equals(SmallryeJwtDevModeProcessor.SMALLRYE_JWT_SIGN_KEY))
+                                .first()
+                                .extracting(s -> s.getValue())
+                                .isEqualTo(privateKey);
+                        context.produce(new FeatureBuildItem("dummy"));
+                    } catch (IOException x) {
+                        throw new UncheckedIOException(x);
+                    }
+                }
+            })
+                    .consumes(RunTimeConfigurationDefaultBuildItem.class)
+                    .consumes(CurateOutcomeBuildItem.class)
+                    .produces(FeatureBuildItem.class)
+                    .build();
+            chain.addBuildStep(new BuildStep() {
+                @Override
+                public void execute(BuildContext context) {
+                    // this is called before the JWT dev mode processor, so we can clean up here
+                    CurateOutcomeBuildItem curateOutcomeBuildItem = context.consume(CurateOutcomeBuildItem.class);
+                    File buildDir = SmallryeJwtDevModeProcessor.getBuildDir(curateOutcomeBuildItem);
+                    new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PRIVATE_KEY_PEM).delete();
+                    new File(buildDir, SmallryeJwtDevModeProcessor.DEV_PUBLIC_KEY_PEM).delete();
+                    context.produce(new GeneratePersistentDevModeJwtKeysBuildItem());
+                }
+            })
+                    .produces(GeneratePersistentDevModeJwtKeysBuildItem.class)
+                    .consumes(CurateOutcomeBuildItem.class)
+                    .build();
+        }
+    }
+
+    @Test
+    void canBeSigned() {
+        // make sure we can sign JWT tokens recognised by the server, since they use the same config
+        String token = Jwt.upn("jdoe@quarkus.io")
+                .groups("User")
+                .sign();
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200);
+    }
+}


### PR DESCRIPTION
- Allow encrypted JWT tokens
- Allow cold-restart-resistant keys

This allows Renarde to keep working after #44272 got released, because otherwise there's no way to disable these, and both Renarde and Quarkus end up generating keys, but not setting the same properties (Quarkus did not support encrypted JWT) and not the same features (Quarkus did not support cold-restart-resistent JWT keys).

So now I've moved support for this from Renarde to Quarkus, but made both features conditional on build items, this way, non-Renarde users keep the same behaviour, until one day anyone asks for this to be made standard.

I did consider using configuration keys for this, but it would defeat the purpose of this working OOTB for users.