### PR TITLE
Add the possibility to configure a custom image for k8s dev container

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-dev-services.adoc
+++ b/docs/src/main/asciidoc/kubernetes-dev-services.adoc
@@ -55,6 +55,15 @@ quarkus.kubernetes-client.devservices.flavor=api-only # k3s or kind
 quarkus.kubernetes-client.devservices.api-version=1.22
 ----
 
+You can also configure a custom image compatible with standard images (kind, k3s & api-server) using the `quarkus.kubernetes-client.devservices.image-name` property. However, it must be consistent with the flavor and api-version properties:
+
+[source, properties]
+----
+quarkus.kubernetes-client.devservices.flavor=api-only # k3s or kind
+quarkus.kubernetes-client.devservices.api-version=1.24.1
+quarkus.kubernetes-client.devservices.image-name=quay.io/giantswarm/kube-apiserver:v1.24.1
+----
+
 `api-only` only starts a Kubernetes API Server (plus the required etcd). If you need a fully-featured Kubernetes cluster that can spin up Pods, you can use `k3s` or `kind`. `k3s` requires to start the container with `privileged mode`. The `kind` test container now also supports using podman's rootless mode.
 
 If `api-version` is not set, the latest version for the given flavor will be used. Otherwise, the version must match a https://github.com/dajudge/kindcontainer/blob/master/k8s-versions.json[version supported by the given flavor].

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesDevServicesBuildTimeConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesDevServicesBuildTimeConfig.java
@@ -27,6 +27,15 @@ public interface KubernetesDevServicesBuildTimeConfig {
     Optional<String> apiVersion();
 
     /**
+     * The kubernetes image to use.
+     * <p>
+     * If not set, Dev Services for Kubernetes will use default image for the specified {@link #apiVersion()} for the given
+     * {@link #flavor()}.
+     */
+
+    Optional<String> imageName();
+
+    /**
      * The flavor to use (kind, k3s or api-only).
      * <p>
      * If not set, Dev Services for Kubernetes will set it to: api-only.

--- a/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/profiles/DevServiceKubernetes.java
+++ b/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/profiles/DevServiceKubernetes.java
@@ -1,6 +1,5 @@
 package io.quarkus.kubernetes.client.devservices.it.profiles;
 
-import java.util.Collections;
 import java.util.Map;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -12,6 +11,8 @@ public class DevServiceKubernetes implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
 
-        return Collections.singletonMap("quarkus.kubernetes-client.devservices.api-version", API_VERSION);
+        return Map.of("quarkus.kubernetes-client.devservices.api-version", API_VERSION,
+                "quarkus.kubernetes-client.devservices.image-name",
+                "quay.io/giantswarm/kube-apiserver:v%s".formatted(API_VERSION));
     }
 }


### PR DESCRIPTION
I wanted to modify Flavor enum in order to make it a factory for the KubernetesContainer class but it's not in the same module so i tried to create a factory like method. 

Be aware that with this implementation the flavor, apiversion & image-name properties should be coherent.
I was wondering if we should parse the image-name in order to deduce the flavor and api version but i wanted to make it simple for a first try. 

For testing, i have no idea if it's possible de retrieve the image used by docker to run the container so i'm just checking for the property and used a mirror repository image before checking if the dev container is started. 

- Closes: https://github.com/quarkusio/quarkus/issues/48299