### PR TITLE
RESTEasy Reactive Client: propagate declared exceptions

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -594,6 +594,11 @@ class RestClientReactiveProcessor {
                     //     return InterfaceClass.super.get();
                     // }
                     MethodCreator methodCreator = classCreator.getMethodCreator(MethodDescriptor.of(method));
+                    for (Type exception : method.exceptions()) {
+                        // declared exceptions are important in case the client is intercepted, because interception
+                        // subclasses wrap undeclared checked exceptions into `ArcUndeclaredThrowableException`
+                        methodCreator.addException(exception.name().toString());
+                    }
                     methodCreator.setSignature(method.genericSignatureIfRequired());
 
                     // copy method annotations, there can be interceptors bound to them:

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientWithExceptionMapperAndInterceptor.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientWithExceptionMapperAndInterceptor.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.rest.client.main;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.it.rest.client.main.MyResponseExceptionMapper.MyException;
+
+@Path("/unprocessable")
+@RegisterProvider(MyResponseExceptionMapper.class)
+@RegisterRestClient(configKey = "w-exception-mapper-and-interceptor")
+public interface ClientWithExceptionMapperAndInterceptor {
+    @GET
+    @Retry(maxRetries = 1, jitter = 0) // any interceptor would do here
+    String get() throws MyException;
+}

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 w-client-logger/mp-rest/url=${test.url}
 w-exception-mapper/mp-rest/url=${test.url}
+w-exception-mapper-and-interceptor/mp-rest/url=${test.url}
 w-fault-tolerance/mp-rest/url=${test.url}
 correlation/mp-rest/url=${test.url}
 io.quarkus.it.rest.client.main.ParamClient/mp-rest/url=${test.url}

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/CheckedExceptionWithInterceptionTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/CheckedExceptionWithInterceptionTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.rest.client;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.rest.client.main.ClientWithExceptionMapperAndInterceptor;
+import io.quarkus.it.rest.client.main.MyResponseExceptionMapper;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class CheckedExceptionWithInterceptionTest {
+    @Inject
+    @RestClient
+    ClientWithExceptionMapperAndInterceptor client;
+
+    @Test
+    public void test() {
+        assertThrows(MyResponseExceptionMapper.MyException.class, () -> {
+            client.get();
+        });
+    }
+}


### PR DESCRIPTION
RESTEasy Reactive Client generates a `$$CDIWrapper` class for each MP RestClient interface, which is then discovered by ArC. The generated classes however used to not declare any exceptions on methods, even if the interface did declare some. This is wrong at least in case the bean is intercepted (for example using MP Fault Tolerance), because undeclared checked exceptions are wrapped into `ArcUndeclaredThrowableException` by interception subclasses. This commit fixes that by propagating all exception types from the interface methods to the `$$CDIWrapper` methods.

Fixes #48286