### PR TITLE
Emit on duplicated context instead of onSubscription

### DIFF
--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/QuarkusAsyncHealthCheckFactory.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/QuarkusAsyncHealthCheckFactory.java
@@ -32,10 +32,10 @@ public class QuarkusAsyncHealthCheckFactory extends AsyncHealthCheckFactory {
     @Override
     public Uni<HealthCheckResponse> callSync(HealthCheck healthCheck) {
         Uni<HealthCheckResponse> healthCheckResponseUni = super.callSync(healthCheck);
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
-        return healthCheckResponseUni.runSubscriptionOn(new Executor() {
+        return healthCheckResponseUni.emitOn(new Executor() {
             @Override
             public void execute(Runnable command) {
+                Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
                 duplicatedContext.executeBlocking(new Callable<Void>() {
                     @Override
                     public Void call() throws Exception {


### PR DESCRIPTION
Reverting the move of the duplicate context creation and switching to `emitOn` seems to do the trick.

This should fix mdc race conditions -> https://github.com/quarkusio/quarkus/issues/48678
Whilst not causing an issue for the vertx context-> https://github.com/quarkusio/quarkus/discussions/47481

Tested with the reproducer from @atanasnik and 1000 repetitions

My incomplete try of explenation 🤷‍♂️:
`runSubscriptionOn` changes downstream operations and therefore might override the mdc of other unis as they are all getting combined.  

- Fixes: #48678
