### PR TITLE
Simplify public key registration with OIDC client registration

### DIFF
--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/ClientMetadata.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/ClientMetadata.java
@@ -2,14 +2,26 @@ package io.quarkus.oidc.client.registration;
 
 import static io.quarkus.jsonp.JsonProviderHolder.jsonProvider;
 
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.EdECPublicKey;
+import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
+import org.jose4j.jwk.JsonWebKey.OutputControlLevel;
+import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.lang.JoseException;
+
+import io.quarkus.oidc.client.registration.runtime.OidcClientRegistrationException;
 import io.quarkus.oidc.common.runtime.AbstractJsonObject;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 
 public class ClientMetadata extends AbstractJsonObject {
 
@@ -100,12 +112,96 @@ public class ClientMetadata extends AbstractJsonObject {
             return this;
         }
 
+        public Builder grantType(String grantType) {
+            return grantTypes(Set.of(grantType));
+        }
+
+        public Builder grantTypes(Set<String> grantTypes) {
+            if (built) {
+                throw new IllegalStateException();
+            }
+            JsonArrayBuilder arrayBuilder = jsonProvider().createArrayBuilder();
+            for (String grantType : grantTypes) {
+                arrayBuilder.add(grantType);
+            }
+            builder.add(OidcConstants.CLIENT_METADATA_GRANT_TYPES, arrayBuilder.build());
+            return this;
+        }
+
+        public Builder tokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+            if (built) {
+                throw new IllegalStateException();
+            }
+            builder.add(OidcConstants.CLIENT_METADATA_TOKEN_ENDPOINT_AUTH_METHOD, tokenEndpointAuthMethod);
+            return this;
+        }
+
+        public Builder jwk(PublicKey publicKey) {
+            return jwks(Set.of(publicKey));
+        }
+
+        public Builder jwks(Set<PublicKey> publicKeys) {
+            if (built) {
+                throw new IllegalStateException();
+            }
+            JsonArrayBuilder keysBuilder = jsonProvider().createArrayBuilder();
+            for (PublicKey publicKey : publicKeys) {
+                JsonObjectBuilder jwkBuilder = jsonProvider().createObjectBuilder();
+                for (Map.Entry<String, Object> entry : convertPublicKeyToJwk(publicKey).entrySet()) {
+                    jwkBuilder.add(entry.getKey(), entry.getValue().toString());
+                }
+                jwkBuilder.add("use", "sig");
+                jwkBuilder.add("alg", getAlgorithm(publicKey));
+                keysBuilder.add(jwkBuilder);
+            }
+            JsonObjectBuilder jwksBuilder = jsonProvider().createObjectBuilder();
+            jwksBuilder.add("keys", keysBuilder);
+            builder.add(OidcConstants.CLIENT_METADATA_JWKS, jwksBuilder);
+            return this;
+        }
+
+        public Builder jwk(Map<String, String> keyProperties) {
+            if (built) {
+                throw new IllegalStateException();
+            }
+            JsonArrayBuilder keysBuilder = jsonProvider().createArrayBuilder();
+            JsonObjectBuilder jwkBuilder = jsonProvider().createObjectBuilder();
+            for (Map.Entry<String, String> entry : keyProperties.entrySet()) {
+                jwkBuilder.add(entry.getKey(), entry.getValue());
+            }
+            keysBuilder.add(jwkBuilder);
+            JsonObjectBuilder jwksBuilder = jsonProvider().createObjectBuilder();
+            jwksBuilder.add("keys", keysBuilder);
+            builder.add(OidcConstants.CLIENT_METADATA_JWKS, jwksBuilder);
+            return this;
+        }
+
         public Builder extraProps(Map<String, String> extraProps) {
             if (built) {
                 throw new IllegalStateException();
             }
             builder.addAll(jsonProvider().createObjectBuilder(extraProps));
             return this;
+        }
+
+        private static Map<String, Object> convertPublicKeyToJwk(PublicKey key) {
+            try {
+                return PublicJsonWebKey.Factory.newPublicJwk(key).toParams(OutputControlLevel.PUBLIC_ONLY);
+            } catch (JoseException ex) {
+                throw new OidcClientRegistrationException(ex);
+            }
+        }
+
+        private static String getAlgorithm(PublicKey publicKey) {
+            if (publicKey instanceof RSAPublicKey) {
+                return SignatureAlgorithm.RS256.getAlgorithm();
+            } else if (publicKey instanceof ECPublicKey) {
+                return SignatureAlgorithm.ES256.getAlgorithm();
+            } else if (publicKey instanceof EdECPublicKey) {
+                return SignatureAlgorithm.EDDSA.getAlgorithm();
+            } else {
+                throw new OidcClientRegistrationException("Unrecognized public key algorithm: " + publicKey.getAlgorithm());
+            }
         }
 
         public ClientMetadata build() {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -86,6 +86,9 @@ public final class OidcConstants {
 
     public static final String CLIENT_METADATA_CLIENT_NAME = "client_name";
     public static final String CLIENT_METADATA_REDIRECT_URIS = "redirect_uris";
+    public static final String CLIENT_METADATA_GRANT_TYPES = "grant_types";
+    public static final String CLIENT_METADATA_JWKS = "jwks";
+    public static final String CLIENT_METADATA_TOKEN_ENDPOINT_AUTH_METHOD = "token_endpoint_auth_method";
     public static final String CLIENT_METADATA_POST_LOGOUT_URIS = "post_logout_redirect_uris";
     public static final String CLIENT_METADATA_SECRET_EXPIRES_AT = "client_secret_expires_at";
     public static final String CLIENT_METADATA_ID_ISSUED_AT = "client_id_issued_at";


### PR DESCRIPTION
I've been planning to do it for a while, this minor PR makes it easier to deal with the advanced cases where the client metadata must include the public key in JWK format, the test code we have for it is good for tests, but is unlikely to work for users in general, but it was the only way to do it since the ClientMetadata builder API that I originally added was pretty limited in what it could do.

So I added two `jwks` methods to the builder to supply `PublicKey` directly, defaulting to the `use=sig` - which I expect to be the only case anyway as we don't deal at the OIDC level with OIDC providers supplying encryption keys in the public JWK set.

I also added one `jwks` method accepting a Map when users need to have more JWK properties like key id (it does not have to be crypto-safe but only unique in a given key set), and other properties.

In the updated test example, I also dropped the `client_uri` property which implies, in the dynamic client reg case, that in this case it can be for example Quarkus that supplies this page... OIDC provider may allocate it itself in some cases too. It is not important for the test in any case. 

