### PR TITLE
Allow to update resolved OIDC dynamic tenant configurations

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -735,6 +735,97 @@ You can populate it by using any settings supported by the `quarkus-oidc` extens
 
 If the dynamic tenant resolver returns `null`, a <<static-tenant-resolution>> is attempted next.
 
+==== Update resolved dynamic tenant configuration
+
+It may be necessary to update the already resolved tenant configuration.
+For example, a client secret may have to be updated following a client secret update in the registered OIDC application.
+
+To update the configuration, use `OidcTenantConfigBuilder` to create a new instance of `OidcTenantConfig` and modify it as required before returning it:
+
+[source,java]
+----
+package org.acme;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.TenantConfigBean;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantConfigResolver implements TenantConfigResolver {
+
+    @Inject
+    TenantConfigBean tenantConfigBean;
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+
+        // Check request path or request context `tenant-id` property to determine the tenant id.
+
+        var currentTenantConfig = tenantConfigBean.getDynamicTenant("some-dynamic-tenant-id").getOidcTenantConfig(); <1>
+        if (currentTenantConfig != null
+            && "name".equals(currentTenantConfig.token().principalClaim().get())) { <2>
+            // This is an original configuration, update it now:
+            OidcTenantConfig updatedConfig = OidcTenantConfig.builder(currentTenantConfig) <3>
+                                .token().principalClaim("email").end()
+                                .build();
+
+            return Uni.createFrom().item(updatedConfig);
+        }
+        // create an initial configuration for the tenant
+        OidcTenantConfig config = OidcTenantConfig.builder() <4>
+                                .token().principalClaim("name").end()
+                                // set other properties
+                                .build();
+        return Uni.createFrom().item(config);
+    }
+}
+----
+<1> Use `io.quarkus.oidc.runtime.TenantConfigBean` to get the already resolved tenant configuration. Alternatively, you can use the tenant `OidcTenantConfig` cached in your resolver.
+<2> You may want to check if this configuration has already been updated, to avoid multiple redundant updates, for example, due to multliple redirects.
+<3> Use the resolved configuration to create a builder and update it as required.
+<4> Create an initial configuration if no configuration already exists.
+
+This is all you have to do update the already resolved dynamic tenantr configuration, without having to reconnect to the provider.
+
+If reconnecting is necessary, for example, the `UserInfo` endpoint address may have changed for the tenant to rediscover it,
+then simply set a `RoutingContext` `replace-tenant-configuration-context` property to `true`:
+
+[source,java]
+----
+@Override
+public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+    OidcTenantConfig updatedConfig = OidcTenantConfig.builder(currentTenantConfig)
+                                    .token().principalClaim("email").end()
+                                    .build();
+    context.put("replace-tenant-configuration-context", "true"); <1>
+
+    return Uni.createFrom().item(updatedConfig);
+}
+----
+<1> Replace the resolved tenant configuration and re-connect to the provider
+
+Finally, if you decide to update the resoved configuration while the existing OIDC session is still active, you may to have the session cookie removed and the user re-authenticated to align with the latest tenant configuration requirements. Set a `RoutingContext` `remove-session-cookie` property to `true` if it is necessary:
+
+[source,java]
+----
+@Override
+public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+    OidcTenantConfig updatedConfig = OidcTenantConfig.builder(currentTenantConfig)
+                                    .token().principalClaim("email").end()
+                                    .build();
+    context.put("remove-session-cookie", "true"); <1>
+
+    return Uni.createFrom().item(updatedConfig);
+}
+----
+<1> Update the tenant configuration, remove the session cookie and triger the user re-authentication. If possible, prefer to get the user log-out first, instead of triggering the re-authentication at the tenant resolution time.
+
 [[static-tenant-resolution]]
 === Static tenant configuration resolution
 
