### PR TITLE
Disable HQL Console for reactive PUs

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
@@ -240,6 +240,9 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
 
     _renderTables() {
         if (this._selectedPersistenceUnit) {
+            if (this._selectedPersistenceUnit.reactive) {
+                return; // Reactive persistence units are not supported
+            }
             return html`
                 <qui-card class="tablesCard" header="Entities">
                     <div slot="content">
@@ -310,6 +313,10 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
     // *** data table and HQL input ***
 
     _renderDataAndInput() {
+        if (this._selectedPersistenceUnit.reactive) {
+            return html`
+                <span style="padding-top:20px;padding-left:20px;">Reactive persistence units are not supported in this console, please use a blocking one.</span>`;
+        }
         return html`
             ${this._renderHqlInput()}
             <div tab="data-tab" style="height:100%;">${this._renderTableData()}</div>`;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -28,6 +28,7 @@ import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.BeanContainerListener;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDefinition;
+import io.quarkus.hibernate.orm.runtime.dev.HibernateOrmDevIntegrator;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationRuntimeDescriptor;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
@@ -71,10 +72,12 @@ public class HibernateOrmRecorder {
     public BeanContainerListener initMetadata(List<QuarkusPersistenceUnitDefinition> parsedPersistenceXmlDescriptors,
             Scanner scanner, Collection<Class<? extends Integrator>> additionalIntegrators) {
         SchemaManagementIntegrator.clearDsMap();
+        HibernateOrmDevIntegrator.clearPuMap();
         for (QuarkusPersistenceUnitDefinition i : parsedPersistenceXmlDescriptors) {
             if (i.getConfig().getDataSource().isPresent()) {
                 SchemaManagementIntegrator.mapDatasource(i.getConfig().getDataSource().get(), i.getName());
             }
+            HibernateOrmDevIntegrator.mapPersistenceUnit(i.getName(), i.getPersistenceUnitDescriptor());
         }
         return new BeanContainerListener() {
             @Override

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevController.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevController.java
@@ -31,6 +31,8 @@ import org.hibernate.tool.schema.spi.ScriptTargetOutput;
 import org.hibernate.tool.schema.spi.SourceDescriptor;
 import org.hibernate.tool.schema.spi.TargetDescriptor;
 
+import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
+
 public class HibernateOrmDevController {
 
     private static final HibernateOrmDevController INSTANCE = new HibernateOrmDevController();
@@ -48,8 +50,8 @@ public class HibernateOrmDevController {
         return info;
     }
 
-    void pushPersistenceUnit(SessionFactoryImplementor sessionFactoryImplementor, String persistenceUnitName,
-            Metadata metadata, ServiceRegistry serviceRegistry, String importFile) {
+    void pushPersistenceUnit(SessionFactoryImplementor sessionFactoryImplementor, QuarkusPersistenceUnitDescriptor descriptor,
+            String persistenceUnitName, Metadata metadata, ServiceRegistry serviceRegistry, String importFile) {
         List<HibernateOrmDevInfo.Entity> managedEntities = new ArrayList<>();
         for (PersistentClass entityBinding : metadata.getEntityBindings()) {
             managedEntities.add(new HibernateOrmDevInfo.Entity(entityBinding.getJpaEntityName(), entityBinding.getClassName(),
@@ -83,7 +85,8 @@ public class HibernateOrmDevController {
         DDLSupplier updateDDLSupplier = new DDLSupplier(Action.UPDATE, metadata, serviceRegistry, importFile);
 
         info.add(new HibernateOrmDevInfo.PersistenceUnit(sessionFactoryImplementor, persistenceUnitName, managedEntities,
-                namedQueries, namedNativeQueries, createDDLSupplier, dropDDLSupplier, updateDDLSupplier));
+                namedQueries, namedNativeQueries, createDDLSupplier, dropDDLSupplier, updateDDLSupplier,
+                descriptor.isReactive()));
     }
 
     class DDLSupplier implements Supplier<String> {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevInfo.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevInfo.java
@@ -55,11 +55,18 @@ public class HibernateOrmDevInfo {
         private final Supplier<String> createDDLSupplier;
         private final Supplier<String> dropDDLSupplier;
         private final Supplier<String> updateDDLSupplier;
+        private final boolean reactive;
 
-        public PersistenceUnit(SessionFactoryImplementor sessionFactory, String name, List<Entity> managedEntities,
+        public PersistenceUnit(
+                SessionFactoryImplementor sessionFactory,
+                String name,
+                List<Entity> managedEntities,
                 List<Query> namedQueries,
-                List<Query> namedNativeQueries, Supplier<String> createDDL, Supplier<String> dropDDL,
-                Supplier<String> updateDDLSupplier) {
+                List<Query> namedNativeQueries,
+                Supplier<String> createDDL,
+                Supplier<String> dropDDL,
+                Supplier<String> updateDDLSupplier,
+                boolean reactive) {
             this.sessionFactory = sessionFactory;
             this.name = name;
             this.managedEntities = managedEntities;
@@ -68,6 +75,7 @@ public class HibernateOrmDevInfo {
             this.createDDLSupplier = createDDL;
             this.dropDDLSupplier = dropDDL;
             this.updateDDLSupplier = updateDDLSupplier;
+            this.reactive = reactive;
         }
 
         // Method name must not be `getSessionFactory` to exclude it from JSON serialization
@@ -119,6 +127,9 @@ public class HibernateOrmDevInfo {
             return updateDDL;
         }
 
+        public boolean isReactive() {
+            return reactive;
+        }
     }
 
     public static class Entity {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevIntegrator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevIntegrator.java
@@ -2,22 +2,40 @@ package io.quarkus.hibernate.orm.runtime.dev;
 
 import static org.hibernate.cfg.AvailableSettings.HBM2DDL_IMPORT_FILES;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 
+import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
+
 public class HibernateOrmDevIntegrator implements Integrator {
+    private static final Map<String, QuarkusPersistenceUnitDescriptor> puDescriptorMap = new ConcurrentHashMap<>();
+
+    public static void clearPuMap() {
+        puDescriptorMap.clear();
+    }
+
+    public static void mapPersistenceUnit(String pu, QuarkusPersistenceUnitDescriptor descriptor) {
+        puDescriptorMap.put(pu, descriptor);
+    }
 
     @Override
     public void integrate(Metadata metadata, BootstrapContext bootstrapContext,
             SessionFactoryImplementor sessionFactoryImplementor) {
+        String name = (String) sessionFactoryImplementor.getProperties()
+                .get(AvailableSettings.PERSISTENCE_UNIT_NAME);
         HibernateOrmDevController.get().pushPersistenceUnit(
                 sessionFactoryImplementor,
-                (String) sessionFactoryImplementor.getProperties()
-                        .get(org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME),
-                metadata, sessionFactoryImplementor.getServiceRegistry(),
+                puDescriptorMap.get(name),
+                name,
+                metadata,
+                sessionFactoryImplementor.getServiceRegistry(),
                 (String) sessionFactoryImplementor.getProperties().get(HBM2DDL_IMPORT_FILES));
     }
 

--- a/integration-tests/devmode/pom.xml
+++ b/integration-tests/devmode/pom.xml
@@ -76,6 +76,16 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-pg-client-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/AbstractDevUIHibernateOrmTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/AbstractDevUIHibernateOrmTest.java
@@ -21,14 +21,16 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
     private final String expectedTableName;
     private final String expectedClassName;
     private final Integer expectedResults;
+    private final boolean reactive;
 
     public AbstractDevUIHibernateOrmTest(String expectedPersistenceUnitName, String expectedTableName,
-            String expectedClassName, Integer expectedResults) {
+            String expectedClassName, Integer expectedResults, boolean reactive) {
         super("io.quarkus.quarkus-hibernate-orm");
         this.expectedPersistenceUnitName = expectedPersistenceUnitName;
         this.expectedTableName = expectedTableName;
         this.expectedClassName = expectedClassName;
         this.expectedResults = expectedResults;
+        this.reactive = reactive;
     }
 
     @Test
@@ -69,6 +71,10 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
                 JsonNode namedQueries = persistenceUnit.get("namedQueries");
                 assertNotNull(namedQueries);
                 assertTrue(namedQueries.isArray());
+
+                JsonNode reactive = persistenceUnit.get("reactive");
+                assertTrue(reactive.isBoolean());
+                assertEquals(this.reactive, reactive.asBoolean());
             }
         }
     }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
@@ -28,7 +28,7 @@ public class DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest extends Abstra
                     .addClasses(MyNamedPuEntity.class));
 
     public DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest() {
-        super("namedpu", "MyNamedPuEntity", "io.quarkus.test.devui.namedpu.MyNamedPuEntity", null);
+        super("namedpu", "MyNamedPuEntity", "io.quarkus.test.devui.namedpu.MyNamedPuEntity", null, false);
     }
 
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseTest.java
@@ -18,7 +18,7 @@ public class DevUIHibernateOrmActiveFalseTest extends AbstractDevUIHibernateOrmT
                     .addClasses(MyEntity.class));
 
     public DevUIHibernateOrmActiveFalseTest() {
-        super(null, null, null, null);
+        super(null, null, null, null, false);
     }
 
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmSmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmSmokeTest.java
@@ -12,12 +12,13 @@ public class DevUIHibernateOrmSmokeTest extends AbstractDevUIHibernateOrmTest {
             .withApplicationRoot((jar) -> jar.addAsResource(
                     new StringAsset("quarkus.datasource.db-kind=h2\n"
                             + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
+                            + "quarkus.datasource.reactive=false\n"
                             + "quarkus.hibernate-orm.schema-management.strategy=drop-and-create\n"),
                     "application.properties")
                     .addAsResource(new StringAsset("INSERT INTO MyEntity(id, field) VALUES(1, 'entity_1');"), "import.sql")
                     .addClasses(MyEntity.class));
 
     public DevUIHibernateOrmSmokeTest() {
-        super("<default>", "MyEntity", "io.quarkus.test.devui.MyEntity", 1);
+        super("<default>", "MyEntity", "io.quarkus.test.devui.MyEntity", 1, false);
     }
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateReactiveSmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateReactiveSmokeTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.test.devui;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class DevUIHibernateReactiveSmokeTest extends AbstractDevUIHibernateOrmTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class)
+                    .addAsResource(new StringAsset("INSERT INTO MyEntity(id, field) VALUES(1, 'entity_1');"), "import.sql")
+                    .addAsResource(new StringAsset("""
+                            quarkus.datasource.jdbc=false
+                            quarkus.datasource.db-kind=postgresql
+                            quarkus.datasource.username=hibernate_orm_test
+                            quarkus.datasource.password=hibernate_orm_test
+                            quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost:5431/hibernate_orm_test
+                            quarkus.hibernate-orm.blocking=false
+                            """),
+                            "application.properties"));
+
+    public DevUIHibernateReactiveSmokeTest() {
+        super("default-reactive", "MyEntity", "io.quarkus.test.devui.MyEntity", null, true);
+    }
+
+    @Test
+    @Override
+    public void testExecuteHQL() {
+        // HQL execution is not supported in reactive mode, so we skip this test
+    }
+}


### PR DESCRIPTION
Fixes #48469

I disabled the HQL console for reactive Persistence Units, as the back-end only supports ORM's blocking version for now:
![Screenshot 2025-06-19 at 14 16 03](https://github.com/user-attachments/assets/3119fbdb-0b5d-44b4-a959-826bdb12170a)