### PR TITLE
Bump to Mutiny 2.9.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -137,7 +137,7 @@
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <mutiny.version>2.9.0</mutiny.version>
+        <mutiny.version>2.9.1</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka3.version>4.0.0</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -47,7 +47,7 @@
         <version.gizmo>1.9.0</version.gizmo>
         <version.jandex>3.3.1</version.jandex>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
-        <version.mutiny>2.9.0</version.mutiny>
+        <version.mutiny>2.9.1</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.12.0</version.smallrye-common>
         <!-- test versions -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -44,7 +44,7 @@
         <version.gizmo>1.9.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.smallrye-common>2.12.0</version.smallrye-common>
-        <version.smallrye-mutiny>2.9.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>2.9.1</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -55,7 +55,7 @@
         <gizmo.version>1.9.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <mutiny.version>2.9.0</mutiny.version>
+        <mutiny.version>2.9.1</mutiny.version>
         <smallrye-common.version>2.12.0</smallrye-common.version>
         <vertx.version>4.5.14</vertx.version>
         <rest-assured.version>5.5.5</rest-assured.version>


### PR DESCRIPTION
This is a bug fix release with a fix to blocking Uni awaiting and cancellation on timeouts.

Also see https://github.com/quarkusio/quarkus/issues/48428

Release notes: https://github.com/smallrye/smallrye-mutiny/releases/tag/2.9.1