### PR TITLE
Add more kafka dev service tests

### DIFF
--- a/integration-tests/kafka-devservices/pom.xml
+++ b/integration-tests/kafka-devservices/pom.xml
@@ -58,6 +58,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
@@ -205,7 +215,31 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
-                    </plugin>
+                            <executions>
+                                <execution>
+                                    <id>default-test</id>
+                                    <goals>
+                                        <goal>test</goal>
+                                    </goals>
+                                    <configuration>
+                                        <excludes>
+                                            <exclude>**/continuoustesting/**/*.java</exclude>
+                                        </excludes>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>devmode-test</id>
+                                    <goals>
+                                        <goal>test</goal>
+                                    </goals>
+                                    <configuration>
+                                        <includes>
+                                            <include>**/continuoustesting/**/*.java</include>
+                                        </includes>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>

--- a/integration-tests/kafka-devservices/src/main/java/io/quarkus/it/kafka/KafkaAdminManager.java
+++ b/integration-tests/kafka-devservices/src/main/java/io/quarkus/it/kafka/KafkaAdminManager.java
@@ -41,6 +41,7 @@ public class KafkaAdminManager {
     }
 
     public int partitions(String topic) {
+
         TopicDescription topicDescription;
         try {
             Map<String, TopicDescription> partitions = admin.describeTopics(Collections.singletonList(topic))
@@ -53,6 +54,17 @@ public class KafkaAdminManager {
             throw new IllegalArgumentException("Topic doesn't exist: " + topic);
         }
         return topicDescription.partitions().size();
+    }
+
+    int port() throws InterruptedException, ExecutionException {
+        return admin.describeCluster().controller().get().port();
+    }
+
+    String image() throws InterruptedException, ExecutionException {
+        // By observation, the red panda does not return anything for the supported features call
+        // It would be nice to have a more robust check, but hopefully this fragile check is good enough
+        boolean isRedPanda = admin.describeFeatures().featureMetadata().get().supportedFeatures().size() == 0;
+        return isRedPanda ? "redpanda" : "kafka-native";
     }
 
 }

--- a/integration-tests/kafka-devservices/src/main/resources/application.properties
+++ b/integration-tests/kafka-devservices/src/main/resources/application.properties
@@ -9,3 +9,6 @@ quarkus.kafka.devservices.provider=kafka-native
 quarkus.kafka.devservices.topic-partitions.test=2
 quarkus.kafka.devservices.topic-partitions.test-consumer=3
 quarkus.kafka.devservices.topic-partitions-timeout=4S
+
+# When running this project itself in dev or test mode, don't try and layer in the dev mode tests
+quarkus.test.exclude-pattern=io.quarkus.it.kafka.continuoustesting.*

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/BundledEndpoint.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/BundledEndpoint.java
@@ -8,7 +8,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 
 @Path("/kafka")
