### PR TITLE
Disable Develocity Predictive Testing feature

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -93,7 +93,8 @@ env:
   # This may be a lot better with maven 4, but with maven 3, excluding a project does not exclude its children, and it's not possible to include a project and explicitly exclude some children; compensate by doing excludes the low-tech way, at the shell level
   JVM_TEST_INTEGRATION_TESTS_SELECTOR: "-f integration-tests -pl !gradle -pl !maven -pl !devmode -pl !devtools"
   JVM_TEST_NORMAL_TESTS_SELECTOR: "-pl !docs -Dno-test-modules"
-  PTS_MAVEN_ARGS: "-Ddevelocity.pts.enabled=${{ github.event_name == 'pull_request' && github.base_ref == 'main' && 'true' || 'false' }}"
+  #PTS_MAVEN_ARGS: "-Ddevelocity.pts.enabled=${{ github.event_name == 'pull_request' && github.base_ref == 'main' && 'true' || 'false' }}"
+  PTS_MAVEN_ARGS: ""
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test


### PR DESCRIPTION
We enabled it for our Gradle tests but since then we have merged several PRs that were failing.

The last occurrence is this PR:
- https://github.com/quarkusio/quarkus/pull/48614

And it caused failures as in:
- https://github.com/quarkusio/quarkus/pull/48627#issuecomment-3008115316

/cc @geoand 

/cc @jprinet for your awareness. And it's not the first time it happens. We had to revert several Gradle related changes these past months.