### PR TITLE
Gradle quarkusDev not working on multiprojects when jandex is present

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -660,11 +660,12 @@ public class QuarkusPlugin implements Plugin<Project> {
                                 .ifPresent(quarkusTask -> quarkusTask.configure(t -> t.dependsOn(jarTask)));
                     }
                 });
-
         getLazyTask(project, QUARKUS_DEV_TASK_NAME).ifPresent(quarkusDev -> {
             getLazyTask(project, JavaPlugin.PROCESS_RESOURCES_TASK_NAME)
                     .ifPresent(t -> quarkusDev.configure(qd -> qd.dependsOn(t)));
-            addDependencyOnJandexIfConfigured(dep, quarkusDev);
+            if (project.getRootProject().equals(dep.getRootProject())) {
+                addDependencyOnJandexIfConfigured(dep, quarkusDev);
+            }
         });
 
         visitProjectDependencies(project, dep, visited);

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/acme-nested/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/acme-nested/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    java
+    id("org.kordamp.gradle.jandex")
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex("io.quarkus.*")
+            includeGroup("org.hibernate.orm")
+        }
+    }
+    mavenCentral()
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
+
+dependencies {
+    implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-rest")
+    testImplementation("io.quarkus:quarkus-junit5")
+    testImplementation("io.rest-assured:rest-assured")
+}
+
+group = "org.acme"
+version = "1.0-SNAPSHOT"
+
+tasks.withType<Test> {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/acme-nested/src/main/java/org/acme/nested/SimpleService.java
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/acme-nested/src/main/java/org/acme/nested/SimpleService.java
@@ -1,0 +1,10 @@
+package org.acme.nested;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SimpleService {
+    public String hello(){
+        return "included-kordamp";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/build.gradle.kts
@@ -1,0 +1,4 @@
+
+group = "org.acme"
+version = "1.0-SNAPSHOT"
+

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/gradle.properties
@@ -1,0 +1,6 @@
+#Quarkus Gradle TS
+#Tue May 06 21:43:16 CEST 2025
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus
+quarkusPlatformVersion=${project.version}
+kordampJandexVersion=2.1.0

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/acme-subproject-nested/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+    val kordampJandexVersion: String by settings
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+                includeGroup("org.hibernate.orm")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id("org.kordamp.gradle.jandex") version kordampJandexVersion
+    }
+}
+
+rootProject.name = "jandex-included-build-kordamp-subproject-nested"
+
+include("acme-nested")

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    java
+    id("io.quarkus")
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex("io.quarkus.*")
+            includeGroup("org.hibernate.orm")
+        }
+    }
+    mavenCentral()
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
+
+dependencies {
+    implementation("org.acme:acme-nested")
+    implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-rest")
+    testImplementation("io.quarkus:quarkus-junit5")
+    testImplementation("io.rest-assured:rest-assured")
+}
+
+group = "org.acme"
+version = "1.0-SNAPSHOT"
+
+tasks.withType<Test> {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/gradle.properties
@@ -1,0 +1,4 @@
+# Gradle properties
+quarkusPluginId=io.quarkus
+quarkusPlatformGroupId=io.quarkus
+quarkusPlatformArtifactId=quarkus-bom

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/settings.gradle.kts
@@ -1,0 +1,21 @@
+pluginManagement {
+    val quarkusPluginVersion: String by settings
+    val quarkusPluginId: String by settings
+    val kotlinVersion: String by settings
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+                includeGroup("org.hibernate.orm")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id(quarkusPluginId) version quarkusPluginVersion
+    }
+}
+rootProject.name = "jandex-included-build-kordamp-root"
+
+includeBuild("acme-subproject-nested")

--- a/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/src/main/java/org/example/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/jandex-included-build-kordamp/src/main/java/org/example/ExampleResource.java
@@ -1,0 +1,22 @@
+package org.example;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.acme.nested.SimpleService;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @Inject
+    SimpleService simpleService;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello " + simpleService.hello();
+    }
+
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/JandexIncludedBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/JandexIncludedBuildTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+
+public class JandexIncludedBuildTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "jandex-included-build-kordamp";
+    }
+
+    /**
+     * Test that jandex works correctly across includedBuild in dev mode
+     */
+    @Override
+    protected void testDevMode() {
+        assertThat(getHttpResponse("/hello")).contains("hello included-kordamp");
+        replace("acme-subproject-nested/acme-nested/src/main/java/org/acme/nested/SimpleService.java",
+                ImmutableMap.of("return \"included-kordamp\";", "return \"included-kordamp-modified\";"));
+        assertUpdatedResponseContains("/hello", "hello included-kordamp-modified");
+    }
+}


### PR DESCRIPTION
Fixes #48637 by avoiding adding a `mustRunAfter` accross build projects