### PR TITLE
Remove the deprecated internal gradle API `DefaultProjectDependency`

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
@@ -26,9 +26,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
-import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -377,9 +374,6 @@ public class DependencyUtils {
                     ped.getDeploymentModule().getGroup().toString(),
                     ped.getDeploymentModule().getName(),
                     ped.getDeploymentModule().getVersion().toString());
-        } else if (ped.getDeploymentModule() instanceof ProjectInternal) {
-            return handler.create(new DefaultProjectDependency((ProjectInternal) ped.getDeploymentModule(), true,
-                    DefaultTaskDependencyFactory.withNoAssociatedProject()));
         } else {
             return handler.create(handler.project(Collections.singletonMap("path", ped.getDeploymentModule().getPath())));
         }


### PR DESCRIPTION
Gradle 9.0 changed the constructor signature from:

```
DefaultProjectDependency(ProjectInternal dependencyProject, boolean buildProjectDependencies, TaskDependencyFactory taskDependencyFactory)
```

to:

```
DefaultProjectDependency(ProjectState projectState)
```

Let's see if CI will pass if we delete:

```
else if (ped.getDeploymentModule() instanceof ProjectInternal) {
    return handler.create(new DefaultProjectDependency((ProjectInternal) ped.getDeploymentModule(), true,
                 DefaultTaskDependencyFactory.withNoAssociatedProject()));
}
```

and depend on the fallback else:

```
else {
    return handler.create(handler.project(Collections.singletonMap("path", ped.getDeploymentModule().getPath())));
}
```

---

Alternative implementation 1:

- Use the new constructor `DefaultProjectDependency(ProjectState projectState)` but that is a breaking change?

Alternative implementation 2:

- Use Reflection to use the appropriate API based on the gradle version.