### PR TITLE
Use production dependency model for remote-dev

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -673,14 +673,13 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                     //we have some filters, for files that we don't want to delete
                     continue;
                 }
-                log.info("Scheduled for removal " + file);
                 if (removedFiles.isEmpty()) {
                     removedFiles = new ArrayList<>();
                 }
                 removedFiles.add(applicationRoot.resolve(file));
             }
             if (!removedFiles.isEmpty()) {
-                DevModeMediator.removedFiles.addLast(removedFiles);
+                DevModeMediator.scheduleDelete(removedFiles);
             }
             return ret;
         } catch (IOException e) {
@@ -727,12 +726,11 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
             final List<Path> moduleChangedSourceFilePaths = new ArrayList<>();
 
             for (Path sourcePath : cuf.apply(module).getSourcePaths()) {
-                final Set<File> changedSourceFiles;
-                Path start = sourcePath;
-                if (!Files.exists(start)) {
+                if (!Files.exists(sourcePath)) {
                     continue;
                 }
-                try (final Stream<Path> sourcesStream = Files.walk(start)) {
+                final Set<File> changedSourceFiles;
+                try (final Stream<Path> sourcesStream = Files.walk(sourcePath)) {
                     changedSourceFiles = sourcesStream
                             .parallel()
                             .filter(p -> matchingHandledExtension(p).isPresent()

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -825,9 +825,9 @@ public class DevMojo extends AbstractMojo {
      * @param reloadPoms POM files to be reloaded from disk instead of taken from the reactor
      * @return map of parameters for the Quarkus plugin goals
      */
-    private static Map<String, String> getQuarkusGoalParams(String bootstrapId, List<String> reloadPoms) {
+    private Map<String, String> getQuarkusGoalParams(String bootstrapId, List<String> reloadPoms) {
         final Map<String, String> result = new HashMap<>(4);
-        result.put(QuarkusBootstrapMojo.MODE_PARAM, LaunchMode.DEVELOPMENT.name());
+        result.put(QuarkusBootstrapMojo.MODE_PARAM, getLaunchModeClasspath().name());
         result.put(QuarkusBootstrapMojo.CLOSE_BOOTSTRAPPED_APP_PARAM, "false");
         result.put(QuarkusBootstrapMojo.BOOTSTRAP_ID_PARAM, bootstrapId);
         if (reloadPoms != null && !reloadPoms.isEmpty()) {
@@ -1524,7 +1524,7 @@ public class DevMojo extends AbstractMojo {
             // the Maven resolver will be checking for newer snapshots in the remote repository and might end up resolving the artifact from there.
             final BootstrapMavenContext mvnCtx = workspaceProvider.createMavenContext(mvnConfig);
             appModel = new BootstrapAppModelResolver(new MavenArtifactResolver(mvnCtx))
-                    .setDevMode(true)
+                    .setDevMode(getLaunchModeClasspath().isDevOrTest())
                     .setTest(LaunchMode.TEST.equals(getLaunchModeClasspath()))
                     .setCollectReloadableDependencies(!noDeps)
                     .setLegacyModelResolver(BootstrapAppModelResolver.isLegacyModelResolver(project.getProperties()))

--- a/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
@@ -4,7 +4,9 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.deployment.dev.DevModeCommandLineBuilder;
+import io.quarkus.runtime.LaunchMode;
 
 /**
  * The dev mojo, that connects to a remote host.
@@ -14,5 +16,13 @@ public class RemoteDevMojo extends DevMojo {
     @Override
     protected void modifyDevModeContext(DevModeCommandLineBuilder builder) {
         builder.remoteDev(true);
+    }
+
+    @Override
+    protected LaunchMode getLaunchModeClasspath() {
+        // For remote-dev we should match the dependency model on the service side, which is a production mutable-jar,
+        // so we return LaunchMode.NORMAL, but we need to enable workspace discovery to be able to watch for source code changes
+        project.getProperties().putIfAbsent(BootstrapConstants.QUARKUS_BOOTSTRAP_WORKSPACE_DISCOVERY, "true");
+        return LaunchMode.NORMAL;
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
@@ -159,9 +159,9 @@ public class HttpRemoteDevClient implements RemoteDevClient {
             //this file needs to be sent last
             //if it is modified it will trigger a reload
             //and we need the rest of the app to be present
-            byte[] lastFile = data.remove(QuarkusEntryPoint.LIB_DEPLOYMENT_DEPLOYMENT_CLASS_PATH_DAT);
+            byte[] lastFile = data.remove(QuarkusEntryPoint.LIB_DEPLOYMENT_APPMODEL_DAT);
             if (lastFile != null) {
-                data.put(QuarkusEntryPoint.LIB_DEPLOYMENT_DEPLOYMENT_CLASS_PATH_DAT, lastFile);
+                data.put(QuarkusEntryPoint.LIB_DEPLOYMENT_APPMODEL_DAT, lastFile);
             }
 
             for (Map.Entry<String, byte[]> entry : data.entrySet()) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
@@ -117,7 +117,6 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                     .putHeader(QUARKUS_ERROR, "Unknown method " + event.method() + " this is not a valid remote dev request")
                     .setStatusCode(405).end();
         }
-
     }
 
     private void handleDev(HttpServerRequest event) {
@@ -139,7 +138,6 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                                 hotReplacementContext.setRemoteProblem(problem);
                             }
                             synchronized (RemoteSyncHandler.class) {
-
                                 RemoteSyncHandler.class.notifyAll();
                                 RemoteSyncHandler.class.wait(10000);
                                 if (checkForChanges) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -457,6 +457,9 @@ public class Injection {
     public Injection(AnnotationTarget target, List<InjectionPointInfo> injectionPoints) {
         this.target = target;
         this.injectionPoints = injectionPoints;
+        if (injectionPoints.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("Null injection point detected for " + target);
+        }
     }
 
     boolean isMethod() {

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
@@ -24,6 +24,7 @@ import io.quarkus.bootstrap.logging.InitialConfigurator;
 public class QuarkusEntryPoint {
 
     public static final String QUARKUS_APPLICATION_DAT = "quarkus/quarkus-application.dat";
+    public static final String LIB_DEPLOYMENT_APPMODEL_DAT = "lib/deployment/appmodel.dat";
     public static final String LIB_DEPLOYMENT_DEPLOYMENT_CLASS_PATH_DAT = "lib/deployment/deployment-class-path.dat";
 
     public static void main(String... args) throws Throwable {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/48198

It fixes a few issues:
* use the same kind of dependency model (production) on the client side, as on the remote side (since a `mutable-jar` is a production packaging);
* local dependencies that have content in directories are packaged in JARs with names that reflect Maven artifact naming, instead of using directory names (such as `classes`) merging content of all the local dependencies in a single JAR and linking to it from multiple `ResolvedDependency`s;
* use `appmodel.dat` update to trigger a restart instead of the `deployment-class-path.dat`, since the `appmodel.dat` includes information about the reloadable dependencies that would need to be updated on the remote side by the client requiring a restart.