### PR TITLE
use `try-with-resources` statement

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -97,17 +97,16 @@ public class QuarkusAugmentor {
         long start = System.nanoTime();
         log.debug("Beginning Quarkus augmentation");
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
-        QuarkusBuildCloseablesBuildItem buildCloseables = new QuarkusBuildCloseablesBuildItem();
-        try {
+        try (QuarkusBuildCloseablesBuildItem buildCloseables = new QuarkusBuildCloseablesBuildItem()) {
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
             final BuildChainBuilder chainBuilder = BuildChain.builder();
             chainBuilder.setClassLoader(deploymentClassLoader);
 
             ExtensionLoader.loadStepsFrom(deploymentClassLoader,
-                    buildSystemProperties == null ? new Properties() : buildSystemProperties,
-                    runtimeProperties == null ? new Properties() : runtimeProperties,
-                    effectiveModel, launchMode, devModeType)
+                            buildSystemProperties == null ? new Properties() : buildSystemProperties,
+                            runtimeProperties == null ? new Properties() : runtimeProperties,
+                            effectiveModel, launchMode, devModeType)
                     .accept(chainBuilder);
 
             Thread.currentThread().setContextClassLoader(classLoader);
@@ -184,7 +183,6 @@ public class QuarkusAugmentor {
 
             }
             Thread.currentThread().setContextClassLoader(originalClassLoader);
-            buildCloseables.close();
         }
     }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/components/Prompter.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/Prompter.java
@@ -48,12 +48,10 @@ public class Prompter {
             return;
         }
         final TerminalConnection connection = new TerminalConnection();
