### PR TITLE
Add functionality to capture Quarkus application runtime data using JFR extension

### DIFF
--- a/docs/src/main/asciidoc/jfr.adoc
+++ b/docs/src/main/asciidoc/jfr.adoc
@@ -251,6 +251,22 @@ We can check if the Resource Method was executed as expected by the HTTP Method 
 
 Client records information about the accessing client.
 
+=== Runtime Event
+This event is recorded by default.
+The following three JFR events are recorded in JFR chunks.
+
+QuarkusRuntime::
+
+  Records information about Quarkus running. This event includes the Quarkus version, its profiles, and the mode in which it is running.
+
+QuarkusApplication::
+
+  Records information about Quarkus application running. This event includes the name of the application and its version.
+
+Extension::
+
+  Records information about extensions included in the running Quarkus. This event includes the name of the extensions installed in Quarkus.
+
 === Native Image
 
 Native executables supports Java Flight Recorder.

--- a/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
+++ b/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
@@ -1,11 +1,21 @@
 package io.quarkus.jfr.deployment;
 
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.builder.Version;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
-import io.quarkus.deployment.annotations.*;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.jfr.runtime.JfrRecorder;
@@ -16,9 +26,13 @@ import io.quarkus.jfr.runtime.http.rest.classic.ClassicServerRecorderProducer;
 import io.quarkus.jfr.runtime.http.rest.reactive.ReactiveServerFilters;
 import io.quarkus.jfr.runtime.http.rest.reactive.ReactiveServerRecorderProducer;
 import io.quarkus.jfr.runtime.http.rest.reactive.ServerStartRecordingHandler;
+import io.quarkus.jfr.runtime.runtime.JfrRuntimeBean;
+import io.quarkus.jfr.runtime.runtime.QuarkusRuntimeInfo;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.GlobalHandlerCustomizerBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomContainerRequestFilterBuildItem;
+import io.quarkus.runtime.ImageMode;
+import io.quarkus.runtime.configuration.ConfigUtils;
 
 @BuildSteps
 public class JfrProcessor {
@@ -26,6 +40,25 @@ public class JfrProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.JFR);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void registerVersion(List<FeatureBuildItem> features, BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<SyntheticBeanBuildItem> beanProduce, JfrRecorder recorder, ApplicationInfoBuildItem applicationInfo) {
+
+        List<String> featureNames = features.stream().map(f -> f.getName()).toList();
+        String quarkusVersion = Version.getVersion();
+
+        beanProduce.produce(SyntheticBeanBuildItem.configure(QuarkusRuntimeInfo.class)
+                .supplier(recorder.quarkusInfoSupplier(quarkusVersion, featureNames, ImageMode.current().name(),
+                        String.join(",", ConfigUtils.getProfiles())))
+                .scope(ApplicationScoped.class)
+                .setRuntimeInit().done());
+
+        additionalBeans.produce(AdditionalBeanBuildItem.builder().setUnremovable()
+                .addBeanClasses(JfrRuntimeBean.class)
+                .build());
     }
 
     @BuildStep

--- a/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/JfrConfigurationTest.java
+++ b/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/JfrConfigurationTest.java
@@ -15,7 +15,8 @@ public class JfrConfigurationTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.jfr.enabled", "false")
-            .overrideConfigKey("quarkus.jfr.rest.enabled", "false");
+            .overrideConfigKey("quarkus.jfr.rest.enabled", "false")
+            .overrideConfigKey("quarkus.jfr.runtime.enabled", "false");
 
     @Inject
     JfrRuntimeConfig runtimeConfig;
@@ -24,5 +25,6 @@ public class JfrConfigurationTest {
     void config() {
         assertFalse(runtimeConfig.enabled());
         assertFalse(runtimeConfig.restEnabled());
+        assertFalse(runtimeConfig.runtimeEnabled());
     }
 }

--- a/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/runtime/JfrRuntimeBeanTest.java
+++ b/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/runtime/JfrRuntimeBeanTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.jfr.test.runtime;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.jfr.runtime.runtime.QuarkusRuntimeInfo;
+import io.quarkus.runtime.ImageMode;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JfrRuntimeBeanTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    QuarkusRuntimeInfo quarkusRuntimeInfo;
+
+    @Test
+    public void test() {
+        Assertions.assertEquals(Version.getVersion(), quarkusRuntimeInfo.version());
+        Assertions.assertEquals(ImageMode.current().name(), quarkusRuntimeInfo.imageMode());
+        Assertions.assertEquals("test", quarkusRuntimeInfo.profiles());
+        Assertions.assertEquals(1, quarkusRuntimeInfo.features().stream().filter(s -> s.equals("cdi")).count());
+        Assertions.assertEquals(1, quarkusRuntimeInfo.features().stream().filter(s -> s.equals("jfr")).count());
+    }
+}

