### PR TITLE
Document that the colon needs to be escaped when typing "classpath:" in application.properties

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -150,11 +150,13 @@ Dev Services volumes can be mapped to the filesystem or the classpath:
 # Using a filesystem volume:
 quarkus.datasource.devservices.volumes."/path/from"=/container/to <1>
 # Using a classpath volume:
-quarkus.datasource.devservices.volumes."classpath:./file"=/container/to <2>
+quarkus.datasource.devservices.volumes."classpath\:./file"=/container/to <2>
 ----
 
 <1> The file or folder "/path/from" from the local machine will be accessible at "/container/to" in the container.
 <2> When using classpath volumes, the location has to start with "classpath:". The file or folder "./file" from the project's classpath will be accessible at "/container/to" in the container.
+
+CAUTION: The colon character `:` needs to be escaped in `.properties` files as `\:`, or it will be interpreted as a key/value separator.
 
 IMPORTANT: when using a classpath volume, the container will only be granted read permission. On the other hand, when using a filesystem volume, the container will be granted read and write permission.
 


### PR DESCRIPTION
Given failure to mount volumes only gives off a warning that doesn't even mention what is being mounted, I can tell you this mistake can cost you a good amount of time...