### PR TITLE
Simplify the dev services model

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/SupplierMap.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/SupplierMap.java
@@ -1,0 +1,109 @@
+package io.quarkus.deployment;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class SupplierMap<K, V> implements Map<K, V> {
+    private final Map<K, Supplier<V>> suppliers;
+    private final Map<K, V> cache;
+
+    public SupplierMap() {
+        this.suppliers = new HashMap<>();
+        this.cache = new HashMap<>();
+    }
+
+    public void put(K key, Supplier<V> supplier) {
+        suppliers.put(key, supplier);
+    }
+
+    @Override
+    public V get(Object key) {
+        if (key == null) {
+            return null;
+        }
+        return cache.computeIfAbsent((K) key, k -> {
+            Supplier<V> supplier = suppliers.get(k);
+            if (supplier == null) {
+                return null;
+            }
+            return supplier.get();
+        });
+    }
+
+    public void clear() {
+        suppliers.clear();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return suppliers.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return suppliers.values().stream().map(Supplier::get).toList();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return suppliers.entrySet().stream()
+                .map(entry -> Map.entry(entry.getKey(), entry.getValue().get()))
+                .collect(Collectors.toSet());
+    }
+
+    public int size() {
+        return suppliers.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return suppliers.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return suppliers.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V put(K key, V value) {
+        Supplier<V> old = suppliers.put(key, () -> value);
+        if (old == null) {
+            return null;
+        }
+        return old.get();
+    }
+
+    @Override
+    public V remove(Object key) {
+        Supplier<? extends V> remove = suppliers.remove(key);
+        if (remove == null) {
+            return null;
+        }
+        return remove.get();
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        for (Map.Entry<? extends K, ? extends V> entry : m.entrySet()) {
+            cache.put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public Map<K, V> asEagerMap() {
+        Map<K, V> result = new HashMap<>();
+        for (K key : suppliers.keySet()) {
+            result.put(key, get(key));
+        }
+        return result;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesCustomizerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesCustomizerBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.function.BiFunction;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class DevServicesCustomizerBuildItem extends MultiBuildItem {
+
+    private final BiFunction<DevServicesResultBuildItem, Startable, Startable> customizer;
+
+    public DevServicesCustomizerBuildItem(BiFunction<DevServicesResultBuildItem, Startable, Startable> customizer) {
+        this.customizer = customizer;
+    }
+
+    public Startable apply(DevServicesResultBuildItem devservice, Startable startable) {
+        return customizer.apply(devservice, startable);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -1,61 +1,137 @@
 package io.quarkus.deployment.builditem;
 
-import java.io.Closeable;
-import java.util.Set;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.crossclassloader.runtime.ComparableDevServicesConfig;
 import io.quarkus.devservices.crossclassloader.runtime.DevServiceOwner;
 import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
+import io.quarkus.devservices.crossclassloader.runtime.RunningService;
 import io.quarkus.runtime.LaunchMode;
 
-// Ideally we would have a unique build item for each processor/feature, but that would need a new KeyedBuildItem or FeatureBuildItem type
-// Needs to be in core because DevServicesResultBuildItem is in core
+/**
+ * This is a wrapper around the RunningDevServicesRegistry, so the registry can be loaded with the system classloader
+ * The QuarkusClassLoader takes care of loading the tracker with the right classloader
+ * <p>
+ * This build item is used to manage the lifecycle of dev services across different features and launch modes.
+ */
 public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
 
-    // This is a fairly thin wrapper around the tracker, so the tracker can be loaded with the system classloader
-    // The QuarkusClassLoader takes care of loading the tracker with the right classloader
-    private final RunningDevServicesRegistry tracker;
+    private static final Logger log = Logger.getLogger(DevServicesRegistryBuildItem.class);
+
     private final UUID uuid;
     private final DevServicesConfig globalConfig;
     private final LaunchMode launchMode;
 
     public DevServicesRegistryBuildItem(UUID uuid, DevServicesConfig globalDevServicesConfig, LaunchMode launchMode) {
         this.launchMode = launchMode;
-        this.tracker = new RunningDevServicesRegistry();
         this.uuid = uuid;
         this.globalConfig = globalDevServicesConfig;
     }
 
-    public Set<Closeable> getRunningServices(String featureName, String configName, Object identifyingConfig) {
+    public RunningService getRunningServices(String featureName, String configName, Object identifyingConfig) {
         DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
         ComparableDevServicesConfig key = new ComparableDevServicesConfig(uuid, owner, globalConfig, identifyingConfig);
-        return tracker.getRunningServices(key);
-    }
-
-    public Set<Closeable> getAllRunningServices(String featureName, String configName) {
-        DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
-        return tracker.getAllRunningServices(owner);
+        return RunningDevServicesRegistry.INSTANCE.getRunningServices(key);
     }
 
     public void addRunningService(String featureName, String configName, Object identifyingConfig,
-            DevServicesResultBuildItem.RunnableDevService service) {
+            RunningService service) {
         DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
         ComparableDevServicesConfig key = new ComparableDevServicesConfig(uuid, owner, globalConfig, identifyingConfig);
-        tracker.addRunningService(key, service);
+        RunningDevServicesRegistry.INSTANCE.addRunningService(key, service);
     }
 
-    public void removeRunningService(String featureName, String configName, Object identifyingConfig,
-            DevServicesResultBuildItem.RunnableDevService service) {
+    public void closeAllRunningServices(String featureName, String configName) {
         DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
-        ComparableDevServicesConfig key = new ComparableDevServicesConfig(uuid, owner, globalConfig, identifyingConfig);
-        tracker.removeRunningService(key, service);
+        RunningDevServicesRegistry.INSTANCE.closeAllRunningServices(owner);
     }
 
     public void closeAllRunningServices() {
-        tracker.closeAllRunningServices(launchMode.name());
+        RunningDevServicesRegistry.INSTANCE.closeAllRunningServices(launchMode.name());
+    }
+
+    public Map<String, String> getConfigForAllRunningServices() {
+        Map<String, String> config = new HashMap<>();
+        for (RunningService service : RunningDevServicesRegistry.INSTANCE.getAllRunningServices(launchMode.name())) {
+            config.putAll(service.configs());
+        }
+        return config;
+    }
+
+    public void startAll(Collection<DevServicesResultBuildItem> services,
+            List<DevServicesCustomizerBuildItem> customizers,
+            ClassLoader augmentClassLoader) {
+        CompletableFuture.allOf(services.stream()
+                .filter(DevServicesResultBuildItem::isStartable)
+                .map(serv -> CompletableFuture.runAsync(() -> {
+                    // We need to set the context classloader to the augment classloader, so that the dev services can be started with the right classloader
+                    Thread.currentThread().setContextClassLoader(augmentClassLoader);
+                    this.start(serv, customizers);
+                }))
+                .toArray(CompletableFuture[]::new)).join();
+    }
+
+    public void start(DevServicesResultBuildItem request, List<DevServicesCustomizerBuildItem> customizers) {
+        // RunningService class is loaded on parent classloader
+        RunningService matchedDevService = this.getRunningServices(request.getName(), request.getServiceName(),
+                request.getServiceConfig());
+        if (matchedDevService == null) {
+            // There isn't a running container that has the right config, we need to do work
+            // Let's get all the running dev services associated with this feature (+ launch mode plus named section), so we can close them
+            closeAllRunningServices(request.getName(), request.getServiceName());
+
+            reallyStart(request, customizers);
+        }
+    }
+
+    private void reallyStart(DevServicesResultBuildItem request, List<DevServicesCustomizerBuildItem> customizers) {
+        StartupLogCompressor compressor = new StartupLogCompressor("Dev Services Startup", null, null);
+        try {
+            Supplier<Startable> startableSupplier = request.getStartableSupplier();
+            if (startableSupplier == null) {
+                throw new IllegalStateException(
+                        "Dev services for " + request.getName() + " requires a startable supplier, but none was provided.");
+            }
+            Startable startable = startableSupplier.get();
+            for (DevServicesCustomizerBuildItem customizer : customizers) {
+                startable = customizer.apply(request, startable);
+            }
+            startable.start();
+
+            RunningService service = new RunningService(request.getName(), request.getDescription(),
+                    request.getConfig(startable), startable.getContainerId(), startable);
+            this.addRunningService(request.getName(), request.getServiceName(), request.getServiceConfig(), service);
+
+            compressor.close();
+
+            Consumer<Startable> postStartAction = request.getPostStartAction();
+            if (postStartAction != null) {
+                try {
+                    postStartAction.accept(startable);
+                } catch (Throwable t) {
+                    log.errorf(t, "An error occurred while executing the post-start action for %s dev service: %s",
+                            request.getName(), t.getMessage());
+                }
+            } else {
+                log.infof("The %s dev service is ready to accept connections on %s", request.getName(),
+                        startable.getConnectionInfo());
+            }
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw t;
+        }
     }
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
@@ -4,37 +4,38 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
 public final class DevServiceDescriptionBuildItem extends MultiBuildItem {
-    private String name;
-    private String description;
-    private Supplier<ContainerInfo> lazyContainerInfo;
-    private Map<String, String> configs;
+    private final String name;
+    private final String description;
+    private final Supplier<ContainerInfo> lazyContainerInfo;
     private final Supplier<Map<String, String>> lazyConfigs;
 
-    public DevServiceDescriptionBuildItem() {
-        this.lazyConfigs = null;
-    }
-
-    public DevServiceDescriptionBuildItem(String name, String description, ContainerInfo containerInfo,
-            Map<String, String> configs) {
-        this(name, description, () -> containerInfo, configs, null);
+    public DevServiceDescriptionBuildItem(String name, Map<String, String> configs) {
+        this(name, null, null, configs);
     }
 
     public DevServiceDescriptionBuildItem(String name, Supplier<ContainerInfo> lazyContainerInfo,
-            Map<String, String> configs, Supplier<Map<String, String>> lazyConfigs) {
-        this(name, null, lazyContainerInfo, configs, lazyConfigs);
+            Supplier<Map<String, String>> lazyConfigs) {
+        this(name, null, lazyContainerInfo, lazyConfigs);
+    }
+
+    public DevServiceDescriptionBuildItem(String name, String description, Map<String, String> config) {
+        this(name, description, null, config);
     }
 
     public DevServiceDescriptionBuildItem(String name, String description, Supplier<ContainerInfo> lazyContainerInfo,
-            Map<String, String> configs, Supplier<Map<String, String>> lazyConfigs) {
+            Map<String, String> configs) {
+        this(name, description, lazyContainerInfo, () -> configs instanceof SortedMap ? configs : new TreeMap<>(configs));
+    }
+
+    public DevServiceDescriptionBuildItem(String name, String description, Supplier<ContainerInfo> lazyContainerInfo,
+            Supplier<Map<String, String>> lazyConfigs) {
         this.name = name;
         this.description = description;
         this.lazyContainerInfo = lazyContainerInfo;
-        this.configs = configs instanceof SortedMap ? configs : new TreeMap<>(configs);
         this.lazyConfigs = lazyConfigs;
     }
 
@@ -51,32 +52,11 @@ public final class DevServiceDescriptionBuildItem extends MultiBuildItem {
     }
 
     public Map<String, String> getConfigs() {
-        if (lazyConfigs == null) {
-            return configs;
-        } else {
-            Map<String, String> result = new TreeMap<>(configs);
-            // This will make sure the lazy config is sorted even though we couldn't sort it up-front
-            result.putAll(lazyConfigs.get());
-            return result;
+        Map<String, String> map = lazyConfigs.get();
+        if (map == null) {
+            return null;
         }
-
+        return new TreeMap<>(map);
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public void setConfigs(Map<String, String> configs) {
-        this.configs = configs;
-    }
-
-    public String formatConfigs() {
-        return configs.entrySet().stream()
-                .map(e -> e.getKey() + "=" + e.getValue())
-                .collect(Collectors.joining(", "));
-    }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -68,6 +68,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ConsoleCommandBuildItem;
 import io.quarkus.deployment.builditem.ConsoleFormatterBannerBuildItem;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
@@ -79,6 +80,7 @@ import io.quarkus.deployment.builditem.LogSocketFormatBuildItem;
 import io.quarkus.deployment.builditem.LogSyslogFormatBuildItem;
 import io.quarkus.deployment.builditem.NamedLogHandlersBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownListenerBuildItem;
 import io.quarkus.deployment.builditem.StreamingLogHandlerBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
@@ -330,13 +332,8 @@ public final class LoggingResourceProcessor {
 
             initializeBuildTimeLogging(logRuntimeConfigInBuild, logBuildTimeConfig, consoleRuntimeConfig,
                     categoryMinLevelDefaults.content, additionalLogCleanupFilters, launchModeBuildItem.getLaunchMode());
-
-            ((QuarkusClassLoader) Thread.currentThread().getContextClassLoader()).addCloseTask(new Runnable() {
-                @Override
-                public void run() {
-                    InitialConfigurator.DELAYED_HANDLER.buildTimeComplete();
-                }
-            });
+            // Build time logging is terminated before the application is started, after dev services are started.
+            // When there is no devservices build time logging is still closed at deployment classloader close #closeBuildTimeLogging
         }
         return new LoggingSetupBuildItem();
     }
@@ -532,6 +529,19 @@ public final class LoggingResourceProcessor {
             generateDefaultLoggers(log.minLevel(), output);
         } else {
             generateCategoryMinLevelLoggers(log.categories(), categoryMinLevelDefaults.content, log.minLevel(), output);
+        }
+    }
+
+    @BuildStep
+    @Produce(ServiceStartBuildItem.class)
+    void closeBuildTimeLogging(List<DevServicesResultBuildItem> devServices) {
+        if (devServices.isEmpty()) {
+            ((QuarkusClassLoader) Thread.currentThread().getContextClassLoader()).addCloseTask(new Runnable() {
+                @Override
+                public void run() {
+                    InitialConfigurator.DELAYED_HANDLER.buildTimeComplete();
+                }
+            });
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
@@ -2,13 +2,13 @@ package io.quarkus.devservices.crossclassloader.runtime;
 
 import static java.util.UUID.randomUUID;
 
-import java.io.Closeable;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 /**
  * Note: This class should only use language-level classes and classes defined in this same package.
@@ -17,112 +17,75 @@ import java.util.function.Supplier;
  * Warning: The methods in this class should *not* be called directly from an extension processor, in the augmentation phase.
  * Tracker-aware running dev services will only be registered post-augmentation, at runtime.
  */
-public class RunningDevServicesRegistry {
+public final class RunningDevServicesRegistry {
+
+    public static final RunningDevServicesRegistry INSTANCE = new RunningDevServicesRegistry();
 
     // A useful uniqueness marker which will persist across profiles and application restarts, since this class lives in the system classloader. The value will be the same between dev and test mode.
     public static final String APPLICATION_UUID = randomUUID().toString();
 
-    private static final Map<String, Set<Supplier<Map>>> configTracker = new ConcurrentHashMap<>();
+    // This index is needed for the DevServicesConfigSource to be able to access the dev services running in a specific launch mode.
+    private static final Map<String, Set<RunningService>> servicesIndexedByLaunchMode = new ConcurrentHashMap<>();
 
     // A dev service owner is a combination of an extension (feature) and the app type (dev or test) which identifies which dev services
     // an extension processor can safely close.
-    private static final Map<DevServiceOwner, Set<Closeable>> servicesIndexedByOwner = new ConcurrentHashMap<>();
-    private static final Map<ComparableDevServicesConfig, Set<Closeable>> servicesIndexedByConfig = new ConcurrentHashMap<>();
+    private final Map<ComparableDevServicesConfig, RunningService> servicesIndexedByConfig = new ConcurrentHashMap<>();
 
-    public void closeAllRunningServices() {
-        // This is called when the application is shutting down, so we can close all running services
-        servicesIndexedByOwner.forEach((owner, services) -> {
-            for (Closeable service : services) {
+    private RunningDevServicesRegistry() {
+    }
+
+    public void closeAllRunningServices(String launchMode) {
+        Iterator<Map.Entry<ComparableDevServicesConfig, RunningService>> it = servicesIndexedByConfig.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<ComparableDevServicesConfig, RunningService> next = it.next();
+            DevServiceOwner owner = next.getKey().owner();
+            if (owner.launchMode().equals(launchMode)) {
+                it.remove();
                 try {
+                    RunningService service = next.getValue();
                     service.close();
                 } catch (Exception e) {
                     // We don't want to fail the shutdown hook if a service fails to close
                     e.printStackTrace();
                 }
             }
-        });
-        servicesIndexedByOwner.clear();
-        servicesIndexedByConfig.clear();
-        configTracker.clear();
+        }
+        servicesIndexedByLaunchMode.remove(launchMode);
     }
 
-    public void closeAllRunningServices(String launchMode) {
-        Iterator<Map.Entry<ComparableDevServicesConfig, Set<Closeable>>> it = servicesIndexedByConfig.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<ComparableDevServicesConfig, Set<Closeable>> next = it.next();
-            DevServiceOwner owner = next.getKey().owner();
-            if (owner.launchMode().equals(launchMode)) {
-                it.remove();
-                servicesIndexedByOwner.remove(owner);
-                for (Closeable service : next.getValue()) {
-                    try {
-                        service.close();
-                    } catch (Exception e) {
-                        // We don't want to fail the shutdown hook if a service fails to close
-                        e.printStackTrace();
-                    }
+    public void closeAllRunningServices(DevServiceOwner owner) {
+        Set<RunningService> launchModeServices = servicesIndexedByLaunchMode.get(owner.launchMode());
+        var iterator = servicesIndexedByConfig.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<ComparableDevServicesConfig, RunningService> entry = iterator.next();
+            DevServiceOwner entryOwner = entry.getKey().owner();
+            if (Objects.equals(entryOwner, owner)) {
+                iterator.remove();
+                RunningService serviceToClose = entry.getValue();
+                if (launchModeServices != null) {
+                    launchModeServices.remove(serviceToClose);
+                }
+                try {
+                    serviceToClose.close();
+                } catch (Exception e) {
+                    // We don't want to fail the shutdown hook if a service fails to close
+                    e.printStackTrace();
                 }
             }
         }
-        configTracker.remove(launchMode);
     }
 
-    /**
-     *
-     * @return may return null
-     */
-    public Set<Supplier<Map>> getConfigForAllRunningServices(String launchMode) {
-        // This gets called an awful lot. Should we cache it? If we did, we'd need to deal with cache invalidation, so maybe not.
-        return configTracker.get(launchMode);
+    public Set<RunningService> getAllRunningServices(String launchMode) {
+        return servicesIndexedByLaunchMode.getOrDefault(launchMode, Collections.emptySet());
     }
 
-    public Set<Closeable> getRunningServices(ComparableDevServicesConfig identifyingConfig) {
+    public RunningService getRunningServices(ComparableDevServicesConfig identifyingConfig) {
         return servicesIndexedByConfig.get(identifyingConfig);
     }
 
-    public Set<Closeable> getAllRunningServices(DevServiceOwner owner) {
-        return servicesIndexedByOwner.get(owner);
+    public void addRunningService(ComparableDevServicesConfig key, RunningService service) {
+        servicesIndexedByConfig.put(key, service);
+        servicesIndexedByLaunchMode.computeIfAbsent(key.owner().launchMode(), k -> new HashSet<>()).add(service);
     }
 
-    public void addRunningService(ComparableDevServicesConfig key, Closeable service) {
-        addServiceToIndex(servicesIndexedByOwner, key.owner(), service);
-        addServiceToIndex(servicesIndexedByConfig, key, service);
-        addServiceToConfig(key.owner().launchMode(), (Supplier<Map>) service);
-    }
-
-    // The service passed in here might be from a different classloader
-    public void removeRunningService(ComparableDevServicesConfig key, Closeable service) {
-        DevServiceOwner owner = key.owner();
-        removeServiceFromIndex(servicesIndexedByConfig, key, service);
-        removeServiceFromIndex(servicesIndexedByOwner, owner, service);
-        removeServiceFromConfig(owner.launchMode(), (Supplier<Map>) service);
-    }
-
-    static <T, K> void addServiceToIndex(Map<K, Set<T>> servicesIndexed, K key, T value) {
-        servicesIndexed.computeIfAbsent(key, k -> new HashSet<>()).add(value);
-    }
-
-    static <T, K> void removeServiceFromIndex(Map<K, Set<T>> servicesIndexed, K key, T value) {
-        Set<T> servicesForOwner = servicesIndexed.get(key);
-        if (servicesForOwner != null) {
-            servicesForOwner.remove(value);
-            if (servicesForOwner.isEmpty()) {
-                servicesIndexed.remove(key);
-            }
-        }
-    }
-
-    void addServiceToConfig(String launchMode, Supplier<Map> configSupplier) {
-        configTracker.computeIfAbsent(launchMode, k -> new HashSet<>()).add(configSupplier);
-    }
-
-    void removeServiceFromConfig(String launchMode, Supplier<Map> configSupplier) {
-        Set<Supplier<Map>> configs = configTracker.get(launchMode);
-        if (configs != null) {
-            configs.remove(configSupplier);
-            if (configs.isEmpty()) {
-                configTracker.remove(launchMode);
-            }
-        }
-    }
 }

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningService.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningService.java
@@ -1,0 +1,52 @@
+package io.quarkus.devservices.crossclassloader.runtime;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Represents a running service in Dev Services.
+ * This class is used to encapsulate the details of a service that has been started by Dev Services,
+ * necessary for tracking and managing the lifecycle of the service.
+ * <p>
+ * It is designed to be loaded with the parent classloader, allowing it to be shared across different classloaders.
+ */
+public final class RunningService implements Closeable {
+
+    private final String feature;
+    private final String description;
+    private final Map<String, String> configs;
+    private final String containerId;
+    private final Closeable closeable;
+
+    public RunningService(String feature, String description, Map<String, String> configs, String containerId,
+            Closeable closeable) {
+        this.feature = feature;
+        this.description = description;
+        this.configs = configs;
+        this.containerId = containerId;
+        this.closeable = closeable;
+    }
+
+    @Override
+    public void close() throws IOException {
+        closeable.close();
+    }
+
+    public String feature() {
+        return feature;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public Map<String, String> configs() {
+        return configs;
+    }
+
+    public String containerId() {
+        return containerId;
+    }
+
+}

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -1,5 +1,9 @@
 package io.quarkus.devservices.common;
 
+import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.common.Labels.QUARKUS_LAUNCH_MODE;
+import static io.quarkus.devservices.common.Labels.QUARKUS_PROCESS_UUID;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -18,6 +22,9 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.utility.Base58;
 
 import com.github.dockerjava.api.command.CreateNetworkCmd;
+
+import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
+import io.quarkus.runtime.LaunchMode;
 
 public final class ConfigureUtil {
 
@@ -38,6 +45,21 @@ public final class ConfigureUtil {
             return configureSharedNetwork(container, hostNamePrefix);
         }
         return container.getHost();
+    }
+
+    public static void configureLabels(GenericContainer<?> container, LaunchMode launchMode, String serviceLabel,
+            String serviceName) {
+        if (serviceName != null) {
+            container.withLabel(serviceLabel, serviceName);
+            container.withLabel(QUARKUS_DEV_SERVICE, serviceName);
+        }
+        configureLabels(container, launchMode);
+    }
+
+    public static void configureLabels(GenericContainer<?> container, LaunchMode launchMode) {
+        // Configure the labels for the container
+        container.withLabel(QUARKUS_PROCESS_UUID, RunningDevServicesRegistry.APPLICATION_UUID);
+        container.withLabel(QUARKUS_LAUNCH_MODE, launchMode.toString());
     }
 
     public static String configureSharedNetwork(GenericContainer<?> container, String hostNamePrefix) {

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -19,18 +19,10 @@ import io.quarkus.runtime.LaunchMode;
 
 public class ContainerLocator {
 
-    /**
-     * Label which indicates that this dev service was started by this process, and therefore should not be discovered for
-     * re-use;
-     * instead reuse should be managed by the DevServicesRegistry, so that config updates apply.
-     * We use a UUID as the value so that we don't filter out dev services from other processes.
-     */
-    public static final String MANAGED_DEV_SERVICE_LABEL = "quarkus-dev-service-process-uuid";
-
     // Read the UUID off the RunningDevServicesRegistry, because it's guaranteed to be parent-first, unlike this class
     public static final BiPredicate<Container, String> IS_NOT_CREATED_BY_US_SELECTOR = (container,
             expectedLabel) -> !RunningDevServicesRegistry.APPLICATION_UUID
-                    .equals(container.getLabels().get(MANAGED_DEV_SERVICE_LABEL));
+                    .equals(container.getLabels().get(Labels.QUARKUS_PROCESS_UUID));
 
     private static final Logger log = Logger.getLogger(ContainerLocator.class);
 

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
@@ -30,6 +30,16 @@ public final class Labels {
 
     public static final String COMPOSE_EXPOSED_PORTS = QUARKUS_COMPOSE_PREFIX + ".exposed_ports";
 
+    public static final String QUARKUS_LAUNCH_MODE = QUARKUS_DEV_SERVICE + ".launch-mode";
+
+    /**
+     * Label which indicates that this dev service was started by this process, and therefore should not be discovered for
+     * re-use;
+     * instead reuse should be managed by the DevServicesRegistry, so that config updates apply.
+     * We use a UUID as the value so that we don't filter out dev services from other processes.
+     */
+    public static final String QUARKUS_PROCESS_UUID = QUARKUS_DEV_SERVICE + ".process-uuid";
+
     private static final String DATASOURCE = "datasource";
 
     public static void addDataSourceLabel(GenericContainer<?> container, String datasourceName) {

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
@@ -1,0 +1,54 @@
+package io.quarkus.devservices.common;
+
+import java.util.function.Function;
+
+import org.testcontainers.containers.GenericContainer;
+
+import io.quarkus.deployment.builditem.Startable;
+
+/**
+ * A wrapper for a {@link GenericContainer} that implements the {@link Startable} interface.
+ *
+ * @param <T> the type of the container
+ */
+public class StartableContainer<T extends GenericContainer<?>> implements Startable {
+
+    private final T container;
+    private final Function<T, String> connectionInfoFunction;
+
+    public StartableContainer(T container) {
+        this(container, null);
+    }
+
+    public StartableContainer(T container, Function<T, String> connectionInfoFunction) {
+        this.container = container;
+        this.connectionInfoFunction = connectionInfoFunction;
+    }
+
+    @Override
+    public void start() {
+        container.start();
+    }
+
+    @Override
+    public String getConnectionInfo() {
+        if (connectionInfoFunction == null) {
+            return container.getContainerId();
+        }
+        return null;
+    }
+
+    public T getContainer() {
+        return container;
+    }
+
+    @Override
+    public String getContainerId() {
+        return container.getContainerId();
+    }
+
+    @Override
+    public void close() {
+        container.close();
+    }
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
@@ -162,12 +162,12 @@ public class ComposeDevServicesProcessor {
     @BuildStep
     public DevServicesResultBuildItem toDevServicesResult(DevServicesComposeProjectBuildItem composeBuildItem) {
         if (composeBuildItem.getProject() != null) {
-            return new DevServicesResultBuildItem(
-                    "Compose Dev Services",
-                    String.format("Project: %s, Services: %s", composeBuildItem.getProject(),
-                            String.join(", ", composeBuildItem.getComposeServices().keySet())),
-                    null,
-                    composeBuildItem.getConfig());
+            return DevServicesResultBuildItem.discovered()
+                    .name("Compose Dev Services")
+                    .description(String.format("Project: %s, Services: %s", composeBuildItem.getProject(),
+                            String.join(", ", composeBuildItem.getComposeServices().keySet())))
+                    .config(composeBuildItem.getConfig())
+                    .build();
         }
         return null;
     }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -2,17 +2,13 @@ package io.quarkus.kafka.client.deployment;
 
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.admin.AdminClient;
@@ -30,22 +26,17 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
-import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
-import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
-import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
-import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
-import io.quarkus.devservices.common.Labels;
-import io.quarkus.runtime.LaunchMode;
+import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.strimzi.test.container.StrimziKafkaContainer;
 
@@ -67,85 +58,83 @@ public class DevServicesKafkaProcessor {
 
     private static final ContainerLocator kafkaContainerLocator = locateContainerWithLabels(KAFKA_PORT, DEV_SERVICE_LABEL);
 
-    static volatile RunningDevService devService;
-    static volatile KafkaDevServiceCfg cfg;
-    static volatile boolean first = true;
-
     @BuildStep
     public DevServicesResultBuildItem startKafkaDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
-            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            DevServicesComposeProjectBuildItem compose,
             LaunchModeBuildItem launchMode,
             KafkaBuildTimeConfig kafkaClientBuildTimeConfig,
-            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
-            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
-            CuratedApplicationShutdownBuildItem closeBuildItem,
-            LoggingSetupBuildItem loggingSetupBuildItem, DevServicesConfig devServicesConfig) {
-
-        KafkaDevServiceCfg configuration = getConfiguration(kafkaClientBuildTimeConfig);
-
-        if (devService != null && devService.isOwner()) {
-            boolean shouldShutdownTheBroker = !configuration.equals(cfg);
-            if (!shouldShutdownTheBroker) {
-                return devService.toBuildItem();
-            }
-            shutdownBroker();
-            cfg = null;
-        }
-
-        StartupLogCompressor compressor = new StartupLogCompressor(
-                (launchMode.isTest() ? "(test) " : "") + "Kafka Dev Services Starting:",
-                consoleInstalledBuildItem, loggingSetupBuildItem);
-        try {
-            devService = startKafka(dockerStatusBuildItem, composeProjectBuildItem, configuration, launchMode,
-                    !devServicesSharedNetworkBuildItem.isEmpty(),
-                    devServicesConfig.timeout());
-            if (devService == null) {
-                compressor.closeAndDumpCaptured();
-            } else {
-                compressor.close();
-            }
-        } catch (Throwable t) {
-            compressor.closeAndDumpCaptured();
-            throw new RuntimeException(t);
-        }
-
-        if (devService == null) {
+            List<DevServicesSharedNetworkBuildItem> sharedNetwork,
+            DevServicesConfig devServicesConfig) {
+        // If the dev service is disabled, we return null to indicate that no dev service was started.
+        KafkaDevServicesBuildTimeConfig config = kafkaClientBuildTimeConfig.devservices();
+        if (devServiceDisabled(dockerStatusBuildItem, config)) {
             return null;
         }
+        boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig, sharedNetwork);
 
-        // Configure the watch dog
-        if (first) {
-            first = false;
-            Runnable closeTask = () -> {
-                if (devService != null) {
-                    shutdownBroker();
+        return kafkaContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+                .or(() -> ComposeLocator.locateContainer(compose,
+                        List.of(config.effectiveImageName(), "kafka", "strimzi", "redpanda"),
+                        KAFKA_PORT, launchMode.getLaunchMode(), useSharedNetwork))
+                .map(containerAddress -> {
+                    createTopicPartitions(containerAddress.getUrl(), config);
+                    return DevServicesResultBuildItem.discovered()
+                            .feature(Feature.KAFKA_CLIENT)
+                            .containerId(containerAddress.getId())
+                            .config(Map.of(KAFKA_BOOTSTRAP_SERVERS, containerAddress.getUrl()))
+                            .build();
+                }).orElseGet(() -> DevServicesResultBuildItem.owned()
+                        .feature(Feature.KAFKA_CLIENT)
+                        .serviceName(config.serviceName())
+                        .serviceConfig(config)
+                        .startable(() -> createContainer(compose, config, useSharedNetwork))
+                        .postStartHook(s -> logStartedAndCreateTopicPartitions(s.getConnectionInfo(), config))
+                        .configProvider(Map.of(KAFKA_BOOTSTRAP_SERVERS, Startable::getConnectionInfo))
+                        .build());
+    }
+
+    private Startable createContainer(DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            KafkaDevServicesBuildTimeConfig config,
+            boolean useSharedNetwork) {
+        Startable startable = switch (config.provider()) {
+            case REDPANDA -> new RedpandaKafkaContainer(DockerImageName.parse(config.effectiveImageName())
+                    .asCompatibleSubstituteFor("redpandadata/redpanda"),
+                    config.port().orElse(0),
+                    composeProjectBuildItem.getDefaultNetworkId(),
+                    useSharedNetwork, config.redpanda())
+                    .withEnv(config.containerEnv());
+            case STRIMZI -> {
+                StrimziKafkaContainer strimzi = new StrimziKafkaContainer(config.effectiveImageName())
+                        .withBrokerId(1)
+                        .withKraft()
+                        .waitForRunning();
+                String hostName = ConfigureUtil.configureNetwork(strimzi,
+                        composeProjectBuildItem.getDefaultNetworkId(), useSharedNetwork, "kafka");
+                if (useSharedNetwork) {
+                    strimzi.withBootstrapServers(c -> String.format("PLAINTEXT://%s:%s", hostName, KAFKA_PORT));
                 }
-                first = true;
-                devService = null;
-                cfg = null;
-            };
-            closeBuildItem.addCloseTask(closeTask, true);
-        }
-        cfg = configuration;
-
-        if (devService.isOwner()) {
-            log.infof(
-                    "Dev Services for Kafka started. Other Quarkus applications in dev mode will find the "
-                            + "broker automatically. For Quarkus applications in production mode, you can connect to"
-                            + " this by starting your application with -Dkafka.bootstrap.servers=%s",
-                    getKafkaBootstrapServers());
-        }
-        createTopicPartitions(getKafkaBootstrapServers(), configuration);
-        return devService.toBuildItem();
+                if (config.port().isPresent() && config.port().get() != 0) {
+                    strimzi.withPort(config.port().get());
+                }
+                strimzi.withEnv(config.containerEnv());
+                yield new StartableContainer<>(strimzi, StrimziKafkaContainer::getBootstrapServers);
+            }
+            case KAFKA_NATIVE -> new KafkaNativeContainer(DockerImageName.parse(config.effectiveImageName()),
+                    config.port().orElse(0),
+                    composeProjectBuildItem.getDefaultNetworkId(),
+                    useSharedNetwork).withEnv(config.containerEnv());
+        };
+        return startable;
     }
 
-    public static String getKafkaBootstrapServers() {
-        return devService.getConfig().get(KAFKA_BOOTSTRAP_SERVERS);
+    public void logStartedAndCreateTopicPartitions(String bootstrapServers, KafkaDevServicesBuildTimeConfig configuration) {
+        logStarted(bootstrapServers);
+        createTopicPartitions(bootstrapServers, configuration);
     }
 
-    public void createTopicPartitions(String bootstrapServers, KafkaDevServiceCfg configuration) {
-        Map<String, Integer> topicPartitions = configuration.topicPartitions;
+    public void createTopicPartitions(String bootstrapServers, KafkaDevServicesBuildTimeConfig configuration) {
+        Map<String, Integer> topicPartitions = configuration.topicPartitions();
         if (topicPartitions.isEmpty()) {
             return;
         }
@@ -153,7 +142,7 @@ public class DevServicesKafkaProcessor {
                 Map.entry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers),
                 Map.entry(AdminClientConfig.CLIENT_ID_CONFIG, "kafka-devservices"));
         try (AdminClient adminClient = KafkaAdminClient.create(props)) {
-            long adminClientTimeout = configuration.topicPartitionsTimeout.toMillis();
+            long adminClientTimeout = configuration.topicPartitionsTimeout().toMillis();
             // get current partitions for topics asked to be created
             Set<String> currentTopics = adminClient.listTopics().names()
                     .get(adminClientTimeout, TimeUnit.MILLISECONDS);
@@ -186,116 +175,39 @@ public class DevServicesKafkaProcessor {
         }
     }
 
-    private void shutdownBroker() {
-        if (devService != null) {
-            try {
-                devService.close();
-            } catch (Throwable e) {
-                log.error("Failed to stop the Kafka broker", e);
-            } finally {
-                devService = null;
-            }
-        }
+    private static void logStarted(String bootstrapServers) {
+        log.infof(
+                "Dev Services for Kafka started. Other Quarkus applications in dev mode will find the "
+                        + "broker automatically. For Quarkus applications in production mode, you can connect to"
+                        + " this by starting your application with -Dkafka.bootstrap.servers=%s",
+                bootstrapServers);
     }
 
-    private RunningDevService startKafka(DockerStatusBuildItem dockerStatusBuildItem,
-            DevServicesComposeProjectBuildItem composeProjectBuildItem,
-            KafkaDevServiceCfg config,
-            LaunchModeBuildItem launchMode, boolean useSharedNetwork, Optional<Duration> timeout) {
-        if (!config.devServicesEnabled) {
+    private boolean devServiceDisabled(DockerStatusBuildItem dockerStatusBuildItem, KafkaDevServicesBuildTimeConfig config) {
+        if (!config.enabled().orElse(true)) {
             // explicitly disabled
             log.debug("Not starting dev services for Kafka, as it has been disabled in the config.");
-            return null;
+            return true;
         }
 
         // Check if kafka.bootstrap.servers is set
         if (ConfigUtils.isPropertyNonEmpty(KAFKA_BOOTSTRAP_SERVERS)) {
             log.debug("Not starting dev services for Kafka, the kafka.bootstrap.servers is configured.");
-            return null;
+            return true;
         }
 
         // Verify that we have kafka channels without bootstrap.servers
         if (!hasKafkaChannelWithoutBootstrapServers()) {
             log.debug("Not starting dev services for Kafka, all the channels are configured.");
-            return null;
+            return true;
         }
 
         if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
             log.warn(
                     "Docker isn't working, please configure the Kafka bootstrap servers property (kafka.bootstrap.servers).");
-            return null;
+            return true;
         }
-
-        // Starting the broker
-        final Supplier<RunningDevService> defaultKafkaBrokerSupplier = () -> {
-            switch (config.provider) {
-                case REDPANDA:
-                    RedpandaKafkaContainer redpanda = new RedpandaKafkaContainer(
-                            DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("redpandadata/redpanda"),
-                            config.fixedExposedPort,
-                            launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
-                            composeProjectBuildItem.getDefaultNetworkId(),
-                            useSharedNetwork, config.redpanda);
-                    timeout.ifPresent(redpanda::withStartupTimeout);
-                    redpanda.withEnv(config.containerEnv);
-                    redpanda.start();
-
-                    return new RunningDevService(Feature.KAFKA_CLIENT.getName(),
-                            redpanda.getContainerId(),
-                            redpanda::close,
-                            KAFKA_BOOTSTRAP_SERVERS, redpanda.getBootstrapServers());
-                case STRIMZI:
-                    StrimziKafkaContainer strimzi = new StrimziKafkaContainer(config.imageName)
-                            .withBrokerId(1)
-                            .withKraft()
-                            .waitForRunning();
-                    String hostName = ConfigureUtil.configureNetwork(strimzi,
-                            composeProjectBuildItem.getDefaultNetworkId(), useSharedNetwork, "kafka");
-                    if (useSharedNetwork) {
-                        strimzi.withBootstrapServers(c -> String.format("PLAINTEXT://%s:%s", hostName, KAFKA_PORT));
-                    }
-                    if (config.serviceName != null) {
-                        strimzi.withLabel(DevServicesKafkaProcessor.DEV_SERVICE_LABEL, config.serviceName);
-                        strimzi.withLabel(Labels.QUARKUS_DEV_SERVICE, config.serviceName);
-                    }
-                    if (config.fixedExposedPort != 0) {
-                        strimzi.withPort(config.fixedExposedPort);
-                    }
-                    timeout.ifPresent(strimzi::withStartupTimeout);
-                    strimzi.withEnv(config.containerEnv);
-
-                    strimzi.start();
-                    return new RunningDevService(Feature.KAFKA_CLIENT.getName(),
-                            strimzi.getContainerId(),
-                            strimzi::close,
-                            KAFKA_BOOTSTRAP_SERVERS, strimzi.getBootstrapServers());
-                case KAFKA_NATIVE:
-                    KafkaNativeContainer kafkaNative = new KafkaNativeContainer(DockerImageName.parse(config.imageName),
-                            config.fixedExposedPort,
-                            launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
-                            composeProjectBuildItem.getDefaultNetworkId(),
-                            useSharedNetwork);
-                    timeout.ifPresent(kafkaNative::withStartupTimeout);
-                    kafkaNative.withEnv(config.containerEnv);
-                    kafkaNative.start();
-
-                    return new RunningDevService(Feature.KAFKA_CLIENT.getName(),
-                            kafkaNative.getContainerId(),
-                            kafkaNative::close,
-                            KAFKA_BOOTSTRAP_SERVERS, kafkaNative.getBootstrapServers());
-            }
-            return null;
-        };
-
-        return kafkaContainerLocator.locateContainer(config.serviceName, config.shared, launchMode.getLaunchMode())
-                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
-                        List.of(config.imageName, "kafka", "strimzi", "redpanda"),
-                        KAFKA_PORT, launchMode.getLaunchMode(), useSharedNetwork))
-                .map(containerAddress -> new RunningDevService(Feature.KAFKA_CLIENT.getName(),
-                        containerAddress.getId(),
-                        null,
-                        KAFKA_BOOTSTRAP_SERVERS, containerAddress.getUrl()))
-                .orElseGet(defaultKafkaBrokerSupplier);
+        return false;
     }
 
     private boolean hasKafkaChannelWithoutBootstrapServers() {
@@ -315,61 +227,6 @@ public class DevServicesKafkaProcessor {
             }
         }
         return false;
-    }
-
-    private KafkaDevServiceCfg getConfiguration(KafkaBuildTimeConfig cfg) {
-        KafkaDevServicesBuildTimeConfig devServicesConfig = cfg.devservices();
-        return new KafkaDevServiceCfg(devServicesConfig);
-    }
-
-    private static final class KafkaDevServiceCfg {
-        private final boolean devServicesEnabled;
-        private final String imageName;
-        private final Integer fixedExposedPort;
-        private final boolean shared;
-        private final String serviceName;
-        private final Map<String, Integer> topicPartitions;
-        private final Duration topicPartitionsTimeout;
-        private final Map<String, String> containerEnv;
-
-        private final KafkaDevServicesBuildTimeConfig.Provider provider;
-
-        private final RedpandaBuildTimeConfig redpanda;
-
-        public KafkaDevServiceCfg(KafkaDevServicesBuildTimeConfig config) {
-            this.devServicesEnabled = config.enabled().orElse(true);
-            this.provider = config.provider();
-            this.imageName = config.imageName().orElseGet(provider::getDefaultImageName);
-            this.fixedExposedPort = config.port().orElse(0);
-            this.shared = config.shared();
-            this.serviceName = config.serviceName();
-            this.topicPartitions = config.topicPartitions();
-            this.topicPartitionsTimeout = config.topicPartitionsTimeout();
-            this.containerEnv = config.containerEnv();
-
-            this.redpanda = config.redpanda();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            KafkaDevServiceCfg that = (KafkaDevServiceCfg) o;
-            return devServicesEnabled == that.devServicesEnabled
-                    && Objects.equals(provider, that.provider)
-                    && Objects.equals(imageName, that.imageName)
-                    && Objects.equals(fixedExposedPort, that.fixedExposedPort)
-                    && Objects.equals(containerEnv, that.containerEnv);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(devServicesEnabled, provider, imageName, fixedExposedPort, containerEnv);
-        }
     }
 
 }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -123,4 +123,11 @@ public interface KafkaDevServicesBuildTimeConfig {
      */
     RedpandaBuildTimeConfig redpanda();
 
+    /**
+     * @return the image name if set, otherwise the default image name for the provider.
+     */
+    default String effectiveImageName() {
+        return imageName().orElseGet(() -> provider().getDefaultImageName());
+    }
+
 }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
@@ -9,10 +9,10 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
+import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
-import io.quarkus.devservices.common.Labels;
 
-public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer> {
+public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer> implements Startable {
 
     private static final String STARTER_SCRIPT = "/work/run.sh";
 
@@ -24,15 +24,11 @@ public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer>
 
     private final String hostName;
 
-    public KafkaNativeContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
-            String defaultNetworkId, boolean useSharedNetwork) {
+    public KafkaNativeContainer(DockerImageName dockerImageName, int fixedExposedPort, String defaultNetworkId,
+            boolean useSharedNetwork) {
         super(dockerImageName);
         this.fixedExposedPort = fixedExposedPort;
         this.useSharedNetwork = useSharedNetwork;
-        if (serviceName != null) {
-            withLabel(DevServicesKafkaProcessor.DEV_SERVICE_LABEL, serviceName);
-            withLabel(Labels.QUARKUS_DEV_SERVICE, serviceName);
-        }
         String cmd = String.format("while [ ! -f %s ]; do sleep 0.1; done; sleep 0.1; %s", STARTER_SCRIPT, STARTER_SCRIPT);
         withCommand("sh", "-c", cmd);
         waitingFor(Wait.forLogMessage(".*Kafka broker started.*", 1));
@@ -99,4 +95,13 @@ public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer>
         return getKafkaAdvertisedListeners();
     }
 
+    @Override
+    public String getConnectionInfo() {
+        return getBootstrapServers();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+    }
 }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
@@ -11,15 +11,15 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
+import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
-import io.quarkus.devservices.common.Labels;
 
 /**
  * Container configuring and starting the Redpanda broker.
  * See <a href=
  * "https://docs.redpanda.com/current/get-started/quick-start/">https://docs.redpanda.com/current/get-started/quick-start/</a>
  */
-final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContainer> {
+final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContainer> implements Startable {
 
     private final Integer fixedExposedPort;
     private final boolean useSharedNetwork;
@@ -30,17 +30,12 @@ final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContain
     private static final String STARTER_SCRIPT = "/var/lib/redpanda/redpanda.sh";
     private static final int PANDAPROXY_PORT = 8082;
 
-    RedpandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
-            String defaultNetworkId, boolean useSharedNetwork, RedpandaBuildTimeConfig redpandaConfig) {
+    RedpandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String defaultNetworkId,
+            boolean useSharedNetwork, RedpandaBuildTimeConfig redpandaConfig) {
         super(dockerImageName);
         this.fixedExposedPort = fixedExposedPort;
         this.useSharedNetwork = useSharedNetwork;
         this.redpandaConfig = redpandaConfig;
-
-        if (serviceName != null) { // Only adds the label in dev mode.
-            withLabel(DevServicesKafkaProcessor.DEV_SERVICE_LABEL, serviceName);
-            withLabel(Labels.QUARKUS_DEV_SERVICE, serviceName);
-        }
 
         // For redpanda, we need to start the broker - see https://vectorized.io/docs/quick-start-docker/
         withCreateContainerCmdModifier(cmd -> {
@@ -117,4 +112,13 @@ final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContain
         return getKafkaAdvertisedAddresses();
     }
 
+    @Override
+    public String getConnectionInfo() {
+        return getBootstrapServers();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+    }
 }

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -1,20 +1,12 @@
 package io.quarkus.redis.deployment.client;
 
-import static io.quarkus.devservices.common.ContainerLocator.MANAGED_DEV_SERVICE_LABEL;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
-import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
-import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
@@ -22,25 +14,19 @@ import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
-import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
-import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunnableDevService;
-import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.Startable;
-import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
-import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
-import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
-import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
 import io.quarkus.redis.deployment.client.RedisBuildTimeConfig.DevServiceConfiguration;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.quarkus.runtime.LaunchMode;
@@ -59,7 +45,6 @@ public class DevServicesRedisProcessor {
      * This allows other applications to discover the running service and use it instead of starting a new instance.
      */
     private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-redis";
-    private static final String LAUNCH_MODE_LABEL = "quarkus-launch-mode";
 
     private static final ContainerLocator redisContainerLocator = locateContainerWithLabels(REDIS_EXPOSED_PORT,
             DEV_SERVICE_LABEL);
@@ -68,135 +53,118 @@ public class DevServicesRedisProcessor {
     private static final String DOT = ".";
 
     @BuildStep
-    public List<DevServicesResultBuildItem> startRedisContainers(LaunchModeBuildItem launchMode,
+    public void startRedisContainers(LaunchModeBuildItem launchMode,
             DockerStatusBuildItem dockerStatusBuildItem,
             DevServicesComposeProjectBuildItem composeProjectBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             RedisBuildTimeConfig config,
-            DevServicesRegistryBuildItem tracker,
-            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
-            LoggingSetupBuildItem loggingSetupBuildItem,
+            BuildProducer<DevServicesResultBuildItem> devServicesResult,
             DevServicesConfig devServicesConfig) {
 
         Map<String, DevServiceConfiguration> currentDevServicesConfiguration = new HashMap<>(config.additionalDevServices());
         currentDevServicesConfiguration.put(RedisConfig.DEFAULT_CLIENT_NAME, config.defaultDevService());
 
-        // We cannot assume an augmentation order, so we cannot just check and reuse previous dev services.
-        // We *could* get the services from the tracker, and short circuit some work. But that short circuit has some risk.
-        // If the matching RunningDevService was in a different classloader, we'd get a ClassCastException.
-
-        List<RunningDevService> newDevServices = new ArrayList<>();
-
-        StartupLogCompressor compressor = new StartupLogCompressor(
-                (launchMode.isTest() ? "(test) " : "") + "Redis Dev Services Starting:", consoleInstalledBuildItem,
-                loggingSetupBuildItem);
         try {
             for (Entry<String, DevServiceConfiguration> entry : currentDevServicesConfiguration.entrySet()) {
-                String connectionName = entry.getKey();
+                String name = entry.getKey();
                 boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                         devServicesSharedNetworkBuildItem);
 
-                // We always get a RunnableDevServices object back, but multiple of these objects might map to the same underlying container, *if* the container locator finds services
-                RunningDevService devService = createContainer(dockerStatusBuildItem, composeProjectBuildItem,
-                        connectionName,
-                        entry.getValue().devservices(),
-                        launchMode.getLaunchMode(),
-                        useSharedNetwork, devServicesConfig.timeout(), tracker);
-                if (devService == null) {
+                String configPrefix = getConfigPrefix(name);
+                io.quarkus.redis.deployment.client.DevServicesConfig redisConfig = entry.getValue().devservices();
+                if (redisDevServicesEnabled(dockerStatusBuildItem, name, redisConfig, configPrefix)) {
+                    // If the dev services are disabled, we don't need to do anything
                     continue;
                 }
 
-                newDevServices.add(devService);
-            }
-            if (newDevServices.isEmpty()) {
-                compressor.closeAndDumpCaptured();
-            } else {
-                compressor.close();
+                DevServicesResultBuildItem discovered = discoverRunningService(composeProjectBuildItem, configPrefix,
+                        redisConfig, launchMode.getLaunchMode(), useSharedNetwork);
+                if (discovered != null) {
+                    devServicesResult.produce(discovered);
+                } else {
+                    devServicesResult
+                            .produce(DevServicesResultBuildItem.owned().feature(Feature.REDIS_CLIENT)
+                                    .serviceName(name)
+                                    .serviceConfig(redisConfig)
+                                    .startable(() -> new QuarkusPortRedisContainer(
+                                            DockerImageName.parse(redisConfig.imageName().orElse(REDIS_IMAGE))
+                                                    .asCompatibleSubstituteFor(REDIS_IMAGE),
+                                            redisConfig.port(),
+                                            composeProjectBuildItem.getDefaultNetworkId(),
+                                            useSharedNetwork)
+                                            .withEnv(redisConfig.containerEnv()))
+                                    .configProvider(Map.of(configPrefix + RedisConfig.HOSTS_CONFIG_NAME,
+                                            s -> REDIS_SCHEME + s.getConnectionInfo()))
+                                    .build());
+                }
             }
         } catch (Throwable t) {
-            compressor.closeAndDumpCaptured();
             throw new RuntimeException(t);
         }
 
-        return newDevServices.stream().map(RunningDevService::toBuildItem).collect(Collectors.toList());
     }
 
-    private RunningDevService createContainer(DockerStatusBuildItem dockerStatusBuildItem,
-            DevServicesComposeProjectBuildItem composeProjectBuildItem,
-            String name,
-            io.quarkus.redis.deployment.client.DevServicesConfig devServicesConfig, LaunchMode launchMode,
-            boolean useSharedNetwork, Optional<Duration> timeout, DevServicesRegistryBuildItem tracker) {
-
-        if (!devServicesConfig.enabled()) {
-            // explicitly disabled
-            log.debug("Not starting devservices for " + (RedisConfig.isDefaultClient(name) ? "default redis client" : name)
-                    + " as it has been disabled in the config");
-            return null;
-        }
-
-        String configPrefix = getConfigPrefix(name);
-
-        boolean needToStart = !ConfigUtils.isPropertyNonEmpty(configPrefix + RedisConfig.HOSTS_CONFIG_NAME);
-        if (!needToStart) {
-            log.debug("Not starting dev services for " + (RedisConfig.isDefaultClient(name) ? "default redis client" : name)
-                    + " as hosts have been provided");
-            return null;
-        }
-
-        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
-            log.warn("Please configure quarkus.redis.hosts for "
-                    + (RedisConfig.isDefaultClient(name) ? "default redis client" : name)
-                    + " or get a working docker instance");
-            return null;
-        }
-
-        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName().orElse(REDIS_IMAGE))
-                .asCompatibleSubstituteFor(REDIS_IMAGE);
-
-        Supplier<RunningDevService> defaultRedisServerSupplier = () -> {
-            OptionalInt fixedExposedPort = devServicesConfig.port();
-            String serviceName = launchMode == DEVELOPMENT ? devServicesConfig.serviceName() : null;
-            String defaultNetworkId = composeProjectBuildItem.getDefaultNetworkId();
-            QuarkusPortRedisContainer redisContainer = new QuarkusPortRedisContainer(dockerImageName, fixedExposedPort,
-                    serviceName,
-                    defaultNetworkId,
-                    useSharedNetwork, launchMode);
-            timeout.ifPresent(redisContainer::withStartupTimeout);
-            redisContainer.withEnv(devServicesConfig.containerEnv());
-
-            Map<String, Supplier<String>> dynamicConfig = new HashMap<>();
-            dynamicConfig.put(configPrefix + RedisConfig.HOSTS_CONFIG_NAME,
-                    () -> REDIS_SCHEME + redisContainer.getHost() + ":" + redisContainer.getPort());
-
-            return new RunnableDevService(Feature.REDIS_CLIENT.getName(), name, redisContainer,
-                    dynamicConfig, devServicesConfig, tracker);
-        };
-
-        // The ideal re-use precedence order is the following:
-        // 1. Re-use existing dev service/container if one with compatible config exists (only knowable post-augmentation, or on the second run of a continuous testing session)
-        // 2. Use the container locator to find an external service (where applicable) (knowable at augmentation)
-        // 3. Create a new container
-        // This swaps 1 and 2, but that's actually ok. If an external service exists and is valid for this configuration,
-        // any matching service would be using it, so option 1 (an existing internal container) can't happen.
-        // If there's no external service, then the order is 1 and then 3, which is what we want.
-        // Because of how the labelling works, dev services we create will not be detected by the locator.
-        // The check for running services happens in RunnableDevService.start(), because it has to happen at runtime, not during augmentation.
-        // We cannot assume the order of container creation in augmentation would be the same as the runtime order.
-
-        // The container locator might find services from other tests, which would not be ok because they'd have the wrong config
-        // We can be fairly confident this isn't happening because of the tests showing config is honoured, but if we wanted to be extra sure we'd put on a special 'not external' label and filter for that, too
+    /**
+     * The ideal re-use precedence order is the following:
+     * 1. Re-use existing dev service/container if one with compatible config exists (only knowable post-augmentation, or on the
+     * second run of a continuous testing session)
+     * 2. Use the container locator to find an external service (where applicable) (knowable at augmentation)
+     * 3. Create a new container
+     * This swaps 1 and 2, but that's actually ok. If an external service exists and is valid for this configuration,
+     * any matching service would be using it, so option 1 (an existing internal container) can't happen.
+     * If there's no external service, then the order is 1 and then 3, which is what we want.
+     * Because of how the labelling works, dev services we create will not be detected by the locator.
+     * The check for running services happens in RunnableDevService.start(), because it has to happen at runtime, not during
+     * augmentation.
+     * We cannot assume the order of container creation in augmentation would be the same as the runtime order.
+     *
+     * The container locator might find services from other tests, which would not be ok because they'd have the wrong config
+     * We can be fairly confident this isn't happening because of the tests showing config is honoured, but if we wanted to be
+     * extra sure we'd put on a special 'not external' label and filter for that, too
+     */
+    private DevServicesResultBuildItem discoverRunningService(DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            String configPrefix,
+            io.quarkus.redis.deployment.client.DevServicesConfig devServicesConfig,
+            LaunchMode launchMode,
+            boolean useSharedNetwork) {
         return redisContainerLocator.locateContainer(devServicesConfig.serviceName(), devServicesConfig.shared(), launchMode)
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
                         List.of(devServicesConfig.imageName().orElse("redis")),
                         REDIS_EXPOSED_PORT, launchMode, useSharedNetwork))
                 .map(containerAddress -> {
                     String redisUrl = REDIS_SCHEME + containerAddress.getUrl();
-                    // If there's a pre-existing container, it's already running, so create a running container, not a runnable one
-                    return new RunningDevService(Feature.REDIS_CLIENT.getName(),
-                            containerAddress.getId(),
-                            null, configPrefix + RedisConfig.HOSTS_CONFIG_NAME, redisUrl);
-                })
-                .orElseGet(defaultRedisServerSupplier);
+                    return DevServicesResultBuildItem.discovered()
+                            .feature(Feature.REDIS_CLIENT)
+                            .containerId(containerAddress.getId())
+                            .config(Map.of(configPrefix + RedisConfig.HOSTS_CONFIG_NAME, redisUrl))
+                            .build();
+                }).orElse(null);
+    }
+
+    private static boolean redisDevServicesEnabled(DockerStatusBuildItem dockerStatusBuildItem, String name,
+            io.quarkus.redis.deployment.client.DevServicesConfig devServicesConfig,
+            String configPrefix) {
+        if (!devServicesConfig.enabled()) {
+            // explicitly disabled
+            log.debug("Not starting devservices for " + (RedisConfig.isDefaultClient(name) ? "default redis client" : name)
+                    + " as it has been disabled in the config");
+            return true;
+        }
+
+        boolean needToStart = !ConfigUtils.isPropertyNonEmpty(configPrefix + RedisConfig.HOSTS_CONFIG_NAME);
+        if (!needToStart) {
+            log.debug("Not starting dev services for " + (RedisConfig.isDefaultClient(name) ? "default redis client" : name)
+                    + " as hosts have been provided");
+            return true;
+        }
+
+        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
+            log.warn("Please configure quarkus.redis.hosts for "
+                    + (RedisConfig.isDefaultClient(name) ? "default redis client" : name)
+                    + " or get a working docker instance");
+            return true;
+        }
+        return false;
     }
 
     private String getConfigPrefix(String name) {
@@ -213,18 +181,11 @@ public class DevServicesRedisProcessor {
 
         private final String hostName;
 
-        public QuarkusPortRedisContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort, String serviceName,
-                String defaultNetworkId, boolean useSharedNetwork, LaunchMode launchMode) {
+        public QuarkusPortRedisContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort,
+                String defaultNetworkId, boolean useSharedNetwork) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
-
-            if (serviceName != null) {
-                withLabel(DEV_SERVICE_LABEL, serviceName);
-                withLabel(QUARKUS_DEV_SERVICE, serviceName);
-            }
-            withLabel(MANAGED_DEV_SERVICE_LABEL, RunningDevServicesRegistry.APPLICATION_UUID);
-            withLabel(LAUNCH_MODE_LABEL, launchMode.toString());
 
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "redis");
         }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devservices/DevServicesRestClientHttpProxyProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devservices/DevServicesRestClientHttpProxyProcessor.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.exception.UncheckedException;
 import org.jboss.logging.Logger;
 
+import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -200,9 +201,11 @@ public class DevServicesRestClientHttpProxyProcessor {
             }
 
             devServicePropertiesProducer.produce(
-                    new DevServicesResultBuildItem("rest-client-" + bi.getClassName() + "-proxy",
-                            null,
-                            Map.of(urlKeyName, urlKeyValue)));
+                    DevServicesResultBuildItem.discovered()
+                            .feature(Feature.REST_CLIENT)
+                            .description("rest-client-" + bi.getClassName() + "-proxy")
+                            .config(Map.of(urlKeyName, urlKeyValue))
+                            .build());
         }
 
         closeBuildItem.addCloseTask(new CloseTask(runningProxies, providerCloseables, runningProviders), true);

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
@@ -222,8 +222,10 @@ public class SmallryeJwtDevModeProcessor {
     }
 
     private DevServicesResultBuildItem smallryeJwtDevServiceWith(Map<String, String> properties) {
-        return new DevServicesResultBuildItem(
-                Feature.SMALLRYE_JWT.name(), null, properties);
+        return DevServicesResultBuildItem.discovered()
+                .feature(Feature.SMALLRYE_JWT)
+                .config(properties)
+                .build();
     }
 
     private static Map<String, String> generateDevServiceProperties(String publicKey, String privateKey,

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtLocationDevModeTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtLocationDevModeTest.java
@@ -38,7 +38,7 @@ public class SmallryeJwtLocationDevModeTest {
                         public void execute(BuildContext context) {
                             List<DevServicesResultBuildItem> buildItems = context
                                     .consumeMulti(DevServicesResultBuildItem.class);
-                            assertThat(buildItems).filteredOn(item -> item.getName().equals("SMALLRYE_JWT"))
+                            assertThat(buildItems).filteredOn(item -> item.getName().equals("smallrye-jwt"))
                                     .first()
                                     .satisfies(item -> {
                                         assertThat(item.getConfig())

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
@@ -74,7 +74,6 @@ public class DevServicesProcessor {
             if (devServicesResultBuildItem.getContainerId() == null) {
                 devServiceDescriptions.add(new DevServiceDescriptionBuildItem(devServicesResultBuildItem.getName(),
                         devServicesResultBuildItem.getDescription(),
-                        null,
                         devServicesResultBuildItem.getConfig()));
             }
         }

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaCustomPortReusableServiceITest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaCustomPortReusableServiceITest.java
@@ -2,7 +2,6 @@ package io.quarkus.it.kafka;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +11,6 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.ports.SocketKit;
 import io.restassured.RestAssured;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/47627")
 @QuarkusTest
 @TestProfile(DevServicesCustomPortReusableServiceProfile.class)
 public class DevServicesKafkaCustomPortReusableServiceITest {

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaNonUniquePortITest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaNonUniquePortITest.java
@@ -2,7 +2,6 @@ package io.quarkus.it.kafka;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +11,6 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.ports.SocketKit;
 import io.restassured.RestAssured;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/47627")
 @QuarkusTest
 @TestProfile(DevServicesNonUniquePortProfile.class)
 public class DevServicesKafkaNonUniquePortITest {

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesDevModeTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesDevModeTest.java
@@ -23,6 +23,7 @@ import com.github.dockerjava.api.model.Container;
 import io.quarkus.it.kafka.BundledEndpoint;
 import io.quarkus.it.kafka.KafkaAdminManager;
 import io.quarkus.it.kafka.KafkaAdminTest;
+import io.quarkus.it.kafka.KafkaEndpoint;
 import io.quarkus.test.QuarkusDevModeTest;
 
 public class DevServicesDevModeTest {
@@ -30,11 +31,11 @@ public class DevServicesDevModeTest {
     @RegisterExtension
     public static QuarkusDevModeTest test = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(KafkaAdminManager.class)
+                    .deleteClass(KafkaEndpoint.class)
                     .addClass(BundledEndpoint.class)
+                    .addClass(KafkaAdminManager.class)
                     .addAsResource(new StringAsset("quarkus.kafka.devservices.provider=kafka-native\n" +
-                            "quarkus.kafka.devservices.topic-partitions.test=2\n"
-                            + "quarkus.kafka.devservices.provider=kafka-native\n"), "application.properties"))
+                            "quarkus.kafka.devservices.topic-partitions.test=2\n"), "application.properties"))
             .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(KafkaAdminTest.class));
 
     @Test

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesCustomPortProfile.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesCustomPortProfile.java
@@ -1,6 +1,5 @@
 package io.quarkus.it.kafka.devservices.profiles;
 
-import java.util.Collections;
 import java.util.Map;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -11,7 +10,9 @@ public class DevServicesCustomPortProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Collections.singletonMap("quarkus.kafka.devservices.port", PORT);
+        return Map.of(
+                "quarkus.kafka.devservices.provider", "kafka-native",
+                "quarkus.kafka.devservices.port", PORT);
     }
 
     @Override

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -43,8 +43,10 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.utils.BuildToolHelper;
 import io.quarkus.bootstrap.workspace.ArtifactSources;
 import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.deployment.builditem.DevServicesCustomizerBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
+import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
 import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
@@ -270,8 +272,8 @@ public final class IntegrationTestUtil {
             public void accept(String s, String s2) {
                 propertyMap.put(s, s2);
             }
-        }, DevServicesLauncherConfigResultBuildItem.class.getName(),
-                DevServicesNetworkIdBuildItem.class.getName());
+        }, DevServicesLauncherConfigResultBuildItem.class.getName(), DevServicesNetworkIdBuildItem.class.getName(),
+                DevServicesRegistryBuildItem.class.getName(), DevServicesCustomizerBuildItem.class.getName());
 
         networkId = propertyMap.get("quarkus.test.container.network");
         boolean manageNetwork = false;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -5,8 +5,10 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import io.quarkus.builder.BuildResult;
+import io.quarkus.deployment.builditem.DevServicesCustomizerBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
+import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 
 public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult> {
@@ -24,16 +26,13 @@ public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult>
             propertyConsumer.accept("quarkus.test.container.network", compose.getNetworkId());
         }
 
-        List<DevServicesResultBuildItem> devServicesResultBuildItems = buildResult
-                .consumeMulti(DevServicesResultBuildItem.class);
-        for (DevServicesResultBuildItem devServicesResultBuildItem : devServicesResultBuildItems) {
-            devServicesResultBuildItem.start();
-
-            // It would be nice to use the config source, but since we have the build item right there and this is a one-shot operation, just ask it instead
-            Map<String, String> dynamicConfig = devServicesResultBuildItem.getDynamicConfig();
-            for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+        List<DevServicesResultBuildItem> devServices = buildResult.consumeMulti(DevServicesResultBuildItem.class);
+        DevServicesRegistryBuildItem devServicesRegistry = buildResult.consumeOptional(DevServicesRegistryBuildItem.class);
+        List<DevServicesCustomizerBuildItem> customizers = buildResult.consumeMulti(DevServicesCustomizerBuildItem.class);
+        if (devServicesRegistry != null) {
+            devServicesRegistry.startAll(devServices, customizers, Thread.currentThread().getContextClassLoader());
+            for (Map.Entry<String, String> entry : devServicesRegistry.getConfigForAllRunningServices().entrySet()) {
                 propertyConsumer.accept(entry.getKey(), entry.getValue());
-
             }
         }
     }


### PR DESCRIPTION
Rebased on #47610 and still very much a draft

This targets ironing out issues from #47610 and provide a cleaner model for development of extensions providing dev services.

Instead of overloading the `DevServicesResultBuildItem` for discovered _and_ to be started services, this PR creates a `DevServicesRequestBuildItem`. A dev services request defines, the name, the build-time config (for identification), how to start the dev service (supplier of startable), and how to extract the configuration to be injected to the app (key/supplier map).

Extensions can discover running services via ContainerLocator and CompseLocator and produce `DevServicesResultBuildItem` or, when they need to create a service, produce `DevServicesRequestBuildItem`.

Changes : 
- Rename `RunningDevServicesTracker` to `RunningDevServicesRegistry`.
- Dev service config providers are done via a regular Map interface implemented by a supplier map. 
- Removed `RunnableDevService` and moved the start/reuse logic to the `DevServicesRegistryBuildItem`. 
- Registry handles a parent-first cross-classloader type `RunningService` instead of Closeable. -> see below
- Neither `DevServicesRegistryBuildItem` nor `DevServicesRequestBuildItem` hold any state. All state is in the registry and `RunningService`s it holds. 

Fixes with still some problems :
- [ ] Fixes the issue in Dev UI listing of dev services when services needs to be switched. But it is not ideal. The whole service description thing needs to be seen again. This was the reason I had to introduce the `RunningService`. 
- [ ] Services start concurrently on forkjoin pool
- [ ] For making the log suppressors work, I added an ugly fix to delay the completion of build time logging after the start of services. Otherwise, we start services when build time logging is completed and runtime logging is not yet started, and there are no handlers to log (and therefore suppress) the logs.

Open for discussion : 
For a given `DevServiceOwner`, do we need to hold a bunch of services or just one ? Having one would simplify things further, ex. we can remove service directly by its owner. 

Edit: Fixes  https://github.com/quarkusio/quarkus/issues/47627