### PR TITLE
Expose negotiated subprotocol to client connections in WebSockets Next

### DIFF
--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/subprotocol/SubprotocolFromConnectionTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/subprotocol/SubprotocolFromConnectionTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.websockets.next.test.subprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class SubprotocolFromConnectionTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Endpoint.class, Client.class);
+            }).overrideConfigKey("quarkus.websockets-next.server.supported-subprotocols", "oak,larch");
+
+    @TestHTTPResource("/")
+    URI endpointUri;
+
+    @Inject
+    WebSocketConnector<Client> connector;
+
+    @Test
+    void testSubprotocolFromConnection() throws InterruptedException, ExecutionException {
+        var connection = connector.baseUri(endpointUri).addSubprotocol("larch").connectAndAwait();
+        assertEquals("larch", connection.subprotocol());
+        assertTrue(Client.OPEN_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals("larch", Client.SUB_PROTOCOL.get());
+        assertTrue(Endpoint.OPEN_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals("larch", Endpoint.SUB_PROTOCOL.get());
+        connection.closeAndAwait();
+    }
+
+    @WebSocket(path = "/endpoint")
+    public static class Endpoint {
+
+        static final CountDownLatch OPEN_LATCH = new CountDownLatch(1);
+
+        static final AtomicReference<String> SUB_PROTOCOL = new AtomicReference<>();
+
+        @OnOpen
+        void connected(WebSocketConnection connection) {
+            SUB_PROTOCOL.set(connection.subprotocol());
+            OPEN_LATCH.countDown();
+        }
+    }
+
+    @WebSocketClient(path = "/endpoint")
+    public static class Client {
+
+        static final CountDownLatch OPEN_LATCH = new CountDownLatch(1);
+
+        static final AtomicReference<String> SUB_PROTOCOL = new AtomicReference<>();
+
+        @OnOpen
+        void connected(WebSocketClientConnection connection) {
+            SUB_PROTOCOL.set(connection.subprotocol());
+            OPEN_LATCH.countDown();
+        }
+    }
+
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/Connection.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/Connection.java
@@ -99,6 +99,12 @@ public interface Connection extends Sender {
 
     /**
      *
+     * @return the subprotocol selected by the handshake
+     */
+    String subprotocol();
+
+    /**
+     *
      * @return the time when this connection was created
      */
     Instant creationTime();

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
@@ -37,12 +37,6 @@ public interface WebSocketConnection extends Connection {
     Set<WebSocketConnection> getOpenConnections();
 
     /**
-     *
-     * @return the subprotocol selected by the handshake
-     */
-    String subprotocol();
-
-    /**
      * Makes it possible to send messages to all clients connected to the same WebSocket endpoint.
      *
      * @see WebSocketConnection#getOpenConnections()

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
@@ -156,6 +156,11 @@ public abstract class WebSocketConnectionBase implements Connection {
     }
 
     @Override
+    public String subprotocol() {
+        return webSocket().subProtocol();
+    }
+
+    @Override
     public Instant creationTime() {
         return creationTime;
     }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
@@ -66,11 +66,6 @@ class WebSocketConnectionImpl extends WebSocketConnectionBase implements WebSock
     }
 
     @Override
-    public String subprotocol() {
-        return webSocket.subProtocol();
-    }
-
-    @Override
     public String toString() {
         return "WebSocket connection [endpointId=" + endpointId + ", path=" + webSocket.path() + ", id=" + identifier + "]";
     }


### PR DESCRIPTION
This PR makes the negotiated subprotocol available to `WebSocketClientConnection` in addition to `WebSocketConnection` by moving the accessor to the common interface/implementation. This is crucial for clients that can support multiple protocols and need to know which protocol was selected by the server.