### PR TITLE
Fix few gradle misconfigurations related to gradle plugin tests

### DIFF
--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/settings.gradle
@@ -15,8 +15,5 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'quarkus-annotation-processor-multi-module-build'
-
-include ':common'
-include ':application'
+rootProject.name = 'annotation-processor-simple-module'
 

--- a/integration-tests/gradle/src/main/resources/included-build/included/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/included-build/included/settings.gradle
@@ -19,5 +19,4 @@ includeBuild 'nested'
 
 rootProject.name = 'included'
 
-include ':dependency'
-include ':included-quarkus'
+include ':nested:included-quarkus'


### PR DESCRIPTION
I am not sure if the misconfigurations here are intended or not.

```
include ':dependency'
include ':included-quarkus'
```

`dependency` does not exist, while `included-quarkus` exists in a sub module.

cc @snazy

related #38607 