### PR TITLE
Avoid IndexOutOfBoundsException in QuarkusErrorHandler when class is in the unnamed package

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/DecorateStackUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/DecorateStackUtil.java
@@ -130,6 +130,9 @@ public class DecorateStackUtil {
 
     private static String getFullPath(String fullClassName, String fileName) {
         int lastDotIndex = fullClassName.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            return fileName;
+        }
         String packageName = fullClassName.substring(0, lastDotIndex);
         String path = packageName.replace('.', '/');
         return path + "/" + fileName;


### PR DESCRIPTION
This PR fixes a bug in `DecorateStackUtil` where classes are assumed to always have a package prefix, resulting in an `IndexOutOfBoundsException` when processing a class in the unnamed package.