### PR TITLE
Trim jvmArgs in DevMojo

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1610,9 +1609,13 @@ public class DevMojo extends AbstractMojo {
             jvmArgs = buf.toString();
         }
         if (jvmArgs != null) {
-            builder.jvmArgs(Arrays.asList(CommandLineUtils.translateCommandline(jvmArgs)));
+            final String[] arr = CommandLineUtils.translateCommandline(jvmArgs);
+            final List<String> list = new ArrayList<>(arr.length);
+            for (var s : arr) {
+                list.add(s.trim());
+            }
+            builder.jvmArgs(list);
         }
-
     }
 
     private void copySurefireVariables() {


### PR DESCRIPTION
Fixes the following issue reported in Zulip

@_**Marco Bungart|285062** [said](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/quarkus-maven-plugin.3A.20jvmArgs/near/525097581):
````quote
hi!
Can someone explain to me why this `configuration` for the `quarkus-maven-plugin` works fine:

```xml
<configuration>
    <skip>${quarkus-maven-plugin.skip}</skip>
    <jvmArgs>--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</jvmArgs>
</configuration>
```

While this configuration:
```xml
<configuration>
    <skip>${quarkus-maven-plugin.skip}</skip>
    <jvmArgs>
        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
        --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
        --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
        --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
        --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
        --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
        --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
        --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
        --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
    </jvmArgs>
</configuration>
```

Results in the following warnings:

```
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-exports
WARNING: Unknown module: ALL-UNNAMED
 specified to --add-opens
```

Is this a bug?
````