-        connection.setSignalHandler(interruptionSignalHandler());
-        try {
+        try (connection) {
+            connection.setSignalHandler(interruptionSignalHandler());
             read(connection, ReadlineBuilder.builder().enableHistory(false).build(), prompts.iterator());
             connection.openBlocking();
-        } finally {
-            connection.close();
         }
     }
 

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/SocketUtil.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/SocketUtil.java
@@ -9,20 +9,11 @@ final class SocketUtil {
     }
 
     static int findAvailablePort() {
-        ServerSocket serverSocket = null;
-        try {
-            serverSocket = new ServerSocket(0);
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
             return serverSocket.getLocalPort();
         } catch (Exception e) {
             // return a default port
             return 25347;
-        } finally {
-            if (serverSocket != null) {
-                try {
-                    serverSocket.close();
-                } catch (IOException e) {
-                }
-            }
         }
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/cdi/WithSpanInterceptor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/cdi/WithSpanInterceptor.java
@@ -147,18 +147,13 @@ public class WithSpanInterceptor {
             });
         } else {
             final Context currentSpanContext = instrumenter.start(parentContext, methodRequest);
-            final Scope currentScope = currentSpanContext.makeCurrent();
-            try {
+            try (Scope currentScope = currentSpanContext.makeCurrent()) {
                 Object result = invocationContext.proceed();
                 instrumenter.end(currentSpanContext, methodRequest, null, null);
                 return result;
             } catch (Throwable t) {
                 instrumenter.end(currentSpanContext, methodRequest, null, t);
                 throw t;
-            } finally {
-                if (currentScope != null) {
-                    currentScope.close();
-                }
             }
         }
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/restclient/OpenTelemetryClientFilter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/restclient/OpenTelemetryClientFilter.java
@@ -121,13 +121,11 @@ public class OpenTelemetryClientFilter implements ClientRequestFilter, ClientRes
 
     @Override
     public void filter(final ClientRequestContext request, final ClientResponseContext response) {
-        Scope scope = (Scope) request.getProperty(REST_CLIENT_OTEL_SPAN_CLIENT_SCOPE);
-        if (scope == null) {
-            return;
-        }
-
-        Context spanContext = (Context) request.getProperty(REST_CLIENT_OTEL_SPAN_CLIENT_CONTEXT);
-        try {
+        try (Scope scope = (Scope) request.getProperty(REST_CLIENT_OTEL_SPAN_CLIENT_SCOPE)) {
+            if (scope == null) {
+                return;
+            }
+            Context spanContext = (Context) request.getProperty(REST_CLIENT_OTEL_SPAN_CLIENT_CONTEXT);
             String pathTemplate = (String) request.getProperty(URL_PATH_TEMPLATE_KEY);
             if (pathTemplate != null && !pathTemplate.isEmpty()) {
                 Span.fromContext(spanContext)
@@ -135,8 +133,6 @@ public class OpenTelemetryClientFilter implements ClientRequestFilter, ClientRes
             }
             instrumenter.end(spanContext, request, response, null);
         } finally {
-            scope.close();
-
             request.removeProperty(REST_CLIENT_OTEL_SPAN_CLIENT_CONTEXT);
             request.removeProperty(REST_CLIENT_OTEL_SPAN_CLIENT_PARENT_CONTEXT);
             request.removeProperty(REST_CLIENT_OTEL_SPAN_CLIENT_SCOPE);

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/jdbc/DBDelegateUtils.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/jdbc/DBDelegateUtils.java
@@ -16,11 +16,8 @@ class DBDelegateUtils {
         }
         // use an instance of the QuarkusObjectInputStream class instead of the ObjectInputStream when deserializing
         // to workaround a CNFE in test and dev mode.
-        ObjectInputStream in = new QuarkusObjectInputStream(binaryInput);
-        try {
+        try (ObjectInputStream in = new QuarkusObjectInputStream(binaryInput)) {
             return in.readObject();
-        } finally {
-            in.close();
         }
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/MediaTypeNegotiationClientQualityTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/MediaTypeNegotiationClientQualityTest.java
@@ -99,14 +99,11 @@ public class MediaTypeNegotiationClientQualityTest {
     public void testClientQuality() throws Exception {
         Invocation.Builder request = client.target(generateURL()).path("echo").request("application/x;q=0.7",
                 "application/y;q=0.9");
-        Response response = request.get();
-        try {
+        try (Response response = request.get()) {
             Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
             MediaType mediaType = response.getMediaType();
             Assertions.assertEquals(mediaType.getType(), "application");
             Assertions.assertEquals(mediaType.getSubtype(), "y");
-        } finally {
-            response.close();
         }
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/MediaTypeNegotiationServerQualityTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/MediaTypeNegotiationServerQualityTest.java
@@ -110,14 +110,11 @@ public class MediaTypeNegotiationServerQualityTest {
     @DisplayName("Test Server Quality")
     public void testServerQuality() throws Exception {
         Invocation.Builder request = client.target(generateURL()).path("foo/echo").request("application/x;", "text/y");
-        Response response = request.get();
-        try {
+        try (Response response = request.get()) {
             Assertions.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
             MediaType mediaType = response.getMediaType();
             Assertions.assertEquals("text", mediaType.getType());
             Assertions.assertEquals("y", mediaType.getSubtype());
-        } finally {
-            response.close();
         }
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/UriInfoTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/UriInfoTest.java
@@ -151,11 +151,8 @@ public class UriInfoTest {
     }
 
     private static void basicTest(String path, String testName) throws Exception {
-        Response response = client.target(PortProviderUtil.generateURL("/" + testName + path)).request().get();
-        try {
+        try (Response response = client.target(PortProviderUtil.generateURL("/" + testName + path)).request().get()) {
             Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        } finally {
-            response.close();
         }
     }
 

--- a/extensions/websockets/server/deployment/src/test/java/io/quarkus/websockets/test/WebsocketRootPathTestCase.java
+++ b/extensions/websockets/server/deployment/src/test/java/io/quarkus/websockets/test/WebsocketRootPathTestCase.java
@@ -43,7 +43,8 @@ public class WebsocketRootPathTestCase {
 
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
         LinkedBlockingDeque<String> pongMessages = new LinkedBlockingDeque<>();
-        Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
+
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
             @Override
             public void onOpen(Session session, EndpointConfig endpointConfig) {
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
@@ -68,14 +69,10 @@ public class WebsocketRootPathTestCase {
                     throw new RuntimeException(e);
                 }
             }
-        }, ClientEndpointConfig.Builder.create().build(), echoUri);
-
-        try {
+        }, ClientEndpointConfig.Builder.create().build(), echoUri)) {
             Assertions.assertEquals("hello", message.poll(20, TimeUnit.SECONDS));
 
             Assertions.assertEquals("PING", pongMessages.poll(20, TimeUnit.SECONDS));
-        } finally {
-            session.close();
         }
     }
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
@@ -84,18 +84,15 @@ public class QuarkusEntryPoint {
                 Files.newInputStream(appRoot.resolve(LIB_DEPLOYMENT_DEPLOYMENT_CLASS_PATH_DAT)))) {
             List<String> paths = (List<String>) in.readObject();
             //yuck, should use runner class loader
-            URLClassLoader loader = new URLClassLoader(paths.stream().map((s) -> {
+            try (URLClassLoader loader = new URLClassLoader(paths.stream().map((s) -> {
                 try {
                     return appRoot.resolve(s).toUri().toURL();
                 } catch (MalformedURLException e) {
                     throw new RuntimeException(e);
                 }
-            }).toArray(URL[]::new));
-            try {
+            }).toArray(URL[]::new))) {
                 loader.loadClass("io.quarkus.deployment.mutability.ReaugmentTask")
                         .getDeclaredMethod("main", Path.class).invoke(null, appRoot);
-            } finally {
-                loader.close();
             }
         }
     }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/ReaderBodyHandler.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/ReaderBodyHandler.java
@@ -29,17 +29,13 @@ public class ReaderBodyHandler implements MessageBodyWriter<Reader>, MessageBody
 
     public void writeTo(Reader inputStream, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
-        try {
+        try (inputStream) {
             int c;
             while ((c = inputStream.read()) != -1) {
                 entityStream.write(c);
             }
-        } finally {
-            try {
-                inputStream.close();
-            } catch (IOException e) {
-                // Drop the exception so we don't mask real IO errors
-            }
+        } catch (IOException e) {
+            // Drop the exception so we don't mask real IO errors
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/MediaTypeNegotiationClientQualityTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/MediaTypeNegotiationClientQualityTest.java
@@ -98,14 +98,11 @@ public class MediaTypeNegotiationClientQualityTest {
     public void testClientQuality() throws Exception {
         Invocation.Builder request = client.target(generateURL()).path("echo").request("application/x;q=0.7",
                 "application/y;q=0.9");
-        Response response = request.get();
-        try {
+        try (Response response = request.get()) {
             Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
             MediaType mediaType = response.getMediaType();
             Assertions.assertEquals(mediaType.getType(), "application");
             Assertions.assertEquals(mediaType.getSubtype(), "y");
-        } finally {
-            response.close();
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/MediaTypeNegotiationServerQualityTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/MediaTypeNegotiationServerQualityTest.java
@@ -109,14 +109,11 @@ public class MediaTypeNegotiationServerQualityTest {
     @DisplayName("Test Server Quality")
     public void testServerQuality() throws Exception {
         Invocation.Builder request = client.target(generateURL()).path("foo/echo").request("application/x;", "text/y");
-        Response response = request.get();
-        try {
+        try (Response response = request.get()) {
             Assertions.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
             MediaType mediaType = response.getMediaType();
             Assertions.assertEquals("text", mediaType.getType());
             Assertions.assertEquals("y", mediaType.getSubtype());
-        } finally {
-            response.close();
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/UriInfoTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/UriInfoTest.java
@@ -161,11 +161,8 @@ public class UriInfoTest {
     }
 
     private static void basicTest(String path, String testName) throws Exception {
-        Response response = client.target(PortProviderUtil.generateURL("/" + testName + path)).request().get();
-        try {
+        try (Response response = client.target(PortProviderUtil.generateURL("/" + testName + path)).request().get()) {
             Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        } finally {
-            response.close();
         }
     }
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -56,17 +56,12 @@ public class KubernetesClientTest {
 
     @Test
     public void testEcKeyIsSupported() throws Exception {
-        InputStream certInputStream = KubernetesClientTest.class.getResourceAsStream("/cert.pem");
-        InputStream keyInputStream = KubernetesClientTest.class.getResourceAsStream("/private-key.pem");
 
-        try {
+        try (InputStream certInputStream = KubernetesClientTest.class.getResourceAsStream("/cert.pem"); InputStream keyInputStream = KubernetesClientTest.class.getResourceAsStream("/private-key.pem")) {
             KeyStore keyStore = CertUtils.createKeyStore(certInputStream, keyInputStream, "EC", "eckey".toCharArray(),
                     (String) null, "keystore".toCharArray());
             Key key = keyStore.getKey("CN=Client,OU=Test,O=Test", "eckey".toCharArray());
             assertTrue(key instanceof ECPrivateKey);
-        } finally {
-            certInputStream.close();
-            keyInputStream.close();
         }
     }
 

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/ServerSentEventResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/ServerSentEventResource.java
@@ -26,7 +26,7 @@ public class ServerSentEventResource {
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public void sendData(@Context SseEventSink sink) {
         // send a stream of few events
-        try {
+        try (sink) {
             for (int i = 0; i < 3; i++) {
                 final OutboundSseEvent.Builder builder = this.sse.newEventBuilder();
                 builder.id(String.valueOf(i)).mediaType(MediaType.TEXT_PLAIN_TYPE)
@@ -35,8 +35,6 @@ public class ServerSentEventResource {
 
                 sink.send(builder.build());
             }
-        } finally {
-            sink.close();
         }
     }
 
@@ -46,7 +44,7 @@ public class ServerSentEventResource {
     @SseElementType("text/html")
     public void sendHtmlData(@Context SseEventSink sink) {
         // send a stream of few events
-        try {
+        try (sink) {
             for (int i = 0; i < 3; i++) {
                 final OutboundSseEvent.Builder builder = this.sse.newEventBuilder();
                 builder.id(String.valueOf(i)).mediaType(MediaType.TEXT_HTML_TYPE)
@@ -55,8 +53,6 @@ public class ServerSentEventResource {
 
                 sink.send(builder.build());
             }
-        } finally {
-            sink.close();
         }
     }
 
@@ -66,7 +62,7 @@ public class ServerSentEventResource {
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public void sendXmlData(@Context SseEventSink sink) {
         // send a stream of few events
-        try {
+        try (sink) {
             for (int i = 0; i < 3; i++) {
                 final OutboundSseEvent.Builder builder = this.sse.newEventBuilder();
                 builder.id(String.valueOf(i)).mediaType(MediaType.TEXT_XML_TYPE)
@@ -75,8 +71,6 @@ public class ServerSentEventResource {
 
                 sink.send(builder.build());
             }
-        } finally {
-            sink.close();
         }
     }
 }

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceForConstructorProperties.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceForConstructorProperties.java
@@ -50,7 +50,7 @@ public class TestResourceForConstructorProperties {
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public void serverSentEvents(@Context SseEventSink sink) {
         VanillaJavaImmutableData data = new VanillaJavaImmutableData("sse", "ssevalue");
-        try {
+        try (sink) {
             OutboundSseEvent.Builder builder = sse.newEventBuilder();
             builder.id(String.valueOf(1))
                     .mediaType(MediaType.APPLICATION_JSON_TYPE)
@@ -58,8 +58,6 @@ public class TestResourceForConstructorProperties {
                     .name("stream of json data");
 
             sink.send(builder.build());
-        } finally {
-            sink.close();
         }
     }
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketTestCase.java
@@ -39,7 +39,8 @@ public class WebsocketTestCase {
     public void websocketTest() throws Exception {
 
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
-        Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
+
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
             @Override
             public void onOpen(Session session, EndpointConfig endpointConfig) {
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
@@ -50,12 +51,8 @@ public class WebsocketTestCase {
                 });
                 session.getAsyncRemote().sendText("hello");
             }
-        }, ClientEndpointConfig.Builder.create().build(), echoUri);
-
-        try {
+        }, ClientEndpointConfig.Builder.create().build(), echoUri)) {
             Assertions.assertEquals("hello", message.poll(20, TimeUnit.SECONDS));
-        } finally {
-            session.close();
         }
     }
 
@@ -63,7 +60,8 @@ public class WebsocketTestCase {
     public void addedWebSocketTest() throws Exception {
 
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
-        Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
+
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
             @Override
             public void onOpen(Session session, EndpointConfig endpointConfig) {
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
@@ -73,19 +71,16 @@ public class WebsocketTestCase {
                     }
                 });
             }
-        }, ClientEndpointConfig.Builder.create().build(), added);
-
-        try {
+        }, ClientEndpointConfig.Builder.create().build(), added)) {
             Assertions.assertEquals("DYNAMIC", message.poll(20, TimeUnit.SECONDS));
-        } finally {
-            session.close();
         }
     }
 
     @Test
     public void websocketServerEncodingAndDecodingTest() throws Exception {
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
-        Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
+
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
             @Override
             public void onOpen(Session session, EndpointConfig endpointConfig) {
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
@@ -96,12 +91,8 @@ public class WebsocketTestCase {
                 });
                 session.getAsyncRemote().sendText("{\"content\":\"message content\"}");
             }
-        }, ClientEndpointConfig.Builder.create().build(), recoderUri);
-
-        try {
+        }, ClientEndpointConfig.Builder.create().build(), recoderUri)) {
             Assertions.assertEquals("{\"content\":\"[recoded]message content\"}", message.poll(20, TimeUnit.SECONDS));
-        } finally {
-            session.close();
         }
     }
 
@@ -132,7 +123,8 @@ public class WebsocketTestCase {
     public void testSendMessageOnOpen() throws Exception {
 
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
-        Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
+
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
             @Override
             public void onOpen(Session session, EndpointConfig endpointConfig) {
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
@@ -142,14 +134,10 @@ public class WebsocketTestCase {
                     }
                 });
             }
-        }, ClientEndpointConfig.Builder.create().build(), openURI);
-
-        try {
+        }, ClientEndpointConfig.Builder.create().build(), openURI)) {
             for (String i : WebSocketOpenEndpoint.messages) {
                 Assertions.assertEquals(i, message.poll(20, TimeUnit.SECONDS));
             }
-        } finally {
-            session.close();
         }
     }
 }

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/WebsocketOidcTestCase.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/WebsocketOidcTestCase.java
@@ -35,7 +35,8 @@ public class WebsocketOidcTestCase {
     public void websocketTest() throws Exception {
 
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();
-        Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
+
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(new Endpoint() {
             @Override
             public void onOpen(Session session, EndpointConfig endpointConfig) {
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
@@ -46,12 +47,8 @@ public class WebsocketOidcTestCase {
                 });
                 session.getAsyncRemote().sendText("hello");
             }
-        }, new BearerTokenClientEndpointConfigurator(client.getAccessToken("alice")), wsUri);
-
-        try {
+        }, new BearerTokenClientEndpointConfigurator(client.getAccessToken("alice")), wsUri)) {
             Assertions.assertEquals("hello alice@gmail.com", message.poll(20, TimeUnit.SECONDS));
-        } finally {
-            session.close();
         }
     }
 

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
@@ -248,13 +248,10 @@ public class ConfiguredBeanTest {
         OutputStream os = socket.getOutputStream();
         os.write("testRuntimeXmlConfigService\n".getBytes("UTF-8"));
         os.flush();
-        try (BufferedReader reader = new BufferedReader(
+        try (socket; os; BufferedReader reader = new BufferedReader(
                 new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
             String reply = reader.readLine();
             Assertions.assertEquals("testRuntimeXmlConfigService-ack", reply);
-        } finally {
-            os.close();
-            socket.close();
         }
     }
 

--- a/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/SocketUtil.java
+++ b/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/SocketUtil.java
@@ -10,20 +10,11 @@ final class SocketUtil {
     }
 
     static int findAvailablePort() {
-        ServerSocket serverSocket = null;
-        try {
-            serverSocket = new ServerSocket(0);
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
             return serverSocket.getLocalPort();
         } catch (Exception e) {
             // return a default port
             return 25347;
-        } finally {
-            if (serverSocket != null) {
-                try {
-                    serverSocket.close();
-                } catch (IOException e) {
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Java 7 introduced the try-with-resources statement. This statement ensures that each resource is closed at the end of the statement. It avoids the need of explicitly closing the resources in a finally block. Additionally exceptions are better handled: If an exception occurred both in the try block and finally block, then the exception from the try block was suppressed. With the try-with-resources statement, the exception thrown from the try-block is preserved.


- https://github.com/openrewrite/rewrite-static-analysis/issues/591
- https://www.baeldung.com/java-try-with-resources
- https://github.com/apache/maven/pull/2426

need to be cautions with this:
- https://github.com/spring-projects/spring-framework/pull/35046
- https://github.com/spring-projects/spring-framework/pull/35046#discussion_r2144654931
- https://mail.openjdk.org/pipermail/coin-dev/2009-April/001503.html



<img width="904" alt="image" src="https://github.com/user-attachments/assets/f98b5ff8-92cd-4e8d-a2fc-f8fe77703ebd" />

