### PR TITLE
Cache nested mapping implementations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -101,6 +101,8 @@ import io.quarkus.runtime.configuration.RuntimeOverrideConfigSource;
 import io.quarkus.runtime.configuration.RuntimeOverrideConfigSourceBuilder;
 import io.quarkus.runtime.configuration.StaticInitConfigBuilder;
 import io.smallrye.config.ConfigMappingInterface;
+import io.smallrye.config.ConfigMappingLoader;
+import io.smallrye.config.ConfigMappingMetadata;
 import io.smallrye.config.ConfigMappings;
 import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.ConfigSourceFactory;
@@ -677,6 +679,13 @@ public class ConfigGenerationBuildStep {
                         .setModifiers(Opcodes.ACC_STATIC).getFieldDescriptor();
                 clinit.writeStaticField(mappingField, clinit.invokeStaticMethod(CONFIG_CLASS,
                         clinit.load(mapping.getType().getName()), clinit.load(mapping.getPrefix())));
+
+                // Cache implementation types of nested elements
+                List<ConfigMappingMetadata> configMappingsMetadata = ConfigMappingLoader
+                        .getConfigMappingsMetadata(mapping.getType());
+                for (ConfigMappingMetadata configMappingMetadata : configMappingsMetadata) {
+                    clinit.invokeStaticMethod(ENSURE_LOADED, clinit.load(configMappingMetadata.getInterfaceType().getName()));
+                }
 
                 fields.put(mapping, mappingField);
             }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
@@ -123,7 +123,8 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
     public static ConfigClass configClass(final String mappingClass, final String prefix) {
         try {
             // To support mappings that are not public
-            return ConfigClass.configClass(Thread.currentThread().getContextClassLoader().loadClass(mappingClass), prefix);
+            Class<?> klass = Thread.currentThread().getContextClassLoader().loadClass(mappingClass);
+            return ConfigClass.configClass(klass, prefix);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
@@ -132,7 +133,8 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
     public static void ensureLoaded(final String mappingClass) {
         try {
             // To support mappings that are not public
-            ConfigMappingLoader.ensureLoaded(Thread.currentThread().getContextClassLoader().loadClass(mappingClass));
+            Class<?> klass = Thread.currentThread().getContextClassLoader().loadClass(mappingClass);
+            ConfigMappingLoader.ensureLoaded(klass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This will reduce runtime operations in the native image by caching nested mapped implementation handles in a static block.