### PR TITLE
Provide a fluent API to set up path-specific authorization programmatically

### DIFF
--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -190,6 +190,7 @@ The context can be activated by users, for example with the `@ActivateRequestCon
 We recommend to let Quarkus activate and prepare CDI request context for you.
 For example, consider a situation where you want to inject a bean from the Jakarta REST context, such as the `jakarta.ws.rs.core.UriInfo` bean.
 In this case, you must apply the `HttpSecurityPolicy` to Jakarta REST endpoints. This can be achieved in one of the following ways:
+
 * Use the `@AuthorizationPolicy` security annotation.
 * Set the `quarkus.http.auth.permission.custom1.applies-to=jaxrs` configuration property.
 
@@ -445,6 +446,23 @@ quarkus.http.auth.roles-mapping.admin=Admin1 <1> <2>
 <1> Map the `admin` role to `Admin1` role. The `SecurityIdentity` will have both `admin` and `Admin1` roles.
 <2> The `/*` path is not secured. You must secure your endpoints with standard security annotations or define HTTP permissions in addition to this configuration property.
 
+If you prefer a programmatic configuration, the same mapping can be added with the `io.quarkus.vertx.http.security.HttpSecurity` CDI event:
+
+[source,java]
+----
+package org.acme.http.security;
+
+import io.quarkus.vertx.http.security.HttpSecurity;
+import jakarta.enterprise.event.Observes;
+
+public class HttpSecurityConfiguration {
+
+    void configure(@Observes HttpSecurity httpSecurity) {
+        httpSecurity.rolesMapping("admin", "Admin1");
+    }
+}
+----
+
 === Shared permission checks
 
 One important rule for unshared permission checks is that only one path match is applied, the most specific one.
@@ -487,6 +505,92 @@ quarkus.http.auth.permission.roles3.policy=role-policy3
 <1> Role `root` will be able to access `/secured/user/\*` and `/secured/admin/*` paths.
 <2> The `/secured/*` path can only be accessed by authenticated users. This way, you have secured the `/secured/all` path and so on.
 <3> Shared permissions are always applied before unshared ones, therefore a `SecurityIdentity` with the `root` role will have the `user` role as well.
+
+=== Set up path-specific authorization programmatically
+
+You can also configure the authorization policies presented by this guide so far programmatically.
+Consider the example mentioned earlier:
+
+[source,properties]
+----
+quarkus.http.auth.permission.permit1.paths=/public/*
+quarkus.http.auth.permission.permit1.policy=permit
+quarkus.http.auth.permission.permit1.methods=GET
+
+quarkus.http.auth.permission.deny1.paths=/forbidden
+quarkus.http.auth.permission.deny1.policy=deny
+
+quarkus.http.auth.permission.roles1.paths=/roles-secured/*,/other/*,/api/*
+quarkus.http.auth.permission.roles1.policy=role-policy1
+quarkus.http.auth.policy.role-policy1.roles-allowed=user,admin
+----
+
+The same authorization policies can be configured programmatically:
+
+[source,java]
+----
+package org.acme.http.security;
+
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.vertx.http.security.HttpSecurity;
+
+public class HttpSecurityConfiguration {
+
+    void configure(@Observes HttpSecurity httpSecurity) {
+        httpSecurity
+                .get("/public/*").permit()
+                .path("/roles-secured/*", "/other/*", "/api/*").roles("admin", "user")
+                .path("/forbidden").authorization().deny();
+    }
+
+}
+----
+
+Additionally, the `io.quarkus.vertx.http.security.HttpSecurity` CDI event can be used to configure specific authentication mechanisms and policies:
+
+[source,java]
+----
+package org.acme.http.security;
+
+import io.quarkus.vertx.http.security.HttpSecurity;
+import jakarta.enterprise.event.Observes;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public class HttpSecurityConfiguration {
+
+    void configure(@Observes HttpSecurity httpSecurity, CustomHttpSecurityPolicy customHttpSecurityPolicy,
+                        @ConfigProperty(name = "secured-path") String securedPath) {
+
+        httpSecurity.path("/api/*").authenticatedWith(new CustomAuthenticationMechanism());   <1>
+
+        httpSecurity.path("/other/*").basic().policy(customHttpSecurityPolicy); <2>
+
+        httpSecurity.path("/roles-secured/*").bearer().authorization()
+                .policy(identity -> identity.hasRole("user") || "root".equals(identity.getPrincipal().getName()));  <3>
+
+        httpSecurity.path("/other/administration").authorizationCodeFlow()
+                .authorization().policy((identity, routingContext) -> {
+                    if (!identity.isAnonymous()) {
+                        String customAuthorization = routingContext.request().getHeader("Custom Authorization");
+                        return yourCustomAuthorizationCheck(customAuthorization);
+                    }
+                    return false;
+                });     <4>
+
+        httpSecurity.path(securedPath).form();  <5>
+
+        httpSecurity.path("/user-info").bearer().authorization().permissions("openid", "email", "profile"); <6>
+    }
+}
+----
+<1> Authenticate all the '/api/' sub-paths with your own `HttpAuthenticationMechanism` instance.
+<2> Use the Basic authentication and authorize the requests with a custom `io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy`.
+<3> Use the Bearer token authentication and authorize the `SecurityIdentity` with your own policy.
+<4> Use Authorization Code Flow mechanism and write your own policy based on incoming request headers.
+<5> When Quarkus fires the `HttpSecurity` CDI event, the runtime configuration is ready.
+<6> Require that all the requests to the `/user-info` path have string permissions `openid`, `email` and `profile`.
+The same authorization can be required with the `@PermissionsAllowed(value = { "openid", "email", "profile" }, inclusive = true)` annotation instance placed on an endpoint.
 
 [[standard-security-annotations]]
 == Authorization using annotations

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -50,11 +50,13 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.DescriptorUtils;
@@ -265,12 +267,14 @@ public class HttpSecurityProcessor {
         }
     }
 
+    @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Produce(PreRouterFinalizationBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    void initializeAuthenticationHandler(Optional<HttpAuthenticationHandlerBuildItem> authenticationHandler,
+    void initializeHttpSecurity(Optional<HttpAuthenticationHandlerBuildItem> authenticationHandler,
             HttpSecurityRecorder recorder, VertxHttpConfig httpConfig, BeanContainerBuildItem beanContainerBuildItem) {
         if (authenticationHandler.isPresent()) {
+            recorder.prepareHttpSecurityConfiguration(httpConfig);
             recorder.initializeHttpAuthenticatorHandler(authenticationHandler.get().handler, httpConfig,
                     beanContainerBuildItem.getValue());
         }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ConfigBasedPathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ConfigBasedPathMatchingHttpSecurityPolicyTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.vertx.http.security;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigBasedPathMatchingHttpSecurityPolicyTest extends PathMatchingHttpSecurityPolicyTest {
+
+    private static final String APP_PROPS = """
+            quarkus.http.auth.permission.authenticated.paths=/
+            quarkus.http.auth.permission.authenticated.policy=authenticated
+            quarkus.http.auth.permission.public.paths=/api*
+            quarkus.http.auth.permission.public.policy=permit
+            quarkus.http.auth.permission.foo.paths=/api/foo/bar
+            quarkus.http.auth.permission.foo.policy=authenticated
+            quarkus.http.auth.permission.unsecured.paths=/api/public
+            quarkus.http.auth.permission.unsecured.policy=permit
+            quarkus.http.auth.permission.inner-wildcard.paths=/api/*/bar
+            quarkus.http.auth.permission.inner-wildcard.policy=authenticated
+            quarkus.http.auth.permission.inner-wildcard2.paths=/api/next/*/prev
+            quarkus.http.auth.permission.inner-wildcard2.policy=authenticated
+            quarkus.http.auth.permission.inner-wildcard3.paths=/api/one/*/three/*
+            quarkus.http.auth.permission.inner-wildcard3.policy=authenticated
+            quarkus.http.auth.permission.inner-wildcard4.paths=/api/one/*/*/five
+            quarkus.http.auth.permission.inner-wildcard4.policy=authenticated
+            quarkus.http.auth.permission.inner-wildcard5.paths=/api/one/*/jamaica/*
+            quarkus.http.auth.permission.inner-wildcard5.policy=permit
+            quarkus.http.auth.permission.inner-wildcard6.paths=/api/*/sadly/*/dont-know
+            quarkus.http.auth.permission.inner-wildcard6.policy=deny
+            quarkus.http.auth.permission.baz.paths=/api/baz
+            quarkus.http.auth.permission.baz.policy=authenticated
+            quarkus.http.auth.permission.static-resource.paths=/static-file.html
+            quarkus.http.auth.permission.static-resource.policy=authenticated
+            quarkus.http.auth.permission.fubar.paths=/api/fubar/baz*
+            quarkus.http.auth.permission.fubar.policy=authenticated
+            quarkus.http.auth.permission.management.paths=/q/*
+            quarkus.http.auth.permission.management.policy=authenticated
+            quarkus.http.auth.policy.shared1.roles.root=admin,user
+            quarkus.http.auth.permission.shared1.paths=/secured/*
+            quarkus.http.auth.permission.shared1.policy=shared1
+            quarkus.http.auth.permission.shared1.shared=true
+            quarkus.http.auth.policy.unshared1.roles-allowed=user
+            quarkus.http.auth.permission.unshared1.paths=/secured/user/*
+            quarkus.http.auth.permission.unshared1.policy=unshared1
+            quarkus.http.auth.policy.unshared2.roles-allowed=admin
+            quarkus.http.auth.permission.unshared2.paths=/secured/admin/*
+            quarkus.http.auth.permission.unshared2.policy=unshared2
+            quarkus.http.auth.permission.shared2.paths=/*
+            quarkus.http.auth.permission.shared2.shared=true
+            quarkus.http.auth.permission.shared2.policy=custom
+            quarkus.http.auth.roles-mapping.root1=admin,user
+            quarkus.http.auth.roles-mapping.admin1=admin
+            quarkus.http.auth.roles-mapping.public1=public2
+            """;
+
+    @RegisterExtension
+    static QuarkusUnitTest test = createQuarkusUnitTest(APP_PROPS);
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiAuthenticationMechanismSelectionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiAuthenticationMechanismSelectionTest.java
@@ -1,0 +1,284 @@
+package io.quarkus.vertx.http.security;
+
+import static io.restassured.matcher.RestAssuredMatchers.detailedCookie;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.StringPermission;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.runtime.security.BasicAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
+public class FluentApiAuthenticationMechanismSelectionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(AuthMechanismConfig.class, TestIdentityController.class, TestIdentityProvider.class,
+                    PathHandler.class, TestTrustedIdentityProvider.class, CustomHttpSecurityPolicy.class,
+                    CustomSchemeAuthenticationMechanism.class, AbstractCustomAuthenticationMechanism.class)
+            .addAsResource(new StringAsset("""
+                    quarkus.http.auth.form.enabled=true
+                    quarkus.http.auth.basic=true
+                    quarkus.http.ssl.client-auth=request
+                    quarkus.http.ssl.certificate.key-store-file=server-keystore.p12
+                    quarkus.http.ssl.certificate.key-store-password=secret
+                    quarkus.http.ssl.certificate.trust-store-file=server-truststore.p12
+                    quarkus.http.ssl.certificate.trust-store-password=secret
+                    """), "application.properties")
+            .addAsResource(new File("target/certs/mtls-test-keystore.p12"), "server-keystore.p12")
+            .addAsResource(new File("target/certs/mtls-test-server-truststore.p12"), "server-truststore.p12"));
+
+    @TestHTTPResource(value = "/mtls", tls = true)
+    URL url;
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", new StringPermission("openid"), new StringPermission("email"),
+                        new StringPermission("profile"))
+                .add("user", "user", new StringPermission("profile"));
+    }
+
+    @Test
+    public void testForm() {
+        CookieFilter adminCookies = new CookieFilter();
+        loginUsingFormAuth(adminCookies, "admin");
+
+        // valid request
+        RestAssured
+                .given()
+                .filter(adminCookies)
+                .redirects().follow(false)
+                .when()
+                .get("/form/admin")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("admin:/form/admin"));
+
+        // the same valid request but policy is applied because we added the header, so expect a failure
+        CookieFilter userCookies = new CookieFilter();
+        loginUsingFormAuth(userCookies, "user");
+        RestAssured
+                .given()
+                .filter(userCookies)
+                .redirects().follow(false)
+                .header("fail", "ignored")
+                .when()
+                .get("/form/admin")
+                .then()
+                .assertThat()
+                .statusCode(403);
+
+        // basic authentication -> authentication must fail
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .redirects().follow(false)
+                .when()
+                .get("/form/admin")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/login.html"));
+
+        // basic authentication & POST -> access is going to be denied as there are permissions with POST method
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .redirects().follow(false)
+                .when()
+                .post("/form/admin")
+                .then()
+                .assertThat()
+                .statusCode(403);
+
+        // basic authentication & PUT -> access is granted because this method is specifically configured for 'basic'
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .redirects().follow(false)
+                .when()
+                .put("/form/admin")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("admin:/form/admin"));
+    }
+
+    @Test
+    public void testBasicAuth() {
+        basicAuthTest("/basic/admin", "admin:/basic/admin");
+    }
+
+    @Test
+    public void testCustomAuthenticationMechanismScheme() {
+        basicAuthTest("/custom-scheme/admin", "admin:/custom-scheme/admin");
+    }
+
+    @Test
+    public void testCustomAuthenticationMechanismInstance() {
+        basicAuthTest("/custom-instance/admin", "admin:/custom-instance/admin");
+    }
+
+    @Test
+    public void testMutualTlsMechanism() {
+        RestAssured.given()
+                .keyStore("target/certs/mtls-test-client-keystore.p12", "secret")
+                .trustStore("target/certs/mtls-test-client-truststore.p12", "secret")
+                .get(url).then().statusCode(200).body(is("CN=localhost:/mtls"));
+        RestAssured.given()
+                .trustStore("target/certs/mtls-test-client-truststore.p12", "secret")
+                .get(url).then().statusCode(401);
+        try {
+            RestAssured
+                    .given()
+                    .auth().preemptive().basic("admin", "admin")
+                    .when()
+                    .get(url)
+                    .then()
+                    .assertThat()
+                    .statusCode(401);
+            Assertions.fail("Request should had fail because mTLS must be required");
+        } catch (Exception exception) {
+            Assertions.assertTrue(exception.getMessage().contains("PKIX path building failed"));
+        }
+    }
+
+    private static void basicAuthTest(String s, String operand) {
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .when()
+                .get(s)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo(operand));
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "user")
+                .when()
+                .get(s)
+                .then()
+                .assertThat()
+                .statusCode(403);
+        RestAssured
+                .given()
+                .get(s)
+                .then()
+                .assertThat()
+                .statusCode(401);
+    }
+
+    private static void loginUsingFormAuth(CookieFilter adminCookies, String user) {
+        RestAssured
+                .given()
+                .filter(adminCookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", user)
+                .formParam("j_password", user)
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/index.html"))
+                .cookie("quarkus-credential",
+                        detailedCookie().value(notNullValue()).path(equalTo("/")));
+    }
+
+    public static class AuthMechanismConfig {
+
+        void configure(@Observes HttpSecurity httpSecurity) {
+            httpSecurity
+                    .get("/form/admin").form().authorization()
+                    .policy(identity -> "admin".equals(identity.getPrincipal().getName()))
+                    .put("/form/admin").basic().authorization()
+                    .policy(identity -> "admin".equals(identity.getPrincipal().getName()))
+                    .path("/basic/admin").methods("GET").basic().authorization().permissions("openid", "email", "profile")
+                    .path("/custom-scheme/admin").authenticatedWith("custom-scheme").policy(new CustomHttpSecurityPolicy())
+                    .path("/custom-instance/admin").authenticatedWith(new AbstractCustomAuthenticationMechanism() {
+                    }).authorization().policy((identity, event) -> identity.hasRole("admin")
+                            && event.normalizedPath().endsWith("/custom-instance/admin"))
+                    .path("/mtls").mTLS();
+        }
+
+    }
+
+    public static final class CustomHttpSecurityPolicy implements HttpSecurityPolicy {
+        @Override
+        public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identityUni,
+                AuthorizationRequestContext requestContext) {
+            return identityUni.onItemOrFailure().transform((identity, throwable) -> {
+                if (throwable == null && identity.hasRole("admin")) {
+                    return CheckResult.PERMIT;
+                }
+                return CheckResult.DENY;
+            });
+        }
+    }
+
+    @ApplicationScoped
+    public static class CustomSchemeAuthenticationMechanism extends AbstractCustomAuthenticationMechanism {
+        @Override
+        public Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
+            return Uni.createFrom()
+                    .item(new HttpCredentialTransport(HttpCredentialTransport.Type.AUTHORIZATION, "custom-scheme"));
+        }
+    }
+
+    public static abstract class AbstractCustomAuthenticationMechanism implements HttpAuthenticationMechanism {
+        private final HttpAuthenticationMechanism delegate = new BasicAuthenticationMechanism(null);
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return delegate.authenticate(context, identityProviderManager);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return delegate.getChallenge(context);
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return delegate.getCredentialTypes();
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiPathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiPathMatchingHttpSecurityPolicyTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.vertx.http.security;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FluentApiPathMatchingHttpSecurityPolicyTest extends PathMatchingHttpSecurityPolicyTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = createQuarkusUnitTest("", HttpPermissionsConfig.class);
+
+    public static class HttpPermissionsConfig {
+
+        void configure(@Observes HttpSecurity httpSecurity, CustomNamedPolicy customNamedPolicy) {
+
+            httpSecurity.path("/api/one/*/jamaica/*", "/api/public", "/api*").permit();
+
+            httpSecurity.path("/api/*/sadly/*/dont-know").authorization().deny();
+
+            httpSecurity.path("/static-file.html", "/api/baz", "/", "/api/foo/bar", "/api/one/*/*/five", "/api/one/*/three/*",
+                    "/api/next/*/prev", "/api/*/bar").authenticated();
+
+            httpSecurity.path("/api/fubar/baz*").authenticated();
+
+            httpSecurity.path("/q/*").authenticated();
+
+            httpSecurity.path("/secured/*").shared().authorization()
+                    .roles(Map.of("root", List.of("admin", "user")), "**");
+
+            httpSecurity.path("/secured/user/*").roles("user");
+
+            httpSecurity.path("/secured/admin/*").authorization().roles("admin");
+
+            httpSecurity.path("/*").shared().policy(customNamedPolicy);
+
+            httpSecurity.rolesMapping(Map.of(
+                    "root1", List.of("admin", "user"),
+                    "admin1", List.of("admin"),
+                    "public1", List.of("public2")));
+        }
+
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
@@ -6,7 +6,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -22,6 +21,7 @@ import io.quarkus.security.StringPermission;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.PolicyConfig;
 import io.quarkus.vertx.http.runtime.PolicyMappingConfig;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityConfiguration.AuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.AuthorizationRequestContext;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.CheckResult;
 import io.quarkus.vertx.http.runtime.security.ImmutablePathMatcher.PathMatch;
@@ -41,7 +41,7 @@ public class AbstractPathMatchingHttpSecurityPolicy {
     private final List<ImmutablePathMatcher<List<HttpMatcher>>> sharedPermissionsPathMatchers;
     private final boolean hasNoPermissions;
 
-    AbstractPathMatchingHttpSecurityPolicy(Map<String, PolicyMappingConfig> permissions,
+    AbstractPathMatchingHttpSecurityPolicy(List<HttpSecurityConfiguration.HttpPermissionCarrier> httpPermissions,
             Map<String, PolicyConfig> rolePolicy, String rootPath, Instance<HttpSecurityPolicy> installedPolicies,
             PolicyMappingConfig.AppliesTo appliesTo) {
         boolean hasNoPermissions = true;
@@ -49,20 +49,20 @@ public class AbstractPathMatchingHttpSecurityPolicy {
         List<ImmutablePathMatcher<List<HttpMatcher>>> sharedPermsMatchers = new ArrayList<>();
         final var builder = ImmutablePathMatcher.<List<HttpMatcher>> builder().handlerAccumulator(List::addAll)
                 .rootPath(rootPath);
-        for (PolicyMappingConfig policyMappingConfig : permissions.values()) {
-            if (appliesTo != policyMappingConfig.appliesTo()) {
+        for (var httpPermission : httpPermissions) {
+            if (appliesTo != httpPermission.getAppliesTo()) {
                 continue;
             }
             if (hasNoPermissions) {
                 hasNoPermissions = false;
             }
-            if (policyMappingConfig.shared()) {
+            if (httpPermission.isShared()) {
                 final var builder1 = ImmutablePathMatcher.<List<HttpMatcher>> builder().handlerAccumulator(List::addAll)
                         .rootPath(rootPath);
-                addPermissionToPathMatcher(namedHttpSecurityPolicies, policyMappingConfig, builder1);
+                addPermissionToPathMatcher(namedHttpSecurityPolicies, httpPermission, builder1);
                 sharedPermsMatchers.add(builder1.build());
             } else {
-                addPermissionToPathMatcher(namedHttpSecurityPolicies, policyMappingConfig, builder);
+                addPermissionToPathMatcher(namedHttpSecurityPolicies, httpPermission, builder);
             }
         }
         this.hasNoPermissions = hasNoPermissions;
@@ -70,16 +70,29 @@ public class AbstractPathMatchingHttpSecurityPolicy {
         this.pathMatcher = builder.build();
     }
 
-    public String getAuthMechanismName(RoutingContext routingContext) {
+    AuthenticationMechanism getAuthMechanism(RoutingContext routingContext) {
         if (sharedPermissionsPathMatchers != null) {
             for (ImmutablePathMatcher<List<HttpMatcher>> matcher : sharedPermissionsPathMatchers) {
-                String authMechanismName = getAuthMechanismName(routingContext, matcher);
-                if (authMechanismName != null) {
-                    return authMechanismName;
+                AuthenticationMechanism authMechanism = getAuthMechanism(routingContext, matcher);
+                if (authMechanism != null) {
+                    return authMechanism;
                 }
             }
         }
-        return getAuthMechanismName(routingContext, pathMatcher);
+        return getAuthMechanism(routingContext, pathMatcher);
+    }
+
+    /**
+     * @deprecated This method is internal by nature, if you have a good use case, please report it
+     *             so that we can document the use case and test it.
+     */
+    @Deprecated(forRemoval = true, since = "3.25")
+    public String getAuthMechanismName(RoutingContext routingContext) {
+        AuthenticationMechanism authenticationMechanism = getAuthMechanism(routingContext);
+        if (authenticationMechanism != null) {
+            return authenticationMechanism.name();
+        }
+        return null;
     }
 
     public boolean hasNoPermissions() {
@@ -160,13 +173,9 @@ public class AbstractPathMatchingHttpSecurityPolicy {
                 });
     }
 
