### PR TITLE
Allow use of Connection interface in callback arguments for WebSockets Next

### DIFF
--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
@@ -12,13 +12,15 @@ class ConnectionCallbackArgument implements CallbackArgument {
     public boolean matches(ParameterContext context) {
         DotName paramTypeName = context.parameter().type().name();
         if (context.callbackTarget() == Target.SERVER) {
-            if (WebSocketDotNames.WEB_SOCKET_CONNECTION.equals(paramTypeName)) {
+            if (WebSocketDotNames.WEB_SOCKET_CONNECTION.equals(paramTypeName)
+                    || WebSocketDotNames.CONNECTION.equals(paramTypeName)) {
                 return true;
             } else if (WebSocketDotNames.WEB_SOCKET_CLIENT_CONNECTION.equals(paramTypeName)) {
                 throw new WebSocketException("@WebSocket callback method may not accept WebSocketClientConnection");
             }
         } else if (context.callbackTarget() == Target.CLIENT) {
-            if (WebSocketDotNames.WEB_SOCKET_CLIENT_CONNECTION.equals(paramTypeName)) {
+            if (WebSocketDotNames.WEB_SOCKET_CLIENT_CONNECTION.equals(paramTypeName)
+                    || WebSocketDotNames.CONNECTION.equals(paramTypeName)) {
                 return true;
             } else if (WebSocketDotNames.WEB_SOCKET_CONNECTION.equals(paramTypeName)) {
                 throw new WebSocketException("@WebSocketClient callback method may not accept WebSocketConnection");

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.websockets.next.CloseReason;
+import io.quarkus.websockets.next.Connection;
 import io.quarkus.websockets.next.HandshakeRequest;
 import io.quarkus.websockets.next.OnBinaryMessage;
 import io.quarkus.websockets.next.OnClose;
@@ -32,6 +33,7 @@ final class WebSocketDotNames {
 
     static final DotName WEB_SOCKET = DotName.createSimple(WebSocket.class);
     static final DotName WEB_SOCKET_CLIENT = DotName.createSimple(WebSocketClient.class);
+    static final DotName CONNECTION = DotName.createSimple(Connection.class);
     static final DotName WEB_SOCKET_CONNECTION = DotName.createSimple(WebSocketConnection.class);
     static final DotName WEB_SOCKET_CLIENT_CONNECTION = DotName.createSimple(WebSocketClientConnection.class);
     static final DotName WEB_SOCKET_CONNECTOR = DotName.createSimple(WebSocketConnector.class);

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/args/ConnectionArgumentTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/args/ConnectionArgumentTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.websockets.next.test.args;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.net.URI;
 
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.Connection;
+import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
 import io.quarkus.websockets.next.WebSocketConnection;
@@ -51,6 +54,11 @@ public class ConnectionArgumentTest {
 
         @Inject
         WebSocketConnection c;
+
+        @OnOpen
+        void connect(Connection connection) {
+            assertInstanceOf(WebSocketConnection.class, connection);
+        }
 
         @OnTextMessage
         Uni<Void> process(WebSocketConnection connection, String message) throws InterruptedException {


### PR DESCRIPTION
This PR adds support for using `Connection` super type in callback arguments that receive `WebSocketConnetion` or `WebSocketClientConnection`. This is useful when a common super class is shared between client and server endpoints.