### PR TITLE
Exclude Redis dev mode tests in dev mode to avoid classloading chaos

### DIFF
--- a/integration-tests/redis-devservices/src/main/resources/application.properties
+++ b/integration-tests/redis-devservices/src/main/resources/application.properties
@@ -3,3 +3,6 @@ quarkus.redis.health.enabled=true
 #quarkus.redis.devservices.image-name=redis:6.0-alpine
 #quarkus.redis.devservices.port=6377
 #quarkus.redis.devservices.enabled=true
+
+# When running this project itself in dev or test mode, don't try and layer in the dev mode tests
+quarkus.test.exclude-pattern=io.quarkus.redis.devservices.continuoustesting.it.*


### PR DESCRIPTION
As suggested by @ozangunalp. 

Avoids these errors:

```
2025-06-10 15:05:09,508 ERROR [io.qua.test] (Test runner thread) >>>>>>>>>>>>>>>>>>>> Summary: <<<<<<<<<<<<<<<<<<<<
testContinuousTestingReusesInstanceWhenPropertiesAreNotChanged() class io.quarkus.test.config.TestConfigProviderResolver cannot be cast to class io.quarkus.test.config.TestConfigProviderResolver (io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @24af801f; io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @46b15282)
DevServicesRedisContinuousTestingTest class io.quarkus.test.config.TestConfigProviderResolver cannot be cast to class io.quarkus.test.config.TestConfigProviderResolver (io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @24af801f; io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @46b15282)
testDevModeServiceDoesNotRestartContainersOnCodeChange() class io.quarkus.test.config.TestConfigProviderResolver cannot be cast to class io.quarkus.test.config.TestConfigProviderResolver (io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @24af801f; io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @46b15282)
testContinuousTestingDisablesDevServicesWhenPropertiesChange() class io.quarkus.test.config.TestConfigProviderResolver cannot be cast to class io.quarkus.test.config.TestConfigProviderResolver (io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @24af801f; io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @46b15282)
testContinuousTestingCreatesANewInstanceWhenPropertiesAreChanged() class io.quarkus.test.config.TestConfigProviderResolver cannot be cast to class io.quarkus.test.config.TestConfigProviderResolver (io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @24af801f; io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @46b15282)
testDevModeServiceUpdatesContainersOnConfigChange() class io.quarkus.test.config.TestConfigProviderResolver cannot be cast to class io.quarkus.test.config.TestConfigProviderResolver (io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @24af801f; io.quarkus.test.config.TestConfigProviderResolver is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @46b15282)
```

The errors aren't great, and ideally we'd fix them, but running continuous testing tests in continuous testing mode isn't something we'd normally expect to be able to do. 