### PR TITLE
Dev UI themed code block

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -506,13 +506,63 @@ https://github.com/qomponent[Qomponent]: A few custom build compoments that can 
 
 Currently the following UI component are available:
 
-- qui-dot - Render dot files
-- qui-code-block - Render code
-- qui-directory-tree - Render a directory tree (like in the workspace)
-- qui-alert - Show an alert
-- qui-card - Card component
-- qui-switch - Switch button
-- qui-badge - Badge component
+- qui-dot - Render dot files.
+- qui-code-block - Render code. (See below *Code block* section)
+- qui-directory-tree - Render a directory tree (like in the workspace).
+- qui-alert - Show an alert.
+- qui-card - Card component.
+- qui-switch - Switch button.
+- qui-badge - Badge component.
+
+====== Code block
+
+Creates a code block (containing marked up code). This could also be made editable. 
+This component use the above mentioned code block from qomponent, that is build with https://codemirror.net/[code-mirror], but adds the automatic theme state when switching themes.
+
+Code can be provided remotely (`src`) or as a property (`content`) or as a slotted value (example below).
+
+[source,javascript]
+----
+import 'qui-themed-code-block';
+----
+
+[source,html]
+----
+<qui-themed-code-block mode="properties">
+      <slot>
+foo = bar
+      </slot>
+</qui-themed-code-block>
+----
+
+Currently the following modes are supported:
+
+- xml
+- javascript
+- php
+- cpp
+- go
+- rust
+- python
+- json
+- java
+- sql
+- yaml
+- html
+- css
+- sass
+- less
+- markdown
+- asciidoc
+- properties
+- asciiArmor
+- powerShell
+- shell
+- protobuf
+- dockerFile
+- diff
+
+See the https://github.com/qomponent/qui-code-block[@qomponent/qui-code-block] for more details.
 
 ====== IDE link
 

--- a/extensions/agroal/deployment/src/main/resources/dev-ui/qwc-agroal-datasource.js
+++ b/extensions/agroal/deployment/src/main/resources/dev-ui/qwc-agroal-datasource.js
@@ -10,7 +10,7 @@ import '@vaadin/grid';
 import '@vaadin/tabs';
 import '@vaadin/tabsheet';
 import { columnBodyRenderer, columnHeaderRenderer } from '@vaadin/grid/lit.js';
-import '@qomponent/qui-code-block';
+import 'qui-themed-code-block';
 import { notifier } from 'notifier';
 import '@vaadin/progress-bar';
 import '@vaadin/button';
