### PR TITLE
Specify Unit as return type for Scala tests in codestarts

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class {resource.class-name}Test {
 
     @Test
-    def testHelloEndpoint() = {
+    def testHelloEndpoint(): Unit = {
         given()
           .`when`().get("{resource.path}")
           .then()

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class {resource.class-name}Test {
 
     @Test
-    def testHelloEndpoint() = {
+    def testHelloEndpoint(): Unit = {
         given()
           .`when`().get("{resource.path}")
           .then()

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class {resource.class-name}Test {
 
     @Test
-    def testHelloEndpoint() = {
+    def testHelloEndpoint(): Unit = {
         given()
           .`when`().get("{resource.path}")
           .then()

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class {resource.class-name}Test {
 
     @Test
-    def testHelloEndpoint() = {
+    def testHelloEndpoint(): Unit = {
         given()
           .`when`().get("{resource.path}")
           .then()


### PR DESCRIPTION
Otherwise the test will not be executed:

```
(1) [WARNING] @Test method 'public io.restassured.response.ValidatableResponse org.acme.foo.GreetingResourceTest.testHelloEndpoint()' must not return a value. It will not be executed.
    Source: MethodSource [className = 'org.acme.foo.GreetingResourceTest', methodName = 'testHelloEndpoint', methodParameterTypes = '']
            at org.acme.foo.GreetingResourceTest.testHelloEndpoint(SourceFile:0)
```

Starting from Gradle 9.0, an error occurs if no tests are discovered:

> There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.