### PR TITLE
Support for OIDC RP-Initiated form post logout mode

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -643,6 +643,7 @@ Quarkus OIDC supports three standard OIDC logout options: <<rp-initiated-logout>
 |quarkus.oidc.logout.post-logout-path || Post logout path
 |quarkus.oidc.logout.post-logout-uri-param || Post logout uri param
 |quarkus.oidc.logout.extra-params || Logout extra params
+|quarkus.oidc.logout.logout-mode |query| Logout mode
 |====
 
 `quarkus.oidc.logout.path` is a relative path where a user logout request should be sent to. For example, given `quarkus.oidc.logout.path=/logout`, a `Logout` link in the SPA page can point to `http://localhost:8080/logout`. This path can be virtual, you do not have to create a JAX-RS endpoint or route handler listening on `/logout`. But for the `quarkus.oidc.logout.path` be effective, it must be secured, see the https://quarkus.io/guides/security-oidc-code-flow-authentication#user-initiated-logout[User-initiated logout] section for more details.
@@ -652,6 +653,9 @@ For example, the logged out user can be returned to the application's welcome pa
 For the post logout redirect to work, OIDC providers usually require registering absolute post logout URLs such as `http://localhost:8080/welcome.html`. Please do not forget, it must be a public endpoint, otherwise the user will be requested to login immediately after choosing to logout.
 
 `quarkus.oidc.logout.post-logout-uri-param` and `quarkus.oidc.logout.extra-params` can be used to customize the RP-initiated logout query parameters, for example, Auth0 might expect Auth0-specific logout query parameters, see the https://quarkus.io/guides/security-oidc-code-flow-authentication#user-initiated-logout[User-initiated logout] section for more details.
+
+By default, all the logout parameters are serialized as logout URL query parameters.
+Some OIDC providers may require that logout parameters are encoded as HTML form values and auto-submitted in the browser with the HTTP POST method and the `application/x-www-form-urlencoded` content type: set `quarkus.oidc.logout.logout-mode=form-post` in this case.
 
 [[back-channel-logout]]
 === Back-channel Logout

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/LogoutUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/LogoutUtils.java
@@ -1,0 +1,51 @@
+package io.quarkus.oidc;
+
+import java.util.Map;
+
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Logout;
+
+public final class LogoutUtils {
+
+    private static final String FORM_POST_LOGOUT_START = "<html>"
+            + "   <head><title>Logout Form</title></head>"
+            + "   <body onload=\"javascript:document.forms[0].submit()\">"
+            + "    <form method=\"post\" action=\"";
+    private static final String FORM_POST_LOGOUT_END = "    </form></body></html>";
+
+    private LogoutUtils() {
+
+    }
+
+    public static String createFormPostLogout(Logout logoutConfig, String logoutUrl,
+            String idToken, String postLogoutUrl, String postLogoutState) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(FORM_POST_LOGOUT_START);
+        sb.append(logoutUrl).append("\">");
+        if (idToken != null) {
+            addInput(sb, OidcConstants.LOGOUT_ID_TOKEN_HINT, idToken);
+        }
+        if (postLogoutUrl != null) {
+            addInput(sb, logoutConfig.postLogoutUriParam(), postLogoutUrl);
+        }
+        if (postLogoutState != null) {
+            addInput(sb, OidcConstants.LOGOUT_STATE, postLogoutState);
+        }
+
+        Map<String, String> extraParams = logoutConfig.extraParams();
+        if (extraParams != null) {
+            for (Map.Entry<String, String> entry : extraParams.entrySet()) {
+                addInput(sb, entry.getKey(), entry.getValue());
+            }
+        }
+        sb.append(FORM_POST_LOGOUT_END);
+        return sb.toString();
+    }
+
+    private static void addInput(StringBuilder sb, String name, String value) {
+        sb.append("<input type=\"hidden\" name=\"").append(name).append("\" ")
+                .append("value=\"").append(value).append("\"")
+                .append("/>");
+    }
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -488,6 +488,8 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
          */
         Optional<Set<ClearSiteData>> clearSiteData = Optional.of(Set.of());
 
