### PR TITLE
Keep the Hibernate ORM and Reactive extensions enabled even when no entity is defined

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -543,7 +543,7 @@ CriteriaBuilder criteriaBuilder;
 [[persistence-unit-active]]
 === Activate/deactivate persistence units
 
-When a persistence unit is configured at build time, the persistence unit is active by default.
+When a persistence unit is configured at build time, and it is assigned entity types or an xref:datasource.adoc#datasource-active[active datasource], the persistence unit is active by default.
 Quarkus starts the corresponding Hibernate ORM `SessionFactory` when the application starts.
 
 To deactivate a persistence unit at runtime, set `quarkus.hibernate-orm[.optional name].active` to `false`.

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -283,7 +283,7 @@ NOTE: Prior to Quarkus 3.0 it was also possible to inject a `@RequestScoped` bea
 [[persistence-unit-active]]
 === Activate/deactivate persistence units
 
-When a persistence unit is configured at build time, the persistence unit is active by default.
+When a persistence unit is configured at build time, and it is assigned entity types or an xref:datasource.adoc#datasource-active[active datasource], the persistence unit is active by default.
 Quarkus starts the corresponding Hibernate Reactive `SessionFactory` when the application starts.
 
 To deactivate a persistence unit at runtime, see xref:hibernate-orm.adoc#persistence-unit-active[the corresponding section of the Hibernate ORM guide].

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.hibernate.orm.deployment;
 
-import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.hasEntities;
-
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -188,6 +186,7 @@ public class HibernateOrmCdiProcessor {
                     true, recorder.checkActiveSupplier(
                             persistenceUnitDescriptor.getPersistenceUnitName(),
                             persistenceUnitDescriptor.getConfig().getDataSource(),
+                            persistenceUnitDescriptor.getConfig().getEntityClassNames(),
                             true));
 
             produceSessionFactoryBean(syntheticBeanBuildItemBuildProducer, recorder, puRef);
@@ -214,6 +213,7 @@ public class HibernateOrmCdiProcessor {
                     recorder.checkActiveSupplier(
                             persistenceUnitDescriptor.getPersistenceUnitName(),
                             persistenceUnitDescriptor.getConfig().getDataSource(),
+                            persistenceUnitDescriptor.getConfig().getEntityClassNames(),
                             persistenceUnitDescriptor.isFromPersistenceXml()));
 
             produceSessionFactoryBean(syntheticBeanBuildItemBuildProducer, recorder, puRef);
