### PR TITLE
Allow applying manifests on Kubernetes Dev Service startup

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-dev-services.adoc
+++ b/docs/src/main/asciidoc/kubernetes-dev-services.adoc
@@ -70,6 +70,27 @@ If `api-version` is not set, the latest version for the given flavor will be use
 
 Once the cluster is configured, you can access it easily as you normally would, for example, by injecting a client instance in your test.
 
+== Applying manifests to the cluster
+Within Quarkus it is possible to apply Kubernetes manifests to the cluster dev service on startup. This is especially useful if your application expects certain resources to be present in the cluster, such as for example a specific namespace or certain Custom Resource Definitions that the application interacts with.
+
+You can configure the manifests to be applied using the `quarkus.kubernetes-client.devservices.manifests` property. This property accepts a list of files within the application's `resources` directory.
+
+As an example, to ensure the `example-namespace` namespace is present in the dev service, create the file `/src/main/resources/kubernetes/namespace.yml`:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace
+```
+
+And then add the following property to your `application.properties`:
+```
+quarkus.kubernetes-client.devservices.manifests=kubernetes/namespace.yaml
+```
+
+=== Deploying helm charts
+`quarkus.kubernetes-client.devservices.manifests` only supports manifests. If you want to deploy a helm chart, you can use the `k3s` flavor and deploy a `HelmChart` manifest. See https://docs.k3s.io/helm for more information on how to use helm charts with k3s.
+
 == Configuration reference
 
 include::{generated-dir}/config/quarkus-kubernetes-client_quarkus.kubernetes-client.devservices.adoc[opts=optional, leveloffset=+1]

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesDevServicesBuildTimeConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesDevServicesBuildTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.kubernetes.client.runtime.internal;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -48,6 +49,13 @@ public interface KubernetesDevServicesBuildTimeConfig {
      */
     @WithDefault("false")
     boolean overrideKubeconfig();
+
+    /**
+     * A list of manifest file paths that should be applied to the Kubernetes cluster Dev Service on startup.
+     *
+     * If not set, no manifests are applied.
+     */
+    Optional<List<String>> manifests();
 
     /**
      * Indicates if the Kubernetes cluster managed by Quarkus Dev Services is shared.

--- a/integration-tests/kubernetes-client-devservices/src/main/resources/application.properties
+++ b/integration-tests/kubernetes-client-devservices/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.kubernetes-client.devservices.manifests=kubernetes/namespace.yaml

--- a/integration-tests/kubernetes-client-devservices/src/main/resources/kubernetes/namespace.yaml
+++ b/integration-tests/kubernetes-client-devservices/src/main/resources/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace

--- a/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/DevServicesKubernetesTest.java
+++ b/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/DevServicesKubernetesTest.java
@@ -24,4 +24,10 @@ public class DevServicesKubernetesTest {
         Assertions.assertEquals("v" + DevServiceKubernetes.API_VERSION,
                 kubernetesClient.getKubernetesVersion().getGitVersion());
     }
+
+    @Test
+    @DisplayName("specified manifest must be applied to the cluster by the dev service")
+    public void manifestIsApplied() {
+        Assertions.assertNotNull(kubernetesClient.namespaces().withName("example-namespace").get());
+    }
 }


### PR DESCRIPTION
This contribution adds a new configuration parameter to the kubernetes-client extension that allows users to deploy manifests to their Kubernetes cluster Dev Service (https://quarkus.io/guides/kubernetes-dev-services).

This is useful because certain applications expect certain resources to be present in the cluster. For our specific use case for example, we expect a custom resource definition to be present such that our Quarkus application can deploy custom resources.

I have for now left out the tests and documentation. I plan to add them as soon as the implementation looks good, but I would first like to figure out if the Quarkus team likes the idea and likes the implementation of it.

You can only deploy manifests using this method and not helm charts. However helm charts are still supported with this feature, since one of the Kubernetes flavors is k3s, which has a helm chart controller built in. I will add this to the documentation with an example of how to deploy a helm chart once I write the documentation for this PR.