### PR TITLE
OIDC: Fix invalid unencrypted session cookie when tokens are split

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -81,7 +81,8 @@ public class DefaultTokenStateManager implements TokenStateManager {
                         .append(CodeAuthenticationMechanism.COOKIE_DELIM)
                         .append(tokens.getAccessTokenExpiresIn() != null ? tokens.getAccessTokenExpiresIn() : "")
                         .append(CodeAuthenticationMechanism.COOKIE_DELIM)
-                        .append(tokens.getAccessTokenScope() != null ? tokens.getAccessTokenScope() : "");
+                        .append(tokens.getAccessTokenScope() != null ? encodeScopes(oidcConfig, tokens.getAccessTokenScope())
+                                : "");
 
                 // Encrypt access token and create a `q_session_at` cookie.
                 CodeAuthenticationMechanism.createCookie(routingContext,

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionNoEncryptionResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionNoEncryptionResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/code-flow-token-introspection-no-encryption")
+@PermissionsAllowed(value = { "email", "openid", "profile" }, inclusive = true)
+public class CodeFlowTokenIntrospectionNoEncryptionResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    TokenIntrospection tokenIntrospection;
+
+    @GET
+    public String access() {
+        if (identity.getPrincipal() instanceof JsonWebToken) {
+            return identity.getPrincipal().getName();
+        } else {
+            return identity.getPrincipal().getName() + ":" + tokenIntrospection.getUsername();
+        }
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -45,6 +45,7 @@ public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmento
                 (routingContext.normalizedPath().endsWith("code-flow-user-info-only")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github")
                         || routingContext.normalizedPath().endsWith("code-flow-token-introspection")
+                        || routingContext.normalizedPath().endsWith("code-flow-token-introspection-no-encryption")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github-cached-in-idtoken")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github-cache-disabled"))) {
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -173,6 +173,20 @@ quarkus.oidc.code-flow-token-introspection.client-id=quarkus-web-app
 quarkus.oidc.code-flow-token-introspection.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-token-introspection.code-grant.headers.X-Custom=XTokenIntrospection
 
+quarkus.oidc.code-flow-token-introspection-no-encryption.provider=github
+quarkus.oidc.code-flow-token-introspection-no-encryption.token.verify-access-token-with-user-info=false
+quarkus.oidc.code-flow-token-introspection-no-encryption.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
+quarkus.oidc.code-flow-token-introspection-no-encryption.authorization-path=/
+quarkus.oidc.code-flow-token-introspection-no-encryption.user-info-path=protocol/openid-connect/userinfo
+quarkus.oidc.code-flow-token-introspection-no-encryption.introspection-path=protocol/openid-connect/token/introspect
+quarkus.oidc.code-flow-token-introspection-no-encryption.token.refresh-token-time-skew=298
+quarkus.oidc.code-flow-token-introspection-no-encryption.roles.source=accesstoken
+quarkus.oidc.code-flow-token-introspection-no-encryption.client-id=quarkus-web-app
+quarkus.oidc.code-flow-token-introspection-no-encryption.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.oidc.code-flow-token-introspection-no-encryption.code-grant.headers.X-Custom=XTokenIntrospection
+quarkus.oidc.code-flow-token-introspection-no-encryption.token-state-manager.split-tokens=true
+quarkus.oidc.code-flow-token-introspection-no-encryption.token-state-manager.encryption-required=false
+
 quarkus.oidc.code-flow-token-introspection-expires-in.auth-server-url=${keycloak.url:replaced-by-test-resource}/realms/quarkus/
 quarkus.oidc.code-flow-token-introspection-expires-in.application-type=web-app
 quarkus.oidc.code-flow-token-introspection-expires-in.authentication.user-info-required=false


### PR DESCRIPTION
- fixes `java.lang.IllegalArgumentException: Cookie value contains an invalid char`
- introduced by https://github.com/quarkusio/quarkus/pull/48153
- reported here https://github.com/quarkusio/quarkus/pull/48153#discussion_r2147522528