### PR TITLE
Replace Gradle's deprecated buildIdentifier.getName() with newer API

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -233,7 +233,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         if (a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier) {
             ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) a.getId()
                     .getComponentIdentifier();
-            var includedBuild = ToolingUtils.includedBuild(project, projectComponentIdentifier.getBuild().getName());
+            var includedBuild = ToolingUtils.includedBuild(project, projectComponentIdentifier.getBuild().getBuildPath());
             final Project projectDep;
             if (includedBuild != null) {
                 projectDep = ToolingUtils.includedBuildProject((IncludedBuildInternal) includedBuild,
@@ -360,7 +360,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                 final String classifier = a.getClassifier();
                 if (classifier == null || classifier.isEmpty()) {
                     final IncludedBuild includedBuild = ToolingUtils.includedBuild(project.getRootProject(),
-                            compId.getBuild().getName());
+                            compId.getBuild().getBuildPath());
                     if (includedBuild != null) {
                         if (includedBuild instanceof IncludedBuildInternal ib) {
                             projectDep = ToolingUtils.includedBuildProject(ib, compId.getProjectPath());

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -46,7 +46,7 @@ public class ToolingUtils {
                 || Category.REGULAR_PLATFORM.equals(category.getName()));
     }
 
-    public static IncludedBuild includedBuild(final Project project, final String buildName) {
+    public static IncludedBuild includedBuild(final Project project, final String buildPath) {
         Gradle currentGradle = project.getRootProject().getGradle();
         while (null != currentGradle) {
             for (IncludedBuild ib : currentGradle.getIncludedBuilds()) {
@@ -54,7 +54,7 @@ public class ToolingUtils {
                     continue;
                 }
 
-                if (ib.getName().equals(buildName)) {
+                if (((IncludedBuildInternal) ib).getTarget().getBuildIdentifier().getBuildPath().equals(buildPath)) {
                     return ib;
                 }
             }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
@@ -96,7 +96,7 @@ public class DependencyUtils {
             projectDependency = getProjectExtensionDependencyOrNull(
                     project,
                     componentId.getProjectPath(),
-                    componentId.getBuild().getName());
+                    componentId.getBuild().getBuildPath());
 
             if (projectDependency != null)
                 return projectDependency;
@@ -198,10 +198,10 @@ public class DependencyUtils {
     public static ExtensionDependency<?> getProjectExtensionDependencyOrNull(
             Project project,
             String projectPath,
-            @Nullable String buildName) {
+            @Nullable String buildPath) {
         Project extensionProject = project.getRootProject().findProject(projectPath);
         if (extensionProject == null) {
-            IncludedBuild extProjIncludedBuild = ToolingUtils.includedBuild(project, buildName);
+            IncludedBuild extProjIncludedBuild = ToolingUtils.includedBuild(project, buildPath);
             if (extProjIncludedBuild instanceof IncludedBuildInternal) {
                 extensionProject = ToolingUtils
                         .includedBuildProject((IncludedBuildInternal) extProjIncludedBuild, projectPath);


### PR DESCRIPTION
`buildIdentifier.getName()` is deprecated since [Gradle 8.2](https://github.com/gradle/gradle/pull/24648) and will be removed in the next release Gradle 9.0.

```
* @deprecated Use {@link #getBuildPath()} instead.
     */
    @Deprecated
    String getName();
```