### PR TITLE
Compose Dev Services MS SQL connection url fix

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
@@ -21,9 +21,13 @@ public interface DatasourceServiceConfigurator {
 
     String getJdbcPrefix();
 
+    default String getParametersStartCharacter() {
+        return "?";
+    }
+
     default String getParameters(Map<String, String> labels) {
         String parameters = labels.get(Labels.COMPOSE_JDBC_PARAMETERS);
-        return StringUtil.isNullOrEmpty(parameters) ? "" : "?" + parameters;
+        return StringUtil.isNullOrEmpty(parameters) ? "" : getParametersStartCharacter() + parameters;
     }
 
 }

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDatasourceServiceConfigurator.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDatasourceServiceConfigurator.java
@@ -1,8 +1,6 @@
 package io.quarkus.devservices.mssql.deployment;
 
-import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
-import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
 
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
@@ -12,17 +10,16 @@ import io.quarkus.devservices.common.DatasourceServiceConfigurator;
 
 public class MSSQLDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
 
-    private final static String[] PASSWORD_ENVS = new String[] { "MSSQL_SA_PASSWORD", "SA_PASSWORD" };
+    private final static String[] PASSWORD_ENVS = new String[] { "MSSQL_SA_PASSWORD", "SA_PASSWORD", "MSSQL_PASSWORD" };
 
-    private final static String[] DATABASE_ENVS = new String[] { "POSTGRES_DB", "POSTGRESQL_DB", "POSTGRESQL_DATABASE" };
+    private final static String DEFAULT_MSSQL_USERNAME = "sa";
 
     public RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
             DevServicesDatasourceContainerConfig containerConfig) {
         RunningContainer container = containerAddress.getRunningContainer();
-        String effectiveDbName = containerConfig.getDbName().orElse(DEFAULT_DATABASE_NAME);
-        String effectiveUsername = containerConfig.getDbName().orElse(DEFAULT_DATABASE_USERNAME);
-        String effectivePassword = containerConfig.getDbName().orElse(DEFAULT_DATABASE_PASSWORD);
-        String jdbcUrl = getJdbcUrl(containerAddress, container.tryGetEnv(DATABASE_ENVS).orElse(effectiveDbName));
+        String effectiveUsername = containerConfig.getUsername().orElse(DEFAULT_MSSQL_USERNAME);
+        String effectivePassword = containerConfig.getPassword().orElse(DEFAULT_DATABASE_PASSWORD);
+        String jdbcUrl = getJdbcUrl(containerAddress, null);
         String reactiveUrl = getReactiveUrl(jdbcUrl);
         return new RunningDevServicesDatasource(
                 containerAddress.getId(),
@@ -36,6 +33,20 @@ public class MSSQLDatasourceServiceConfigurator implements DatasourceServiceConf
     @Override
     public String getJdbcPrefix() {
         return "sqlserver";
+    }
+
+    @Override
+    public String getParametersStartCharacter() {
+        return ";";
+    }
+
+    @Override
+    public String getJdbcUrl(ContainerAddress containerAddress, String databaseName) {
+        return String.format("jdbc:%s://%s:%d%s",
+                getJdbcPrefix(),
+                containerAddress.getHost(),
+                containerAddress.getPort(),
+                getParameters(containerAddress.getRunningContainer().containerInfo().labels()));
     }
 
 }


### PR DESCRIPTION
Tested with the following service definition:

```yml
services:
  mssql_db:
    image: mcr.microsoft.com/azure-sql-edge:latest
    labels:
      io.quarkus.devservices.compose.wait_for.logs: .*Recovery is complete.*
    cap_add:
      - SYS_PTRACE
    environment:
      ACCEPT_EULA: "Y"
      MSSQL_SA_PASSWORD: "bigStrongPwd1"
      MSSQL_DATA_DIR: /var/opt/mssql/customdata
    volumes:
      - sqldata:/var/opt/mssql/customdata
    ports:
      - "1433"
    restart: unless-stopped
volumes:
  sqldata:

```