### PR TITLE
Revert "Replace Gradle's deprecated project.exe() with project.providers.exe()"

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -358,7 +358,7 @@ public abstract class QuarkusDev extends QuarkusTask {
             final DevModeCommandLine runner = newLauncher(analyticsService);
             String outputFile = System.getProperty(IO_QUARKUS_DEVMODE_ARGS);
             if (outputFile == null) {
-                getProject().getProviders().exec(action -> {
+                getProject().exec(action -> {
                     action.commandLine(runner.getArguments()).workingDir(getWorkingDirectory().get());
                     action.environment(getEnvVars());
                     action.setStandardInput(System.in)


### PR DESCRIPTION
This reverts commit 47eac6705cc323776dbd210e61b75b4e8cee74d3

As per discussion in [#48486](https://github.com/quarkusio/quarkus/pull/48486)