### PR TITLE
Using systemPropertiesPrefixedBy to retrieve quarkus.test properties

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -462,7 +461,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                     });
 
                     tasks.withType(Test.class).configureEach(t -> {
-                        t.setSystemProperties(extractQuarkusTestSystemProperties());
+                        t.setSystemProperties(extractQuarkusTestSystemProperties(project));
 
                         t.getInputs().files(quarkusGenerateTestAppModelTask);
                         // Quarkus test configuration action which should be executed before any Quarkus test
@@ -731,16 +730,9 @@ public class QuarkusPlugin implements Plugin<Project> {
         }
     }
 
-    private static Map<String, Object> extractQuarkusTestSystemProperties() {
-        Properties systemProperties = System.getProperties();
-        Map<String, Object> quarkusSystemProperties = new HashMap<>();
-        for (String propertyName : systemProperties.stringPropertyNames()) {
-            if (!propertyName.startsWith("quarkus.test.")) {
-                continue;
-            }
-
-            quarkusSystemProperties.put(propertyName, systemProperties.get(propertyName));
-        }
-        return quarkusSystemProperties;
+    private static Map<String, Object> extractQuarkusTestSystemProperties(Project project) {
+        return new HashMap<>(project.getProviders()
+                .systemPropertiesPrefixedBy("quarkus.test.")
+                .get());
     }
 }


### PR DESCRIPTION
We observed configuration cache invalidations when changing arbitrary system properties via the command line.

The root cause is the usage of `System.getProperties()` in the `extractQuarkusTestSystemProperties` method, which captures all system properties and breaks cacheability.

This PR replaces the general `System.getProperties()` call with Gradle’s `systemPropertiesPrefixedBy` provider. This returns a name-to-value map of system properties filtered by the given prefix.