-public class KafkaEndpoint {
+public class BundledEndpoint {
 
     @Inject
     KafkaAdminManager admin;
@@ -21,13 +21,7 @@ public class KafkaEndpoint {
 
     @GET
     @Path("/port")
-    public Integer partitions() throws ExecutionException, InterruptedException {
+    public Integer port() throws ExecutionException, InterruptedException {
         return admin.port();
-    }
-
-    @GET
-    @Path("/image")
-    public String image() throws ExecutionException, InterruptedException {
-        return admin.image();
     }
 }

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaCustomPortITest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaCustomPortITest.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.kafka;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.kafka.devservices.profiles.DevServicesCustomPortProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.ports.SocketKit;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@TestProfile(DevServicesCustomPortProfile.class)
+public class DevServicesKafkaCustomPortITest {
+
+    @Test
+    @DisplayName("should start kafka container with the given custom port")
+    public void shouldStartKafkaContainer() {
+        Assertions.assertTrue(SocketKit.isPortAlreadyUsed(5050));
+        RestAssured.when().get("/kafka/port").then().body(Matchers.is("5050"));
+    }
+
+    @Test
+    public void shouldBeCorrectImage() {
+        RestAssured.when().get("/kafka/image").then().body(Matchers.is("kafka-native"));
+    }
+
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaCustomPortReusableServiceITest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaCustomPortReusableServiceITest.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.kafka;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.kafka.devservices.profiles.DevServicesCustomPortReusableServiceProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.ports.SocketKit;
+import io.restassured.RestAssured;
+
+@Disabled("https://github.com/quarkusio/quarkus/issues/47627")
+@QuarkusTest
+@TestProfile(DevServicesCustomPortReusableServiceProfile.class)
+public class DevServicesKafkaCustomPortReusableServiceITest {
+
+    @Test
+    @DisplayName("should start kafka container with the given custom port")
+    public void shouldStartKafkaContainer() {
+        // We could strengthen this test to make sure the container is the same as seen by other tests, but it's hard since we won't know the order
+        Assertions.assertTrue(SocketKit.isPortAlreadyUsed(5050));
+        RestAssured.when().get("/kafka/port").then().body(Matchers.is("5050"));
+    }
+
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaNonUniquePortITest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaNonUniquePortITest.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.kafka;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.kafka.devservices.profiles.DevServicesNonUniquePortProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.ports.SocketKit;
+import io.restassured.RestAssured;
+
+@Disabled("https://github.com/quarkusio/quarkus/issues/47627")
+@QuarkusTest
+@TestProfile(DevServicesNonUniquePortProfile.class)
+public class DevServicesKafkaNonUniquePortITest {
+
+    @Test
+    @DisplayName("should start kafka container with the given custom port")
+    public void shouldStartKafkaContainer() {
+        Assertions.assertTrue(SocketKit.isPortAlreadyUsed(5050));
+        RestAssured.when().get("/kafka/port").then().body(Matchers.is("5050"));
+    }
+
+    @Test
+    public void shouldBeCorrectImage() {
+        RestAssured.when().get("/kafka/image").then().body(Matchers.is("redpanda"));
+    }
+
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesDevModeTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesDevModeTest.java
@@ -1,0 +1,211 @@
+package io.quarkus.it.kafka.continuoustesting;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.model.Container;
+
+import io.quarkus.it.kafka.BundledEndpoint;
+import io.quarkus.it.kafka.KafkaAdminManager;
+import io.quarkus.it.kafka.KafkaAdminTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class DevServicesDevModeTest {
+
+    @RegisterExtension
+    public static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(KafkaAdminManager.class)
+                    .addClass(BundledEndpoint.class)
+                    .addAsResource(new StringAsset("quarkus.kafka.devservices.provider=kafka-native\n" +
+                            "quarkus.kafka.devservices.topic-partitions.test=2\n"
+                            + "quarkus.kafka.devservices.provider=kafka-native\n"), "application.properties"))
+            .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(KafkaAdminTest.class));
+
+    @Test
+    public void testDevModeServiceUpdatesContainersOnConfigChange() {
+        // Interacting with the app will force a refresh
+        // Note that driving continuous testing concurrently can sometimes cause 500s caused by containers not yet being available on slow machines
+        ping();
+        List<Container> started = getKafkaContainers();
+
+        assertFalse(started.isEmpty());
+        Container container = started.get(0);
+        assertTrue(Arrays.stream(container.getPorts()).noneMatch(p -> p.getPublicPort() == 6377),
+                "Expected random port, but got: " + Arrays.toString(container.getPorts()));
+
+        int newPort = 6388;
+        test.modifyResourceFile("application.properties", s -> s + "quarkus.kafka.devservices.port=" + newPort);
+
+        // Force another refresh
+        ping();
+
+        List<Container> newContainers = getKafkaContainersExcludingExisting(started);
+
+        // We expect 1 new containers, since test was not refreshed.
+        // On some VMs that's what we get, but on others, a test-mode augmentation happens, and then we get two containers
+        assertEquals(1, newContainers.size(),
+                "There were " + newContainers.size() + " new containers, and should have been 1 or 2. New containers: "
+                        + prettyPrintContainerList(newContainers)
+                        + "\n Old containers: " + prettyPrintContainerList(started) + "\n All containers: "
+                        + prettyPrintContainerList(getAllContainers())); // this can be wrong
+        // We need to inspect the dev-mode container; we don't have a non-brittle way of distinguishing them, so just look in them all
+        boolean hasRightPort = newContainers.stream()
+                .anyMatch(newContainer -> hasPublicPort(newContainer, newPort));
+        assertTrue(hasRightPort,
+                "Expected port " + newPort + ", but got: "
+                        + newContainers.stream().map(c -> Arrays.toString(c.getPorts())).collect(Collectors.joining(", ")));
+    }
+
+    @Test
+    public void testDevModeServiceDoesNotRestartContainersOnCodeChange() {
+        ping();
+        List<Container> started = getKafkaContainers();
+
+        assertFalse(started.isEmpty());
+        Container container = started.get(0);
+        assertTrue(Arrays.stream(container.getPorts()).noneMatch(p -> p.getPublicPort() == 6377),
+                "Expected random port 6377, but got: " + Arrays.toString(container.getPorts()));
+
+        // Make a change that shouldn't affect dev services
+        test.modifySourceFile(BundledEndpoint.class, s -> s.replaceAll("topic", "tropic"));
+
+        ping();
+
+        List<Container> newContainers = getKafkaContainersExcludingExisting(started);
+
+        // No new containers should have spawned
+        assertEquals(0, newContainers.size(),
+                "New containers: " + newContainers + "\n Old containers: " + started + "\n All containers: "
+                        + getAllContainers()); // this can be wrong
+    }
+
+    @Test
+    public void testDevModeKeepsSameInstanceWhenRefreshedOnSecondChange() {
+        // Step 1: Ensure we have a dev service running
+        System.out.println("Step 1: Ensure we have a dev service running");
+        ping();
+        List<Container> step1Containers = getKafkaContainers();
+        assertFalse(step1Containers.isEmpty());
+        Container container = step1Containers.get(0);
+        assertFalse(hasPublicPort(container, 6377));
+
+        // Step 2: Make a change that should affect dev services
+        System.out.println("Step 2: Make a change that should affect dev services");
+        int someFixedPort = 36377;
+        // Make a change that SHOULD affect dev services
+        test.modifyResourceFile("application.properties",
+                s -> s
+                        + "quarkus.kafka.devservices.port=" + someFixedPort + "\n");
+
+        ping();
+
+        List<Container> step2Containers = getKafkaContainersExcludingExisting(step1Containers);
+
+        // New containers should have spawned
+        assertEquals(1, step2Containers.size(),
+                "New containers: " + step2Containers + "\n Old containers: " + step1Containers + "\n All containers: "
+                        + getAllContainers());
+
+        assertTrue(hasPublicPort(step2Containers.get(0), someFixedPort));
+
+        // Step 3: Now change back to a random port, which should cause a new container to spawn
+        System.out.println("Step 3: Now change back to a random port, which should cause a new container to spawn");
+        test.modifyResourceFile("application.properties",
+                s -> s.replaceAll("quarkus.kafka.devservices.port=" + someFixedPort, ""));
+
+        ping();
+
+        List<Container> step3Containers = getKafkaContainersExcludingExisting(step2Containers);
+
+        // New containers should have spawned
+        assertEquals(1, step3Containers.size(),
+                "New containers: " + step3Containers + "\n Old containers: " + step2Containers + "\n All containers: "
+                        + getAllContainers());
+
+        // Step 4: Now make a change that should not affect dev services
+        System.out.println("Step 4: Now make a change that should not affect dev services");
+        test.modifySourceFile(BundledEndpoint.class, s -> s.replaceAll("topic", "tropic"));
+
+        ping();
+
+        List<Container> step4Containers = getKafkaContainersExcludingExisting(step3Containers);
+
+        // No new containers should have spawned
+        assertEquals(0, step4Containers.size(),
+                "New containers: " + step4Containers + "\n Old containers: " + step3Containers + "\n All containers: "
+                        + getAllContainers()); // this can be wrong
+
+        // Step 5: Now make a change that should not affect dev services, but is not the same as the previous change
+        System.out.println(
+                "Step 5: Now make a change that should not affect dev services, but is not the same as the previous change");
+        test.modifySourceFile(BundledEndpoint.class, s -> s.replaceAll("tropic", "topic"));
+
+        ping();
+
+        List<Container> step5Containers = getKafkaContainersExcludingExisting(step3Containers);
+
+        // No new containers should have spawned
+        assertEquals(0, step5Containers.size(),
+                "New containers: " + step5Containers + "\n Old containers: " + step5Containers + "\n All containers: "
+                        + getAllContainers()); // this can be wrong
+    }
+
+    private static List<Container> getAllContainers() {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(container -> isKafkaContainer(container)).toList();
+    }
+
+    private static List<Container> getKafkaContainers() {
+        return getAllContainers();
+    }
+
+    private static List<Container> getKafkaContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getKafkaContainers().stream().filter(
+                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    private static List<Container> getAllContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getAllContainers().stream().filter(
+                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    private static boolean isKafkaContainer(Container container) {
+        // This could be redpanda or kafka-native or other variants
+        return container.getImage().contains("kafka") || container.getImage().contains("redpanda");
+    }
+
+    private static String prettyPrintContainerList(List<Container> newContainers) {
+        return newContainers.stream()
+                .map(c -> Arrays.toString(c.getPorts()) + " -- " + Arrays.toString(c.getNames()) + " -- " + c.getLabels())
+                .collect(Collectors.joining(", \n"));
+    }
+
+    private static boolean hasPublicPort(Container newContainer, int newPort) {
+        return Arrays.stream(newContainer.getPorts()).anyMatch(p -> p.getPublicPort() == newPort);
+    }
+
+    void ping() {
+        when().get("/kafka/partitions/test").then()
+                .statusCode(200)
+                .body(is("2"));
+    }
+
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesKafkaContinuousTestingTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesKafkaContinuousTestingTest.java
@@ -1,0 +1,268 @@
+package io.quarkus.it.kafka.continuoustesting;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
+
+import io.quarkus.it.kafka.BundledEndpoint;
+import io.quarkus.it.kafka.KafkaAdminManager;
+import io.quarkus.it.kafka.KafkaAdminTest;
+import io.quarkus.test.ContinuousTestingTestUtils;
+import io.quarkus.test.QuarkusDevModeTest;
+
+/**
+ * Note that if this test is specifically selected on the command line with -Dtest=DevServicesKafkaContinuousTestingTest, that
+ * will override the maven executions and cause it to run twice.
+ * That doesn't help debug anything.
+ */
+public class DevServicesKafkaContinuousTestingTest {
+
+    static final String DEVSERVICES_DISABLED_PROPERTIES = ContinuousTestingTestUtils.appProperties(
+            "quarkus.devservices.enabled=false");
+
+    static final String FIXED_PORT_PROPERTIES = ContinuousTestingTestUtils.appProperties(
+            "quarkus.kafka.devservices.port=6377");
+
+    static final String UPDATED_FIXED_PORT_PROPERTIES = ContinuousTestingTestUtils.appProperties(
+            "quarkus.kafka.devservices.port=6342");
+
+    @RegisterExtension
+    public static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(BundledEndpoint.class)
+                    .addClass(KafkaAdminManager.class)
+                    .addAsResource(
+                            new StringAsset(ContinuousTestingTestUtils
+                                    .appProperties("quarkus.kafka.devservices.provider=kafka-native",
+                                            "quarkus.kafka.devservices.topic-partitions.test=2",
+                                            "quarkus.kafka.devservices.topic-partitions.test-consumer=3",
+                                            "quarkus.kafka.health.enabled=true",
+                                            "quarkus.kafka.devservices.provider=kafka-native")),
+                            "application.properties"))
+            .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(KafkaAdminTest.class));
+
+    @AfterAll
+    static void afterAll() {
+        stopAllContainers();
+    }
+
+    @Disabled("Not currently working")
+    @Test
+    public void testContinuousTestingDisablesDevServicesWhenPropertiesChange() {
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        var result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+
+        // Now let's disable dev services globally ... BOOOOOM! Splat!
+        test.modifyResourceFile("application.properties", s -> DEVSERVICES_DISABLED_PROPERTIES);
+        result = utils.waitForNextCompletion();
+        assertEquals(0, result.getTotalTestsPassed());
+        assertEquals(1, result.getTotalTestsFailed());
+
+        // We could check the container goes away, but we'd have to check slowly, because ryuk can be slow
+    }
+
+    // This tests behaviour in dev mode proper when combined with continuous testing. This creates a possibility of port conflicts, false sharing of state, and all sorts of race conditions.
+    @Test
+    public void testDevModeCoexistingWithContinuousTestingServiceUpdatesContainersOnConfigChange() {
+        // Note that driving continuous testing concurrently can sometimes cause 500s caused by containers not yet being available on slow machines
+        ContinuousTestingTestUtils continuousTestingTestUtils = new ContinuousTestingTestUtils();
+        ContinuousTestingTestUtils.TestStatus result = continuousTestingTestUtils.waitForNextCompletion();
+        assertEquals(2, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+        // Interacting with the app will force a refresh
+        ping();
+
+        List<Container> started = getKafkaContainers();
+        assertFalse(started.isEmpty());
+        Container container = started.get(0);
+        assertTrue(Arrays.stream(container.getPorts()).noneMatch(p -> p.getPublicPort() == 6377),
+                "Expected random port, but got: " + Arrays.toString(container.getPorts()));
+
+        int newPort = 6388;
+        int testPort = newPort + 1;
+        // Continuous tests and dev mode should *not* share containers, even if the port is fixed
+        // Specify that the fixed port is for dev mode, or one launch will fail with port conflicts
+        test.modifyResourceFile("application.properties",
+                s -> s + "\n%dev.quarkus.kafka.devservices.port=" + newPort
+                        + "\n%test.quarkus.kafka.devservices.port=" + testPort);
+        test.modifyTestSourceFile(KafkaAdminTest.class, s -> s.replaceAll("test\\(\\) ", "someTest()"));
+
+        // Force another refresh
+        result = continuousTestingTestUtils.waitForNextCompletion();
+        assertEquals(2, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+        ping();
+
+        List<Container> newContainers = getKafkaContainersExcludingExisting(started);
+
+        // We expect 2 new containers, since test was also refreshed
+        assertEquals(2, newContainers.size(),
+                "New containers: "
+                        + prettyPrintContainerList(newContainers)
+                        + "\n Old containers: " + prettyPrintContainerList(started) + "\n All containers: "
+                        + prettyPrintContainerList(getAllContainers())); // this can be wrong
+        // We need to inspect the dev-mode container; we don't have a non-brittle way of distinguishing them, so just look in them all
+        boolean hasRightPort = newContainers.stream()
+                .anyMatch(newContainer -> hasPublicPort(newContainer, newPort));
+        assertTrue(hasRightPort,
+                "Expected port " + newPort + ", but got: "
+                        + newContainers.stream().map(c -> Arrays.toString(c.getPorts())).collect(Collectors.joining(", ")));
+        boolean hasRightTestPort = newContainers.stream()
+                .anyMatch(newContainer -> hasPublicPort(newContainer, testPort));
+        assertTrue(hasRightTestPort,
+                "Expected port " + testPort + ", but got: "
+                        + newContainers.stream().map(c -> Arrays.toString(c.getPorts())).collect(Collectors.joining(", ")));
+
+    }
+
+    private static String prettyPrintContainerList(List<Container> newContainers) {
+        return newContainers.stream()
+                .map(c -> Arrays.toString(c.getPorts()) + " -- " + Arrays.toString(c.getNames()) + " -- " + c.getLabels())
+                .collect(Collectors.joining(", \n"));
+    }
+
+    private static boolean hasPublicPort(Container newContainer, int newPort) {
+        return Arrays.stream(newContainer.getPorts()).anyMatch(p -> p.getPublicPort() == newPort);
+    }
+
+    void ping() {
+        when().get("/kafka/partitions/test").then()
+                .statusCode(200)
+                .body(is("2"));
+    }
+
+    @Test
+    public void testContinuousTestingReusesInstanceWhenPropertiesAreNotChanged() {
+
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        var result = utils.waitForNextCompletion();
+        assertEquals(2, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+        List<Container> kafkaContainers = getKafkaContainers();
+
+        // Make a change that shouldn't affect dev services
+        test.modifyTestSourceFile(KafkaAdminTest.class, s -> s.replaceAll("test\\(\\)", "myTest()"));
+
+        result = utils.waitForNextCompletion();
+        assertEquals(2, result.getTestsPassed());
+        assertEquals(0, result.getTestsFailed());
+
+        // Some containers could have disappeared, because ryuk cleaned them up, but no new containers should have appeared
+        List<Container> newContainers = getKafkaContainersExcludingExisting(kafkaContainers);
+        assertEquals(0, newContainers.size(),
+                "New containers: " + newContainers + "\n Old containers: " + kafkaContainers + "\n All containers: "
+                        + getAllContainers());
+    }
+
+    @Disabled("Image change is not working, should be fixed by https://github.com/quarkusio/quarkus/issues/47627")
+    @Test
+    public void testContinuousTestingCreatesANewInstanceWhenPropertiesAreChanged() {
+
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        var result = utils.waitForNextCompletion();
+        assertEquals(2, result.getTotalTestsPassed());
+        assertEquals(0, result.getTotalTestsFailed());
+        List<Container> existingContainers = new ArrayList<>();
+        existingContainers.addAll(getKafkaContainers());
+
+        test.modifyResourceFile("application.properties", s -> s.replaceAll("kafka-native", "Redpanda"));
+
+        result = utils.waitForNextCompletion();
+        assertEquals(2, result.getTestsPassed());
+        assertEquals(0, result.getTestsFailed());
+
+        // A new container should have appeared
+        {
+            List<Container> newContainers = getKafkaContainersExcludingExisting(existingContainers);
+            existingContainers.addAll(newContainers);
+            assertEquals(1, newContainers.size(),
+                    "New containers: " + newContainers + "\n Old containers: " + existingContainers + "\n All containers: "
+                            + getAllContainers());
+
+            // The new container should be on the new port
+            List<Integer> ports = Arrays.stream(newContainers.get(0).getPorts())
+                    .map(ContainerPort::getPublicPort)
+                    .toList();
+
+            // Oh good, it's one port, so it should be the expected one
+            assertTrue(ports.contains(6377), "Container ports: " + ports);
+        }
+        test.modifyResourceFile("application.properties", s -> UPDATED_FIXED_PORT_PROPERTIES);
+
+        result = utils.waitForNextCompletion();
+        assertEquals(1, result.getTestsPassed());
+        assertEquals(0, result.getTestsFailed());
+
+        // Another new container should have appeared
+
+        {
+            List<Container> newContainers = getKafkaContainersExcludingExisting(existingContainers);
+            assertEquals(1, newContainers.size(),
+                    "New containers: " + newContainers + "\n Old containers: " + existingContainers + "\n All containers: "
+                            + getAllContainers());
+
+            // The new container should be on the new port
+            List<Integer> ports = Arrays.stream(newContainers.get(0).getPorts())
+                    .map(ContainerPort::getPublicPort)
+                    .toList();
+            assertTrue(ports.contains(6342), "Container ports: " + ports);
+
+        }
+    }
+
+    private static List<Container> getAllContainers() {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(container -> isKafkaContainer(container)).toList();
+    }
+
+    private static void stopAllContainers() {
+        DockerClient dockerClient = DockerClientFactory.lazyClient();
+        dockerClient.listContainersCmd().exec().stream()
+                .filter(DevServicesKafkaContinuousTestingTest::isKafkaContainer)
+                .forEach(c -> dockerClient.stopContainerCmd(c.getId()).exec());
+    }
+
+    private static List<Container> getKafkaContainers() {
+        return getAllContainers();
+    }
+
+    private static List<Container> getKafkaContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getKafkaContainers().stream().filter(
+                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    private static List<Container> getAllContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getAllContainers().stream().filter(
+                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    private static boolean isKafkaContainer(Container container) {
+        // The output of getCommand() seems to vary by host OS (it's different on CI and mac), but the image name should be reliable
+        return container.getImage().contains("kafka");
+    }
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServiceKafka.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServiceKafka.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.kafka.devservices.profiles;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServiceKafka implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("quarkus.kafka.devservices.port", "6379");
+    }
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesCustomPortProfile.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesCustomPortProfile.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.kafka.devservices.profiles;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesCustomPortProfile implements QuarkusTestProfile {
+
+    public static final String PORT = "5050";
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("quarkus.kafka.devservices.port", PORT);
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "test";
+    }
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesCustomPortReusableServiceProfile.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesCustomPortReusableServiceProfile.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.kafka.devservices.profiles;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesCustomPortReusableServiceProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        // This is a distinct profile, but its config should be identical to the custom port profile, so the dev service can be the same
+        return Collections.singletonMap("quarkus.kafka.devservices.port", DevServicesCustomPortProfile.PORT);
+    }
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesDisabledProfile.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesDisabledProfile.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.kafka.devservices.profiles;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesDisabledProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("quarkus.kafka.devservices.enabled", "false");
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "test";
+    }
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesNonUniquePortProfile.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesNonUniquePortProfile.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.kafka.devservices.profiles;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesNonUniquePortProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        // Set an image, both for coverage, and so we know we're connecting to the right service
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put("quarkus.kafka.devservices.port", "5050");
+        // Choose an image which is different what other tests use, so we can identify we're running on it
+        overrides.put("quarkus.kafka.devservices.provider", "Redpanda");
+        return overrides;
+    }
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesRandomPortProfile.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/devservices/profiles/DevServicesRandomPortProfile.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.kafka.devservices.profiles;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServicesRandomPortProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        // Don't set a port, to exercise the random port path
+        return Collections.emptyMap();
+    }
+}

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortITest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.redis.devservices.it.profiles.DevServicesCustomPortProfile;
-import io.quarkus.redis.devservices.it.utils.SocketKit;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.ports.SocketKit;
 
 @QuarkusTest
 @TestProfile(DevServicesCustomPortProfile.class)

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceITest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.redis.devservices.it.profiles.DevServicesCustomPortReusableServiceProfile;
-import io.quarkus.redis.devservices.it.utils.SocketKit;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.ports.SocketKit;
 
 @QuarkusTest
 @TestProfile(DevServicesCustomPortReusableServiceProfile.class)

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisITest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisITest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.redis.client.RedisClient;
 import io.quarkus.redis.devservices.it.profiles.DevServiceRedis;
-import io.quarkus.redis.devservices.it.utils.SocketKit;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.ports.SocketKit;
 
 @QuarkusTest
 @TestProfile(DevServiceRedis.class)

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ports/SocketKit.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ports/SocketKit.java
@@ -1,11 +1,11 @@
-package io.quarkus.redis.devservices.it.utils;
+package io.quarkus.test.ports;
 
 import java.io.IOException;
 import java.net.Socket;
 
 public class SocketKit {
 
-    public static boolean isPortAlreadyUsed(Integer port) {
+    public static boolean isPortAlreadyUsed(int port) {
         try (Socket ignored = new Socket("localhost", port)) {
             ignored.close();
             return true;


### PR DESCRIPTION
I've added more test coverage for Kafka dev services. Three of the tests don't pass, but should pass once https://github.com/quarkusio/quarkus/issues/47627 is implemented. In the meantime I've `@Disable`d them. 

I also moved a port checking utility into a common location. 

@ozangunalp and @cescoffier,  do we have tests for the Kafka container re-use and shared networking and so on? I couldn't spot them, but I didn't really know what I was looking for. I assumed they were there, so I didn't add any, but it seems like an area at risk of regression when implementing #47627, so we will want the protection of tests. 