### PR TITLE
Expose path params and user data to upgrade check in WebSockets Next

### DIFF
--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/upgrade/HttpUpgradeCheckPathParamsTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/upgrade/HttpUpgradeCheckPathParamsTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.websockets.next.test.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.HttpUpgradeCheck;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.UpgradeRejectedException;
+
+public class HttpUpgradeCheckPathParamsTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Endpoint.class, UpgradeCheck.class, WSClient.class));
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("accept")
+    URI acceptUri;
+
+    @TestHTTPResource("reject")
+    URI rejectUri;
+
+    @BeforeEach
+    public void cleanUp() {
+        Endpoint.OPENED.set(false);
+    }
+
+    @Test
+    public void testHttpUpgradeRejected() {
+        try (WSClient client = new WSClient(vertx)) {
+            CompletionException ce = assertThrows(CompletionException.class,
+                    () -> client.connect(rejectUri));
+            Throwable root = ExceptionUtil.getRootCause(ce);
+            assertInstanceOf(UpgradeRejectedException.class, root);
+            assertTrue(root.getMessage().contains("404"), root.getMessage());
+        }
+    }
+
+    @Test
+    public void testHttpUpgradePermitted() {
+        try (WSClient client = new WSClient(vertx)) {
+            client.connect(acceptUri);
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until(Endpoint.OPENED::get);
+        }
+    }
+
+    @WebSocket(path = "/{action}")
+    public static class Endpoint {
+
+        static final AtomicBoolean OPENED = new AtomicBoolean();
+
+        @OnOpen
+        void onOpen() {
+            OPENED.set(true);
+        }
+
+    }
+
+    @Singleton
+    public static class UpgradeCheck implements HttpUpgradeCheck {
+
+        @Override
+        public Uni<CheckResult> perform(HttpUpgradeContext context) {
+            if ("reject".equals(context.pathParam("action"))) {
+                return CheckResult.rejectUpgrade(404);
+            }
+            return CheckResult.permitUpgrade();
+        }
+
+    }
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/upgrade/HttpUpgradeCheckUserDataTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/upgrade/HttpUpgradeCheckUserDataTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.websockets.next.test.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.HttpUpgradeCheck;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.UserData;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+
+public class HttpUpgradeCheckUserDataTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Endpoint.class, UpgradeCheck.class, WSClient.class));
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("endpoint")
+    URI endpointUri;
+
+    @Test
+    public void testHttpUpgradeCheckPassesUserData() throws InterruptedException {
+        try (WSClient client = new WSClient(vertx)) {
+            client.connect(endpointUri);
+            assertTrue(Endpoint.OPEN.await(2, TimeUnit.SECONDS));
+            assertTrue(Endpoint.USER_DATA.get().get(UserData.TypedKey.forBoolean("boolean")));
+            assertEquals(Integer.MAX_VALUE, Endpoint.USER_DATA.get().get(UserData.TypedKey.forInt("int")));
+            assertEquals(Long.MAX_VALUE, Endpoint.USER_DATA.get().get(UserData.TypedKey.forLong("long")));
+            assertEquals("Hello", Endpoint.USER_DATA.get().get(UserData.TypedKey.forString("string")));
+        }
+    }
+
+    @WebSocket(path = "/endpoint")
+    public static class Endpoint {
+
+        static final CountDownLatch OPEN = new CountDownLatch(1);
+        static final AtomicReference<UserData> USER_DATA = new AtomicReference<>();
+
+        @OnOpen
+        void onOpen(WebSocketConnection connection) {
+            USER_DATA.set(connection.userData());
+            OPEN.countDown();
+        }
+
+    }
+
+    @Singleton
+    public static class UpgradeCheck implements HttpUpgradeCheck {
+
+        @Override
+        public Uni<CheckResult> perform(HttpUpgradeContext context) {
+            context.userData().put(UserData.TypedKey.forBoolean("boolean"), true);
+            context.userData().put(UserData.TypedKey.forInt("int"), Integer.MAX_VALUE);
+            context.userData().put(UserData.TypedKey.forLong("long"), Long.MAX_VALUE);
+            context.userData().put(UserData.TypedKey.forString("string"), "Hello");
+            return CheckResult.permitUpgrade();
+        }
+
+    }
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/HttpUpgradeCheck.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/HttpUpgradeCheck.java
@@ -9,6 +9,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.VertxContextSupport;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * A check that controls which requests are allowed to upgrade the HTTP connection to a WebSocket connection.
@@ -44,6 +45,21 @@ public interface HttpUpgradeCheck {
     }
 
     interface HttpUpgradeContext {
+
+        /**
+         * @return userData {@link UserData}; mutable user data to associate with an upgraded connection
+         * @see WebSocketConnection#userData()
+         */
+        UserData userData();
+
+        /**
+         * Gets the value of a single path parameter
+         *
+         * @param name the name of parameter as defined in path declaration
+         * @return the actual value of the parameter or null if it doesn't exist
+         * @see RoutingContext#pathParam(String)
+         */
+        String pathParam(String name);
 
         /**
          * @return httpRequest {@link HttpServerRequest}; the HTTP 1.X request employing the 'Upgrade' header

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/HttpUpgradeContextImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/HttpUpgradeContextImpl.java
@@ -2,12 +2,18 @@ package io.quarkus.websockets.next.runtime;
 
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.websockets.next.HttpUpgradeCheck;
+import io.quarkus.websockets.next.UserData;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 
-record HttpUpgradeContextImpl(RoutingContext routingContext,
+record HttpUpgradeContextImpl(RoutingContext routingContext, UserData userData,
         Uni<SecurityIdentity> securityIdentity, String endpointId) implements HttpUpgradeCheck.HttpUpgradeContext {
+
+    @Override
+    public String pathParam(String name) {
+        return routingContext.pathParam(name);
+    }
 
     @Override
     public HttpServerRequest httpRequest() {

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
@@ -13,6 +13,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import io.quarkus.websockets.next.HandshakeRequest;
+import io.quarkus.websockets.next.UserData;
 import io.quarkus.websockets.next.WebSocketConnection;
 import io.quarkus.websockets.next.runtime.telemetry.SendingInterceptor;
 import io.smallrye.mutiny.Uni;
@@ -37,10 +38,10 @@ class WebSocketConnectionImpl extends WebSocketConnectionBase implements WebSock
 
     WebSocketConnectionImpl(String generatedEndpointClass, String endpointClass, ServerWebSocket webSocket,
             ConnectionManager connectionManager, Codecs codecs, RoutingContext ctx,
-            TrafficLogger trafficLogger, SendingInterceptor sendingInterceptor,
+            TrafficLogger trafficLogger, UserData userData, SendingInterceptor sendingInterceptor,
             Function<WebSocketConnectionImpl, SecuritySupport> securitySupportCreator) {
         super(Map.copyOf(ctx.pathParams()), codecs, new HandshakeRequestImpl(webSocket, ctx), trafficLogger,
-                new UserDataImpl(), sendingInterceptor);
+                userData, sendingInterceptor);
         this.generatedEndpointClass = generatedEndpointClass;
         this.endpointId = endpointClass;
         this.webSocket = Objects.requireNonNull(webSocket);


### PR DESCRIPTION
This PR provides a way to coordinate private state between an `HttpUpgradeCheck` implementation and the resulting `WebSocketConnection` by exposing the `UserData` via `HttpUpgradeContext`. It also provides a convenient way for upgrade checks to access path parameters by exposing `RoutingContext::pathParam`.