### PR TITLE
Support Form Auth cookie domain property

### DIFF
--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
@@ -79,7 +79,7 @@ public class WebAuthnRecorder {
                         config.sessionTimeout().toMillis(),
                         config.newCookieInterval().toMillis(), false, config.cookieSameSite().name(),
                         config.cookiePath().orElse(null),
-                        config.cookieMaxAge().map(Duration::toSeconds).orElse(-1L));
+                        config.cookieMaxAge().map(Duration::toSeconds).orElse(-1L), null);
                 String loginPage = config.loginPage().startsWith("/") ? config.loginPage() : "/" + config.loginPage();
                 return new WebAuthnAuthenticationMechanism(loginManager, loginPage);
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
@@ -107,6 +107,11 @@ public interface FormAuthRuntimeConfig {
     Optional<String> cookiePath();
 
     /**
+     * Cookie domain parameter value which, if set, will be used for the session and location cookies.
+     */
+    Optional<String> cookieDomain();
+
+    /**
      * Set the HttpOnly attribute to prevent access to the cookie via JavaScript.
      */
     @WithDefault("false")

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
@@ -40,9 +40,10 @@ public class PersistentLoginManager {
     private final CookieSameSite cookieSameSite;
     private final String cookiePath;
     private final long maxAgeSeconds;
+    private final String cookieDomain;
 
     public PersistentLoginManager(String encryptionKey, String cookieName, long timeoutMillis, long newCookieIntervalMillis,
-            boolean httpOnlyCookie, String cookieSameSite, String cookiePath, long maxAgeSeconds) {
+            boolean httpOnlyCookie, String cookieSameSite, String cookiePath, long maxAgeSeconds, String cookieDomain) {
         this.cookieName = cookieName;
         this.newCookieIntervalMillis = newCookieIntervalMillis;
         this.timeoutMillis = timeoutMillis;
@@ -50,6 +51,7 @@ public class PersistentLoginManager {
         this.cookieSameSite = CookieSameSite.valueOf(cookieSameSite);
         this.cookiePath = cookiePath;
         this.maxAgeSeconds = maxAgeSeconds;
+        this.cookieDomain = cookieDomain;
         try {
             if (encryptionKey == null) {
                 this.secretKey = KeyGenerator.getInstance("AES").generateKey();
@@ -149,6 +151,9 @@ public class PersistentLoginManager {
                     .setHttpOnly(httpOnlyCookie);
             if (maxAgeSeconds >= 0) {
                 cookie.setMaxAge(maxAgeSeconds);
+            }
+            if (cookieDomain != null) {
+                cookie.setDomain(cookieDomain);
             }
             context.addCookie(cookie);
         } catch (Exception e) {


### PR DESCRIPTION
I'm not sure if the cookie domain should participate in `FormAuthenticationMechanism#logout(RoutingContext)` in the same way that `COOKIE_PATH` participates.

One thing I don't understand `COOKIE_PATH` in the `logout(RoutingContext)` method should be non null, even though it may be null in the configuration.

- Closes: #48519