### PR TITLE
Warn if Runtime configuration is used in BuildSteps and without a RuntimeValue in Recorders

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoaderConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoaderConfig.java
@@ -1,0 +1,20 @@
+package io.quarkus.deployment;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.extension-loader")
+@ConfigRoot
+public interface ExtensionLoaderConfig {
+    /**
+     * Report runtime Config objects used during deployment time.
+     */
+    @WithDefault("warn")
+    ReportRuntimeConfigAtDeployment reportRuntimeConfigAtDeployment();
+
+    enum ReportRuntimeConfigAtDeployment {
+        warn,
+        fail
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/RunTimeConfigurationProxyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/RunTimeConfigurationProxyBuildItem.java
@@ -7,6 +7,7 @@ import io.quarkus.builder.item.SimpleBuildItem;
 /**
  * A build item that carries all the "fake" run time config objects for use by recorders.
  */
+@Deprecated(forRemoval = true, since = "3.25")
 public final class RunTimeConfigurationProxyBuildItem extends SimpleBuildItem {
     private final Map<Class<?>, Object> objects;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -191,9 +191,9 @@ public class ConfigMappingUtils {
         }
     }
 
+    @Deprecated(forRemoval = true, since = "3.25")
     public static Object newInstance(Class<?> configClass) {
         if (configClass.isAnnotationPresent(ConfigMapping.class)) {
-            // TODO - radcortez - mapping classes cannot be initialized like this.
             return ReflectUtil.newInstance(ConfigMappingLoader.ensureLoaded(configClass).implementation());
         } else {
             return ReflectUtil.newInstance(configClass);

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -240,8 +240,6 @@ public final class LoggingResourceProcessor {
     LoggingSetupBuildItem setupLoggingRuntimeInit(
             final RecorderContext context,
             final LoggingSetupRecorder recorder,
-            final LogRuntimeConfig logRuntimeConfig,
-            final LogBuildTimeConfig logBuildTimeConfig,
             final CombinedIndexBuildItem combinedIndexBuildItem,
             final LogCategoryMinLevelDefaultsBuildItem categoryMinLevelDefaults,
             final Optional<StreamingLogHandlerBuildItem> streamingLogStreamHandlerBuildItem,
@@ -308,7 +306,7 @@ public final class LoggingResourceProcessor {
             }
 
             shutdownListenerBuildItemBuildProducer.produce(new ShutdownListenerBuildItem(
-                    recorder.initializeLogging(logRuntimeConfig, logBuildTimeConfig, discoveredLogComponents,
+                    recorder.initializeLogging(discoveredLogComponents,
                             categoryMinLevelDefaults.content, alwaysEnableLogStream,
                             streamingDevUiLogHandler, handlers, namedHandlers,
                             possibleConsoleFormatters, possibleFileFormatters, possibleSyslogFormatters,
@@ -326,6 +324,7 @@ public final class LoggingResourceProcessor {
             }
 
             SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+            LogBuildTimeConfig logBuildTimeConfig = config.getConfigMapping(LogBuildTimeConfig.class);
             LogRuntimeConfig logRuntimeConfigInBuild = config.getConfigMapping(LogRuntimeConfig.class);
             ConsoleRuntimeConfig consoleRuntimeConfig = config.getConfigMapping(ConsoleRuntimeConfig.class);
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/BannerRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/BannerRecorder.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class BannerRecorder {
-    final RuntimeValue<BannerRuntimeConfig> bannerRuntimeConfig;
+    private final RuntimeValue<BannerRuntimeConfig> bannerRuntimeConfig;
 
     public BannerRecorder(RuntimeValue<BannerRuntimeConfig> bannerRuntimeConfig) {
         this.bannerRuntimeConfig = bannerRuntimeConfig;

--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -24,20 +24,19 @@ import io.smallrye.common.cpu.ProcessorInfo;
  */
 @Recorder
 public class ExecutorRecorder {
-
     private static final Logger log = Logger.getLogger("io.quarkus.thread-pool");
 
     private static volatile Executor current;
 
-    final ThreadPoolConfig threadPoolConfig;
+    private final RuntimeValue<ThreadPoolConfig> threadPoolConfig;
 
-    public ExecutorRecorder(ThreadPoolConfig threadPoolConfig) {
+    public ExecutorRecorder(RuntimeValue<ThreadPoolConfig> threadPoolConfig) {
         this.threadPoolConfig = threadPoolConfig;
     }
 
     public ScheduledExecutorService setupRunTime(ShutdownContext shutdownContext,
             LaunchMode launchMode, ThreadFactory threadFactory, ContextHandler<Object> contextHandler) {
-        final EnhancedQueueExecutor underlying = createExecutor(threadPoolConfig, threadFactory, contextHandler);
+        final EnhancedQueueExecutor underlying = createExecutor(threadPoolConfig.getValue(), threadFactory, contextHandler);
         if (launchMode == LaunchMode.DEVELOPMENT) {
             shutdownContext.addLastShutdownTask(new Runnable() {
                 @Override
@@ -52,10 +51,10 @@ public class ExecutorRecorder {
                 }
             });
         } else {
-            Runnable shutdownTask = createShutdownTask(threadPoolConfig, underlying);
+            Runnable shutdownTask = createShutdownTask(threadPoolConfig.getValue(), underlying);
             shutdownContext.addLastShutdownTask(shutdownTask);
         }
-        if (threadPoolConfig.prefill()) {
+        if (threadPoolConfig.getValue().prefill()) {
             underlying.prestartAllCoreThreads();
         }
         ScheduledExecutorService managed = underlying;

--- a/core/runtime/src/main/java/io/quarkus/runtime/init/InitializationTaskRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/init/InitializationTaskRecorder.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 
 import io.quarkus.runtime.PreventFurtherStepsException;
 import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 /**
@@ -13,14 +14,14 @@ import io.quarkus.runtime.annotations.Recorder;
  */
 @Recorder
 public class InitializationTaskRecorder {
-    private final InitRuntimeConfig initRuntimeConfig;
+    private final RuntimeValue<InitRuntimeConfig> initRuntimeConfig;
 
-    public InitializationTaskRecorder(InitRuntimeConfig initRuntimeConfig) {
+    public InitializationTaskRecorder(RuntimeValue<InitRuntimeConfig> initRuntimeConfig) {
         this.initRuntimeConfig = initRuntimeConfig;
     }
 
     public void exitIfNeeded() {
-        if (initRuntimeConfig.initAndExit()) {
+        if (initRuntimeConfig.getValue().initAndExit()) {
             preventFurtherRecorderSteps(5, "Error attempting to gracefully shutdown after initialization",
                     () -> new PreventFurtherStepsException("Gracefully exiting after initialization.", 0));
         }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -73,12 +73,18 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 
 @Recorder
 public class LoggingSetupRecorder {
-
     private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggingSetupRecorder.class);
 
-    final RuntimeValue<ConsoleRuntimeConfig> consoleRuntimeConfig;
+    private final LogBuildTimeConfig logBuildTimeConfig;
+    private final RuntimeValue<LogRuntimeConfig> logRuntimeConfig;
+    private final RuntimeValue<ConsoleRuntimeConfig> consoleRuntimeConfig;
 
-    public LoggingSetupRecorder(RuntimeValue<ConsoleRuntimeConfig> consoleRuntimeConfig) {
+    public LoggingSetupRecorder(
+            final LogBuildTimeConfig logBuildTimeConfig,
+            final RuntimeValue<LogRuntimeConfig> logRuntimeConfig,
+            final RuntimeValue<ConsoleRuntimeConfig> consoleRuntimeConfig) {
+        this.logBuildTimeConfig = logBuildTimeConfig;
+        this.logRuntimeConfig = logRuntimeConfig;
         this.consoleRuntimeConfig = consoleRuntimeConfig;
     }
 
@@ -114,18 +120,17 @@ public class LoggingSetupRecorder {
                         return "Logging Config";
                     }
                 }).build();
-        LogRuntimeConfig logRuntimeConfig = loggingConfig.getConfigMapping(LogRuntimeConfig.class);
         LogBuildTimeConfig logBuildTimeConfig = loggingConfig.getConfigMapping(LogBuildTimeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = loggingConfig.getConfigMapping(LogRuntimeConfig.class);
         ConsoleRuntimeConfig consoleRuntimeConfig = loggingConfig.getConfigMapping(ConsoleRuntimeConfig.class);
-        new LoggingSetupRecorder(new RuntimeValue<>(consoleRuntimeConfig)).initializeLogging(logRuntimeConfig,
-                logBuildTimeConfig,
-                DiscoveredLogComponents.ofEmpty(), emptyMap(), false, null, emptyList(), emptyList(), emptyList(), emptyList(),
-                emptyList(), emptyList(), banner, LaunchMode.DEVELOPMENT, false);
+        new LoggingSetupRecorder(logBuildTimeConfig, new RuntimeValue<>(logRuntimeConfig),
+                new RuntimeValue<>(consoleRuntimeConfig)).initializeLogging(
+                        DiscoveredLogComponents.ofEmpty(), emptyMap(), false, null, emptyList(), emptyList(), emptyList(),
+                        emptyList(),
+                        emptyList(), emptyList(), banner, LaunchMode.DEVELOPMENT, false);
     }
 
     public ShutdownListener initializeLogging(
-            final LogRuntimeConfig config,
-            final LogBuildTimeConfig buildConfig,
             final DiscoveredLogComponents discoveredLogComponents,
             final Map<String, InheritableLevel> categoryDefaultMinLevels,
             final boolean enableWebStream,
@@ -139,6 +144,9 @@ public class LoggingSetupRecorder {
             final RuntimeValue<Optional<Supplier<String>>> possibleBannerSupplier,
             final LaunchMode launchMode,
             final boolean includeFilters) {
+
+        LogBuildTimeConfig buildConfig = logBuildTimeConfig;
+        LogRuntimeConfig config = logRuntimeConfig.getValue();
 
         ShutdownNotifier shutdownNotifier = new ShutdownNotifier();
         Map<String, CategoryConfig> categories = config.categories();

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -46,7 +46,6 @@ import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -253,7 +252,6 @@ class AgroalProcessor {
     @BuildStep
     @Consume(NarayanaInitBuildItem.class)
     void generateDataSourceBeans(AgroalRecorder recorder,
-            DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
             List<AggregatedDataSourceBuildTimeConfigBuildItem> aggregatedBuildTimeConfigBuildItems,
             SslNativeConfigBuildItem sslNativeConfig,
             Capabilities capabilities,
@@ -280,10 +278,7 @@ class AgroalProcessor {
                     .addInjectionPoint(ClassType.create(DotName.createSimple(DataSources.class)))
                     .startup()
                     .checkActive(recorder.agroalDataSourceCheckActiveSupplier(dataSourceName))
-                    // pass the runtime config into the recorder to ensure that the DataSource related beans
-                    // are created after runtime configuration has been set up
-                    .createWith(recorder.agroalDataSourceSupplier(
-                            dataSourceName, dataSourcesRuntimeConfig, isOtelSdkEnabled(openTelemetrySdkBuildItem)))
+                    .createWith(recorder.agroalDataSourceSupplier(dataSourceName, isOtelSdkEnabled(openTelemetrySdkBuildItem)))
                     .destroyer(BeanDestroyer.AutoCloseableDestroyer.class);
 
             if (!DataSourceUtil.isDefault(dataSourceName)) {

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalRecorder.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalRecorder.java
@@ -55,7 +55,6 @@ public class AgroalRecorder {
 
     public Function<SyntheticCreationalContext<AgroalDataSource>, AgroalDataSource> agroalDataSourceSupplier(
             String dataSourceName,
-            @SuppressWarnings("unused") DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
             Optional<RuntimeValue<Boolean>> otelEnabled) {
         return new Function<>() {
             @SuppressWarnings("deprecation")

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -14,7 +14,6 @@ import io.quarkus.amazon.lambda.deployment.ProvidedAmazonLambdaHandlerBuildItem;
 import io.quarkus.amazon.lambda.http.AwsHttpContextProducers;
 import io.quarkus.amazon.lambda.http.DefaultLambdaIdentityProvider;
 import io.quarkus.amazon.lambda.http.LambdaHttpAuthenticationMechanism;
-import io.quarkus.amazon.lambda.http.LambdaHttpConfig;
 import io.quarkus.amazon.lambda.http.LambdaHttpHandler;
 import io.quarkus.amazon.lambda.http.LambdaHttpRecorder;
 import io.quarkus.amazon.lambda.http.model.Headers;
@@ -61,8 +60,9 @@ public class AmazonLambdaHttpProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void setupConfig(LambdaHttpConfig config, LambdaHttpRecorder recorder) {
-        recorder.setConfig(config);
+    public void setupConfig(LambdaHttpRecorder recorder) {
+        // force config to be set as static var in the recorder - TODO - rewrite this, it shouldn't use static vars
+        recorder.setConfig();
     }
 
     @BuildStep

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
@@ -2,16 +2,30 @@ package io.quarkus.amazon.lambda.http;
 
 import java.util.regex.Pattern;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class LambdaHttpRecorder {
+    /**
+     * @deprecated Properly use the config object
+     */
+    @Deprecated
     static LambdaHttpConfig config;
+    /**
+     * @deprecated Properly use the config object
+     */
+    @Deprecated
     static Pattern groupPattern;
 
-    public void setConfig(LambdaHttpConfig c) {
-        config = c;
-        String pattern = c.cognitoClaimMatcher();
-        groupPattern = Pattern.compile(pattern);
+    private final RuntimeValue<LambdaHttpConfig> runtimeConfig;
+
+    public LambdaHttpRecorder(final RuntimeValue<LambdaHttpConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void setConfig() {
+        config = runtimeConfig.getValue();
+        groupPattern = Pattern.compile(runtimeConfig.getValue().cognitoClaimMatcher());
     }
 }

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -9,7 +9,6 @@ import io.quarkus.amazon.lambda.deployment.ProvidedAmazonLambdaHandlerBuildItem;
 import io.quarkus.amazon.lambda.http.AwsHttpContextProducers;
 import io.quarkus.amazon.lambda.http.DefaultLambdaIdentityProvider;
 import io.quarkus.amazon.lambda.http.LambdaHttpAuthenticationMechanism;
-import io.quarkus.amazon.lambda.http.LambdaHttpConfig;
 import io.quarkus.amazon.lambda.http.LambdaHttpHandler;
 import io.quarkus.amazon.lambda.http.LambdaHttpRecorder;
 import io.quarkus.amazon.lambda.http.model.AlbContext;
@@ -61,8 +60,9 @@ public class AmazonLambdaHttpProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void setupConfig(LambdaHttpConfig config, LambdaHttpRecorder recorder) {
-        recorder.setConfig(config);
+    public void setupConfig(LambdaHttpRecorder recorder) {
+        // force config to be set as static var in the recorder - TODO - rewrite this, it shouldn't use static vars
+        recorder.setConfig();
     }
 
     @BuildStep

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
@@ -2,16 +2,30 @@ package io.quarkus.amazon.lambda.http;
 
 import java.util.regex.Pattern;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class LambdaHttpRecorder {
+    /**
+     * @deprecated Properly use the config object
+     */
+    @Deprecated
     static LambdaHttpConfig config;
+    /**
+     * @deprecated Properly use the config object
+     */
+    @Deprecated
     static Pattern groupPattern;
 
-    public void setConfig(LambdaHttpConfig c) {
-        config = c;
-        String pattern = c.cognitoClaimMatcher();
-        groupPattern = Pattern.compile(pattern);
+    private final RuntimeValue<LambdaHttpConfig> runtimeConfig;
+
+    public LambdaHttpRecorder(final RuntimeValue<LambdaHttpConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void setConfig() {
+        config = runtimeConfig.getValue();
+        groupPattern = Pattern.compile(runtimeConfig.getValue().cognitoClaimMatcher());
     }
 }

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.jboss.logging.Logger;
-
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
@@ -21,6 +19,7 @@ import io.quarkus.amazon.lambda.runtime.handlers.CollectionInputReader;
 import io.quarkus.amazon.lambda.runtime.handlers.S3EventInputReader;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -30,9 +29,6 @@ import io.quarkus.runtime.annotations.Recorder;
  */
 @Recorder
 public class AmazonLambdaRecorder {
-
-    private static final Logger log = Logger.getLogger(AmazonLambdaRecorder.class);
-
     private static Class<? extends RequestHandler<?, ?>> handlerClass;
     static Class<? extends RequestStreamHandler> streamHandlerClass;
     private static BeanContainer beanContainer;
@@ -40,10 +36,10 @@ public class AmazonLambdaRecorder {
     private static LambdaOutputWriter objectWriter;
     protected static Set<Class<?>> expectedExceptionClasses;
 
-    private final LambdaConfig config;
+    private final RuntimeValue<LambdaConfig> runtimeConfig;
 
-    public AmazonLambdaRecorder(LambdaConfig config) {
-        this.config = config;
+    public AmazonLambdaRecorder(RuntimeValue<LambdaConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
     }
 
     public void setStreamHandlerClass(Class<? extends RequestStreamHandler> handler) {
@@ -120,12 +116,12 @@ public class AmazonLambdaRecorder {
 
         Class<? extends RequestHandler<?, ?>> handlerClass = null;
         Class<? extends RequestStreamHandler> handlerStreamClass = null;
-        if (config.handler().isPresent()) {
-            handlerClass = namedHandlerClasses.get(config.handler().get());
-            handlerStreamClass = namedStreamHandlerClasses.get(config.handler().get());
+        if (runtimeConfig.getValue().handler().isPresent()) {
+            handlerClass = namedHandlerClasses.get(runtimeConfig.getValue().handler().get());
+            handlerStreamClass = namedStreamHandlerClasses.get(runtimeConfig.getValue().handler().get());
 
             if (handlerClass == null && handlerStreamClass == null) {
-                String errorMessage = "Unable to find handler class with name " + config.handler().get()
+                String errorMessage = "Unable to find handler class with name " + runtimeConfig.getValue().handler().get()
                         + " make sure there is a handler class in the deployment with the correct @Named annotation";
                 throw new RuntimeException(errorMessage);
             }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -19,8 +19,7 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "quarkus.arc")
 public interface ArcConfig {
 
-    public static final Set<String> ALLOWED_REMOVE_UNUSED_BEANS_VALUES = Set.of("all", "true", "none", "false", "fwk",
-            "framework");
+    Set<String> ALLOWED_REMOVE_UNUSED_BEANS_VALUES = Set.of("all", "true", "none", "false", "fwk", "framework");
 
     /**
      * <ul>

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/DataSourcesExcludedFromHealthChecksProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/DataSourcesExcludedFromHealthChecksProcessor.java
@@ -7,8 +7,6 @@ import jakarta.inject.Singleton;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.datasource.runtime.DataSourceRecorder;
 import io.quarkus.datasource.runtime.DataSourceSupport;
-import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -21,12 +19,11 @@ public class DataSourcesExcludedFromHealthChecksProcessor {
     void produceBean(
             Capabilities capabilities,
             DataSourceRecorder recorder,
-            DataSourcesBuildTimeConfig buildTimeConfig, DataSourcesRuntimeConfig runtimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(DataSourceSupport.class)
                 .scope(Singleton.class)
                 .unremovable()
-                .runtimeValue(recorder.createDataSourceSupport(buildTimeConfig, runtimeConfig))
+                .runtimeValue(recorder.createDataSourceSupport())
                 .setRuntimeInit()
                 .done());
     }

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRecorder.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRecorder.java
@@ -12,10 +12,17 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class DataSourceRecorder {
+    private final DataSourcesBuildTimeConfig buildTimeConfig;
+    private final RuntimeValue<DataSourcesRuntimeConfig> runtimeConfig;
 
-    public RuntimeValue<DataSourceSupport> createDataSourceSupport(
-            DataSourcesBuildTimeConfig buildTimeConfig,
-            DataSourcesRuntimeConfig runtimeConfig) {
+    public DataSourceRecorder(
+            final DataSourcesBuildTimeConfig buildTimeConfig,
+            final RuntimeValue<DataSourcesRuntimeConfig> runtimeConfig) {
+        this.buildTimeConfig = buildTimeConfig;
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public RuntimeValue<DataSourceSupport> createDataSourceSupport() {
         Stream.Builder<String> excludedForHealthChecks = Stream.builder();
         for (Map.Entry<String, DataSourceBuildTimeConfig> dataSource : buildTimeConfig.dataSources().entrySet()) {
             if (dataSource.getValue().healthExclude()) {
@@ -25,7 +32,7 @@ public class DataSourceRecorder {
         Set<String> excludedNames = excludedForHealthChecks.build().collect(toUnmodifiableSet());
 
         Stream.Builder<String> inactive = Stream.builder();
-        for (Map.Entry<String, DataSourceRuntimeConfig> entry : runtimeConfig.dataSources().entrySet()) {
+        for (Map.Entry<String, DataSourceRuntimeConfig> entry : runtimeConfig.getValue().dataSources().entrySet()) {
             Optional<Boolean> active = entry.getValue().active();
             if (active.isPresent() && !active.get()) {
                 inactive.add(entry.getKey());

--- a/extensions/elytron-security-jdbc/deployment/src/main/java/io/quarkus/elytron/security/jdbc/deployment/ElytronSecurityJdbcProcessor.java
+++ b/extensions/elytron-security-jdbc/deployment/src/main/java/io/quarkus/elytron/security/jdbc/deployment/ElytronSecurityJdbcProcessor.java
@@ -17,7 +17,6 @@ import io.quarkus.elytron.security.deployment.ElytronPasswordMarkerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityRealmBuildItem;
 import io.quarkus.elytron.security.jdbc.JdbcRecorder;
 import io.quarkus.elytron.security.jdbc.JdbcSecurityRealmBuildTimeConfig;
-import io.quarkus.elytron.security.jdbc.JdbcSecurityRealmRuntimeConfig;
 import io.quarkus.runtime.RuntimeValue;
 
 class ElytronSecurityJdbcProcessor {
@@ -44,15 +43,14 @@ class ElytronSecurityJdbcProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void configureJdbcRealmAuthConfig(JdbcRecorder recorder,
             JdbcSecurityRealmBuildTimeConfig jdbcSecurityRealmBuildTimeConfig,
-            JdbcSecurityRealmRuntimeConfig jdbcSecurityRealmRuntimeConfig,
             BuildProducer<SecurityRealmBuildItem> securityRealm,
             BeanContainerBuildItem beanContainerBuildItem, //we need this to make sure ArC is initialized
-            List<JdbcDataSourceBuildItem> dataSourcesConfigured) throws Exception {
+            List<JdbcDataSourceBuildItem> dataSourcesConfigured) {
         if (!jdbcSecurityRealmBuildTimeConfig.enabled()) {
             return;
         }
 
-        RuntimeValue<SecurityRealm> realm = recorder.createRealm(jdbcSecurityRealmRuntimeConfig);
+        RuntimeValue<SecurityRealm> realm = recorder.createRealm();
         securityRealm.produce(new SecurityRealmBuildItem(realm, jdbcSecurityRealmBuildTimeConfig.realmName(), null));
     }
 

--- a/extensions/elytron-security-jdbc/runtime/src/main/java/io/quarkus/elytron/security/jdbc/JdbcRecorder.java
+++ b/extensions/elytron-security-jdbc/runtime/src/main/java/io/quarkus/elytron/security/jdbc/JdbcRecorder.java
@@ -18,16 +18,20 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class JdbcRecorder {
-
     private static final Provider[] PROVIDERS = new Provider[] { new WildFlyElytronPasswordProvider() };
+
+    private final RuntimeValue<JdbcSecurityRealmRuntimeConfig> runtimeConfig;
+
+    public JdbcRecorder(final RuntimeValue<JdbcSecurityRealmRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     /**
      * Create a runtime value for a {@linkplain JdbcSecurityRealm}
      *
-     * @param config - the realm config
      * @return - runtime value wrapper for the SecurityRealm
      */
-    public RuntimeValue<SecurityRealm> createRealm(JdbcSecurityRealmRuntimeConfig config) {
+    public RuntimeValue<SecurityRealm> createRealm() {
         Supplier<Provider[]> providers = new Supplier<Provider[]>() {
             @Override
             public Provider[] get() {
@@ -35,7 +39,7 @@ public class JdbcRecorder {
             }
         };
         JdbcSecurityRealmBuilder builder = JdbcSecurityRealm.builder().setProviders(providers);
-        PrincipalQueriesConfig principalQueries = config.principalQueries();
+        PrincipalQueriesConfig principalQueries = runtimeConfig.getValue().principalQueries();
         registerPrincipalQuery(principalQueries.defaultPrincipalQuery(), builder);
         principalQueries.namedPrincipalQueries()
                 .forEach((name, principalQuery) -> registerPrincipalQuery(principalQuery, builder));

--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
@@ -15,7 +15,6 @@ import io.quarkus.elytron.security.deployment.ElytronPasswordMarkerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityRealmBuildItem;
 import io.quarkus.elytron.security.ldap.LdapRecorder;
 import io.quarkus.elytron.security.ldap.QuarkusDirContextFactory;
-import io.quarkus.elytron.security.ldap.config.LdapSecurityRealmRuntimeConfig;
 import io.quarkus.elytron.security.ldap.deployment.config.LdapSecurityRealmBuildTimeConfig;
 import io.quarkus.runtime.RuntimeValue;
 
@@ -40,7 +39,6 @@ class ElytronSecurityLdapProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void configureLdapRealmAuthConfig(LdapRecorder recorder,
             LdapSecurityRealmBuildTimeConfig ldapSecurityRealmBuildTimeConfig,
-            LdapSecurityRealmRuntimeConfig ldapSecurityRealmRuntimeConfig,
             BuildProducer<SecurityRealmBuildItem> securityRealm,
             BeanContainerBuildItem beanContainerBuildItem //we need this to make sure ArC is initialized
     ) throws Exception {
@@ -48,7 +46,7 @@ class ElytronSecurityLdapProcessor {
             return;
         }
 
-        RuntimeValue<SecurityRealm> realm = recorder.createRealm(ldapSecurityRealmRuntimeConfig);
+        RuntimeValue<SecurityRealm> realm = recorder.createRealm();
         securityRealm.produce(new SecurityRealmBuildItem(realm, ldapSecurityRealmBuildTimeConfig.realmName(), null));
     }
 

--- a/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/LdapRecorder.java
+++ b/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/LdapRecorder.java
@@ -26,16 +26,22 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class LdapRecorder {
-
     private static final Logger log = LoggerFactory.getLogger(LdapRecorder.class);
+
+    private final RuntimeValue<LdapSecurityRealmRuntimeConfig> runtimeConfig;
+
+    public LdapRecorder(final RuntimeValue<LdapSecurityRealmRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     /**
      * Create a runtime value for a {@linkplain LdapSecurityRealm}
      *
-     * @param runtimeConfig the realm config
      * @return runtime value wrapper for the SecurityRealm
      */
-    public RuntimeValue<SecurityRealm> createRealm(LdapSecurityRealmRuntimeConfig runtimeConfig) {
+    public RuntimeValue<SecurityRealm> createRealm() {
+        LdapSecurityRealmRuntimeConfig runtimeConfig = this.runtimeConfig.getValue();
+
         LdapSecurityRealmBuilder.IdentityMappingBuilder identityMappingBuilder = LdapSecurityRealmBuilder.builder()
                 .setDirContextSupplier(createDirContextSupplier(runtimeConfig.dirContext()))
                 .identityMapping();

--- a/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
+++ b/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
@@ -17,7 +17,6 @@ import io.quarkus.elytron.security.deployment.ElytronTokenMarkerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityRealmBuildItem;
 import io.quarkus.elytron.security.oauth2.runtime.OAuth2BuildTimeConfig;
 import io.quarkus.elytron.security.oauth2.runtime.OAuth2Recorder;
-import io.quarkus.elytron.security.oauth2.runtime.OAuth2RuntimeConfig;
 import io.quarkus.elytron.security.oauth2.runtime.auth.OAuth2AuthMechanism;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
@@ -54,13 +53,12 @@ class OAuth2DeploymentProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     AdditionalBeanBuildItem configureOauth2RealmAuthConfig(OAuth2Recorder recorder,
             OAuth2BuildTimeConfig oauth2BuildTimeConfig,
-            OAuth2RuntimeConfig oauth2RuntimeConfig,
             BuildProducer<SecurityRealmBuildItem> securityRealm) throws Exception {
         if (!oauth2BuildTimeConfig.enabled()) {
             return null;
         }
 
-        RuntimeValue<SecurityRealm> realm = recorder.createRealm(oauth2RuntimeConfig);
+        RuntimeValue<SecurityRealm> realm = recorder.createRealm();
         securityRealm.produce(new SecurityRealmBuildItem(realm, REALM_NAME, null));
         return AdditionalBeanBuildItem.unremovableOf(OAuth2AuthMechanism.class);
     }

--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
@@ -30,9 +30,16 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 
 @Recorder
 public class OAuth2Recorder {
+    private final RuntimeValue<OAuth2RuntimeConfig> runtimeConfig;
 
-    public RuntimeValue<SecurityRealm> createRealm(OAuth2RuntimeConfig runtimeConfig)
+    public OAuth2Recorder(final RuntimeValue<OAuth2RuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public RuntimeValue<SecurityRealm> createRealm()
             throws IOException, NoSuchAlgorithmException, CertificateException, KeyStoreException, KeyManagementException {
+        OAuth2RuntimeConfig runtimeConfig = this.runtimeConfig.getValue();
+
         if (!runtimeConfig.clientId().isPresent() || !runtimeConfig.clientSecret().isPresent()
                 || !runtimeConfig.introspectionUrl().isPresent()) {
             throw new ConfigurationException(

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/properties/runtime/ElytronPropertiesFileRecorder.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/properties/runtime/ElytronPropertiesFileRecorder.java
@@ -44,14 +44,23 @@ public class ElytronPropertiesFileRecorder {
 
     private static final Provider[] PROVIDERS = new Provider[] { new WildFlyElytronPasswordProvider() };
 
+    private final RuntimeValue<MPRealmRuntimeConfig> runtimeConfig;
+    private final SecurityUsersConfig propertiesConfig;
+
+    public ElytronPropertiesFileRecorder(
+            final RuntimeValue<MPRealmRuntimeConfig> runtimeConfig,
+            final SecurityUsersConfig propertiesConfig) {
+        this.runtimeConfig = runtimeConfig;
+        this.propertiesConfig = propertiesConfig;
+    }
+
     /**
      * Load the user.properties and roles.properties files into the {@linkplain SecurityRealm}
      *
      * @param realm - a {@linkplain LegacyPropertiesSecurityRealm}
-     * @param propertiesConfig - properties config with a realm configuration info
      * @throws Exception
      */
-    public Runnable loadRealm(RuntimeValue<SecurityRealm> realm, SecurityUsersConfig propertiesConfig) throws Exception {
+    public Runnable loadRealm(RuntimeValue<SecurityRealm> realm) throws Exception {
         return new Runnable() {
             @Override
             public void run() {
@@ -110,12 +119,10 @@ public class ElytronPropertiesFileRecorder {
      * Load the embedded user and role information into the {@linkplain SecurityRealm}
      *
      * @param realm - a {@linkplain SimpleMapBackedSecurityRealm}
-     * @param propertiesConfig - properties config with the realm config
      * @throws Exception
      */
-    public Runnable loadEmbeddedRealm(RuntimeValue<SecurityRealm> realm, SecurityUsersConfig propertiesConfig,
-            MPRealmRuntimeConfig runtimeConfig)
-            throws Exception {
+    public Runnable loadEmbeddedRealm(RuntimeValue<SecurityRealm> realm) throws Exception {
+        MPRealmRuntimeConfig runtimeConfig = this.runtimeConfig.getValue();
         return new Runnable() {
             @Override
             public void run() {
@@ -174,11 +181,10 @@ public class ElytronPropertiesFileRecorder {
     /**
      * Create a runtime value for a {@linkplain LegacyPropertiesSecurityRealm}
      *
-     * @param propertiesConfig - properties config
      * @return - runtime value wrapper for the SecurityRealm
      * @throws Exception
      */
-    public RuntimeValue<SecurityRealm> createRealm(SecurityUsersConfig propertiesConfig) throws Exception {
+    public RuntimeValue<SecurityRealm> createRealm() throws Exception {
         PropertiesRealmConfig config = propertiesConfig.file();
         log.debugf("createRealm, config=%s", config);
 
@@ -198,11 +204,10 @@ public class ElytronPropertiesFileRecorder {
     /**
      * Create a runtime value for a {@linkplain SimpleMapBackedSecurityRealm}
      *
-     * @param propertiesConfig - properties config with the realm config
      * @return - runtime value wrapper for the SecurityRealm
      * @throws Exception
      */
-    public RuntimeValue<SecurityRealm> createEmbeddedRealm(SecurityUsersConfig propertiesConfig) {
+    public RuntimeValue<SecurityRealm> createEmbeddedRealm() {
         MPRealmConfig config = propertiesConfig.embedded();
         log.debugf("createRealm, config=%s", config);
 

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
@@ -68,7 +68,6 @@ import io.quarkus.flyway.runtime.FlywayContainer;
 import io.quarkus.flyway.runtime.FlywayContainerProducer;
 import io.quarkus.flyway.runtime.FlywayDataSourceBuildTimeConfig;
 import io.quarkus.flyway.runtime.FlywayRecorder;
-import io.quarkus.flyway.runtime.FlywayRuntimeConfig;
 import io.quarkus.runtime.util.ClassPathUtils;
 
 @BuildSteps(onlyIf = FlywayEnabled.class)
@@ -273,7 +272,6 @@ class FlywayProcessor {
     @Consume(BeanContainerBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     public ServiceStartBuildItem startActions(FlywayRecorder recorder,
-            FlywayRuntimeConfig config,
             BuildProducer<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem,
             BuildProducer<InitTaskCompletedBuildItem> initializationCompleteBuildItem,
             List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyLambdaBuildStep.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyLambdaBuildStep.java
@@ -20,9 +20,6 @@ import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.funqy.deployment.FunctionBuildItem;
 import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
 import io.quarkus.funqy.lambda.FunqyLambdaBindingRecorder;
-import io.quarkus.funqy.lambda.config.FunqyAmazonBuildTimeConfig;
-import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
-import io.quarkus.funqy.runtime.FunqyConfig;
 import io.quarkus.runtime.LaunchMode;
 
 public class FunqyLambdaBuildStep {
@@ -39,20 +36,17 @@ public class FunqyLambdaBuildStep {
             BuildProducer<FeatureBuildItem> feature,
             Optional<FunctionInitializedBuildItem> hasFunctions,
             LambdaObjectMapperInitializedBuildItem mapperDependency,
-            BeanContainerBuildItem beanContainer,
-            FunqyAmazonBuildTimeConfig buildTimeConfig) throws Exception {
+            BeanContainerBuildItem beanContainer) {
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;
         feature.produce(new FeatureBuildItem(FUNQY_AMAZON_LAMBDA));
-        recorder.init(beanContainer.getValue(), buildTimeConfig);
+        recorder.init(beanContainer.getValue());
     }
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public RuntimeComplete choose(FunqyConfig config,
-            FunqyAmazonConfig amazonConfig,
-            FunqyLambdaBindingRecorder recorder) {
-        recorder.chooseInvoker(config, amazonConfig);
+    public RuntimeComplete choose(FunqyLambdaBindingRecorder recorder) {
+        recorder.chooseInvoker();
         return new RuntimeComplete();
     }
 

--- a/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/FunqyCloudFunctionsBuildStep.java
+++ b/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/FunqyCloudFunctionsBuildStep.java
@@ -18,7 +18,6 @@ import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.funqy.deployment.FunctionBuildItem;
 import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
 import io.quarkus.funqy.gcp.functions.FunqyCloudFunctionsBindingRecorder;
-import io.quarkus.funqy.runtime.FunqyConfig;
 import io.quarkus.jackson.runtime.ObjectMapperProducer;
 
 public class FunqyCloudFunctionsBuildStep {
@@ -40,7 +39,7 @@ public class FunqyCloudFunctionsBuildStep {
     public void init(List<FunctionBuildItem> functions,
             FunqyCloudFunctionsBindingRecorder recorder,
             Optional<FunctionInitializedBuildItem> hasFunctions,
-            BeanContainerBuildItem beanContainer) throws Exception {
+            BeanContainerBuildItem beanContainer) {
         if (!hasFunctions.isPresent())
             return;
 
@@ -49,8 +48,8 @@ public class FunqyCloudFunctionsBuildStep {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public void choose(FunqyConfig config, FunqyCloudFunctionsBindingRecorder recorder) {
-        recorder.chooseInvoker(config);
+    public void choose(FunqyCloudFunctionsBindingRecorder recorder) {
+        recorder.chooseInvoker();
     }
 
     @BuildStep

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
@@ -17,6 +17,7 @@ import io.quarkus.funqy.runtime.FunctionRecorder;
 import io.quarkus.funqy.runtime.FunqyConfig;
 import io.quarkus.funqy.runtime.FunqyServerResponse;
 import io.quarkus.funqy.runtime.RequestContextImpl;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 /**
@@ -29,6 +30,12 @@ public class FunqyCloudFunctionsBindingRecorder {
     private static ObjectMapper objectMapper;
     private static ObjectReader reader;
     private static ObjectWriter writer;
+
+    private final RuntimeValue<FunqyConfig> config;
+
+    public FunqyCloudFunctionsBindingRecorder(final RuntimeValue<FunqyConfig> config) {
+        this.config = config;
+    }
 
     public void init(BeanContainer bc) {
         beanContainer = bc;
@@ -50,12 +57,13 @@ public class FunqyCloudFunctionsBindingRecorder {
         FunctionConstructor.CONTAINER = bc;
     }
 
-    public void chooseInvoker(FunqyConfig config) {
+    public void chooseInvoker() {
         // this is done at Runtime so that we can change it with an environment variable.
-        if (config.export().isPresent()) {
-            invoker = FunctionRecorder.registry.matchInvoker(config.export().get());
+        if (config.getValue().export().isPresent()) {
+            invoker = FunctionRecorder.registry.matchInvoker(config.getValue().export().get());
             if (invoker == null) {
-                throw new RuntimeException("quarkus.funqy.export does not match a function: " + config.export().get());
+                throw new RuntimeException(
+                        "quarkus.funqy.export does not match a function: " + config.getValue().export().get());
             }
         } else if (FunctionRecorder.registry.invokers().size() == 0) {
             throw new RuntimeException("There are no functions to process lambda");

--- a/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
+++ b/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
@@ -52,7 +52,7 @@ public class FunqyHttpBuildStep {
     public void staticInit(FunqyHttpBindingRecorder binding,
             BeanContainerBuildItem beanContainer, // dependency
             Optional<FunctionInitializedBuildItem> hasFunctions,
-            VertxHttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) {
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;
 
@@ -72,7 +72,7 @@ public class FunqyHttpBuildStep {
             List<FunctionBuildItem> functions,
             BeanContainerBuildItem beanContainer,
             VertxHttpBuildTimeConfig httpConfig,
-            ExecutorBuildItem executorBuildItem) throws Exception {
+            ExecutorBuildItem executorBuildItem) {
 
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;

--- a/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
@@ -20,8 +20,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.funqy.deployment.FunctionBuildItem;
 import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
-import io.quarkus.funqy.runtime.FunqyConfig;
-import io.quarkus.funqy.runtime.bindings.knative.events.FunqyKnativeEventsConfig;
 import io.quarkus.funqy.runtime.bindings.knative.events.KnativeEventsBindingRecorder;
 import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
@@ -66,8 +64,6 @@ public class FunqyKnativeEventsBuildStep {
     @BuildStep
     @Record(RUNTIME_INIT)
     public void boot(ShutdownContextBuildItem shutdown,
-            FunqyConfig funqyConfig,
-            FunqyKnativeEventsConfig eventsConfig,
             KnativeEventsBindingRecorder binding,
             Optional<FunctionInitializedBuildItem> hasFunctions,
             List<FunctionBuildItem> functions,
@@ -76,7 +72,7 @@ public class FunqyKnativeEventsBuildStep {
             CoreVertxBuildItem vertx,
             BeanContainerBuildItem beanContainer,
             VertxHttpBuildTimeConfig httpBuildTimeConfig,
-            ExecutorBuildItem executorBuildItem) throws Exception {
+            ExecutorBuildItem executorBuildItem) {
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;
 
@@ -89,7 +85,7 @@ public class FunqyKnativeEventsBuildStep {
             rootPath += "/";
         }
 
-        Handler<RoutingContext> handler = binding.start(rootPath, funqyConfig, eventsConfig, vertx.getVertx(),
+        Handler<RoutingContext> handler = binding.start(rootPath, vertx.getVertx(),
                 shutdown,
                 beanContainer.getValue(),
                 executorBuildItem.getExecutorProxy());

--- a/extensions/google-cloud-functions/deployment/src/main/java/io/quarkus/gcp/functions/deployment/GoogleCloudFunctionsProcessor.java
+++ b/extensions/google-cloud-functions/deployment/src/main/java/io/quarkus/gcp/functions/deployment/GoogleCloudFunctionsProcessor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.gcp.functions.GoogleCloudFunctionInfo;
 import io.quarkus.gcp.functions.GoogleCloudFunctionRecorder;
-import io.quarkus.gcp.functions.GoogleCloudFunctionsConfig;
 
 public class GoogleCloudFunctionsProcessor {
     private static final String FEATURE_NAME = "google-cloud-functions";
@@ -96,14 +95,12 @@ public class GoogleCloudFunctionsProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void selectDelegate(List<CloudFunctionBuildItem> cloudFunctions,
-            GoogleCloudFunctionsConfig config,
-            GoogleCloudFunctionRecorder recorder) throws BuildException {
+    public void selectDelegate(List<CloudFunctionBuildItem> cloudFunctions, GoogleCloudFunctionRecorder recorder) {
 
         List<GoogleCloudFunctionInfo> functionInfos = cloudFunctions.stream()
                 .map(CloudFunctionBuildItem::build)
                 .collect(Collectors.toList());
 
-        recorder.selectDelegate(config, functionInfos);
+        recorder.selectDelegate(functionInfos);
     }
 }

--- a/extensions/google-cloud-functions/runtime/src/main/java/io/quarkus/gcp/functions/GoogleCloudFunctionRecorder.java
+++ b/extensions/google-cloud-functions/runtime/src/main/java/io/quarkus/gcp/functions/GoogleCloudFunctionRecorder.java
@@ -4,16 +4,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class GoogleCloudFunctionRecorder {
+    private final RuntimeValue<GoogleCloudFunctionsConfig> runtimeConfig;
 
-    public void selectDelegate(GoogleCloudFunctionsConfig config, List<GoogleCloudFunctionInfo> cloudFunctions) {
+    public GoogleCloudFunctionRecorder(final RuntimeValue<GoogleCloudFunctionsConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void selectDelegate(List<GoogleCloudFunctionInfo> cloudFunctions) {
         Map<GoogleCloudFunctionInfo.FunctionType, String> delegates = new HashMap<>();
         // if a function name is defined, check that it exists
-        if (config.function().isPresent()) {
-            String functionName = config.function().get();
+        if (runtimeConfig.getValue().function().isPresent()) {
+            String functionName = runtimeConfig.getValue().function().get();
             boolean found = false;
             for (GoogleCloudFunctionInfo info : cloudFunctions) {
                 if (functionName.equals(info.getBeanName())) {

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -81,7 +81,6 @@ import io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator;
 import io.quarkus.grpc.runtime.GrpcContainer;
 import io.quarkus.grpc.runtime.GrpcServerRecorder;
 import io.quarkus.grpc.runtime.ServerInterceptorStorage;
-import io.quarkus.grpc.runtime.config.GrpcConfiguration;
 import io.quarkus.grpc.runtime.config.GrpcServerBuildTimeConfig;
 import io.quarkus.grpc.runtime.health.GrpcHealthEndpoint;
 import io.quarkus.grpc.runtime.health.GrpcHealthStorage;
@@ -695,7 +694,6 @@ public class GrpcServerProcessor {
     @Record(value = ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     ServiceStartBuildItem initializeServer(GrpcServerRecorder recorder,
-            GrpcConfiguration config,
             GrpcBuildTimeConfig buildTimeConfig,
             ShutdownContextBuildItem shutdown,
             List<BindableServiceBuildItem> bindables,
@@ -736,7 +734,7 @@ public class GrpcServerProcessor {
                             .collect(Collectors.toMap(f -> f.getPriority() * -1, FilterBuildItem::getHandler));
                     // for the moment being, the main router doesn't have QuarkusErrorHandler, but we need to make
                     // sure that exceptions raised during proactive authentication or HTTP authorization are handled
-                    recorder.addMainRouterErrorHandlerIfSameServer(routerRuntimeValue, config);
+                    recorder.addMainRouterErrorHandlerIfSameServer(routerRuntimeValue);
                 }
             } else {
                 routerRuntimeValue = routerBuildItem.getHttpRouter();
@@ -751,7 +749,7 @@ public class GrpcServerProcessor {
                     });
             recorder.initializeGrpcServer(bindableServiceBeanStream.isEmpty(), beanContainerBuildItem.getValue(),
                     vertx.getVertx(), routerRuntimeValue,
-                    config, shutdown, blocking, virtuals, launchModeBuildItem.getLaunchMode(),
+                    shutdown, blocking, virtuals, launchModeBuildItem.getLaunchMode(),
                     capabilities.isPresent(Capability.SECURITY), securityHandlers);
             return new ServiceStartBuildItem(GRPC_SERVER);
         }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -95,12 +95,18 @@ public class GrpcServerRecorder {
 
     private static final Pattern GRPC_CONTENT_TYPE = Pattern.compile("^application/grpc.*");
 
+    private final RuntimeValue<GrpcConfiguration> runtimeConfig;
+
+    public GrpcServerRecorder(final RuntimeValue<GrpcConfiguration> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
     public static List<GrpcServiceDefinition> getServices() {
         return services;
     }
 
-    public void addMainRouterErrorHandlerIfSameServer(RuntimeValue<Router> mainRouter, GrpcConfiguration config) {
-        if (!config.server().useSeparateServer()) {
+    public void addMainRouterErrorHandlerIfSameServer(RuntimeValue<Router> mainRouter) {
+        if (!runtimeConfig.getValue().server().useSeparateServer()) {
             mainRouter.getValue().route().last().failureHandler(new Handler<>() {
 
                 private final Handler<RoutingContext> errorHandler = new QuarkusErrorHandler(LaunchMode.current().isDevOrTest(),
@@ -125,7 +131,6 @@ public class GrpcServerRecorder {
     public void initializeGrpcServer(boolean hasNoBindableServiceBeans, BeanContainer beanContainer,
             RuntimeValue<Vertx> vertxSupplier,
             RuntimeValue<Router> routerSupplier,
-            GrpcConfiguration cfg,
             ShutdownContext shutdown,
             Map<String, List<String>> blockingMethodsPerService,
             Map<String, List<String>> virtualMethodsPerService,
@@ -136,7 +141,7 @@ public class GrpcServerRecorder {
         }
 
         Vertx vertx = vertxSupplier.getValue();
-        GrpcServerConfiguration configuration = cfg.server();
+        GrpcServerConfiguration configuration = runtimeConfig.getValue().server();
         GrpcBuilderProvider<?> provider = GrpcBuilderProvider.findServerBuilderProvider(configuration);
 
         if (configuration.useSeparateServer()) {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
@@ -70,7 +70,6 @@ import io.quarkus.gizmo.ClassTransformer;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRecorder;
-import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.JPAConfig;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.RequestScopedSessionHolder;
@@ -160,7 +159,6 @@ public class HibernateOrmCdiProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateJpaConfigBean(HibernateOrmRecorder recorder,
             Capabilities capabilities,
-            HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
         ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
                 .configure(JPAConfig.class)
@@ -168,7 +166,7 @@ public class HibernateOrmCdiProcessor {
                 .scope(Singleton.class)
                 .unremovable()
                 .setRuntimeInit()
-                .supplier(recorder.jpaConfigSupplier(hibernateOrmRuntimeConfig))
+                .supplier(recorder.jpaConfigSupplier())
                 .destroyer(JPAConfig.Destroyer.class);
 
         // Add a synthetic dependency from JPAConfig to any datasource/pool,

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmDisabledProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmDisabledProcessor.java
@@ -5,19 +5,17 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmDisabledRecorder;
-import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 
 @BuildSteps(onlyIfNot = HibernateOrmEnabled.class)
 class HibernateOrmDisabledProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void disableHibernateOrm(HibernateOrmDisabledRecorder recorder, HibernateOrmRuntimeConfig runtimeConfig) {
+    public void disableHibernateOrm(HibernateOrmDisabledRecorder recorder) {
         // The disabling itself is done through conditions on build steps (see uses of HibernateOrmEnabled.class)
 
         // We still want to check that nobody tries to set quarkus.hibernate-orm.active = true at runtime
         // if Hibernate ORM is disabled, though:
-        recorder.checkNoExplicitActiveTrue(runtimeConfig);
+        recorder.checkNoExplicitActiveTrue();
     }
-
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -219,11 +219,10 @@ public final class HibernateOrmProcessor {
     @Record(RUNTIME_INIT)
     @Consume(ServiceStartBuildItem.class)
     @BuildStep(onlyIf = IsDevelopment.class)
-    void warnOfSchemaProblems(HibernateOrmConfig hibernateOrmBuildTimeConfig,
-            HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig, HibernateOrmRecorder recorder) {
+    void warnOfSchemaProblems(HibernateOrmRecorder recorder, HibernateOrmConfig hibernateOrmBuildTimeConfig) {
         for (var e : hibernateOrmBuildTimeConfig.persistenceUnits().entrySet()) {
             if (e.getValue().validateInDevMode()) {
-                recorder.doValidation(hibernateOrmRuntimeConfig, e.getKey());
+                recorder.doValidation(e.getKey());
             }
         }
     }
@@ -643,8 +642,8 @@ public final class HibernateOrmProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public void build(HibernateOrmRecorder recorder, HibernateOrmConfig hibernateOrmConfig,
-            HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig,
+    public void build(
+            HibernateOrmRecorder recorder,
             BuildProducer<JpaModelPersistenceUnitMappingBuildItem> jpaModelPersistenceUnitMapping,
             List<PersistenceUnitDescriptorBuildItem> descriptors,
             JpaModelBuildItem jpaModel) throws Exception {
@@ -665,12 +664,13 @@ public final class HibernateOrmProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public PersistenceProviderSetUpBuildItem setupPersistenceProvider(HibernateOrmRecorder recorder,
-            Capabilities capabilities, HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig,
+    public PersistenceProviderSetUpBuildItem setupPersistenceProvider(
+            HibernateOrmRecorder recorder,
+            Capabilities capabilities,
             List<HibernateOrmIntegrationRuntimeConfiguredBuildItem> integrationBuildItems,
             BuildProducer<RecorderBeanInitializedBuildItem> orderEnforcer) {
         if (capabilities.isPresent(Capability.AGROAL)) {
-            recorder.setupPersistenceProvider(hibernateOrmRuntimeConfig,
+            recorder.setupPersistenceProvider(
                     HibernateOrmIntegrationRuntimeConfiguredBuildItem.collectDescriptors(integrationBuildItems));
         }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmDisabledRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmDisabledRecorder.java
@@ -2,14 +2,20 @@ package io.quarkus.hibernate.orm.runtime;
 
 import java.util.Set;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 @Recorder
 public class HibernateOrmDisabledRecorder {
+    private final RuntimeValue<HibernateOrmRuntimeConfig> runtimeConfig;
 
-    public void checkNoExplicitActiveTrue(HibernateOrmRuntimeConfig runtimeConfig) {
-        for (var entry : runtimeConfig.persistenceUnits().entrySet()) {
+    public HibernateOrmDisabledRecorder(final RuntimeValue<HibernateOrmRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void checkNoExplicitActiveTrue() {
+        for (var entry : runtimeConfig.getValue().persistenceUnits().entrySet()) {
             var config = entry.getValue();
             if (config.active().isPresent() && config.active().get()) {
                 var puName = entry.getKey();

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -58,7 +58,6 @@ import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
-import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 import io.quarkus.hibernate.orm.runtime.customized.FormatMapperKind;
 import io.quarkus.hibernate.orm.runtime.recording.RecordedConfig;
@@ -225,10 +224,9 @@ public final class HibernateReactiveProcessor {
     @BuildStep
     @Record(RUNTIME_INIT)
     PersistenceProviderSetUpBuildItem setUpPersistenceProviderAndWaitForVertxPool(HibernateReactiveRecorder recorder,
-            HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig,
             List<HibernateOrmIntegrationRuntimeConfiguredBuildItem> integrationBuildItems,
             BuildProducer<RecorderBeanInitializedBuildItem> orderEnforcer) {
-        recorder.initializePersistenceProvider(hibernateOrmRuntimeConfig,
+        recorder.initializePersistenceProvider(
                 HibernateOrmIntegrationRuntimeConfiguredBuildItem.collectDescriptors(integrationBuildItems));
         return new PersistenceProviderSetUpBuildItem();
     }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
@@ -11,10 +11,16 @@ import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.JPAConfig;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationRuntimeDescriptor;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class HibernateReactiveRecorder {
+    private final RuntimeValue<HibernateOrmRuntimeConfig> runtimeConfig;
+
+    public HibernateReactiveRecorder(final RuntimeValue<HibernateOrmRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     /**
      * The feature needs to be initialized, even if it's not enabled.
@@ -25,9 +31,9 @@ public class HibernateReactiveRecorder {
         HibernateReactive.featureInit(enabled);
     }
 
-    public void initializePersistenceProvider(HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig,
+    public void initializePersistenceProvider(
             Map<String, List<HibernateOrmIntegrationRuntimeDescriptor>> integrationRuntimeDescriptors) {
-        ReactivePersistenceProviderSetup.registerRuntimePersistenceProvider(hibernateOrmRuntimeConfig,
+        ReactivePersistenceProviderSetup.registerRuntimePersistenceProvider(runtimeConfig.getValue(),
                 integrationRuntimeDescriptors);
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
@@ -21,7 +21,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 
 @BuildSteps(onlyIf = HibernateSearchEnabled.class)
 public class HibernateSearchElasticsearchCdiProcessor {
@@ -29,7 +28,6 @@ public class HibernateSearchElasticsearchCdiProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     void generateSearchBeans(HibernateSearchElasticsearchRecorder recorder,
-            HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
         for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem persistenceUnit : configuredPersistenceUnits) {
@@ -40,13 +38,13 @@ public class HibernateSearchElasticsearchCdiProcessor {
                     .produce(createSyntheticBean(persistenceUnitName,
                             isDefaultPersistenceUnit,
                             SearchMapping.class,
-                            recorder.searchMappingSupplier(runtimeConfig, persistenceUnitName, isDefaultPersistenceUnit)));
+                            recorder.searchMappingSupplier(persistenceUnitName, isDefaultPersistenceUnit)));
 
             syntheticBeanBuildItemBuildProducer
                     .produce(createSyntheticBean(persistenceUnitName,
                             PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName),
                             SearchSession.class,
-                            recorder.searchSessionSupplier(runtimeConfig, persistenceUnitName, isDefaultPersistenceUnit)));
+                            recorder.searchSessionSupplier(persistenceUnitName, isDefaultPersistenceUnit)));
         }
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchDisabledProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchDisabledProcessor.java
@@ -13,7 +13,6 @@ import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationStaticConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 
 @BuildSteps(onlyIfNot = HibernateSearchEnabled.class)
 class HibernateSearchElasticsearchDisabledProcessor {
@@ -33,10 +32,9 @@ class HibernateSearchElasticsearchDisabledProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     public void disableHibernateSearchRuntimeInit(HibernateSearchElasticsearchRecorder recorder,
-            HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
             List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
             BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeIntegrations) {
-        recorder.checkNoExplicitActiveTrue(runtimeConfig);
+        recorder.checkNoExplicitActiveTrue();
         for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
             String puName = puDescriptor.getPersistenceUnitName();
             runtimeIntegrations.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -54,7 +54,6 @@ import io.quarkus.hibernate.search.backend.elasticsearch.common.runtime.Elastics
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchOrmElasticsearchMapperContext;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
@@ -182,7 +181,6 @@ class HibernateSearchElasticsearchProcessor {
             CombinedIndexBuildItem combinedIndexBuildItem,
             List<HibernateSearchIntegrationStaticConfiguredBuildItem> integrationStaticConfigBuildItems,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
-            HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig,
             BuildProducer<HibernateOrmIntegrationStaticConfiguredBuildItem> staticConfigured) {
         // Make it possible to record the settings as bytecode:
         recorderContext.registerSubstitution(ElasticsearchVersion.class,
@@ -212,7 +210,6 @@ class HibernateSearchElasticsearchProcessor {
                                     // we cannot pass a config group to a recorder so passing the whole config
                                     recorder.createStaticInitListener(
                                             configuredPersistenceUnit.mapperContext,
-                                            buildTimeConfig,
                                             rootAnnotationMappedClassNames,
                                             integrationStaticInitListeners))
                             .setXmlMappingRequired(xmlMappingRequired));
@@ -247,7 +244,6 @@ class HibernateSearchElasticsearchProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void setRuntimeConfig(HibernateSearchElasticsearchRecorder recorder,
-            HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
             List<HibernateSearchIntegrationRuntimeConfiguredBuildItem> integrationRuntimeConfigBuildItems,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeConfigured) {
@@ -264,9 +260,8 @@ class HibernateSearchElasticsearchProcessor {
             }
             runtimeConfigured.produce(
                     new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH, puName)
-                            .setInitListener(
-                                    recorder.createRuntimeInitListener(configuredPersistenceUnit.mapperContext,
-                                            runtimeConfig, integrationRuntimeInitListeners)));
+                            .setInitListener(recorder.createRuntimeInitListener(configuredPersistenceUnit.mapperContext,
+                                    integrationRuntimeInitListeners)));
         }
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/dev/HibernateSearchElasticsearchDevUIProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/dev/HibernateSearchElasticsearchDevUIProcessor.java
@@ -17,7 +17,6 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchEnabled;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.dev.HibernateSearchElasticsearchDevJsonRpcService;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.dev.HibernateSearchElasticsearchDevRecorder;
 
@@ -27,12 +26,11 @@ public class HibernateSearchElasticsearchDevUIProcessor {
     @BuildStep
     @Record(RUNTIME_INIT)
     public CardPageBuildItem create(HibernateSearchElasticsearchDevRecorder recorder,
-            HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> persistenceUnitBuildItems) {
         Set<String> persistenceUnitNames = persistenceUnitBuildItems.stream()
                 .map(HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem::getPersistenceUnitName)
                 .collect(Collectors.toSet());
-        recorder.initController(runtimeConfig, persistenceUnitNames);
+        recorder.initController(persistenceUnitNames);
 
         CardPageBuildItem card = new CardPageBuildItem();
         card.addPage(Page.webComponentPageBuilder()

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/dev/HibernateSearchElasticsearchDevRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/dev/HibernateSearchElasticsearchDevRecorder.java
@@ -7,14 +7,20 @@ import java.util.stream.Collectors;
 
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfigPersistenceUnit;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class HibernateSearchElasticsearchDevRecorder {
+    private final RuntimeValue<HibernateSearchElasticsearchRuntimeConfig> runtimeConfig;
 
-    public void initController(
-            HibernateSearchElasticsearchRuntimeConfig runtimeConfig, Set<String> persistenceUnitNames) {
-        Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> puConfigs = runtimeConfig
+    public HibernateSearchElasticsearchDevRecorder(
+            final RuntimeValue<HibernateSearchElasticsearchRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void initController(Set<String> persistenceUnitNames) {
+        Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> puConfigs = runtimeConfig.getValue()
                 .persistenceUnits();
         Set<String> activePersistenceUnitNames = persistenceUnitNames.stream()
                 .filter(name -> {

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -19,9 +19,7 @@ import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchE
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchIntegrationStaticConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit;
-import io.quarkus.hibernate.search.orm.outboxpolling.runtime.HibernateSearchOutboxPollingBuildTimeConfig;
 import io.quarkus.hibernate.search.orm.outboxpolling.runtime.HibernateSearchOutboxPollingRecorder;
-import io.quarkus.hibernate.search.orm.outboxpolling.runtime.HibernateSearchOutboxPollingRuntimeConfig;
 
 @BuildSteps(onlyIf = HibernateSearchEnabled.class)
 class HibernateSearchOutboxPollingProcessor {
@@ -46,7 +44,6 @@ class HibernateSearchOutboxPollingProcessor {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void setStaticConfig(HibernateSearchOutboxPollingRecorder recorder,
-            HibernateSearchOutboxPollingBuildTimeConfig buildTimeConfig,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<HibernateSearchIntegrationStaticConfiguredBuildItem> staticConfigured) {
         for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
@@ -56,7 +53,7 @@ class HibernateSearchOutboxPollingProcessor {
             String puName = configuredPersistenceUnit.getPersistenceUnitName();
             staticConfigured.produce(new HibernateSearchIntegrationStaticConfiguredBuildItem(
                     HIBERNATE_SEARCH_ORM_COORDINATION_OUTBOX_POLLING, puName,
-                    recorder.createStaticInitListener(buildTimeConfig, puName))
+                    recorder.createStaticInitListener(puName))
                     // Additional entities such as Agent and OutboxEvent are defined through XML
                     // (because there's no other way).
                     .setXmlMappingRequired(true));
@@ -66,7 +63,6 @@ class HibernateSearchOutboxPollingProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void setRuntimeConfig(HibernateSearchOutboxPollingRecorder recorder,
-            HibernateSearchOutboxPollingRuntimeConfig runtimeConfig,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<HibernateSearchIntegrationRuntimeConfiguredBuildItem> runtimeConfigured) {
         for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
@@ -76,7 +72,7 @@ class HibernateSearchOutboxPollingProcessor {
             String puName = configuredPersistenceUnit.getPersistenceUnitName();
             runtimeConfigured.produce(new HibernateSearchIntegrationRuntimeConfiguredBuildItem(
                     HIBERNATE_SEARCH_ORM_COORDINATION_OUTBOX_POLLING, puName,
-                    recorder.createRuntimeInitListener(runtimeConfig, puName)));
+                    recorder.createRuntimeInitListener(puName)));
         }
     }
 

--- a/extensions/hibernate-search-orm-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/runtime/HibernateSearchOutboxPollingRecorder.java
+++ b/extensions/hibernate-search-orm-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/runtime/HibernateSearchOutboxPollingRecorder.java
@@ -10,21 +10,29 @@ import org.hibernate.search.mapper.orm.outboxpolling.cfg.HibernateOrmMapperOutbo
 
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationRuntimeInitListener;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticInitListener;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class HibernateSearchOutboxPollingRecorder {
+    private final HibernateSearchOutboxPollingBuildTimeConfig buildTimeConfig;
+    private final RuntimeValue<HibernateSearchOutboxPollingRuntimeConfig> runtimeConfig;
 
-    public HibernateOrmIntegrationStaticInitListener createStaticInitListener(
-            HibernateSearchOutboxPollingBuildTimeConfig buildTimeConfig, String persistenceUnitName) {
+    public HibernateSearchOutboxPollingRecorder(
+            final HibernateSearchOutboxPollingBuildTimeConfig buildTimeConfig,
+            final RuntimeValue<HibernateSearchOutboxPollingRuntimeConfig> runtimeConfig) {
+        this.buildTimeConfig = buildTimeConfig;
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public HibernateOrmIntegrationStaticInitListener createStaticInitListener(String persistenceUnitName) {
         HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit puConfig = buildTimeConfig.persistenceUnits()
                 .get(persistenceUnitName);
         return new StaticInitListener(puConfig);
     }
 
-    public HibernateOrmIntegrationRuntimeInitListener createRuntimeInitListener(
-            HibernateSearchOutboxPollingRuntimeConfig runtimeConfig, String persistenceUnitName) {
-        HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit puConfig = runtimeConfig.persistenceUnits()
+    public HibernateOrmIntegrationRuntimeInitListener createRuntimeInitListener(String persistenceUnitName) {
+        HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit puConfig = runtimeConfig.getValue().persistenceUnits()
                 .get(persistenceUnitName);
         return new RuntimeInitListener(puConfig);
     }

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneDisabledProcessor.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneDisabledProcessor.java
@@ -5,15 +5,13 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRecorder;
-import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRuntimeConfig;
 
 @BuildSteps(onlyIfNot = HibernateSearchStandaloneEnabled.class)
 class HibernateSearchStandaloneDisabledProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void disableHibernateSearch(HibernateSearchStandaloneRecorder recorder,
-            HibernateSearchStandaloneRuntimeConfig runtimeConfig) {
-        recorder.checkNoExplicitActiveTrue(runtimeConfig);
+    public void disableHibernateSearch(HibernateSearchStandaloneRecorder recorder) {
+        recorder.checkNoExplicitActiveTrue();
         recorder.clearPreBootState();
     }
 }

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
@@ -53,7 +53,6 @@ import io.quarkus.hibernate.search.backend.elasticsearch.common.runtime.Elastics
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneBuildTimeConfig;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneElasticsearchMapperContext;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRecorder;
-import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRuntimeConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
 
@@ -165,7 +164,6 @@ class HibernateSearchStandaloneProcessor {
     @BuildStep
     void defineSearchMappingBean(Optional<HibernateSearchStandaloneEnabledBuildItem> enabled,
             HibernateSearchStandaloneRecorder recorder,
-            HibernateSearchStandaloneRuntimeConfig runtimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
         if (!enabled.isPresent()) {
             // No boot
@@ -179,7 +177,7 @@ class HibernateSearchStandaloneProcessor {
                 .unremovable()
                 .addQualifier(Default.class)
                 .setRuntimeInit()
-                .createWith(recorder.createSearchMappingFunction(enabled.get().mapperContext, runtimeConfig))
+                .createWith(recorder.createSearchMappingFunction(enabled.get().mapperContext))
                 .destroyer(BeanDestroyer.AutoCloseableDestroyer.class)
                 .done());
     }
@@ -189,8 +187,7 @@ class HibernateSearchStandaloneProcessor {
     @Consume(BeanContainerBuildItem.class) // Pre-boot needs access to the CDI container
     public void preBoot(Optional<HibernateSearchStandaloneEnabledBuildItem> enabled,
             RecorderContext recorderContext,
-            HibernateSearchStandaloneRecorder recorder,
-            HibernateSearchStandaloneBuildTimeConfig buildTimeConfig) {
+            HibernateSearchStandaloneRecorder recorder) {
         if (enabled.isEmpty()) {
             // No pre-boot
             return;
@@ -199,8 +196,7 @@ class HibernateSearchStandaloneProcessor {
         // Make it possible to record the settings as bytecode:
         recorderContext.registerSubstitution(ElasticsearchVersion.class,
                 String.class, ElasticsearchVersionSubstitution.class);
-        recorder.preBoot(enabled.get().mapperContext, buildTimeConfig,
-                enabled.get().getRootAnnotationMappedClassNames());
+        recorder.preBoot(enabled.get().mapperContext, enabled.get().getRootAnnotationMappedClassNames());
     }
 
     @BuildStep
@@ -208,13 +204,12 @@ class HibernateSearchStandaloneProcessor {
     @Consume(BeanContainerBuildItem.class)
     void boot(Optional<HibernateSearchStandaloneEnabledBuildItem> enabled,
             HibernateSearchStandaloneRecorder recorder,
-            HibernateSearchStandaloneRuntimeConfig runtimeConfig,
             BuildProducer<ServiceStartBuildItem> serviceStart) {
         if (enabled.isEmpty()) {
             // No boot
             return;
         }
-        recorder.bootEagerly(runtimeConfig);
+        recorder.bootEagerly();
         serviceStart.produce(new ServiceStartBuildItem("Hibernate Search Standalone"));
     }
 

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/dev/HibernateSearchStandaloneDevUIProcessor.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/dev/HibernateSearchStandaloneDevUIProcessor.java
@@ -15,7 +15,6 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.hibernate.search.standalone.elasticsearch.deployment.HibernateSearchStandaloneEnabled;
 import io.quarkus.hibernate.search.standalone.elasticsearch.deployment.HibernateSearchStandaloneEnabledBuildItem;
-import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRuntimeConfig;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.dev.HibernateSearchStandaloneDevJsonRpcService;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.dev.HibernateSearchStandaloneDevRecorder;
 
@@ -25,9 +24,8 @@ public class HibernateSearchStandaloneDevUIProcessor {
     @BuildStep
     @Record(RUNTIME_INIT)
     public CardPageBuildItem create(HibernateSearchStandaloneDevRecorder recorder,
-            HibernateSearchStandaloneRuntimeConfig runtimeConfig,
             Optional<HibernateSearchStandaloneEnabledBuildItem> enabled) {
-        recorder.initController(enabled.isPresent(), runtimeConfig);
+        recorder.initController(enabled.isPresent());
 
         CardPageBuildItem card = new CardPageBuildItem();
         card.addPage(Page.webComponentPageBuilder()

--- a/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/dev/HibernateSearchStandaloneDevRecorder.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/dev/HibernateSearchStandaloneDevRecorder.java
@@ -1,12 +1,18 @@
 package io.quarkus.hibernate.search.standalone.elasticsearch.runtime.dev;
 
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRuntimeConfig;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class HibernateSearchStandaloneDevRecorder {
+    private final RuntimeValue<HibernateSearchStandaloneRuntimeConfig> runtimeConfig;
 
-    public void initController(boolean enabled, HibernateSearchStandaloneRuntimeConfig runtimeConfig) {
-        HibernateSearchStandaloneDevController.get().setActive(enabled && runtimeConfig.active().orElse(true));
+    public HibernateSearchStandaloneDevRecorder(final RuntimeValue<HibernateSearchStandaloneRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void initController(boolean enabled) {
+        HibernateSearchStandaloneDevController.get().setActive(enabled && runtimeConfig.getValue().active().orElse(true));
     }
 }

--- a/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
+++ b/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
@@ -11,7 +11,6 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildI
 import io.quarkus.jfr.runtime.JfrRecorder;
 import io.quarkus.jfr.runtime.OTelIdProducer;
 import io.quarkus.jfr.runtime.QuarkusIdProducer;
-import io.quarkus.jfr.runtime.config.JfrRuntimeConfig;
 import io.quarkus.jfr.runtime.http.rest.classic.ClassicServerFilter;
 import io.quarkus.jfr.runtime.http.rest.classic.ClassicServerRecorderProducer;
 import io.quarkus.jfr.runtime.http.rest.reactive.ReactiveServerFilters;
@@ -88,7 +87,7 @@ public class JfrProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void runtimeInit(JfrRecorder recorder, JfrRuntimeConfig runtimeConfig) {
-        recorder.runtimeInit(runtimeConfig);
+    public void runtimeInit(JfrRecorder recorder) {
+        recorder.runtimeInit();
     }
 }

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/JfrRecorder.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/JfrRecorder.java
@@ -6,21 +6,27 @@ import io.quarkus.jfr.runtime.config.JfrRuntimeConfig;
 import io.quarkus.jfr.runtime.http.rest.RestEndEvent;
 import io.quarkus.jfr.runtime.http.rest.RestPeriodEvent;
 import io.quarkus.jfr.runtime.http.rest.RestStartEvent;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import jdk.jfr.FlightRecorder;
 
 @Recorder
 public class JfrRecorder {
+    private final RuntimeValue<JfrRuntimeConfig> runtimeConfig;
 
-    public void runtimeInit(JfrRuntimeConfig runtimeConfig) {
+    public JfrRecorder(final RuntimeValue<JfrRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void runtimeInit() {
 
         Logger logger = Logger.getLogger(JfrRecorder.class);
 
-        if (!runtimeConfig.enabled()) {
+        if (!runtimeConfig.getValue().enabled()) {
             logger.info("quarkus-jfr is disabled at runtime");
             this.disabledQuarkusJfr();
         } else {
-            if (!runtimeConfig.restEnabled()) {
+            if (!runtimeConfig.getValue().restEnabled()) {
                 logger.info("quarkus-jfr for REST server is disabled at runtime");
                 this.disabledRestJfr();
             }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -35,7 +35,6 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuil
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsProducer;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsRecorder;
-import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsSupport;
 import io.quarkus.kafka.streams.runtime.graal.KafkaStreamsFeature;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
@@ -249,7 +248,7 @@ class KafkaStreamsProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void loadRocksDb(KafkaStreamsRecorder recorder, KafkaStreamsRuntimeConfig runtimeConfig) {
+    void loadRocksDb(KafkaStreamsRecorder recorder) {
         // Explicitly loading RocksDB native libs, as that's normally done from within
         // static initializers which already ran during build
         recorder.loadRocksDb();

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -12,7 +12,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.keycloak.pep.runtime.DefaultPolicyEnforcerResolver;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerAuthorizer;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerBuildTimeConfig;
-import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerConfig;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerRecorder;
 import io.quarkus.oidc.deployment.OidcBuildTimeConfig;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
@@ -23,10 +22,9 @@ public class KeycloakPolicyEnforcerBuildStep {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     RequireBodyHandlerBuildItem requireBody(OidcBuildTimeConfig oidcBuildTimeConfig,
-            KeycloakPolicyEnforcerRecorder recorder,
-            KeycloakPolicyEnforcerConfig runtimeConfig) {
+            KeycloakPolicyEnforcerRecorder recorder) {
         if (oidcBuildTimeConfig.enabled()) {
-            return new RequireBodyHandlerBuildItem(recorder.createBodyHandlerRequiredEvaluator(runtimeConfig));
+            return new RequireBodyHandlerBuildItem(recorder.createBodyHandlerRequiredEvaluator());
         }
         return null;
     }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
@@ -4,19 +4,25 @@ import java.util.Map;
 import java.util.function.BooleanSupplier;
 
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerTenantConfig.KeycloakConfigPolicyEnforcer.PathConfig;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class KeycloakPolicyEnforcerRecorder {
+    private final RuntimeValue<KeycloakPolicyEnforcerConfig> runtimeConfig;
 
-    public BooleanSupplier createBodyHandlerRequiredEvaluator(KeycloakPolicyEnforcerConfig config) {
+    public KeycloakPolicyEnforcerRecorder(final RuntimeValue<KeycloakPolicyEnforcerConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public BooleanSupplier createBodyHandlerRequiredEvaluator() {
         return new BooleanSupplier() {
             @Override
             public boolean getAsBoolean() {
-                if (isBodyHandlerRequired(config.defaultTenant())) {
+                if (isBodyHandlerRequired(runtimeConfig.getValue().defaultTenant())) {
                     return true;
                 }
-                for (KeycloakPolicyEnforcerTenantConfig tenantConfig : config.namedTenants().values()) {
+                for (KeycloakPolicyEnforcerTenantConfig tenantConfig : runtimeConfig.getValue().namedTenants().values()) {
                     if (isBodyHandlerRequired(tenantConfig)) {
                         return true;
                     }

--- a/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
+++ b/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
@@ -9,7 +9,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.kubernetes.config.runtime.KubernetesConfigBuildTimeConfig;
 import io.quarkus.kubernetes.config.runtime.KubernetesConfigRecorder;
-import io.quarkus.kubernetes.config.runtime.KubernetesConfigSourceConfig;
 import io.quarkus.kubernetes.config.runtime.KubernetesConfigSourceFactoryBuilder;
 import io.quarkus.kubernetes.config.runtime.SecretsRoleConfig;
 import io.quarkus.kubernetes.spi.KubernetesClusterRoleBuildItem;
@@ -35,7 +34,6 @@ public class KubernetesConfigProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public void handleAccessToSecrets(
             KubernetesConfigBuildTimeConfig buildTimeConfig,
-            KubernetesConfigSourceConfig config,
             BuildProducer<KubernetesRoleBuildItem> roleProducer,
             BuildProducer<KubernetesClusterRoleBuildItem> clusterRoleProducer,
             BuildProducer<KubernetesServiceAccountBuildItem> serviceAccountProducer,
@@ -61,6 +59,6 @@ public class KubernetesConfigProcessor {
             roleBindingProducer.produce(new KubernetesRoleBindingBuildItem(roleName, roleConfig.clusterWide()));
         }
 
-        recorder.warnAboutSecrets(buildTimeConfig, config);
+        recorder.warnAboutSecrets();
     }
 }

--- a/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/KubernetesConfigRecorder.java
+++ b/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/KubernetesConfigRecorder.java
@@ -2,18 +2,28 @@ package io.quarkus.kubernetes.config.runtime;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class KubernetesConfigRecorder {
-
     private static final Logger log = Logger.getLogger(KubernetesConfigRecorder.class);
 
-    public void warnAboutSecrets(KubernetesConfigBuildTimeConfig buildTimeConfig, KubernetesConfigSourceConfig config) {
-        if (config.secrets().isPresent()
-                && !config.secrets().get().isEmpty()
+    private final KubernetesConfigBuildTimeConfig buildTimeConfig;
+    private final RuntimeValue<KubernetesConfigSourceConfig> runtimeConfig;
+
+    public KubernetesConfigRecorder(
+            final KubernetesConfigBuildTimeConfig buildTimeConfig,
+            final RuntimeValue<KubernetesConfigSourceConfig> runtimeConfig) {
+        this.buildTimeConfig = buildTimeConfig;
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void warnAboutSecrets() {
+        if (runtimeConfig.getValue().secrets().isPresent()
+                && !runtimeConfig.getValue().secrets().get().isEmpty()
                 && !buildTimeConfig.secretsEnabled()) {
-            log.warn("Configuration is read from Secrets " + config.secrets().get()
+            log.warn("Configuration is read from Secrets " + runtimeConfig.getValue().secrets().get()
                     + ", but quarkus.kubernetes-config.secrets.enabled is false."
                     + " Check if your application's service account has enough permissions to read secrets.");
         }

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -44,11 +44,9 @@ import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.liquibase.mongodb.LiquibaseMongodbFactory;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbBuildTimeConfig;
-import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbConfig;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbRecorder;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.mongodb.runtime.MongodbConfig;
 import io.quarkus.paths.PathFilter;
 import liquibase.change.Change;
 import liquibase.change.DatabaseChangeProperty;
@@ -215,9 +213,6 @@ class LiquibaseMongodbProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createBeans(LiquibaseMongodbRecorder recorder,
-            LiquibaseMongodbConfig liquibaseMongodbConfig,
-            LiquibaseMongodbBuildTimeConfig liquibaseMongodbBuildTimeConfig,
-            MongodbConfig mongodbConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
 
         SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
@@ -225,7 +220,7 @@ class LiquibaseMongodbProcessor {
                 .scope(ApplicationScoped.class) // this is what the existing code does, but it doesn't seem reasonable
                 .setRuntimeInit()
                 .unremovable()
-                .supplier(recorder.liquibaseSupplier(liquibaseMongodbConfig, liquibaseMongodbBuildTimeConfig, mongodbConfig));
+                .supplier(recorder.liquibaseSupplier());
 
         syntheticBeanBuildItemBuildProducer.produce(configurator.done());
     }

--- a/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
+++ b/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
@@ -16,25 +16,30 @@ import liquibase.Liquibase;
 
 @Recorder
 public class LiquibaseMongodbRecorder {
+    private final LiquibaseMongodbBuildTimeConfig buildTimeConfig;
+    private final RuntimeValue<LiquibaseMongodbConfig> runtimeConfig;
+    private final RuntimeValue<MongodbConfig> mongodbRuntimeConfig;
 
-    private final RuntimeValue<LiquibaseMongodbConfig> config;
-
-    public LiquibaseMongodbRecorder(RuntimeValue<LiquibaseMongodbConfig> config) {
-        this.config = config;
+    public LiquibaseMongodbRecorder(
+            final LiquibaseMongodbBuildTimeConfig buildTimeConfig,
+            final RuntimeValue<LiquibaseMongodbConfig> runtimeConfig,
+            final RuntimeValue<MongodbConfig> mongodbRuntimeConfig) {
+        this.buildTimeConfig = buildTimeConfig;
+        this.runtimeConfig = runtimeConfig;
+        this.mongodbRuntimeConfig = mongodbRuntimeConfig;
     }
 
-    public Supplier<LiquibaseMongodbFactory> liquibaseSupplier(LiquibaseMongodbConfig config,
-            LiquibaseMongodbBuildTimeConfig buildTimeConfig, MongodbConfig mongodbConfig) {
+    public Supplier<LiquibaseMongodbFactory> liquibaseSupplier() {
         return new Supplier<LiquibaseMongodbFactory>() {
             @Override
             public LiquibaseMongodbFactory get() {
-                return new LiquibaseMongodbFactory(config, buildTimeConfig, mongodbConfig);
+                return new LiquibaseMongodbFactory(runtimeConfig.getValue(), buildTimeConfig, mongodbRuntimeConfig.getValue());
             }
         };
     }
 
     public void doStartActions() {
-        if (!config.getValue().enabled()) {
+        if (!runtimeConfig.getValue().enabled()) {
             return;
         }
         try {

--- a/extensions/logging-gelf/deployment/src/main/java/io/quarkus/logging/gelf/deployment/GelfLogHandlerProcessor.java
+++ b/extensions/logging-gelf/deployment/src/main/java/io/quarkus/logging/gelf/deployment/GelfLogHandlerProcessor.java
@@ -8,7 +8,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.logging.gelf.GelfConfig;
 import io.quarkus.logging.gelf.GelfLogHandlerRecorder;
 
 class GelfLogHandlerProcessor {
@@ -20,8 +19,8 @@ class GelfLogHandlerProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    LogHandlerBuildItem build(GelfLogHandlerRecorder recorder, GelfConfig config) {
-        return new LogHandlerBuildItem(recorder.initializeHandler(config));
+    LogHandlerBuildItem build(GelfLogHandlerRecorder recorder) {
+        return new LogHandlerBuildItem(recorder.initializeHandler());
     }
 
     @BuildStep

--- a/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfLogHandlerRecorder.java
+++ b/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfLogHandlerRecorder.java
@@ -12,7 +12,14 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class GelfLogHandlerRecorder {
-    public RuntimeValue<Optional<Handler>> initializeHandler(final GelfConfig config) {
+    private final RuntimeValue<GelfConfig> runtimeConfig;
+
+    public GelfLogHandlerRecorder(final RuntimeValue<GelfConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public RuntimeValue<Optional<Handler>> initializeHandler() {
+        GelfConfig config = runtimeConfig.getValue();
         if (!config.enabled()) {
             return new RuntimeValue<>(Optional.empty());
         }

--- a/extensions/logging-json/deployment/src/main/java/io/quarkus/logging/json/deployment/LoggingJsonProcessor.java
+++ b/extensions/logging-json/deployment/src/main/java/io/quarkus/logging/json/deployment/LoggingJsonProcessor.java
@@ -7,32 +7,31 @@ import io.quarkus.deployment.builditem.LogConsoleFormatBuildItem;
 import io.quarkus.deployment.builditem.LogFileFormatBuildItem;
 import io.quarkus.deployment.builditem.LogSocketFormatBuildItem;
 import io.quarkus.deployment.builditem.LogSyslogFormatBuildItem;
-import io.quarkus.logging.json.runtime.JsonLogConfig;
 import io.quarkus.logging.json.runtime.LoggingJsonRecorder;
 
 public final class LoggingJsonProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public LogConsoleFormatBuildItem setUpConsoleFormatter(LoggingJsonRecorder recorder, JsonLogConfig config) {
-        return new LogConsoleFormatBuildItem(recorder.initializeConsoleJsonLogging(config));
+    public LogConsoleFormatBuildItem setUpConsoleFormatter(LoggingJsonRecorder recorder) {
+        return new LogConsoleFormatBuildItem(recorder.initializeConsoleJsonLogging());
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public LogFileFormatBuildItem setUpFileFormatter(LoggingJsonRecorder recorder, JsonLogConfig config) {
-        return new LogFileFormatBuildItem(recorder.initializeFileJsonLogging(config));
+    public LogFileFormatBuildItem setUpFileFormatter(LoggingJsonRecorder recorder) {
+        return new LogFileFormatBuildItem(recorder.initializeFileJsonLogging());
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public LogSyslogFormatBuildItem setUpSyslogFormatter(LoggingJsonRecorder recorder, JsonLogConfig config) {
-        return new LogSyslogFormatBuildItem(recorder.initializeSyslogJsonLogging(config));
+    public LogSyslogFormatBuildItem setUpSyslogFormatter(LoggingJsonRecorder recorder) {
+        return new LogSyslogFormatBuildItem(recorder.initializeSyslogJsonLogging());
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public LogSocketFormatBuildItem setUpSocketFormatter(LoggingJsonRecorder recorder, JsonLogConfig config) {
-        return new LogSocketFormatBuildItem(recorder.initializeSocketJsonLogging(config));
+    public LogSocketFormatBuildItem setUpSocketFormatter(LoggingJsonRecorder recorder) {
+        return new LogSocketFormatBuildItem(recorder.initializeSocketJsonLogging());
     }
 }

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -22,21 +22,26 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class LoggingJsonRecorder {
+    private final RuntimeValue<JsonLogConfig> runtimeConfig;
 
-    public RuntimeValue<Optional<Formatter>> initializeConsoleJsonLogging(final JsonLogConfig config) {
-        return getFormatter(config.consoleJson());
+    public LoggingJsonRecorder(final RuntimeValue<JsonLogConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
     }
 
-    public RuntimeValue<Optional<Formatter>> initializeFileJsonLogging(final JsonLogConfig config) {
-        return getFormatter(config.fileJson());
+    public RuntimeValue<Optional<Formatter>> initializeConsoleJsonLogging() {
+        return getFormatter(runtimeConfig.getValue().consoleJson());
     }
 
-    public RuntimeValue<Optional<Formatter>> initializeSyslogJsonLogging(JsonLogConfig config) {
-        return getFormatter(config.syslogJson());
+    public RuntimeValue<Optional<Formatter>> initializeFileJsonLogging() {
+        return getFormatter(runtimeConfig.getValue().fileJson());
     }
 
-    public RuntimeValue<Optional<Formatter>> initializeSocketJsonLogging(JsonLogConfig config) {
-        return getFormatter(config.socketJson());
+    public RuntimeValue<Optional<Formatter>> initializeSyslogJsonLogging() {
+        return getFormatter(runtimeConfig.getValue().syslogJson());
+    }
+
+    public RuntimeValue<Optional<Formatter>> initializeSocketJsonLogging() {
+        return getFormatter(runtimeConfig.getValue().socketJson());
     }
 
     private RuntimeValue<Optional<Formatter>> getFormatter(JsonConfig config) {

--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
@@ -52,7 +52,6 @@ import io.quarkus.mailer.runtime.MailerRecorder;
 import io.quarkus.mailer.runtime.MailerSupport;
 import io.quarkus.mailer.runtime.Mailers;
 import io.quarkus.mailer.runtime.MailersBuildTimeConfig;
-import io.quarkus.mailer.runtime.MailersRuntimeConfig;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.deployment.CheckedTemplateAdapterBuildItem;
 import io.quarkus.qute.deployment.QuteProcessor;
@@ -165,16 +164,15 @@ public class MailerProcessor {
     @BuildStep
     void generateMailerBeans(MailerRecorder recorder,
             MailersBuildItem mailers,
-            MailersRuntimeConfig mailersRuntimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             // Just to make sure it is initialized
             TlsRegistryBuildItem tlsRegistryBuildItem) {
         if (mailers.hasDefaultMailer()) {
-            generateMailerBeansForName(Mailers.DEFAULT_MAILER_NAME, recorder, mailersRuntimeConfig, syntheticBeans);
+            generateMailerBeansForName(Mailers.DEFAULT_MAILER_NAME, recorder, syntheticBeans);
         }
 
         for (String name : mailers.getNamedMailers()) {
-            generateMailerBeansForName(name, recorder, mailersRuntimeConfig, syntheticBeans);
+            generateMailerBeansForName(name, recorder, syntheticBeans);
         }
     }
 
@@ -185,7 +183,6 @@ public class MailerProcessor {
 
     private void generateMailerBeansForName(String name,
             MailerRecorder recorder,
-            MailersRuntimeConfig mailersRuntimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
         AnnotationInstance qualifier;
         if (Mailers.DEFAULT_MAILER_NAME.equals(name)) {
@@ -201,7 +198,7 @@ public class MailerProcessor {
                 .defaultBean()
                 .setRuntimeInit()
                 .addInjectionPoint(ClassType.create(DotName.createSimple(Mailers.class)))
-                .createWith(recorder.mailClientFunction(name, mailersRuntimeConfig))
+                .createWith(recorder.mailClientFunction(name))
                 .done());
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(io.vertx.mutiny.ext.mail.MailClient.class)
                 .scope(Singleton.class)
@@ -210,7 +207,7 @@ public class MailerProcessor {
                 .defaultBean()
                 .setRuntimeInit()
                 .addInjectionPoint(ClassType.create(DotName.createSimple(Mailers.class)))
-                .createWith(recorder.reactiveMailClientFunction(name, mailersRuntimeConfig))
+                .createWith(recorder.reactiveMailClientFunction(name))
                 .done());
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(Mailer.class)
                 .scope(Singleton.class)
@@ -219,7 +216,7 @@ public class MailerProcessor {
                 .defaultBean()
                 .setRuntimeInit()
                 .addInjectionPoint(ClassType.create(DotName.createSimple(Mailers.class)))
-                .createWith(recorder.mailerFunction(name, mailersRuntimeConfig))
+                .createWith(recorder.mailerFunction(name))
                 .done());
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(ReactiveMailer.class)
                 .scope(Singleton.class)
@@ -228,7 +225,7 @@ public class MailerProcessor {
                 .defaultBean()
                 .setRuntimeInit()
                 .addInjectionPoint(ClassType.create(DotName.createSimple(Mailers.class)))
-                .createWith(recorder.reactiveMailerFunction(name, mailersRuntimeConfig))
+                .createWith(recorder.reactiveMailerFunction(name))
                 .done());
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(MockMailbox.class)
                 .scope(Singleton.class)
@@ -237,7 +234,7 @@ public class MailerProcessor {
                 .defaultBean()
                 .setRuntimeInit()
                 .addInjectionPoint(ClassType.create(DotName.createSimple(Mailers.class)))
-                .createWith(recorder.mockMailboxFunction(name, mailersRuntimeConfig))
+                .createWith(recorder.mockMailboxFunction(name))
                 .done());
     }
 

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRecorder.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRecorder.java
@@ -22,8 +22,7 @@ public class MailerRecorder {
         };
     }
 
-    public Function<SyntheticCreationalContext<MailClient>, MailClient> mailClientFunction(String name,
-            @SuppressWarnings("unused") MailersRuntimeConfig mailersRuntimeConfig) {
+    public Function<SyntheticCreationalContext<MailClient>, MailClient> mailClientFunction(String name) {
         return new Function<SyntheticCreationalContext<MailClient>, MailClient>() {
             @Override
             public MailClient apply(SyntheticCreationalContext<MailClient> context) {
@@ -33,8 +32,7 @@ public class MailerRecorder {
     }
 
     public Function<SyntheticCreationalContext<io.vertx.mutiny.ext.mail.MailClient>, io.vertx.mutiny.ext.mail.MailClient> reactiveMailClientFunction(
-            String name,
-            @SuppressWarnings("unused") MailersRuntimeConfig mailersRuntimeConfig) {
+            String name) {
         return new Function<SyntheticCreationalContext<io.vertx.mutiny.ext.mail.MailClient>, io.vertx.mutiny.ext.mail.MailClient>() {
             @Override
             public io.vertx.mutiny.ext.mail.MailClient apply(
@@ -44,8 +42,7 @@ public class MailerRecorder {
         };
     }
 
-    public Function<SyntheticCreationalContext<Mailer>, Mailer> mailerFunction(String name,
-            @SuppressWarnings("unused") MailersRuntimeConfig mailersRuntimeConfig) {
+    public Function<SyntheticCreationalContext<Mailer>, Mailer> mailerFunction(String name) {
         return new Function<SyntheticCreationalContext<Mailer>, Mailer>() {
             @Override
             public Mailer apply(SyntheticCreationalContext<Mailer> context) {
@@ -54,8 +51,7 @@ public class MailerRecorder {
         };
     }
 
-    public Function<SyntheticCreationalContext<ReactiveMailer>, ReactiveMailer> reactiveMailerFunction(String name,
-            @SuppressWarnings("unused") MailersRuntimeConfig mailersRuntimeConfig) {
+    public Function<SyntheticCreationalContext<ReactiveMailer>, ReactiveMailer> reactiveMailerFunction(String name) {
         return new Function<SyntheticCreationalContext<ReactiveMailer>, ReactiveMailer>() {
             @Override
             public ReactiveMailer apply(SyntheticCreationalContext<ReactiveMailer> context) {
@@ -64,8 +60,7 @@ public class MailerRecorder {
         };
     }
 
-    public Function<SyntheticCreationalContext<MockMailbox>, MockMailbox> mockMailboxFunction(String name,
-            @SuppressWarnings("unused") MailersRuntimeConfig mailersRuntimeConfig) {
+    public Function<SyntheticCreationalContext<MockMailbox>, MockMailbox> mockMailboxFunction(String name) {
         return new Function<SyntheticCreationalContext<MockMailbox>, MockMailbox>() {
             @Override
             public MockMailbox apply(SyntheticCreationalContext<MockMailbox> context) {

--- a/extensions/micrometer-opentelemetry/deployment/src/main/java/io/quarkus/micrometer/opentelemetry/deployment/MicrometerOtelBridgeProcessor.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/main/java/io/quarkus/micrometer/opentelemetry/deployment/MicrometerOtelBridgeProcessor.java
@@ -26,7 +26,6 @@ import io.quarkus.micrometer.deployment.MicrometerProcessor;
 import io.quarkus.micrometer.opentelemetry.runtime.MicrometerOtelBridgeRecorder;
 import io.quarkus.opentelemetry.deployment.OpenTelemetryEnabled;
 import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig;
-import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 
 @BuildSteps(onlyIf = {
         MicrometerProcessor.MicrometerEnabled.class,
@@ -56,11 +55,12 @@ public class MicrometerOtelBridgeProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void createBridgeBean(OTelRuntimeConfig otelRuntimeConfig,
+    void createBridgeBean(
+            OTelBuildConfig oTelBuildConfig,
             MicrometerOtelBridgeRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanProducer) {
 
-        if (otelRuntimeConfig.sdkDisabled()) {
+        if (!oTelBuildConfig.enabled()) {
             return; // No point in creating the bridge if the SDK is disabled
         }
 
@@ -71,7 +71,7 @@ public class MicrometerOtelBridgeProcessor {
                 .scope(Singleton.class)
                 .addInjectionPoint(ParameterizedType.create(DotName.createSimple(Instance.class),
                         new Type[] { ClassType.create(DotName.createSimple(OpenTelemetry.class.getName())) }, null))
-                .createWith(recorder.createBridge(otelRuntimeConfig))
+                .createWith(recorder.createBridge())
                 .done());
     }
 

--- a/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
+++ b/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
@@ -12,15 +12,12 @@ import io.micrometer.core.instrument.Metrics;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
 import io.quarkus.arc.SyntheticCreationalContext;
-import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class MicrometerOtelBridgeRecorder {
 
-    public Function<SyntheticCreationalContext<MeterRegistry>, MeterRegistry> createBridge(
-            OTelRuntimeConfig otelRuntimeConfig) {
-
+    public Function<SyntheticCreationalContext<MeterRegistry>, MeterRegistry> createBridge() {
         return new Function<>() {
             @Override
             public MeterRegistry apply(SyntheticCreationalContext<MeterRegistry> context) {

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -186,10 +186,9 @@ public class MicrometerProcessor {
     @Consume(BeanContainerBuildItem.class)
     @Record(ExecutionTime.STATIC_INIT)
     RootMeterRegistryBuildItem createRootRegistry(MicrometerRecorder recorder,
-            MicrometerConfig config,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
 
-        RuntimeValue<MeterRegistry> registry = recorder.createRootRegistry(config,
+        RuntimeValue<MeterRegistry> registry = recorder.createRootRegistry(
                 nonApplicationRootPathBuildItem.getNonApplicationRootPath(),
                 nonApplicationRootPathBuildItem.getNormalizedHttpRootPath());
         return new RootMeterRegistryBuildItem(registry);
@@ -213,7 +212,6 @@ public class MicrometerProcessor {
     @Consume(LoggingSetupBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void configureRegistry(MicrometerRecorder recorder,
-            MicrometerConfig config,
             List<MicrometerRegistryProviderBuildItem> providerClassItems,
             List<MetricsFactoryConsumerBuildItem> metricsFactoryConsumerBuildItems,
             ShutdownContextBuildItem shutdownContextBuildItem) {
@@ -224,7 +222,7 @@ public class MicrometerProcessor {
         }
 
         // Runtime config at play here: host+port, API keys, etc.
-        recorder.configureRegistries(config, typeClasses, shutdownContextBuildItem);
+        recorder.configureRegistries(typeClasses, shutdownContextBuildItem);
 
         for (MetricsFactoryConsumerBuildItem item : metricsFactoryConsumerBuildItems) {
             if (item != null && item.executionTime() == ExecutionTime.RUNTIME_INIT) {

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/HttpBinderProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/HttpBinderProcessor.java
@@ -19,9 +19,6 @@ import io.quarkus.micrometer.deployment.MicrometerProcessor;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
-import io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig;
-import io.quarkus.micrometer.runtime.config.runtime.HttpServerConfig;
-import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
 
 /**
  * Avoid directly referencing optional dependencies
@@ -60,9 +57,6 @@ public class HttpBinderProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     SyntheticBeanBuildItem enableHttpBinders(MicrometerRecorder recorder,
             MicrometerConfig buildTimeConfig,
-            HttpServerConfig serverConfig,
-            HttpClientConfig clientConfig,
-            VertxConfig vertxConfig,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
 
         boolean clientEnabled = buildTimeConfig.checkBinderEnabledWithDefault(buildTimeConfig.binder().httpClient());
@@ -79,8 +73,7 @@ public class HttpBinderProcessor {
                 .scope(Singleton.class)
                 .setRuntimeInit()
                 .unremovable()
-                .runtimeValue(recorder.configureHttpMetrics(serverEnabled, clientEnabled,
-                        serverConfig, clientConfig, vertxConfig))
+                .runtimeValue(recorder.configureHttpMetrics(serverEnabled, clientEnabled))
                 .done();
     }
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -73,7 +73,6 @@ import io.quarkus.mongodb.runtime.MongoClientSupport;
 import io.quarkus.mongodb.runtime.MongoClients;
 import io.quarkus.mongodb.runtime.MongoReactiveContextProvider;
 import io.quarkus.mongodb.runtime.MongoServiceBindingConverter;
-import io.quarkus.mongodb.runtime.MongodbConfig;
 import io.quarkus.mongodb.runtime.dns.MongoDnsClient;
 import io.quarkus.mongodb.runtime.dns.MongoDnsClientProvider;
 import io.quarkus.mongodb.tracing.MongoTracingCommandListener;
@@ -338,7 +337,6 @@ public class MongoClientProcessor {
             BeanRegistrationPhaseBuildItem registrationPhase,
             List<MongoClientNameBuildItem> mongoClientNames,
             MongoClientBuildTimeConfig mongoClientBuildTimeConfig,
-            MongodbConfig mongodbConfig,
             List<MongoUnremovableClientsBuildItem> mongoUnremovableClientsBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
             VertxBuildItem vertxBuildItem) {
@@ -368,12 +366,12 @@ public class MongoClientProcessor {
         }
 
         if (createDefaultBlockingMongoClient) {
-            syntheticBeanBuildItemBuildProducer.produce(createBlockingSyntheticBean(recorder, mongodbConfig,
+            syntheticBeanBuildItemBuildProducer.produce(createBlockingSyntheticBean(recorder,
                     makeUnremovable || mongoClientBuildTimeConfig.forceDefaultClients(),
                     MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME, false));
         }
         if (createDefaultReactiveMongoClient) {
-            syntheticBeanBuildItemBuildProducer.produce(createReactiveSyntheticBean(recorder, mongodbConfig,
+            syntheticBeanBuildItemBuildProducer.produce(createReactiveSyntheticBean(recorder,
                     makeUnremovable || mongoClientBuildTimeConfig.forceDefaultClients(),
                     MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME, false));
         }
@@ -381,18 +379,18 @@ public class MongoClientProcessor {
         for (MongoClientNameBuildItem mongoClientName : mongoClientNames) {
             // named blocking client
             syntheticBeanBuildItemBuildProducer
-                    .produce(createBlockingSyntheticBean(recorder, mongodbConfig, makeUnremovable, mongoClientName.getName(),
+                    .produce(createBlockingSyntheticBean(recorder, makeUnremovable, mongoClientName.getName(),
                             mongoClientName.isAddQualifier()));
             // named reactive client
             syntheticBeanBuildItemBuildProducer
-                    .produce(createReactiveSyntheticBean(recorder, mongodbConfig, makeUnremovable, mongoClientName.getName(),
+                    .produce(createReactiveSyntheticBean(recorder, makeUnremovable, mongoClientName.getName(),
                             mongoClientName.isAddQualifier()));
         }
 
-        recorder.performInitialization(mongodbConfig, vertxBuildItem.getVertx());
+        recorder.performInitialization(vertxBuildItem.getVertx());
     }
 
-    private SyntheticBeanBuildItem createBlockingSyntheticBean(MongoClientRecorder recorder, MongodbConfig mongodbConfig,
+    private SyntheticBeanBuildItem createBlockingSyntheticBean(MongoClientRecorder recorder,
             boolean makeUnremovable, String clientName, boolean addMongoClientQualifier) {
 
         SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
@@ -400,13 +398,13 @@ public class MongoClientProcessor {
                 .scope(ApplicationScoped.class)
                 // pass the runtime config into the recorder to ensure that the DataSource related beans
                 // are created after runtime configuration has been set up
-                .supplier(recorder.mongoClientSupplier(clientName, mongodbConfig))
+                .supplier(recorder.mongoClientSupplier(clientName))
                 .setRuntimeInit();
 
         return applyCommonBeanConfig(makeUnremovable, clientName, addMongoClientQualifier, configurator, false);
     }
 
-    private SyntheticBeanBuildItem createReactiveSyntheticBean(MongoClientRecorder recorder, MongodbConfig mongodbConfig,
+    private SyntheticBeanBuildItem createReactiveSyntheticBean(MongoClientRecorder recorder,
             boolean makeUnremovable, String clientName, boolean addMongoClientQualifier) {
 
         SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
@@ -414,7 +412,7 @@ public class MongoClientProcessor {
                 .scope(ApplicationScoped.class)
                 // pass the runtime config into the recorder to ensure that the DataSource related beans
                 // are created after runtime configuration has been set up
-                .supplier(recorder.reactiveMongoClientSupplier(clientName, mongodbConfig))
+                .supplier(recorder.reactiveMongoClientSupplier(clientName))
                 .setRuntimeInit();
 
         return applyCommonBeanConfig(makeUnremovable, clientName, addMongoClientQualifier, configurator, true);

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -24,6 +24,11 @@ import io.vertx.core.Vertx;
 
 @Recorder
 public class MongoClientRecorder {
+    private final RuntimeValue<MongodbConfig> runtimeConfig;
+
+    public MongoClientRecorder(final RuntimeValue<MongodbConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public Supplier<MongoClientSupport> mongoClientSupportSupplier(List<String> bsonDiscriminators,
             List<Supplier<ConnectionPoolListener>> connectionPoolListenerSuppliers, boolean disableSslSupport) {
@@ -61,13 +66,11 @@ public class MongoClientRecorder {
         }
     }
 
-    public Supplier<MongoClient> mongoClientSupplier(String clientName,
-            @SuppressWarnings("unused") MongodbConfig mongodbConfig) {
+    public Supplier<MongoClient> mongoClientSupplier(String clientName) {
         return new MongoClientSupplier<>(mongoClients -> mongoClients.createMongoClient(clientName));
     }
 
-    public Supplier<ReactiveMongoClient> reactiveMongoClientSupplier(String clientName,
-            @SuppressWarnings("unused") MongodbConfig mongodbConfig) {
+    public Supplier<ReactiveMongoClient> reactiveMongoClientSupplier(String clientName) {
         return new MongoClientSupplier<>(mongoClients -> mongoClients.createReactiveMongoClient(clientName));
     }
 
@@ -113,10 +116,10 @@ public class MongoClientRecorder {
      * resolution)
      * don't end up being performed on the event loop
      */
-    public void performInitialization(MongodbConfig config, RuntimeValue<Vertx> vertx) {
+    public void performInitialization(RuntimeValue<Vertx> vertx) {
         MongoDnsClientProvider.vertx = vertx.getValue();
-        initializeDNSLookup(config.defaultMongoClientConfig());
-        for (MongoClientConfig mongoClientConfig : config.mongoClientConfigs().values()) {
+        initializeDNSLookup(runtimeConfig.getValue().defaultMongoClientConfig());
+        for (MongoClientConfig mongoClientConfig : runtimeConfig.getValue().mongoClientConfigs().values()) {
             initializeDNSLookup(mongoClientConfig);
         }
     }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -26,6 +26,7 @@ import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 import com.arjuna.common.util.propertyservice.PropertiesFactory;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -39,13 +40,18 @@ public class NarayanaJtaRecorder {
 
     private static final Logger log = Logger.getLogger(NarayanaJtaRecorder.class);
 
-    public void setNodeName(final TransactionManagerConfiguration transactions) {
+    private final RuntimeValue<TransactionManagerConfiguration> transactions;
 
+    public NarayanaJtaRecorder(final RuntimeValue<TransactionManagerConfiguration> transactions) {
+        this.transactions = transactions;
+    }
+
+    public void setNodeName() {
         try {
-            String nodeName = transactions.nodeName();
+            String nodeName = transactions.getValue().nodeName();
             if (nodeName.getBytes(StandardCharsets.UTF_8).length > 28
-                    && transactions.shortenNodeNameIfNecessary()) {
-                nodeName = shortenNodeName(transactions.nodeName());
+                    && transactions.getValue().shortenNodeNameIfNecessary()) {
+                nodeName = shortenNodeName(transactions.getValue().nodeName());
             }
             arjPropertyManager.getCoreEnvironmentBean().setNodeIdentifier(nodeName);
             jtaPropertyManager.getJTAEnvironmentBean().setXaRecoveryNodes(List.of(nodeName));
@@ -90,10 +96,10 @@ public class NarayanaJtaRecorder {
         defaultProperties = properties;
     }
 
-    public void setDefaultTimeout(TransactionManagerConfiguration transactions) {
+    public void setDefaultTimeout() {
         arjPropertyManager.getCoordinatorEnvironmentBean()
-                .setDefaultTimeout((int) transactions.defaultTransactionTimeout().getSeconds());
-        TxControl.setDefaultTimeout((int) transactions.defaultTransactionTimeout().getSeconds());
+                .setDefaultTimeout((int) transactions.getValue().defaultTransactionTimeout().getSeconds());
+        TxControl.setDefaultTimeout((int) transactions.getValue().defaultTransactionTimeout().getSeconds());
     }
 
     public static Properties getDefaultProperties() {
@@ -105,19 +111,19 @@ public class NarayanaJtaRecorder {
                 .setTransactionStatusManagerEnable(false);
     }
 
-    public void setConfig(final TransactionManagerConfiguration transactions) {
+    public void setConfig() {
         List<String> objectStores = Arrays.asList(null, "communicationStore", "stateStore");
-        if (transactions.objectStore().type().equals(ObjectStoreType.File_System)) {
-            objectStores.forEach(name -> setObjectStoreDir(name, transactions));
-        } else if (transactions.objectStore().type().equals(ObjectStoreType.JDBC)) {
-            objectStores.forEach(name -> setJDBCObjectStore(name, transactions));
+        if (transactions.getValue().objectStore().type().equals(ObjectStoreType.File_System)) {
+            objectStores.forEach(name -> setObjectStoreDir(name, transactions.getValue()));
+        } else if (transactions.getValue().objectStore().type().equals(ObjectStoreType.JDBC)) {
+            objectStores.forEach(name -> setJDBCObjectStore(name, transactions.getValue()));
         }
         BeanPopulator.getDefaultInstance(RecoveryEnvironmentBean.class)
-                .setRecoveryModuleClassNames(transactions.recoveryModules());
+                .setRecoveryModuleClassNames(transactions.getValue().recoveryModules());
         BeanPopulator.getDefaultInstance(RecoveryEnvironmentBean.class)
-                .setExpiryScannerClassNames(transactions.expiryScanners());
+                .setExpiryScannerClassNames(transactions.getValue().expiryScanners());
         BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class)
-                .setXaResourceOrphanFilterClassNames(transactions.xaResourceOrphanFilters());
+                .setXaResourceOrphanFilterClassNames(transactions.getValue().xaResourceOrphanFilters());
     }
 
     /**
@@ -158,13 +164,12 @@ public class NarayanaJtaRecorder {
         instance.setTablePrefix(config.objectStore().tablePrefix());
     }
 
-    public void startRecoveryService(final TransactionManagerConfiguration transactions,
-            Map<String, String> configuredDataSourcesConfigKeys,
+    public void startRecoveryService(Map<String, String> configuredDataSourcesConfigKeys,
             Set<String> dataSourcesWithTransactionIntegration) {
 
-        if (transactions.objectStore().type().equals(ObjectStoreType.JDBC)) {
+        if (transactions.getValue().objectStore().type().equals(ObjectStoreType.JDBC)) {
             final String objectStoreDataSourceName;
-            if (transactions.objectStore().datasource().isEmpty()) {
+            if (transactions.getValue().objectStore().datasource().isEmpty()) {
                 if (!DataSourceUtil.hasDefault(configuredDataSourcesConfigKeys.keySet())) {
                     throw new ConfigurationException(
                             "The Narayana JTA extension does not have a datasource configured as the JDBC object store,"
@@ -177,7 +182,7 @@ public class NarayanaJtaRecorder {
                 }
                 objectStoreDataSourceName = DataSourceUtil.DEFAULT_DATASOURCE_NAME;
             } else {
-                objectStoreDataSourceName = transactions.objectStore().datasource().get();
+                objectStoreDataSourceName = transactions.getValue().objectStore().datasource().get();
 
                 if (!configuredDataSourcesConfigKeys.keySet().contains(objectStoreDataSourceName)) {
                     throw new ConfigurationException(
@@ -201,15 +206,15 @@ public class NarayanaJtaRecorder {
                         objectStoreDataSourceName, configuredDataSourcesConfigKeys.get(objectStoreDataSourceName)));
             }
         }
-        if (transactions.enableRecovery()) {
+        if (transactions.getValue().enableRecovery()) {
             QuarkusRecoveryService.getInstance().create();
             QuarkusRecoveryService.getInstance().start();
         }
     }
 
-    public void handleShutdown(ShutdownContext context, TransactionManagerConfiguration transactions) {
+    public void handleShutdown(ShutdownContext context) {
         context.addShutdownTask(() -> {
-            if (transactions.enableRecovery()) {
+            if (transactions.getValue().enableRecovery()) {
                 try {
                     QuarkusRecoveryService.getInstance().stop();
                 } catch (Exception e) {

--- a/extensions/narayana-jta/runtime/src/test/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorderTest.java
+++ b/extensions/narayana-jta/runtime/src/test/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorderTest.java
@@ -8,6 +8,8 @@ import java.security.NoSuchAlgorithmException;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.RuntimeValue;
+
 public class NarayanaJtaRecorderTest {
 
     //this string has been chosen as when hashed and Base64 encoded the resulted byte array will have a length > 28, so it will be trimmed too.
@@ -17,7 +19,7 @@ public class NarayanaJtaRecorderTest {
     void testByteLengthWithLongerString() throws NoSuchAlgorithmException {
         // create nodeNames larger than 28 bytes
         assertTrue(NODE_NAME_TO_SHORTEN.getBytes(StandardCharsets.UTF_8).length > 28);
-        NarayanaJtaRecorder recorder = new NarayanaJtaRecorder();
+        NarayanaJtaRecorder recorder = new NarayanaJtaRecorder(new RuntimeValue<>());
         String shorterNodeName = recorder.shortenNodeName(NODE_NAME_TO_SHORTEN);
         int numberOfBytes = shorterNodeName.getBytes(StandardCharsets.UTF_8).length;
         assertEquals(28, numberOfBytes,
@@ -27,7 +29,7 @@ public class NarayanaJtaRecorderTest {
     @Test
     void testPredictableConversion() throws NoSuchAlgorithmException {
         assertTrue(NODE_NAME_TO_SHORTEN.getBytes(StandardCharsets.UTF_8).length > 28);
-        NarayanaJtaRecorder recorder = new NarayanaJtaRecorder();
+        NarayanaJtaRecorder recorder = new NarayanaJtaRecorder(new RuntimeValue<>());
         String firstConversion = recorder.shortenNodeName(NODE_NAME_TO_SHORTEN);
         int numberOfBytes = firstConversion.getBytes(StandardCharsets.UTF_8).length;
         assertEquals(28, numberOfBytes,

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAProcessor.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAProcessor.java
@@ -27,7 +27,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.narayana.lra.runtime.LRAConfiguration;
 import io.quarkus.narayana.lra.runtime.NarayanaLRAProducers;
 import io.quarkus.narayana.lra.runtime.NarayanaLRARecorder;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
@@ -56,10 +55,8 @@ class NarayanaLRAProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public void build(NarayanaLRARecorder recorder,
-            LRAConfiguration configuration) {
-
-        recorder.setConfig(configuration);
+    public void build(NarayanaLRARecorder recorder) {
+        recorder.setConfig();
     }
 
     @BuildStep()

--- a/extensions/narayana-lra/runtime/src/main/java/io/quarkus/narayana/lra/runtime/NarayanaLRARecorder.java
+++ b/extensions/narayana-lra/runtime/src/main/java/io/quarkus/narayana/lra/runtime/NarayanaLRARecorder.java
@@ -9,6 +9,7 @@ import org.jboss.logging.Logger;
 import io.narayana.lra.client.internal.NarayanaLRAClient;
 import io.narayana.lra.client.internal.proxy.nonjaxrs.LRAParticipant;
 import io.narayana.lra.client.internal.proxy.nonjaxrs.LRAParticipantRegistry;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
@@ -17,9 +18,15 @@ public class NarayanaLRARecorder {
 
     static LRAParticipantRegistry registry;
 
-    public void setConfig(final LRAConfiguration config) {
+    private final RuntimeValue<LRAConfiguration> runtimeConfig;
+
+    public NarayanaLRARecorder(final RuntimeValue<LRAConfiguration> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void setConfig() {
         if (System.getProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY) == null) {
-            System.setProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY, config.coordinatorURL());
+            System.setProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY, runtimeConfig.getValue().coordinatorURL());
         }
     }
 

--- a/extensions/oidc-client-registration/deployment/src/main/java/io/quarkus/oidc/client/registration/deployment/OidcClientRegistrationBuildStep.java
+++ b/extensions/oidc-client-registration/deployment/src/main/java/io/quarkus/oidc/client/registration/deployment/OidcClientRegistrationBuildStep.java
@@ -16,7 +16,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.oidc.client.registration.OidcClientRegistration;
 import io.quarkus.oidc.client.registration.OidcClientRegistrations;
 import io.quarkus.oidc.client.registration.runtime.OidcClientRegistrationRecorder;
-import io.quarkus.oidc.client.registration.runtime.OidcClientRegistrationsConfig;
 import io.quarkus.tls.deployment.spi.TlsRegistryBuildItem;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 
@@ -31,13 +30,12 @@ public class OidcClientRegistrationBuildStep {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     public void setup(
-            OidcClientRegistrationsConfig oidcConfig,
             OidcClientRegistrationRecorder recorder,
             CoreVertxBuildItem vertxBuildItem,
             TlsRegistryBuildItem tlsRegistry,
             BuildProducer<SyntheticBeanBuildItem> syntheticBean) {
 
-        OidcClientRegistrations oidcClientRegistrations = recorder.setup(oidcConfig, vertxBuildItem.getVertx(),
+        OidcClientRegistrations oidcClientRegistrations = recorder.setup(vertxBuildItem.getVertx(),
                 tlsRegistry.registry());
 
         syntheticBean.produce(SyntheticBeanBuildItem.configure(OidcClientRegistration.class).unremovable()

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
@@ -24,6 +24,7 @@ import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.tls.TlsConfigurationRegistry;
@@ -35,20 +36,23 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 
 @Recorder
 public class OidcClientRegistrationRecorder {
-
     private static final Logger LOG = Logger.getLogger(OidcClientRegistrationRecorder.class);
     private static final String DEFAULT_ID = "Default";
 
-    public OidcClientRegistrations setup(OidcClientRegistrationsConfig oidcClientRegsConfig,
-            Supplier<Vertx> vertx, Supplier<TlsConfigurationRegistry> registrySupplier) {
+    private final RuntimeValue<OidcClientRegistrationsConfig> runtimeConfig;
 
+    public OidcClientRegistrationRecorder(final RuntimeValue<OidcClientRegistrationsConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public OidcClientRegistrations setup(Supplier<Vertx> vertx, Supplier<TlsConfigurationRegistry> registrySupplier) {
         var tlsSupport = OidcTlsSupport.of(registrySupplier);
         OidcClientRegistration defaultClientReg = createOidcClientRegistration(
-                getDefaultClientRegistration(oidcClientRegsConfig),
+                getDefaultClientRegistration(runtimeConfig.getValue()),
                 tlsSupport, vertx);
 
         Map<String, OidcClientRegistration> staticOidcClientRegs = new HashMap<>();
-        for (var config : oidcClientRegsConfig.namedClientRegistrations().entrySet()) {
+        for (var config : runtimeConfig.getValue().namedClientRegistrations().entrySet()) {
             staticOidcClientRegs.put(config.getKey(), createOidcClientRegistration(config.getValue(), tlsSupport, vertx));
         }
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -89,7 +89,6 @@ import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.oidc.runtime.DefaultTokenStateManager;
 import io.quarkus.oidc.runtime.Jose4jRecorder;
 import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
-import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.oidc.runtime.OidcConfigurationAndProviderProducer;
 import io.quarkus.oidc.runtime.OidcIdentityProvider;
 import io.quarkus.oidc.runtime.OidcJsonWebTokenProducer;
@@ -103,7 +102,6 @@ import io.quarkus.oidc.runtime.health.OidcTenantHealthCheck;
 import io.quarkus.oidc.runtime.providers.AzureAccessTokenCustomizer;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.Authenticated;
-import io.quarkus.security.runtime.SecurityConfig;
 import io.quarkus.security.spi.AdditionalSecuredMethodsBuildItem;
 import io.quarkus.security.spi.ClassSecurityAnnotationBuildItem;
 import io.quarkus.security.spi.RegisterClassSecurityCheckBuildItem;
@@ -218,12 +216,12 @@ public class OidcBuildStep {
 
     @BuildStep(onlyIf = IsCacheEnabled.class)
     @Record(ExecutionTime.RUNTIME_INIT)
-    public SyntheticBeanBuildItem addDefaultCacheBean(OidcConfig config,
+    public SyntheticBeanBuildItem addDefaultCacheBean(
             OidcRecorder recorder,
             CoreVertxBuildItem vertxBuildItem) {
         return SyntheticBeanBuildItem.configure(DefaultTokenIntrospectionUserInfoCache.class).unremovable()
                 .types(DefaultTokenIntrospectionUserInfoCache.class, TokenIntrospectionCache.class, UserInfoCache.class)
-                .supplier(recorder.setupTokenCache(config, vertxBuildItem.getVertx()))
+                .supplier(recorder.setupTokenCache(vertxBuildItem.getVertx()))
                 .scope(Singleton.class)
                 .setRuntimeInit()
                 .done();
@@ -347,12 +345,11 @@ public class OidcBuildStep {
 
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    SyntheticBeanBuildItem setup(OidcConfig config, OidcRecorder recorder, SecurityConfig securityConfig,
-            CoreVertxBuildItem vertxBuildItem, TlsRegistryBuildItem tlsRegistryBuildItem) {
+    SyntheticBeanBuildItem setup(OidcRecorder recorder, CoreVertxBuildItem vertxBuildItem,
+            TlsRegistryBuildItem tlsRegistryBuildItem) {
         return SyntheticBeanBuildItem.configure(TenantConfigBean.class).unremovable().types(TenantConfigBean.class)
                 .addInjectionPoint(ParameterizedType.create(EVENT, ClassType.create(Oidc.class)))
-                .createWith(recorder.createTenantConfigBean(config, vertxBuildItem.getVertx(), tlsRegistryBuildItem.registry(),
-                        securityConfig))
+                .createWith(recorder.createTenantConfigBean(vertxBuildItem.getVertx(), tlsRegistryBuildItem.registry()))
                 .destroyer(TenantConfigBean.Destroyer.class)
                 .scope(Singleton.class) // this should have been @ApplicationScoped but fails for some reason
                 .setRuntimeInit()

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
@@ -19,7 +19,6 @@ import io.quarkus.oidc.runtime.dev.ui.OidcDevUiRpcSvcPropertiesBean;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 public abstract class AbstractDevUIProcessor {
     protected static final String CONFIG_PREFIX = "quarkus.oidc.";
@@ -43,7 +42,8 @@ public abstract class AbstractDevUIProcessor {
             Map<String, String> keycloakUsers,
             List<String> keycloakRealms,
             boolean alwaysLogoutUserInDevUiOnReload,
-            VertxHttpConfig httpConfig, boolean discoverMetadata, String authServerUrl) {
+            boolean discoverMetadata,
+            String authServerUrl) {
         final CardPageBuildItem cardPage = new CardPageBuildItem();
 
         cardPage.setLogo("oidc_logo.png", "oidc_logo.png");
@@ -85,7 +85,7 @@ public abstract class AbstractDevUIProcessor {
                 graphqlIsAvailable, swaggerUiPath, graphqlUiPath, alwaysLogoutUserInDevUiOnReload, discoverMetadata,
                 authServerUrl);
 
-        recorder.createJsonRPCService(beanContainer.getValue(), runtimeProperties, httpConfig);
+        recorder.createJsonRPCService(beanContainer.getValue(), runtimeProperties);
 
         return cardPage;
     }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
@@ -26,7 +26,6 @@ import io.quarkus.oidc.runtime.providers.KnownOidcProviders;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
-import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 public class OidcDevUIProcessor extends AbstractDevUIProcessor {
 
@@ -48,7 +47,6 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
     @Consume(CoreVertxBuildItem.class) // metadata discovery requires Vertx instance
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     void prepareOidcDevConsole(Capabilities capabilities,
-            VertxHttpConfig httpConfig,
             BeanContainerBuildItem beanContainer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BuildProducer<CardPageBuildItem> cardPageProducer,
@@ -90,7 +88,8 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
                     null,
                     null,
                     true,
-                    httpConfig, discoverMetadata, authServerUrl);
+                    discoverMetadata,
+                    authServerUrl);
             cardPageProducer.produce(cardPage);
         }
     }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -26,7 +26,6 @@ import io.quarkus.oidc.runtime.dev.ui.OidcDevLoginObserver;
 import io.quarkus.oidc.runtime.dev.ui.OidcDevUiRecorder;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
 
@@ -37,7 +36,6 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     void produceProviderComponent(Optional<KeycloakDevServicesConfigBuildItem> configProps,
             BuildProducer<KeycloakAdminPageBuildItem> keycloakAdminPageProducer,
-            VertxHttpConfig httpConfig,
             OidcDevUiRecorder recorder,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BeanContainerBuildItem beanContainer,
@@ -69,7 +67,7 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
                     users,
                     keycloakRealms,
                     configProps.get().isContainerRestarted(),
-                    httpConfig, false, null);
+                    false, null);
 
             cardPageBuildItem.setLogo("keycloak_logo.svg", "keycloak_logo.svg");
 

--- a/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevUiRecorder.java
+++ b/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevUiRecorder.java
@@ -22,13 +22,18 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 
 @Recorder
 public class OidcDevUiRecorder {
-
     private static final Logger LOG = Logger.getLogger(OidcDevUiRecorder.class);
 
+    private final RuntimeValue<VertxHttpConfig> httpConfig;
+
+    public OidcDevUiRecorder(final RuntimeValue<VertxHttpConfig> httpConfig) {
+        this.httpConfig = httpConfig;
+    }
+
     public void createJsonRPCService(BeanContainer beanContainer,
-            RuntimeValue<OidcDevUiRpcSvcPropertiesBean> oidcDevUiRpcSvcPropertiesBean, VertxHttpConfig httpConfig) {
+            RuntimeValue<OidcDevUiRpcSvcPropertiesBean> oidcDevUiRpcSvcPropertiesBean) {
         OidcDevJsonRpcService jsonRpcService = beanContainer.beanInstance(OidcDevJsonRpcService.class);
-        jsonRpcService.hydrate(oidcDevUiRpcSvcPropertiesBean.getValue(), httpConfig);
+        jsonRpcService.hydrate(oidcDevUiRpcSvcPropertiesBean.getValue(), httpConfig.getValue());
     }
 
     public RuntimeValue<OidcDevUiRpcSvcPropertiesBean> getRpcServiceProperties(String authorizationUrl, String tokenUrl,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -23,6 +23,7 @@ import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.Oidc;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TenantIdentityProvider;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.annotations.RuntimeInit;
 import io.quarkus.runtime.annotations.StaticInit;
@@ -39,15 +40,23 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class OidcRecorder {
-
     public static final String ACR_VALUES_TO_MAX_AGE_SEPARATOR = "@#$%@";
+
     static final Logger LOG = Logger.getLogger(OidcRecorder.class);
 
-    public Supplier<DefaultTokenIntrospectionUserInfoCache> setupTokenCache(OidcConfig config, Supplier<Vertx> vertx) {
+    private final RuntimeValue<OidcConfig> oidcConfig;
+    private final RuntimeValue<SecurityConfig> securityConfig;
+
+    public OidcRecorder(final RuntimeValue<OidcConfig> oidcConfig, final RuntimeValue<SecurityConfig> securityConfig) {
+        this.oidcConfig = oidcConfig;
+        this.securityConfig = securityConfig;
+    }
+
+    public Supplier<DefaultTokenIntrospectionUserInfoCache> setupTokenCache(Supplier<Vertx> vertx) {
         return new Supplier<DefaultTokenIntrospectionUserInfoCache>() {
             @Override
             public DefaultTokenIntrospectionUserInfoCache get() {
-                return new DefaultTokenIntrospectionUserInfoCache(config, vertx.get());
+                return new DefaultTokenIntrospectionUserInfoCache(oidcConfig.getValue(), vertx.get());
             }
         };
     }
@@ -59,15 +68,14 @@ public class OidcRecorder {
 
     @RuntimeInit
     public Function<SyntheticCreationalContext<TenantConfigBean>, TenantConfigBean> createTenantConfigBean(
-            OidcConfig config, Supplier<Vertx> vertx, Supplier<TlsConfigurationRegistry> registry,
-            SecurityConfig securityConfig) {
+            Supplier<Vertx> vertx, Supplier<TlsConfigurationRegistry> registry) {
         return new Function<SyntheticCreationalContext<TenantConfigBean>, TenantConfigBean>() {
             @Override
             public TenantConfigBean apply(SyntheticCreationalContext<TenantConfigBean> ctx) {
-                final OidcImpl oidc = new OidcImpl(config);
+                final OidcImpl oidc = new OidcImpl(oidcConfig.getValue());
                 ctx.getInjectedReference(new TypeLiteral<Event<Oidc>>() {
                 }).fire(oidc);
-                return new TenantConfigBean(vertx.get(), registry.get(), oidc, securityConfig.events().enabled());
+                return new TenantConfigBean(vertx.get(), registry.get(), oidc, securityConfig.getValue().events().enabled());
             }
         };
     }

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -74,7 +74,6 @@ import io.quarkus.opentelemetry.runtime.OpenTelemetryRecorder;
 import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
 import io.quarkus.opentelemetry.runtime.config.build.ExporterType;
 import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig;
-import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 import io.quarkus.opentelemetry.runtime.tracing.cdi.AddingSpanAttributesInterceptor;
 import io.quarkus.opentelemetry.runtime.tracing.cdi.WithSpanInterceptor;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.InstrumentationRecorder;
@@ -138,7 +137,6 @@ public class OpenTelemetryProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void openTelemetryBean(OpenTelemetryRecorder recorder,
-            OTelRuntimeConfig oTelRuntimeConfig,
             OTelBuildConfig oTelBuildConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticProducer,
             BuildProducer<OpenTelemetrySdkBuildItem> openTelemetrySdkBuildItemBuildProducer) {
@@ -154,7 +152,7 @@ public class OpenTelemetryProcessor {
                                         DotName.createSimple(
                                                 AutoConfiguredOpenTelemetrySdkBuilderCustomizer.class.getName())) },
                                 null))
-                .createWith(recorder.opentelemetryBean(oTelRuntimeConfig))
+                .createWith(recorder.opentelemetryBean())
                 .destroyer(OpenTelemetryDestroyer.class)
                 .done());
 
@@ -172,7 +170,7 @@ public class OpenTelemetryProcessor {
                 .orElseGet(oTelBuildConfig::enabled);
 
         openTelemetrySdkBuildItemBuildProducer.produce(new OpenTelemetrySdkBuildItem(
-                tracingEnabled, metricsEnabled, loggingEnabled, recorder.isOtelSdkEnabled(oTelRuntimeConfig)));
+                tracingEnabled, metricsEnabled, loggingEnabled, recorder.isOtelSdkEnabled()));
     }
 
     @BuildStep
@@ -324,17 +322,14 @@ public class OpenTelemetryProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupVertx(InstrumentationRecorder recorder, BeanContainerBuildItem beanContainerBuildItem,
-            Capabilities capabilities, OTelBuildConfig config) {
+            Capabilities capabilities) {
         boolean sqlClientAvailable = capabilities.isPresent(Capability.REACTIVE_DB2_CLIENT)
                 || capabilities.isPresent(Capability.REACTIVE_MSSQL_CLIENT)
                 || capabilities.isPresent(Capability.REACTIVE_MYSQL_CLIENT)
                 || capabilities.isPresent(Capability.REACTIVE_ORACLE_CLIENT)
                 || capabilities.isPresent(Capability.REACTIVE_PG_CLIENT);
         boolean redisClientAvailable = capabilities.isPresent(Capability.REDIS_CLIENT);
-        recorder.setupVertxTracer(beanContainerBuildItem.getValue(),
-                sqlClientAvailable,
-                redisClientAvailable,
-                config);
+        recorder.setupVertxTracer(beanContainerBuildItem.getValue(), sqlClientAvailable, redisClientAvailable);
     }
 
     @BuildStep

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -26,9 +26,7 @@ import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig;
 import io.quarkus.opentelemetry.runtime.config.build.exporter.OtlpExporterBuildConfig;
-import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 import io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfigBuilder;
-import io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig;
 import io.quarkus.opentelemetry.runtime.exporter.otlp.OTelExporterRecorder;
 import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.LateBoundSpanProcessor;
 import io.quarkus.tls.TlsConfigurationRegistry;
@@ -94,9 +92,6 @@ public class OtlpExporterProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(TlsRegistryBuildItem.class)
     void createSpanProcessor(OTelExporterRecorder recorder,
-            OTelBuildConfig oTelBuildConfig,
-            OTelRuntimeConfig otelRuntimeConfig,
-            OtlpExporterRuntimeConfig exporterRuntimeConfig,
             CoreVertxBuildItem vertxBuildItem,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
@@ -113,8 +108,7 @@ public class OtlpExporterProcessor {
                 .addInjectionPoint(ParameterizedType.create(DotName.createSimple(Instance.class),
                         new Type[] { ClassType.create(DotName.createSimple(SpanExporter.class.getName())) }, null))
                 .addInjectionPoint(ClassType.create(DotName.createSimple(TlsConfigurationRegistry.class)))
-                .createWith(recorder.spanProcessorForOtlp(oTelBuildConfig, otelRuntimeConfig,
-                        exporterRuntimeConfig, vertxBuildItem.getVertx()))
+                .createWith(recorder.spanProcessorForOtlp(vertxBuildItem.getVertx()))
                 .done());
     }
 
@@ -125,8 +119,6 @@ public class OtlpExporterProcessor {
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             OTelExporterRecorder recorder,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
-            OTelRuntimeConfig otelRuntimeConfig,
-            OtlpExporterRuntimeConfig exporterRuntimeConfig,
             CoreVertxBuildItem vertxBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
 
@@ -150,8 +142,7 @@ public class OtlpExporterProcessor {
                 .addInjectionPoint(ParameterizedType.create(DotName.createSimple(Instance.class),
                         new Type[] { ClassType.create(DotName.createSimple(MetricExporter.class.getName())) }, null))
                 .addInjectionPoint(ClassType.create(DotName.createSimple(TlsConfigurationRegistry.class)))
-                .createWith(recorder.createMetricExporter(otelRuntimeConfig, exporterRuntimeConfig,
-                        vertxBuildItem.getVertx()))
+                .createWith(recorder.createMetricExporter(vertxBuildItem.getVertx()))
                 .done());
     }
 
@@ -162,8 +153,6 @@ public class OtlpExporterProcessor {
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             OTelExporterRecorder recorder,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
-            OTelRuntimeConfig otelRuntimeConfig,
-            OtlpExporterRuntimeConfig exporterRuntimeConfig,
             CoreVertxBuildItem vertxBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
 
@@ -187,8 +176,7 @@ public class OtlpExporterProcessor {
                 .addInjectionPoint(ParameterizedType.create(DotName.createSimple(Instance.class),
                         new Type[] { ClassType.create(DotName.createSimple(LogRecordExporter.class.getName())) }, null))
                 .addInjectionPoint(ClassType.create(DotName.createSimple(TlsConfigurationRegistry.class)))
-                .createWith(recorder.createLogRecordExporter(otelRuntimeConfig, exporterRuntimeConfig,
-                        vertxBuildItem.getVertx()))
+                .createWith(recorder.createLogRecordExporter(vertxBuildItem.getVertx()))
                 .done());
     }
 }

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/LogHandlerProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/LogHandlerProcessor.java
@@ -20,7 +20,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig;
-import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 import io.quarkus.opentelemetry.runtime.logs.OpenTelemetryLogRecorder;
 import io.quarkus.opentelemetry.runtime.logs.spi.LogsExporterCDIProvider;
 
@@ -47,9 +46,8 @@ class LogHandlerProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(OpenTelemetrySdkBuildItem.class)
     LogHandlerBuildItem build(OpenTelemetryLogRecorder recorder,
-            OTelRuntimeConfig config,
             BeanContainerBuildItem beanContainerBuildItem) {
-        return new LogHandlerBuildItem(recorder.initializeHandler(beanContainerBuildItem.getValue(), config));
+        return new LogHandlerBuildItem(recorder.initializeHandler(beanContainerBuildItem.getValue()));
     }
 
     public static class LogsEnabled implements BooleanSupplier {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogRecorder.java
@@ -11,14 +11,19 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class OpenTelemetryLogRecorder {
-    public RuntimeValue<Optional<Handler>> initializeHandler(final BeanContainer beanContainer,
-            final OTelRuntimeConfig config) {
-        if (config.sdkDisabled() || !config.logs().handlerEnabled()) {
+    private final RuntimeValue<OTelRuntimeConfig> runtimeConfig;
+
+    public OpenTelemetryLogRecorder(final RuntimeValue<OTelRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public RuntimeValue<Optional<Handler>> initializeHandler(final BeanContainer beanContainer) {
+        if (runtimeConfig.getValue().sdkDisabled() || !runtimeConfig.getValue().logs().handlerEnabled()) {
             return new RuntimeValue<>(Optional.empty());
         }
         final OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class);
         final OpenTelemetryLogHandler logHandler = new OpenTelemetryLogHandler(openTelemetry);
-        logHandler.setLevel(config.logs().level());
+        logHandler.setLevel(runtimeConfig.getValue().logs().level());
         return new RuntimeValue<>(Optional.of(logHandler));
     }
 }

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -62,7 +62,6 @@ import io.quarkus.quartz.runtime.QuarkusQuartzConnectionPoolProvider;
 import io.quarkus.quartz.runtime.QuartzBuildTimeConfig;
 import io.quarkus.quartz.runtime.QuartzExtensionPointConfig;
 import io.quarkus.quartz.runtime.QuartzRecorder;
-import io.quarkus.quartz.runtime.QuartzRuntimeConfig;
 import io.quarkus.quartz.runtime.QuartzSchedulerImpl;
 import io.quarkus.quartz.runtime.QuartzSupport;
 import io.quarkus.quartz.runtime.jdbc.QuarkusDBv8Delegate;
@@ -331,7 +330,7 @@ public class QuartzProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public void quartzSupportBean(QuartzRuntimeConfig runtimeConfig, QuartzBuildTimeConfig buildTimeConfig,
+    public void quartzSupportBean(
             QuartzRecorder recorder,
             QuartzJDBCDriverDialectBuildItem driverDialect,
             List<ScheduledBusinessMethodItem> scheduledMethods,
@@ -347,9 +346,7 @@ public class QuartzProcessor {
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(QuartzSupport.class)
                 .scope(Singleton.class) // this should be @ApplicationScoped but it fails for some reason
                 .setRuntimeInit()
-                .supplier(recorder.quartzSupportSupplier(runtimeConfig, buildTimeConfig, driverDialect.getDriver(),
-                        nonconcurrentMethods))
+                .supplier(recorder.quartzSupportSupplier(driverDialect.getDriver(), nonconcurrentMethods))
                 .done());
     }
-
 }

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRecorder.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRecorder.java
@@ -4,17 +4,26 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class QuartzRecorder {
+    private final QuartzBuildTimeConfig buildTimeConfig;
+    private final RuntimeValue<QuartzRuntimeConfig> runtimeConfig;
 
-    public Supplier<QuartzSupport> quartzSupportSupplier(QuartzRuntimeConfig runtimeConfig,
-            QuartzBuildTimeConfig buildTimeConfig, Optional<String> driverDialect, Set<String> nonconcurrentMethods) {
+    public QuartzRecorder(
+            final QuartzBuildTimeConfig buildTimeConfig,
+            final RuntimeValue<QuartzRuntimeConfig> runtimeConfig) {
+        this.buildTimeConfig = buildTimeConfig;
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<QuartzSupport> quartzSupportSupplier(Optional<String> driverDialect, Set<String> nonconcurrentMethods) {
         return new Supplier<QuartzSupport>() {
             @Override
             public QuartzSupport get() {
-                return new QuartzSupport(runtimeConfig, buildTimeConfig, driverDialect, nonconcurrentMethods);
+                return new QuartzSupport(runtimeConfig.getValue(), buildTimeConfig, driverDialect, nonconcurrentMethods);
             }
         };
     }

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
@@ -38,7 +38,6 @@ import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -55,9 +54,7 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.reactive.datasource.deployment.VertxPoolBuildItem;
 import io.quarkus.reactive.datasource.runtime.DataSourceReactiveBuildTimeConfig;
 import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveBuildTimeConfig;
-import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveRuntimeConfig;
 import io.quarkus.reactive.mssql.client.MSSQLPoolCreator;
-import io.quarkus.reactive.mssql.client.runtime.DataSourcesReactiveMSSQLConfig;
 import io.quarkus.reactive.mssql.client.runtime.MSSQLPoolRecorder;
 import io.quarkus.reactive.mssql.client.runtime.MSSQLPoolSupport;
 import io.quarkus.reactive.mssql.client.runtime.MsSQLServiceBindingConverter;
@@ -87,10 +84,8 @@ class ReactiveMSSQLClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
-            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig, DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
+            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveMSSQLConfig dataSourcesReactiveMSSQLConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
@@ -104,8 +99,7 @@ class ReactiveMSSQLClientProcessor {
                 continue;
             }
 
-            createPool(recorder, vertx, eventLoopCount, shutdown, msSQLPool, syntheticBeans, dataSourceName,
-                    dataSourcesRuntimeConfig, dataSourcesReactiveRuntimeConfig, dataSourcesReactiveMSSQLConfig);
+            createPool(recorder, vertx, eventLoopCount, shutdown, msSQLPool, syntheticBeans, dataSourceName);
 
             msSQLPoolNamesBuilder.add(dataSourceName);
         }
@@ -203,18 +197,10 @@ class ReactiveMSSQLClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<MSSQLPoolBuildItem> msSQLPool,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            String dataSourceName,
-            DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveMSSQLConfig dataSourcesReactiveMSSQLConfig) {
+            String dataSourceName) {
 
         Function<SyntheticCreationalContext<MSSQLPool>, MSSQLPool> poolFunction = recorder.configureMSSQLPool(vertx.getVertx(),
-                eventLoopCount.getEventLoopCount(),
-                dataSourceName,
-                dataSourcesRuntimeConfig,
-                dataSourcesReactiveRuntimeConfig,
-                dataSourcesReactiveMSSQLConfig,
-                shutdown);
+                eventLoopCount.getEventLoopCount(), dataSourceName, shutdown);
         msSQLPool.produce(new MSSQLPoolBuildItem(dataSourceName, poolFunction));
 
         ExtendedBeanConfigurator msSQLPoolBeanConfigurator = SyntheticBeanBuildItem.configure(MSSQLPool.class)

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
@@ -38,7 +38,6 @@ import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -55,9 +54,7 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.reactive.datasource.deployment.VertxPoolBuildItem;
 import io.quarkus.reactive.datasource.runtime.DataSourceReactiveBuildTimeConfig;
 import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveBuildTimeConfig;
-import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveRuntimeConfig;
 import io.quarkus.reactive.mysql.client.MySQLPoolCreator;
-import io.quarkus.reactive.mysql.client.runtime.DataSourcesReactiveMySQLConfig;
 import io.quarkus.reactive.mysql.client.runtime.MySQLPoolRecorder;
 import io.quarkus.reactive.mysql.client.runtime.MySQLPoolSupport;
 import io.quarkus.reactive.mysql.client.runtime.MySQLServiceBindingConverter;
@@ -87,10 +84,8 @@ class ReactiveMySQLClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
-            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig, DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
+            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveMySQLConfig dataSourcesReactiveMySQLConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
@@ -104,8 +99,7 @@ class ReactiveMySQLClientProcessor {
                 continue;
             }
 
-            createPool(recorder, vertx, eventLoopCount, shutdown, mySQLPool, syntheticBeans, dataSourceName,
-                    dataSourcesRuntimeConfig, dataSourcesReactiveRuntimeConfig, dataSourcesReactiveMySQLConfig);
+            createPool(recorder, vertx, eventLoopCount, shutdown, mySQLPool, syntheticBeans, dataSourceName);
 
             mySQLPoolNamesBuilder.add(dataSourceName);
         }
@@ -204,18 +198,10 @@ class ReactiveMySQLClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<MySQLPoolBuildItem> mySQLPool,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            String dataSourceName,
-            DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveMySQLConfig dataSourcesReactiveMySQLConfig) {
+            String dataSourceName) {
 
         Function<SyntheticCreationalContext<MySQLPool>, MySQLPool> poolFunction = recorder.configureMySQLPool(vertx.getVertx(),
-                eventLoopCount.getEventLoopCount(),
-                dataSourceName,
-                dataSourcesRuntimeConfig,
-                dataSourcesReactiveRuntimeConfig,
-                dataSourcesReactiveMySQLConfig,
-                shutdown);
+                eventLoopCount.getEventLoopCount(), dataSourceName, shutdown);
         mySQLPool.produce(new MySQLPoolBuildItem(dataSourceName, poolFunction));
 
         ExtendedBeanConfigurator mySQLPoolBeanConfigurator = SyntheticBeanBuildItem.configure(MySQLPool.class)

--- a/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
+++ b/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
@@ -38,7 +38,6 @@ import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -55,9 +54,7 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.reactive.datasource.deployment.VertxPoolBuildItem;
 import io.quarkus.reactive.datasource.runtime.DataSourceReactiveBuildTimeConfig;
 import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveBuildTimeConfig;
-import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveRuntimeConfig;
 import io.quarkus.reactive.oracle.client.OraclePoolCreator;
-import io.quarkus.reactive.oracle.client.runtime.DataSourcesReactiveOracleConfig;
 import io.quarkus.reactive.oracle.client.runtime.OraclePoolRecorder;
 import io.quarkus.reactive.oracle.client.runtime.OraclePoolSupport;
 import io.quarkus.reactive.oracle.client.runtime.OracleServiceBindingConverter;
@@ -87,10 +84,8 @@ class ReactiveOracleClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
-            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig, DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
+            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveOracleConfig dataSourcesReactiveOracleConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
@@ -104,8 +99,7 @@ class ReactiveOracleClientProcessor {
                 continue;
             }
 
-            createPool(recorder, vertx, eventLoopCount, shutdown, oraclePool, syntheticBeans, dataSourceName,
-                    dataSourcesRuntimeConfig, dataSourcesReactiveRuntimeConfig, dataSourcesReactiveOracleConfig);
+            createPool(recorder, vertx, eventLoopCount, shutdown, oraclePool, syntheticBeans, dataSourceName);
 
             oraclePoolNamesBuilder.add(dataSourceName);
         }
@@ -203,19 +197,10 @@ class ReactiveOracleClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<OraclePoolBuildItem> oraclePool,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            String dataSourceName,
-            DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveOracleConfig dataSourcesReactiveOracleConfig) {
+            String dataSourceName) {
 
-        Function<SyntheticCreationalContext<OraclePool>, OraclePool> poolFunction = recorder.configureOraclePool(
-                vertx.getVertx(),
-                eventLoopCount.getEventLoopCount(),
-                dataSourceName,
-                dataSourcesRuntimeConfig,
-                dataSourcesReactiveRuntimeConfig,
-                dataSourcesReactiveOracleConfig,
-                shutdown);
+        Function<SyntheticCreationalContext<OraclePool>, OraclePool> poolFunction = recorder
+                .configureOraclePool(vertx.getVertx(), eventLoopCount.getEventLoopCount(), dataSourceName, shutdown);
         oraclePool.produce(new OraclePoolBuildItem(dataSourceName, poolFunction));
 
         ExtendedBeanConfigurator oraclePoolBeanConfigurator = SyntheticBeanBuildItem.configure(OraclePool.class)

--- a/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
+++ b/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
@@ -14,7 +14,6 @@ import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
-import jakarta.inject.Inject;
 
 import org.jboss.logging.Logger;
 
@@ -51,12 +50,15 @@ public class OraclePoolRecorder {
 
     private final RuntimeValue<DataSourcesRuntimeConfig> runtimeConfig;
     private final RuntimeValue<DataSourcesReactiveRuntimeConfig> reactiveRuntimeConfig;
+    private final RuntimeValue<DataSourcesReactiveOracleConfig> reactiveOracleRuntimeConfig;
 
-    @Inject
-    public OraclePoolRecorder(RuntimeValue<DataSourcesRuntimeConfig> runtimeConfig,
-            RuntimeValue<DataSourcesReactiveRuntimeConfig> reactiveRuntimeConfig) {
+    public OraclePoolRecorder(
+            final RuntimeValue<DataSourcesRuntimeConfig> runtimeConfig,
+            final RuntimeValue<DataSourcesReactiveRuntimeConfig> reactiveRuntimeConfig,
+            final RuntimeValue<DataSourcesReactiveOracleConfig> reactiveOracleRuntimeConfig) {
         this.runtimeConfig = runtimeConfig;
         this.reactiveRuntimeConfig = reactiveRuntimeConfig;
+        this.reactiveOracleRuntimeConfig = reactiveOracleRuntimeConfig;
     }
 
     public Supplier<ActiveResult> poolCheckActiveSupplier(String dataSourceName) {
@@ -77,21 +79,16 @@ public class OraclePoolRecorder {
     }
 
     public Function<SyntheticCreationalContext<OraclePool>, OraclePool> configureOraclePool(RuntimeValue<Vertx> vertx,
-            Supplier<Integer> eventLoopCount,
-            String dataSourceName,
-            DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveOracleConfig dataSourcesReactiveOracleConfig,
-            ShutdownContext shutdown) {
+            Supplier<Integer> eventLoopCount, String dataSourceName, ShutdownContext shutdown) {
         return new Function<>() {
             @Override
             public OraclePool apply(SyntheticCreationalContext<OraclePool> context) {
                 OraclePool pool = initialize((VertxInternal) vertx.getValue(),
                         eventLoopCount.get(),
                         dataSourceName,
-                        dataSourcesRuntimeConfig.dataSources().get(dataSourceName),
-                        dataSourcesReactiveRuntimeConfig.dataSources().get(dataSourceName).reactive(),
-                        dataSourcesReactiveOracleConfig.dataSources().get(dataSourceName).reactive().oracle(),
+                        runtimeConfig.getValue().dataSources().get(dataSourceName),
+                        reactiveRuntimeConfig.getValue().dataSources().get(dataSourceName).reactive(),
+                        reactiveOracleRuntimeConfig.getValue().dataSources().get(dataSourceName).reactive().oracle(),
                         context);
 
                 shutdown.addShutdownTask(pool::close);

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
@@ -38,7 +38,6 @@ import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
-import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -56,9 +55,7 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.reactive.datasource.deployment.VertxPoolBuildItem;
 import io.quarkus.reactive.datasource.runtime.DataSourceReactiveBuildTimeConfig;
 import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveBuildTimeConfig;
-import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveRuntimeConfig;
 import io.quarkus.reactive.pg.client.PgPoolCreator;
-import io.quarkus.reactive.pg.client.runtime.DataSourcesReactivePostgreSQLConfig;
 import io.quarkus.reactive.pg.client.runtime.PgPoolRecorder;
 import io.quarkus.reactive.pg.client.runtime.PgPoolSupport;
 import io.quarkus.reactive.pg.client.runtime.PostgreSQLServiceBindingConverter;
@@ -99,10 +96,8 @@ class ReactivePgClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
-            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig, DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
+            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactivePostgreSQLConfig dataSourcesReactivePostgreSQLConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
@@ -116,8 +111,7 @@ class ReactivePgClientProcessor {
                 continue;
             }
 
-            createPool(recorder, vertx, eventLoopCount, shutdown, pgPool, syntheticBeans, dataSourceName,
-                    dataSourcesRuntimeConfig, dataSourcesReactiveRuntimeConfig, dataSourcesReactivePostgreSQLConfig);
+            createPool(recorder, vertx, eventLoopCount, shutdown, pgPool, syntheticBeans, dataSourceName);
 
             pgPoolNamesBuilder.add(dataSourceName);
         }
@@ -209,18 +203,10 @@ class ReactivePgClientProcessor {
             ShutdownContextBuildItem shutdown,
             BuildProducer<PgPoolBuildItem> pgPool,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            String dataSourceName,
-            DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
-            DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactivePostgreSQLConfig dataSourcesReactivePostgreSQLConfig) {
+            String dataSourceName) {
 
         Function<SyntheticCreationalContext<PgPool>, PgPool> poolFunction = recorder.configurePgPool(vertx.getVertx(),
-                eventLoopCount.getEventLoopCount(),
-                dataSourceName,
-                dataSourcesRuntimeConfig,
-                dataSourcesReactiveRuntimeConfig,
-                dataSourcesReactivePostgreSQLConfig,
-                shutdown);
+                eventLoopCount.getEventLoopCount(), dataSourceName, shutdown);
         pgPool.produce(new PgPoolBuildItem(dataSourceName, poolFunction));
 
         ExtendedBeanConfigurator pgPoolBeanConfigurator = SyntheticBeanBuildItem.configure(PgPool.class)

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientProcessor.java
@@ -124,7 +124,6 @@ public class RedisClientProcessor {
             BeanDiscoveryFinishedBuildItem beans,
             ShutdownContextBuildItem shutdown,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            RedisConfig config,
             VertxBuildItem vertxBuildItem,
             ApplicationArchivesBuildItem applicationArchivesBuildItem, LaunchModeBuildItem launchMode,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
@@ -11,10 +11,9 @@ import io.smallrye.config.WithParentName;
 @ConfigMapping(prefix = "quarkus.redis")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface RedisConfig {
-
-    public final static String REDIS_CONFIG_ROOT_NAME = "redis";
-    public final static String HOSTS_CONFIG_NAME = "hosts";
-    public static final String DEFAULT_CLIENT_NAME = "<default>";
+    String REDIS_CONFIG_ROOT_NAME = "redis";
+    String HOSTS_CONFIG_NAME = "hosts";
+    String DEFAULT_CLIENT_NAME = "<default>";
 
     /**
      * The default redis client

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -31,7 +31,6 @@ import io.quarkus.resteasy.runtime.AuthenticationCompletionExceptionMapper;
 import io.quarkus.resteasy.runtime.AuthenticationFailedExceptionMapper;
 import io.quarkus.resteasy.runtime.AuthenticationRedirectExceptionMapper;
 import io.quarkus.resteasy.runtime.NonJaxRsClassMappings;
-import io.quarkus.resteasy.runtime.ResteasyVertxConfig;
 import io.quarkus.resteasy.runtime.standalone.ResteasyStandaloneRecorder;
 import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentBuildItem;
 import io.quarkus.security.AuthenticationCompletionException;
@@ -96,7 +95,6 @@ public class ResteasyStandaloneBuildStep {
             Optional<RequireVirtualHttpBuildItem> requireVirtual,
             Optional<NonJaxRsClassBuildItem> nonJaxRsClassBuildItem,
             ExecutorBuildItem executorBuildItem,
-            ResteasyVertxConfig resteasyVertxConfig,
             VertxHttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
 
         if (standalone == null) {
@@ -110,8 +108,8 @@ public class ResteasyStandaloneBuildStep {
         if (nonJaxRsClassBuildItem.isPresent()) {
             nonJaxRsClassNameToMethodPaths = nonJaxRsClassBuildItem.get().nonJaxRsPaths;
         }
-        Handler<RoutingContext> handler = recorder.vertxRequestHandler(vertx.getVertx(),
-                executorBuildItem.getExecutorProxy(), nonJaxRsClassNameToMethodPaths, resteasyVertxConfig, httpBuildTimeConfig);
+        Handler<RoutingContext> handler = recorder.vertxRequestHandler(vertx.getVertx(), executorBuildItem.getExecutorProxy(),
+                nonJaxRsClassNameToMethodPaths);
 
         final boolean noCustomAuthCompletionExMapper;
         final boolean noCustomAuthFailureExMapper;
@@ -133,8 +131,8 @@ public class ResteasyStandaloneBuildStep {
         // we add the failure handler right before QuarkusErrorHandler
         // so that user can define failure handlers that precede exception mappers
         final Handler<RoutingContext> failureHandler = recorder.vertxFailureHandler(vertx.getVertx(),
-                executorBuildItem.getExecutorProxy(), resteasyVertxConfig, noCustomAuthCompletionExMapper,
-                noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, httpBuildTimeConfig.auth().proactive());
+                executorBuildItem.getExecutorProxy(), noCustomAuthCompletionExMapper, noCustomAuthFailureExMapper,
+                noCustomAuthRedirectExMapper);
         filterBuildItemBuildProducer.produce(FilterBuildItem.ofAuthenticationFailureHandler(failureHandler));
 
         // Exact match for resources matched to the root path

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -179,7 +179,6 @@ import io.quarkus.resteasy.reactive.server.runtime.QuarkusServerPathBodyHandler;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveInitialiser;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRuntimeRecorder;
-import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveServerRuntimeConfig;
 import io.quarkus.resteasy.reactive.server.runtime.StandardSecurityCheckInterceptor;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationCompletionExceptionMapper;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationFailedExceptionMapper;
@@ -1707,13 +1706,12 @@ public class ResteasyReactiveProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public void runtimeConfiguration(ResteasyReactiveRuntimeRecorder recorder,
             Optional<ResteasyReactiveDeploymentBuildItem> deployment,
-            ResteasyReactiveServerRuntimeConfig resteasyReactiveServerRuntimeConf,
             BuildProducer<HandlerConfigurationProviderBuildItem> producer) {
         if (deployment.isEmpty()) {
             return;
         }
         producer.produce(new HandlerConfigurationProviderBuildItem(RuntimeConfiguration.class,
-                recorder.runtimeConfiguration(deployment.get().getDeployment(), resteasyReactiveServerRuntimeConf)));
+                recorder.runtimeConfiguration(deployment.get().getDeployment())));
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
@@ -17,28 +17,33 @@ import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 @Recorder
 public class ResteasyReactiveRuntimeRecorder {
 
-    final VertxHttpConfig httpConfig;
+    private final RuntimeValue<ResteasyReactiveServerRuntimeConfig> runtimeConfig;
+    private final RuntimeValue<VertxHttpConfig> httpRuntimeConfig;
 
-    public ResteasyReactiveRuntimeRecorder(VertxHttpConfig httpConfig) {
-        this.httpConfig = httpConfig;
+    public ResteasyReactiveRuntimeRecorder(
+            final RuntimeValue<ResteasyReactiveServerRuntimeConfig> runtimeConfig,
+            final RuntimeValue<VertxHttpConfig> httpRuntimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+        this.httpRuntimeConfig = httpRuntimeConfig;
     }
 
-    public Supplier<RuntimeConfiguration> runtimeConfiguration(RuntimeValue<Deployment> deployment,
-            ResteasyReactiveServerRuntimeConfig runtimeConf) {
-        Optional<Long> maxBodySize;
+    public Supplier<RuntimeConfiguration> runtimeConfiguration(RuntimeValue<Deployment> deployment) {
+        ResteasyReactiveServerRuntimeConfig runtimeConfig = this.runtimeConfig.getValue();
+        VertxHttpConfig httpRuntimeConfig = this.httpRuntimeConfig.getValue();
 
-        if (httpConfig.limits().maxBodySize().isPresent()) {
-            maxBodySize = Optional.of(httpConfig.limits().maxBodySize().get().asLongValue());
+        Optional<Long> maxBodySize;
+        if (httpRuntimeConfig.limits().maxBodySize().isPresent()) {
+            maxBodySize = Optional.of(httpRuntimeConfig.limits().maxBodySize().get().asLongValue());
         } else {
             maxBodySize = Optional.empty();
         }
 
-        RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpConfig.readTimeout(),
-                httpConfig.body().deleteUploadedFilesOnEnd(), httpConfig.body().uploadsDirectory(),
-                httpConfig.body().multipart().fileContentTypes().orElse(null),
-                runtimeConf.multipart().inputPart().defaultCharset(), maxBodySize,
-                httpConfig.limits().maxFormAttributeSize().asLongValue(),
-                httpConfig.limits().maxParameters());
+        RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpRuntimeConfig.readTimeout(),
+                httpRuntimeConfig.body().deleteUploadedFilesOnEnd(), httpRuntimeConfig.body().uploadsDirectory(),
+                httpRuntimeConfig.body().multipart().fileContentTypes().orElse(null),
+                runtimeConfig.multipart().inputPart().defaultCharset(), maxBodySize,
+                httpRuntimeConfig.limits().maxFormAttributeSize().asLongValue(),
+                httpRuntimeConfig.limits().maxParameters());
 
         deployment.getValue().setRuntimeConfiguration(runtimeConfiguration);
 

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -361,10 +361,14 @@ public class SchedulerProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public FeatureBuildItem build(SchedulerConfig config, BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            SchedulerRecorder recorder, List<ScheduledBusinessMethodItem> scheduledMethods,
-            BuildProducer<GeneratedClassBuildItem> generatedClasses, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            AnnotationProxyBuildItem annotationProxy, List<ForceStartSchedulerBuildItem> schedulerForcedStartItems,
+    public FeatureBuildItem build(
+            SchedulerRecorder recorder,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
+            List<ScheduledBusinessMethodItem> scheduledMethods,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            AnnotationProxyBuildItem annotationProxy,
+            List<ForceStartSchedulerBuildItem> schedulerForcedStartItems,
             DiscoveredImplementationsBuildItem discoveredImplementations) {
 
         List<MutableScheduledMethod> scheduledMetadata = new ArrayList<>();
@@ -399,7 +403,7 @@ public class SchedulerProcessor {
         }
 
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(SchedulerContext.class).setRuntimeInit()
-                .supplier(recorder.createContext(config, scheduledMetadata, !schedulerForcedStartItems.isEmpty(),
+                .supplier(recorder.createContext(scheduledMetadata, !schedulerForcedStartItems.isEmpty(),
                         discoveredImplementations.getAutoImplementation()))
                 .done());
 

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRecorder.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRecorder.java
@@ -15,9 +15,14 @@ import io.quarkus.scheduler.common.runtime.SchedulerContext;
 
 @Recorder
 public class SchedulerRecorder {
+    private final SchedulerConfig schedulerConfig;
 
-    public Supplier<Object> createContext(SchedulerConfig config,
-            List<MutableScheduledMethod> scheduledMethods, boolean forceSchedulerStart, String autoImplementation) {
+    public SchedulerRecorder(final SchedulerConfig schedulerConfig) {
+        this.schedulerConfig = schedulerConfig;
+    }
+
+    public Supplier<Object> createContext(List<MutableScheduledMethod> scheduledMethods, boolean forceSchedulerStart,
+            String autoImplementation) {
         // Defensive design - make an immutable copy of the scheduled method metadata
         List<ScheduledMethod> metadata = immutableCopy(scheduledMethods);
         return new Supplier<Object>() {
@@ -27,7 +32,7 @@ public class SchedulerRecorder {
 
                     @Override
                     public CronType getCronType() {
-                        return config.cronType();
+                        return schedulerConfig.cronType();
                     }
 
                     @Override

--- a/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
+++ b/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
@@ -50,7 +50,6 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientBuildConfig;
 import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientCertificateUpdateEventListener;
 import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientSupport;
-import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientsConfig;
 import io.quarkus.smallrye.graphql.client.runtime.SmallRyeGraphQLClientRecorder;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.smallrye.graphql.client.model.ClientModelBuilder;
@@ -200,7 +199,6 @@ public class SmallRyeGraphQLClientProcessor {
     @Record(RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     GraphQLClientConfigInitializedBuildItem mergeClientConfigurations(SmallRyeGraphQLClientRecorder recorder,
-            GraphQLClientsConfig quarkusConfig,
             BeanArchiveIndexBuildItem index) {
         // to store config keys of all clients found in the application code
         List<String> knownConfigKeys = new ArrayList<>();
@@ -226,7 +224,7 @@ public class SmallRyeGraphQLClientProcessor {
         support.setShortNamesToQualifiedNamesMapping(shortNamesToQualifiedNames);
         support.setKnownConfigKeys(knownConfigKeys);
 
-        recorder.mergeClientConfigurations(support, quarkusConfig);
+        recorder.mergeClientConfigurations(support);
         return new GraphQLClientConfigInitializedBuildItem();
     }
 

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
@@ -30,8 +30,13 @@ import io.vertx.core.Vertx;
 
 @Recorder
 public class SmallRyeGraphQLClientRecorder {
-
     private final Logger logger = Logger.getLogger(SmallRyeGraphQLClientRecorder.class);
+
+    private final RuntimeValue<GraphQLClientsConfig> runtimeConfig;
+
+    public SmallRyeGraphQLClientRecorder(final RuntimeValue<GraphQLClientsConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public <T> Function<SyntheticCreationalContext<T>, T> typesafeClientSupplier(Class<T> targetClassName) {
         return new Function<>() {
@@ -57,9 +62,9 @@ public class SmallRyeGraphQLClientRecorder {
         configBean.addTypesafeClientApis(classes);
     }
 
-    public void mergeClientConfigurations(GraphQLClientSupport support, GraphQLClientsConfig quarkusConfiguration) {
+    public void mergeClientConfigurations(GraphQLClientSupport support) {
         GraphQLClientsConfiguration upstreamConfigs = GraphQLClientsConfiguration.getInstance();
-        for (Map.Entry<String, GraphQLClientConfig> client : quarkusConfiguration.clients().entrySet()) {
+        for (Map.Entry<String, GraphQLClientConfig> client : runtimeConfig.getValue().clients().entrySet()) {
             // the raw config key provided in the config, this might be a short class name,
             // so translate that into the fully qualified name if applicable
             String rawConfigKey = client.getKey();

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -69,7 +69,6 @@ import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLConfig;
 import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLConfigMapping;
 import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLLocaleResolver;
 import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLRecorder;
-import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLRuntimeConfig;
 import io.quarkus.vertx.http.deployment.BodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
@@ -367,8 +366,7 @@ public class SmallRyeGraphQLProcessor {
         if (graphQLDevUILogBuildItem.isPresent()) {
             publisher = Optional.of(graphQLDevUILogBuildItem.get().getPublisher());
         }
-        RuntimeValue<Boolean> initialized = recorder.createExecutionService(beanContainer.getValue(), schema, graphQLConfig,
-                publisher);
+        RuntimeValue<Boolean> initialized = recorder.createExecutionService(beanContainer.getValue(), schema, publisher);
         graphQLInitializedProducer.produce(new SmallRyeGraphQLInitializedBuildItem(initialized));
 
         // Make sure the complex object from the application can work in native mode
@@ -838,7 +836,6 @@ public class SmallRyeGraphQLProcessor {
     void registerGraphQLUiHandler(
             BuildProducer<RouteBuildItem> routeProducer,
             SmallRyeGraphQLRecorder recorder,
-            SmallRyeGraphQLRuntimeConfig runtimeConfig,
             LaunchModeBuildItem launchMode,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             SmallRyeGraphQLConfig graphQLConfig,
@@ -856,7 +853,7 @@ public class SmallRyeGraphQLProcessor {
                     .produce(new SmallRyeGraphQLBuildItem(result.getFinalDestination(), graphQLUiPath));
 
             Handler<RoutingContext> handler = recorder.uiHandler(result.getFinalDestination(),
-                    graphQLUiPath, result.getWebRootConfigurations(), runtimeConfig, shutdownContext);
+                    graphQLUiPath, result.getWebRootConfigurations(), shutdownContext);
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .route(graphQLConfig.ui().rootPath())
                     .displayOnNotFoundPage("GraphQL UI")

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -27,14 +27,21 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class SmallRyeGraphQLRecorder {
+    private final SmallRyeGraphQLConfig graphQLConfig;
+    private final RuntimeValue<SmallRyeGraphQLRuntimeConfig> runtimeConfig;
+
+    public SmallRyeGraphQLRecorder(
+            final SmallRyeGraphQLConfig graphQLConfig,
+            final RuntimeValue<SmallRyeGraphQLRuntimeConfig> runtimeConfig) {
+        this.graphQLConfig = graphQLConfig;
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public RuntimeValue<SubmissionPublisher<String>> createTraficLogPublisher() {
         return new RuntimeValue<>(new SubmissionPublisher<>());
     }
 
-    public RuntimeValue<Boolean> createExecutionService(BeanContainer beanContainer,
-            Schema schema,
-            SmallRyeGraphQLConfig graphQLConfig,
+    public RuntimeValue<Boolean> createExecutionService(BeanContainer beanContainer, Schema schema,
             Optional<RuntimeValue<SubmissionPublisher<String>>> publisher) {
         GraphQLProducer graphQLProducer = beanContainer.beanInstance(GraphQLProducer.class);
         if (graphQLConfig.extraScalars().isPresent()) {
@@ -95,9 +102,9 @@ public class SmallRyeGraphQLRecorder {
 
     public Handler<RoutingContext> uiHandler(String graphqlUiFinalDestination,
             String graphqlUiPath, List<FileSystemStaticHandler.StaticWebRootConfiguration> webRootConfigurations,
-            SmallRyeGraphQLRuntimeConfig runtimeConfig, ShutdownContext shutdownContext) {
+            ShutdownContext shutdownContext) {
 
-        if (runtimeConfig.enable()) {
+        if (runtimeConfig.getValue().enable()) {
             WebJarStaticHandler handler = new WebJarStaticHandler(graphqlUiFinalDestination, graphqlUiPath,
                     webRootConfigurations);
             shutdownContext.addShutdownTask(new ShutdownContext.CloseRunnable(handler));

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -55,11 +55,9 @@ import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.smallrye.health.runtime.QuarkusAsyncHealthCheckFactory;
 import io.quarkus.smallrye.health.runtime.ShutdownReadinessCheck;
 import io.quarkus.smallrye.health.runtime.ShutdownReadinessListener;
-import io.quarkus.smallrye.health.runtime.SmallRyeHealthBuildFixedConfig;
 import io.quarkus.smallrye.health.runtime.SmallRyeHealthGroupHandler;
 import io.quarkus.smallrye.health.runtime.SmallRyeHealthHandler;
 import io.quarkus.smallrye.health.runtime.SmallRyeHealthRecorder;
-import io.quarkus.smallrye.health.runtime.SmallRyeHealthRuntimeConfig;
 import io.quarkus.smallrye.health.runtime.SmallRyeIndividualHealthGroupHandler;
 import io.quarkus.smallrye.health.runtime.SmallRyeLivenessHandler;
 import io.quarkus.smallrye.health.runtime.SmallRyeReadinessHandler;
@@ -417,7 +415,6 @@ class SmallRyeHealthProcessor {
     void registerHealthUiHandler(
             BuildProducer<RouteBuildItem> routeProducer,
             SmallRyeHealthRecorder recorder,
-            SmallRyeHealthRuntimeConfig runtimeConfig,
             WebJarResultsBuildItem webJarResultsBuildItem,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             LaunchModeBuildItem launchMode,
@@ -434,7 +431,7 @@ class SmallRyeHealthProcessor {
                     .produce(new SmallRyeHealthBuildItem(result.getFinalDestination(), healthUiPath));
 
             Handler<RoutingContext> handler = recorder.uiHandler(result.getFinalDestination(),
-                    healthUiPath, result.getWebRootConfigurations(), runtimeConfig, shutdownContext);
+                    healthUiPath, result.getWebRootConfigurations(), shutdownContext);
 
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .management(CONFIG_KEY_HEALTH_MANAGEMENT_ENABLED)
@@ -455,12 +452,8 @@ class SmallRyeHealthProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
-    void processSmallRyeHealthRuntimeConfig(
-            SmallRyeHealthRecorder recorder,
-            SmallRyeHealthRuntimeConfig runtimeConfig,
-            SmallRyeHealthBuildFixedConfig buildFixedConfig) {
-
-        recorder.processSmallRyeHealthRuntimeConfiguration(runtimeConfig, buildFixedConfig);
+    void processSmallRyeHealthRuntimeConfig(SmallRyeHealthRecorder recorder) {
+        recorder.processSmallRyeHealthRuntimeConfiguration();
     }
 
     // Replace health URL in static files

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -106,7 +106,6 @@ import io.quarkus.smallrye.openapi.deployment.spi.OpenApiDocumentBuildItem;
 import io.quarkus.smallrye.openapi.runtime.OpenApiConstants;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService;
 import io.quarkus.smallrye.openapi.runtime.OpenApiRecorder;
-import io.quarkus.smallrye.openapi.runtime.OpenApiRuntimeConfig;
 import io.quarkus.smallrye.openapi.runtime.filter.AutoBasicSecurityFilter;
 import io.quarkus.smallrye.openapi.runtime.filter.AutoBearerTokenSecurityFilter;
 import io.quarkus.smallrye.openapi.runtime.filter.AutoSecurityFilter;
@@ -255,7 +254,6 @@ public class SmallRyeOpenApiProcessor {
             BuildProducer<SystemPropertyBuildItem> systemProperties,
             OpenApiRecorder recorder,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            OpenApiRuntimeConfig openApiRuntimeConfig,
             ShutdownContextBuildItem shutdownContext,
             SmallRyeOpenApiConfig openApiConfig,
             List<FilterBuildItem> filterBuildItems,
@@ -275,7 +273,7 @@ public class SmallRyeOpenApiProcessor {
             recorder.setupClDevMode(shutdownContext);
         }
 
-        Handler<RoutingContext> handler = recorder.handler(openApiRuntimeConfig);
+        Handler<RoutingContext> handler = recorder.handler();
 
         Consumer<Route> corsFilter = null;
         // Add CORS filter if the path is not attached to main root

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -17,10 +17,13 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class OpenApiRecorder {
+    private final RuntimeValue<OpenApiRuntimeConfig> openApiConfig;
+    private final RuntimeValue<VertxHttpConfig> httpConfig;
 
-    final RuntimeValue<VertxHttpConfig> httpConfig;
-
-    public OpenApiRecorder(RuntimeValue<VertxHttpConfig> httpConfig) {
+    public OpenApiRecorder(
+            final RuntimeValue<OpenApiRuntimeConfig> openApiConfig,
+            final RuntimeValue<VertxHttpConfig> httpConfig) {
+        this.openApiConfig = openApiConfig;
         this.httpConfig = httpConfig;
     }
 
@@ -36,8 +39,8 @@ public class OpenApiRecorder {
         return null;
     }
 
-    public Handler<RoutingContext> handler(OpenApiRuntimeConfig runtimeConfig) {
-        if (runtimeConfig.enable()) {
+    public Handler<RoutingContext> handler() {
+        if (openApiConfig.getValue().enable()) {
             return new OpenApiHandler();
         } else {
             return new OpenApiNotFoundHandler();

--- a/extensions/smallrye-stork/deployment/src/main/java/io/quarkus/stork/deployment/SmallRyeStorkProcessor.java
+++ b/extensions/smallrye-stork/deployment/src/main/java/io/quarkus/stork/deployment/SmallRyeStorkProcessor.java
@@ -22,7 +22,6 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.stork.SmallRyeStorkRecorder;
 import io.quarkus.stork.StorkConfigProvider;
-import io.quarkus.stork.StorkConfiguration;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 import io.smallrye.stork.spi.LoadBalancerProvider;
 import io.smallrye.stork.spi.ServiceDiscoveryProvider;
@@ -87,9 +86,8 @@ public class SmallRyeStorkProcessor {
     @Consume(AlwaysBuildItem.class)
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
-    void initializeStork(SmallRyeStorkRecorder storkRecorder, ShutdownContextBuildItem shutdown, VertxBuildItem vertx,
-            StorkConfiguration configuration) {
-        storkRecorder.initialize(shutdown, vertx.getVertx(), configuration);
+    void initializeStork(SmallRyeStorkRecorder storkRecorder, ShutdownContextBuildItem shutdown, VertxBuildItem vertx) {
+        storkRecorder.initialize(shutdown, vertx.getVertx());
     }
 
     private static final class AlwaysBuildItem extends EmptyBuildItem {

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRecorder.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRecorder.java
@@ -15,9 +15,14 @@ import io.vertx.core.Vertx;
 
 @Recorder
 public class SmallRyeStorkRecorder {
+    private final RuntimeValue<StorkConfiguration> runtimeConfig;
 
-    public void initialize(ShutdownContext shutdown, RuntimeValue<Vertx> vertx, StorkConfiguration configuration) {
-        List<ServiceConfig> serviceConfigs = StorkConfigUtil.toStorkServiceConfig(configuration);
+    public SmallRyeStorkRecorder(final RuntimeValue<StorkConfiguration> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public void initialize(ShutdownContext shutdown, RuntimeValue<Vertx> vertx) {
+        List<ServiceConfig> serviceConfigs = StorkConfigUtil.toStorkServiceConfig(runtimeConfig.getValue());
         StorkConfigProvider.init(serviceConfigs);
         Instance<ObservationCollector> instance = CDI.current().select(ObservationCollector.class);
         if (instance.isResolvable()) {

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -32,7 +32,6 @@ import io.quarkus.maven.dependency.GACT;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
-import io.quarkus.swaggerui.runtime.SwaggerUiRuntimeConfig;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
@@ -144,7 +143,6 @@ public class SwaggerUiProcessor {
             BuildProducer<RouteBuildItem> routes,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             WebJarResultsBuildItem webJarResultsBuildItem,
-            SwaggerUiRuntimeConfig runtimeConfig,
             LaunchModeBuildItem launchMode,
             SwaggerUiConfig swaggerUiConfig,
             BuildProducer<SwaggerUiBuildItem> swaggerUiBuildProducer,
@@ -159,9 +157,8 @@ public class SwaggerUiProcessor {
             String swaggerUiPath = nonApplicationRootPathBuildItem.resolvePath(swaggerUiConfig.path());
             swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(result.getFinalDestination(), swaggerUiPath));
 
-            Handler<RoutingContext> handler = recorder.handler(result.getFinalDestination(),
-                    swaggerUiPath, result.getWebRootConfigurations(),
-                    runtimeConfig, shutdownContext);
+            Handler<RoutingContext> handler = recorder.handler(result.getFinalDestination(), swaggerUiPath,
+                    result.getWebRootConfigurations(), shutdownContext);
 
             routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .management("quarkus.smallrye-openapi.management.enabled")

--- a/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiRecorder.java
+++ b/extensions/swagger-ui/runtime/src/main/java/io/quarkus/swaggerui/runtime/SwaggerUiRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.swaggerui.runtime;
 
 import java.util.List;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.devmode.FileSystemStaticHandler;
@@ -12,12 +13,15 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class SwaggerUiRecorder {
+    private final RuntimeValue<SwaggerUiRuntimeConfig> runtimeConfig;
+
+    public SwaggerUiRecorder(final RuntimeValue<SwaggerUiRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public Handler<RoutingContext> handler(String swaggerUiFinalDestination, String swaggerUiPath,
-            List<FileSystemStaticHandler.StaticWebRootConfiguration> webRootConfigurations,
-            SwaggerUiRuntimeConfig runtimeConfig, ShutdownContext shutdownContext) {
-
-        if (runtimeConfig.enable()) {
+            List<FileSystemStaticHandler.StaticWebRootConfiguration> webRootConfigurations, ShutdownContext shutdownContext) {
+        if (runtimeConfig.getValue().enable()) {
             WebJarStaticHandler handler = new WebJarStaticHandler(swaggerUiFinalDestination, swaggerUiPath,
                     webRootConfigurations);
             shutdownContext.addShutdownTask(new ShutdownContext.CloseRunnable(handler));

--- a/extensions/tls-registry/deployment/src/main/java/io/quarkus/tls/deployment/CertificatesProcessor.java
+++ b/extensions/tls-registry/deployment/src/main/java/io/quarkus/tls/deployment/CertificatesProcessor.java
@@ -27,7 +27,6 @@ import io.quarkus.tls.runtime.CertificateRecorder;
 import io.quarkus.tls.runtime.KeyStoreProvider;
 import io.quarkus.tls.runtime.LetsEncryptRecorder;
 import io.quarkus.tls.runtime.TrustStoreProvider;
-import io.quarkus.tls.runtime.config.TlsConfig;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
 import io.smallrye.common.annotation.Identifier;
@@ -45,7 +44,7 @@ public class CertificatesProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public TlsRegistryBuildItem initializeCertificate(TlsConfig config,
+    public TlsRegistryBuildItem initializeCertificate(
             Optional<VertxBuildItem> vertx,
             BeanDiscoveryFinishedBuildItem beadDiscovery,
             CertificateRecorder recorder,
@@ -55,7 +54,7 @@ public class CertificatesProcessor {
 
         if (vertx.isPresent()) {
             var providerBucketNames = getProviderBucketNames(beadDiscovery);
-            recorder.validateCertificates(providerBucketNames, config, vertx.get().getVertx(), shutdown);
+            recorder.validateCertificates(providerBucketNames, vertx.get().getVertx(), shutdown);
         }
 
         for (TlsCertificateBuildItem certificate : otherCertificates) {

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -117,7 +117,6 @@ import io.quarkus.undertow.runtime.HttpSessionContext;
 import io.quarkus.undertow.runtime.QuarkusIdentityManager;
 import io.quarkus.undertow.runtime.ServletHttpSecurityPolicy;
 import io.quarkus.undertow.runtime.ServletProducer;
-import io.quarkus.undertow.runtime.ServletRuntimeConfig;
 import io.quarkus.undertow.runtime.ServletSecurityInfoProxy;
 import io.quarkus.undertow.runtime.ServletSecurityInfoSubstitution;
 import io.quarkus.undertow.runtime.UndertowDeploymentRecorder;
@@ -180,25 +179,23 @@ public class UndertowBuildStep {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public ServiceStartBuildItem boot(UndertowDeploymentRecorder recorder,
+    public ServiceStartBuildItem boot(
+            UndertowDeploymentRecorder recorder,
             ServletDeploymentManagerBuildItem servletDeploymentManagerBuildItem,
             List<HttpHandlerWrapperBuildItem> wrappers,
             ShutdownContextBuildItem shutdown,
             Consumer<DefaultRouteBuildItem> undertowProducer,
             BuildProducer<RouteBuildItem> routeProducer,
             ExecutorBuildItem executorBuildItem,
-            ServletRuntimeConfig servletRuntimeConfig,
             ServletContextPathBuildItem servletContextPathBuildItem,
-            Capabilities capabilities,
-            VertxHttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
+            Capabilities capabilities) throws Exception {
 
         if (capabilities.isPresent(Capability.SECURITY)) {
             recorder.setupSecurity(servletDeploymentManagerBuildItem.getDeploymentManager());
         }
         Handler<RoutingContext> ut = recorder.startUndertow(shutdown, executorBuildItem.getExecutorProxy(),
                 servletDeploymentManagerBuildItem.getDeploymentManager(),
-                wrappers.stream().map(HttpHandlerWrapperBuildItem::getValue).collect(Collectors.toList()),
-                servletRuntimeConfig, httpBuildTimeConfig);
+                wrappers.stream().map(HttpHandlerWrapperBuildItem::getValue).collect(Collectors.toList()));
 
         if (servletContextPathBuildItem.getServletContextPath().equals("/")) {
             undertowProducer.accept(new DefaultRouteBuildItem(ut));

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
@@ -22,7 +22,6 @@ import io.quarkus.devui.runtime.logstream.MutinyLogHandler;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.runtime.RuntimeValue;
-import io.quarkus.runtime.logging.LogBuildTimeConfig;
 
 /**
  * Processor for Log stream in Dev UI
@@ -42,13 +41,9 @@ public class LogStreamProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     @SuppressWarnings("unchecked")
     public void handler(BuildProducer<StreamingLogHandlerBuildItem> streamingLogHandlerBuildItem,
-            LogBuildTimeConfig logBuildTimeConfig,
-            LoggingDecorateBuildItem loggingDecorateBuildItem,
-            LogStreamRecorder recorder) {
+            LoggingDecorateBuildItem loggingDecorateBuildItem, LogStreamRecorder recorder) {
         RuntimeValue<Optional<MutinyLogHandler>> mutinyLogHandler = recorder.mutinyLogHandler(
-                logBuildTimeConfig.decorateStacktraces(),
-                loggingDecorateBuildItem.getSrcMainJava().toString(),
-                loggingDecorateBuildItem.getKnowClasses());
+                loggingDecorateBuildItem.getSrcMainJava().toString(), loggingDecorateBuildItem.getKnowClasses());
         streamingLogHandlerBuildItem.produce(new StreamingLogHandlerBuildItem((RuntimeValue) mutinyLogHandler));
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -73,7 +73,6 @@ import io.quarkus.security.spi.RegisterClassSecurityCheckBuildItem;
 import io.quarkus.security.spi.runtime.MethodDescription;
 import io.quarkus.vertx.core.deployment.IgnoredContextLocalDataKeysBuildItem;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.AuthorizationPolicyStorage;
 import io.quarkus.vertx.http.runtime.security.BasicAuthenticationMechanism;
@@ -132,10 +131,9 @@ public class HttpSecurityProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void setMtlsCertificateRoleProperties(
             HttpSecurityRecorder recorder,
-            VertxHttpConfig httpConfig,
             VertxHttpBuildTimeConfig httpBuildTimeConfig) {
         if (isMtlsClientAuthenticationEnabled(httpBuildTimeConfig)) {
-            recorder.setMtlsCertificateRoleProperties(httpConfig);
+            recorder.setMtlsCertificateRoleProperties();
         }
     }
 
@@ -178,7 +176,6 @@ public class HttpSecurityProcessor {
     @BuildStep(onlyIf = IsApplicationBasicAuthRequired.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     SyntheticBeanBuildItem initBasicAuth(HttpSecurityRecorder recorder,
-            VertxHttpConfig httpConfig,
             VertxHttpBuildTimeConfig httpBuildTimeConfig,
             BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
 
@@ -190,7 +187,7 @@ public class HttpSecurityProcessor {
                 .configure(BasicAuthenticationMechanism.class)
                 .types(io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism.class)
                 .scope(Singleton.class)
-                .supplier(recorder.basicAuthenticationMechanismBean(httpConfig, httpBuildTimeConfig.auth().form().enabled()))
+                .supplier(recorder.basicAuthenticationMechanismBean(httpBuildTimeConfig.auth().form().enabled()))
                 .setRuntimeInit()
                 .unremovable();
         if (makeBasicAuthMechDefaultBean(httpBuildTimeConfig)) {
@@ -272,11 +269,10 @@ public class HttpSecurityProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     void initializeHttpSecurity(Optional<HttpAuthenticationHandlerBuildItem> authenticationHandler,
-            HttpSecurityRecorder recorder, VertxHttpConfig httpConfig, BeanContainerBuildItem beanContainerBuildItem) {
+            HttpSecurityRecorder recorder, BeanContainerBuildItem beanContainerBuildItem) {
         if (authenticationHandler.isPresent()) {
-            recorder.prepareHttpSecurityConfiguration(httpConfig);
-            recorder.initializeHttpAuthenticatorHandler(authenticationHandler.get().handler, httpConfig,
-                    beanContainerBuildItem.getValue());
+            recorder.prepareHttpSecurityConfiguration();
+            recorder.initializeHttpAuthenticatorHandler(authenticationHandler.get().handler, beanContainerBuildItem.getValue());
         }
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
@@ -17,7 +17,6 @@ import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.HttpSecurityProcessor.IsApplicationBasicAuthRequired;
-import io.quarkus.vertx.http.runtime.management.ManagementConfig;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.management.ManagementSecurityRecorder;
 import io.quarkus.vertx.http.runtime.security.BasicAuthenticationMechanism;
@@ -85,9 +84,9 @@ public class ManagementInterfaceSecurityProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     void initializeAuthMechanismHandler(Optional<ManagementAuthenticationHandlerBuildItem> managementAuthenticationHandler,
-            ManagementSecurityRecorder recorder, ManagementConfig managementConfig, BeanContainerBuildItem containerBuildItem) {
+            ManagementSecurityRecorder recorder, BeanContainerBuildItem containerBuildItem) {
         if (managementAuthenticationHandler.isPresent()) {
-            recorder.initializeAuthenticationHandler(managementAuthenticationHandler.get().handler, managementConfig,
+            recorder.initializeAuthenticationHandler(managementAuthenticationHandler.get().handler,
                     containerBuildItem.getValue());
         }
     }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -57,7 +57,6 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.LiveReloadConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.logging.LogBuildTimeConfig;
-import io.quarkus.runtime.shutdown.ShutdownConfig;
 import io.quarkus.tls.deployment.spi.TlsRegistryBuildItem;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.core.deployment.EventLoopCountBuildItem;
@@ -340,7 +339,6 @@ class VertxHttpProcessor {
             BodyHandlerBuildItem bodyHandlerBuildItem,
             List<ErrorPageActionsBuildItem> errorPageActionsBuildItems,
             BuildProducer<ShutdownListenerBuildItem> shutdownListenerBuildItemBuildProducer,
-            ShutdownConfig shutdownConfig,
             LiveReloadConfig lrc,
             CoreVertxBuildItem core, // Injected to be sure that Vert.x has been produced before calling this method.
             ExecutorBuildItem executorBuildItem,
@@ -411,7 +409,7 @@ class VertxHttpProcessor {
             publisher = Optional.of(vertxDevUILogBuildItem.get().getPublisher());
         }
 
-        recorder.finalizeRouter(beanContainer.getValue(),
+        recorder.finalizeRouter(
                 defaultRoute.map(DefaultRouteBuildItem::getRoute).orElse(null),
                 listOfFilters, listOfManagementInterfaceFilters,
                 vertx.getVertx(), lrc, mainRouter, httpRouteRouter.getHttpRouter(),
@@ -420,8 +418,10 @@ class VertxHttpProcessor {
                 httpRootPathBuildItem.getRootPath(),
                 nonApplicationRootPathBuildItem.getNonApplicationRootPath(),
                 launchMode.getLaunchMode(),
-                getBodyHandlerRequiredConditions(requireBodyHandlerBuildItems), bodyHandlerBuildItem.getHandler(),
-                gracefulShutdownFilter, shutdownConfig, executorBuildItem.getExecutorProxy(),
+                getBodyHandlerRequiredConditions(requireBodyHandlerBuildItems),
+                bodyHandlerBuildItem.getHandler(),
+                gracefulShutdownFilter,
+                executorBuildItem.getExecutorProxy(),
                 logBuildTimeConfig,
                 srcMainJava,
                 knowClasses,

--- a/extensions/vertx-http/runtime-dev/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamRecorder.java
+++ b/extensions/vertx-http/runtime-dev/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamRecorder.java
@@ -5,13 +5,18 @@ import java.util.Optional;
 
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.logging.LogBuildTimeConfig;
 
 @Recorder
 public class LogStreamRecorder {
+    private final LogBuildTimeConfig logBuildTimeConfig;
 
-    public RuntimeValue<Optional<MutinyLogHandler>> mutinyLogHandler(boolean decorateStack, String srcMainJava,
-            List<String> knownClasses) {
-        return new RuntimeValue<>(Optional.of(new MutinyLogHandler(decorateStack, srcMainJava, knownClasses)));
+    public LogStreamRecorder(final LogBuildTimeConfig logBuildTimeConfig) {
+        this.logBuildTimeConfig = logBuildTimeConfig;
     }
 
+    public RuntimeValue<Optional<MutinyLogHandler>> mutinyLogHandler(String srcMainJava, List<String> knownClasses) {
+        return new RuntimeValue<>(
+                Optional.of(new MutinyLogHandler(logBuildTimeConfig.decorateStacktraces(), srcMainJava, knownClasses)));
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
@@ -25,12 +25,14 @@ public class StaticResourcesRecorder {
 
     private static volatile List<Path> hotDeploymentResourcePaths;
 
-    final RuntimeValue<VertxHttpConfig> httpConfig;
-    final VertxHttpBuildTimeConfig httpBuildTimeConfig;
+    private final VertxHttpBuildTimeConfig httpBuildTimeConfig;
+    private final RuntimeValue<VertxHttpConfig> httpConfig;
 
-    public StaticResourcesRecorder(RuntimeValue<VertxHttpConfig> httpConfig, VertxHttpBuildTimeConfig httpBuildTimeConfig) {
-        this.httpConfig = httpConfig;
+    public StaticResourcesRecorder(
+            final VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            final RuntimeValue<VertxHttpConfig> httpConfig) {
         this.httpBuildTimeConfig = httpBuildTimeConfig;
+        this.httpConfig = httpConfig;
     }
 
     public static void setHotDeploymentResources(List<Path> resources) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime.cors;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.vertx.core.Handler;
@@ -7,15 +8,15 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class CORSRecorder {
-    final VertxHttpConfig httpConfig;
+    private final RuntimeValue<VertxHttpConfig> httpConfig;
 
-    public CORSRecorder(VertxHttpConfig httpConfig) {
+    public CORSRecorder(RuntimeValue<VertxHttpConfig> httpConfig) {
         this.httpConfig = httpConfig;
     }
 
     public Handler<RoutingContext> corsHandler() {
-        if (httpConfig.corsEnabled()) {
-            return new CORSFilter(httpConfig.cors());
+        if (httpConfig.getValue().corsEnabled()) {
+            return new CORSFilter(httpConfig.getValue().cors());
         }
         return null;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementSecurityRecorder.java
@@ -17,6 +17,11 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class ManagementSecurityRecorder {
+    private final RuntimeValue<ManagementConfig> managementConfig;
+
+    public ManagementSecurityRecorder(final RuntimeValue<ManagementConfig> managementConfig) {
+        this.managementConfig = managementConfig;
+    }
 
     public RuntimeValue<AuthenticationHandler> managementAuthenticationHandler(boolean proactiveAuthentication) {
         return new RuntimeValue<>(new AuthenticationHandler(proactiveAuthentication));
@@ -26,10 +31,9 @@ public class ManagementSecurityRecorder {
         return handlerRuntimeValue.getValue();
     }
 
-    public void initializeAuthenticationHandler(RuntimeValue<AuthenticationHandler> handler,
-            ManagementConfig managementConfig, BeanContainer beanContainer) {
+    public void initializeAuthenticationHandler(RuntimeValue<AuthenticationHandler> handler, BeanContainer beanContainer) {
         handler.getValue().init(beanContainer.beanInstance(ManagementPathMatchingHttpSecurityPolicy.class),
-                RolesMapping.of(managementConfig.auth().rolesMapping()));
+                RolesMapping.of(managementConfig.getValue().auth().rolesMapping()));
     }
 
     public Handler<RoutingContext> permissionCheckHandler() {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -53,8 +53,13 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class HttpSecurityRecorder {
-
     private static final Logger log = Logger.getLogger(HttpSecurityRecorder.class);
+
+    private final RuntimeValue<VertxHttpConfig> httpConfig;
+
+    public HttpSecurityRecorder(final RuntimeValue<VertxHttpConfig> httpConfig) {
+        this.httpConfig = httpConfig;
+    }
 
     public RuntimeValue<AuthenticationHandler> authenticationMechanismHandler(boolean proactiveAuthentication,
             boolean propagateRoutingContext) {
@@ -66,9 +71,9 @@ public class HttpSecurityRecorder {
     }
 
     public void initializeHttpAuthenticatorHandler(RuntimeValue<AuthenticationHandler> handlerRuntimeValue,
-            VertxHttpConfig httpConfig, BeanContainer beanContainer) {
+            BeanContainer beanContainer) {
         handlerRuntimeValue.getValue().init(beanContainer.beanInstance(PathMatchingHttpSecurityPolicy.class),
-                HttpSecurityConfiguration.get(httpConfig).rolesMapping());
+                HttpSecurityConfiguration.get(httpConfig.getValue()).rolesMapping());
     }
 
     public Handler<RoutingContext> permissionCheckHandler() {
@@ -163,9 +168,9 @@ public class HttpSecurityRecorder {
         };
     }
 
-    public void prepareHttpSecurityConfiguration(VertxHttpConfig httpConfig) {
+    public void prepareHttpSecurityConfiguration() {
         // this is done so that we prepare and validate HTTP Security config before the first incoming request
-        HttpSecurityConfiguration.get(httpConfig);
+        HttpSecurityConfiguration.get(httpConfig.getValue());
     }
 
     public static abstract class DefaultAuthFailureHandler implements BiConsumer<RoutingContext, Throwable> {
@@ -440,11 +445,11 @@ public class HttpSecurityRecorder {
         }
     }
 
-    public void setMtlsCertificateRoleProperties(VertxHttpConfig httpConfig) {
+    public void setMtlsCertificateRoleProperties() {
         InstanceHandle<MtlsAuthenticationMechanism> mtls = Arc.container().instance(MtlsAuthenticationMechanism.class);
 
-        if (mtls.isAvailable() && httpConfig.auth().certificateRoleProperties().isPresent()) {
-            Path rolesPath = httpConfig.auth().certificateRoleProperties().get();
+        if (mtls.isAvailable() && httpConfig.getValue().auth().certificateRoleProperties().isPresent()) {
+            Path rolesPath = httpConfig.getValue().auth().certificateRoleProperties().get();
             URL rolesResource = null;
             if (Files.exists(rolesPath)) {
                 try {
@@ -473,7 +478,8 @@ public class HttpSecurityRecorder {
                 }
 
                 if (!roles.isEmpty()) {
-                    var certRolesAttribute = new CertificateRoleAttribute(httpConfig.auth().certificateRoleAttribute(), roles);
+                    var certRolesAttribute = new CertificateRoleAttribute(
+                            httpConfig.getValue().auth().certificateRoleAttribute(), roles);
                     mtls.get().setCertificateToRolesMapper(certRolesAttribute.rolesMapper());
                 }
             } catch (Exception e) {
@@ -535,14 +541,12 @@ public class HttpSecurityRecorder {
         return Set.copyOf(roles);
     }
 
-    public Supplier<BasicAuthenticationMechanism> basicAuthenticationMechanismBean(VertxHttpConfig httpConfig,
-            boolean formAuthEnabled) {
+    public Supplier<BasicAuthenticationMechanism> basicAuthenticationMechanismBean(boolean formAuthEnabled) {
         return new Supplier<>() {
             @Override
             public BasicAuthenticationMechanism get() {
-                return new BasicAuthenticationMechanism(httpConfig.auth().realm().orElse(null), formAuthEnabled);
+                return new BasicAuthenticationMechanism(httpConfig.getValue().auth().realm().orElse(null), formAuthEnabled);
             }
         };
     }
-
 }

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -53,12 +53,10 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.gizmo.Gizmo;
 import io.quarkus.netty.deployment.EventLoopSupplierBuildItem;
-import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.vertx.VertxOptionsCustomizer;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.core.runtime.VertxLocalsHelper;
 import io.quarkus.vertx.core.runtime.VertxLogDelegateFactory;
-import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
 import io.quarkus.vertx.core.runtime.context.SafeVertxContextInterceptor;
 import io.quarkus.vertx.deployment.VertxBuildConfig;
 import io.quarkus.vertx.mdc.provider.LateBoundMDCProvider;
@@ -103,8 +101,8 @@ class VertxCoreProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    EventLoopCountBuildItem eventLoopCount(VertxCoreRecorder recorder, VertxConfiguration vertxConfiguration) {
-        return new EventLoopCountBuildItem(recorder.calculateEventLoopThreads(vertxConfiguration));
+    EventLoopCountBuildItem eventLoopCount(VertxCoreRecorder recorder) {
+        return new EventLoopCountBuildItem(recorder.calculateEventLoopThreads());
     }
 
     @BuildStep
@@ -229,10 +227,11 @@ class VertxCoreProcessor {
     @BuildStep
     @Produce(ServiceStartBuildItem.class)
     @Record(value = ExecutionTime.RUNTIME_INIT)
-    CoreVertxBuildItem build(VertxCoreRecorder recorder,
-            LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown, VertxConfiguration config,
+    CoreVertxBuildItem build(
+            VertxCoreRecorder recorder,
+            LaunchModeBuildItem launchMode,
+            ShutdownContextBuildItem shutdown,
             List<VertxOptionsConsumerBuildItem> vertxOptionsConsumers,
-            ThreadPoolConfig threadPoolConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<EventLoopSupplierBuildItem> eventLoops,
             ExecutorBuildItem executorBuildItem) {
@@ -243,8 +242,8 @@ class VertxCoreProcessor {
             consumers.add(x.getConsumer());
         }
 
-        Supplier<Vertx> vertx = recorder.configureVertx(config, threadPoolConfig,
-                launchMode.getLaunchMode(), shutdown, consumers, executorBuildItem.getExecutorProxy());
+        Supplier<Vertx> vertx = recorder.configureVertx(launchMode.getLaunchMode(), shutdown, consumers,
+                executorBuildItem.getExecutorProxy());
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(Vertx.class)
                 .types(Vertx.class)
                 .scope(Singleton.class)

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.runtime.configuration.DurationConverter;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxOptionsCustomizer;
@@ -37,7 +38,7 @@ public class VertxCoreProducerTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        recorder = new VertxCoreRecorder();
+        recorder = new VertxCoreRecorder(new RuntimeValue<>(), new RuntimeValue<>());
     }
 
     @AfterEach

--- a/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/deployment/VirtualThreadsProcessor.java
+++ b/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/deployment/VirtualThreadsProcessor.java
@@ -15,20 +15,19 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.virtual.threads.VirtualThreads;
-import io.quarkus.virtual.threads.VirtualThreadsConfig;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 
 public class VirtualThreadsProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    public void setup(VirtualThreadsConfig config, VirtualThreadsRecorder recorder,
+    public void setup(VirtualThreadsRecorder recorder,
             ShutdownContextBuildItem shutdownContextBuildItem,
             LaunchModeBuildItem launchModeBuildItem,
             BuildProducer<AdditionalBeanBuildItem> beans,
             BuildProducer<SyntheticBeanBuildItem> producer) {
         beans.produce(new AdditionalBeanBuildItem(VirtualThreads.class));
-        recorder.setupVirtualThreads(config, shutdownContextBuildItem, launchModeBuildItem.getLaunchMode());
+        recorder.setupVirtualThreads(shutdownContextBuildItem, launchModeBuildItem.getLaunchMode());
         producer.produce(
                 SyntheticBeanBuildItem.configure(ExecutorService.class)
                         .addType(Executor.class)
@@ -38,5 +37,4 @@ public class VirtualThreadsProcessor {
                         .supplier(recorder.getCurrentSupplier())
                         .done());
     }
-
 }

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
@@ -17,13 +17,22 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class VirtualThreadsRecorder {
-
     private static final Logger logger = Logger.getLogger("io.quarkus.virtual-threads");
 
+    /**
+     * Should use the instance variable instead.
+     */
+    @Deprecated
     static volatile VirtualThreadsConfig config;
-
     private static volatile ExecutorService current;
     private static final Object lock = new Object();
+
+    private final VirtualThreadsConfig runtimeConfig;
+
+    public VirtualThreadsRecorder(final VirtualThreadsConfig runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+        config = runtimeConfig;
+    }
 
     public static Supplier<ExecutorService> VIRTUAL_THREADS_EXECUTOR_SUPPLIER = new Supplier<ExecutorService>() {
         @Override
@@ -32,9 +41,8 @@ public class VirtualThreadsRecorder {
         }
     };
 
-    public void setupVirtualThreads(VirtualThreadsConfig c, ShutdownContext shutdownContext, LaunchMode launchMode) {
-        config = c;
-        if (config.enabled()) {
+    public void setupVirtualThreads(ShutdownContext shutdownContext, LaunchMode launchMode) {
+        if (runtimeConfig.enabled()) {
             if (launchMode == LaunchMode.DEVELOPMENT) {
                 shutdownContext.addLastShutdownTask(new Runnable() {
                     @Override
@@ -55,8 +63,9 @@ public class VirtualThreadsRecorder {
                         if (service != null) {
                             service.shutdown();
 
-                            final long timeout = config.shutdownTimeout().toNanos();
-                            final long interval = config.shutdownCheckInterval().orElse(config.shutdownTimeout()).toNanos();
+                            final long timeout = runtimeConfig.shutdownTimeout().toNanos();
+                            final long interval = runtimeConfig.shutdownCheckInterval().orElse(
+                                    runtimeConfig.shutdownTimeout()).toNanos();
 
                             long start = System.nanoTime();
                             int loop = 1;

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
@@ -488,8 +488,7 @@ public class WebSocketProcessor {
             List<GeneratedEndpointBuildItem> generatedEndpoints, WebSocketsServerBuildConfig config,
             ValidationPhaseBuildItem validationPhase, BuildProducer<RouteBuildItem> routes,
             Optional<PermissionsAllowedMetaAnnotationBuildItem> metaPermissionsAllowed,
-            EndpointSecurityChecksBuildItem endpointSecurityChecks, Capabilities capabilities,
-            WebSocketsServerRuntimeConfig runtimeConfig) {
+            EndpointSecurityChecksBuildItem endpointSecurityChecks, Capabilities capabilities) {
         boolean securityEnabled = capabilities.isPresent(Capability.SECURITY);
         for (GeneratedEndpointBuildItem endpoint : generatedEndpoints.stream().filter(GeneratedEndpointBuildItem::isServer)
                 .toList()) {
@@ -506,7 +505,7 @@ public class WebSocketProcessor {
                                     new ScopeInfo(DotName.createSimple(SessionScoped.class), true), endpoint.endpointId,
                                     endpoints, validationPhase.getBeanResolver(), metaPermissionsAllowed, securityEnabled,
                                     httpUpgradeSecured),
-                            endpoint.path, runtimeConfig));
+                            endpoint.path));
             routes.produce(builder.build());
         }
     }

--- a/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -64,7 +64,6 @@ import io.quarkus.extest.runtime.config.TestBuildTimeConfig;
 import io.quarkus.extest.runtime.config.TestConfigRoot;
 import io.quarkus.extest.runtime.config.TestMappingBuildTime;
 import io.quarkus.extest.runtime.config.TestMappingBuildTimeRunTime;
-import io.quarkus.extest.runtime.config.TestMappingRunTime;
 import io.quarkus.extest.runtime.config.UnremovableMappingFromBuildItem;
 import io.quarkus.extest.runtime.config.XmlConfig;
 import io.quarkus.extest.runtime.logging.AdditionalLogHandlerValueFactory;
@@ -392,8 +391,8 @@ public final class TestProcessor {
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    void configMappingRuntime(TestRecorder recorder, TestMappingBuildTimeRunTime buildTimeRunTime, TestMappingRunTime runTime) {
-        recorder.configMappingRuntime(buildTimeRunTime, runTime);
+    void configMappingRuntime(TestRecorder recorder, TestMappingBuildTimeRunTime buildTimeRunTime) {
+        recorder.configMappingRuntime(buildTimeRunTime);
     }
 
     /**

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/TestRecorder.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/TestRecorder.java
@@ -9,7 +9,6 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.extest.runtime.beans.PublicKeyProducer;
 import io.quarkus.extest.runtime.config.TestMappingBuildTimeRunTime;
-import io.quarkus.extest.runtime.config.TestMappingRunTime;
 import io.quarkus.extest.runtime.config.XmlConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
@@ -79,20 +78,12 @@ public class TestRecorder {
         }
     }
 
-    public void configMappingRuntime(TestMappingBuildTimeRunTime buildTimeRunTime, TestMappingRunTime runTime) {
+    public void configMappingRuntime(TestMappingBuildTimeRunTime buildTimeRunTime) {
         if (!buildTimeRunTime.value().equals("value")) {
             throw new IllegalStateException();
         }
 
         if (!buildTimeRunTime.group().value().equals("value")) {
-            throw new IllegalStateException();
-        }
-
-        if (!runTime.value().equals("value")) {
-            throw new IllegalStateException();
-        }
-
-        if (!runTime.group().value().equals("value")) {
             throw new IllegalStateException();
         }
     }


### PR DESCRIPTION
Historically, the way to use a Config object, which is Runtime in a Recorder, was to inject it in the BuildStep and call the recorder method with a reference to the config. Obviously, you would get an instance at the BuildStep level that was not initialized. In most cases, these instances were not being used, but I did find a couple of places where it was, which is incorrect.

The correct way to retrieve Runtime configuration at the Recorder level is via injection via a constructor.

Even in such cases, There was also another misleading pattern, which was to use the Config object directly without being wrapped in a `RuntimeValue`.

This PR, adds a warning about injecting Runtime Config objects in BuildSteps, or using Config objects without being wrapped in `RuntimeValue` at the Recorder. This can be changed to an error via `quarkus.extension-loader.runtime-config-at-deployment=fail`. Most likely, many extensions out there are still using the old pattern, and we will need a transition period until we completely disallow such behaviour.

This PR also changed all the BuildSteps and Recorders to follow the pattern of Runtime config injection via constructor with `RuntimeValue`.

This only applies to config objects like `@ConfigRoot` and `@ConfigMapping`. We know there are places where extensions directly query for runtime config (which we should also disallow), but it will be done separately.

- Fixes https://github.com/quarkusio/quarkus/issues/5514