### PR TITLE
Add missing @Test to grpc-multi-module-project tests

### DIFF
--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-project/application/src/test/java/org/acme/quarkus/sample/HelloWorld2Test.java
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-project/application/src/test/java/org/acme/quarkus/sample/HelloWorld2Test.java
@@ -1,8 +1,13 @@
 package org.acme.quarkus.sample;
 
 import examples2.MutinyGreeter2Grpc;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
 
+@QuarkusTest
 public class HelloWorld2Test {
+
+    @Test
     public void someTest() {
         MutinyGreeter2Grpc.MutinyGreeter2Stub stub = null;
     }


### PR DESCRIPTION
Starting from Gradle 9.0:

> When test sources are present and no filters are applied, the test task will now fail with an error if it runs but doesn’t discover any tests. This is to help prevent misconfigurations where the tests are written for one test framework but the test task is mistakenly configured to use another test framework.