@@ -405,7 +405,7 @@ export class QwcAgroalDatasource extends observeState(QwcHotReloadElement) {
     }
     
     _renderImportSqlDialogContents(){
-        return html`<qui-code-block content="${this._insertSQL}" mode="sql" theme="dark"></qui-code-block>`;
+        return html`<qui-themed-code-block content="${this._insertSQL}" mode="sql"></qui-themed-code-block>`;
     }
     
     _renderDotViewerDialogContents(){
@@ -598,9 +598,9 @@ export class QwcAgroalDatasource extends observeState(QwcHotReloadElement) {
         if (this._allowSql) {
             return html`
                 <div class="sqlInput">
-                    <qui-code-block @shiftEnter=${this._shiftEnterPressed} content="${this._currentSQL}"
-                                    class="font-large cursor-text" id="sql" mode="sql" theme="dark"
-                                    value='${this._currentSQL}' editable></qui-code-block>
+                    <qui-themed-code-block @shiftEnter=${this._shiftEnterPressed} content="${this._currentSQL}"
+                                    class="font-large cursor-text" id="sql" mode="sql"
+                                    value='${this._currentSQL}' editable></qui-themed-code-block>
                     <vaadin-button class="no-margin" slot="suffix" theme="icon tertiary small" aria-label="Clear">
                         <vaadin-tooltip .hoverDelay=${500} slot="tooltip" text="Clear"></vaadin-tooltip>
                         <vaadin-icon class="small-icon" @click=${this._clearSqlInput}

--- a/extensions/smallrye-graphql/deployment/src/main/resources/dev-ui/qwc-graphql-generate-client.js
+++ b/extensions/smallrye-graphql/deployment/src/main/resources/dev-ui/qwc-graphql-generate-client.js
@@ -4,12 +4,10 @@ import '@vaadin/combo-box';
 import '@vaadin/progress-bar';
 import '@vaadin/button';
 import '@vaadin/icon';
-import '@qomponent/qui-code-block';
-import { themeState } from 'theme-state';
-import { observeState } from 'lit-element-state';
+import 'qui-themed-code-block';
 import { notifier } from 'notifier';
 
-export class QwcGraphqlGenerateClient extends observeState(LitElement) {
+export class QwcGraphqlGenerateClient extends LitElement {
     jsonRpc = new JsonRpc(this);
 
     static styles = css`
@@ -139,12 +137,11 @@ export class QwcGraphqlGenerateClient extends observeState(LitElement) {
                 Copy
             </vaadin-button>
         </div>
-        <qui-code-block
+        <qui-themed-code-block
             mode="${lang.mode}"
             content="${code}"
-            theme="${themeState.theme.name}"
             showLineNumbers>
-        </qui-code-block>
+        </qui-themed-code-block>
       </div>
     `;
     }

--- a/extensions/smallrye-openapi/deployment/src/main/resources/dev-ui/qwc-openapi-generate-client.js
+++ b/extensions/smallrye-openapi/deployment/src/main/resources/dev-ui/qwc-openapi-generate-client.js
@@ -4,12 +4,10 @@ import '@vaadin/combo-box';
 import '@vaadin/progress-bar';
 import '@vaadin/button';
 import '@vaadin/icon';
-import '@qomponent/qui-code-block';
-import { themeState } from 'theme-state';
-import { observeState } from 'lit-element-state';
+import 'qui-themed-code-block';
 import { notifier } from 'notifier';
 
-export class QwcOpenapiGenerateClient extends observeState(LitElement) {
+export class QwcOpenapiGenerateClient extends LitElement {
     jsonRpc = new JsonRpc(this);
 
     static styles = css`
@@ -139,12 +137,11 @@ export class QwcOpenapiGenerateClient extends observeState(LitElement) {
                 Copy
             </vaadin-button>
         </div>
-        <qui-code-block
+        <qui-themed-code-block
             mode="${lang.mode}"
             content="${code}"
-            theme="${themeState.theme.name}"
             showLineNumbers>
-        </qui-code-block>
+        </qui-themed-code-block>
       </div>
     `;
     }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -115,6 +115,7 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("qwc-extension-link", contextRoot + "qwc/qwc-extension-link.js");
         // Quarkus UI
         internalImportMapBuildItem.add("qui-ide-link", contextRoot + "qui/qui-ide-link.js");
+        internalImportMapBuildItem.add("qui-themed-code-block", contextRoot + "qui/qui-themed-code-block.js");
         internalImportMapBuildItem.add("qui-assistant-warning", contextRoot + "qui/qui-assistant-warning.js");
         internalImportMapBuildItem.add("qui-assistant-button", contextRoot + "qui/qui-assistant-button.js");
 

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qui/qui-themed-code-block.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qui/qui-themed-code-block.js
@@ -1,0 +1,61 @@
+import { LitElement, html, css } from 'lit';
+import '@qomponent/qui-code-block';
+import { observeState } from 'lit-element-state';
+import { themeState } from 'theme-state';
+
+class QuiThemedCodeBlock extends observeState(LitElement) {
+   
+    static properties = {
+        mode: { type: String },
+        content: { type: String },
+        src: { type: String },
+        showLineNumbers: {type: Boolean},
+        editable: {type: Boolean},
+        value: {type: String, reflect: true }
+    };
+
+    constructor() {
+        super();
+        this.mode = null;
+        this.content = '';
+        this.showLineNumbers = false;
+        this.editable = false;
+        this.value = null;
+    }
+    
+    render() {
+        return html`
+            <qui-code-block
+                .mode=${this.mode}
+                .content=${this.content}
+                .src=${this.src}
+                .showLineNumbers=${this.showLineNumbers}
+                .editable=${this.editable}
+                .value=${this.value}
+                theme='${themeState.theme.name}'
+                @value-changed=${(e) => this._onValueChanged(e)}
+                @shiftEnter=${(e) => this._onShiftEnter(e)}>
+                    <slot></slot>
+            </qui-code-block>
+        `;
+    }
+
+    _onValueChanged(e) {
+        // re-dispatch event so parent can listen on <qui-themed-code-block>
+        this.dispatchEvent(new CustomEvent('value-changed', {
+            detail: e.detail,
+            bubbles: true,
+            composed: true
+        }));
+    }
+    
+    _onShiftEnter(e) {
+        this.dispatchEvent(new CustomEvent('shiftEnter', {
+            detail: e.detail,
+            bubbles: true,
+            composed: true
+        }));
+    }
+}
+
+customElements.define('qui-themed-code-block', QuiThemedCodeBlock);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration-editor.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration-editor.js
@@ -3,8 +3,7 @@ import { JsonRpc } from 'jsonrpc';
 import { notifier } from 'notifier';
 import { observeState } from 'lit-element-state';
 import { devuiState } from 'devui-state';
-import { themeState } from 'theme-state';
-import '@qomponent/qui-code-block';
+import 'qui-themed-code-block';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/progress-bar';
@@ -76,13 +75,12 @@ export class QwcConfigurationEditor extends observeState(LitElement) {
 
         return html`
         ${this._renderToolbar()}
-        <qui-code-block id="code"
+        <qui-themed-code-block id="code"
             mode='${this._type}'
             content='${this._value}'
             value='${this._value}'
-            theme='${themeState.theme.name}'
             editable>
-        </qui-code-block>`;
+        </qui-themed-code-block>`;
     }
 
     _renderToolbar(){

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-raw-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-raw-page.js
@@ -1,13 +1,11 @@
 import { LitElement, html, css} from 'lit';
 import { RouterController } from 'router-controller';
-import { observeState } from 'lit-element-state';
-import { themeState } from 'theme-state';
-import '@qomponent/qui-code-block';
+import 'qui-themed-code-block';
 
 /**
  * This component renders build time data in raw json format
  */
-export class QwcDataRawPage extends observeState(LitElement) {
+export class QwcDataRawPage extends LitElement {
     routerController = new RouterController(this);
     
     static styles = css`
@@ -51,12 +49,11 @@ export class QwcDataRawPage extends observeState(LitElement) {
         var json = JSON.stringify(this._buildTimeData, null, '\t');
 
         return html`<div class="codeBlock">
-                        <qui-code-block 
+                        <qui-themed-code-block
                             mode='json'
                             content='${json}'
-                            theme='${themeState.theme.name}'
                             showLineNumbers>
-                        </qui-code-block>
+                        </qui-themed-code-block>
             </div>`;
     }
 

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -1,17 +1,15 @@
 import {css, html, QwcHotReloadElement} from 'qwc-hot-reload-element';
 import {JsonRpc} from 'jsonrpc';
 import {devServices} from 'devui-data';
-import {observeState} from 'lit-element-state';
-import {themeState} from 'theme-state';
 import '@vaadin/icon';
-import '@qomponent/qui-code-block';
+import 'qui-themed-code-block';
 import '@qomponent/qui-card';
 import 'qwc-no-data';
 
 /**
  * This component shows the Dev Services Page
  */
-export class QwcDevServices extends observeState(QwcHotReloadElement) {
+export class QwcDevServices extends QwcHotReloadElement {
     jsonRpc = new JsonRpc("devui-dev-services", false);
 
     static styles = css`
@@ -125,11 +123,10 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
             let properties = ''.concat(...list);
             return html`<span class="configHeader">Config:</span>
                         <div class="config">
-                            <qui-code-block 
+                            <qui-themed-code-block 
                                 mode='properties'
-                                theme='${themeState.theme.name}'    
                                 content='${properties.trim()}'>
-                            </qui-code-block>
+                            </qui-themed-code-block>
                         </div>`;
         }
     }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
@@ -1,16 +1,14 @@
 import { LitElement, html, css} from 'lit';
 import { RouterController } from 'router-controller';
 import { JsonRpc } from 'jsonrpc';
-import { observeState } from 'lit-element-state';
-import { themeState } from 'theme-state';
 import '@vaadin/icon';
-import '@qomponent/qui-code-block';
+import 'qui-themed-code-block';
 import '@vaadin/progress-bar';
 
 /**
  * This component loads an external page
  */
-export class QwcExternalPage extends observeState(LitElement) {
+export class QwcExternalPage extends LitElement {
     routerController = new RouterController(this);
     
     static styles = css`
@@ -113,11 +111,10 @@ export class QwcExternalPage extends observeState(LitElement) {
                                 <vaadin-icon class="icon" icon="font-awesome-solid:download"></vaadin-icon>
                                 Download
                             </span>
-                            <qui-code-block 
+                            <qui-themed-code-block 
                                 mode='${this._mode}'
-                                src='${this._externalUrl}'
-                                theme='${themeState.theme.name}'>
-                            </qui-code-block>
+                                src='${this._externalUrl}'>
+                            </qui-themed-code-block>
                         </div>
                         `;
             }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
@@ -5,7 +5,7 @@ import '@vaadin/button';
 import '@vaadin/split-layout';
 import '@vaadin/menu-bar';
 import '@vaadin/tooltip';
-import '@qomponent/qui-code-block';
+import 'qui-themed-code-block';
 import '@qomponent/qui-directory-tree';
 import '@qomponent/qui-badge';
 import '@vaadin/dialog';
@@ -15,7 +15,6 @@ import MarkdownIt from 'markdown-it';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { dialogHeaderRenderer, dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { observeState } from 'lit-element-state';
-import { themeState } from 'theme-state';
 import { notifier } from 'notifier';
 import './qwc-workspace-binary.js';
 import 'qui-ide-link';
@@ -332,12 +331,11 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
             // Maybe return name|content ?
             return html`<div class="actionResult">
                             ${this._renderAssistantWarning()}    
-                            <qui-code-block id="code" class='codeBlock'
+                            <qui-themed-code-block id="code" class='codeBlock'
                                 mode='${this._getMode(this._actionResult?.name ?? this._actionResult?.path)}' 
-                                theme='${themeState.theme.name}'
                                 .content='${this._actionResult.content}'
                                 showLineNumbers>
-                            </qui-code-block>
+                            </qui-themed-code-block>
                         </div>`;
         }else if(this._actionResult && this._actionResult.content && this._actionResult.displayType === "markdown"){
             const htmlContent = this.md.render(this._actionResult.content);
@@ -396,14 +394,13 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     }
     
     _renderTextContent(){
-        return html`<qui-code-block id="code" class='codeBlock' @keydown="${this._onKeyDown}"
+        return html`<qui-themed-code-block id="code" class='codeBlock' @keydown="${this._onKeyDown}"
                         mode='${this._getMode(this._selectedWorkspaceItem.name)}'
-                        theme='${themeState.theme.name}'
                         .content='${this._selectedWorkspaceItem.content}'
                         value='${this._selectedWorkspaceItem.content}'
                         showLineNumbers
                         editable>
-                    </qui-code-block>
+                    </qui-themed-code-block>
                     ${this._renderAssistantWarningInline()}`;
     }
 


### PR DESCRIPTION
While doing the Dev UI documentation, I realized we can make the usage of code-blocks less cumbersome by wrapping the qomponent code-block and add the Quarkus theme state there. That means extension developers using the code block don't have to get into the theme state.

