### PR TITLE
Support back-channel logout for dynamic OIDC tenants

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -1,71 +1,170 @@
 package io.quarkus.oidc.runtime;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
 
 import org.eclipse.microprofile.jwt.Claims;
 import org.jboss.logging.Logger;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 
+import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.SecurityEvent.Type;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
+import io.quarkus.vertx.http.runtime.security.ImmutablePathMatcher;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
-public class BackChannelLogoutHandler {
+@Singleton
+public final class BackChannelLogoutHandler implements Handler<RoutingContext> {
     private static final Logger LOG = Logger.getLogger(BackChannelLogoutHandler.class);
     private static final String SLASH = "/";
+    private final DefaultTenantConfigResolver resolver;
+    private volatile ImmutablePathMatcher<Handler<RoutingContext>> pathMatcher;
 
-    void setup(@Observes Router router, DefaultTenantConfigResolver resolver) {
-        final TenantConfigBean tenantConfigBean = resolver.getTenantConfigBean();
-        addRoute(router, tenantConfigBean.getDefaultTenant().oidcConfig(), resolver);
-        for (var nameToOidcTenantConfig : tenantConfigBean.getStaticTenantsConfig().values()) {
-            if (nameToOidcTenantConfig.oidcConfig() != null) {
-                addRoute(router, nameToOidcTenantConfig.oidcConfig(), resolver);
+    record NewBackChannelLogoutPath() {
+    }
+
+    BackChannelLogoutHandler(DefaultTenantConfigResolver resolver) {
+        this.resolver = resolver;
+        this.pathMatcher = null;
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+        var matcher = pathMatcher;
+        if (matcher != null) {
+            Handler<RoutingContext> routeHandler = matcher.match(routingContext.normalizedPath()).getValue();
+            if (routeHandler != null) {
+                routeHandler.handle(routingContext);
+                return;
+            }
+        }
+
+        routingContext.next();
+    }
+
+    // hook up to the router because then we the tenant config bean is surely ready
+    void createPathMatcher(@Observes Router ignored) {
+        createOrUpdatePathMatcher();
+    }
+
+    synchronized void updatePathMatcher(@Observes NewBackChannelLogoutPath ignored, Vertx vertx) {
+        Set<String> currentTenantIds = createOrUpdatePathMatcher();
+        clearCache(vertx, currentTenantIds);
+    }
+
+    void clearCacheOnShutdown(@Observes ShutdownEvent event, Vertx vertx) {
+        clearCache(vertx, null);
+    }
+
+    private void clearCache(Vertx vertx, Set<String> currentTenantIds) {
+        if (currentTenantIds == null) {
+            // clear all as currently we have no tenants with a back-channel logout path
+            for (BackChannelLogoutTokenCache cache : resolver.getBackChannelLogoutTokens().values()) {
+                cache.shutdown(vertx);
+            }
+            resolver.getBackChannelLogoutTokens().clear();
+        } else {
+            // clear only the ones that currently don't have a logout back-channel
+            Set<String> cachedTenantIds = new HashSet<>(resolver.getBackChannelLogoutTokens().keySet());
+            for (String cachedTenantId : cachedTenantIds) {
+                if (!currentTenantIds.contains(cachedTenantId)) {
+                    var cache = resolver.getBackChannelLogoutTokens().remove(cachedTenantId);
+                    if (cache != null) {
+                        cache.shutdown(vertx);
+                    }
+                }
             }
         }
     }
 
-    private static void addRoute(Router router, OidcTenantConfig oidcTenantConfig, DefaultTenantConfigResolver resolver) {
-        if (oidcTenantConfig.tenantEnabled() && oidcTenantConfig.logout().backchannel().path().isPresent()) {
-            router.route(oidcTenantConfig.logout().backchannel().path().get())
-                    .handler(new RouteHandler(oidcTenantConfig, resolver));
+    private Set<String> createOrUpdatePathMatcher() {
+        ImmutablePathMatcher.ImmutablePathMatcherBuilder<Handler<RoutingContext>> builder = null;
+        Map<String, OidcTenantConfig> pathCache = null;
+        Set<String> tenantIdCache = null;
+        for (TenantConfigContext configContext : resolver.getTenantConfigBean().getAllTenantConfigs()) {
+            if (configContext.ready() && configContext.oidcConfig().tenantEnabled()
+                    && configContext.oidcConfig().logout().backchannel().path().isPresent()) {
+                if (builder == null) {
+                    builder = ImmutablePathMatcher.builder();
+                    pathCache = new HashMap<>();
+                    tenantIdCache = new HashSet<>();
+                }
+                String routePath = getTenantLogoutPath(configContext);
+                if (routePath.contains("*")) {
+                    throw new IllegalStateException("Back-channel logout path cannot contain a wildcard '*' character");
+                }
+                OidcTenantConfig previousConfig = pathCache.put(routePath, configContext.oidcConfig());
+                tenantIdCache.add(configContext.oidcConfig().tenantId().get());
+                if (previousConfig == null) {
+                    Handler<RoutingContext> routeHandler = new RouteHandler(configContext, resolver);
+                    builder.addPath(routePath, routeHandler);
+                } else {
+                    String previousTenantId = previousConfig.tenantId().get();
+                    String currentTenantId = configContext.oidcConfig().tenantId().get();
+                    // maybe invalid state, but technically it could happen that some produces a static tenant with
+                    // a same id as a dynamic tenant
+                    if (!previousTenantId.equals(currentTenantId)) {
+                        String errorMessage = "OIDC tenants '%s' and '%s' shares same back-channel logout path '%s', which is not supported"
+                                .formatted(previousTenantId, currentTenantId, routePath);
+                        LOG.error(errorMessage);
+                        throw new OIDCException(errorMessage);
+                    }
+                }
+            }
         }
+        if (builder != null) {
+            pathMatcher = builder.build();
+        } else {
+            pathMatcher = null;
+        }
+        return tenantIdCache;
     }
 
-    private static class RouteHandler implements Handler<RoutingContext> {
-        private final OidcTenantConfig oidcTenantConfig;
-        private final DefaultTenantConfigResolver resolver;
+    private String getTenantLogoutPath(TenantConfigContext tenant) {
+        return getRootPath() + tenant.oidcConfig().logout().backchannel().path().orElse(null);
+    }
 
-        RouteHandler(OidcTenantConfig oidcTenantConfig, DefaultTenantConfigResolver resolver) {
-            this.oidcTenantConfig = oidcTenantConfig;
+    private String getRootPath() {
+        // Prepend '/' if it is not present
+        String rootPath = OidcCommonUtils.prependSlash(resolver.getRootPath());
+        // Strip trailing '/' if the length is > 1
+        if (rootPath.length() > 1 && rootPath.endsWith("/")) {
+            rootPath = rootPath.substring(rootPath.length() - 1);
+        }
+        // if it is only '/' then return an empty value
+        return SLASH.equals(rootPath) ? "" : rootPath;
+    }
+
+    private static final class RouteHandler implements Handler<RoutingContext> {
+        private final TenantConfigContext tenantContext;
+        private final DefaultTenantConfigResolver resolver;
+        private final String tenantId;
+
+        private RouteHandler(TenantConfigContext tenantContext, DefaultTenantConfigResolver resolver) {
+            this.tenantContext = tenantContext;
             this.resolver = resolver;
+            this.tenantId = tenantContext.oidcConfig().tenantId().get();
         }
 
         @Override
         public void handle(RoutingContext context) {
-            LOG.debugf("Back channel logout request for the tenant %s received", oidcTenantConfig.tenantId().get());
-            final String requestPath = context.request().path();
-            final TenantConfigContext tenantContext = getTenantConfigContext(requestPath);
-            if (tenantContext == null) {
-                LOG.errorf(
-                        "Tenant configuration for the tenant %s is not available "
-                                + "or does not match the backchannel logout path %s",
-                        oidcTenantConfig.tenantId().get(), requestPath);
-                context.response().setStatusCode(400);
-                context.response().end();
-                return;
-            }
-
+            LOG.debugf("Back channel logout request for the tenant %s received", tenantId);
             if (OidcUtils.isFormUrlEncodedRequest(context)) {
                 OidcUtils.getFormUrlEncodedData(context)
                         .subscribe().with(new Consumer<MultiMap>() {
@@ -85,13 +184,14 @@ public class BackChannelLogoutHandler {
 
                                         if (verifyLogoutTokenClaims(result)) {
                                             String key = result.localVerificationResult
-                                                    .getString(oidcTenantConfig.logout().backchannel().logoutTokenKey());
-                                            BackChannelLogoutTokenCache tokens = resolver
-                                                    .getBackChannelLogoutTokens().get(oidcTenantConfig.tenantId().get());
+                                                    .getString(
+                                                            tenantContext.oidcConfig().logout().backchannel().logoutTokenKey());
+                                            BackChannelLogoutTokenCache tokens = resolver.getBackChannelLogoutTokens()
+                                                    .get(tenantId);
                                             if (tokens == null) {
-                                                tokens = new BackChannelLogoutTokenCache(oidcTenantConfig, context.vertx());
-                                                resolver.getBackChannelLogoutTokens().put(oidcTenantConfig.tenantId().get(),
-                                                        tokens);
+                                                tokens = new BackChannelLogoutTokenCache(tenantContext.oidcConfig(),
+                                                        context.vertx());
+                                                resolver.getBackChannelLogoutTokens().put(tenantId, tokens);
                                             }
                                             tokens.addTokenVerification(key, result);
 
@@ -130,9 +230,10 @@ public class BackChannelLogoutHandler {
                 LOG.debug("Back channel logout token does not have a valid 'events' claim");
                 return false;
             }
-            if (!result.localVerificationResult.containsKey(oidcTenantConfig.logout().backchannel().logoutTokenKey())) {
+            if (!result.localVerificationResult
+                    .containsKey(tenantContext.oidcConfig().logout().backchannel().logoutTokenKey())) {
                 LOG.debugf("Back channel logout token does not have %s",
-                        oidcTenantConfig.logout().backchannel().logoutTokenKey());
+                        tenantContext.oidcConfig().logout().backchannel().logoutTokenKey());
                 return false;
             }
             if (result.localVerificationResult.containsKey(Claims.nonce.name())) {
@@ -141,35 +242,6 @@ public class BackChannelLogoutHandler {
             }
 
             return true;
-        }
-
-        private TenantConfigContext getTenantConfigContext(final String requestPath) {
-            if (isMatchingTenant(requestPath, resolver.getTenantConfigBean().getDefaultTenant())) {
-                return resolver.getTenantConfigBean().getDefaultTenant();
-            }
-            for (TenantConfigContext tenant : resolver.getTenantConfigBean().getStaticTenantsConfig().values()) {
-                if (isMatchingTenant(requestPath, tenant)) {
-                    return tenant;
-                }
-            }
-            return null;
-        }
-
-        private boolean isMatchingTenant(String requestPath, TenantConfigContext tenant) {
-            return tenant.oidcConfig().tenantEnabled()
-                    && tenant.oidcConfig().tenantId().get().equals(oidcTenantConfig.tenantId().get())
-                    && requestPath.equals(getRootPath() + tenant.oidcConfig().logout().backchannel().path().orElse(null));
-        }
-
-        private String getRootPath() {
-            // Prepend '/' if it is not present
-            String rootPath = OidcCommonUtils.prependSlash(resolver.getRootPath());
-            // Strip trailing '/' if the length is > 1
-            if (rootPath.length() > 1 && rootPath.endsWith("/")) {
-                rootPath = rootPath.substring(rootPath.length() - 1);
-            }
-            // if it is only '/' then return an empty value
-            return SLASH.equals(rootPath) ? "" : rootPath;
         }
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
@@ -1,8 +1,5 @@
 package io.quarkus.oidc.runtime;
 
-import jakarta.enterprise.event.Observes;
-
-import io.quarkus.runtime.ShutdownEvent;
 import io.vertx.core.Vertx;
 
 public class BackChannelLogoutTokenCache {
@@ -27,7 +24,7 @@ public class BackChannelLogoutTokenCache {
         return cache.containsKey(token);
     }
 
-    void shutdown(@Observes ShutdownEvent event, Vertx vertx) {
+    void shutdown(Vertx vertx) {
         cache.stopTimer(vertx);
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -323,7 +323,7 @@ public class DefaultTenantConfigResolver {
         return enableHttpForwardedPrefix;
     }
 
-    public Map<String, BackChannelLogoutTokenCache> getBackChannelLogoutTokens() {
+    Map<String, BackChannelLogoutTokenCache> getBackChannelLogoutTokens() {
         return backChannelLogoutTokens;
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
@@ -7,12 +7,16 @@ import java.util.function.Supplier;
 
 import javax.crypto.SecretKey;
 
+import jakarta.enterprise.event.Event;
+
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.oidc.OidcConfigurationMetadata;
 import io.quarkus.oidc.OidcRedirectFilter;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.Redirect;
+import io.quarkus.oidc.runtime.BackChannelLogoutHandler.NewBackChannelLogoutPath;
 import io.smallrye.mutiny.Uni;
 
 final class LazyTenantConfigContext implements TenantConfigContext {
@@ -32,7 +36,14 @@ final class LazyTenantConfigContext implements TenantConfigContext {
         if (!delegate.ready()) {
             LOG.debugf("Tenant '%s' is not initialized yet, trying to create OIDC connection now",
                     delegate.oidcConfig().tenantId().get());
-            return staticTenantCreator.get().invoke(ctx -> LazyTenantConfigContext.this.delegate = ctx);
+            return staticTenantCreator.get().invoke(ctx -> {
+                LazyTenantConfigContext.this.delegate = ctx;
+                if (ctx.ready() && ctx.oidcConfig().logout().backchannel().path().isPresent()) {
+                    Event<NewBackChannelLogoutPath> event = Arc.container().beanManager().getEvent()
+                            .select(NewBackChannelLogoutPath.class);
+                    event.fire(new NewBackChannelLogoutPath());
+                }
+            });
         }
         return Uni.createFrom().item(delegate);
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -18,6 +18,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.Oidc;
@@ -34,6 +35,7 @@ import io.quarkus.security.runtime.SecurityConfig;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
 
@@ -172,6 +174,10 @@ public class OidcRecorder {
                 };
             }
         };
+    }
+
+    public Handler<RoutingContext> getBackChannelLogoutHandler(BeanContainer beanContainer) {
+        return beanContainer.beanInstance(BackChannelLogoutHandler.class);
     }
 
     private static final class TenantSpecificOidcIdentityProvider extends OidcIdentityProvider

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
@@ -79,10 +79,6 @@ final class TenantContextFactory {
         if (OidcUtils.DEFAULT_TENANT_ID.equals(tenantId)) {
             throw new ConfigurationException("Dynamic tenant ID cannot be same as the default tenant ID: " + tenantId);
         }
-        if (oidcConfig.logout().backchannel().path().isPresent()) {
-            throw new ConfigurationException(
-                    "BackChannel Logout is currently not supported for dynamic tenants");
-        }
         return createTenantContext(oidcConfig, false, tenantId)
                 .onFailure().transform(new Function<Throwable, Throwable>() {
                     @Override

--- a/integration-tests/oidc-wiremock-logout/src/main/java/io/quarkus/it/keycloak/DynamicTenantConfigResolver.java
+++ b/integration-tests/oidc-wiremock-logout/src/main/java/io/quarkus/it/keycloak/DynamicTenantConfigResolver.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.logging.Log;
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcConfig;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class DynamicTenantConfigResolver implements TenantConfigResolver {
+
+    private final Set<String> createdTenants = ConcurrentHashMap.newKeySet();
+
+    @Inject
+    OidcConfig oidcConfig;
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext routingContext, OidcRequestContext<OidcTenantConfig> requestContext) {
+        String normalizedPath = routingContext.normalizedPath();
+        if (normalizedPath.contains("dynamic-tenant-")) {
+            String tenantId = normalizedPath.substring(normalizedPath.lastIndexOf("/") + 1);
+            if (!createdTenants.contains(tenantId)) {
+                var oidcTenantConfigBuilder = OidcTenantConfig.builder(oidcConfig.namedTenants().get("code-flow-form-post"));
+                oidcTenantConfigBuilder.tenantId(tenantId);
+                oidcTenantConfigBuilder.logout().backchannel().path("/back-channel-logout/" + tenantId).endLogout();
+                oidcTenantConfigBuilder.tenantPaths("/service/" + tenantId, "/service/back-channel-logout/" + tenantId);
+                Log.info("Created dynamic tenant config for tenant " + tenantId);
+                createdTenants.add(tenantId);
+                return Uni.createFrom().item(oidcTenantConfigBuilder.build());
+            }
+        }
+        return Uni.createFrom().nullItem();
+    }
+}

--- a/integration-tests/oidc-wiremock-logout/src/main/java/io/quarkus/it/keycloak/DynamicTenantsCodeFlowFormPostResource.java
+++ b/integration-tests/oidc-wiremock-logout/src/main/java/io/quarkus/it/keycloak/DynamicTenantsCodeFlowFormPostResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/")
+public class DynamicTenantsCodeFlowFormPostResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Path("/{tenant-id}")
+    @GET
+    @Authenticated
+    public String access() {
+        return identity.getPrincipal().getName();
+    }
+}

--- a/integration-tests/oidc-wiremock-logout/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock-logout/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.Callable;
@@ -43,10 +44,20 @@ public class CodeFlowAuthorizationTest {
 
     @Test
     public void testCodeFlowFormPostAndBackChannelLogout() throws Exception {
+        testCodeFlowFormPostAndBackChannelLogout("code-flow-form-post", "back-channel-logout");
+    }
+
+    @Test
+    public void testBackChannelLogoutForDynamicTenants() throws IOException {
+        testCodeFlowFormPostAndBackChannelLogout("dynamic-tenant-one", "back-channel-logout/dynamic-tenant-one");
+        testCodeFlowFormPostAndBackChannelLogout("dynamic-tenant-two", "back-channel-logout/dynamic-tenant-two");
+    }
+
+    private void testCodeFlowFormPostAndBackChannelLogout(String tenantId, String backChannelPath) throws IOException {
         defineRevokeTokenStubs();
         try (final WebClient webClient = createWebClient()) {
             webClient.getOptions().setRedirectEnabled(true);
-            HtmlPage page = webClient.getPage("http://localhost:8081/service/code-flow-form-post");
+            HtmlPage page = webClient.getPage("http://localhost:8081/service/" + tenantId);
 
             HtmlForm form = page.getFormByName("form");
             form.getInputByName("username").type("alice");
@@ -56,28 +67,28 @@ public class CodeFlowAuthorizationTest {
 
             assertEquals("alice", textPage.getContent());
 
-            assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
+            assertNotNull(getSessionCookie(webClient, tenantId));
 
-            textPage = webClient.getPage("http://localhost:8081/service/code-flow-form-post");
+            textPage = webClient.getPage("http://localhost:8081/service/" + tenantId);
             assertEquals("alice", textPage.getContent());
 
             // Session is still active
-            assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
+            assertNotNull(getSessionCookie(webClient, tenantId));
 
             // ID token subject is `123456`
             // request a back channel logout for some other subject
             RestAssured.given()
                     .when().contentType(ContentType.URLENC)
                     .body("logout_token=" + OidcWiremockTestResource.getLogoutToken("789"))
-                    .post("http://localhost:8081/service/back-channel-logout")
+                    .post("http://localhost:8081/service/" + backChannelPath)
                     .then()
                     .statusCode(200);
 
             // No logout:
-            textPage = webClient.getPage("http://localhost:8081/service/code-flow-form-post");
+            textPage = webClient.getPage("http://localhost:8081/service/" + tenantId);
             assertEquals("alice", textPage.getContent());
             // Session is still active
-            assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
+            assertNotNull(getSessionCookie(webClient, tenantId));
 
             wireMockServer.verify(0,
                     postRequestedFor(urlPathMatching("/auth/realms/quarkus/revoke")));
@@ -86,19 +97,19 @@ public class CodeFlowAuthorizationTest {
             RestAssured.given()
                     .when().contentType(ContentType.URLENC).body("logout_token="
                             + OidcWiremockTestResource.getLogoutToken("123456"))
-                    .post("http://localhost:8081/service/back-channel-logout")
+                    .post("http://localhost:8081/service/" + backChannelPath)
                     .then()
                     .statusCode(200);
 
             // Confirm 302 is returned and the session cookie is null
             webClient.getOptions().setRedirectEnabled(false);
             WebResponse webResponse = webClient
-                    .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/service/code-flow-form-post").toURL()));
+                    .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/service/" + tenantId).toURL()));
             assertEquals(302, webResponse.getStatusCode());
             String clearSiteData = webResponse.getResponseHeaderValue("clear-site-data");
             assertTrue(clearSiteData.equals("\"cache\",\"cookies\"") || clearSiteData.equals("\"cookies\",\"cache\""));
 
-            assertNull(getSessionCookie(webClient, "code-flow-form-post"));
+            assertNull(getSessionCookie(webClient, tenantId));
 
             await().atMost(10, TimeUnit.SECONDS)
                     .pollInterval(Duration.ofSeconds(3))


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/48578
- `io.quarkus.oidc.runtime.BackChannelLogoutTokenCache#shutdown` didn't work (which is not a big problem because I think Vert.X attempts to close all timers anyway), so I refactored it