-    private static String getAuthMechanismName(RoutingContext routingContext,
+    private static AuthenticationMechanism getAuthMechanism(RoutingContext routingContext,
             ImmutablePathMatcher<List<HttpMatcher>> pathMatcher) {
-        PathMatch<List<HttpMatcher>> toCheck = pathMatcher.match(routingContext.normalizedPath());
-        if (toCheck.getValue() == null || toCheck.getValue().isEmpty()) {
-            return null;
-        }
-        for (HttpMatcher i : toCheck.getValue()) {
+        for (HttpMatcher i : findHttpMatchers(routingContext, pathMatcher)) {
             if (i.authMechanism != null) {
                 return i.authMechanism;
             }
@@ -175,50 +184,59 @@ public class AbstractPathMatchingHttpSecurityPolicy {
     }
 
     private static void addPermissionToPathMatcher(Map<String, HttpSecurityPolicy> permissionCheckers,
-            PolicyMappingConfig policyMappingConfig,
+            HttpSecurityConfiguration.HttpPermissionCarrier httpPermission,
             ImmutablePathMatcher.ImmutablePathMatcherBuilder<List<HttpMatcher>> builder) {
-        HttpSecurityPolicy checker = permissionCheckers.get(policyMappingConfig.policy());
-        if (checker == null) {
-            throw new RuntimeException("Unable to find HTTP security policy " + policyMappingConfig.policy());
+        final HttpSecurityPolicy policy;
+        if (httpPermission.getPolicy().instance() != null) {
+            policy = httpPermission.getPolicy().instance();
+        } else {
+            String policyName = httpPermission.getPolicy().name();
+            policy = permissionCheckers.get(policyName);
+            if (policy == null) {
+                throw new RuntimeException("Unable to find HTTP security policy " + policyName);
+            }
         }
 
-        if (policyMappingConfig.enabled().orElse(Boolean.TRUE)) {
-            for (String path : policyMappingConfig.paths().orElse(Collections.emptyList())) {
-                HttpMatcher m = new HttpMatcher(policyMappingConfig.authMechanism().orElse(null),
-                        new HashSet<>(policyMappingConfig.methods().orElse(Collections.emptyList())), checker);
-                List<HttpMatcher> perms = new ArrayList<>();
-                perms.add(m);
-                builder.addPath(path, perms);
-            }
+        for (String path : httpPermission.getPaths()) {
+            HttpMatcher m = new HttpMatcher(httpPermission.getAuthMechanism(), httpPermission.getMethods(), policy);
+            List<HttpMatcher> perms = new ArrayList<>();
+            perms.add(m);
+            builder.addPath(path, perms);
         }
     }
 
     private static List<HttpSecurityPolicy> findPermissionCheckers(RoutingContext context,
             ImmutablePathMatcher<List<HttpMatcher>> pathMatcher) {
-        var result = new ArrayList<HttpSecurityPolicy>();
+        List<HttpSecurityPolicy> list = new ArrayList<>();
+        for (HttpMatcher httpMatcher : findHttpMatchers(context, pathMatcher)) {
+            list.add(httpMatcher.checker);
+        }
+        return list;
+    }
 
+    private static List<HttpMatcher> findHttpMatchers(RoutingContext context,
+            ImmutablePathMatcher<List<HttpMatcher>> pathMatcher) {
         PathMatch<List<HttpMatcher>> toCheck = pathMatcher.match(context.normalizedPath());
         if (toCheck.getValue() == null || toCheck.getValue().isEmpty()) {
-            return result;
+            return List.of();
         }
-        List<HttpSecurityPolicy> methodMatch = new ArrayList<>();
-        List<HttpSecurityPolicy> noMethod = new ArrayList<>();
+        List<HttpMatcher> methodMatch = new ArrayList<>();
+        List<HttpMatcher> noMethod = new ArrayList<>();
         for (HttpMatcher i : toCheck.getValue()) {
             if (i.methods == null || i.methods.isEmpty()) {
-                noMethod.add(i.checker);
+                noMethod.add(i);
             } else if (i.methods.contains(context.request().method().toString())) {
-                methodMatch.add(i.checker);
+                methodMatch.add(i);
             }
         }
         if (!methodMatch.isEmpty()) {
-            result.addAll(methodMatch);
+            return methodMatch;
         } else if (!noMethod.isEmpty()) {
-            result.addAll(noMethod);
+            return noMethod;
         } else {
             //we deny if we did not match due to method filtering
-            result.add(DenySecurityPolicy.INSTANCE);
+            return List.of(HttpMatcher.DENY);
         }
-        return result;
     }
 
     static boolean policyApplied(RoutingContext routingContext) {
@@ -283,15 +301,15 @@ public class AbstractPathMatchingHttpSecurityPolicy {
             }
         }
 
-        var previousPolicy = namedPolicies.put("deny", DenySecurityPolicy.INSTANCE);
+        var previousPolicy = namedPolicies.put(DenySecurityPolicy.NAME, DenySecurityPolicy.INSTANCE);
         if (previousPolicy != null) {
             throw duplicateNamedPoliciesNotAllowedEx(previousPolicy, DenySecurityPolicy.INSTANCE);
         }
-        previousPolicy = namedPolicies.put("permit", new PermitSecurityPolicy());
+        previousPolicy = namedPolicies.put(PermitSecurityPolicy.NAME, new PermitSecurityPolicy());
         if (previousPolicy != null) {
             throw duplicateNamedPoliciesNotAllowedEx(previousPolicy, new PermitSecurityPolicy());
         }
-        previousPolicy = namedPolicies.put("authenticated", new AuthenticatedHttpSecurityPolicy());
+        previousPolicy = namedPolicies.put(AuthenticatedHttpSecurityPolicy.NAME, new AuthenticatedHttpSecurityPolicy());
         if (previousPolicy != null) {
             throw duplicateNamedPoliciesNotAllowedEx(previousPolicy, new AuthenticatedHttpSecurityPolicy());
         }
@@ -411,7 +429,7 @@ public class AbstractPathMatchingHttpSecurityPolicy {
                 + policy1.name() + "' is allowed, but found: " + policyClassName1 + " and " + policyClassName2);
     }
 
-    record HttpMatcher(String authMechanism, Set<String> methods, HttpSecurityPolicy checker) {
-
+    record HttpMatcher(AuthenticationMechanism authMechanism, Set<String> methods, HttpSecurityPolicy checker) {
+        private static final HttpMatcher DENY = new HttpMatcher(null, Set.of(), DenySecurityPolicy.INSTANCE);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticatedHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticatedHttpSecurityPolicy.java
@@ -11,6 +11,8 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class AuthenticatedHttpSecurityPolicy implements HttpSecurityPolicy {
 
+    public static final String NAME = "authenticated";
+
     @Override
     public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
             AuthorizationRequestContext requestContext) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/DenySecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/DenySecurityPolicy.java
@@ -7,6 +7,7 @@ import io.vertx.ext.web.RoutingContext;
 public class DenySecurityPolicy implements HttpSecurityPolicy {
 
     public static final DenySecurityPolicy INSTANCE = new DenySecurityPolicy();
+    public static final String NAME = "deny";
 
     @Override
     public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityConfiguration.java
@@ -1,0 +1,145 @@
+package io.quarkus.vertx.http.runtime.security;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.event.Event;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.vertx.http.runtime.AuthRuntimeConfig;
+import io.quarkus.vertx.http.runtime.PolicyMappingConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
+import io.quarkus.vertx.http.security.HttpSecurity;
+
+/**
+ * This singleton carries final HTTP Security configuration and act as a single source of truth for it.
+ */
+record HttpSecurityConfiguration(RolesMapping rolesMapping, List<HttpPermissionCarrier> httpPermissions) {
+
+    private static volatile HttpSecurityConfiguration instance = null;
+
+    record Policy(String name, HttpSecurityPolicy instance) {
+    }
+
+    record AuthenticationMechanism(String name, HttpAuthenticationMechanism instance) {
+    }
+
+    interface HttpPermissionCarrier {
+
+        Set<String> getPaths();
+
+        boolean isShared();
+
+        boolean shouldApplyToJaxRs();
+
+        Set<String> getMethods();
+
+        AuthenticationMechanism getAuthMechanism();
+
+        Policy getPolicy();
+
+        default PolicyMappingConfig.AppliesTo getAppliesTo() {
+            return shouldApplyToJaxRs() ? PolicyMappingConfig.AppliesTo.JAXRS : PolicyMappingConfig.AppliesTo.ALL;
+        }
+    }
+
+    // this instance is not in the CDI container to avoid "potential" (I am guessing) circular dependencies
+    // during the bean instantiation as we can't be sure what users will inject when they observe the HTTP Security;
+    // we could get 'VertxHttpConfig' from SR Config, but this way, we have "guaranteed" that the runtime config is ready
+    static HttpSecurityConfiguration get(VertxHttpConfig vertxHttpConfig) {
+        if (instance == null) {
+            synchronized (HttpSecurityConfiguration.class) {
+                if (instance == null) {
+                    HttpSecurityImpl httpSecurity = prepareHttpSecurity(vertxHttpConfig.auth());
+                    instance = new HttpSecurityConfiguration(httpSecurity.getRolesMapping(), httpSecurity.getHttpPermissions());
+                }
+            }
+        }
+        return instance;
+    }
+
+    private static HttpSecurityImpl prepareHttpSecurity(AuthRuntimeConfig authConfig) {
+        HttpSecurityImpl httpSecurity = new HttpSecurityImpl();
+        addAuthRuntimeConfigToHttpSecurity(authConfig, httpSecurity);
+        Event<HttpSecurity> httpSecurityEvent = Arc.container().beanManager().getEvent().select(HttpSecurity.class);
+        httpSecurityEvent.fire(httpSecurity);
+        return httpSecurity;
+    }
+
+    private static void addAuthRuntimeConfigToHttpSecurity(AuthRuntimeConfig authConfig, HttpSecurityImpl httpSecurity) {
+        if (!authConfig.rolesMapping().isEmpty()) {
+            httpSecurity.rolesMapping(authConfig.rolesMapping());
+        }
+        List<HttpPermissionCarrier> httpPermissions = adaptToHttpPermissionCarriers(authConfig.permissions());
+        httpSecurity.addHttpPermissions(httpPermissions);
+    }
+
+    static List<HttpPermissionCarrier> adaptToHttpPermissionCarriers(Map<String, PolicyMappingConfig> mappings) {
+        List<HttpPermissionCarrier> httpPermissions = new ArrayList<>();
+        for (PolicyMappingConfig mappingConfig : mappings.values()) {
+            HttpPermissionCarrier httpPermissionCarrier = adaptToHttpPermissionCarrier(mappingConfig);
+            if (httpPermissionCarrier != null) {
+                httpPermissions.add(httpPermissionCarrier);
+            }
+        }
+        return httpPermissions;
+    }
+
+    private static HttpPermissionCarrier adaptToHttpPermissionCarrier(PolicyMappingConfig mapping) {
+        if (!mapping.enabled().orElse(true)) {
+            // permission disabled
+            return null;
+        }
+        if (mapping.paths().isEmpty() || mapping.paths().get().isEmpty()) {
+            // no paths means no path-based HTTP permission
+            return null;
+        }
+        return new HttpPermissionCarrier() {
+            @Override
+            public Set<String> getPaths() {
+                return Set.copyOf(mapping.paths().get());
+            }
+
+            @Override
+            public boolean isShared() {
+                return mapping.shared();
+            }
+
+            @Override
+            public boolean shouldApplyToJaxRs() {
+                return mapping.appliesTo() == PolicyMappingConfig.AppliesTo.JAXRS;
+            }
+
+            @Override
+            public Set<String> getMethods() {
+                if (mapping.methods().isEmpty()) {
+                    return Set.of();
+                }
+                return Set.copyOf(mapping.methods().get());
+            }
+
+            @Override
+            public AuthenticationMechanism getAuthMechanism() {
+                if (mapping.authMechanism().isPresent()) {
+                    String authMech = mapping.authMechanism().get();
+                    if (!authMech.isEmpty()) {
+                        return new AuthenticationMechanism(authMech, null);
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public Policy getPolicy() {
+                return new Policy(mapping.policy(), null);
+            }
+
+            @Override
+            public PolicyMappingConfig.AppliesTo getAppliesTo() {
+                return mapping.appliesTo();
+            }
+        };
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityImpl.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityImpl.java
@@ -1,0 +1,499 @@
+package io.quarkus.vertx.http.runtime.security;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.security.StringPermission;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityConfiguration.HttpPermissionCarrier;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityConfiguration.Policy;
+import io.quarkus.vertx.http.runtime.security.annotation.BasicAuthentication;
+import io.quarkus.vertx.http.runtime.security.annotation.FormAuthentication;
+import io.quarkus.vertx.http.runtime.security.annotation.MTLSAuthentication;
+import io.quarkus.vertx.http.security.HttpSecurity;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.http.ClientAuth;
+import io.vertx.ext.web.RoutingContext;
+
+final class HttpSecurityImpl implements HttpSecurity {
+
+    private static final Logger LOG = Logger.getLogger(HttpSecurityImpl.class.getName());
+
+    private final List<HttpPermissionCarrier> httpPermissions;
+    private RolesMapping rolesMapping;
+
+    HttpSecurityImpl() {
+        this.rolesMapping = null;
+        this.httpPermissions = new ArrayList<>();
+    }
+
+    @Override
+    public HttpPermission path(String... patterns) {
+        if (patterns == null || patterns.length == 0) {
+            throw new IllegalArgumentException("Paths must not be empty");
+        }
+        var httpPermission = new HttpPermissionImpl(patterns);
+        httpPermissions.add(httpPermission);
+        return httpPermission;
+    }
+
+    @Override
+    public HttpPermission get(String... paths) {
+        return path(paths).methods("GET");
+    }
+
+    @Override
+    public HttpPermission put(String... paths) {
+        return path(paths).methods("PUT");
+    }
+
+    @Override
+    public HttpPermission post(String... paths) {
+        return path(paths).methods("POST");
+    }
+
+    @Override
+    public HttpPermission delete(String... paths) {
+        return path(paths).methods("DELETE");
+    }
+
+    @Override
+    public HttpSecurity rolesMapping(Map<String, List<String>> roleToRoles) {
+        if (rolesMapping != null) {
+            throw new IllegalStateException("Roles mapping is already configured");
+        }
+        if (roleToRoles == null || roleToRoles.isEmpty()) {
+            throw new IllegalArgumentException("Roles must not be empty");
+        }
+        roleToRoles.forEach(new BiConsumer<String, List<String>>() {
+            @Override
+            public void accept(String sourceRole, List<String> targetRoles) {
+                if (sourceRole.isEmpty()) {
+                    throw new IllegalArgumentException("Source role must not be empty");
+                }
+                if (targetRoles == null || targetRoles.isEmpty()) {
+                    throw new IllegalArgumentException("Target roles for role '%s' must not be empty".formatted(sourceRole));
+                }
+            }
+        });
+
+        this.rolesMapping = RolesMapping.of(roleToRoles);
+        return this;
+    }
+
+    @Override
+    public HttpSecurity rolesMapping(String sourceRole, List<String> targetRoles) {
+        if (sourceRole == null) {
+            throw new IllegalArgumentException("Source role must not be null");
+        }
+        if (targetRoles == null) {
+            throw new IllegalArgumentException("Target roles for role '%s' must not be null".formatted(sourceRole));
+        }
+        return rolesMapping(Map.of(sourceRole, targetRoles));
+    }
+
+    @Override
+    public HttpSecurity rolesMapping(String sourceRole, String targetRole) {
+        if (targetRole == null) {
+            throw new IllegalArgumentException("Target role for role '%s' must not be null".formatted(sourceRole));
+        }
+        return rolesMapping(sourceRole, List.of(targetRole));
+    }
+
+    void addHttpPermissions(List<HttpPermissionCarrier> httpPermissions) {
+        this.httpPermissions.addAll(httpPermissions);
+    }
+
+    private final class AuthorizationPolicy implements Authorization {
+
+        private Policy policy = null;
+
+        @Override
+        public HttpSecurity permit() {
+            validatePolicyNotSetYet();
+            this.policy = new Policy(PermitSecurityPolicy.NAME, null);
+            return HttpSecurityImpl.this;
+        }
+
+        @Override
+        public HttpSecurity deny() {
+            validatePolicyNotSetYet();
+            this.policy = new Policy(DenySecurityPolicy.NAME, null);
+            return HttpSecurityImpl.this;
+        }
+
+        @Override
+        public HttpSecurity roles(Map<String, List<String>> roleToRoles, String... roles) {
+            validatePolicyNotSetYet();
+            if (roles == null || roles.length == 0) {
+                throw new IllegalArgumentException("Roles must not be empty");
+            }
+            if (roleToRoles == null) {
+                throw new IllegalArgumentException("Role to roles mapping must not be null");
+            }
+            this.policy = new Policy(null, new RolesAllowedHttpSecurityPolicy(Arrays.asList(roles), null, roleToRoles));
+            return HttpSecurityImpl.this;
+        }
+
+        @Override
+        public HttpSecurity roles(String... roles) {
+            return roles(Map.of(), roles);
+        }
+
+        @Override
+        public HttpSecurity permissions(Permission... permissions) {
+            validatePolicyNotSetYet();
+            if (permissions == null || permissions.length == 0) {
+                throw new IllegalArgumentException("Permissions must not be empty");
+            }
+            policy = new Policy(null, new PermissionsHttpSecurityPolicy(permissions));
+            return HttpSecurityImpl.this;
+        }
+
+        @Override
+        public HttpSecurity permissions(String... permissionNames) {
+            Objects.requireNonNull(permissionNames);
+            StringPermission[] stringPermissions = new StringPermission[permissionNames.length];
+            for (int i = 0; i < permissionNames.length; i++) {
+                stringPermissions[i] = new StringPermission(permissionNames[i]);
+            }
+            return permissions(stringPermissions);
+        }
+
+        @Override
+        public HttpSecurity policy(HttpSecurityPolicy httpSecurityPolicy) {
+            validatePolicyNotSetYet();
+            if (httpSecurityPolicy == null) {
+                throw new IllegalArgumentException("HttpSecurityPolicy must not be null");
+            }
+            this.policy = new Policy(null, httpSecurityPolicy);
+            return HttpSecurityImpl.this;
+        }
+
+        @Override
+        public HttpSecurity policy(Predicate<SecurityIdentity> predicate) {
+            return policy((identity, request) -> !identity.isAnonymous() && predicate.test(identity));
+        }
+
+        @Override
+        public HttpSecurity policy(BiPredicate<SecurityIdentity, RoutingContext> predicate) {
+            return policy(new SimpleHttpSecurityPolicy(predicate));
+        }
+
+        private HttpSecurity authenticated() {
+            validatePolicyNotSetYet();
+            this.policy = new Policy(AuthenticatedHttpSecurityPolicy.NAME, null);
+            return HttpSecurityImpl.this;
+        }
+
+        private void validatePolicyNotSetYet() {
+            if (policy != null) {
+                throw new IllegalArgumentException("Policy has already been set");
+            }
+        }
+    }
+
+    private final class HttpPermissionImpl implements HttpPermission, HttpPermissionCarrier {
+
+        private final String[] paths;
+        private boolean shared;
+        private boolean applyToJaxRs;
+        private String[] methods;
+        private HttpSecurityConfiguration.AuthenticationMechanism authMechanism;
+        private AuthorizationPolicy authorizationPolicy;
+
+        private HttpPermissionImpl(String[] paths) {
+            this.paths = Arrays.copyOf(paths, paths.length);
+            this.authMechanism = null;
+            this.authorizationPolicy = null;
+            this.shared = false;
+            this.methods = null;
+            this.applyToJaxRs = false;
+        }
+
+        private void requireAuthenticationByDefault() {
+            // if someone selects authentication mechanism and doesn't configure
+            // authorization policy, it is reasonable to expect they require authentication
+            // similarly to what we do with @BasicAuthentication etc.
+            if (authorizationPolicy == null) {
+                authenticated();
+            }
+        }
+
+        private void validateAuthenticationNotSetYet() {
+            if (authMechanism != null) {
+                throw new IllegalArgumentException("Authentication has already been set");
+            }
+        }
+
+        private void validateAuthorizationNotSetYet() {
+            if (authMechanism == null && authorizationPolicy != null) {
+                throw new IllegalArgumentException("Authorization has already been set");
+            }
+        }
+
+        @Override
+        public HttpPermission basic() {
+            // TODO: we can enable it automatically during the runtime instead of this
+            boolean isBasicAuthDisabled = !Arc.container().select(BasicAuthenticationMechanism.class).isResolvable();
+            if (isBasicAuthDisabled) {
+                LOG.debug("Basic authentication is not available, you can enable it by setting " +
+                        "the 'quarkus.http.auth.basic' configuration property to 'true'. " +
+                        "Please ignore this warning if you provided a custom basic authentication mechanism.");
+            }
+            return authenticatedWith(BasicAuthentication.AUTH_MECHANISM_SCHEME);
+        }
+
+        @Override
+        public HttpPermission form() {
+            // TODO: we can enable it automatically during the runtime instead of this
+            boolean isFormAuthDisabled = !Arc.container().select(FormAuthenticationMechanism.class).isResolvable();
+            if (isFormAuthDisabled) {
+                LOG.debug("Form-based authentication is not available, you can enable it by setting " +
+                        "the 'quarkus.http.auth.form.enabled' configuration property to 'true'. " +
+                        "Please ignore this warning if you provided a custom form-based authentication mechanism.");
+            }
+            return authenticatedWith(FormAuthentication.AUTH_MECHANISM_SCHEME);
+        }
+
+        @Override
+        public HttpPermission mTLS() {
+            boolean mTlsDisabled = ClientAuth.NONE.equals(getHttpBuildTimeConfig().tlsClientAuth());
+            if (mTlsDisabled) {
+                throw new IllegalStateException(
+                        "TLS client authentication is not available, please set the 'quarkus.http.ssl.client-auth'"
+                                + " configuration property to 'required' or 'request'");
+            }
+            return authenticatedWith(MTLSAuthentication.AUTH_MECHANISM_SCHEME);
+        }
+
+        @Override
+        public HttpPermission bearer() {
+            return authenticatedWith("Bearer");
+        }
+
+        @Override
+        public HttpPermission webAuthn() {
+            return authenticatedWith("webauthn");
+        }
+
+        @Override
+        public HttpPermission authorizationCodeFlow() {
+            return authenticatedWith("code");
+        }
+
+        @Override
+        public HttpSecurity authenticated() {
+            return authorization().authenticated();
+        }
+
+        @Override
+        public HttpPermission authenticatedWith(String mechanism) {
+            validateAuthenticationNotSetYet();
+            requireAuthenticationByDefault();
+            if (mechanism == null || mechanism.isBlank()) {
+                throw new IllegalArgumentException("Authentication mechanism must not be null or blank");
+            }
+            this.authMechanism = new HttpSecurityConfiguration.AuthenticationMechanism(mechanism, null);
+            return this;
+        }
+
+        @Override
+        public HttpPermission authenticatedWith(HttpAuthenticationMechanism mechanism) {
+            validateAuthenticationNotSetYet();
+            requireAuthenticationByDefault();
+            if (mechanism == null) {
+                throw new IllegalArgumentException("HttpAuthenticationMechanism must not be null");
+            }
+            this.authMechanism = new HttpSecurityConfiguration.AuthenticationMechanism(null, mechanism);
+            return this;
+        }
+
+        @Override
+        public HttpPermission shared() {
+            this.shared = true;
+            return this;
+        }
+
+        @Override
+        public HttpPermission applyToJaxRs() {
+            this.applyToJaxRs = true;
+            return this;
+        }
+
+        @Override
+        public HttpPermission methods(String... httpMethods) {
+            if (httpMethods == null || httpMethods.length == 0) {
+                throw new IllegalArgumentException("HTTP methods must not be null or empty");
+            }
+            this.methods = Arrays.copyOf(httpMethods, httpMethods.length);
+            return this;
+        }
+
+        @Override
+        public AuthorizationPolicy authorization() {
+            validateAuthorizationNotSetYet();
+            this.authorizationPolicy = new AuthorizationPolicy();
+            return authorizationPolicy;
+        }
+
+        @Override
+        public HttpSecurity permit() {
+            return authorization().permit();
+        }
+
+        @Override
+        public HttpSecurity roles(String... roles) {
+            return authorization().roles(roles);
+        }
+
+        @Override
+        public HttpSecurity policy(HttpSecurityPolicy httpSecurityPolicy) {
+            return authorization().policy(httpSecurityPolicy);
+        }
+
+        @Override
+        public Set<String> getPaths() {
+            return Set.of(paths);
+        }
+
+        @Override
+        public boolean isShared() {
+            return shared;
+        }
+
+        @Override
+        public boolean shouldApplyToJaxRs() {
+            return applyToJaxRs;
+        }
+
+        @Override
+        public Set<String> getMethods() {
+            return methods == null ? Set.of() : Set.of(methods);
+        }
+
+        @Override
+        public HttpSecurityConfiguration.AuthenticationMechanism getAuthMechanism() {
+            return authMechanism;
+        }
+
+        @Override
+        public Policy getPolicy() {
+            if (authorizationPolicy == null || authorizationPolicy.policy == null) {
+                throw new IllegalStateException("Authorization Policy has not been set for paths: " + getPaths());
+            }
+            return authorizationPolicy.policy;
+        }
+    }
+
+    private static final class PermissionsHttpSecurityPolicy implements HttpSecurityPolicy {
+
+        private final Permission[] permissions;
+
+        private PermissionsHttpSecurityPolicy(Permission[] permissions) {
+            this.permissions = Arrays.copyOf(permissions, permissions.length);
+        }
+
+        @Override
+        public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identityUni,
+                AuthorizationRequestContext requestContext) {
+            return identityUni.onItemOrFailure()
+                    .transformToUni(new BiFunction<SecurityIdentity, Throwable, Uni<? extends CheckResult>>() {
+                        @Override
+                        public Uni<? extends CheckResult> apply(SecurityIdentity securityIdentity, Throwable throwable) {
+                            if (throwable != null || securityIdentity == null || securityIdentity.isAnonymous()) {
+                                if (throwable != null) {
+                                    LOG.debug("Authentication failed, denying access", throwable);
+                                }
+                                return CheckResult.deny();
+                            }
+                            return logicalAndPermissionCheck(securityIdentity, 0);
+                        }
+                    });
+        }
+
+        private Uni<CheckResult> logicalAndPermissionCheck(SecurityIdentity securityIdentity, int i) {
+            if (permissions.length == i) {
+                return CheckResult.permit();
+            }
+            return securityIdentity
+                    .checkPermission(permissions[i])
+                    .onItemOrFailure().transformToUni(new BiFunction<Boolean, Throwable, Uni<? extends CheckResult>>() {
+                        @Override
+                        public Uni<? extends CheckResult> apply(Boolean aBoolean, Throwable throwable) {
+                            if (throwable == null && Boolean.TRUE.equals(aBoolean)) {
+                                return logicalAndPermissionCheck(securityIdentity, i + 1);
+                            }
+                            if (throwable != null) {
+                                LOG.debug("Failed to check permission, denying access", throwable);
+                            }
+                            return CheckResult.deny();
+                        }
+                    });
+        }
+    }
+
+    private static final class SimpleHttpSecurityPolicy implements HttpSecurityPolicy {
+
+        private final BiPredicate<SecurityIdentity, RoutingContext> predicate;
+
+        private SimpleHttpSecurityPolicy(BiPredicate<SecurityIdentity, RoutingContext> predicate) {
+            this.predicate = predicate;
+        }
+
+        @Override
+        public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identityUni,
+                AuthorizationRequestContext requestContext) {
+            return identityUni.onItemOrFailure()
+                    .transform(new BiFunction<SecurityIdentity, Throwable, CheckResult>() {
+                        @Override
+                        public CheckResult apply(SecurityIdentity securityIdentity, Throwable throwable) {
+                            if (securityIdentity == null) {
+                                // shouldn't be possible happen...
+                                return CheckResult.DENY;
+                            }
+                            if (throwable != null) {
+                                LOG.debug("Failed to retrieve SecurityIdentity, denying access", throwable);
+                                return CheckResult.DENY;
+                            }
+                            boolean deny;
+                            try {
+                                deny = !predicate.test(securityIdentity, request);
+                            } catch (Exception e) {
+                                LOG.debug("Failed to check permission, denying access", e);
+                                deny = true;
+                            }
+                            return deny ? CheckResult.DENY : CheckResult.PERMIT;
+                        }
+                    });
+        }
+    }
+
+    List<HttpPermissionCarrier> getHttpPermissions() {
+        return List.copyOf(httpPermissions);
+    }
+
+    RolesMapping getRolesMapping() {
+        return rolesMapping;
+    }
+
+    private static VertxHttpBuildTimeConfig getHttpBuildTimeConfig() {
+        return ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
+                .getConfigMapping(VertxHttpBuildTimeConfig.class);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -68,7 +68,7 @@ public class HttpSecurityRecorder {
     public void initializeHttpAuthenticatorHandler(RuntimeValue<AuthenticationHandler> handlerRuntimeValue,
             VertxHttpConfig httpConfig, BeanContainer beanContainer) {
         handlerRuntimeValue.getValue().init(beanContainer.beanInstance(PathMatchingHttpSecurityPolicy.class),
-                RolesMapping.of(httpConfig.auth().rolesMapping()));
+                HttpSecurityConfiguration.get(httpConfig).rolesMapping());
     }
 
     public Handler<RoutingContext> permissionCheckHandler() {
@@ -161,6 +161,11 @@ public class HttpSecurityRecorder {
                 return Map.of();
             }
         };
+    }
+
+    public void prepareHttpSecurityConfiguration(VertxHttpConfig httpConfig) {
+        // this is done so that we prepare and validate HTTP Security config before the first incoming request
+        HttpSecurityConfiguration.get(httpConfig);
     }
 
     public static abstract class DefaultAuthFailureHandler implements BiConsumer<RoutingContext, Throwable> {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/JaxRsPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/JaxRsPathMatchingHttpSecurityPolicy.java
@@ -37,7 +37,8 @@ public class JaxRsPathMatchingHttpSecurityPolicy {
             Instance<HttpSecurityPolicy> installedPolicies, VertxHttpConfig httpConfig,
             VertxHttpBuildTimeConfig httpBuildTimeConfig, BlockingSecurityExecutor blockingSecurityExecutor) {
         this.storage = storage;
-        this.delegate = new AbstractPathMatchingHttpSecurityPolicy(httpConfig.auth().permissions(),
+        this.delegate = new AbstractPathMatchingHttpSecurityPolicy(
+                HttpSecurityConfiguration.get(httpConfig).httpPermissions(),
                 httpConfig.auth().rolePolicy(), httpBuildTimeConfig.rootPath(), installedPolicies, JAXRS);
         this.foundNoAnnotatedMethods = storage.getMethodToPolicyName().isEmpty();
         this.requestContext = new DefaultAuthorizationRequestContext(blockingSecurityExecutor);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime.security;
 
 import static io.quarkus.vertx.http.runtime.PolicyMappingConfig.AppliesTo.ALL;
+import static io.quarkus.vertx.http.runtime.security.HttpSecurityConfiguration.adaptToHttpPermissionCarriers;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
@@ -18,7 +19,7 @@ public class ManagementPathMatchingHttpSecurityPolicy extends AbstractPathMatchi
     ManagementPathMatchingHttpSecurityPolicy(
             ManagementInterfaceBuildTimeConfig managementBuildTimeConfig,
             ManagementConfig managementConfig, Instance<HttpSecurityPolicy> installedPolicies) {
-        super(managementConfig.auth().permissions(), managementConfig.auth().rolePolicy(), managementBuildTimeConfig.rootPath(),
-                installedPolicies, ALL);
+        super(adaptToHttpPermissionCarriers(managementConfig.auth().permissions()),
+                managementConfig.auth().rolePolicy(), managementBuildTimeConfig.rootPath(), installedPolicies, ALL);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -18,8 +18,8 @@ public class PathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecu
     PathMatchingHttpSecurityPolicy(
             VertxHttpConfig httpConfig, VertxHttpBuildTimeConfig httpBuildTimeConfig,
             Instance<HttpSecurityPolicy> installedPolicies) {
-        super(httpConfig.auth().permissions(), httpConfig.auth().rolePolicy(), httpBuildTimeConfig.rootPath(),
-                installedPolicies,
-                ALL);
+        super(HttpSecurityConfiguration.get(httpConfig).httpPermissions(),
+                httpConfig.auth().rolePolicy(), httpBuildTimeConfig.rootPath(),
+                installedPolicies, ALL);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PermitSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PermitSecurityPolicy.java
@@ -6,6 +6,8 @@ import io.vertx.ext.web.RoutingContext;
 
 public class PermitSecurityPolicy implements HttpSecurityPolicy {
 
+    public static final String NAME = "permit";
+
     @Override
     public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
             AuthorizationRequestContext requestContext) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/HttpSecurity.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/HttpSecurity.java
@@ -1,0 +1,290 @@
+package io.quarkus.vertx.http.security;
+
+import java.security.Permission;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A CDI event that facilitates programmatic path-specific authorization setup.
+ * The event can be observed with synchronous observer method like in the example below:
+ *
+ * <pre>
+ * {@code
+ * import jakarta.enterprise.event.Observes;
+ *
+ * public class HttpSecurityConfiguration {
+ *
+ *     void observe(@Observes HttpSecurity httpSecurity) {
+ *         httpSecurity
+ *                 .path("/admin/*").basic().roles("admin")
+ *                 .path("/user/*").form().roles("user")
+ *                 .path("/public/*").permit();
+ *         // and:
+ *         httpSecurity.path("/root*").authorization()
+ *                 .policy(identity -> "root".equals(identity.getPrincipal().getName()));
+ *     }
+ * }
+ * }
+ * </pre>
+ *
+ * If multiple path-patterns matches an incoming request path, the most specific pattern wins.
+ * Expected behavior for the programmatic configuration is very much same as for the HTTP permissions
+ * specified in the 'application.properties' file.
+ * For example following configuration properties:
+ *
+ * <pre>
+ * {@code
+ * quarkus.http.auth.permission.deny1.paths=/forbidden
+ * quarkus.http.auth.permission.deny1.policy=deny
+ * }
+ * </pre>
+ *
+ * can be also written as:
+ *
+ * <pre>
+ * {@code
+ * httpSecurity.path("/forbidden").authorization().deny();
+ * }
+ * </pre>
+ *
+ * Programmatic setup for the management interface is currently not supported.
+ * This CDI event is fired when the runtime configuration is ready,
+ * therefore you can inject configuration properties like this:
+ *
+ * <pre>
+ * {@code
+ * import jakarta.enterprise.event.Observes;
+ *
+ * import io.quarkus.vertx.http.security.HttpSecurity;
+ * import org.eclipse.microprofile.config.inject.ConfigProperty;
+ *
+ * public class HttpSecurityConfiguration {
+ *
+ *     void configure(@Observes HttpSecurity httpSecurity, @ConfigProperty(name = "admin1-role") String admin1) {
+ *         httpSecurity.rolesMapping("admin", admin1);
+ *     }
+ * }
+ * }
+ * </pre>
+ */
+public interface HttpSecurity {
+
+    /**
+     * Creates {@link HttpPermission}.
+     *
+     * @param paths path patterns; this is programmatic analogy to the 'quarkus.http.auth.permission."permissions".paths'
+     *        configuration property, same rules apply
+     * @return new {@link HttpPermission}
+     */
+    HttpPermission path(String... paths);
+
+    /**
+     * This method is a shortcut for {@code path(path).methods("GET")}.
+     *
+     * @see #path(String...)
+     */
+    HttpPermission get(String... paths);
+
+    /**
+     * This method is a shortcut for {@code path(path).methods("PUT")}.
+     *
+     * @see #path(String...)
+     */
+    HttpPermission put(String... paths);
+
+    /**
+     * This method is a shortcut for {@code path(path).methods("POST")}.
+     *
+     * @see #path(String...)
+     */
+    HttpPermission post(String... paths);
+
+    /**
+     * This method is a shortcut for {@code path(path).methods("DELETE")}.
+     *
+     * @see #path(String...)
+     */
+    HttpPermission delete(String... paths);
+
+    /**
+     * Map the `SecurityIdentity` roles to deployment specific roles and add the matching roles to `SecurityIdentity`.
+     * Programmatic analogy to the 'quarkus.http.auth.roles-mapping."role-name"' configuration property.
+     * If the configuration property is already set, invocation of this method fails as both methods are mutually exclusive.
+     */
+    HttpSecurity rolesMapping(Map<String, List<String>> roleToRoles);
+
+    /**
+     * @see #rolesMapping(Map)
+     */
+    HttpSecurity rolesMapping(String sourceRole, List<String> targetRoles);
+
+    /**
+     * @see #rolesMapping(Map)
+     */
+    HttpSecurity rolesMapping(String sourceRole, String targetRole);
+
+    /**
+     * Represents authorization and authentication requirements for given path patterns.
+     */
+    interface HttpPermission {
+
+        /**
+         * HTTP request must be authenticated using basic authentication.
+         */
+        HttpPermission basic();
+
+        /**
+         * HTTP request must be authenticated using form-based authentication.
+         */
+        HttpPermission form();
+
+        /**
+         * HTTP request must be authenticated using mutual-TLS authentication.
+         */
+        HttpPermission mTLS();
+
+        /**
+         * HTTP request must be authenticated using Bearer token authentication.
+         */
+        HttpPermission bearer();
+
+        /**
+         * HTTP request must be authenticated using WebAuthn mechanism.
+         */
+        HttpPermission webAuthn();
+
+        /**
+         * HTTP request must be authenticated using Authorization Code Flow mechanism.
+         */
+        HttpPermission authorizationCodeFlow();
+
+        /**
+         * HTTP requests will only be accessible if {@link io.quarkus.security.identity.SecurityIdentity}
+         * is not anonymous.
+         */
+        HttpSecurity authenticated();
+
+        /**
+         * HTTP request must be authenticated using a mechanism
+         * with matching {@link HttpCredentialTransport#getAuthenticationScheme()}.
+         * Please note that annotation-based mechanism selection has higher priority during the mechanism selection.
+         */
+        HttpPermission authenticatedWith(String scheme);
+
+        /**
+         * HTTP request must be authenticated with this mechanism.
+         * Please note that annotation-based mechanism selection has higher priority during the mechanism selection.
+         */
+        HttpPermission authenticatedWith(HttpAuthenticationMechanism mechanism);
+
+        /**
+         * Indicates that this policy always applies to the matched paths in addition to the policy with a winning path.
+         * Programmatic analogy to the 'quarkus.http.auth.permission."permissions".shared' configuration property.
+         */
+        HttpPermission shared();
+
+        /**
+         * Whether permission check should be applied on all matching paths, or paths specific for the Jakarta REST resources.
+         * Programmatic analogy to the 'quarkus.http.auth.permission."permissions".applies-to' configuration property.
+         */
+        HttpPermission applyToJaxRs();
+
+        /**
+         * The methods that this permission set applies to. If this is not set then they apply to all methods.
+         * Programmatic analogy to the 'quarkus.http.auth.permission."permissions".methods' configuration property.
+         */
+        HttpPermission methods(String... httpMethods);
+
+        /**
+         * Allows to configure HTTP request authorization requirement on the returned instance.
+         */
+        Authorization authorization();
+
+        /**
+         * This method is a shortcut for {@link Authorization#permit()}.
+         */
+        HttpSecurity permit();
+
+        /**
+         * This method is a shortcut for {@link Authorization#roles(String...)}.
+         */
+        HttpSecurity roles(String... roles);
+
+        /**
+         * This method is a shortcut for {@link Authorization#policy(HttpSecurityPolicy)}.
+         */
+        HttpSecurity policy(HttpSecurityPolicy httpSecurityPolicy);
+    }
+
+    /**
+     * Represents HTTP request authorization.
+     */
+    interface Authorization {
+
+        /**
+         * Access to HTTP requests will be permitted.
+         */
+        HttpSecurity permit();
+
+        /**
+         * Access to HTTP requests will be denied.
+         */
+        HttpSecurity deny();
+
+        /**
+         * HTTP requests will only be accessible if {@link io.quarkus.security.identity.SecurityIdentity}
+         * has all the required roles. Roles must be literal, property expansion is not supported here.
+         *
+         * @param roleToRoles see the 'quarkus.http.auth.policy."role-policy".roles."role-name"' configuration property
+         * @param rolesAllowed see the 'quarkus.http.auth.policy."role-policy".roles-allowed' configuration property
+         * @return HttpSecurity
+         */
+        HttpSecurity roles(Map<String, List<String>> roleToRoles, String... rolesAllowed);
+
+        /**
+         * HTTP requests will only be accessible if {@link io.quarkus.security.identity.SecurityIdentity}
+         * has all the required roles. Roles must be literal, property expansion is not supported here.
+         */
+        HttpSecurity roles(String... roles);
+
+        /**
+         * HTTP requests will only be accessible if {@link io.quarkus.security.identity.SecurityIdentity}
+         * has all the required permissions.
+         */
+        HttpSecurity permissions(Permission... requiredPermissions);
+
+        /**
+         * HTTP requests will only be accessible if {@link io.quarkus.security.identity.SecurityIdentity}
+         * has all the required {@link io.quarkus.security.StringPermission}s.
+         *
+         * @param permissionNames required {@link Permission#getName()}
+         */
+        HttpSecurity permissions(String... permissionNames);
+
+        /**
+         * HTTP requests will only be accessible if the passed {@link HttpSecurityPolicy} grants access.
+         */
+        HttpSecurity policy(HttpSecurityPolicy policy);
+
+        /**
+         * HTTP requests will only be accessible if the passed predicate returns {@code true}.
+         * This is a shortcut method for {@link #policy(HttpSecurityPolicy)}.
+         * The {@link SecurityIdentity} in this special case is never anonymous, anonymous requests will be denied.
+         */
+        HttpSecurity policy(Predicate<SecurityIdentity> predicate);
+
+        /**
+         * HTTP requests will only be accessible if the passed predicate returns {@code true}.
+         * This is a shortcut method for {@link #policy(HttpSecurityPolicy)}.
+         */
+        HttpSecurity policy(BiPredicate<SecurityIdentity, RoutingContext> predicate);
+    }
+}


### PR DESCRIPTION
- allow to configure path-specific authorization in code instead of in `application.properties`
- this PR covers portion of https://github.com/quarkusio/quarkus/issues/16728
- more will follow in separate smaller PRs for other configuration (like form auth config, inclusive auth and so on), the specifics needs to be discussed first