### PR TITLE
Use JBoss Logging in LogsExporterCDIProvider

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/spi/LogsExporterCDIProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/spi/LogsExporterCDIProvider.java
@@ -2,11 +2,11 @@ package io.quarkus.opentelemetry.runtime.logs.spi;
 
 import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constants.CDI_VALUE;
 
-import java.util.logging.Logger;
-
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
+
+import org.jboss.logging.Logger;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
@@ -20,14 +20,16 @@ public class LogsExporterCDIProvider implements ConfigurableLogRecordExporterPro
     @Override
     public LogRecordExporter createExporter(ConfigProperties configProperties) {
         Instance<LogRecordExporter> exporters = CDI.current().select(LogRecordExporter.class, Any.Literal.INSTANCE);
-        log.fine("available exporters: " + exporters.stream()
-                .map(e -> e.getClass().getName())
-                .reduce((a, b) -> a + ", " + b)
-                .orElse("none"));
+        if (log.isDebugEnabled()) {
+            log.debug("available exporters: " + exporters.stream()
+                    .map(e -> e.getClass().getName())
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("none"));
+        }
         if (exporters.isUnsatisfied()) {
             return NoopLogRecordExporter.INSTANCE;
         } else {
-            log.fine("using exporter: " + exporters.get().getClass().getName());
+            log.debugf("using exporter: %s", exporters.get().getClass().getName());
             return exporters.get();
         }
     }


### PR DESCRIPTION
We should not use `java.util.logging`.

Also let's not do work that is useless if debug is not enabled.