### PR TITLE
Contain the use of reflection in amazon-lambda

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -114,8 +114,6 @@ public final class AmazonLambdaProcessor {
             final DotName name = info.name();
             final String lambda = name.toString();
             builder.addBeanClass(lambda);
-            reflectiveClassBuildItemBuildProducer
-                    .produce(ReflectiveClassBuildItem.builder(lambda).methods().build());
 
             String cdiName = null;
             AnnotationInstance named = info.declaredAnnotation(NAMED);
@@ -150,9 +148,18 @@ public final class AmazonLambdaProcessor {
                         }
                     }
                 }
-                current = combinedIndexBuildItem.getIndex().getClassByName(current.superName());
+                if (!done) {
+                    current = combinedIndexBuildItem.getIndex().getClassByName(current.superName());
+                }
             }
-            ret.add(new AmazonLambdaBuildItem(lambda, cdiName, streamHandler));
+            if (done) {
+                String handlerClass = current.name().toString();
+                ret.add(new AmazonLambdaBuildItem(handlerClass, cdiName, streamHandler));
+                reflectiveClassBuildItemBuildProducer.produce(ReflectiveClassBuildItem.builder(handlerClass).methods()
+                        .reason(getClass().getName()
+                                + ": reflectively accessed in io.quarkus.amazon.lambda.runtime.AmazonLambdaRecorder.discoverHandlerMethod")
+                        .build());
+            }
         }
         additionalBeanBuildItemBuildProducer.produce(builder.build());
         reflectiveClassBuildItemBuildProducer

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -92,7 +92,7 @@ public class AmazonLambdaRecorder {
     }
 
     private static Method discoverHandlerMethod(Class<? extends RequestHandler<?, ?>> handlerClass) {
-        final Method[] methods = handlerClass.getMethods();
+        final Method[] methods = handlerClass.getDeclaredMethods();
         Method method = null;
         for (int i = 0; i < methods.length && method == null; i++) {
             if (methods[i].getName().equals("handleRequest")) {


### PR DESCRIPTION
Instead of registering subclasses of the class actually implementing the
handler, registers the class that actually implements the handler.

This way Quarkus can use `getDeclaredMethods` instead of `getMethods` at
runtime, which has less coverage (it doesn't return inherited methods).

- Closes: https://github.com/quarkusio/quarkus/issues/44656