@@ -812,9 +903,9 @@ quarkus.oidc.b.tenant-paths=/*/hello <3>
 TIP: Path-matching mechanism works exactly same as in the xref:security-authorize-web-endpoints-reference.adoc#authorization-using-configuration[Authorization using configuration].
 
 [[default-tenant-resolver]]
-==== Use last request path segment as tenant id
+==== Use request path segments to find tenant id
 
-The default resolution for a tenant identifier is convention based, whereby the authentication request must include the tenant identifier in the last segment of the request path.
+The default resolution for a tenant identifier is convention based, whereby the authentication request must include the tenant identifier in one of the path segments of the request path.
 
 The following `application.properties` example shows how you can configure two tenants named `google` and `github`:
 
@@ -845,6 +936,7 @@ quarkus.http.auth.permission.login.policy=authenticated
 ----
 
 If the endpoint is running on `http://localhost:8080`, you can also provide UI options for users to log in to either `http://localhost:8080/google` or `http://localhost:8080/github`, without having to add specific `/google` or `/github` JAX-RS resource paths.
+
 Tenant identifiers are also recorded in the session cookie names after the authentication is completed.
 Therefore, authenticated users can access the secured application area without requiring either the `google` or `github` path values to be included in the secured URL.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -3035,11 +3035,9 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     }
 
     /**
-     * Creates {@link OidcTenantConfigBuilder} builder populated with {@code staticTenantMapping} values.
-     * You want to use this constructor when you have configured static tenant in the application.properties
-     * and your dynamic tenant only differ in a couple of the configuration properties.
+     * Creates {@link OidcTenantConfigBuilder} builder from the existing {@link io.quarkus.oidc.runtime.OidcTenantConfig}
      *
-     * @param mapping OidcTenantConfig created by the SmallRye Config; must not be null
+     * @param mapping existing io.quarkus.oidc.runtime.OidcTenantConfig
      */
     public static OidcTenantConfigBuilder builder(io.quarkus.oidc.runtime.OidcTenantConfig mapping) {
         return new OidcTenantConfigBuilder(mapping);
@@ -3049,7 +3047,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      * Creates {@link OidcTenantConfig} from the {@code mapping}. This method is more efficient than
      * the {@link #builder()} method if you don't need to modify the {@code mapping}.
      *
-     * @param mapping tenant config as returned from the SmallRye Config; must not be null
+     * @param mapping existing io.quarkus.oidc.runtime.OidcTenantConfig
      * @return OidcTenantConfig
      */
     public static OidcTenantConfig of(io.quarkus.oidc.runtime.OidcTenantConfig mapping) {
@@ -3057,7 +3055,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     }
 
     /**
-     * Creates {@link OidcTenantConfigBuilder} builder populated with documented default values.
+     * Creates {@link OidcTenantConfigBuilder} builder populated with documented default values and the provided base URL.
      *
      * @param authServerUrl {@link #authServerUrl()}
      * @return OidcTenantConfigBuilder builder
@@ -3067,7 +3065,8 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     }
 
     /**
-     * Creates {@link OidcTenantConfigBuilder} builder populated with documented default values.
+     * Creates {@link OidcTenantConfigBuilder} builder populated with documented default values and the provided client
+     * registration path.
      *
      * @param registrationPath {@link #registrationPath()}
      * @return OidcTenantConfigBuilder builder
@@ -3077,7 +3076,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     }
 
     /**
-     * Creates {@link OidcTenantConfigBuilder} builder populated with documented default values.
+     * Creates {@link OidcTenantConfigBuilder} builder populated with documented default values and the provided token path.
      *
      * @param tokenPath {@link #tokenPath()}
      * @return OidcTenantConfigBuilder builder

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantConfigResolver.java
@@ -11,6 +11,10 @@ import io.vertx.ext.web.RoutingContext;
  * Instead of implementing a {@link TenantResolver} that maps the tenant configuration based on an identifier and its
  * corresponding entry in the application configuration file, beans implementing this interface can dynamically construct the
  * tenant configuration without having to define each tenant in the application configuration file.
+ * <p>
+ * If the resolved tenant configuration must be updated, do not modify it in the resolver because it is not thread-safe.
+ * Use {@link OidcTenantConfig#builder(io.quarkus.oidc.runtime.OidcTenantConfig)} to copy the resolved configuration,
+ * modify it as required, and build a new configuration instance instead.
  */
 public interface TenantConfigResolver {
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -24,6 +24,7 @@ import io.quarkus.oidc.TokenIntrospectionCache;
 import io.quarkus.oidc.TokenStateManager;
 import io.quarkus.oidc.UserInfo;
 import io.quarkus.oidc.UserInfoCache;
+import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
@@ -37,6 +38,8 @@ public class DefaultTenantConfigResolver {
     private static final String CURRENT_STATIC_TENANT_ID = "static.tenant.id";
     private static final String CURRENT_STATIC_TENANT_ID_NULL = "static.tenant.id.null";
     private static final String CURRENT_DYNAMIC_TENANT_CONFIG = "dynamic.tenant.config";
+    private static final String REPLACE_TENANT_CONFIG_CONTEXT = "replace-tenant-configuration-context";
+    private static final String REMOVE_SESSION_COOKIE = "remove-session-cookie";
     private final ConcurrentHashMap<String, BackChannelLogoutTokenCache> backChannelLogoutTokens = new ConcurrentHashMap<>();
     private final BlockingTaskRunner<OidcTenantConfig> blockingRequestContext;
     private final boolean securityEventObserved;
@@ -259,13 +262,46 @@ public class DefaultTenantConfigResolver {
 
         return getDynamicTenantConfig(context).chain(new Function<OidcTenantConfig, Uni<? extends TenantConfigContext>>() {
             @Override
-            public Uni<? extends TenantConfigContext> apply(OidcTenantConfig tenantConfig) {
+            public Uni<TenantConfigContext> apply(OidcTenantConfig tenantConfig) {
                 if (tenantConfig != null) {
                     var tenantId = tenantConfig.tenantId()
                             .orElseThrow(() -> new OIDCException("Tenant configuration must have tenant id"));
                     var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                     if (tenantContext == null) {
                         return tenantConfigBean.createDynamicTenantContext(tenantConfig);
+                    } else if (tenantContext.getOidcTenantConfig() != tenantConfig) {
+
+                        Uni<TenantConfigContext> dynamicContextUni = null;
+                        if (Boolean.valueOf(context.get(REPLACE_TENANT_CONFIG_CONTEXT))) {
+                            // replace the context and reconnect
+                            dynamicContextUni = tenantConfigBean.replaceDynamicTenantContext(tenantConfig);
+                        } else {
+                            // update the context without reconnect
+                            dynamicContextUni = tenantConfigBean.updateDynamicTenantContext(tenantConfig);
+                        }
+                        final Uni<TenantConfigContext> contextUni = dynamicContextUni;
+                        if (Boolean.valueOf(context.get(REMOVE_SESSION_COOKIE))) {
+                            final String message = """
+                                    Requesting re-authentication for the tenant %s to align with the new dynamic tenant context requirements.
+                                    """
+                                    .formatted(tenantId);
+                            LOG.debug(message);
+                            // Clear the session cookie using the current configuration
+                            return Uni.createFrom().item(tenantContext.getOidcTenantConfig())
+                                    .chain(new Function<OidcTenantConfig, Uni<? extends Void>>() {
+                                        @Override
+                                        public Uni<Void> apply(OidcTenantConfig oidcConfig) {
+                                            OidcUtils.setClearSiteData(context, oidcConfig);
+                                            return OidcUtils.removeSessionCookie(context, oidcConfig, tokenStateManager.get());
+                                        }
+                                    })
+                                    // Deal with updating or replacing the dynamic context
+                                    .chain(() -> contextUni)
+                                    // Finally, request re-authentication
+                                    .onItem().failWith(() -> new AuthenticationFailedException(message));
+                        } else {
+                            return dynamicContextUni;
+                        }
                     } else {
                         return Uni.createFrom().item(tenantContext);
                     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc.runtime;
 
 import java.security.Key;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.crypto.SecretKey;
@@ -89,5 +90,10 @@ final class LazyTenantConfigContext implements TenantConfigContext {
     @Override
     public List<OidcRedirectFilter> getOidcRedirectFilters(Redirect.Location loc) {
         return delegate.getOidcRedirectFilters(loc);
+    }
+
+    @Override
+    public Map<Redirect.Location, List<OidcRedirectFilter>> getLocationToRedirectFilters() {
+        return delegate.getLocationToRedirectFilters();
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc.runtime;
 
 import java.security.Key;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.crypto.SecretKey;
@@ -41,6 +42,8 @@ public sealed interface TenantConfigContext permits TenantConfigContextImpl, Laz
     Key getTokenDecryptionKey();
 
     List<OidcRedirectFilter> getOidcRedirectFilters(Redirect.Location loc);
+
+    Map<Redirect.Location, List<OidcRedirectFilter>> getLocationToRedirectFilters();
 
     /**
      * Only static tenants that are not {@link #ready()} can and need to be initialized.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
@@ -81,6 +81,22 @@ final class TenantConfigContextImpl implements TenantConfigContext {
         tokenDecryptionKey = providerIsNoNull(provider) ? createTokenDecryptionKey(provider) : null;
     }
 
+    TenantConfigContextImpl(TenantConfigContext tenantConfigContext, OidcTenantConfig oidcConfig) {
+        this.oidcConfig = oidcConfig;
+        this.ready = tenantConfigContext.ready();
+        this.provider = tenantConfigContext.provider();
+        this.sessionCookieEncryptionKey = tenantConfigContext.getSessionCookieEncryptionKey();
+        this.stateCookieEncryptionKey = tenantConfigContext.getStateCookieEncryptionKey();
+        this.internalIdTokenSigningKey = tenantConfigContext.getInternalIdTokenSigningKey();
+        this.redirectFilters = tenantConfigContext.getLocationToRedirectFilters();
+        this.tokenDecryptionKey = tenantConfigContext.getTokenDecryptionKey();
+    }
+
+    @Override
+    public Map<Redirect.Location, List<OidcRedirectFilter>> getLocationToRedirectFilters() {
+        return redirectFilters;
+    }
+
     private static boolean providerIsNoNull(OidcProvider provider) {
         return provider != null && provider.client != null;
     }


### PR DESCRIPTION
Fixes #48216

This PR allows custom `TenantConfigResolver`s to indicate that `OidcTenantConfig` which it already resolved before must be updated by returning a new instance of `OidcTenantConfig`. Here is a summary of various changes:

1. Whenever `DefaultTenantConfigResolver` detects that the returned `OidcTenantConfig` for a given tenant is not the same instance as already resolved `OidcTenantConfig`, it goes ahead with updating the current `TenantConfigContext`
2. By default, the  current `TenantConfigContext`'s properties are safely reset, `without re-connecting` to the OIDC provider. This also covers the case where a custom resolver `returns a new instance on every request to represent the same tenant configuration` (even though, IMHO, it is rather unlikely to happen in prod).
3. IMHO, the way the default case is handled is a reasonable approach toward handing cases where a custom resolver returns a new instance on every request to represent the same tenant configuration, not only because it is quite unlikely to be a real prod case, but also because it is very cheap, possibly even more effective than complete `equals`.
4. Next case, when the instances are different, if when a resolver indicates with a property that a reconnection is required - this knowledge that it may be necessary is only available to the resolver
5. Finally,  if really needed, the resolver may also request cleaning the existing session cookie leading to a user re-authentication - though in this case, the updated docs recommend to logout the user first and only then deal with updating the resolved configuration.
6. `TenantConfigResolver` docs have been updated to tell users that they should not try to modify cached instances directly, and I'll look into protecting against such updates later
7. Tests added, one case where the configuration is updated without the reconnect, leading to the next request returning a different principal name; and another one leading to a reconnect with a session clean up, causing a discovery of the different UriInfo content and a user re-authentication.
8. OidcClientRegistrationTest: 2 tests were doing multiple client registrations in the client provider without checking if the registration was already complete, causing side-effects with the same tenant having different client ids during the same authorization code flow - it worked before because only the first created configuration was recognized. 

I think the default case at `2.` is likely to be a mainstream 85% case, the one with an optional reconnect at `4.` might take 10-15%.