### PR TITLE
Fix Asciidoc link syntax limitations in vertx-reference

### DIFF
--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -730,7 +730,7 @@ Read xref:./virtual-threads.adoc[the virtual thread guide] for more details.
 
 === Use codecs
 
-The https://vertx.io/docs/vertx-core/java/#event_bus[Vert.x Event Bus] uses https://vertx.io/docs/vertx-core/java/#_message_codecs[codecs] to _serialize_ and _deserialize_ message objects.
+The link:++https://vertx.io/docs/vertx-core/java/#event_bus++[Vert.x Event Bus] uses link:++https://vertx.io/docs/vertx-core/java/#_message_codecs++[codecs] to _serialize_ and _deserialize_ message objects.
 Quarkus provides a default codec for local delivery.
 This codec is automatically used for return types and message body parameters of local consumers, i.e. methods annotated with `@ConsumeEvent` where `ConsumeEvent#local() == true` (which is the default).
 


### PR DESCRIPTION
See https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro/

Characters like `_` break Asciidoc parsing, even in links, so they need escaping + the link macro.