### PR TITLE
Fix group and version space assignment in Gradle

### DIFF
--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -444,9 +444,9 @@ public class CliProjectGradleTest {
                 "build.gradle should exist: " + buildGradle.toAbsolutePath().toString());
 
         String buildContent = CliDriver.readFileAsString(buildGradle);
-        Assertions.assertTrue(buildContent.contains("group '" + group + "'"),
+        Assertions.assertTrue(buildContent.contains("group = '" + group + "'"),
                 "build.gradle should include the group id:\n" + buildContent);
-        Assertions.assertTrue(buildContent.contains("version '" + version + "'"),
+        Assertions.assertTrue(buildContent.contains("version = '" + version + "'"),
                 "build.gradle should include the version:\n" + buildContent);
 
         Path settings = project.resolve("settings.gradle");

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
@@ -36,8 +36,8 @@ public class TestUtils {
                 "id 'java'\n" +
                 "id 'io.quarkus.extension'\n" +
                 "}\n" +
-                "group 'org.acme'\n" +
-                "version '1.0.0'\n" +
+                "group = 'org.acme'\n" +
+                "version = '1.0.0'\n" +
                 "repositories { \n" +
                 "mavenCentral()\n" +
                 "mavenLocal()\n" +
@@ -63,8 +63,8 @@ public class TestUtils {
         return "plugins {\n" +
                 "id 'java'\n" +
                 "}\n" +
-                "group 'org.acme'\n" +
-                "version '1.0.0'\n" +
+                "group = 'org.acme'\n" +
+                "version = '1.0.0'\n" +
                 "repositories { \n" +
                 "mavenCentral()\n" +
                 "mavenLocal()\n" +

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group '${groupId}'
-version '${version}'
+group = '${groupId}'
+version = '${version}'
 
 compileJava {
     options.compilerArgs << '-parameters'

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
@@ -40,8 +40,8 @@ dependencies {
 {/}
 
 {#insert project}
-group '{project.group-id}'
-version '{project.version}'
+group = '{project.group-id}'
+version = '{project.version}'
 {/}
 
 {#insert java}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -398,8 +398,8 @@ class QuarkusCodestartGenerationTest {
         assertThat(projectDir.resolve("settings.gradle.kts")).doesNotExist();
         assertThat(projectDir.resolve("build.gradle"))
                 .exists()
-                .satisfies(checkContains("group 'org.test'"))
-                .satisfies(checkContains("version '1.0.0-codestart'"));
+                .satisfies(checkContains("group = 'org.test'"))
+                .satisfies(checkContains("version = '1.0.0-codestart'"));
         assertThat(projectDir.resolve("gradle.properties")).exists();
         assertThat(projectDir.resolve("settings.gradle"))
                 .exists()

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
@@ -185,8 +185,8 @@ public class CreateProjectTest extends PlatformAwareTestBase {
                 .satisfies(checkContains("@Path(\"/foo\")"));
         assertThat(projectDir.resolve("build.gradle"))
                 .exists()
-                .satisfies(checkContains("group 'io.foo'"))
-                .satisfies(checkContains("version '1.0.0-FOO'"))
+                .satisfies(checkContains("group = 'io.foo'"))
+                .satisfies(checkContains("version = '1.0.0-FOO'"))
                 .satisfies(checkContains("implementation 'io.quarkus:quarkus-resteasy'"));
 
         assertThat(projectDir.resolve("settings.gradle"))

--- a/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testGradleContent/build.gradle
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testGradleContent/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.test'
-version '1.0.0-codestart'
+group = 'org.test'
+version = '1.0.0-codestart'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/avro-simple-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/avro-simple-project/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-avro'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 test {
     systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/application/build.gradle
@@ -5,8 +5,8 @@ plugins{
 
 
 
-group 'io.quarkus.test.application'
-version '1.0-SNAPSHOT'
+group = 'io.quarkus.test.application'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/extensions/example-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/extensions/example-extension/build.gradle
@@ -6,8 +6,8 @@ subprojects {subProject->
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 
-    group 'org.acme.extensions'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.extensions'
+    version = '1.0-SNAPSHOT'
     publishing {
         publications {
             maven(MavenPublication) {
@@ -30,5 +30,5 @@ publishing {
         }
     }
 }
-group 'org.acme.extensions'
-version '1.0-SNAPSHOT'
+group = 'org.acme.extensions'
+version = '1.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryA/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryA/build.gradle
@@ -4,8 +4,8 @@ plugins{
 
 
 
-group 'org.acme.libs'
-version '1.0-SNAPSHOT'
+group = 'org.acme.libs'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryB/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryB/build.gradle
@@ -4,8 +4,8 @@ plugins{
 
 
 
-group 'org.acme.libs'
-version '1.0-SNAPSHOT'
+group = 'org.acme.libs'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-project/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-project/application/build.gradle
@@ -5,8 +5,8 @@ plugins{
 
 
 
-group 'io.quarkus.test.application'
-version '1.0-SNAPSHOT'
+group = 'io.quarkus.test.application'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryA/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryA/build.gradle
@@ -4,8 +4,8 @@ plugins{
 
 
 
-group 'org.acme.libs'
-version '1.0-SNAPSHOT'
+group = 'org.acme.libs'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryB/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryB/build.gradle
@@ -4,8 +4,8 @@ plugins{
 
 
 
-group 'org.acme.libs'
-version '1.0-SNAPSHOT'
+group = 'org.acme.libs'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 }
 
 allprojects {
-     group 'org.acme'
-     version '1.0.0-SNAPSHOT'
+     group = 'org.acme'
+     version = '1.0.0-SNAPSHOT'
 }
 
 subprojects{

--- a/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 }
 
 allprojects {
-     group 'org.acme'
-     version '1.0.0-SNAPSHOT'
+     group = 'org.acme'
+     version = '1.0.0-SNAPSHOT'
 }
 
 subprojects{

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 allOpen {
     annotation("jakarta.ws.rs.Path")

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/build.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 quarkus {
     properties {

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/build.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 quarkus {
     properties {

--- a/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/build.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
@@ -21,5 +21,5 @@ subprojects {
     }
 }
 
-group 'org.acme'
-version '1.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusPlatformVersion}")
 }
 
-group 'org.acme'
-version '1.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0-SNAPSHOT'
 
 
 compileTestJava {

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/build.gradle
@@ -11,6 +11,6 @@ repositories {
      mavenCentral()
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/common/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/common/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'java-library'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/componly/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/componly/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     }
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/quarkus/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags/quarkus/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     compileOnly project(':componly')
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'io.playground'
-version '1.0'
+group = 'io.playground'
+version = '1.0'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme.gradle.multi'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme.gradle.multi'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme.gradle.multi'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme.gradle.multi'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/build.gradle
@@ -1,7 +1,7 @@
 allprojects {
 
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.g'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.g'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.i'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.i'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.j'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.j'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.k'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.k'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.r'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.r'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.s'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.s'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.t'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.t'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
-    group 'org.acme.u'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.u'
+    version = '1.0-SNAPSHOT'
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/custom-jar-classifier-dependency/project-a/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-jar-classifier-dependency/project-a/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'java'
 }
 
-group 'io.example'
-version '1.0-SNAPSHOT'
+group = 'io.example'
+version = '1.0-SNAPSHOT'
 
 dependencies {
     implementation project(':project-b')

--- a/integration-tests/gradle/src/main/resources/custom-jar-classifier-dependency/project-b/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-jar-classifier-dependency/project-b/build.gradle
@@ -2,5 +2,5 @@ plugins {
     id 'java'
 }
 
-group 'io.example'
-version '1.0-SNAPSHOT'
+group = 'io.example'
+version = '1.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/custom-jar-classifier-dependency/runner/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-jar-classifier-dependency/runner/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'io.example'
-version '1.0-SNAPSHOT'
+group = 'io.example'
+version = '1.0-SNAPSHOT'
 
 test {
     systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"

--- a/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
@@ -1,7 +1,7 @@
 subprojects {
     apply plugin: 'java-library'
 
-    version '0.0.1-SNAPSHOT'
+    version = '0.0.1-SNAPSHOT'
     repositories {
         mavenLocal {
             content {

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-grpc'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-grpc'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-grpc'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-grpc'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 }
 
 allprojects {
-     group 'org.acme'
-     version '1.0.0-SNAPSHOT'
+     group = 'org.acme'
+     version = '1.0.0-SNAPSHOT'
 }
 
 subprojects{

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     testImplementation 'io.rest-assured:kotlin-extensions'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 allOpen {
     annotation("jakarta.ws.rs.Path")

--- a/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/maven-exclusion-in-extension-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/maven-exclusion-in-extension-dependency/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 test {
     systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/build.gradle
@@ -5,8 +5,8 @@ plugins{
 
 
 
-group 'io.quarkus.test.application'
-version '1.0-SNAPSHOT'
+group = 'io.quarkus.test.application'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/another-example-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/another-example-extension/build.gradle
@@ -6,8 +6,8 @@ subprojects {subProject->
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 
-    group 'org.acme.extensions'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.extensions'
+    version = '1.0-SNAPSHOT'
     publishing {
         publications {
             maven(MavenPublication) {
@@ -30,5 +30,5 @@ publishing {
         }
     }
 }
-group 'org.acme.extensions'
-version '1.0-SNAPSHOT'
+group = 'org.acme.extensions'
+version = '1.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/example-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/example-extension/build.gradle
@@ -6,8 +6,8 @@ subprojects {subProject->
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 
-    group 'org.acme.extensions'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.extensions'
+    version = '1.0-SNAPSHOT'
     publishing {
         publications {
             maven(MavenPublication) {
@@ -30,5 +30,5 @@ publishing {
         }
     }
 }
-group 'org.acme.extensions'
-version '1.0-SNAPSHOT'
+group = 'org.acme.extensions'
+version = '1.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/libraries/libraryA/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/libraries/libraryA/build.gradle
@@ -4,8 +4,8 @@ plugins{
 
 
 
-group 'org.acme.libs'
-version '1.0-SNAPSHOT'
+group = 'org.acme.libs'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/libraries/libraryB/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/libraries/libraryB/build.gradle
@@ -4,8 +4,8 @@ plugins{
 
 
 
-group 'org.acme.libs'
-version '1.0-SNAPSHOT'
+group = 'org.acme.libs'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     implementation 'org.acme:external-library:1.0.0-SNAPSHOT'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-core'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
@@ -18,8 +18,8 @@ allOpen {
 }
 
 allprojects {
-    group 'org.acme'
-    version '1.0.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0.0-SNAPSHOT'
 
     apply {
         plugin 'org.jetbrains.kotlin.jvm'

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
@@ -11,6 +11,6 @@ repositories {
      mavenCentral()
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/common/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/common/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     api 'io.quarkus:quarkus-smallrye-health'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation project(':common')
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/multi-module-with-lib-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-with-lib-module/build.gradle
@@ -1,5 +1,5 @@
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 allprojects {
     repositories {

--- a/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     testImplementation 'io.rest-assured:kotlin-extensions'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 allOpen {
     annotation("jakarta.ws.rs.Path")

--- a/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
+++ b/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/quarkus-component-test/build.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-component-test/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     testImplementation 'io.quarkus:quarkus-junit5-component'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency-analytics/build.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency-analytics/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'application'
 }
 
-group 'com.analytics'
+group = 'com.analytics'
 
 repositories {
     mavenLocal {

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/build.gradle
@@ -5,8 +5,8 @@ plugins{
 
 
 
-group 'io.quarkus.test.application'
-version '1.0-SNAPSHOT'
+group = 'io.quarkus.test.application'
+version = '1.0-SNAPSHOT'
 
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/build.gradle
@@ -6,8 +6,8 @@ subprojects {subProject->
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 
-    group 'org.acme.extensions'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme.extensions'
+    version = '1.0-SNAPSHOT'
     publishing {
         publications {
             maven(MavenPublication) {
@@ -30,5 +30,5 @@ publishing {
         }
     }
 }
-group 'org.acme.extensions'
-version '1.0-SNAPSHOT'
+group = 'org.acme.extensions'
+version = '1.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module-with-package-private-parent/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'my-groupId'
-version 'my-version'
+group = 'my-groupId'
+version = 'my-version'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'my-groupId'
-version 'my-version'
+group = 'my-groupId'
+version = 'my-version'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/build.gradle
@@ -9,6 +9,6 @@ repositories {
 }
 
 allprojects {
-    group 'my-groupId'
-    version 'my-version'
+    group = 'my-groupId'
+    version = 'my-version'
 }

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
@@ -14,8 +14,8 @@ buildscript {
 apply plugin: 'java'
 
 allprojects {
-    group 'org.acme'
-    version '1.0-SNAPSHOT'
+    group = 'org.acme'
+    version = '1.0-SNAPSHOT'
 }
 
 subprojects {

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 }
 
-group 'org.acme'
-version '1.0.0-SNAPSHOT'
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
 
 compileJava {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
As of Gradle 8.12 space assignments have been deprecated, it will be removed with Gradle 10.0.

See:
* https://github.com/gradle/gradle/issues/31413
* https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

This will fix the space assignment deprecation warnings
```
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('group = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.13/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
at build_2tm6oly7c0zfwpdy5fegfl6bl.run([...]/code-with-quarkus/build.gradle:19)
(Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '[...]/code-with-quarkus/build.gradle': line 20
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('version = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.13/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
at build_2tm6oly7c0zfwpdy5fegfl6bl.run([...]/code-with-quarkus/build.gradle:20)
```
of https://github.com/quarkusio/quarkus/issues/47923

I tested it successfully on my local machine with `java -jar C:\src\quarkus\devtools\cli\target\quarkus-cli-999-SNAPSHOT-runner.jar create app my-groupId:my-artifactId --extensions=rest --gradle`