### PR TITLE
Upgrade to Hibernate ORM 7.0.2 + Fix ClassCastException in Jakarta Data

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/StatelessSessionLazyDelegator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/StatelessSessionLazyDelegator.java
@@ -502,4 +502,9 @@ class StatelessSessionLazyDelegator implements StatelessSession {
     public void setCacheMode(CacheMode cacheMode) {
         delegate.get().setCacheMode(cacheMode);
     }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        return delegate.get().unwrap(type);
+    }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedStatelessSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedStatelessSession.java
@@ -875,4 +875,15 @@ public class TransactionScopedStatelessSession implements StatelessSession {
             emr.statelessSession.setCacheMode(cacheMode);
         }
     }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        if (type.isAssignableFrom(StatelessSession.class)) {
+            return (T) this;
+        }
+        checkBlocking();
+        try (SessionResult emr = acquireSession()) {
+            return emr.statelessSession.unwrap(type);
+        }
+    }
 }

--- a/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/jpamodelgen/data/MyEntityResource.java
+++ b/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/jpamodelgen/data/MyEntityResource.java
@@ -2,6 +2,8 @@ package io.quarkus.it.hibernate.jpamodelgen.data;
 
 import java.util.List;
 
+import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -28,6 +30,11 @@ public class MyEntityResource {
     @Transactional
     public void create(MyEntity entity) {
         repository.insert(entity);
+    }
+
+    @GET
+    public List<MyEntity> get() {
+        return repository.findAll(Order.by(Sort.asc(MyEntity_.NAME))).toList();
     }
 
     @GET

--- a/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/jpamodelgen/data/MyRepository.java
+++ b/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/jpamodelgen/data/MyRepository.java
@@ -1,14 +1,20 @@
 package io.quarkus.it.hibernate.jpamodelgen.data;
 
 import java.util.List;
+import java.util.stream.Stream;
 
+import jakarta.data.Order;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 @Repository
 public interface MyRepository extends CrudRepository<MyEntity, Integer> {
+
+    @Find
+    Stream<MyEntity> findAll(Order<MyEntity> order);
 
     @Query("select e from MyEntity e where e.name like :name")
     List<MyEntity> findByName(String name);

--- a/integration-tests/hibernate-orm-data/src/test/java/io/quarkus/it/hibernate/jpamodelgen/data/HibernateOrmDataTest.java
+++ b/integration-tests/hibernate-orm-data/src/test/java/io/quarkus/it/hibernate/jpamodelgen/data/HibernateOrmDataTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.it.hibernate.jpamodelgen.data;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +23,12 @@ public class HibernateOrmDataTest {
                 .then()
                 .statusCode(404);
         given()
+                .contentType(ContentType.JSON)
+                .when().get(ROOT)
+                .then()
+                .statusCode(200)
+                .body(equalTo("[]"));
+        given()
                 .body(new MyEntity("foo"))
                 .contentType(ContentType.JSON)
                 .when().post(ROOT)
@@ -32,6 +40,12 @@ public class HibernateOrmDataTest {
                 .when().get(ROOT + "/by/name/{name}")
                 .then()
                 .statusCode(200);
+        given()
+                .contentType(ContentType.JSON)
+                .when().get(ROOT)
+                .then()
+                .statusCode(200)
+                .body(containsString("\"foo\""));
 
         // Update
         given()

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jacoco.version>0.8.13</jacoco.version>
         <kubernetes-client.version>7.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.5</rest-assured.version>
-        <hibernate-orm.version>7.0.1.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.0.2.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
This fixes issues we've been seeing in Jakarta Data when using Quarkus. Here, for example: https://github.com/quarkusio/quarkus-quickstarts/pull/1544#issuecomment-2966489198
The upstream fix is there: https://github.com/hibernate/hibernate-orm/pull/10314

This also adds a non-regression test.

~~Opening as draft because we need a Hibernate ORM release.~~ => 7.0.2.Final was released