### PR TITLE
Interrogate candidate resources/return types to stop REST server endpoint indexer from scanning REST clients

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -132,6 +132,7 @@ import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.arc.processor.KotlinUtils;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -739,9 +740,13 @@ public class ResteasyReactiveProcessor {
 
             checkForDuplicateEndpoint(config, allServerMethods);
 
-            Function<Type, DotName> typeToReturnName = new Function<Type, DotName>() {
+            Function<MethodInfo, DotName> methodToReturnName = new Function<MethodInfo, DotName>() {
                 @Override
-                public DotName apply(Type type) {
+                public DotName apply(MethodInfo method) {
+                    var type = method.returnType();
+                    if (type.name().equals(DotName.OBJECT_NAME) && KotlinUtils.isKotlinSuspendMethod(method)) {
+                        type = KotlinUtils.getKotlinSuspendMethodResult(method);
+                    }
                     DotName typeName = type.name();
                     if (type.kind() == Type.Kind.CLASS) {
                         return typeName;
@@ -757,6 +762,19 @@ public class ResteasyReactiveProcessor {
                 }
             };
 
+            // Provides a predicate for filtering classes/methods that have annotations from one of the client
+            // packages. This only reduces the false positives as a "base" interface could be derived and
+            // client-related annotation applies. Although it seems unlikely that an endpoint without any
+            // client annotations violates the specification for server resources methods; this type of false
+            // positive would only mean needless processing as there would be no exception thrown.
+            Predicate<AnnotationInstance> knownClientAnnotation = new Predicate<AnnotationInstance>() {
+                public boolean test(AnnotationInstance ann) {
+                    return ann.name().packagePrefix().startsWith("io.quarkus.rest.client") ||
+                            ann.name().packagePrefix().startsWith("org.eclipse.microprofile.rest.client") ||
+                            ann.name().packagePrefix().startsWith("org.jboss.resteasy.reactive.client");
+                }
+            };
+
             Map<DotName, Set<DotName>> returnsBySubResources = new HashMap<>();
             //now index possible sub resources. These are all classes that have method annotations
             //that are not annotated @Path
@@ -765,8 +783,16 @@ public class ResteasyReactiveProcessor {
                     MethodInfo method = instance.target().asMethod();
                     ClassInfo classInfo = method.declaringClass();
 
+                    // Reject known client interfaces (See predicate above)
+                    if (classInfo.annotations().stream().anyMatch(knownClientAnnotation)
+                            || method.annotations().stream().anyMatch(knownClientAnnotation)
+                            || method.parameters().stream().flatMap(p -> p.annotations().stream())
+                                    .anyMatch(knownClientAnnotation)) {
+                        continue;
+                    }
+
                     returnsBySubResources.computeIfAbsent(classInfo.name(), ignored -> new HashSet<>())
-                            .add(typeToReturnName.apply(method.returnType()));
+                            .add(methodToReturnName.apply(method));
                 }
             }
             //sub resources can also have just a path annotation
@@ -776,8 +802,16 @@ public class ResteasyReactiveProcessor {
                     MethodInfo method = instance.target().asMethod();
                     ClassInfo classInfo = method.declaringClass();
 
+                    // Reject known client interfaces (See predicate above)
+                    if (classInfo.annotations().stream().anyMatch(knownClientAnnotation)
+                            || method.annotations().stream().anyMatch(knownClientAnnotation)
+                            || method.parameters().stream().flatMap(p -> p.annotations().stream())
+                                    .anyMatch(knownClientAnnotation)) {
+                        continue;
+                    }
+
                     returnsBySubResources.computeIfAbsent(classInfo.name(), ignored -> new HashSet<>())
-                            .add(typeToReturnName.apply(method.returnType()));
+                            .add(methodToReturnName.apply(method));
                 }
             }
 


### PR DESCRIPTION
As detailed in #48464 certain methods cause the server endpoint indexer to scan _all_ REST client methods, which can lead to errors if any client method violates the requirements for resource methods.

This fixes this in two ways:
### 1.  Detect `java.lang.Object` returning methods and attempt further deduction.

Since the crux of the issue is `java.lang.Object` infecting the candidate list (which causes any query of does X derive Y to always result in true) this step tries to reduce the false positives here. The only method I could implement was for Kotlin suspend methods, since by view of Java they always return `Object`. If the method is a suspend method we extract the real return type.

Unfortunately while this reduces the pollution of the list dramatically, any method must be allowed to return `Object` (or Kotlin `Any`) which may dynamically return a sub-resource.

### 2. Check candidates for annotations from one of the Q-REST, MP-REST, or JAX-RS REST client pacakges.

Since we can’t always ensure the return type list is “free” of `Object`, the candidates are filtered based on if the class or method uses any annotatoins from the spec client packages. Reasonably this _should_ filter the majority of client interfaces because they generally have at least one client annotation (e.g. `RegisterRestClient`).

—-

These issuees are tested were tested in our, fairly large set of projects, which all use Kotlin. and even include some methods returning `Any`. with no client interfaces being sent to the server indexer.

This wont fully ensure all client interfaces won’t ever be scanned by the server indexer, but the likelihood has been reduced dramatically. To get a REST client scanned by the server indexer you would need to:
1. Write a Java method returning `java.lang.Object` or `Kotlin.Any`, this could be anywhere in the project.
2. Write an interface with no client specific annotations and register it programmatically.

In this scenario, the liklihood of an issue arising is further reduced by the fact that errors are only raised when a method on the client interface fails to validate as a server method as well. From my investigation this seems very unlikely. E.g., in the REST client that triggered the error in our project, the method used an extra parameter annotated with `@NotBody` together with the `@ClientHeaders` annotation to add special client request headers. Now, the presence of either of thse annotations causes the interface to be filtered before being scanned.

- Fixes: #48464