### PR TITLE
Fix injecting SecurityIdentity to Quarkus REST endpoint with payload using Hibernate Reactive Panache session in augmentor

### DIFF
--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/AbstractSecurityIdentityAssociation.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/AbstractSecurityIdentityAssociation.java
@@ -24,6 +24,26 @@ public abstract class AbstractSecurityIdentityAssociation implements CurrentIden
         this.deferredIdentity = null;
     }
 
+    /**
+     * This method shouldn't be treated as part of public API, it can be removed at any time.
+     * It's meant to be used internally by Quarkus Security.
+     */
+    public void setIdentityIfAbsent(SecurityIdentity identity) {
+        if (this.identity == null && this.deferredIdentity == null) {
+            setIdentity(identity);
+        }
+    }
+
+    /**
+     * This method shouldn't be treated as part of public API, it can be removed at any time.
+     * It's meant to be used internally by Quarkus Security.
+     */
+    public void setIdentityIfAbsent(Uni<SecurityIdentity> identity) {
+        if (this.identity == null && this.deferredIdentity == null) {
+            setIdentity(identity);
+        }
+    }
+
     @Override
     public void setIdentity(Uni<SecurityIdentity> identity) {
         this.identity = null;

--- a/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/AdminResource.java
+++ b/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/AdminResource.java
@@ -2,17 +2,37 @@ package io.quarkus.it.security.webauthn;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
 
 @Path("/api/admin")
 public class AdminResource {
+
+    @Context
+    SecurityIdentity identity;
 
     @GET
     @RolesAllowed("admin")
     @Produces(MediaType.TEXT_PLAIN)
     public String adminResource() {
         return "admin";
+    }
+
+    public record Dto(String payload) {
+    }
+
+    @Path("/payload")
+    @POST
+    @RolesAllowed("admin")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> adminResourceWithPayload(Dto dto) {
+        String response = dto.payload + " - " + identity.getPrincipal().getName();
+        return Uni.createFrom().item(response);
     }
 }

--- a/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/WithSessionOnDemandAugmentor.java
+++ b/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/WithSessionOnDemandAugmentor.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.security.webauthn;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+
+import io.quarkus.hibernate.reactive.panache.common.WithSessionOnDemand;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class WithSessionOnDemandAugmentor implements SecurityIdentityAugmentor {
+
+    // required to reproduce https://github.com/quarkusio/quarkus/issues/47259
+    @Override
+    @ActivateRequestContext
+    @WithSessionOnDemand
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        return Uni.createFrom().item(identity);
+    }
+}

--- a/integration-tests/security-webauthn/src/test/java/io/quarkus/it/security/webauthn/test/WebAuthnResourceTest.java
+++ b/integration-tests/security-webauthn/src/test/java/io/quarkus/it/security/webauthn/test/WebAuthnResourceTest.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.it.security.webauthn.AdminResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.webauthn.WebAuthnEndpointHelper;
@@ -140,6 +141,17 @@ public class WebAuthnResourceTest {
                     .then()
                     .statusCode(200)
                     .body(Matchers.is("admin"));
+
+            // verifies https://github.com/quarkusio/quarkus/issues/47259
+            // it's here because it requires security + hibernate reactive
+            RestAssured.given().filter(cookieFilter)
+                    .when()
+                    .body(new AdminResource.Dto("Woman of the World"))
+                    .post("/api/admin/payload")
+                    .then()
+                    .statusCode(200)
+                    .body(Matchers.containsString("Woman of the World"))
+                    .body(Matchers.containsString("admin"));
         } else {
             RestAssured.given().filter(cookieFilter)
                     .when()


### PR DESCRIPTION
- this takes couple of things to reproduce, see the analysis I left in the linked issue. The main things you need is `@POST` REST endpoint with a payload an Hibernate Reactive session in the augmentor and proactive authentication
- as I explained here https://github.com/quarkusio/quarkus/issues/47259#issuecomment-2789826649, at one point CDI request context is just gone, so proper fix is probably somewhere on the Hibernate Reactive side. On the other hand, I think noone else than security can reproduce it because it happens before the CDI request context is prepared by Quarkus REST, so why not to fix it on our side.

- fixes: https://github.com/quarkusio/quarkus/issues/47259