--- a/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/runtime/JfrRuntimeDisableTest.java
+++ b/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/runtime/JfrRuntimeDisableTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.jfr.test.runtime;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+public class JfrRuntimeDisableTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.jfr.runtime.enabled", "false");
+
+    @Test
+    public void test() throws IOException {
+        final Path dumpPath = Path.of("./dump.jfr");
+        try {
+            try (Recording r = new Recording()) {
+                r.start();
+                r.stop();
+                r.dump(dumpPath);
+            } catch (Exception e) {
+                Assertions.fail(e);
+            }
+            List<RecordedEvent> recordedEvents = RecordingFile.readAllEvents(dumpPath);
+            Assertions.assertEquals(0, recordedEvents.size());
+        } finally {
+            if (Files.exists(dumpPath)) {
+                Files.delete(dumpPath);
+            }
+        }
+    }
+}

--- a/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/runtime/JfrRuntimeTest.java
+++ b/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/test/runtime/JfrRuntimeTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.jfr.test.runtime;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.jfr.runtime.runtime.QuarkusRuntimeInfo;
+import io.quarkus.runtime.ApplicationConfig;
+import io.quarkus.test.QuarkusUnitTest;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+public class JfrRuntimeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    QuarkusRuntimeInfo quarkusRuntimeInfo;
+
+    @Inject
+    ApplicationConfig applicationConfig;
+
+    @Test
+    public void test() throws IOException {
+        final Path dumpPath = Path.of("./dump.jfr");
+        try {
+            try (Recording r = new Recording()) {
+                r.start();
+                r.stop();
+                r.dump(dumpPath);
+            } catch (Exception e) {
+                Assertions.fail(e);
+            }
+            List<RecordedEvent> recordedEvents = RecordingFile.readAllEvents(dumpPath);
+
+            testApplicationEvent(recordedEvents);
+            testRuntimeEvent(recordedEvents);
+            testExtensionEvent(recordedEvents);
+        } finally {
+            if (Files.exists(dumpPath)) {
+                Files.delete(dumpPath);
+            }
+        }
+    }
+
+    private void testApplicationEvent(List<RecordedEvent> recordedEvents) {
+        List<RecordedEvent> applicationEvents = recordedEvents.stream()
+                .filter(e -> e.getEventType().getName().equals("quarkus.application")).toList();
+        RecordedEvent applicationEvent = applicationEvents.get(0);
+        Assertions.assertTrue(applicationEvents.size() >= 1);
+        Assertions.assertEquals(applicationConfig.name().get(), applicationEvent.getString("name"));
+        Assertions.assertEquals(applicationConfig.version().get(), applicationEvent.getString("version"));
+    }
+
+    private void testRuntimeEvent(List<RecordedEvent> recordedEvents) {
+        List<RecordedEvent> runtimeEvents = recordedEvents.stream()
+                .filter(e -> e.getEventType().getName().equals("quarkus.runtime")).toList();
+        RecordedEvent runtimeEvent = runtimeEvents.get(0);
+        Assertions.assertTrue(runtimeEvents.size() >= 1);
+        Assertions.assertEquals(quarkusRuntimeInfo.imageMode(), runtimeEvent.getString("imageMode"));
+        Assertions.assertEquals(quarkusRuntimeInfo.version(), runtimeEvent.getString("version"));
+        Assertions.assertEquals(quarkusRuntimeInfo.profiles(), runtimeEvent.getString("profiles"));
+    }
+
+    private void testExtensionEvent(List<RecordedEvent> recordedEvents) {
+        List<RecordedEvent> extensionEvents = recordedEvents.stream()
+                .filter(e -> e.getEventType().getName().equals("quarkus.extension")).toList();
+        List<String> recordedExtensionNames = extensionEvents.stream().map(e -> e.getString("name")).distinct().toList();
+        Assertions.assertEquals(quarkusRuntimeInfo.features().size(), recordedExtensionNames.size());
+        Assertions.assertTrue(recordedExtensionNames.containsAll(quarkusRuntimeInfo.features()));
+    }
+}

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/JfrRecorder.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/JfrRecorder.java
@@ -1,11 +1,15 @@
 package io.quarkus.jfr.runtime;
 