+        LogoutMode logoutMode = LogoutMode.QUERY;
+
         /**
          * Back-Channel Logout configuration
          */
@@ -552,6 +554,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             postLogoutUriParam = mapping.postLogoutUriParam();
             extraParams = mapping.extraParams();
             clearSiteData = mapping.clearSiteData();
+            logoutMode = mapping.logoutMode();
             backchannel.addConfigMappingValues(mapping.backchannel());
             frontchannel.addConfigMappingValues(mapping.frontchannel());
         }
@@ -589,6 +592,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         @Override
         public Optional<Set<ClearSiteData>> clearSiteData() {
             return clearSiteData;
+        }
+
+        @Override
+        public LogoutMode logoutMode() {
+            return logoutMode;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -339,6 +339,25 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
          * Clear-Site-Data header directives
          */
         Optional<Set<ClearSiteData>> clearSiteData();
+
+        enum LogoutMode {
+            /**
+             * Logout parameters are encoded in the query string
+             */
+            QUERY,
+
+            /**
+             * Logout parameters are encoded as HTML form values that are auto-submitted in the browser
+             * and transmitted by the HTTP POST method using the application/x-www-form-urlencoded content type
+             */
+            FORM_POST
+        }
+
+        /**
+         * Logout mode
+         */
+        @WithDefault("query")
+        LogoutMode logoutMode();
     }
 
     interface Backchannel {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/LogoutConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/LogoutConfigBuilder.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import io.quarkus.oidc.OidcTenantConfigBuilder;
 import io.quarkus.oidc.runtime.OidcTenantConfig;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Logout.ClearSiteData;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Logout.LogoutMode;
 
 /**
  * Builder for the {@link OidcTenantConfig.Logout}.
@@ -20,7 +21,8 @@ public final class LogoutConfigBuilder {
     private record LogoutImpl(Optional<String> path, Optional<String> postLogoutPath, String postLogoutUriParam,
             Map<String, String> extraParams, OidcTenantConfig.Backchannel backchannel,
             OidcTenantConfig.Frontchannel frontchannel,
-            Optional<Set<ClearSiteData>> clearSiteData) implements OidcTenantConfig.Logout {
+            Optional<Set<ClearSiteData>> clearSiteData,
+            LogoutMode logoutMode) implements OidcTenantConfig.Logout {
     }
 
     private record FrontchannelImpl(Optional<String> path) implements OidcTenantConfig.Frontchannel {
@@ -34,6 +36,7 @@ public final class LogoutConfigBuilder {
     private OidcTenantConfig.Backchannel backchannel;
     private OidcTenantConfig.Frontchannel frontchannel;
     private Optional<Set<ClearSiteData>> clearSiteData = Optional.of(new HashSet<>());
+    private LogoutMode logoutMode;
 
     public LogoutConfigBuilder() {
         this(new OidcTenantConfigBuilder());
@@ -51,6 +54,7 @@ public final class LogoutConfigBuilder {
         this.backchannel = logout.backchannel();
         this.frontchannel = logout.frontchannel();
         this.clearSiteData = logout.clearSiteData();
+        this.logoutMode = logout.logoutMode();
     }
 
     /**
@@ -132,6 +136,21 @@ public final class LogoutConfigBuilder {
         return this;
     }
 
+    public LogoutConfigBuilder logoutMode() {
+        this.logoutMode(LogoutMode.QUERY);
+        return this;
+    }
+
+    /**
+     * @param clear site data directives {@link OidcTenantConfig.Logout#clearSiteData()}
+     * @return this builder
+     */
+    public LogoutConfigBuilder logoutMode(LogoutMode logoutMode) {
+        Objects.requireNonNull(logoutMode);
+        this.logoutMode = logoutMode;
+        return this;
+    }
+
     /**
      * @param backchannel {@link OidcTenantConfig.Logout#backchannel()}
      * @return this builder
@@ -162,7 +181,7 @@ public final class LogoutConfigBuilder {
      */
     public OidcTenantConfig.Logout build() {
         return new LogoutImpl(path, postLogoutPath, postLogoutUriParam, Map.copyOf(extraParams), backchannel, frontchannel,
-                clearSiteData);
+                clearSiteData, logoutMode);
     }
 
     /**

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -162,6 +162,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         LOGOUT_POST_LOGOUT_PATH,
         LOGOUT_POST_LOGOUT_URI_PARAM,
         LOGOUT_CLEAR_SITE_DATA,
+        LOGOUT_MODE,
         LOGOUT_EXTRA_PARAMS,
         LOGOUT_BACK_CHANNEL,
         LOGOUT_FRONT_CHANNEL,
@@ -504,6 +505,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             public Optional<Set<ClearSiteData>> clearSiteData() {
                 invocationsRecorder.put(ConfigMappingMethods.LOGOUT_CLEAR_SITE_DATA, true);
                 return Optional.of(Set.of());
+            }
+
+            @Override
+            public LogoutMode logoutMode() {
+                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_MODE, true);
+                return LogoutMode.QUERY;
             }
 
             @Override

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationRedirectExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationRedirectExceptionMapper.java
@@ -2,21 +2,34 @@ package io.quarkus.resteasy.runtime;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.security.AuthenticationRedirectException;
 
 @Provider
 public class AuthenticationRedirectExceptionMapper implements ExceptionMapper<AuthenticationRedirectException> {
+    private static final Logger log = Logger.getLogger(AuthenticationRedirectExceptionMapper.class);
 
     @Override
     public Response toResponse(AuthenticationRedirectException ex) {
-        return Response.status(ex.getCode())
-                .header(HttpHeaders.LOCATION, ex.getRedirectUri())
+
+        ResponseBuilder builder = Response.status(ex.getCode())
                 .header(HttpHeaders.CACHE_CONTROL, "no-store")
-                .header("Pragma", "no-cache")
-                .build();
+                .header("Pragma", "no-cache");
+        if (ex.getCode() == 200) {
+            // The target URL is embedded in the auto-submitted form post payload
+            log.debugf("Form post redirect to %s", ex.getRedirectUri());
+            builder.entity(ex.getRedirectUri())
+                    .type("text/html; charset=UTF-8");
+        } else {
+            log.debugf("Redirect to %s ", ex.getRedirectUri());
+            builder.header(HttpHeaders.LOCATION, ex.getRedirectUri());
+        }
+        return builder.build();
     }
 
 }

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationRedirectExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationRedirectExceptionMapper.java
@@ -2,19 +2,31 @@ package io.quarkus.resteasy.reactive.server.runtime.exceptionmappers;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.ext.ExceptionMapper;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.security.AuthenticationRedirectException;
 
 public class AuthenticationRedirectExceptionMapper implements ExceptionMapper<AuthenticationRedirectException> {
+    private static final Logger log = Logger.getLogger(AuthenticationRedirectExceptionMapper.class);
 
     @Override
     public Response toResponse(AuthenticationRedirectException ex) {
-        return Response.status(ex.getCode())
-                .header(HttpHeaders.LOCATION, ex.getRedirectUri())
-                .header(HttpHeaders.CACHE_CONTROL, "no-store")
-                .header("Pragma", "no-cache")
-                .build();
-    }
 
+        ResponseBuilder builder = Response.status(ex.getCode())
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .header("Pragma", "no-cache");
+        if (ex.getCode() == 200) {
+            // The target URL is embedded in the auto-submitted form post payload
+            log.debugf("Form post redirect to %s", ex.getRedirectUri());
+            builder.entity(ex.getRedirectUri())
+                    .type("text/html; charset=UTF-8");
+        } else {
+            log.debugf("Redirect to %s ", ex.getRedirectUri());
+            builder.header(HttpHeaders.LOCATION, ex.getRedirectUri());
+        }
+        return builder.build();
+    }
 }

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -76,8 +76,8 @@ public class OidcClientTest {
         long now = System.currentTimeMillis() / 1000;
         long expectedExpiresAt = now + 7;
         long accessTokenExpiresAt = Long.valueOf(data[1]);
-        assertTrue(accessTokenExpiresAt >= expectedExpiresAt
-                && accessTokenExpiresAt <= expectedExpiresAt + 4);
+        assertTrue(accessTokenExpiresAt >= expectedExpiresAt - 1
+                && accessTokenExpiresAt <= expectedExpiresAt + 5);
     }
 
     @Order(9)

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -252,4 +252,9 @@ public class TenantResource {
         return name;
     }
 
+    @GET
+    @Path("form-post-post-logout")
+    public String formPostPostLogout(@QueryParam("username") String userName) {
+        return userName + ", you have been logged out with the form post logout";
+    }
 }

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -55,6 +55,10 @@ quarkus.oidc.tenant-web-app.credentials.secret=secret
 quarkus.oidc.tenant-web-app.application-type=web-app
 quarkus.oidc.tenant-web-app.roles.source=userinfo
 quarkus.oidc.tenant-web-app.allow-user-info-cache=false
+quarkus.oidc.tenant-web-app.end-session-path=http://localhost:8081/oidc/form-post-logout
+quarkus.oidc.tenant-web-app.logout.path=/tenant/tenant-web-app/form-post-logout
+quarkus.oidc.tenant-web-app.logout.post-logout-path=/tenant/tenant-web-app/api/user/form-post-post-logout
+quarkus.oidc.tenant-web-app.logout.logout-mode=form-post
 # Adding this property should not affect the flow if no expected request header
 # "HX-Request" identifying it as a JavaScript request is found
 quarkus.oidc.tenant-web-app.authentication.java-script-auto-redirect=false
@@ -191,6 +195,9 @@ quarkus.http.auth.permission.basic-policy.auth-mechanism=basic
 quarkus.http.auth.permission.bearer-policy.paths=/multiple-auth-mech/bearer/policy
 quarkus.http.auth.permission.bearer-policy.policy=authenticated
 quarkus.http.auth.permission.bearer-policy.auth-mechanism=Bearer
+
+quarkus.http.auth.permission.logout.paths=/tenant/tenant-web-app/form-post-logout
+quarkus.http.auth.permission.logout.policy=authenticated
 
 quarkus.oidc.step-up-auth-required-claims.client-id=client
 quarkus.oidc.step-up-auth-required-claims.allow-token-introspection-cache=false


### PR DESCRIPTION
Fixes #48435.

This PR supports an OIDC RP-Initiated logout mode where the logout parameters are auto-submitted to the OIDC logout endpoint as form parameters.

FYI, initially, I thought that in this case, I'd write the response direct in the `CodeAuthenticationMechanism`, but then I thought, even though it is not an actual 302 redirect, it is still an implicit redirect via the auto-submitting HTML form and if users have `AuthenticationRedirectException` mappers then they should still be able to catch such exceptions, and also should be able to filter such implicit redirects.

**Initial idea how to to pass the form post logout content alongside AuthenticationRedirectException**:

I ended up passing the form post logout data as a request context property that `AuthenticationRedirectException` handlers can access from `RoutingContext`

**How it was implemented in the end**:

I simply pass the form post logout content that actually inlines OIDC logout endpoint URL as the `AuthenticationRedirectException` redirect URI parameter but with the 200 code, and the handlers can distinguish how to respond given the code. Injecting `RoutingContext` into the exception mappers may not work and dealing with RoutingContext is more complex.

Michal, @michalvavrik,  I believe we can think how to extend `AuthenticationRedirectException` to represent the form post logout content cleaner in one of the next `quarkus-security` api releases.

I've worked on the test today with HtmlUnit and it works well with the automatic form submission.


CC @calvernaz