### PR TITLE
Version bumps for Vert.x 4.5.16

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <microprofile-jwt.version>2.1</microprofile-jwt.version>
         <microprofile-lra.version>2.0.1</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
-        <smallrye-common.version>2.12.0</smallrye-common.version>
+        <smallrye-common.version>2.12.2</smallrye-common.version>
         <smallrye-config.version>3.13.2</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.19.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.19.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.28.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
@@ -111,7 +111,7 @@
         <wildfly-elytron.version>2.6.4.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.3.Final</jboss-marshalling.version>
         <jboss-threads.version>3.9.1</jboss-threads.version>
-        <vertx.version>4.5.14</vertx.version>
+        <vertx.version>4.5.16</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -656,21 +656,18 @@ This means that context captured through Emitters won't be propagated to the out
 This behaviour can be configured using `quarkus.messaging.connector-context-propagation` configuration property, by listing the context types to propagate.
 For example `quarkus.messaging.connector-context-propagation=CDI` will only propagate the CDI context.
 
-<<internal-channels>> however do propagate the context, as they are part of the same application and the context is not lost.
+=== Context Propagation with Emitters
 
-For example, you might want to propagate the caller context from an incoming HTTP request to the message processing stage.
-For emitters, it is recommended to use the `MutinyEmitter`, as it exposes methods such as `sendAndAwait` that makes sure to wait until a message processing is terminated.
+When using messaging emitters, the context is not propagated by default.
 
-[WARNING]
-====
-The execution context to which the RequestScoped context is bound, in the previous example the REST call, controls the lifecycle of the context.
-This means that when the REST call is completed the RequestScoped context is destroyed.
-Therefore, you need to make sure that your processing or message dispatch is completed before the REST call completes.
+In some scenarios, you might want to propagate the caller context to the message processing stage, using <<internal-channels,internal channels>>.
 
-For more information check the xref:context-propagation.adoc#context-propagation-for-cdi[Context Propagation] guide.
-====
+Quarkus provides `ContextualEmitter`, a drop in replacement for `MutinyEmitter` and `Emitter`, that allows you to propagate the context when sending messages.
+You can use the context propagation annotation `@CurrentThreadContext` to configure the contexts that will be propagated from an _emitter_ method.
+The annotation configures the contexts that will be captured and propagated from that method,
+and needs to be present on the propagator method, i.e. the caller of the emitter, not the processing method.
 
-For example, let `RequestScopedBean` a request-scoped bean, `MutinyEmitter` can be used to dispatch messages locally through the internal channel `app`:
+Let `RequestScopedBean` a request-scoped bean, `ContextualEmitter` can be used to dispatch messages locally through the internal channel `app`:
 
 [source, java]
 ----
@@ -681,19 +678,15 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import io.smallrye.reactive.messaging.MutinyEmitter;
 
 import io.quarkus.logging.Log;
