### PR TITLE
Do not rely on JPATraversableResolver / add JPA aware resolver only if ORM is enabled

### DIFF
--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -55,6 +55,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-derby-deployment</artifactId>
             <optional>true</optional>  <!-- conditional dependency -->
         </dependency>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -131,6 +131,7 @@ import io.quarkus.hibernate.orm.runtime.schema.SchemaManagementIntegrator;
 import io.quarkus.hibernate.orm.runtime.service.FlatClassLoaderService;
 import io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver;
 import io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver;
+import io.quarkus.hibernate.validator.spi.BeanValidationTraversableResolverBuildItem;
 import io.quarkus.panache.hibernate.common.deployment.HibernateEnhancersRegisteredBuildItem;
 import io.quarkus.panache.hibernate.common.deployment.HibernateModelClassCandidatesForFieldAccessBuildItem;
 import io.quarkus.runtime.LaunchMode;
@@ -518,9 +519,11 @@ public final class HibernateOrmProcessor {
     public void build(RecorderContext recorderContext, HibernateOrmRecorder recorder,
             Capabilities capabilities,
             JpaModelBuildItem jpaModel,
+            HibernateOrmConfig hibernateOrmConfig,
             List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
             List<HibernateOrmIntegrationStaticConfiguredBuildItem> integrationBuildItems,
             BuildProducer<BeanContainerListenerBuildItem> beanContainerListener,
+            BuildProducer<BeanValidationTraversableResolverBuildItem> beanValidationTraversableResolver,
             LaunchModeBuildItem launchMode) throws Exception {
         validateHibernatePropertiesNotUsed();
 
@@ -578,6 +581,10 @@ public final class HibernateOrmProcessor {
         beanContainerListener
                 .produce(new BeanContainerListenerBuildItem(
                         recorder.initMetadata(finalStagePUDescriptors, scanner, integratorClasses)));
+        if (capabilities.isPresent(Capability.HIBERNATE_VALIDATOR) && hibernateOrmConfig.enabled()) {
+            beanValidationTraversableResolver
+                    .produce(new BeanValidationTraversableResolverBuildItem(recorder.attributeLoadedPredicate()));
+        }
     }
 
     private void validateHibernatePropertiesNotUsed() {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -13,6 +14,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.Cache;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.metamodel.Metamodel;
+import jakarta.persistence.spi.LoadState;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -249,5 +251,30 @@ public class HibernateOrmRecorder {
                 SchemaManagementIntegrator.runPostBootValidation(puName);
             }
         }, "Hibernate post-boot validation thread for " + puName).start();
+    }
+
+    public BiPredicate<Object, String> attributeLoadedPredicate() {
+        return new IsAttributeLoadedPredicate();
+    }
+
+    private static class IsAttributeLoadedPredicate implements BiPredicate<Object, String> {
+        private final ProviderUtil providerUtil = new ProviderUtil();
+
+        @Override
+        public boolean test(Object entity, String attributeName) {
+            LoadState loadstate = providerUtil.isLoadedWithoutReference(entity, attributeName);
+            if (loadstate == LoadState.LOADED) {
+                return true;
+            } else if (loadstate == LoadState.NOT_LOADED) {
+                return false;
+            }
+            loadstate = providerUtil.isLoadedWithReference(entity, attributeName);
+            if (loadstate == LoadState.LOADED) {
+                return true;
+            } else if (loadstate == LoadState.NOT_LOADED) {
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -120,6 +120,7 @@ import io.quarkus.hibernate.validator.runtime.jaxrs.ViolationReport;
 import io.quarkus.hibernate.validator.runtime.locale.LocaleResolversWrapper;
 import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
 import io.quarkus.hibernate.validator.spi.BeanValidationAnnotationsBuildItem;
+import io.quarkus.hibernate.validator.spi.BeanValidationTraversableResolverBuildItem;
 import io.quarkus.jaxrs.spi.deployment.AdditionalJaxRsResourceMethodAnnotationsBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyConfigBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyDotNames;
@@ -475,7 +476,7 @@ class HibernateValidatorProcessor {
             ShutdownContextBuildItem shutdownContext,
             List<ConfigClassBuildItem> configClasses,
             List<AdditionalJaxRsResourceMethodAnnotationsBuildItem> additionalJaxRsResourceMethodAnnotations,
-            Capabilities capabilities,
+            Optional<BeanValidationTraversableResolverBuildItem> beanValidationTraversableResolver,
             LocalesBuildTimeConfig localesBuildTimeConfig,
             HibernateValidatorBuildTimeConfig hibernateValidatorBuildTimeConfig) throws Exception {
 
@@ -607,7 +608,8 @@ class HibernateValidatorProcessor {
                 .createWith(recorder.hibernateValidatorFactory(classesToBeValidated, detectedBuiltinConstraints,
                         valueExtractorClassProxies,
                         hasXmlConfiguration(),
-                        capabilities.isPresent(Capability.HIBERNATE_ORM),
+                        beanValidationTraversableResolver
+                                .map(BeanValidationTraversableResolverBuildItem::getAttributeLoadedPredicate),
                         localesBuildTimeConfig,
                         hibernateValidatorBuildTimeConfig))
                 .addQualifier().annotation(DotNames.NAMED).addValue("value", VALIDATOR_FACTORY_NAME).done()

--- a/extensions/hibernate-validator/spi/src/main/java/io/quarkus/hibernate/validator/spi/BeanValidationTraversableResolverBuildItem.java
+++ b/extensions/hibernate-validator/spi/src/main/java/io/quarkus/hibernate/validator/spi/BeanValidationTraversableResolverBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.hibernate.validator.spi;
+
+import java.util.function.BiPredicate;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * BuildItem to replace the default traversable resolver
+ */
+public final class BeanValidationTraversableResolverBuildItem extends SimpleBuildItem {
+
+    private final BiPredicate<Object, String> attributeLoadedPredicate;
+
+    public BeanValidationTraversableResolverBuildItem(BiPredicate<Object, String> attributeLoadedPredicate) {
+        this.attributeLoadedPredicate = attributeLoadedPredicate;
+    }
+
+    public BiPredicate<Object, String> getAttributeLoadedPredicate() {
+        return attributeLoadedPredicate;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-models.version>1.0.0</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>3.0.0.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
-        <hibernate-validator.version>9.0.0.Final</hibernate-validator.version>
+        <hibernate-validator.version>9.0.1.Final</hibernate-validator.version>
         <hibernate-search.version>8.0.0.Final</hibernate-search.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->


### PR DESCRIPTION
This PR tries to address a few things

- The upgrade to Hibernate Validator 9.0.1 https://github.com/quarkusio/quarkus/pull/48380#issuecomment-2972597972
- "simplification" of the traversable resolver that is part of the Hibernate Validator. I may have "oversimplified" it here but here are my thoughts. Since the change to cache the persistence utils in the built-in `JPATraversalbeResolver` I was thinking that we could skip even more operations when we are within Quarkus. From what I can see the current implementation in the JPA would eventually delegate to `ProviderUtil` that have its own implementation in Quarkus, which is shared by ORM/Reactive. I was thinking that we could also try to eliminate the extra calls to retrieve the persistence providers and also the loops if we know that all we'd get is `ProviderUtil`. 
- Since the "predicate" to delegate the resolver check is now added only if ORM is enabled, it should also address the problem with the native build mentioned here: https://github.com/quarkusio/quarkus/issues/48270