### PR TITLE
Annotation processor - Error on legacy config classes

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -43,6 +43,13 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
         boolean useConfigMapping = !Boolean
                 .parseBoolean(utils.processingEnv().getOptions().getOrDefault(Options.LEGACY_CONFIG_ROOT, "false"));
+
+        if (!useConfigMapping) {
+            throw new IllegalArgumentException(
+                    "Starting with Quarkus 3.25, legacy config classes (deprecated since Quarkus 3.19) are not supported anymore. "
+                            + "Please migrate the configuration of your extension to interfaces annotated with @ConfigMapping. See https://quarkus.io/guides/config-mappings#config-mappings for more information.");
+        }
+
         boolean debug = Boolean.getBoolean(DEBUG);
 
         ExtensionModule extensionModule = utils.extension().getExtensionModule();


### PR DESCRIPTION
We deprecated the legacy config classes in 3.19.
Most of the ecosystem has moved to the interfaces annotated with @ConfigMapping.

It is time to complain loudly about them now, so that we can envision dropping the support for legacy config classes