-
-import io.smallrye.mutiny.Uni;
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter;
 
 @Path("/")
 public class Resource {
 
     @Channel("app")
-    MutinyEmitter<String> emitter;
+    ContextualEmitter<String> emitter;
 
     @Inject
     RequestScopedBean requestScopedBean;
@@ -736,16 +729,7 @@ public class Processor {
 }
 ----
 
-[TIP]
-====
-You can use the context propagation annotation `@CurrentThreadContext` to configure the contexts that will be propagated from an _emitter_ method.
-The annotation configures the contexts that will be captured and propagated from that method,
-and needs to be present on the propagator method, i.e. the caller of the emitter, not the processing method.
-
-Because Quarkus Messaging dispatches messages on link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/message-context[message context],
-propagation plans with cleared or not propagated contexts can lead to race conditions using emitters in <<internal-channels,internal channels>>.
-It is recommended to use `ContextualEmitter` to ensure the context propagation plan is applied correctly.
-
+You can also use the `@CurrentThreadContext` annotation to control which contexts are propagated.
 The following example shows how to avoid propagating any context to the message processing stage:
 
 [source, java]
@@ -785,7 +769,15 @@ public class Resource {
 }
 ----
 
+[WARNING]
 ====
+The execution context to which the RequestScoped context is bound, in the previous example the REST call, controls the lifecycle of the context.
+This means that when the REST call is completed the RequestScoped context is destroyed.
+Therefore, you need to make sure that your processing or message dispatch is completed before the REST call completes.
+
+For more information check the xref:context-propagation.adoc#context-propagation-for-cdi[Context Propagation] guide.
+====
+
 
 === Request Context Activation
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
@@ -170,6 +170,11 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    public Future<Void> writeHead() {
+        return delegate.writeHead();
+    }
+
+    @Override
 
     public Future<Void> write(String chunk, String enc) {
         return delegate.write(chunk, enc);

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,7 +57,7 @@
 
         <mutiny.version>2.9.1</mutiny.version>
         <smallrye-common.version>2.12.0</smallrye-common.version>
-        <vertx.version>4.5.14</vertx.version>
+        <vertx.version>4.5.16</vertx.version>
         <rest-assured.version>5.5.5</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.19.1</jackson-bom.version>
@@ -66,7 +66,7 @@
         <yasson.version>3.0.4</yasson.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <smallrye-mutiny-vertx-core.version>3.19.0</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.19.1</smallrye-mutiny-vertx-core.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <mockito.version>5.18.0</mockito.version>
         <wiremock.version>3.13.1</wiremock.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.14</vertx.version>
+        <vertx.version>4.5.16</vertx.version>
     </properties>
 
     <dependencies>

--- a/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationTest.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationTest.java
@@ -22,6 +22,7 @@ import io.quarkus.test.kafka.KafkaCompanionResource;
 public class KafkaContextPropagationTest {
 
     @Nested
+    // FlowerResource
     class ContextNotPropagated {
         @Test
         void testNonBlocking() {
@@ -131,6 +132,7 @@ public class KafkaContextPropagationTest {
     }
 
     @Nested
+    // FlowerContextualResource
     class ContextPropagated {
         @Test
         void testNonBlocking() {
@@ -192,63 +194,112 @@ public class KafkaContextPropagationTest {
     }
 
     @Nested
-    class MutinyContextPropagated {
+    // FlowerMutinyResource
+    class MutinyContextNotPropagated {
         @Test
         void testNonBlocking() {
-            given().body("rose").post("/flowers/mutiny").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
 
         @Test
         void testNonBlockingUni() {
-            given().body("rose").post("/flowers/mutiny/uni").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny/uni").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny/uni").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny/uni").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny/uni").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny/uni").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
 
         @Test
         void testBlocking() {
-            given().body("rose").post("/flowers/mutiny/blocking").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny/blocking").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny/blocking").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
 
         @Test
         void testBlockingUni() {
-            given().body("rose").post("/flowers/mutiny/uni/blocking").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny/uni/blocking").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny/uni/blocking").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny/uni/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny/uni/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny/uni/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
 
         @Test
         void testBlockingNamed() {
-            given().body("rose").post("/flowers/mutiny/blocking-named").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny/blocking-named").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny/blocking-named").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
 
         @Test
         void testBlockingNamedUni() {
-            given().body("rose").post("/flowers/mutiny/uni/blocking-named").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny/uni/blocking-named").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny/uni/blocking-named").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny/uni/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny/uni/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny/uni/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
 
         @Test
         @EnabledForJreRange(min = JRE.JAVA_21)
         void testVirtualThread() {
-            given().body("rose").post("/flowers/mutiny/virtual-thread").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny/virtual-thread").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny/virtual-thread").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
 
         @Test
         @EnabledForJreRange(min = JRE.JAVA_21)
         void testVirtualThreadUni() {
-            given().body("rose").post("/flowers/mutiny/uni/virtual-thread").then().statusCode(204);
-            given().body("peony").post("/flowers/mutiny/uni/virtual-thread").then().statusCode(204);
-            given().body("daisy").post("/flowers/mutiny/uni/virtual-thread").then().statusCode(204);
+            given().body("rose").post("/flowers/mutiny/uni/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/mutiny/uni/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/mutiny/uni/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
         }
     }
 


### PR DESCRIPTION
This is a coordinated version bumps across:

- Mutiny Vert.x bindings 3.19.1
- Vert.x 4.5.16

This also fixes a breaking change in HttpServerResponse impacting AbstractResponseWrapper.

Fix https://github.com/quarkusio/quarkus/security/advisories/GHSA-9623-mj7j-p9v4.