### PR TITLE
Config doc - Write the model as JSON in jars

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Outputs.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Outputs.java
@@ -17,8 +17,8 @@ public final class Outputs {
     public static final String META_INF_QUARKUS_CONFIG = "META-INF/" + QUARKUS_CONFIG_DOC;
     public static final String META_INF_QUARKUS_CONFIG_JAVADOC_JSON = META_INF_QUARKUS_CONFIG + "/quarkus-config-javadoc.json";
     public static final String META_INF_QUARKUS_CONFIG_MODEL_JSON = META_INF_QUARKUS_CONFIG + "/quarkus-config-model.json";
-    public static final String META_INF_QUARKUS_CONFIG_JAVADOC_YAML = META_INF_QUARKUS_CONFIG + "/quarkus-config-javadoc.yaml";
-    public static final String META_INF_QUARKUS_CONFIG_MODEL_YAML = META_INF_QUARKUS_CONFIG + "/quarkus-config-model.yaml";
+    public static final String META_INF_QUARKUS_CONFIG_MODEL_VERSION = META_INF_QUARKUS_CONFIG
+            + "/quarkus-config-model-version";
 
     /**
      * Ideally, we should remove this file at some point.

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/FilerUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/FilerUtil.java
@@ -37,6 +37,28 @@ public class FilerUtil {
     /**
      * This method uses the annotation processor Filer API and we shouldn't use a Path as paths containing \ are not supported.
      */
+    public void write(String filePath, String value) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+
+        try {
+            final FileObject listResource = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "",
+                    filePath);
+
+            try (BufferedWriter writer = new BufferedWriter(
+                    new OutputStreamWriter(listResource.openOutputStream(), StandardCharsets.UTF_8))) {
+                writer.write(value);
+            }
+        } catch (IOException e) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to write " + filePath + ": " + e);
+            return;
+        }
+    }
+
+    /**
+     * This method uses the annotation processor Filer API and we shouldn't use a Path as paths containing \ are not supported.
+     */
     public void write(String filePath, Set<String> set) {
         if (set.isEmpty()) {
             return;
@@ -44,7 +66,7 @@ public class FilerUtil {
 
         try {
             final FileObject listResource = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "",
-                    filePath.toString());
+                    filePath);
 
             try (BufferedWriter writer = new BufferedWriter(
                     new OutputStreamWriter(listResource.openOutputStream(), StandardCharsets.UTF_8))) {
@@ -69,7 +91,7 @@ public class FilerUtil {
 
         try {
             final FileObject propertiesResource = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "",
-                    filePath.toString());
+                    filePath);
 
             try (BufferedWriter writer = new BufferedWriter(
                     new OutputStreamWriter(propertiesResource.openOutputStream(), StandardCharsets.UTF_8))) {
@@ -91,7 +113,7 @@ public class FilerUtil {
 
         try {
             final FileObject jsonResource = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "",
-                    filePath.toString());
+                    filePath);
 
             try (OutputStream os = jsonResource.openOutputStream()) {
                 JacksonMappers.jsonObjectWriter().writeValue(os, value);
@@ -112,7 +134,7 @@ public class FilerUtil {
 
         try {
             final FileObject yamlResource = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "",
-                    filePath.toString());
+                    filePath);
 
             try (OutputStream os = yamlResource.openOutputStream()) {
                 JacksonMappers.yamlObjectWriter().writeValue(os, value);


### PR DESCRIPTION
It comes with a version marker.

/cc @radcortez this is what I had in mind.

You're going to write a merger similar to `JavadocMerger` and `ModelMerger` but for the JSON files coming from the class loader.

There's a bit too much logic in `ModelMerger` to duplicate it so it probably needs to be made more generic.

I would prefer to avoid having the YAML mapper as a Dev UI dependency so we will need to extract the model and the JSON merger in a separate jar.

Happy to discuss it further with you. Note: in the end everything coming from the IDE config experiment had already been extracted, improved and merged so it should be all good for you to play with it.