### PR TITLE
Use separate surefire execution DevMode tests in OpenAPI extension

### DIFF
--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -132,6 +132,35 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+                <executions>
+                    <!--
+                    The dev mode tests are run as a different execution to ensure that they don't mess with the standard tests.
+                    By adding this configuration we ensure that the maven surefire plugin will execute twice, one for the regular **/*Test.java
+                    tests (using the 'default-test' execution), and one for the prod mode tests (this 'dev-mode' execution)
+                    -->
+                    <execution>
+                        <id>dev-mode</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>**/*DMT.java</includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/hotreload/DisplayOpenAPiEndpointInNotFoundExceptionPageDMT.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/hotreload/DisplayOpenAPiEndpointInNotFoundExceptionPageDMT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
-public class DisplayOpenAPiEndpointInNotFoundExceptionPageTest {
+public class DisplayOpenAPiEndpointInNotFoundExceptionPageDMT {
     private static final String OPEN_API_PATH = "/openapi-path";
     private static final String SWAGGER_UI_PATH = "/swagger-path";
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/hotreload/OpenApiHotReloadDMT.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/hotreload/OpenApiHotReloadDMT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-public class OpenApiHotReloadTest {
+public class OpenApiHotReloadDMT {
 
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityDisabledTestDMT.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityDisabledTestDMT.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-public class AutoSecurityDisabledTestCase {
+public class AutoSecurityDisabledTestDMT {
 
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()


### PR DESCRIPTION
This is done in order to circumvent the `java.lang.OutOfMemoryError` we are seeing