### PR TITLE
Removing cacheability for QuarkusApplicationModelTask

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -42,7 +42,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -78,7 +77,6 @@ import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.util.HashUtil;
 
-@CacheableTask
 public abstract class QuarkusApplicationModelTask extends DefaultTask {
 
     /* @formatter:off */


### PR DESCRIPTION
Following up on [issue #47926](https://github.com/quarkusio/quarkus/issues/47926), we initially attempted to address the problem in [PR #48290](https://github.com/quarkusio/quarkus/pull/48290). However, the CI execution revealed failures in the Conditional Dependencies tests. Upon investigation, we found that the proposed fix was resolving the configuration eagerly—before the Conditional Dependencies logic was applied—thereby breaking the expected functionality.

I explored alternative solutions, such as using QuarkusExtensionView in the model task. This worked partially for the same module but did not handle the case described in the original reproducer, where JARs are manually removed.

The root cause of the issue is that ModelTask hits the cache even when the Quarkus version changes, since the version does not affect the application model's classpath. To address this, this PR proposes disabling the cacheability of the ModelTask. This effectively resolves the main issue reported in the original ticket.

As a follow-up, we could explore more targeted solutions—such as introducing a dedicated input for ModelTask that resolves the configuration during execution and captures the dependency versions.

cc @HerrDerb 