### PR TITLE
Use lazy data for dev services in dev ui

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -1,7 +1,8 @@
-import { QwcHotReloadElement, html, css } from 'qwc-hot-reload-element';
-import { devServices } from 'devui-data';
-import { observeState } from 'lit-element-state';
-import { themeState } from 'theme-state';
+import {css, html, QwcHotReloadElement} from 'qwc-hot-reload-element';
+import {JsonRpc} from 'jsonrpc';
+import {devServices} from 'devui-data';
+import {observeState} from 'lit-element-state';
+import {themeState} from 'theme-state';
 import '@vaadin/icon';
 import '@qomponent/qui-code-block';
 import '@qomponent/qui-card';
@@ -11,6 +12,8 @@ import 'qwc-no-data';
  * This component shows the Dev Services Page
  */
 export class QwcDevServices extends observeState(QwcHotReloadElement) {
+    jsonRpc = new JsonRpc("devui-dev-services", false);
+
     static styles = css`
         .cards {
             height: 100%;
@@ -58,9 +61,15 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
         this._services = devServices;
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+
+        this.hotReload();
+    }
+
     hotReload(){
-        import(`devui/devui-data.js?${Date.now()}`).then(newDevUIData => {
-            this._services = newDevUIData.devServices;
+        this.jsonRpc.getDevServices().then(jsonRpcResponse => {
+            this._services = jsonRpcResponse.result;
         });
     }
 


### PR DESCRIPTION
This is necessary once #47610 merges to show full data. Because dev services may not be started in the augmentation phase, we can't populate things like container ids and port numbers in the static page build. 

 I believe this change is a near no-op without the dev service life cycle changes. It's not beneficial, but it's also not harmful. At most it might introduce one extra call to the backend from the front end, I think? I've manually checked postgres codestart and the redis integration test and visually things are identical on `main` to what they were before:

<img width="831" alt="image" src="https://github.com/user-attachments/assets/007d352e-ed09-4ca7-a732-b25a0e3328ed" />

Raising it separately so that @phillip-kruger can have a good look to make sure I updated the UI in the right, idiomatic, way – and also to keep the size of #47610 manageable for review.

