### PR TITLE
Revert "Replace Gradle's deprecated project.exe() with project.providers.exe()"

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -358,7 +358,7 @@ public abstract class QuarkusDev extends QuarkusTask {
             final DevModeCommandLine runner = newLauncher(analyticsService);
             String outputFile = System.getProperty(IO_QUARKUS_DEVMODE_ARGS);
             if (outputFile == null) {
-                getProject().getProviders().exec(action -> {
+                getProject().exec(action -> {
                     action.commandLine(runner.getArguments()).workingDir(getWorkingDirectory().get());
                     action.environment(getEnvVars());
                     action.setStandardInput(System.in)


### PR DESCRIPTION
This reverts commit b9e6b39e07f324c9acfdbd219a8de453577683c4.

It looks like the original change breaks the Gradle vev mode tests.