### PR TITLE
Handle VS Code case and improve exception message for IDE test launch failures

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
@@ -67,6 +67,10 @@ public class CustomLauncherInterceptor implements LauncherDiscoveryListener, Lau
 
     @Override
     public void launcherDiscoveryStarted(LauncherDiscoveryRequest request) {
+        // If anything comes through this method for which there are non-null classloaders on the selectors, that will bypass our classloading
+        // To check that case, the code would be something like this. We could detect and warn early, and possibly even filter that test out, but that's not necessarily a better UX than failing later
+        // request.getSelectorsByType(ClassSelector.class).stream().map(ClassSelector::getClassLoader) ... and then check for non-emptiness on that field
+
         // Do not do any classloading dance for prod mode tests;
         if (!isProductionModeTests()) {
             initializeFacadeClassLoader();


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/48014 (well, sort of fixes it by improving error messages, and otherwise throwing up our hands).

Annoyingly, VS Code has the same problem as Eclipse, but fewer workarounds. We will have to hope the tooling updates to Eclipse 4.37 soonish, but September would be the earliest that train starts. In the interim, the only solution is helpful error messages. :/ 

VS Code:
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/97facd3a-a94e-4f71-ae5d-6d5b857c251e" />

Eclipse:

<img width="678" alt="image" src="https://github.com/user-attachments/assets/8e9f7610-2094-46ff-8863-cc1d3a228051" />

