### PR TITLE
Redis Client: fix BLPOP and BRPOP

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractListCommands.java
@@ -127,7 +127,6 @@ class AbstractListCommands<K, V> extends ReactiveSortable<K, V> {
         validate(timeout, "timeout");
 
         RedisCommand cmd = RedisCommand.of(Command.BLPOP);
-        cmd.put(timeout.toSeconds());
         cmd.putAll(marshaller.encode(keys));
         cmd.put(timeout.toSeconds());
 
@@ -140,7 +139,6 @@ class AbstractListCommands<K, V> extends ReactiveSortable<K, V> {
         validate(timeout, "timeout");
 
         RedisCommand cmd = RedisCommand.of(Command.BRPOP);
-        cmd.put(timeout.toSeconds());
         cmd.putAll(marshaller.encode(keys));
         cmd.put(timeout.toSeconds());
 


### PR DESCRIPTION
The timeout value was added to the command twice, which is incorrect. The correct position is _after_ the keys; inserting it before the keys makes the timeout value a key itself (one that likely does not exist).

That doesn't need to be especially problematic with a standalone client, because Redis will just ignore keys that do not exist, but it becomes especially problematic with a cluster client, because the command may suddenly target multiple nodes. This ends up with an error immediately, on the client side.

Fixes #48585