### PR TITLE
Default value for Syslog counting framing

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
@@ -372,8 +372,8 @@ public interface LogRuntimeConfig {
         /**
          * If enabled, the message being sent is prefixed with the size of the message
          */
-        @WithDefault("false")
-        boolean useCountingFraming();
+        @WithDefault("protocol-dependent")
+        CountingFraming useCountingFraming();
 
         /**
          * Set to {@code true} to truncate the message if it exceeds maximum length
@@ -420,6 +420,20 @@ public interface LogRuntimeConfig {
          * Syslog async logging config
          */
         AsyncConfig async();
+
+        /**
+         * Syslog counting framing type used for smarter handling of counting framing value.
+         * <p>
+         * If {@link CountingFraming#PROTOCOL_DEPENDENT} is used, the counting framing will be {@code true}, when the
+         * {@link Protocol#TCP} or {@link Protocol#SSL_TCP} is used. Otherwise {@code false}.
+         * <p>
+         * More information in <a href="http://tools.ietf.org/html/rfc6587#section-3.4.1">http://tools.ietf.org/html/rfc6587</a>
+         */
+        enum CountingFraming {
+            TRUE,
+            FALSE,
+            PROTOCOL_DEPENDENT
+        }
     }
 
     interface SocketConfig {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -745,7 +745,12 @@ public class LoggingSetupRecorder {
             handler.setProtocol(config.protocol());
             handler.setBlockOnReconnect(config.blockOnReconnect());
             handler.setTruncate(config.truncate());
-            handler.setUseCountingFraming(config.useCountingFraming());
+            handler.setUseCountingFraming(switch (config.useCountingFraming()) {
+                case PROTOCOL_DEPENDENT ->
+                    config.protocol() == SyslogHandler.Protocol.TCP || config.protocol() == SyslogHandler.Protocol.SSL_TCP;
+                case TRUE -> true;
+                case FALSE -> false;
+            });
             handler.setLevel(config.level());
             if (config.maxLength().isPresent()) {
                 BigInteger maxLen = config.maxLength().get().asBigInteger();

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogCountingFramingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogCountingFramingTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.logging;
+
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.logmanager.handlers.SyslogHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SyslogCountingFramingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-syslog-output.properties")
+            .overrideConfigKey("quarkus.log.syslog.protocol", "UDP")
+            .withApplicationRoot((jar) -> jar.addClass(LoggingTestsHelper.class));
+
+    @Test
+    public void syslogOutputTest() {
+        SyslogHandler syslogHandler = (SyslogHandler) getHandler(SyslogHandler.class);
+
+        assertThat(syslogHandler.getProtocol()).isEqualTo(SyslogHandler.Protocol.UDP);
+        // counting framing is default 'protocol_dependent', and for UDP the counting framing is off
+        assertThat(syslogHandler.isUseCountingFraming()).isEqualTo(false);
+    }
+}

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
@@ -42,7 +42,7 @@ public class SyslogHandlerTest {
         assertThat(syslogHandler.getFacility()).isEqualTo(SyslogHandler.Facility.USER_LEVEL);
         assertThat(syslogHandler.getSyslogType()).isEqualTo(SyslogHandler.SyslogType.RFC5424);
         assertThat(syslogHandler.getProtocol()).isEqualTo(SyslogHandler.Protocol.TCP);
-        assertThat(syslogHandler.isUseCountingFraming()).isEqualTo(false);
+        assertThat(syslogHandler.isUseCountingFraming()).isEqualTo(true);
         assertThat(syslogHandler.isTruncate()).isEqualTo(true);
         assertThat(syslogHandler.isBlockOnReconnect()).isEqualTo(false);
     }


### PR DESCRIPTION
The expected behavior described in the #48036 issue seems reasonable and also the suggested approach on how to achieve it described in https://github.com/quarkusio/quarkus/issues/48036#issuecomment-2922422764.

It should be in compliance with [RFC-5425](https://datatracker.ietf.org/doc/html/rfc5425) and [RFC-6587](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4).

@dmlloyd Could you please check it? Thanks!

- Closes: #48036