+import java.util.List;
+import java.util.function.Supplier;
+
 import org.jboss.logging.Logger;
 
 import io.quarkus.jfr.runtime.config.JfrRuntimeConfig;
 import io.quarkus.jfr.runtime.http.rest.RestEndEvent;
 import io.quarkus.jfr.runtime.http.rest.RestPeriodEvent;
 import io.quarkus.jfr.runtime.http.rest.RestStartEvent;
+import io.quarkus.jfr.runtime.runtime.QuarkusRuntimeInfo;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import jdk.jfr.FlightRecorder;
@@ -41,5 +45,35 @@ public class JfrRecorder {
 
     public void disabledQuarkusJfr() {
         this.disabledRestJfr();
+    }
+
+    public Supplier<QuarkusRuntimeInfo> quarkusInfoSupplier(String version, List<String> features, String imageMode,
+            String profiles) {
+        return new Supplier<>() {
+            @Override
+            public QuarkusRuntimeInfo get() {
+                return new QuarkusRuntimeInfo() {
+                    @Override
+                    public String imageMode() {
+                        return imageMode;
+                    }
+
+                    @Override
+                    public String profiles() {
+                        return profiles;
+                    }
+
+                    @Override
+                    public String version() {
+                        return version;
+                    }
+
+                    @Override
+                    public List<String> features() {
+                        return features;
+                    }
+                };
+            }
+        };
     }
 }

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/config/JfrRuntimeConfig.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/config/JfrRuntimeConfig.java
@@ -27,4 +27,14 @@ public interface JfrRuntimeConfig {
     @WithName("rest.enabled")
     @WithDefault("true")
     boolean restEnabled();
+
+    /**
+     * If false, only Runtime events in quarkus-jfr are not recorded even if JFR is enabled.
+     * In this case, other quarkus-jfr, Java standard API and virtual machine information will be recorded according to the
+     * setting.
+     * Default value is <code>true</code>
+     */
+    @WithName("runtime.enabled")
+    @WithDefault("true")
+    boolean runtimeEnabled();
 }

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/ExtensionEvent.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/ExtensionEvent.java
@@ -1,0 +1,30 @@
+package io.quarkus.jfr.runtime.runtime;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Period;
+import jdk.jfr.StackTrace;
+
+@Label("Quarkus Extension")
+@Category({ "Quarkus", "Runtime" })
+@Name("quarkus.extension")
+@Description("Extension installed in Quarkus")
+@StackTrace(false)
+@Period
+public class ExtensionEvent extends Event {
+
+    @Label("Extension Name")
+    @Description("The name of extension that is installed in Quarkus")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/JfrRuntimeBean.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/JfrRuntimeBean.java
@@ -1,0 +1,96 @@
+package io.quarkus.jfr.runtime.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import io.quarkus.jfr.runtime.config.JfrRuntimeConfig;
+import io.quarkus.runtime.ApplicationConfig;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import jdk.jfr.FlightRecorder;
+
+@ApplicationScoped
+public class JfrRuntimeBean {
+
+    @Inject
+    JfrRuntimeConfig jfrRuntimeConfig;
+
+    @Inject
+    QuarkusRuntimeInfo quarkusRuntimeInfo;
+
+    @Inject
+    ApplicationConfig applicationConfig;
+
+    private final Runnable runtimeEventTask = new RuntimeEventTask();
+    private final Runnable applicationEventTask = new ApplicationEventTask();
+    private final Runnable extensionEventTask = new ExtensionEventTask();
+
+    public void enable() {
+        FlightRecorder.register(QuarkusRuntimeEvent.class);
+        FlightRecorder.register(QuarkusApplicationEvent.class);
+        FlightRecorder.register(ExtensionEvent.class);
+        FlightRecorder.addPeriodicEvent(QuarkusRuntimeEvent.class, runtimeEventTask);
+        FlightRecorder.addPeriodicEvent(QuarkusApplicationEvent.class, applicationEventTask);
+        FlightRecorder.addPeriodicEvent(ExtensionEvent.class, extensionEventTask);
+    }
+
+    public void disable() {
+        FlightRecorder.removePeriodicEvent(runtimeEventTask);
+        FlightRecorder.removePeriodicEvent(applicationEventTask);
+        FlightRecorder.removePeriodicEvent(extensionEventTask);
+        FlightRecorder.unregister(QuarkusRuntimeEvent.class);
+        FlightRecorder.unregister(QuarkusApplicationEvent.class);
+        FlightRecorder.unregister(ExtensionEvent.class);
+    }
+
+    public void onStart(@Observes StartupEvent ev) {
+        if (jfrRuntimeConfig.runtimeEnabled()) {
+            this.enable();
+        }
+    }
+
+    public void onStop(@Observes ShutdownEvent ev) {
+        if (jfrRuntimeConfig.runtimeEnabled()) {
+            this.disable();
+        }
+    }
+
+    class RuntimeEventTask implements Runnable {
+        @Override
+        public void run() {
+            QuarkusRuntimeEvent event = new QuarkusRuntimeEvent();
+            if (event.shouldCommit()) {
+                event.setVersion(quarkusRuntimeInfo.version());
+                event.setImageMode(quarkusRuntimeInfo.imageMode());
+                event.setProfiles(quarkusRuntimeInfo.profiles());
+                event.commit();
+            }
+        }
+    }
+
+    class ApplicationEventTask implements Runnable {
+        @Override
+        public void run() {
+            QuarkusApplicationEvent event = new QuarkusApplicationEvent();
+            if (event.shouldCommit()) {
+                event.setName(applicationConfig.name().get());
+                event.setVersion(applicationConfig.version().get());
+                event.commit();
+            }
+        }
+    }
+
+    class ExtensionEventTask implements Runnable {
+        @Override
+        public void run() {
+            for (String feature : quarkusRuntimeInfo.features()) {
+                ExtensionEvent event = new ExtensionEvent();
+                if (event.shouldCommit()) {
+                    event.setName(feature);
+                    event.commit();
+                }
+            }
+        }
+    }
+}

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/QuarkusApplicationEvent.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/QuarkusApplicationEvent.java
@@ -1,0 +1,42 @@
+package io.quarkus.jfr.runtime.runtime;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Period;
+import jdk.jfr.StackTrace;
+
+@Label("Quarkus Application")
+@Category({ "Quarkus" })
+@Name("quarkus.application")
+@Description("Applications developed using Quarkus")
+@StackTrace(false)
+@Period
+public class QuarkusApplicationEvent extends Event {
+
+    @Label("Application Name")
+    @Description("The name of application that is running")
+    private String name;
+
+    @Label("Application Version")
+    @Description("The version of application that is running")
+    private String version;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/QuarkusRuntimeEvent.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/QuarkusRuntimeEvent.java
@@ -1,0 +1,54 @@
+package io.quarkus.jfr.runtime.runtime;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Period;
+import jdk.jfr.StackTrace;
+
+@Label("Quarkus Runtime")
+@Category({ "Quarkus", "Runtime" })
+@Name("quarkus.runtime")
+@Description("Quarkus running")
+@StackTrace(false)
+@Period
+public class QuarkusRuntimeEvent extends Event {
+
+    @Label("Version")
+    @Description("The version of Quarkus on which application is running")
+    private String version;
+
+    @Label("Image Mode")
+    @Description("The image mode of Quarkus in which application is running")
+    private String imageMode;
+
+    @Label("Profiles")
+    @Description("The profiles of Quarkus which application is running")
+    private String profiles;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getImageMode() {
+        return imageMode;
+    }
+
+    public void setImageMode(String imageMode) {
+        this.imageMode = imageMode;
+    }
+
+    public String getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(String profiles) {
+        this.profiles = profiles;
+    }
+}

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/QuarkusRuntimeInfo.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/runtime/QuarkusRuntimeInfo.java
@@ -1,0 +1,14 @@
+package io.quarkus.jfr.runtime.runtime;
+
+import java.util.List;
+
+public interface QuarkusRuntimeInfo {
+
+    String imageMode();
+
+    String profiles();
+
+    String version();
+
+    List<String> features();
+}


### PR DESCRIPTION
Added support for integrating Quarkus runtime data with JDK Flight Recorder extension. 
This enables detailed recording application information as followings,

- Application name
- Application version
- Quarkus version
- Image mode
- Profiles
- Extensions installed