### PR TITLE
Replace Gradle's deprecated project.getBuildDir() with newer API

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
@@ -95,7 +95,7 @@ public abstract class Deploy extends QuarkusBuildTask {
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)
-                .setTargetDirectory(getProject().getBuildDir().toPath())
+                .setTargetDirectory(getProject().getLayout().getBuildDirectory().getAsFile().get().toPath())
                 .setBaseName(extension().finalName())
                 .setBuildSystemProperties(sysProps)
                 .setAppArtifact(appModel.getAppArtifact())

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -106,7 +106,7 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)
-                .setTargetDirectory(getProject().getBuildDir().toPath())
+                .setTargetDirectory(getProject().getLayout().getBuildDirectory().getAsFile().get().toPath())
                 .setBaseName(extension().finalName())
                 .setBuildSystemProperties(sysProps)
                 .setAppArtifact(appModel.getAppArtifact())

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -34,7 +34,7 @@ public abstract class QuarkusTask extends DefaultTask {
         setGroup("quarkus");
         this.extension = getProject().getExtensions().findByType(QuarkusPluginExtension.class);
         this.projectDir = getProject().getProjectDir();
-        this.buildDir = getProject().getBuildDir();
+        this.buildDir = getProject().getLayout().getBuildDirectory().getAsFile().get();
 
         // Calling this method tells Gradle that it should not fail the build. Side effect is that the configuration
         // cache will be at least degraded, but the build will not fail.

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -97,10 +97,11 @@ public class QuarkusPluginTest {
 
         final Set<File> outputSourceDirs = extension.combinedOutputSourceDirs();
         assertThat(outputSourceDirs).hasSize(4);
-        assertThat(outputSourceDirs).contains(new File(project.getBuildDir(), "classes/java/main"),
-                new File(project.getBuildDir(), "classes/java/test"),
-                new File(project.getBuildDir(), "classes/scala/main"),
-                new File(project.getBuildDir(), "classes/scala/test"));
+        assertThat(outputSourceDirs).contains(
+                new File(project.getLayout().getBuildDirectory().getAsFile().get(), "classes/java/main"),
+                new File(project.getLayout().getBuildDirectory().getAsFile().get(), "classes/java/test"),
+                new File(project.getLayout().getBuildDirectory().getAsFile().get(), "classes/scala/main"),
+                new File(project.getLayout().getBuildDirectory().getAsFile().get(), "classes/scala/test"));
     }
 
     @Test

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -171,7 +171,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                 .setModuleId(
                         WorkspaceModuleId.of(appArtifact.getGroupId(), appArtifact.getArtifactId(), appArtifact.getVersion()))
                 .setModuleDir(project.getProjectDir().toPath())
-                .setBuildDir(project.getBuildDir().toPath())
+                .setBuildDir(project.getLayout().getBuildDirectory().getAsFile().get().toPath())
                 .setBuildFile(project.getBuildFile().toPath());
 
         initProjectModule(project, mainModule, sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME), ArtifactSources.MAIN);


### PR DESCRIPTION
`project.getBuildDir` is deprecated since [Gradle 8.3](https://github.com/gradle/gradle/issues/20210):

```
* @deprecated Use {@code getLayout().getBuildDirectory()} instead
     */
    @Deprecated
    File getBuildDir();
```