### PR TITLE
Do not require a default datasource definition when using a MultiTenantConnectionProvider

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -248,6 +248,9 @@ public class FastBootMetadataBuilder {
 
         if (multiTenancyStrategy != null && multiTenancyStrategy != MultiTenancyStrategy.NONE
                 && multiTenancyStrategy != MultiTenancyStrategy.DISCRIMINATOR) {
+            // Note: the counterpart of this code, but for single-tenancy (injecting the datasource),
+            // can be found in io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.injectDataSource
+
             // We need to initialize the multi tenant connection provider
             // on static init as it is used in MetadataBuildingOptionsImpl
             // to determine if multi-tenancy is enabled.

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
@@ -6,8 +6,10 @@ quarkus.hibernate-orm.multitenant=database
 quarkus.hibernate-orm.dialect=MariaDB
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 
-# We create datasources manually, so a lack of configuration doesn't mean Quarkus should step in with defaults.
-quarkus.datasource.devservices.enabled=false
+# We create datasources programmatically, so we don't need the default datasource.
+# This makes sure Quarkus won't create a default datasource in test/dev mode.
+# This also helps reproduce https://github.com/quarkusio/quarkus/issues/29269.
+quarkus.datasource.active=false
 
 # Inventory persistence unit
 quarkus.hibernate-orm."inventory".schema-management.strategy=none

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
@@ -6,8 +6,10 @@ quarkus.hibernate-orm.multitenant=database
 quarkus.hibernate-orm.dialect=MariaDB
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 
-# We create datasources manually, so a lack of configuration doesn't mean Quarkus should step in with defaults.
-quarkus.datasource.devservices.enabled=false
+# We create datasources programmatically, so we don't need the default datasource.
+# This makes sure Quarkus won't create a default datasource in test/dev mode.
+# This also helps reproduce https://github.com/quarkusio/quarkus/issues/29269.
+quarkus.datasource.active=false
 
 # Inventory persistence unit
 quarkus.hibernate-orm."inventory".schema-management.strategy=none


### PR DESCRIPTION
There's definitely a lot of cleanup to do in this area, but I tried to keep the changes minimal for now... hopefully we'll be able to make configuration much simpler once we upgrade to a version of Hibernate ORM with https://github.com/hibernate/hibernate-orm/pull/10424

- Closes: #29269 
