### PR TITLE
Update io.spring.dependency-management plugin version

### DIFF
--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
     }
     plugins {
       id 'io.quarkus' version "${quarkusPluginVersion}"
-      id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+      id 'io.spring.dependency-management' version 'v1.1.7'
     }
 }
 rootProject.name='code-with-quarkus'


### PR DESCRIPTION
The old version 1.0.11.RELEASE uses a deprecated class `org.gradle.api.tasks.Upload` which will removed in Gradle 9.0.