### PR TITLE
Config doc - Avoid target directories from dropped modules

### DIFF
--- a/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/GenerateConfigDocMojo.java
+++ b/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/GenerateConfigDocMojo.java
@@ -276,7 +276,11 @@ public class GenerateConfigDocMojo extends AbstractMojo {
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
                     if (dir.endsWith(TARGET)) {
-                        targets.add(dir);
+                        // we check if there is a POM around as it might happen that the target/ directory is still around
+                        // while the module has been dropped
+                        if (Files.exists(dir.resolve("../pom.xml"))) {
+                            targets.add(dir);
+                        }
 
                         // a target directory can contain target directories for test projects
                         // so let's make sure we ignore whatever is nested in a target


### PR DESCRIPTION
It has been a problem from time to time and it's simple enough to fix so let's fix it.