@@ -228,8 +228,9 @@ public class HibernateOrmCdiProcessor {
     void registerBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
             Capabilities capabilities,
+            List<PersistenceUnitDescriptorBuildItem> descriptors,
             JpaModelBuildItem jpaModel) {
-        if (!hasEntities(jpaModel)) {
+        if (descriptors.isEmpty()) {
             return;
         }
 
@@ -257,8 +258,9 @@ public class HibernateOrmCdiProcessor {
     @BuildStep
     void transformBeans(JpaModelBuildItem jpaModel, JpaModelIndexBuildItem indexBuildItem,
             BeanDiscoveryFinishedBuildItem beans,
+            List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
             BuildProducer<BytecodeTransformerBuildItem> producer) {
-        if (!hasEntities(jpaModel)) {
+        if (persistenceUnitDescriptors.isEmpty()) {
             return;
         }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -686,14 +686,21 @@ public final class HibernateOrmProcessor {
         }
 
         Map<String, Set<String>> entityPersistenceUnitMapping = new HashMap<>();
+        boolean incomplete = false;
         for (PersistenceUnitDescriptorBuildItem descriptor : descriptors) {
+            if (descriptor.isFromPersistenceXml()) {
+                // In this case some entities might be detected by Hibernate on boot,
+                // so we need to let Panache know that this mapping may be incomplete.
+                incomplete = true;
+            }
             for (String entityClass : descriptor.getManagedClassNames()) {
                 entityPersistenceUnitMapping.putIfAbsent(entityClass, new HashSet<>());
                 entityPersistenceUnitMapping.get(entityClass).add(descriptor.getPersistenceUnitName());
             }
         }
 
-        jpaModelPersistenceUnitMapping.produce(new JpaModelPersistenceUnitMappingBuildItem(entityPersistenceUnitMapping));
+        jpaModelPersistenceUnitMapping
+                .produce(new JpaModelPersistenceUnitMappingBuildItem(entityPersistenceUnitMapping, incomplete));
     }
 
     @BuildStep

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaModelPersistenceUnitMappingBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaModelPersistenceUnitMappingBuildItem.java
@@ -12,12 +12,18 @@ import io.quarkus.builder.item.SimpleBuildItem;
 public final class JpaModelPersistenceUnitMappingBuildItem extends SimpleBuildItem {
 
     private final Map<String, Set<String>> entityToPersistenceUnits;
+    private final boolean incomplete;
 
-    public JpaModelPersistenceUnitMappingBuildItem(Map<String, Set<String>> entityToPersistenceUnits) {
+    public JpaModelPersistenceUnitMappingBuildItem(Map<String, Set<String>> entityToPersistenceUnits, boolean incomplete) {
         this.entityToPersistenceUnits = Collections.unmodifiableMap(entityToPersistenceUnits);
+        this.incomplete = incomplete;
     }
 
     public Map<String, Set<String>> getEntityToPersistenceUnits() {
         return entityToPersistenceUnits;
+    }
+
+    public boolean isIncomplete() {
+        return incomplete;
     }
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
@@ -43,7 +43,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.hibernate.orm.deployment.HibernateConfigUtil;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfigPersistenceUnit;
-import io.quarkus.hibernate.orm.deployment.JpaModelBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
@@ -62,10 +61,6 @@ public final class HibernateProcessorUtil {
     public static final String NO_SQL_LOAD_SCRIPT_FILE = "no-file";
 
     private HibernateProcessorUtil() {
-    }
-
-    public static boolean hasEntities(JpaModelBuildItem jpaModel) {
-        return !jpaModel.getEntityClassNames().isEmpty();
     }
 
     public static Optional<FormatMapperKind> jsonMapperKind(Capabilities capabilities, BuiltinFormatMapperBehaviour behaviour) {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/NoEntitiesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/NoEntitiesTest.java
@@ -2,26 +2,53 @@ package io.quarkus.hibernate.orm.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
 import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusUnitTest;
 
+/**
+ * Test that a persistence unit without any entities does get started,
+ * and can be used, be it only for native queries.
+ */
 public class NoEntitiesTest {
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withEmptyApplication();
 
-    // When having no entities,
-    // as long as the Hibernate ORM beans are not injected anywhere,
-    // we should still be able to start the application.
+    @Inject
+    private SessionFactory sessionFactory;
+
+    @Inject
+    private Session session;
+
+    @Inject
+    private StatelessSession statelessSession;
+
     @Test
-    public void testBootSucceedsButHibernateOrmDeactivated() {
-        // ... but Hibernate ORM's beans should not be available.
-        assertThat(Arc.container().instance(Session.class).get()).isNull();
+    public void testNoEntities() {
+        assertThat(sessionFactory.getMetamodel().getEntities()).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    public void testSessionNativeQuery() {
+        assertThat(session.createNativeQuery("select 1", Long.class).getResultList())
+                .containsExactly(1L);
+    }
+
+    @Test
+    @Transactional
+    public void testStatelessSessionNativeQuery() {
+        assertThat(statelessSession.createNativeQuery("select 1", Long.class).getResultList())
+                .containsExactly(1L);
     }
 
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseDynamicInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseDynamicInjectionTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.SchemaManager;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesDefaultPUDatasourceActiveFalseDynamicInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.active", "false");
+
+    @Inject
+    InjectableInstance<SessionFactory> sessionFactory;
+
+    @Inject
+    InjectableInstance<Session> session;
+
+    // Just try another bean type, but not all of them...
+    @Inject
+    InjectableInstance<SchemaManager> schemaManager;
+
+    @Test
+    public void sessionFactory() {
+        doTest(sessionFactory, SessionFactory::getCriteriaBuilder);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void session() {
+        doTest(session, s -> s.createNativeQuery("select 1", Long.class).uniqueResult());
+    }
+
+    @Test
+    public void schemaManager() {
+        doTest(schemaManager, m -> m.truncate());
+    }
+
+    private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {
+        // The bean is always available to be injected during static init
+        // since we don't know whether it will be active at runtime.
+        // So the bean proxy cannot be null.
+        assertThat(instance.getHandle().getBean())
+                .isNotNull()
+                .returns(false, InjectableBean::isActive);
+        var object = instance.get();
+        assertThat(object).isNotNull();
+        // However, any attempt to use it at runtime will fail.
+        assertThatThrownBy(() -> action.accept(object))
+                .isInstanceOf(InactiveBeanException.class)
+                .hasMessageContainingAll(
+                        "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
+                        "Datasource '<default>' was deactivated through configuration properties",
+                        "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                        "To activate the datasource, set configuration property 'quarkus.datasource.active'"
+                                + " to 'true' and configure datasource '<default>'",
+                        "Refer to https://quarkus.io/guides/datasource for guidance.");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseStaticInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseStaticInjectionTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesDefaultPUDatasourceActiveFalseStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.active", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
+                            "Datasource '<default>' was deactivated through configuration properties",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.active'"
+                                    + " to 'true' and configure datasource '<default>'",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        Session session;
+
+        @Transactional
+        public void useHibernate() {
+            session.createNativeQuery("select 1", Long.class).uniqueResult();
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceUrlMissingDynamicInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceUrlMissingDynamicInjectionTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.SchemaManager;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesDefaultPUDatasourceUrlMissingDynamicInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "")
+            // The URL won't be missing if dev services are enabled
+            .overrideConfigKey("quarkus.devservices.enabled", "false");
+
+    @Inject
+    InjectableInstance<SessionFactory> sessionFactory;
+
+    @Inject
+    InjectableInstance<Session> session;
+
+    // Just try another bean type, but not all of them...
+    @Inject
+    InjectableInstance<SchemaManager> schemaManager;
+
+    @Test
+    public void sessionFactory() {
+        doTest(sessionFactory, SessionFactory::getCriteriaBuilder);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void session() {
+        doTest(session, s -> s.createNativeQuery("select 1", Long.class).uniqueResult());
+    }
+
+    @Test
+    public void schemaManager() {
+        doTest(schemaManager, m -> m.truncate());
+    }
+
+    private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {
+        // The bean is always available to be injected during static init
+        // since we don't know whether it will be active at runtime.
+        // So the bean proxy cannot be null.
+        assertThat(instance.getHandle().getBean())
+                .isNotNull()
+                .returns(false, InjectableBean::isActive);
+        var object = instance.get();
+        assertThat(object).isNotNull();
+        // However, any attempt to use it at runtime will fail.
+        assertThatThrownBy(() -> action.accept(object))
+                .isInstanceOf(InactiveBeanException.class)
+                .hasMessageContainingAll(
+                        "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
+                        "Datasource '<default>' was deactivated automatically because its URL is not set.",
+                        "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                        "To activate the datasource, set configuration property 'quarkus.datasource.jdbc.url'.",
+                        "Refer to https://quarkus.io/guides/datasource for guidance.");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceUrlMissingStaticInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesDefaultPUDatasourceUrlMissingStaticInjectionTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesDefaultPUDatasourceUrlMissingStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "")
+            // The URL won't be missing if dev services are enabled
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
+                            "Datasource '<default>' was deactivated automatically because its URL is not set.",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.jdbc.url'.",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        Session session;
+
+        @Transactional
+        public void useHibernate() {
+            session.createNativeQuery("select 1", Long.class).uniqueResult();
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseDynamicInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseDynamicInjectionTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.SchemaManager;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesNamedPUDatasourceActiveFalseDynamicInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".active", "false");
+
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<SessionFactory> sessionFactory;
+
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<Session> session;
+
+    // Just try another bean type, but not all of them...
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<SchemaManager> schemaManager;
+
+    @Test
+    public void sessionFactory() {
+        doTest(sessionFactory, SessionFactory::getCriteriaBuilder);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void session() {
+        doTest(session, s -> s.createNativeQuery("select 1", Long.class).uniqueResult());
+    }
+
+    @Test
+    public void schemaManager() {
+        doTest(schemaManager, m -> m.truncate());
+    }
+
+    private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {
+        // The bean is always available to be injected during static init
+        // since we don't know whether it will be active at runtime.
+        // So the bean proxy cannot be null.
+        assertThat(instance.getHandle().getBean())
+                .isNotNull()
+                .returns(false, InjectableBean::isActive);
+        var object = instance.get();
+        assertThat(object).isNotNull();
+        // However, any attempt to use it at runtime will fail.
+        assertThatThrownBy(() -> action.accept(object))
+                .isInstanceOf(InactiveBeanException.class)
+                .hasMessageContainingAll(
+                        "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                        "Datasource 'mydatasource' was deactivated through configuration properties",
+                        "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                        "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".active'"
+                                + " to 'true' and configure datasource 'mydatasource'",
+                        "Refer to https://quarkus.io/guides/datasource for guidance.");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseStaticInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseStaticInjectionTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesNamedPUDatasourceActiveFalseStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".active", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                            "Datasource 'mydatasource' was deactivated through configuration properties",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".active'"
+                                    + " to 'true' and configure datasource 'mydatasource'",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        @PersistenceUnit("mypu")
+        Session session;
+
+        @Transactional
+        public void useHibernate() {
+            session.createNativeQuery("select 1", Long.class).uniqueResult();
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingDynamicInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingDynamicInjectionTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.SchemaManager;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesNamedPUDatasourceUrlMissingDynamicInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".jdbc.url", "")
+            // The URL won't be missing if dev services are enabled
+            .overrideConfigKey("quarkus.devservices.enabled", "false");
+
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<SessionFactory> sessionFactory;
+
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<Session> session;
+
+    // Just try another bean type, but not all of them...
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<SchemaManager> schemaManager;
+
+    @Test
+    public void sessionFactory() {
+        doTest(sessionFactory, SessionFactory::getCriteriaBuilder);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void session() {
+        doTest(session, s -> s.createNativeQuery("select 1", Long.class).uniqueResult());
+    }
+
+    @Test
+    public void schemaManager() {
+        doTest(schemaManager, m -> m.truncate());
+    }
+
+    private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {
+        // The bean is always available to be injected during static init
+        // since we don't know whether it will be active at runtime.
+        // So the bean proxy cannot be null.
+        assertThat(instance.getHandle().getBean())
+                .isNotNull()
+                .returns(false, InjectableBean::isActive);
+        var object = instance.get();
+        assertThat(object).isNotNull();
+        // However, any attempt to use it at runtime will fail.
+        assertThatThrownBy(() -> action.accept(object))
+                .isInstanceOf(InactiveBeanException.class)
+                .hasMessageContainingAll(
+                        "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                        "Datasource 'mydatasource' was deactivated automatically because its URL is not set.",
+                        "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                        "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".jdbc.url'.",
+                        "Refer to https://quarkus.io/guides/datasource for guidance.");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingStaticInjectionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingStaticInjectionTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.hibernate.orm.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesNamedPUDatasourceUrlMissingStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".jdbc.url", "")
+            // The URL won't be missing if dev services are enabled
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                            "Datasource 'mydatasource' was deactivated automatically because its URL is not set.",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".jdbc.url'.",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        @PersistenceUnit("mypu")
+        Session session;
+
+        @Transactional
+        public void useHibernate() {
+            session.createNativeQuery("select 1", Long.class).uniqueResult();
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -28,7 +28,7 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
      *
      * @asciidoclet
      */
-    @ConfigDocDefault("'true' if Hibernate ORM is enabled; 'false' otherwise")
+    @ConfigDocDefault("`true` if Hibernate ORM is enabled and there are entity types or an active datasource assigned to the persistence unit; `false` otherwise")
     Optional<Boolean> active();
 
     /**

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.runtime.recording;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import io.quarkus.hibernate.orm.runtime.config.DatabaseOrmCompatibilityVersion;
 import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
@@ -19,6 +20,7 @@ public class RecordedConfig {
     private final Optional<String> supportedDBkind;
     private final Optional<String> dbVersion;
     private final Optional<String> explicitDialect;
+    private final Set<String> entityClassNames;
     private final MultiTenancyStrategy multiTenancyStrategy;
     private final Map<String, String> quarkusConfigUnsupportedProperties;
     private final DatabaseOrmCompatibilityVersion databaseOrmCompatibilityVersion;
@@ -28,7 +30,7 @@ public class RecordedConfig {
     @RecordableConstructor
     public RecordedConfig(Optional<String> dataSource, Optional<String> dbKind,
             Optional<String> supportedDBkind,
-            Optional<String> dbVersion, Optional<String> explicitDialect,
+            Optional<String> dbVersion, Optional<String> explicitDialect, Set<String> entityClassNames,
             MultiTenancyStrategy multiTenancyStrategy,
             DatabaseOrmCompatibilityVersion databaseOrmCompatibilityVersion,
             BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour,
@@ -44,6 +46,7 @@ public class RecordedConfig {
         this.supportedDBkind = supportedDBkind;
         this.dbVersion = dbVersion;
         this.explicitDialect = explicitDialect;
+        this.entityClassNames = entityClassNames;
         this.multiTenancyStrategy = multiTenancyStrategy;
         this.databaseOrmCompatibilityVersion = databaseOrmCompatibilityVersion;
         this.builtinFormatMapperBehaviour = builtinFormatMapperBehaviour;
@@ -69,6 +72,10 @@ public class RecordedConfig {
 
     public Optional<String> getExplicitDialect() {
         return explicitDialect;
+    }
+
+    public Set<String> getEntityClassNames() {
+        return entityClassNames;
     }
 
     public MultiTenancyStrategy getMultiTenancyStrategy() {

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveCdiProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveCdiProcessor.java
@@ -57,7 +57,8 @@ public class HibernateReactiveCdiProcessor {
                         // This startup() call is only necessary in order to trigger Arc's usage checks (fail startup if bean injected when a PU is inactive).
                         .startup()
                         .checkActive(recorder.checkActiveSupplier(persistenceUnitName,
-                                persistenceUnitDescriptor.getConfig().getDataSource()))
+                                persistenceUnitDescriptor.getConfig().getDataSource(),
+                                persistenceUnitDescriptor.getConfig().getEntityClassNames()))
                         .createWith(recorder.mutinySessionFactory(persistenceUnitName))
                         .addInjectionPoint(ClassType.create(DotName.createSimple(JPAConfig.class)));
 

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoEntitiesTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoEntitiesTest.java
@@ -13,7 +13,8 @@ public class NoEntitiesTest {
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
-            .withEmptyApplication();
+            .withEmptyApplication()
+            .withConfigurationResource("application.properties");
 
     // When having no entities,
     // as long as the Hibernate Reactive beans are not injected anywhere,

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/NoConfigNoEntitiesTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/NoConfigNoEntitiesTest.java
@@ -1,13 +1,19 @@
 package io.quarkus.hibernate.reactive.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.arc.Arc;
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
 import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
 
 public class NoConfigNoEntitiesTest {
 
@@ -17,13 +23,31 @@ public class NoConfigNoEntitiesTest {
             // The config won't really be empty if dev services are enabled
             .overrideConfigKey("quarkus.devservices.enabled", "false");
 
+    @Inject
+    InjectableInstance<Mutiny.SessionFactory> sessionFactory;
+
     // When having no entities, no configuration, no datasource,
     // as long as the Hibernate ORM beans are not injected anywhere,
     // we should still be able to start the application.
     @Test
+    @RunOnVertxContext
     public void testBootSucceedsButHibernateReactiveDeactivated() {
-        // ... but Hibernate Reactive's beans should not be available.
-        assertThat(Arc.container().instance(Mutiny.SessionFactory.class).get()).isNull();
+        // ... and Hibernate Reactive's beans should be available, but inactive.
+        var instance = sessionFactory;
+        assertThat(instance.getHandle().getBean())
+                .isNotNull()
+                .returns(false, InjectableBean::isActive);
+        var object = instance.get();
+        assertThat(object).isNotNull();
+        // and any attempt to use these beans at runtime should fail.
+        assertThatThrownBy(object::getCriteriaBuilder)
+                .isInstanceOf(InactiveBeanException.class)
+                .hasMessageContainingAll(
+                        "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
+                        "Datasource '<default>' was deactivated automatically because its URL is not set",
+                        "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                        "To activate the datasource, set configuration property 'quarkus.datasource.reactive.url'",
+                        "Refer to https://quarkus.io/guides/datasource for guidance.");
     }
 
 }

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseDynamicInjectionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseDynamicInjectionTest.java
@@ -1,7 +1,9 @@
-package io.quarkus.hibernate.reactive;
+package io.quarkus.hibernate.reactive.config.datasource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
 
 import jakarta.inject.Inject;
 
@@ -14,38 +16,40 @@ import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableInstance;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class NoConfigNoEntitiesTest {
+public class ConfigNoEntitiesDefaultPUDatasourceActiveFalseDynamicInjectionTest {
 
     @RegisterExtension
-    static QuarkusUnitTest runner = new QuarkusUnitTest()
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withEmptyApplication()
-            // The config won't really be empty if dev services are enabled
-            .overrideConfigKey("quarkus.devservices.enabled", "false");
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.active", "false");
 
     @Inject
     InjectableInstance<Mutiny.SessionFactory> sessionFactory;
 
-    // When having no entities, no configuration, no datasource,
-    // as long as the Hibernate Reactive beans are not injected anywhere,
-    // we should still be able to start the application.
     @Test
-    public void testBootSucceedsButHibernateOrmDeactivated() {
-        // ... and Hibernate Reactive's beans should be available, but inactive.
-        var instance = sessionFactory;
+    public void sessionFactory() {
+        doTest(sessionFactory, Mutiny.SessionFactory::getCriteriaBuilder);
+    }
+
+    private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {
+        // The bean is always available to be injected during static init
+        // since we don't know whether it will be active at runtime.
+        // So the bean proxy cannot be null.
         assertThat(instance.getHandle().getBean())
                 .isNotNull()
                 .returns(false, InjectableBean::isActive);
         var object = instance.get();
         assertThat(object).isNotNull();
-        // and any attempt to use these beans at runtime should fail.
-        assertThatThrownBy(() -> object.getMetamodel())
+        // However, any attempt to use it at runtime will fail.
+        assertThatThrownBy(() -> action.accept(object))
                 .isInstanceOf(InactiveBeanException.class)
                 .hasMessageContainingAll(
                         "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
-                        "Datasource '<default>' was deactivated automatically because its URL is not set",
+                        "Datasource '<default>' was deactivated through configuration properties",
                         "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
-                        "To activate the datasource, set configuration property 'quarkus.datasource.reactive.url'",
+                        "To activate the datasource, set configuration property 'quarkus.datasource.active'"
+                                + " to 'true' and configure datasource '<default>'",
                         "Refer to https://quarkus.io/guides/datasource for guidance.");
     }
-
 }

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseStaticInjectionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesDefaultPUDatasourceActiveFalseStaticInjectionTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.hibernate.reactive.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class ConfigNoEntitiesDefaultPUDatasourceActiveFalseStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.active", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
+                            "Datasource '<default>' was deactivated through configuration properties",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.active'"
+                                    + " to 'true' and configure datasource '<default>'",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        Mutiny.SessionFactory sessionFactory;
+
+        public Uni<Long> useHibernate() {
+            return sessionFactory.withTransaction(s -> s.createNativeQuery("select 1", Long.class).getSingleResult());
+        }
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesDefaultPUDatasourceUrlMissingStaticInjectionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesDefaultPUDatasourceUrlMissingStaticInjectionTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.hibernate.reactive.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class ConfigNoEntitiesDefaultPUDatasourceUrlMissingStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.reactive.url", "")
+            // The URL won't be missing if dev services are enabled
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit '<default>' was deactivated automatically because it doesn't include any entity type and its datasource '<default>' was deactivated",
+                            "Datasource '<default>' was deactivated automatically because its URL is not set.",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.reactive.url'.",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        Mutiny.SessionFactory sessionFactory;
+
+        public Uni<Long> useHibernate() {
+            return sessionFactory.withTransaction(s -> s.createNativeQuery("select 1", Long.class).getSingleResult());
+        }
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseDynamicInjectionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseDynamicInjectionTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.hibernate.reactive.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesNamedPUDatasourceActiveFalseDynamicInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".active", "false");
+
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<Mutiny.SessionFactory> sessionFactory;
+
+    @Test
+    public void sessionFactory() {
+        doTest(sessionFactory, Mutiny.SessionFactory::getCriteriaBuilder);
+    }
+
+    private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {
+        // The bean is always available to be injected during static init
+        // since we don't know whether it will be active at runtime.
+        // So the bean proxy cannot be null.
+        assertThat(instance.getHandle().getBean())
+                .isNotNull()
+                .returns(false, InjectableBean::isActive);
+        var object = instance.get();
+        assertThat(object).isNotNull();
+        // However, any attempt to use it at runtime will fail.
+        assertThatThrownBy(() -> action.accept(object))
+                .isInstanceOf(InactiveBeanException.class)
+                .hasMessageContainingAll(
+                        "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                        "Datasource 'mydatasource' was deactivated through configuration properties",
+                        "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                        "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".active'"
+                                + " to 'true' and configure datasource 'mydatasource'",
+                        "Refer to https://quarkus.io/guides/datasource for guidance.");
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseStaticInjectionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceActiveFalseStaticInjectionTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.reactive.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class ConfigNoEntitiesNamedPUDatasourceActiveFalseStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".active", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                            "Datasource 'mydatasource' was deactivated through configuration properties",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".active'"
+                                    + " to 'true' and configure datasource 'mydatasource'",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        @PersistenceUnit("mypu")
+        Mutiny.SessionFactory sessionFactory;
+
+        public Uni<Long> useHibernate() {
+            return sessionFactory.withTransaction(s -> s.createNativeQuery("select 1", Long.class).getSingleResult());
+        }
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingDynamicInjectionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingDynamicInjectionTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.hibernate.reactive.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigNoEntitiesNamedPUDatasourceUrlMissingDynamicInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".reactive.url", "")
+            // The URL won't be missing if dev services are enabled
+            .overrideConfigKey("quarkus.devservices.enabled", "false");
+
+    @Inject
+    @PersistenceUnit("mypu")
+    InjectableInstance<Mutiny.SessionFactory> sessionFactory;
+
+    @Test
+    public void sessionFactory() {
+        doTest(sessionFactory, Mutiny.SessionFactory::getCriteriaBuilder);
+    }
+
+    private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {
+        // The bean is always available to be injected during static init
+        // since we don't know whether it will be active at runtime.
+        // So the bean proxy cannot be null.
+        assertThat(instance.getHandle().getBean())
+                .isNotNull()
+                .returns(false, InjectableBean::isActive);
+        var object = instance.get();
+        assertThat(object).isNotNull();
+        // However, any attempt to use it at runtime will fail.
+        assertThatThrownBy(() -> action.accept(object))
+                .isInstanceOf(InactiveBeanException.class)
+                .hasMessageContainingAll(
+                        "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                        "Datasource 'mydatasource' was deactivated automatically because its URL is not set.",
+                        "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                        "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".reactive.url'.",
+                        "Refer to https://quarkus.io/guides/datasource for guidance.");
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingStaticInjectionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigNoEntitiesNamedPUDatasourceUrlMissingStaticInjectionTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.hibernate.reactive.config.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class ConfigNoEntitiesNamedPUDatasourceUrlMissingStaticInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .withConfigurationResource("application-config-named-pu.properties")
+            .overrideConfigKey("quarkus.datasource.\"mydatasource\".reactive.url", "")
+            // The URL won't be missing if dev services are enabled
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            .assertException(e -> assertThat(e)
+                    // Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            "Persistence unit 'mypu' was deactivated automatically because it doesn't include any entity type and its datasource 'mydatasource' was deactivated",
+                            "Datasource 'mydatasource' was deactivated automatically because its URL is not set.",
+                            "To avoid this exception while keeping the bean inactive", // Message from Arc with generic hints
+                            "To activate the datasource, set configuration property 'quarkus.datasource.\"mydatasource\".reactive.url'.",
+                            "Refer to https://quarkus.io/guides/datasource for guidance.",
+                            "This bean is injected into",
+                            MyBean.class.getName() + "#session"));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        @PersistenceUnit("mypu")
+        Mutiny.SessionFactory sessionFactory;
+
+        public Uni<Long> useHibernate() {
+            return sessionFactory.withTransaction(s -> s.createNativeQuery("select 1", Long.class).getSingleResult());
+        }
+    }
+}

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -16,10 +16,8 @@ import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
 
-import io.agroal.api.AgroalDataSource;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.panache.common.Parameters;
@@ -81,12 +79,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
     public Session getSession(String persistentUnitName) {
         ArcContainer arcContainer = Arc.container();
         if (persistentUnitName == null || PersistenceUnitUtil.isDefaultPersistenceUnit(persistentUnitName)) {
-            InstanceHandle<Session> sessionHandle = arcContainer.instance(Session.class);
-            if (!sessionHandle.isAvailable() && !arcContainer.instance(AgroalDataSource.class).isAvailable()) {
-                throw new IllegalStateException(
-                        "The default datasource has not been properly configured. See https://quarkus.io/guides/datasource#jdbc-datasource for information on how to do that.");
-            }
-            return sessionHandle.get();
+            return arcContainer.instance(Session.class).get();
         } else {
             return arcContainer.instance(Session.class,
                     new PersistenceUnit.PersistenceUnitLiteral(persistentUnitName))

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
@@ -142,8 +142,10 @@ public final class KotlinPanacheResourceProcessor {
         }
 
         Map<String, Set<String>> collectedEntityToPersistenceUnits = new HashMap<>();
+        boolean incomplete = true;
         if (jpaModelPersistenceUnitMapping.isPresent()) {
             collectedEntityToPersistenceUnits = jpaModelPersistenceUnitMapping.get().getEntityToPersistenceUnits();
+            incomplete = jpaModelPersistenceUnitMapping.get().isIncomplete();
         }
 
         Map<String, String> panacheEntityToPersistenceUnit = new HashMap<>();
@@ -159,7 +161,7 @@ public final class KotlinPanacheResourceProcessor {
 
             panacheEntityToPersistenceUnit.put(entityName, selectedPersistenceUnits.get(0));
         }
-        recorder.setEntityToPersistenceUnit(panacheEntityToPersistenceUnit);
+        recorder.setEntityToPersistenceUnit(panacheEntityToPersistenceUnit, incomplete);
     }
 
     private void processRepositories(CombinedIndexBuildItem index,

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
@@ -141,11 +141,15 @@ public final class KotlinPanacheResourceProcessor {
             }
         }
 
-        Map<String, Set<String>> collectedEntityToPersistenceUnits = new HashMap<>();
-        boolean incomplete = true;
+        Map<String, Set<String>> collectedEntityToPersistenceUnits;
+        boolean incomplete;
         if (jpaModelPersistenceUnitMapping.isPresent()) {
             collectedEntityToPersistenceUnits = jpaModelPersistenceUnitMapping.get().getEntityToPersistenceUnits();
             incomplete = jpaModelPersistenceUnitMapping.get().isIncomplete();
+        } else {
+            collectedEntityToPersistenceUnits = new HashMap<>();
+            // This happens if there is no persistence unit, in which case we definitely know this metadata is complete.
+            incomplete = false;
         }
 
         Map<String, String> panacheEntityToPersistenceUnit = new HashMap<>();

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/kotlin/io/quarkus/hibernate/orm/panache/kotlin/deployment/test/NoConfigTest.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/test/kotlin/io/quarkus/hibernate/orm/panache/kotlin/deployment/test/NoConfigTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 class NoConfigTest {
     @Test
     fun testNoConfig() {
-        // we should be able to start the application, even with no configuration at all
+        // we should be able to start the application, even with no (Hibernate/Panache) configuration at all
     }
 
     companion object {

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheKotlinHibernateOrmRecorder.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheKotlinHibernateOrmRecorder.kt
@@ -5,7 +5,10 @@ import io.quarkus.runtime.annotations.Recorder
 
 @Recorder
 open class PanacheKotlinHibernateOrmRecorder {
-    open fun setEntityToPersistenceUnit(entityToPersistenceUnit: Map<String?, String?>?) {
-        AbstractJpaOperations.setEntityToPersistenceUnit(entityToPersistenceUnit)
+    open fun setEntityToPersistenceUnit(
+        entityToPersistenceUnit: Map<String?, String?>?,
+        incomplete: Boolean,
+    ) {
+        AbstractJpaOperations.setEntityToPersistenceUnit(entityToPersistenceUnit, incomplete)
     }
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -142,7 +142,9 @@ public final class PanacheHibernateResourceProcessor {
             map.put(item.getEntityClass(), item.getPersistenceUnitName());
         }
         recorder.setEntityToPersistenceUnit(map,
-                jpaModelPersistenceUnitMapping.map(JpaModelPersistenceUnitMappingBuildItem::isIncomplete).orElse(true));
+                jpaModelPersistenceUnitMapping.map(JpaModelPersistenceUnitMappingBuildItem::isIncomplete)
+                        // This happens if there is no persistence unit, in which case we definitely know this metadata is complete.
+                        .orElse(false));
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -135,12 +135,14 @@ public final class PanacheHibernateResourceProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    void recordEntityToPersistenceUnit(List<EntityToPersistenceUnitBuildItem> items, PanacheHibernateOrmRecorder recorder) {
+    void recordEntityToPersistenceUnit(Optional<JpaModelPersistenceUnitMappingBuildItem> jpaModelPersistenceUnitMapping,
+            List<EntityToPersistenceUnitBuildItem> items, PanacheHibernateOrmRecorder recorder) {
         Map<String, String> map = new HashMap<>();
         for (EntityToPersistenceUnitBuildItem item : items) {
             map.put(item.getEntityClass(), item.getPersistenceUnitName());
         }
-        recorder.setEntityToPersistenceUnit(map);
+        recorder.setEntityToPersistenceUnit(map,
+                jpaModelPersistenceUnitMapping.map(JpaModelPersistenceUnitMappingBuildItem::isIncomplete).orElse(true));
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/ErroneousConfigHotReloadTestCase.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/ErroneousConfigHotReloadTestCase.java
@@ -14,14 +14,19 @@ import io.restassured.RestAssured;
 public class ErroneousConfigHotReloadTestCase {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setAllowFailedStart(true)
             .withApplicationRoot((jar) -> jar
                     .addClasses(UnAnnotatedEntity.class, UnAnnotatedEntityResource.class)
                     .addAsResource("application-commented-out.properties", "application.properties"));
 
     @Test
     public void test() {
-        RestAssured.when().get("/unannotatedEntity").then().statusCode(500)
-                .body(containsString("The default datasource has not been properly configured."))
+        RestAssured.when()
+                .get("/unannotatedEntity").then().statusCode(500)
+                // Weirdly, in case of build errors, Quarkus will return the error as HTML, even if we set the content type to JSON...
+                // Hence the &lt; / &gt;
+                .body(containsString(
+                        "Datasource '&lt;default&gt;' is not configured. To solve this, configure datasource '&lt;default&gt;'."))
                 .body(not(containsString("NullPointer")));
 
         TEST.modifyResourceFile("application.properties", new Function<String, String>() {

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/NoConfigTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/NoConfigTest.java
@@ -15,6 +15,6 @@ public class NoConfigTest {
 
     @Test
     public void testNoConfig() {
-        // we should be able to start the application, even with no configuration at all
+        // we should be able to start the application, even with no (Hibernate/Panache) configuration at all
     }
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheHibernateOrmRecorder.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheHibernateOrmRecorder.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class PanacheHibernateOrmRecorder {
-    public void setEntityToPersistenceUnit(Map<String, String> entityToPersistenceUnit) {
-        AbstractJpaOperations.setEntityToPersistenceUnit(entityToPersistenceUnit);
+    public void setEntityToPersistenceUnit(Map<String, String> entityToPersistenceUnit, boolean incomplete) {
+        AbstractJpaOperations.setEntityToPersistenceUnit(entityToPersistenceUnit, incomplete);
     }
 }

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/DuplicateIdEntityTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/DuplicateIdEntityTest.java
@@ -15,7 +15,8 @@ public class DuplicateIdEntityTest {
             .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
             .setExpectedException(BuildException.class)
             .withApplicationRoot((jar) -> jar
-                    .addClasses(DuplicateIdEntity.class));
+                    .addClasses(DuplicateIdEntity.class)
+                    .addAsResource("application.properties"));
 
     @Test
     void shouldThrow() {

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/DuplicateIdWithParentTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/DuplicateIdWithParentTest.java
@@ -14,7 +14,8 @@ public class DuplicateIdWithParentTest {
             .setExpectedException(BuildException.class)
             .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
             .withApplicationRoot((jar) -> jar
-                    .addClasses(DuplicateIdWithParentEntity.class, DuplicateIdParentEntity.class));
+                    .addClasses(DuplicateIdWithParentEntity.class, DuplicateIdParentEntity.class)
+                    .addAsResource("application.properties"));
 
     @Test
     void shouldThrow() {

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/NoConfigTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/NoConfigTest.java
@@ -13,10 +13,11 @@ public class NoConfigTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .overrideConfigKey("quarkus.datasource.devservices.enabled", "false")
             .setArchiveProducer(
-                    () -> ShrinkWrap.create(JavaArchive.class));
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addAsResource("application-datasource-only.properties", "application.properties"));
 
     @Test
     public void testNoConfig() {
-        // we should be able to start the application, even with no configuration at all
+        // we should be able to start the application, even with no (Hibernate/Panache) configuration at all
     }
 }

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/resources/application-datasource-only.properties
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/resources/application-datasource-only.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.username=hibernate_orm_test
+quarkus.datasource.password=hibernate_orm_test
+quarkus.datasource.reactive.url=${postgres.reactive.url}
+quarkus.datasource.devservices.enabled=false

--- a/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/processor/data/MySqlOnlyResource.java
+++ b/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/processor/data/MySqlOnlyResource.java
@@ -1,0 +1,64 @@
+package io.quarkus.it.hibernate.processor.data;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import org.hibernate.Session;
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.it.hibernate.processor.data.pusqlonly.MySqlOnlyRepository;
+import io.quarkus.runtime.Startup;
+
+@ApplicationScoped
+@Produces("application/json")
+@Consumes("application/json")
+@Path("/data/sqlonly")
+public class MySqlOnlyResource {
+
+    @Inject
+    MySqlOnlyRepository repository;
+
+    @Startup
+    @Transactional
+    public void init() {
+        // Workaround for Hibernate ORM not running schema management at all
+        // (not even import.sql) when there are no entities
+
+        Session session = Arc.container().instance(Session.class).get();
+
+        session.createNativeQuery("DROP TABLE myuser IF EXISTS")
+                .executeUpdate();
+        session.createNativeQuery("""
+                CREATE TABLE myuser (
+                   id INT,
+                   username VARCHAR(255),
+                   password VARCHAR(255),
+                   role VARCHAR(255)
+                );
+                """)
+                .executeUpdate();
+    }
+
+    @PUT
+    @Transactional
+    @Path("/myuser/{id}")
+    public void insert(@RestPath Integer id, MySqlOnlyRepository.MyUserDto user) {
+        repository.insert(id, user.username(), user.role());
+    }
+
+    @GET
+    @Transactional
+    @Path("/myuser/by/username/{name}")
+    public MySqlOnlyRepository.MyUserDto getByName(@RestPath String name) {
+        return repository.findByUsername(name).orElseThrow(NotFoundException::new);
+    }
+
+}

--- a/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/processor/data/pusqlonly/MySqlOnlyRepository.java
+++ b/integration-tests/hibernate-orm-data/src/main/java/io/quarkus/it/hibernate/processor/data/pusqlonly/MySqlOnlyRepository.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.hibernate.processor.data.pusqlonly;
+
+import java.util.Optional;
+
+import jakarta.data.repository.Repository;
+
+import org.hibernate.annotations.processing.SQL;
+
+@Repository(dataStore = "sqlonly")
+public interface MySqlOnlyRepository {
+
+    @SQL("insert into myuser (id, username, role) VALUES (:id, :username, :role)")
+    void insert(int id, String username, String role);
+
+    @SQL("select id, username, role from myuser where username = :username")
+    Optional<MyUserDto> findByUsername(String username);
+
+    record MyUserDto(Integer id, String username, String role) {
+    }
+}

--- a/integration-tests/hibernate-orm-data/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-data/src/main/resources/application.properties
@@ -7,3 +7,9 @@ quarkus.hibernate-orm."other".datasource=<default>
 quarkus.hibernate-orm."other".packages=io.quarkus.it.hibernate.processor.data.puother
 quarkus.hibernate-orm."other".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."other".schema-management.create-schemas=true
+# Define yet another PU that doesn't have any entity type so that we can test "native-only" repositories.
+quarkus.hibernate-orm."sqlonly".datasource=<default>
+quarkus.hibernate-orm."sqlonly".packages=io.quarkus.it.hibernate.processor.data.pusqlonly
+quarkus.hibernate-orm."sqlonly".schema-management.strategy=drop-and-create
+quarkus.hibernate-orm."sqlonly".schema-management.create-schemas=true
+

--- a/integration-tests/hibernate-orm-data/src/test/java/io/quarkus/it/hibernate/processor/data/HibernateOrmDataTest.java
+++ b/integration-tests/hibernate-orm-data/src/test/java/io/quarkus/it/hibernate/processor/data/HibernateOrmDataTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -16,7 +17,7 @@ public class HibernateOrmDataTest {
 
     @ValueSource(strings = { "/data", "/data/other" })
     @ParameterizedTest
-    public void repositoryDefaultPu(String root) {
+    public void testEntities(String root) {
         // Create/retrieve
         given()
                 .pathParam("name", "foo")
@@ -83,5 +84,29 @@ public class HibernateOrmDataTest {
                 .when().get(root + "/by/name/{name}")
                 .then()
                 .statusCode(404);
+    }
+
+    @Test
+    public void testSqlOnly() {
+        given()
+                .pathParam("name", "admin")
+                .contentType(ContentType.JSON)
+                .when().get("/data/sqlonly/myuser/by/username/{name}")
+                .then()
+                .statusCode(404);
+        given()
+                .pathParam("id", 42)
+                .contentType(ContentType.JSON)
+                .body("{\"username\":\"admin\",\"role\":\"admin\"}")
+                .when().put("/data/sqlonly/myuser/{id}")
+                .then()
+                .statusCode(204);
+        given()
+                .pathParam("name", "admin")
+                .contentType(ContentType.JSON)
+                .when().get("/data/sqlonly/myuser/by/username/{name}")
+                .then()
+                .statusCode(200)
+                .body(equalTo("{\"id\":42,\"username\":\"admin\",\"role\":\"admin\"}"));
     }
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PropertyWarningsPMT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PropertyWarningsPMT.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.logging.LogRecord;
 
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -16,7 +17,8 @@ public class PropertyWarningsPMT {
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
-            .withApplicationRoot((jar) -> jar.addClasses(FruitResource.class))
+            .withApplicationRoot((jar) -> jar.addClasses(FruitResource.class)
+                    .addAsResource(new StringAsset(""), "import.sql"))
             .setApplicationName("property-warnings")
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogRecordPredicate(r -> "io.quarkus.spring.data.deployment.SpringDataJPAProcessor".equals(r.getLoggerName()))


### PR DESCRIPTION
~~Opening as draft because this is based on #48726, which must be merged first.~~ => Done

This should be neutral for most applications.

It will impact applications that depend on the Hibernate ORM extension without defining any entity (no `orm.xml`, no `hbm.xml`, no class annotated with `@Entity`). These applications will now start Hibernate ORM, whereas they would previously have skipped starting it.

If the extension configuration is valid, this will allow running e.g. native queries using `Session` or (preferably) `StatelessSession`.

If the extension configuration is invalid (missing datasource, ...) this might result in errors.

The extension can still be disabled explicitly by setting `quarkus.hibernate-orm.enabled=false`, which will be approximately the same as not defining any entity before this patch -- except some native image configuration might get skipped.

Note: I added automatic deactivation to persistence units, to limit the impact on existing applications: if a PU has no entity _and_ the datasource is deactivated (no JDBC URL, ...) at runtime, then the PU will get deactivated automatically too, which in practice means the `SessionFactory` won't start and the user won't notice the change as long as they don't try to inject it anywhere.

* Fixes: #7148

Migration guide entry:


`````asciidoc
== Hibernate ORM

[[hibernate-orm-no-entity]]
=== Hibernate ORM enabled even no entities are defined

Quarkus will now start Hibernate ORM even if no Hibernate/JPA entities are defined, provided the Hibernate ORM extension is in the classpath and the persistence unit's datasource is configured (URL set, ...).
This allows running native queries through Hibernate ORM in particular.

To forcefully disable Hibernate ORM at build time even if the extension is in your classpath, set `quarkus.hibernate-orm.enabled` to `false`.

To only prevent Hibernate ORM from starting at runtime (e.g. in certain deployments only), set `quarkus.hibernate-orm.active` or `quarkus.hibernate-orm."persistence-unit-name".active` to `false`.

== Hibernate Reactive

[[hibernate-reactive-no-entity]]
=== Hibernate Reactive enabled even no entities are defined

Quarkus will now start Hibernate Reactive even if no Hibernate/JPA entities are defined, provided the Hibernate Reactive extension is in the classpath and the persistence unit's (reactive) datasource is configured (URL set, ...).
This allows running native queries through Hibernate Reactive in particular.

To forcefully disable Hibernate ORM/Reactive at build time even if the extension is in your classpath, set `quarkus.hibernate-orm.enabled` to `false`.

To only prevent Hibernate ORM/Reactive from starting at runtime (e.g. in certain deployments only), set `quarkus.hibernate-orm.active` or `quarkus.hibernate-orm."persistence-unit-name".active` to `false`.
`````