### PR TITLE
[S1161] use `staticanalysis.MissingOverrideAnnotation` to avoid missing `@Override` on overriding and implementing methods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,7 @@ updates:
       # Maven plugins
       - dependency-name: org.apache.maven.plugins:*
       - dependency-name: org.codehaus.mojo:*
+      - dependency-name: org.openrewrite.maven:rewrite-maven-plugin
       - dependency-name: io.fabric8:docker-maven-plugin
       - dependency-name: net.revelc.code.formatter:formatter-maven-plugin
       - dependency-name: net.revelc.code:impsort-maven-plugin

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -35,6 +35,8 @@
         <version.plugin.plugin>3.15.1</version.plugin.plugin>
         <version.release.plugin>3.1.1</version.release.plugin>
         <version.resources.plugin>3.3.1</version.resources.plugin>
+        <version.rewrite.plugin>6.10.0</version.rewrite.plugin>
+        <version.rewrite.static.analysis>2.10.0</version.rewrite.static.analysis>
         <!-- Do not update for now as it is causing test issues in integration-tests/devmode
         java.lang.NoClassDefFoundError: com/salesforce/jprotoc/Generator -->
         <version.shade.plugin>3.2.1</version.shade.plugin>
@@ -362,6 +364,34 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>${version.rewrite.plugin}</version>
+                    <configuration>
+                        <activeRecipes>
+                            <recipe>org.openrewrite.staticanalysis.MissingOverrideAnnotation</recipe>
+<!--                            <recipe>org.openrewrite.staticanalysis.NoToStringOnStringType</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.NoValueOfOnStringType</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.RemoveUnusedLocalVariables</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.RemoveUnusedPrivateFields</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.UnnecessaryCloseInTryWithResources</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement</recipe>-->
+<!--                            <recipe>org.openrewrite.staticanalysis.UnnecessaryThrows</recipe>-->
+                        </activeRecipes>
+                        <failOnDryRunResults>true</failOnDryRunResults>
+                        <rewriteSkip>${format.skip}</rewriteSkip>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-static-analysis</artifactId>
+                            <version>${version.rewrite.static.analysis}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
                     <version>${version.formatter.plugin}</version>
@@ -621,6 +651,104 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>format</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!no-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>rewrite-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sort-imports</id>
+                                <goals>
+                                    <goal>sort</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>validate</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>no-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>rewrite-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>dryRun</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>validate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>check-imports</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>


### PR DESCRIPTION
[S1161] fix build setup to avoid missing `@Override` on overriding and implementing methods by consolidating `rewrite` and `spotless`.

While its not required, it still seems best practice to do so.

take advantage of the compiler check:

- https://stackoverflow.com/a/94411


refs:

- https://github.com/apache/maven/pull/2402
- https://github.com/apache/maven/pull/2322
- https://github.com/Ekryd/sortpom

