### PR TITLE
fix local compilation failure

### DIFF
--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -69,6 +69,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
fix local build error:

item: ignore: `package grpc.`


@javax.annotation.Generated(

<img width="921" alt="image" src="https://github.com/user-attachments/assets/4cbbf394-7cb9-4226-be2e-9bfb2ba09985" />


```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project quarkus-grpc-stubs: Compilation failure: Compilation failure: 
[ERROR] /Users/vincent.potucek/IdeaProjects/quarkus/extensions/grpc/stubs/target/generated-sources/protobuf/grpc-java/grpc/health/v1/HealthGrpc.java:[7,18] cannot find symbol
[ERROR]   symbol:   class Generated
[ERROR]   location: package javax.annotation
[ERROR] /Users/vincent.potucek/IdeaProjects/quarkus/extensions/grpc/stubs/target/generated-sources/protobuf/grpc-java/grpc/reflection/v1alpha/ServerReflectionGrpc.java:[7,18] cannot find symbol
[ERROR]   symbol:   class Generated
[ERROR]   location: package javax.annotation
[ERROR] /Users/vincent.potucek/IdeaProjects/quarkus/extensions/grpc/stubs/target/generated-sources/protobuf/grpc-java/io/grpc/reflection/v1/ServerReflectionGrpc.java:[7,18] cannot find symbol
[ERROR]   symbol:   class Generated
[ERROR]   location: package javax.annotation
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :quarkus-grpc-stubs
➜  quarkus git:(missing-override) ✗ mvn compile 

```