### PR TITLE
Align WebSockets Next with Vert.x 4.5.16 close behavior

### DIFF
--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/CloseReason.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/CloseReason.java
@@ -15,18 +15,30 @@ public class CloseReason {
 
     public static final CloseReason NORMAL = new CloseReason(WebSocketCloseStatus.NORMAL_CLOSURE.code());
 
+    public static final CloseReason ABNORMAL = new CloseReason(WebSocketCloseStatus.ABNORMAL_CLOSURE.code(), null, false);
+
+    public static final CloseReason EMPTY = new CloseReason(WebSocketCloseStatus.EMPTY.code(), null, false);
+
     public static final CloseReason INTERNAL_SERVER_ERROR = new CloseReason(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code());
 
     private final int code;
 
     private final String message;
 
+    private CloseReason(int code, String message, boolean validate) {
+        if (validate && !WebSocketCloseStatus.isValidStatusCode(code)) {
+            throw new IllegalArgumentException("Invalid status code: " + code);
+        }
+        this.code = code;
+        this.message = message;
+    }
+
     /**
      *
      * @param code The status code must comply with RFC-6455
      */
     public CloseReason(int code) {
-        this(code, null);
+        this(code, null, true);
     }
 
     /**
@@ -35,11 +47,7 @@ public class CloseReason {
      * @param message
      */
     public CloseReason(int code, String message) {
-        if (!WebSocketCloseStatus.isValidStatusCode(code)) {
-            throw new IllegalArgumentException("Invalid status code: " + code);
-        }
-        this.code = code;
-        this.message = message;
+        this(code, message, true);
     }
 
     public int getCode() {

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
@@ -25,6 +25,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.WebSocketBase;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.http.WebSocketFrameType;
@@ -342,6 +343,9 @@ class Endpoints {
     }
 
     static boolean isWebSocketIsClosedFailure(Throwable throwable, WebSocketConnectionBase connection) {
+        if (throwable instanceof HttpClosedException) {
+            return true;
+        }
         if (!connection.isClosed()) {
             return false;
         }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
@@ -193,6 +193,10 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
                 clientOptions.setIdleTimeout((int) timeout.toMillis());
             }
         }
+        if (config.connectionClosingTimeout().isPresent()) {
+            long timeoutSeconds = config.connectionClosingTimeout().get().toSeconds();
+            clientOptions.setClosingTimeout(timeoutSeconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) timeoutSeconds);
+        }
         Optional<TlsConfiguration> maybeTlsConfiguration = TlsConfiguration.from(tlsConfigurationRegistry,
                 Optional.ofNullable(tlsConfigurationName));
         if (maybeTlsConfiguration.isEmpty()) {

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/config/WebSocketsClientRuntimeConfig.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/config/WebSocketsClientRuntimeConfig.java
@@ -36,7 +36,7 @@ public interface WebSocketsClientRuntimeConfig {
 
     /**
      * The maximum size of a frame in bytes. The default values is
-     * {@value io.vertx.core.http.HttpClientOptions#DEFAULT_MAX_WEBSOCKET_FRAME_SIZEX}.
+     * {@value io.vertx.core.http.HttpClientOptions#DEFAULT_MAX_WEBSOCKET_FRAME_SIZE}.
      */
     OptionalInt maxFrameSize();
 
@@ -51,6 +51,15 @@ public interface WebSocketsClientRuntimeConfig {
      * If set then a connection will be closed if no data is received nor sent within the given timeout.
      */
     Optional<Duration> connectionIdleTimeout();
+
+    /**
+     * The amount of time a client will wait until it closes the TCP connection after sending a close frame.
+     * Any value will be {@link Duration#toSeconds() converted to seconds} and limited to {@link Integer#MAX_VALUE}.
+     * The default value is {@value io.vertx.core.http.HttpClientOptions#DEFAULT_WEBSOCKET_CLOSING_TIMEOUT}s
+     *
+     * @see io.vertx.core.http.WebSocketClientOptions#setClosingTimeout(int)
+     */
+    Optional<Duration> connectionClosingTimeout();
 
     /**
      * The strategy used when an error occurs but no error handler can handle the failure.


### PR DESCRIPTION
This PR makes some minor changes in preparation for new `WebSocket::close` behavior in the forthcoming Vert.x 4.5.16 release. https://github.com/eclipse-vertx/vert.x/pull/5609

- treat `HttpClosedException` as a "close failure"
- introduce `CloseReason` constants `EMPTY` (matches missing or `1005` status code) and `ABNORMAL` (matches `1006` status code)
- add support for configuring `ClientOptions::setClosingTimeout` 