### PR TITLE
Fix GraalVM version parsing for JDK 26-based builds

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -28,7 +28,6 @@ public final class GraalVM {
         private static final String OPT = "(?:-(?<OPT>[-a-zA-Z0-9.]+))?";
         private static final String VSTR_FORMAT = VNUM + PRE + BUILD + OPT;
 
-        private static final String VNUM_GROUP = "VNUM";
         private static final String VENDOR_VERSION_GROUP = "VENDOR";
         private static final String BUILD_INFO_GROUP = "BUILDINFO";
 
@@ -67,7 +66,7 @@ public final class GraalVM {
 
                 String vendorVersion = secondMatcher.group(VENDOR_VERSION_GROUP);
 
-                String graalVersion = graalVersion(javaVersion, v.feature());
+                String graalVersion = graalVersion(javaVersion, v);
                 if (vendorVersion.contains("-dev")) {
                     graalVersion = graalVersion + "-dev";
                 }
@@ -137,7 +136,7 @@ public final class GraalVM {
             return null;
         }
 
-        private static String graalVersion(String buildInfo, int jdkFeature) {
+        private static String graalVersion(String buildInfo, Runtime.Version v) {
             if (buildInfo == null) {
                 return null;
             }
@@ -152,7 +151,10 @@ public final class GraalVM {
             if (versMatcher.find()) {
                 return matchVersion(version);
             } else {
-                return Version.GRAAL_MAPPING.get(Integer.toString(jdkFeature));
+                // Only versions from JDK 22 to JDK 25 had GraalVM version mappings.
+                // Use the JDK version triplet for JDK N where N > 25.
+                String fullJDKVersion = String.format("%d.%d.%d", v.feature(), v.interim(), v.update());
+                return Version.GRAAL_MAPPING.getOrDefault(Integer.toString(v.feature()), fullJDKVersion);
             }
         }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -1,7 +1,10 @@
 package io.quarkus.runtime.graal;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -40,16 +43,23 @@ public final class GraalVM {
 
         private static final String VERSION_GROUP = "VNUM";
 
-        private static final Version UNKNOWN_VERSION = null;
-
         static Version parse(String value) {
             Matcher versionMatcher = VENDOR_VERS_PATTERN.matcher(value);
             if (versionMatcher.find()) {
                 String vendor = versionMatcher.group(VENDOR_PREFIX_GROUP);
                 if (GRAALVM_CE_VERS_PREFIX.equals(vendor) || ORACLE_GRAALVM_VERS_PREFIX.equals(vendor)) {
                     String version = versionMatcher.group(VERSION_GROUP);
-                    String jdkFeature = version.split("\\.", 2)[0];
-                    return new Version(value, Version.GRAAL_MAPPING.get(jdkFeature), Distribution.GRAALVM);
+                    String tokens[] = version.split("\\.", 3);
+                    String jdkFeature = tokens[0];
+                    String jdkVers = jdkFeature;
+                    if (tokens.length == 3) {
+                        String interim = tokens[1];
+                        String update = tokens[2].split("\\+")[0];
+                        jdkVers = String.format("%s.%s.%s", jdkFeature, interim, update);
+                    }
+                    // For JDK 26+ there is no more version mapping use the JDK version
+                    String versionMapping = Version.GRAAL_MAPPING.getOrDefault(jdkFeature, version);
+                    return new Version(value, versionMapping, jdkVers, Distribution.GRAALVM);
                 } else if (LIBERICA_NIK_VERS_PREFIX.equals(vendor)) {
                     return new Version(value, versionMatcher.group(VERSION_GROUP), Distribution.LIBERICA);
                 } else if (MANDREL_VERS_PREFIX.equals(vendor)) {
@@ -78,8 +88,18 @@ public final class GraalVM {
                 "21", "23.1",
                 "22", "24.0",
                 "23", "24.1",
-                "24", "24.2",
-                "25", "25.0");
+                "24", "24.2");
+        // Mapping of community major.minor pair to the JDK major version based on
+        // GRAAL_MAPPING
+        private static final Map<String, String> MANDREL_JDK_REV_MAP;
+
+        static {
+            Map<String, String> reverseMap = new HashMap<>(GRAAL_MAPPING.size());
+            for (Entry<String, String> entry : GRAAL_MAPPING.entrySet()) {
+                reverseMap.put(entry.getValue(), entry.getKey());
+            }
+            MANDREL_JDK_REV_MAP = Collections.unmodifiableMap(reverseMap);
+        }
 
         /**
          * The minimum version of GraalVM supported by Quarkus.
@@ -97,6 +117,7 @@ public final class GraalVM {
          */
         public static final Version MINIMUM_SUPPORTED = CURRENT;
 
+        private static final String DEFAULT_JDK_VERSION = "21";
         protected final String fullVersion;
         public final Runtime.Version javaVersion;
         protected final Distribution distribution;
@@ -104,7 +125,10 @@ public final class GraalVM {
         private String suffix;
 
         Version(String fullVersion, String version, Distribution distro) {
-            this(fullVersion, version, "21", distro);
+            this(fullVersion, version,
+                    distro == Distribution.MANDREL || distro == Distribution.LIBERICA ? communityJDKvers(version)
+                            : DEFAULT_JDK_VERSION,
+                    distro);
         }
 
         Version(String fullVersion, String version, String javaVersion, Distribution distro) {
@@ -125,6 +149,33 @@ public final class GraalVM {
                 version = version.substring(0, dash);
             }
             this.versions = Arrays.stream(version.split("\\.")).mapToInt(Integer::parseInt).toArray();
+        }
+
+        /*
+         * Reconstruct the JDK version from the given GraalVM community version (Mandrel or Liberica)
+         */
+        private static String communityJDKvers(String communityVersion) {
+            try {
+                String[] parts = communityVersion.split("\\.", 4);
+                int major = Integer.parseInt(parts[0]);
+                int minor = Integer.parseInt(parts[1]);
+                if ((major == 23 && minor > 0) ||
+                        major > 23) {
+                    String mandrelMajorMinor = String.format("%s.%s", parts[0], parts[1]);
+                    // If we don't find a reverse mapping we use a JDK version >= 25, thus
+                    // the feature version is the first part of the quadruple.
+                    String feature = MANDREL_JDK_REV_MAP.getOrDefault(mandrelMajorMinor, parts[0]);
+                    // Heuristic: The update version of Mandrel and the JDK match.
+                    // Interim is usually 0 for the JDK version.
+                    return String.format("%s.%s.%s", feature, "0", parts[2]);
+                }
+            } catch (Throwable e) {
+                // fall-through do default
+                Log.warnf("Failed to parse JDK version from GraalVM version: %s. Defaulting to currently supported version %s ",
+                        communityVersion,
+                        DEFAULT_JDK_VERSION);
+            }
+            return DEFAULT_JDK_VERSION;
         }
 
         @Override


### PR DESCRIPTION
JDK 26+ based GraalVM builds won't have a version mapping any more. They use the JDK version scheme instead. This also fixes an issue with wrong JDK versions being detected with `io.quarkus.runtime.graal.GraalVM.Version.getCurrent()` API and adds tests for it.

**Testing**
- [x] Ran various native integration tests with various Mandrel/GraalVM builds (including JDK 26). All pass.
- [x] Unit tests in `GraalVMTest.java`

- Closes: #48403