### PR TITLE
Track start/end template + before/after node resolve

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import io.quarkus.qute.TemplateLocator.TemplateLocation;
+import io.quarkus.qute.trace.TraceListener;
 
 /**
  * Represents a central point for template management.
@@ -191,4 +192,41 @@ public interface Engine extends ErrorInitializer {
      * @return a new builder instance initialized from this engine
      */
     EngineBuilder newBuilder();
+
+    /**
+     * Returns {@code true} if there are any trace listeners currently registered,
+     * {@code false} otherwise.
+     * <p>
+     * Trace listeners monitor and react to template rendering events.
+     *
+     * @return {@code true} if at least one trace listener is registered, {@code false} otherwise
+     */
+    boolean hasTraceListeners();
+
+    /**
+     * Returns the {@link TraceManager} responsible for managing trace listeners and
+     * firing trace events during template rendering.
+     *
+     * @return the trace manager instance
+     */
+    TraceManager getTraceManager();
+
+    /**
+     * Registers a new {@link TraceListener} to receive trace events.
+     * <p>
+     * The listener will be notified of template rendering and resolution events.
+     *
+     * @param listener the trace listener to add; must not be {@code null}
+     */
+    void addTraceListener(TraceListener listener);
+
+    /**
+     * Unregisters a previously registered {@link TraceListener}.
+     * <p>
+     * After removal, the listener will no longer receive trace events.
+     *
+     * @param listener the trace listener to remove; must not be {@code null}
+     */
+    void removeTraceListener(TraceListener listener);
+
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
@@ -184,30 +184,11 @@ public interface Engine extends ErrorInitializer {
     boolean removeStandaloneLines();
 
     /**
-     * Initializes a new {@link EngineBuilder} instance from this engine.
-     * <p>
-     * The {@link EngineBuilder#iterationMetadataPrefix(String) is not set but if a
-     * {@link io.quarkus.qute.LoopSectionHelper.Factory} is registered then the original prefix should be honored.
-     *
-     * @return a new builder instance initialized from this engine
-     */
-    EngineBuilder newBuilder();
-
-    /**
-     * Returns {@code true} if there are any trace listeners currently registered,
-     * {@code false} otherwise.
-     * <p>
-     * Trace listeners monitor and react to template rendering events.
-     *
-     * @return {@code true} if at least one trace listener is registered, {@code false} otherwise
-     */
-    boolean hasTraceListeners();
-
-    /**
      * Returns the {@link TraceManager} responsible for managing trace listeners and
      * firing trace events during template rendering.
      *
-     * @return the trace manager instance
+     * @return the trace manager instance or {@code null} if tracing is disabled
+     * @see EngineBuilder#enableTracing(boolean)
      */
     TraceManager getTraceManager();
 
@@ -218,7 +199,13 @@ public interface Engine extends ErrorInitializer {
      *
      * @param listener the trace listener to add; must not be {@code null}
      */
-    void addTraceListener(TraceListener listener);
+    default void addTraceListener(TraceListener listener) {
+        TraceManager manager = getTraceManager();
+        if (manager == null) {
+            throw new IllegalStateException("Tracing not enabled");
+        }
+        manager.addTraceListener(listener);
+    }
 
     /**
      * Unregisters a previously registered {@link TraceListener}.
@@ -227,6 +214,22 @@ public interface Engine extends ErrorInitializer {
      *
      * @param listener the trace listener to remove; must not be {@code null}
      */
-    void removeTraceListener(TraceListener listener);
+    default void removeTraceListener(TraceListener listener) {
+        TraceManager manager = getTraceManager();
+        if (manager == null) {
+            throw new IllegalStateException("Tracing not enabled");
+        }
+        manager.removeTraceListener(listener);
+    }
+
+    /**
+     * Initializes a new {@link EngineBuilder} instance from this engine.
+     * <p>
+     * The {@link EngineBuilder#iterationMetadataPrefix(String) is not set but if a
+     * {@link io.quarkus.qute.LoopSectionHelper.Factory} is registered then the original prefix should be honored.
+     *
+     * @return a new builder instance initialized from this engine
+     */
+    EngineBuilder newBuilder();
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -43,6 +43,7 @@ public final class EngineBuilder {
     long timeout;
     boolean useAsyncTimeout;
     final List<EngineListener> listeners;
+    boolean enableTracing;
 
     EngineBuilder() {
         this.sectionHelperFactories = new HashMap<>();
@@ -333,6 +334,19 @@ public final class EngineBuilder {
      */
     public EngineBuilder addEngineListener(EngineListener listener) {
         this.listeners.add(Objects.requireNonNull(listener));
+        return this;
+    }
+
+    /**
+     * If set to {@code true} then trace listeners that enable logging, profiling, or building interactive debugging tools, can
+     * be registered with the {@link TraceManager}.
+     *
+     * @param value
+     * @return self
+     * @see Engine#getTraceManager()
+     */
+    public EngineBuilder enableTracing(boolean value) {
+        this.enableTracing = value;
         return this;
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.qute.Parser.StringReader;
 import io.quarkus.qute.TemplateInstance.Initializer;
 import io.quarkus.qute.TemplateLocator.TemplateLocation;
+import io.quarkus.qute.trace.TraceListener;
 
 class EngineImpl implements Engine {
 
@@ -39,6 +40,7 @@ class EngineImpl implements Engine {
     final boolean removeStandaloneLines;
     private final long timeout;
     private final boolean useAsyncTimeout;
+    private final TraceManager traceManager;
 
     EngineImpl(EngineBuilder builder) {
         this.sectionHelperFactories = Map.copyOf(builder.sectionHelperFactories);
@@ -55,6 +57,7 @@ class EngineImpl implements Engine {
         this.initializers = ImmutableList.copyOf(builder.initializers);
         this.timeout = builder.timeout;
         this.useAsyncTimeout = builder.useAsyncTimeout;
+        this.traceManager = new TraceManager();
     }
 
     @Override
@@ -234,6 +237,26 @@ class EngineImpl implements Engine {
         return reader instanceof BufferedReader ? reader
                 : new BufferedReader(
                         reader);
+    }
+
+    @Override
+    public boolean hasTraceListeners() {
+        return traceManager.hasTraceListeners();
+    }
+
+    @Override
+    public TraceManager getTraceManager() {
+        return traceManager;
+    }
+
+    @Override
+    public void addTraceListener(TraceListener listener) {
+        getTraceManager().addTraceListener(listener);
+    }
+
+    @Override
+    public void removeTraceListener(TraceListener listener) {
+        getTraceManager().removeTraceListener(listener);
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
@@ -20,7 +20,6 @@ import org.jboss.logging.Logger;
 import io.quarkus.qute.Parser.StringReader;
 import io.quarkus.qute.TemplateInstance.Initializer;
 import io.quarkus.qute.TemplateLocator.TemplateLocation;
-import io.quarkus.qute.trace.TraceListener;
 
 class EngineImpl implements Engine {
 
@@ -40,7 +39,7 @@ class EngineImpl implements Engine {
     final boolean removeStandaloneLines;
     private final long timeout;
     private final boolean useAsyncTimeout;
-    private final TraceManager traceManager;
+    final TraceManagerImpl traceManager;
 
     EngineImpl(EngineBuilder builder) {
         this.sectionHelperFactories = Map.copyOf(builder.sectionHelperFactories);
@@ -57,7 +56,7 @@ class EngineImpl implements Engine {
         this.initializers = ImmutableList.copyOf(builder.initializers);
         this.timeout = builder.timeout;
         this.useAsyncTimeout = builder.useAsyncTimeout;
-        this.traceManager = new TraceManager();
+        this.traceManager = builder.enableTracing ? new TraceManagerImpl() : null;
     }
 
     @Override
@@ -240,23 +239,8 @@ class EngineImpl implements Engine {
     }
 
     @Override
-    public boolean hasTraceListeners() {
-        return traceManager.hasTraceListeners();
-    }
-
-    @Override
-    public TraceManager getTraceManager() {
+    public TraceManagerImpl getTraceManager() {
         return traceManager;
-    }
-
-    @Override
-    public void addTraceListener(TraceListener listener) {
-        getTraceManager().addTraceListener(listener);
-    }
-
-    @Override
-    public void removeTraceListener(TraceListener listener) {
-        getTraceManager().removeTraceListener(listener);
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
@@ -45,7 +45,8 @@ public final class Results {
         return CompletedStage.of(NotFound.EMPTY);
     }
 
-    static CompletionStage<ResultNode> resolveAndProcess(List<TemplateNode> nodes, ResolutionContext context, Engine engine) {
+    static CompletionStage<ResultNode> resolveAndProcess(List<TemplateNode> nodes, ResolutionContext context,
+            EngineImpl engine) {
         int nodesCount = nodes.size();
         if (nodesCount == 1) {
             // Single node in the block
@@ -102,13 +103,13 @@ public final class Results {
      * the performance of trivial implementations like TextNode::resolve, which is as simple as a field access.
      */
     private static CompletionStage<ResultNode> resolveWith(TemplateNode templateNode, ResolutionContext context,
-            Engine engine) {
-        if (!engine.hasTraceListeners()) {
+            EngineImpl engine) {
+        TraceManagerImpl traceManager = engine.traceManager;
+        if (traceManager == null) {
             return doResolveWith(templateNode, context);
         }
 
         // Notify trace listeners before resolving the template node.
-        TraceManager traceManager = engine.getTraceManager();
         final ResolveEvent event = new ResolveEvent(templateNode, context, engine);
         traceManager.fireBeforeResolveEvent(event);
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
@@ -13,6 +13,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.quarkus.qute.trace.ResolveEvent;
+
 public final class Results {
 
     public static final CompletedStage<Object> FALSE = CompletedStage.of(false);
@@ -43,18 +45,18 @@ public final class Results {
         return CompletedStage.of(NotFound.EMPTY);
     }
 
-    static CompletionStage<ResultNode> resolveAndProcess(List<TemplateNode> nodes, ResolutionContext context) {
+    static CompletionStage<ResultNode> resolveAndProcess(List<TemplateNode> nodes, ResolutionContext context, Engine engine) {
         int nodesCount = nodes.size();
         if (nodesCount == 1) {
             // Single node in the block
-            return resolveWith(nodes.get(0), context);
+            return resolveWith(nodes.get(0), context, engine);
         }
         @SuppressWarnings("unchecked")
         Supplier<ResultNode>[] allResults = new Supplier[nodesCount];
         List<CompletableFuture<ResultNode>> asyncResults = null;
         int idx = 0;
         for (TemplateNode templateNode : nodes) {
-            final CompletionStage<ResultNode> result = resolveWith(templateNode, context);
+            final CompletionStage<ResultNode> result = resolveWith(templateNode, context, engine);
             if (result instanceof CompletedStage) {
                 // No async computation needed
                 allResults[idx++] = (CompletedStage<ResultNode>) result;
@@ -99,7 +101,29 @@ public final class Results {
      * This method is trying to speed-up the resolve method which could become a virtual dispatch, harming
      * the performance of trivial implementations like TextNode::resolve, which is as simple as a field access.
      */
-    private static CompletionStage<ResultNode> resolveWith(TemplateNode templateNode, ResolutionContext context) {
+    private static CompletionStage<ResultNode> resolveWith(TemplateNode templateNode, ResolutionContext context,
+            Engine engine) {
+        if (!engine.hasTraceListeners()) {
+            return doResolveWith(templateNode, context);
+        }
+
+        // Notify trace listeners before resolving the template node.
+        TraceManager traceManager = engine.getTraceManager();
+        final ResolveEvent event = new ResolveEvent(templateNode, context, engine);
+        traceManager.fireBeforeResolveEvent(event);
+
+        return doResolveWith(templateNode, context).whenComplete((result, error) -> {
+            // Notify trace listeners after resolving the template node.
+            event.resolve(result, error);
+            traceManager.fireAfterResolveEvent(event);
+        });
+    }
+
+    /**
+     * This method is trying to speed-up the resolve method which could become a virtual dispatch, harming
+     * the performance of trivial implementations like TextNode::resolve, which is as simple as a field access.
+     */
+    private static CompletionStage<ResultNode> doResolveWith(TemplateNode templateNode, ResolutionContext context) {
         if (templateNode instanceof TextNode textNode) {
             return textNode.resolve(context);
         }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
@@ -31,9 +31,9 @@ public class SectionNode implements TemplateNode {
     final SectionHelper helper;
     private final Origin origin;
     private final boolean traceLevel;
-    private final Engine engine;
+    private final EngineImpl engine;
 
-    SectionNode(String name, List<SectionBlock> blocks, SectionHelper helper, Origin origin, Engine engine) {
+    SectionNode(String name, List<SectionBlock> blocks, SectionHelper helper, Origin origin, EngineImpl engine) {
         this.name = name;
         this.blocks = blocks;
         this.helper = helper;
@@ -224,9 +224,10 @@ public class SectionNode implements TemplateNode {
 
         private final Map<String, Object> params;
         private final ResolutionContext resolutionContext;
-        private final Engine engine;
+        private final EngineImpl engine;
 
-        public SectionResolutionContextImpl(ResolutionContext resolutionContext, Map<String, Object> params, Engine engine) {
+        public SectionResolutionContextImpl(ResolutionContext resolutionContext, Map<String, Object> params,
+                EngineImpl engine) {
             this.resolutionContext = resolutionContext;
             this.params = params;
             this.engine = engine;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -274,11 +274,10 @@ class TemplateImpl implements Template {
             ResolutionContext rootContext = new ResolutionContextImpl(data,
                     engine.getEvaluator(), null, this);
             setAttribute(DataNamespaceResolver.ROOT_CONTEXT, rootContext);
-            TemplateEvent event = engine.hasTraceListeners() ? new TemplateEvent(this, engine) : null;
-            if (engine.hasTraceListeners()) {
+            TemplateEvent event = engine.traceManager != null ? new TemplateEvent(this, engine) : null;
+            if (event != null) {
                 // Notify trace listeners that template rendering has started.
-                TraceManager traceManager = engine.getTraceManager();
-                traceManager.fireStartTemplate(event);
+                engine.getTraceManager().fireStartTemplate(event);
             }
             // Async resolution
             root.resolve(rootContext).whenComplete((r, t) -> {
@@ -304,11 +303,10 @@ class TemplateImpl implements Template {
 
                     }
                 }
-                if (engine.hasTraceListeners()) {
+                if (event != null) {
                     // Notify trace listeners that template rendering has ended.
-                    TraceManager traceManager = engine.getTraceManager();
                     event.done();
-                    traceManager.fireEndTemplate(event);
+                    engine.getTraceManager().fireEndTemplate(event);
                 }
             });
             return result;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TraceManager.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TraceManager.java
@@ -1,0 +1,103 @@
+package io.quarkus.qute;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.quarkus.qute.trace.ResolveEvent;
+import io.quarkus.qute.trace.TemplateEvent;
+import io.quarkus.qute.trace.TraceListener;
+
+/**
+ * Manager that holds and dispatches events to registered
+ * {@link TraceListener}s.
+ * <p>
+ * Each {@link Engine} instance has its own {@code TraceManager} to coordinate
+ * tracing callbacks during template rendering.
+ */
+public class TraceManager {
+
+    private final List<TraceListener> listeners;
+
+    public TraceManager() {
+        listeners = new CopyOnWriteArrayList<>();
+    }
+
+    /**
+     * Registers a new trace listener.
+     *
+     * @param listener the listener to add
+     */
+    public void addTraceListener(TraceListener listener) {
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes a previously registered trace listener.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeTraceListener(TraceListener listener) {
+        listeners.remove(listener);
+    }
+
+    /**
+     * Fires an event to all listeners indicating the start of a template rendering.
+     *
+     * @param event the template event
+     */
+    void fireStartTemplate(TemplateEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onStartTemplate(event);
+            }
+        }
+    }
+
+    /**
+     * Fires an event to all listeners before a template node is resolved.
+     *
+     * @param event the resolve event
+     */
+    void fireBeforeResolveEvent(ResolveEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onBeforeResolve(event);
+            }
+        }
+    }
+
+    /**
+     * Fires an event to all listeners after a template node has been resolved.
+     *
+     * @param event the resolve event
+     */
+    void fireAfterResolveEvent(ResolveEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onAfterResolve(event);
+            }
+        }
+    }
+
+    /**
+     * Fires an event to all listeners indicating the end of a template rendering.
+     *
+     * @param event the template event
+     */
+    void fireEndTemplate(TemplateEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onEndTemplate(event);
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if there is at least one registered listener.
+     *
+     * @return whether any trace listeners are registered
+     */
+    public boolean hasTraceListeners() {
+        return !listeners.isEmpty();
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TraceManager.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TraceManager.java
@@ -1,10 +1,5 @@
 package io.quarkus.qute;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import io.quarkus.qute.trace.ResolveEvent;
-import io.quarkus.qute.trace.TemplateEvent;
 import io.quarkus.qute.trace.TraceListener;
 
 /**
@@ -14,90 +9,34 @@ import io.quarkus.qute.trace.TraceListener;
  * Each {@link Engine} instance has its own {@code TraceManager} to coordinate
  * tracing callbacks during template rendering.
  */
-public class TraceManager {
-
-    private final List<TraceListener> listeners;
-
-    public TraceManager() {
-        listeners = new CopyOnWriteArrayList<>();
-    }
+public interface TraceManager {
 
     /**
-     * Registers a new trace listener.
+     * Registers a new {@link TraceListener} to receive trace events.
+     * <p>
+     * The listener will be notified of template rendering and resolution events.
      *
-     * @param listener the listener to add
+     * @param listener the trace listener to add; must not be {@code null}
      */
-    public void addTraceListener(TraceListener listener) {
-        listeners.add(listener);
-    }
+    void addTraceListener(TraceListener listener);
 
     /**
-     * Removes a previously registered trace listener.
+     * Unregisters a previously registered {@link TraceListener}.
+     * <p>
+     * After removal, the listener will no longer receive trace events.
      *
-     * @param listener the listener to remove
+     * @param listener the trace listener to remove; must not be {@code null}
      */
-    public void removeTraceListener(TraceListener listener) {
-        listeners.remove(listener);
-    }
+    void removeTraceListener(TraceListener listener);
 
     /**
-     * Fires an event to all listeners indicating the start of a template rendering.
+     * Returns {@code true} if there are any trace listeners currently registered,
+     * {@code false} otherwise.
+     * <p>
+     * Trace listeners monitor and react to template rendering events.
      *
-     * @param event the template event
+     * @return {@code true} if at least one trace listener is registered, {@code false} otherwise
      */
-    void fireStartTemplate(TemplateEvent event) {
-        if (hasTraceListeners()) {
-            for (TraceListener listener : listeners) {
-                listener.onStartTemplate(event);
-            }
-        }
-    }
+    boolean hasTraceListeners();
 
-    /**
-     * Fires an event to all listeners before a template node is resolved.
-     *
-     * @param event the resolve event
-     */
-    void fireBeforeResolveEvent(ResolveEvent event) {
-        if (hasTraceListeners()) {
-            for (TraceListener listener : listeners) {
-                listener.onBeforeResolve(event);
-            }
-        }
-    }
-
-    /**
-     * Fires an event to all listeners after a template node has been resolved.
-     *
-     * @param event the resolve event
-     */
-    void fireAfterResolveEvent(ResolveEvent event) {
-        if (hasTraceListeners()) {
-            for (TraceListener listener : listeners) {
-                listener.onAfterResolve(event);
-            }
-        }
-    }
-
-    /**
-     * Fires an event to all listeners indicating the end of a template rendering.
-     *
-     * @param event the template event
-     */
-    void fireEndTemplate(TemplateEvent event) {
-        if (hasTraceListeners()) {
-            for (TraceListener listener : listeners) {
-                listener.onEndTemplate(event);
-            }
-        }
-    }
-
-    /**
-     * Returns {@code true} if there is at least one registered listener.
-     *
-     * @return whether any trace listeners are registered
-     */
-    public boolean hasTraceListeners() {
-        return !listeners.isEmpty();
-    }
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TraceManagerImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TraceManagerImpl.java
@@ -1,0 +1,108 @@
+package io.quarkus.qute;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.quarkus.qute.trace.ResolveEvent;
+import io.quarkus.qute.trace.TemplateEvent;
+import io.quarkus.qute.trace.TraceListener;
+
+/**
+ *
+ */
+class TraceManagerImpl implements TraceManager {
+
+    private final List<TraceListener> listeners;
+
+    TraceManagerImpl() {
+        listeners = new CopyOnWriteArrayList<>();
+    }
+
+    /**
+     * Registers a new trace listener.
+     *
+     * @param listener the listener to add
+     */
+    @Override
+    public void addTraceListener(TraceListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener must not be null");
+        }
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes a previously registered trace listener.
+     *
+     * @param listener the listener to remove
+     */
+    @Override
+    public void removeTraceListener(TraceListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener must not be null");
+        }
+        listeners.remove(listener);
+    }
+
+    /**
+     * Fires an event to all listeners indicating the start of a template rendering.
+     *
+     * @param event the template event
+     */
+    void fireStartTemplate(TemplateEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onStartTemplate(event);
+            }
+        }
+    }
+
+    /**
+     * Fires an event to all listeners before a template node is resolved.
+     *
+     * @param event the resolve event
+     */
+    void fireBeforeResolveEvent(ResolveEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onBeforeResolve(event);
+            }
+        }
+    }
+
+    /**
+     * Fires an event to all listeners after a template node has been resolved.
+     *
+     * @param event the resolve event
+     */
+    void fireAfterResolveEvent(ResolveEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onAfterResolve(event);
+            }
+        }
+    }
+
+    /**
+     * Fires an event to all listeners indicating the end of a template rendering.
+     *
+     * @param event the template event
+     */
+    void fireEndTemplate(TemplateEvent event) {
+        if (hasTraceListeners()) {
+            for (TraceListener listener : listeners) {
+                listener.onEndTemplate(event);
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if there is at least one registered listener.
+     *
+     * @return whether any trace listeners are registered
+     */
+    @Override
+    public boolean hasTraceListeners() {
+        return !listeners.isEmpty();
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/BaseEvent.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/BaseEvent.java
@@ -7,7 +7,7 @@ import io.quarkus.qute.Engine;
  * <p>
  * Captures the engine instance and tracks execution duration.
  */
-public class BaseEvent {
+public abstract class BaseEvent {
 
     private final Engine engine;
     private final long startTime;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/BaseEvent.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/BaseEvent.java
@@ -1,0 +1,56 @@
+package io.quarkus.qute.trace;
+
+import io.quarkus.qute.Engine;
+
+/**
+ * Base class for trace events related to template rendering.
+ * <p>
+ * Captures the engine instance and tracks execution duration.
+ */
+public class BaseEvent {
+
+    private final Engine engine;
+    private final long startTime;
+    private volatile long endTime = -1;
+
+    /**
+     * Creates a new event and starts the timer.
+     *
+     * @param engine the engine managing the rendering process
+     */
+    public BaseEvent(Engine engine) {
+        this.engine = engine;
+        this.startTime = System.nanoTime();
+    }
+
+    /**
+     * Returns the engine managing the rendering process.
+     *
+     * @return the engine
+     */
+    public Engine getEngine() {
+        return engine;
+    }
+
+    /**
+     * Marks the event as completed and records the end time.
+     */
+    public void done() {
+        endTime = System.nanoTime();
+    }
+
+    /**
+     * Returns the elapsed time in nanoseconds between the start and end of the
+     * event.
+     * <p>
+     * If the event is not marked as done, returns {@code -1}.
+     *
+     * @return elapsed time in nanoseconds, or -1 if not finished
+     */
+    public long getEllapsedTime() {
+        if (endTime == -1) {
+            return -1;
+        }
+        return endTime - startTime;
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/ResolveEvent.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/ResolveEvent.java
@@ -18,7 +18,7 @@ import io.quarkus.qute.TemplateNode;
  * Used by trace listeners to monitor or inspect the evaluation of template
  * nodes.
  */
-public class ResolveEvent extends BaseEvent {
+public final class ResolveEvent extends BaseEvent {
 
     private final TemplateNode templateNode;
     private final ResolutionContext context;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/ResolveEvent.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/ResolveEvent.java
@@ -1,0 +1,94 @@
+package io.quarkus.qute.trace;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.ResolutionContext;
+import io.quarkus.qute.ResultNode;
+import io.quarkus.qute.TemplateNode;
+
+/**
+ * Represents an event fired during the resolution of a template node.
+ * <p>
+ * This event encapsulates information about the node currently being resolved,
+ * the resolution context, and the engine managing the rendering process.
+ * <p>
+ * It also holds the result of the resolution as a {@link ResultNode} and any
+ * {@link Throwable} error that may have occurred during resolution. These
+ * fields can be set by the code handling the event.
+ * <p>
+ * Used by trace listeners to monitor or inspect the evaluation of template
+ * nodes.
+ */
+public class ResolveEvent extends BaseEvent {
+
+    private final TemplateNode templateNode;
+    private final ResolutionContext context;
+    private volatile ResultNode resultNode;
+    private volatile Throwable error;
+
+    /**
+     * Creates a new {@code ResolveEvent} for the given template node, resolution
+     * context, and engine.
+     *
+     * @param templateNode the template node being resolved
+     * @param context the current resolution context
+     * @param engine the engine managing the rendering
+     */
+    public ResolveEvent(TemplateNode templateNode, ResolutionContext context, Engine engine) {
+        super(engine);
+        this.templateNode = templateNode;
+        this.context = context;
+    }
+
+    /**
+     * Returns the template node currently being resolved.
+     *
+     * @return the template node
+     */
+    public TemplateNode getTemplateNode() {
+        return templateNode;
+    }
+
+    /**
+     * Returns the current resolution context.
+     *
+     * @return the resolution context
+     */
+    public ResolutionContext getContext() {
+        return context;
+    }
+
+    /**
+     * Returns the result of resolving the template node.
+     * <p>
+     * May be {@code null} if the resolution has not yet been performed or if an
+     * error occurred.
+     *
+     * @return the result node or {@code null}
+     */
+    public ResultNode getResultNode() {
+        return resultNode;
+    }
+
+    /**
+     * Returns the error thrown during resolution, if any.
+     * <p>
+     * May be {@code null} if no error occurred.
+     *
+     * @return the error or {@code null}
+     */
+    public Throwable getError() {
+        return error;
+    }
+
+    /**
+     * Sets the result of resolving the template node along with any error.
+     *
+     * @param resultNode the resolved result, or {@code null} if resolution failed
+     * @param error the error thrown during resolution, or {@code null} if none
+     */
+    public void resolve(ResultNode resultNode, Throwable error) {
+        this.resultNode = resultNode;
+        this.error = error;
+        super.done();
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/TemplateEvent.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/TemplateEvent.java
@@ -17,7 +17,7 @@ import io.quarkus.qute.TemplateInstance;
  * @param templateInstance the template instance involved in the event
  * @param engine the engine managing the template rendering
  */
-public class TemplateEvent extends BaseEvent {
+public final class TemplateEvent extends BaseEvent {
 
     private final TemplateInstance templateInstance;
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/TemplateEvent.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/TemplateEvent.java
@@ -1,0 +1,33 @@
+package io.quarkus.qute.trace;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateInstance;
+
+/**
+ * Event representing a significant moment in the lifecycle of a template
+ * rendering, such as the start or the end of rendering a
+ * {@link TemplateInstance}.
+ * <p>
+ * This event provides access to the {@link TemplateInstance} being rendered and
+ * the {@link Engine} that manages the rendering process.
+ * <p>
+ * Typically used by {@link TraceListener}s to monitor template rendering
+ * progress.
+ *
+ * @param templateInstance the template instance involved in the event
+ * @param engine the engine managing the template rendering
+ */
+public class TemplateEvent extends BaseEvent {
+
+    private final TemplateInstance templateInstance;
+
+    public TemplateEvent(TemplateInstance templateInstance, Engine engine) {
+        super(engine);
+        this.templateInstance = templateInstance;
+    }
+
+    public TemplateInstance getTemplateInstance() {
+        return templateInstance;
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/TraceListener.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/trace/TraceListener.java
@@ -1,0 +1,55 @@
+package io.quarkus.qute.trace;
+
+/**
+ * Listener interface for tracing the rendering process of Qute templates.
+ * <p>
+ * Implementations receive callbacks at key points during template rendering:
+ * <ul>
+ * <li>When a template rendering starts and ends.</li>
+ * <li>Before and after resolving each template node (expressions, sections,
+ * etc.).</li>
+ * </ul>
+ * <p>
+ * This enables logging, profiling, or building interactive debugging tools.
+ */
+public interface TraceListener {
+
+    /**
+     * Called when the rendering of a template starts.
+     *
+     * @param event the template event containing information about the template
+     *        instance and timing
+     */
+    default void onStartTemplate(TemplateEvent event) {
+
+    }
+
+    /**
+     * Called before a template node is resolved.
+     *
+     * @param event the resolve event containing the context and node to be resolved
+     */
+    default void onBeforeResolve(ResolveEvent event) {
+
+    }
+
+    /**
+     * Called after a template node has been resolved.
+     *
+     * @param event the resolve event containing the context, node, result and any
+     *        error encountered
+     */
+    default void onAfterResolve(ResolveEvent event) {
+
+    }
+
+    /**
+     * Called when the rendering of a template ends.
+     *
+     * @param event the template event containing information about the template
+     *        instance and timing
+     */
+    default void onEndTemplate(TemplateEvent event) {
+
+    }
+}

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/TraceListenerTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/TraceListenerTest.java
@@ -1,0 +1,136 @@
+package io.quarkus.qute;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.qute.trace.ResolveEvent;
+import io.quarkus.qute.trace.TemplateEvent;
+import io.quarkus.qute.trace.TraceListener;
+
+public class TraceListenerTest {
+
+    private static final Comparator<String> NODE_COMPARATOR = (o1, o2) -> o1.compareTo(o2);
+
+    @Test
+    public void trackTemplate() {
+        Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
+
+        String templateId = "hello";
+        Template template = engine.parse("""
+                <html>
+                   {#for item in items}
+                   {#if item_count > 0}FOO{/if}
+                       {item} {item_count}
+                   {/for}
+                </html>
+                """, null, templateId);
+
+        StringBuilder trace = new StringBuilder();
+        engine.addTraceListener(new TraceListener() {
+
+            @Override
+            public void onStartTemplate(TemplateEvent event) {
+                String templateId = event.getTemplateInstance().getTemplate().getId();
+                trace.append("<").append(templateId).append(">");
+            }
+
+            @Override
+            public void onEndTemplate(TemplateEvent event) {
+                String templateId = event.getTemplateInstance().getTemplate().getId();
+                trace.append("</").append(templateId).append(">");
+            }
+
+        });
+
+        List<String> items = List.of("foo", "bar", "baz");
+        template.data("items", items).render();
+
+        assertEquals("<hello></hello>", trace.toString());
+    }
+
+    @Test
+    public void trackNodes() {
+        Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
+
+        Template template = engine.parse("""
+                <html>
+                   {#for item in items}
+                   {#if item_count > 0}FOO{/if}
+                       {item} {item_count}
+                   {/for}
+                </html>
+                """);
+
+        List<String> actualBeforeResolve = new ArrayList<>();
+        List<String> actualAfterResolve = new ArrayList<>();
+        engine.addTraceListener(new TraceListener() {
+            @Override
+            public void onBeforeResolve(ResolveEvent event) {
+                actualBeforeResolve.add(toStringNode(event.getTemplateNode()));
+            }
+
+            @Override
+            public void onAfterResolve(ResolveEvent event) {
+                actualAfterResolve.add(toStringNode(event.getTemplateNode()));
+            }
+
+        });
+
+        List<String> items = List.of("foo", "bar", "baz");
+        template.data("items", items).render();
+
+        // Before and after resolve, nodes are equal but not necessarily in the same
+        // order, as some nodes may take longer to resolve.
+        List<String> sortedBeforeResolve = new ArrayList<>(actualBeforeResolve);
+        List<String> sortedAfterResolve = new ArrayList<>(actualAfterResolve);
+        Collections.sort(sortedBeforeResolve, NODE_COMPARATOR);
+        Collections.sort(sortedAfterResolve, NODE_COMPARATOR);
+        assertEquals(sortedAfterResolve, sortedAfterResolve);
+
+        assertArrayEquals(expectedBeforeResolve().toArray(), actualBeforeResolve.toArray());
+
+    }
+
+    private static List<String> expectedBeforeResolve() {
+        List<String> actual = new ArrayList<String>();
+        actual.add("TextNode [value=<html>]");
+        actual.add("SectionNode [helper=LoopSectionHelper, origin= ]");
+        actual.add("TextNode [value=   ]");
+        actual.add("SectionNode [helper=IfSectionHelper, origin= ]");
+        actual.add("TextNode [value=FOO]");
+        actual.add("TextNode [value=       ]");
+        actual.add("ExpressionNode [expression=Expression [namespace=null, parts=[item], literal=null]]");
+        actual.add("TextNode [value= ]");
+        actual.add("ExpressionNode [expression=Expression [namespace=null, parts=[item_count], literal=null]]");
+        actual.add("TextNode [value=]");
+        actual.add("TextNode [value=   ]");
+        actual.add("SectionNode [helper=IfSectionHelper, origin= ]");
+        actual.add("TextNode [value=FOO]");
+        actual.add("TextNode [value=       ]");
+        actual.add("ExpressionNode [expression=Expression [namespace=null, parts=[item], literal=null]]");
+        actual.add("TextNode [value= ]");
+        actual.add("ExpressionNode [expression=Expression [namespace=null, parts=[item_count], literal=null]]");
+        actual.add("TextNode [value=]");
+        actual.add("TextNode [value=   ]");
+        actual.add("SectionNode [helper=IfSectionHelper, origin= ]");
+        actual.add("TextNode [value=FOO]");
+        actual.add("TextNode [value=       ]");
+        actual.add("ExpressionNode [expression=Expression [namespace=null, parts=[item], literal=null]]");
+        actual.add("TextNode [value= ]");
+        actual.add("ExpressionNode [expression=Expression [namespace=null, parts=[item_count], literal=null]]");
+        actual.add("TextNode [value=]");
+        actual.add("TextNode [value=</html>]");
+        return actual;
+    }
+
+    private static String toStringNode(TemplateNode templateNode) {
+        return templateNode.toString().replace("\r", "").replace("\n", "");
+    }
+}

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/TraceListenerTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/TraceListenerTest.java
@@ -2,6 +2,9 @@ package io.quarkus.qute;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,7 +23,11 @@ public class TraceListenerTest {
 
     @Test
     public void trackTemplate() {
-        Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
+        Engine engine = Engine.builder()
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver())
+                .enableTracing(true)
+                .build();
 
         String templateId = "hello";
         Template template = engine.parse("""
@@ -57,7 +64,11 @@ public class TraceListenerTest {
 
     @Test
     public void trackNodes() {
-        Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
+        Engine engine = Engine.builder()
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver())
+                .enableTracing(true)
+                .build();
 
         Template template = engine.parse("""
                 <html>
@@ -95,7 +106,24 @@ public class TraceListenerTest {
         assertEquals(sortedAfterResolve, sortedAfterResolve);
 
         assertArrayEquals(expectedBeforeResolve().toArray(), actualBeforeResolve.toArray());
+    }
 
+    @Test
+    public void testRegistration() {
+        Engine engine = Engine.builder()
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver())
+                .enableTracing(true)
+                .build();
+
+        TraceListener empty = new TraceListener() {
+        };
+        engine.addTraceListener(empty);
+        assertTrue(engine.getTraceManager().hasTraceListeners());
+        engine.removeTraceListener(empty);
+        assertFalse(engine.getTraceManager().hasTraceListeners());
+
+        assertNull(Engine.builder().addDefaults().enableTracing(false).build().getTraceManager());
     }
 
     private static List<String> expectedBeforeResolve() {


### PR DESCRIPTION
This PR provides the capability to track start/end template rendering and before/after node resolve (it follows the same idea than Saxon events used to implement a debugger). I need this support to provide the Qute debugger that I am implementing and integrating in IntelliJ (and it will be easy to integrate in vscode and even in Eclipse IDE):

Here a demo with breakpoint and steps:

![QuteDebuggerDemo](https://github.com/user-attachments/assets/f28884f2-509e-4d63-a1c3-c43306636923)

Here a demo with expression eval:

![QuteDebuggerDemoEval2](https://github.com/user-attachments/assets/1fd8bb29-ab71-4936-82f9-99ebf9ef2889)

Breakpoint with condition is supported:

![image](https://github.com/user-attachments/assets/015697f4-ac97-4226-9dd3-a2323dd77919)

![image](https://github.com/user-attachments/assets/d1b7faaa-b4f1-4b1b-8771-4e8bfae212b4)

# Engine#addTraceListener(TraceListener listener)

The track can be done by adding a TraceListener registered with `Engine#addTraceListener(TraceListener listener)`

Here a sample how to use TraceListener:

```java
import io.quarkus.qute.Engine;
import io.quarkus.qute.ReflectionValueResolver;
import io.quarkus.qute.Template;
import io.quarkus.qute.trace.ResolveEvent;
import io.quarkus.qute.trace.TemplateEvent;
import io.quarkus.qute.trace.TraceListener;

public class TraceSample {

    public static void main(String[] args) throws InterruptedException {

        Engine engine = Engine.builder()
                .addDefaults()
                .addValueResolver(new ReflectionValueResolver()).build();

        Template template = engine.parse("""
                <html>
                   Hello {name}!
                </html>
                """);

        engine.addTraceListener(new TraceListener() {
            @Override
            public void onStartTemplate(TemplateEvent event) {
                System.err.println("Starting template (id): " + event.getTemplateInstance().getTemplate().getId());
            }

            @Override
            public void onBeforeResolve(ResolveEvent event) {
                System.err.println("Before node resolve: " + event.getTemplateNode());
            }

            @Override
            public void onAfterResolve(ResolveEvent event) {
                System.err.println("After node resolve: " + event.getTemplateNode() + " in " + event.getEllapsedTime() + "ms");
            }

            @Override
            public void onEndTemplate(TemplateEvent event) {
                System.err.println("Rendering template (id): " + event.getTemplateInstance().getTemplate().getId() + " in " + event.getEllapsedTime() + "ms");
            }
        });


        String s = template.data("name", "Quarkus")
                .render();
        System.err.println(s);

    }
}
```

You will see in the console the following trace:

```
Starting template (id): 1
Before node resolve: TextNode [value=<html>
   Hello ]
After node resolve: TextNode [value=<html>
   Hello ] in 1ms
Before node resolve: ExpressionNode [expression=Expression [namespace=null, parts=[name], literal=null]]
After node resolve: ExpressionNode [expression=Expression [namespace=null, parts=[name], literal=null]] in 8ms
Before node resolve: TextNode [value=!
</html>
]
After node resolve: TextNode [value=!
</html>
] in 0ms
Rendering template (id): 1 in 23ms
<html>
   Hello Quarkus!
</html>
```

# Register TraceListener with Java SPI

As you can see the PR have no dependencies to the Qute debugger. How Qute debugger can be registered?

The answer is that Qute debugger will track creation of Engine instance with the existing EngineListener API. Qute debugger need to register a custom EngineListener (RegisterDebugServerAdapter) to track Engine build. To do that the Qute debugger register this custom EngineListener with Java SPI with the following file stored in the Qute debugger artifact

`src/main/resources/META-INF/services/io.quarkus.qute.EngineBuilder$EngineListener` which contains `io.quarkus.qute.debug.adapter.RegisterDebugServerAdapter`

The Qute debugger adds a custom TraceListener to block the process (by using wait() in onAfterResolve if there is a breakpoint defined for the resolved node.



