### PR TITLE
Replace Gradle's deprecated project.exe() with project.providers.exe()

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -358,7 +358,7 @@ public abstract class QuarkusDev extends QuarkusTask {
             final DevModeCommandLine runner = newLauncher(analyticsService);
             String outputFile = System.getProperty(IO_QUARKUS_DEVMODE_ARGS);
             if (outputFile == null) {
-                getProject().exec(action -> {
+                getProject().getProviders().exec(action -> {
                     action.commandLine(runner.getArguments()).workingDir(getWorkingDirectory().get());
                     action.environment(getEnvVars());
                     action.setStandardInput(System.in)


### PR DESCRIPTION
`project.exe()` is deprecated since [Gradle 8.11](https://github.com/gradle/gradle/issues/30481) and will be removed in the next release Gradle 9.0.

```
* @deprecated Since 8.11. This method will be removed in Gradle 9.0. Use {@link org.gradle.process.ExecOperations#exec(Action)} or {@link ProviderFactory#exec(Action)} instead.
     */
    @Deprecated
    ExecResult exec(Action<? super ExecSpec> action);
```