### PR TITLE
3.20: Provide a temporary option to remove OIDC dynamic tenants

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -64,6 +64,17 @@ public final class TenantConfigBean {
         return dynamicTenantsConfig.get(tenantId);
     }
 
+    /**
+     * Remove dynamic tenant
+     *
+     * @param tenantId dynamic tenant id
+     * @return the removed dynamic tenant
+     */
+    @Deprecated(forRemoval = true)
+    public TenantConfigContext removeDynamicTenant(String tenantId) {
+        return dynamicTenantsConfig.remove(tenantId);
+    }
+
     public static class Destroyer implements BeanDestroyer<TenantConfigBean> {
 
         @Override


### PR DESCRIPTION
In #48199, @maag03 reported that it was not possible to `update already resolved dynamic OIDC tenant configuration`.
For example, the application is already running, and the tokens are verified with an already resolved OIDC provider, but now, some parts of the resolved configuration need to be updated on the fly, to sync with some OIDC provider related  updates, such as the change of the registered OIDC application's client secret, etc...

That was happening because Quarkus OIDC was not considering newly resolved `OidcTenantConfig` instances if the current tenant already had the previously resolved one and this logic was there from the day one. 

As it happens, @maag03 was able to achieve replacing the already resolved dynamic tenant configurations before 3.20 by finding out that the runtime package `TenantConfigBean` was returning a `modifiable` map of dynamic tenants, so after removing the existing tenant context, a new `OidcTenantConfig` instance was accepted as expected. Note, `remove` was always causing a reconnect to the OIDC provider, possibly with another round of the keys fetch, even of it was unnecessary for a given configuration update.

However, before 3.20, we worked on encapsulating the dynamic tenant management, to support the likely cache support and avoid users be able to modify the map of tenants directly, with thanks to Michal Vavrik,  and an option to `remove` dynamic tenants from custom resolvers was gone. I don't consider as a breaking change as this option was not expected to be used by users and was only available in in the runtime package due to my earlier design miscalculation.

So, on `main` we addressed the issue of modifying the already resolved dynamic OIDC tenants with #48278. 
But for 3.20, with this PR which temporarily introduces a `remove` option on `TenantConfigBean`, we'd like to help @maag03 and other users who might need this option, to continue be able to update such configurations in the 3.20 LTS line.

@gsmet, I think #48278 is rather safe to backport, but I thought, that it may not be backported, which is why I'm going ahead with this PR. If you would be open to backporting #48278 to 3.20, then I can prepare the backport of that PR instead.

CC @michalvavrik 

Thanks
