### PR TITLE
Bump vineflower to 1.11.1

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -154,7 +154,7 @@ public class JarResultBuildStep {
     public static final String DEFAULT_FAST_JAR_DIRECTORY_NAME = "quarkus-app";
 
     public static final String MP_CONFIG_FILE = "META-INF/microprofile-config.properties";
-    private static final String VINEFLOWER_VERSION = "1.10.1";
+    private static final String VINEFLOWER_VERSION = "1.11.1";
 
     @BuildStep
     OutputTargetBuildItem outputTarget(BuildSystemTargetBuildItem bst, PackageConfig packageConfig) {


### PR DESCRIPTION
https://github.com/Vineflower/vineflower/releases/tag/1.11.0
https://github.com/Vineflower/vineflower/releases/tag/1.11.1

**NOTE**
This version bumps the minimum required Java version to Java 17