### PR TITLE
Remove obsolete warning about dev mode in lambda quickstarts

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/base/README.tpl.qute.md
@@ -1,4 +1,3 @@
 {#include readme-header /}
 
-> :warning: **INCOMPATIBLE WITH DEV MODE**: Amazon Lambda Binding is not compatible with dev mode yet!
 

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-amazon-lambda-example/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-amazon-lambda-example/base/README.tpl.qute.md
@@ -1,3 +1,2 @@
 {#include readme-header /}
 
-> :warning: **INCOMPATIBLE WITH DEV MODE**: Funqy Amazon Lambda Binding is not compatible with dev mode yet!


### PR DESCRIPTION
Our lambda quickstarts have a big warning saying dev mode doesn't work. (See https://github.com/dagrammy/lambda-test-reproducer?tab=readme-ov-file for an example).

This warning is obsolete. 

https://quarkus.io/guides/aws-lambda says 
> Quarkus’s integration with lambdas also supports Quarkus’s Live Coding development cycle. You can bring up your Quarkus lambda project in dev or test mode and code on your project live.

https://quarkus.io/guides/funqy-knative-events says 
> Funqy Knative Events support dev mode and unit testing using RestAssured.

I raised a separate PR (https://github.com/quarkusio/quarkus/pull/48713) for the bad guide link in the quickstart readme.