### PR TITLE
Update Hibernate integration artifact name

### DIFF
--- a/docs/src/main/asciidoc/blaze-persistence.adoc
+++ b/docs/src/main/asciidoc/blaze-persistence.adoc
@@ -51,7 +51,7 @@ Add the following dependencies to your project:
 </dependency>
 <dependency>
     <groupId>com.blazebit</groupId>
-    <artifactId>blaze-persistence-integration-hibernate-6.2</artifactId>
+    <artifactId>blaze-persistence-integration-hibernate-7.0</artifactId>
     <scope>runtime</scope>
 </dependency>
 ----
@@ -60,7 +60,7 @@ Add the following dependencies to your project:
 .Using Gradle
 ----
 implementation("com.blazebit:blaze-persistence-integration-quarkus-3")
-runtimeOnly("com.blazebit:blaze-persistence-integration-hibernate-6.2")
+runtimeOnly("com.blazebit:blaze-persistence-integration-hibernate-7.0")
 ----
 
 The use in native images requires a dependency on the entity view annotation processor that may be extracted into a separate `native` profile:


### PR DESCRIPTION
Still a draft, because this depends on the release of 1.6.16 that comes with this new artifact: https://github.com/Blazebit/blaze-persistence/issues/2048