### PR TITLE
Support for OAuth2 Protected Resource Metadata (RFC 9728)

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -68,10 +68,10 @@ You can configure or create as many tenant configurations as you need and have t
 
 See the <<multi-tenancy>> section for more details.
 
-[[metadata-properties]]
+[[oidc-metadata-properties]]
 === Metadata
 
-.Metadata properties
+.OIDC Metadata properties
 [options="header"]
 |====
 |Property name |Default |Description
@@ -116,6 +116,8 @@ Applications xref:security-openid-connect-client-reference.adoc#revoke-access-to
 Applications that already work with `quarkus-oidc` can use `quarkus.oidc.registration-path` to xref:security-openid-connect-client-registration.adoc[dynamically register OIDC clients].
 
 But please remember, all or some of these OIDC endpoint specific URLs may be discoverable when your provider supports the metadata discovery.
+
+See also the <<resource-metadata-properties>> section about accessing the protected resource metadata.
 
 [[application-type]]
 === Application type
@@ -1277,6 +1279,37 @@ Use xref:security-openid-connect-client-reference.adoc#token-propagation-rest[Qu
 
 You may need to revoke access tokens, for example, in case of the local logout.
 See the xref:security-oidc-code-flow-authentication#oidc-token-revocation[Token revocation] section for more information.
+
+[[resource-metadata-properties]]
+=== Protected Resource Metadata
+
+https://datatracker.ietf.org/doc/rfc9728/[OAuth2 Protected Resource Metadata] specification defines a metadata format enabling OAuth 2.0 clients to obtain information needed to interact with an OAuth 2.0 protected resource.
+
+Quarkus OIDC provides an initial https://datatracker.ietf.org/doc/rfc9728/[Protected Resource Metadata] support allowing a Quarkus endpoint to return a URL of the OIDC or OAuth2 provider that secures this endpoint.
+In turn, a client that requested the protected resource metadata can use its properties, such as an authorization server URL, to discover the provider's metadata and bootstrap itself to work with this provider, for example, to login SPA users and access Quarkus on their behalf with bearer access tokens.
+
+.Resource Metadata properties
+[options="header"]
+|====
+|Property name |Default |Description
+
+|quarkus.oidc.resource-metadata.enabled |false|Enable resource metadata properties
+|quarkus.oidc.resource-metadata.resource ||Resource identifier
+|quarkus.oidc.resource-metadata.force-https-scheme |true|Force that a resource identifier URL has an HTTPS scheme
+|====
+
+`quarkus.oidc.resource-metadata.enabled` property allows Quarkus OIDC to return the protected resource metadata and it is disabled by default. The reason behind it is that letting public clients see a list of authorization server(s) that the endpoint is secured with can be considered a security information leak, therefore it should only be enabled when publishing such information is considered to be safe.
+
+`quarkus.oidc.resource-metadata.resource` represents a protected resource identifier.
+According to the https://datatracker.ietf.org/doc/rfc9728/[OAuth2 Protected Resource Metadata] specification, it must be presented as an HTTPS-based URL in the published metadata and the structure of this URL must be aligned with the well-known URL that the client used to access the protected resource metadata.
+
+`quarkus.oidc.resource-metadata.resource` can be configured as an absolute URL.
+
+If it is configured as a relative path then it is added to the current request URL's host and port to build a resource identifier URL. If it is not configured at all then, unless it is a default tenant id, the tenand id is added to the current request URL's host and port to build a resource identifier URL.
+
+In such cases, the `quarkus.oidc.resource-metadata.force-https-scheme` property can be used to set a correct URL scheme, which is set to HTTPS by default.
+
+See also the <<oidc-metadata-properties>> for details about the OIDC provider metadata that Quarkus OIDC uses for its work.
 
 == References
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -105,4 +105,8 @@ public final class OidcConstants {
     public static final String ACR = "acr";
     public static final String ACR_VALUES = "acr_values";
     public static final String MAX_AGE = "max_age";
+
+    public static final String RESOURCE_METADATA_WELL_KNOWN_PATH = "/.well-known/oauth-protected-resource";
+    public static final String RESOURCE_METADATA_RESOURCE = "resource";
+    public static final String RESOURCE_METADATA_AUTHORIZATION_SERVERS = "authorization_servers";
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -45,6 +45,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         roles.addConfigMappingValues(mapping.roles());
         token.addConfigMappingValues(mapping.token());
         logout.addConfigMappingValues(mapping.logout());
+        resourceMetadata.addConfigMappingValues(mapping.resourceMetadata());
         certificateChain.addConfigMappingValues(mapping.certificateChain());
         authentication.addConfigMappingValues(mapping.authentication());
         codeGrant.addConfigMappingValues(mapping.codeGrant());
@@ -2742,6 +2743,38 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         }
     }
 
+    @Deprecated(since = "3.25", forRemoval = true)
+    ResourceMetadata resourceMetadata = new ResourceMetadata();
+
+    @Deprecated(since = "3.25", forRemoval = true)
+    public static class ResourceMetadata implements io.quarkus.oidc.runtime.OidcTenantConfig.ResourceMetadata {
+
+        public boolean enabled;
+        public Optional<String> resource = Optional.empty();
+        public boolean forceHttpsScheme = true;
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public Optional<String> resource() {
+            return resource;
+        }
+
+        @Override
+        public boolean forceHttpsScheme() {
+            return forceHttpsScheme;
+        }
+
+        private void addConfigMappingValues(io.quarkus.oidc.runtime.OidcTenantConfig.ResourceMetadata mapping) {
+            enabled = mapping.enabled();
+            resource = mapping.resource();
+            forceHttpsScheme = mapping.forceHttpsScheme();
+        }
+    }
+
     public static enum ApplicationType {
         /**
          * A {@code WEB_APP} is a client that serves pages, usually a front-end application. For this type of client the
@@ -2986,6 +3019,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     @Override
     public io.quarkus.oidc.runtime.OidcTenantConfig.Logout logout() {
         return logout;
+    }
+
+    @Override
+    public io.quarkus.oidc.runtime.OidcTenantConfig.ResourceMetadata resourceMetadata() {
+        return resourceMetadata;
     }
 
     @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
@@ -21,6 +21,7 @@ import io.quarkus.oidc.runtime.OidcTenantConfig.IntrospectionCredentials;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Jwks;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Logout;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Provider;
+import io.quarkus.oidc.runtime.OidcTenantConfig.ResourceMetadata;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Roles;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Token;
@@ -60,6 +61,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
         private final Roles roles;
         private final Token token;
         private final Logout logout;
+        private final ResourceMetadata resourceMetadata;
         private final CertificateChain certificateChain;
         private final Authentication authentication;
         private final CodeGrant codeGrant;
@@ -87,6 +89,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
             this.token = builder.token;
             this.logout = builder.logout;
             this.certificateChain = builder.certificateChain;
+            this.resourceMetadata = builder.resourceMetadata;
             this.authentication = builder.authentication;
             this.codeGrant = builder.codeGrant;
             this.tokenStateManager = builder.tokenStateManager;
@@ -163,6 +166,11 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
         }
 
         @Override
+        public ResourceMetadata resourceMetadata() {
+            return resourceMetadata;
+        }
+
+        @Override
         public Logout logout() {
             return logout;
         }
@@ -225,6 +233,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
     private Optional<String> publicKey;
     private IntrospectionCredentials introspectionCredentials;
     private Roles roles;
+    private ResourceMetadata resourceMetadata;
     private CertificateChain certificateChain;
     private CodeGrant codeGrant;
     private TokenStateManager tokenStateManager;
@@ -257,6 +266,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
         this.token = mapping.token();
         this.logout = mapping.logout();
         this.certificateChain = mapping.certificateChain();
+        this.resourceMetadata = mapping.resourceMetadata();
         this.authentication = mapping.authentication();
         this.codeGrant = mapping.codeGrant();
         this.tokenStateManager = mapping.tokenStateManager();
@@ -497,6 +507,24 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
      */
     public LogoutConfigBuilder logout() {
         return new LogoutConfigBuilder(this);
+    }
+
+    /**
+     * @param resourceMetadata {@link OidcTenantConfig#resourceMetadata()}
+     * @return this builder
+     */
+    public OidcTenantConfigBuilder resourceMetadata(ResourceMetadata resourceMetadata) {
+        this.resourceMetadata = Objects.requireNonNull(resourceMetadata);
+        return this;
+    }
+
+    /**
+     * Creates builder for the {@link OidcTenantConfig#resourceMetadata()}.
+     *
+     * @return ResourceMetadataConfigBuilder
+     */
+    public ResourceMetadataBuilder resourceMetadata() {
+        return new ResourceMetadataBuilder(this);
     }
 
     /**
@@ -826,6 +854,91 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
         public CertificateChain build() {
             return new CertificateChainImpl(leafCertificateName, trustStoreFile, trustStorePassword, trustStoreCertAlias,
                     trustStoreFileType);
+        }
+    }
+
+    /**
+     * Builder for the {@link IntrospectionCredentials}.
+     */
+    public static final class ResourceMetadataBuilder {
+
+        private record ResourceMetadataImpl(boolean enabled, Optional<String> resource,
+                boolean forceHttpsScheme) implements ResourceMetadata {
+        }
+
+        private final OidcTenantConfigBuilder builder;
+        private boolean enabled;
+        private Optional<String> resource;
+        private boolean forceHttpsScheme;
+
+        public ResourceMetadataBuilder() {
+            this(new OidcTenantConfigBuilder());
+        }
+
+        public ResourceMetadataBuilder(OidcTenantConfigBuilder builder) {
+            this.builder = Objects.requireNonNull(builder);
+            this.enabled = builder.resourceMetadata.enabled();
+            this.resource = builder.resourceMetadata.resource();
+            this.forceHttpsScheme = builder.resourceMetadata.forceHttpsScheme();
+        }
+
+        /**
+         * {@link ResourceMetadata#enabled()}
+         *
+         * @return this builder
+         */
+        public ResourceMetadataBuilder enabled() {
+            return enabled(true);
+        }
+
+        /**
+         * @param enabled {@link ResourceMetadata#enabled()}
+         * @return this builder
+         */
+        public ResourceMetadataBuilder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        /**
+         * @param resource {@link ResourceMetadata#resource()}
+         * @return this builder
+         */
+        public ResourceMetadataBuilder resource(String resource) {
+            this.resource = Optional.ofNullable(resource);
+            return this;
+        }
+
+        /**
+         * forceHttpsScheme {@link ResourceMetadata#forceHttpsScheme()}
+         *
+         * @return this builder
+         */
+        public ResourceMetadataBuilder forceHttpsScheme() {
+            return forceHttpsScheme(true);
+        }
+
+        /**
+         * @param forceHttpsScheme {@link ResourceMetadata#forceHttpsScheme()}
+         * @return this builder
+         */
+        public ResourceMetadataBuilder forceHttpsScheme(boolean forceHttpsScheme) {
+            this.forceHttpsScheme = forceHttpsScheme;
+            return this;
+        }
+
+        /**
+         * @return OidcTenantConfigBuilder builder
+         */
+        public OidcTenantConfigBuilder end() {
+            return builder.resourceMetadata(build());
+        }
+
+        /**
+         * @return built ResourceMetadata
+         */
+        public ResourceMetadata build() {
+            return new ResourceMetadataImpl(enabled, resource, forceHttpsScheme);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -138,12 +138,16 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         return tenantContext.onItem().transformToUni(new Function<TenantConfigContext, Uni<? extends ChallengeData>>() {
             @Override
             public Uni<ChallengeData> apply(TenantConfigContext tenantContext) {
-                final String wwwAuthHeaderValue;
+                String wwwAuthHeaderValue;
                 if (StepUpAuthenticationPolicy.isInsufficientUserAuthException(context)) {
                     wwwAuthHeaderValue = tenantContext.oidcConfig().token().authorizationScheme() +
                             StepUpAuthenticationPolicy.getAuthRequirementChallenge(context);
                 } else {
                     wwwAuthHeaderValue = tenantContext.oidcConfig().token().authorizationScheme();
+                    if (tenantContext.oidcConfig().resourceMetadata().enabled()) {
+                        wwwAuthHeaderValue += ResourceMetadataHandler.resourceMetadataAuthenticateParameter(context, resolver,
+                                tenantContext.oidcConfig());
+                    }
                 }
                 return Uni.createFrom().item(new ChallengeData(HttpResponseStatus.UNAUTHORIZED.code(),
                         HttpHeaderNames.WWW_AUTHENTICATE, wwwAuthHeaderValue));

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
@@ -7,16 +7,12 @@ import java.util.function.Supplier;
 
 import javax.crypto.SecretKey;
 
-import jakarta.enterprise.event.Event;
-
 import org.jboss.logging.Logger;
 
-import io.quarkus.arc.Arc;
 import io.quarkus.oidc.OidcConfigurationMetadata;
 import io.quarkus.oidc.OidcRedirectFilter;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.Redirect;
-import io.quarkus.oidc.runtime.BackChannelLogoutHandler.NewBackChannelLogoutPath;
 import io.smallrye.mutiny.Uni;
 
 final class LazyTenantConfigContext implements TenantConfigContext {
@@ -38,10 +34,9 @@ final class LazyTenantConfigContext implements TenantConfigContext {
                     delegate.oidcConfig().tenantId().get());
             return staticTenantCreator.get().invoke(ctx -> {
                 LazyTenantConfigContext.this.delegate = ctx;
-                if (ctx.ready() && ctx.oidcConfig().logout().backchannel().path().isPresent()) {
-                    Event<NewBackChannelLogoutPath> event = Arc.container().beanManager().getEvent()
-                            .select(NewBackChannelLogoutPath.class);
-                    event.fire(new NewBackChannelLogoutPath());
+                if (ctx.ready()) {
+                    BackChannelLogoutHandler.fireBackChannelLogoutReadyEvent(ctx.oidcConfig());
+                    ResourceMetadataHandler.fireResourceMetadataReadyEvent(ctx.oidcConfig());
                 }
             });
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -178,4 +178,8 @@ public class OidcRecorder {
         return beanContainer.beanInstance(BackChannelLogoutHandler.class);
     }
 
+    public Handler<RoutingContext> getResourceMetadataHandler(BeanContainer beanContainer) {
+        return beanContainer.beanInstance(ResourceMetadataHandler.class);
+    }
+
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -142,6 +142,35 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
     Roles roles();
 
     /**
+     * Configuration to provide protected resource metadata.
+     */
+    @ConfigDocSection
+    ResourceMetadata resourceMetadata();
+
+    /**
+     * Protected resource metadata.
+     */
+    interface ResourceMetadata {
+        /**
+         * If the resource metadata can be provided.
+         */
+        @WithDefault("false")
+        boolean enabled();
+
+        /**
+         * Protected resource identifier.
+         */
+        Optional<String> resource();
+
+        /**
+         * Force a protected resource identifier HTTPS scheme.
+         * This property is ignored if {@link #resource() is an absolute URL}
+         */
+        @WithDefault("true")
+        boolean forceHttpsScheme();
+    }
+
+    /**
      * Configuration to customize validation of token claims.
      */
     @ConfigDocSection

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -938,4 +938,15 @@ public final class OidcUtils {
     public static boolean isDPoPScheme(String authorizationScheme) {
         return OidcConstants.DPOP_SCHEME.equalsIgnoreCase(authorizationScheme);
     }
+
+    public static String getRootPath(String configuredRootPath) {
+        // Prepend '/' if it is not present
+        String rootPath = OidcCommonUtils.prependSlash(configuredRootPath);
+        // Strip trailing '/' if the length is > 1
+        if (rootPath.length() > 1 && rootPath.endsWith("/")) {
+            rootPath = rootPath.substring(0, rootPath.length() - 1);
+        }
+        // if it is only '/' then return an empty value
+        return "/".equals(rootPath) ? "" : rootPath;
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
@@ -1,0 +1,231 @@
+package io.quarkus.oidc.runtime;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.oidc.OIDCException;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.vertx.http.runtime.security.ImmutablePathMatcher;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+@Singleton
+public class ResourceMetadataHandler implements Handler<RoutingContext> {
+    private static final Logger LOG = Logger.getLogger(ResourceMetadataHandler.class);
+    private static final String SLASH = "/";
+    private static final String HTTP_SCHEME = "http";
+    private static final String RESOURCE_METADATA_AUTHENTICATE_PARAM = "resource_metadata";
+    private final DefaultTenantConfigResolver resolver;
+    private volatile ImmutablePathMatcher<Handler<RoutingContext>> pathMatcher;
+
+    record NewResourceMetadata() {
+    }
+
+    ResourceMetadataHandler(DefaultTenantConfigResolver resolver) {
+        this.resolver = resolver;
+        this.pathMatcher = null;
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+        var matcher = pathMatcher;
+        if (matcher != null) {
+            Handler<RoutingContext> routeHandler = matcher.match(routingContext.normalizedPath()).getValue();
+            if (routeHandler != null) {
+                routeHandler.handle(routingContext);
+                return;
+            }
+        }
+
+        routingContext.next();
+    }
+
+    void setup(@Observes Router router) {
+        createOrUpdatePathMatcher();
+    }
+
+    synchronized void updatePathMatcher(@Observes NewResourceMetadata ignored) {
+        createOrUpdatePathMatcher();
+    }
+
+    private void createOrUpdatePathMatcher() {
+        ImmutablePathMatcher.ImmutablePathMatcherBuilder<Handler<RoutingContext>> builder = null;
+        Map<String, OidcTenantConfig> pathCache = null;
+        for (TenantConfigContext configContext : resolver.getTenantConfigBean().getAllTenantConfigs()) {
+            if (configContext.ready() && configContext.oidcConfig().tenantEnabled()
+                    && configContext.oidcConfig().resourceMetadata().enabled()) {
+                if (builder == null) {
+                    builder = ImmutablePathMatcher.builder();
+                    pathCache = new HashMap<>();
+                }
+                String routePath = getResourceMetadataPath(configContext.oidcConfig(), resolver.getRootPath());
+                if (routePath.contains("*")) {
+                    throw new IllegalStateException("Resource metadata path cannot contain a wildcard '*' character");
+                }
+                OidcTenantConfig previousConfig = pathCache.put(routePath, configContext.oidcConfig());
+                if (previousConfig == null) {
+                    Handler<RoutingContext> routeHandler = new RouteHandler(configContext.oidcConfig(), resolver);
+                    builder.addPath(routePath, routeHandler);
+                } else {
+                    String previousTenantId = previousConfig.tenantId().get();
+                    String currentTenantId = configContext.oidcConfig().tenantId().get();
+                    // maybe invalid state, but technically it could happen that some produces a static tenant with
+                    // a same id as a dynamic tenant
+                    if (!previousTenantId.equals(currentTenantId)) {
+                        String errorMessage = "OIDC tenants '%s' and '%s' share the same resource metadata path '%s', which is not supported"
+                                .formatted(previousTenantId, currentTenantId, routePath);
+                        LOG.error(errorMessage);
+                        throw new OIDCException(errorMessage);
+                    }
+                }
+            }
+        }
+        if (builder != null) {
+            pathMatcher = builder.build();
+        } else {
+            pathMatcher = null;
+        }
+    }
+
+    static String getResourceMetadataPath(OidcTenantConfig oidcConfig, String configuredRootPath) {
+        String configuredResource = oidcConfig.resourceMetadata().resource().orElse("");
+
+        String relativePath = null;
+
+        if (configuredResource.startsWith(HTTP_SCHEME)) {
+            relativePath = URI.create(configuredResource).getRawPath();
+        } else {
+            relativePath = configuredResource;
+        }
+
+        String protectedResourceMetadataPath = OidcUtils.getRootPath(configuredRootPath)
+                + OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH;
+        if (!relativePath.isEmpty()) {
+            if (!SLASH.equals(relativePath)) {
+                protectedResourceMetadataPath += OidcCommonUtils.prependSlash(relativePath);
+            }
+        } else if (!OidcUtils.DEFAULT_TENANT_ID.equals(oidcConfig.tenantId().get())) {
+            protectedResourceMetadataPath += OidcCommonUtils.prependSlash(oidcConfig.tenantId().get().toLowerCase());
+        }
+
+        return protectedResourceMetadataPath;
+    }
+
+    private static class RouteHandler implements Handler<RoutingContext> {
+        private final OidcTenantConfig oidcConfig;
+        private final DefaultTenantConfigResolver resolver;
+
+        RouteHandler(OidcTenantConfig oidcTenantConfig, DefaultTenantConfigResolver resolver) {
+            this.oidcConfig = oidcTenantConfig;
+            this.resolver = resolver;
+        }
+
+        @Override
+        public void handle(RoutingContext context) {
+            LOG.debugf("Resource metadata request for the tenant %s received", oidcConfig.tenantId().get());
+            context.response().setStatusCode(200);
+            context.response().end(prepareMetadata(context));
+        }
+
+        private String prepareMetadata(RoutingContext context) {
+            JsonObject metadata = new JsonObject();
+
+            String resourceIdentifier = buildResourceIdentifierUrl(context, resolver, oidcConfig);
+            metadata.put(OidcConstants.RESOURCE_METADATA_RESOURCE, resourceIdentifier);
+
+            JsonArray authorizationServers = new JsonArray();
+            authorizationServers.add(0, oidcConfig.authServerUrl().get());
+            metadata.put(OidcConstants.RESOURCE_METADATA_AUTHORIZATION_SERVERS, authorizationServers);
+            return metadata.toString();
+        }
+
+    }
+
+    static void fireResourceMetadataChangedEvent(OidcTenantConfig oidcConfig, TenantConfigContext tenant) {
+        if (oidcConfig.resourceMetadata().enabled() ||
+                (tenant.oidcConfig() != null && tenant.oidcConfig().resourceMetadata().enabled())) {
+            boolean resourceChanged = tenant.oidcConfig() == null
+                    || !oidcConfig.resourceMetadata().resource().orElse("")
+                            .equals(tenant.oidcConfig().resourceMetadata().resource().orElse(""))
+                    || oidcConfig.resourceMetadata().enabled() != tenant.oidcConfig().resourceMetadata().enabled()
+                    || oidcConfig.resourceMetadata().forceHttpsScheme() != tenant.oidcConfig().resourceMetadata()
+                            .forceHttpsScheme();
+            if (resourceChanged) {
+                fireResourceMetadataEvent();
+            }
+        }
+    }
+
+    static void fireResourceMetadataReadyEvent(OidcTenantConfig oidcConfig) {
+        if (oidcConfig.resourceMetadata().enabled()) {
+            fireResourceMetadataEvent();
+        }
+
+    }
+
+    private static void fireResourceMetadataEvent() {
+        Event<NewResourceMetadata> event = Arc.container().beanManager().getEvent()
+                .select(NewResourceMetadata.class);
+        event.fire(new NewResourceMetadata());
+    }
+
+    static String resourceMetadataAuthenticateParameter(RoutingContext context, DefaultTenantConfigResolver resolver,
+            OidcTenantConfig oidcConfig) {
+        return " " + RESOURCE_METADATA_AUTHENTICATE_PARAM + "=\"" + buildResourceIdentifierUrl(context, resolver, oidcConfig)
+                + "\"";
+    }
+
+    static String buildResourceIdentifierUrl(RoutingContext context, DefaultTenantConfigResolver resolver,
+            OidcTenantConfig oidcConfig) {
+        String configuredResource = oidcConfig.resourceMetadata().resource().orElse("");
+
+        if (configuredResource.startsWith(HTTP_SCHEME)) {
+            return configuredResource;
+        } else {
+            if (!configuredResource.isEmpty()) {
+                if (!SLASH.equals(configuredResource)) {
+                    configuredResource = OidcCommonUtils.prependSlash(configuredResource);
+                }
+            } else if (!OidcUtils.DEFAULT_TENANT_ID.equals(oidcConfig.tenantId().get())) {
+                configuredResource += OidcCommonUtils.prependSlash(oidcConfig.tenantId().get().toLowerCase());
+            }
+            String authority = URI.create(context.request().absoluteURI()).getAuthority();
+            return buildUri(context, resolver.isEnableHttpForwardedPrefix(),
+                    oidcConfig.resourceMetadata().forceHttpsScheme(), authority, configuredResource);
+        }
+    }
+
+    private static String buildUri(RoutingContext context,
+            boolean enableHttpForwardedPrefix, boolean forceHttps, String authority, String path) {
+        final String scheme = forceHttps ? "https" : context.request().scheme();
+        String forwardedPrefix = "";
+        if (enableHttpForwardedPrefix) {
+            String forwardedPrefixHeader = context.request().getHeader("X-Forwarded-Prefix");
+            if (forwardedPrefixHeader != null && !forwardedPrefixHeader.equals("/")
+                    && !forwardedPrefixHeader.equals("//")) {
+                forwardedPrefix = forwardedPrefixHeader;
+                if (forwardedPrefix.endsWith("/")) {
+                    forwardedPrefix = forwardedPrefix.substring(0, forwardedPrefix.length() - 1);
+                }
+            }
+        }
+        return new StringBuilder(scheme).append("://")
+                .append(authority)
+                .append(forwardedPrefix)
+                .append(path)
+                .toString();
+    }
+}

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -96,6 +96,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         CODE_GRANT,
         AUTHENTICATION,
         CERTIFICATION_CHAIN,
+        RESOURCE_METADATA,
         LOGOUT,
         TOKEN,
         ROLES,
@@ -158,6 +159,9 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         CERTIFICATION_CHAIN_TRUST_STORE_PASSWORD,
         CERTIFICATION_CHAIN_TRUST_STORE_CERT_ALIAS,
         CERTIFICATION_CHAIN_TRUST_STORE_FILE_TYPE,
+        RESOURCE_METADATA_ENABLED,
+        RESOURCE_METADATA_RESOURCE,
+        RESOURCE_METADATA_FORCE_HTTPS_SCHEME,
         LOGOUT_PATH,
         LOGOUT_POST_LOGOUT_PATH,
         LOGOUT_POST_LOGOUT_URI_PARAM,
@@ -596,6 +600,30 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             public Optional<String> trustStoreFileType() {
                 invocationsRecorder.put(ConfigMappingMethods.CERTIFICATION_CHAIN_TRUST_STORE_FILE_TYPE, true);
                 return Optional.empty();
+            }
+        };
+    }
+
+    @Override
+    public ResourceMetadata resourceMetadata() {
+        invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA, true);
+        return new ResourceMetadata() {
+            @Override
+            public boolean enabled() {
+                invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA_ENABLED, true);
+                return false;
+            }
+
+            @Override
+            public Optional<String> resource() {
+                invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA_RESOURCE, true);
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean forceHttpsScheme() {
+                invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA_FORCE_HTTPS_SCHEME, true);
+                return false;
             }
         };
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -34,6 +34,15 @@ import io.vertx.core.json.JsonObject;
 public class OidcUtilsTest {
 
     @Test
+    public void getRoorPath() throws Exception {
+
+        assertEquals("", OidcUtils.getRootPath("/"));
+        assertEquals("/root", OidcUtils.getRootPath("/root"));
+        assertEquals("/root", OidcUtils.getRootPath("root"));
+        assertEquals("/root", OidcUtils.getRootPath("/root/"));
+    }
+
+    @Test
     public void testDpopScheme() throws Exception {
 
         assertTrue(OidcUtils.isDPoPScheme("DPoP"));

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/ResourceMetadataHandlerTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/ResourceMetadataHandlerTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+
+public class ResourceMetadataHandlerTest {
+
+    @Test
+    public void testResourceMetadataPathDefaultTenant() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId(OidcUtils.DEFAULT_TENANT_ID)
+                .resourceMetadata().enabled().end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/");
+
+        assertEquals(OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH, resourceMetadataPath);
+    }
+
+    @Test
+    public void testResourceMetadataPathDefaultTenantRelativeResource() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId(OidcUtils.DEFAULT_TENANT_ID)
+                .resourceMetadata().enabled().resource("/metadata").end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/");
+
+        assertEquals(OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH + "/metadata", resourceMetadataPath);
+    }
+
+    @Test
+    public void testResourceMetadataPathDefaultTenantRelativeResource2() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId(OidcUtils.DEFAULT_TENANT_ID)
+                .resourceMetadata().enabled().resource("metadata").end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/");
+
+        assertEquals(OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH + "/metadata", resourceMetadataPath);
+    }
+
+    @Test
+    public void testResourceMetadataPathDefaultTenantRelativeResourceSlash() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId(OidcUtils.DEFAULT_TENANT_ID)
+                .resourceMetadata().enabled().resource("/").end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/");
+
+        assertEquals(OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH, resourceMetadataPath);
+    }
+
+    @Test
+    public void testResourceMetadataPathCustomTenant() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId("tenant")
+                .resourceMetadata().enabled().end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/");
+
+        assertEquals(OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH + "/tenant", resourceMetadataPath);
+    }
+
+    @Test
+    public void testResourceMetadataPathAbsoluteResource() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId(OidcUtils.DEFAULT_TENANT_ID)
+                .resourceMetadata().enabled().resource("https://some-ngrok-domain").end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/");
+
+        assertEquals(OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH, resourceMetadataPath);
+    }
+
+    @Test
+    public void testResourceMetadataPathAbsoluteResource2() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId(OidcUtils.DEFAULT_TENANT_ID)
+                .resourceMetadata().enabled().resource("https://some-ngrok-domain/metadata").end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/");
+
+        assertEquals(OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH + "/metadata", resourceMetadataPath);
+    }
+
+    @Test
+    public void testResourceMetadataPathCustomRoot() {
+
+        OidcTenantConfig oidcConfig = OidcTenantConfig.builder().tenantId(OidcUtils.DEFAULT_TENANT_ID)
+                .resourceMetadata().enabled().end().build();
+        String resourceMetadataPath = ResourceMetadataHandler.getResourceMetadataPath(oidcConfig, "/root");
+
+        assertEquals("/root" + OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH, resourceMetadataPath);
+    }
+
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -18,6 +18,7 @@ quarkus.oidc.application-type=web-app
 quarkus.oidc.authentication.cookie-suffix=test
 quarkus.oidc.token-state-manager.encryption-required=false
 quarkus.oidc.token.allow-jwt-introspection=false
+quarkus.oidc.resource-metadata.enabled=true
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
@@ -97,6 +98,7 @@ quarkus.oidc.tenant-refresh.authentication.cookie-path=/tenant-refresh
 quarkus.oidc.tenant-refresh.authentication.session-age-extension=2M
 quarkus.oidc.tenant-refresh.authentication.session-expired-path=/tenant-refresh/session-expired-page
 quarkus.oidc.tenant-refresh.token.refresh-expired=true
+quarkus.oidc.tenant-refresh.resource-metadata.enabled=true
 
 quarkus.oidc.tenant-autorefresh.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-autorefresh.client-id=quarkus-app
@@ -134,7 +136,8 @@ quarkus.oidc.tenant-nonce.authentication.nonce-required=true
 quarkus.oidc.tenant-nonce.authentication.state-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-nonce.token-state-manager.encryption-required=false
 quarkus.oidc.tenant-nonce.token.allow-jwt-introspection=false
-
+quarkus.oidc.tenant-nonce.resource-metadata.enabled=true
+quarkus.oidc.tenant-nonce.resource-metadata.resource=/metadata
 
 quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-javascript.client-id=quarkus-app

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -56,6 +56,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -63,10 +64,12 @@ import io.quarkus.test.oidc.server.OidcWireMock;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.build.Jwt;
 import io.smallrye.jwt.util.KeyUtils;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 @QuarkusTest
@@ -674,8 +677,14 @@ public class CodeFlowAuthorizationTest {
             textPage = webClient.getPage("http://localhost:8081/code-flow-user-info-dynamic-github");
             assertEquals("alice:alice:alice, cache size: 0, TenantConfigResolver: true", textPage.getContent());
 
+            // Dynamic `code-flow-user-info-dynamic-github` tenant, resource is `code-flow-user-info-dynamic-github`
+            checkResourceMetadata("code-flow-user-info-dynamic-github", "quarkus");
+
             textPage = webClient.getPage("http://localhost:8081/code-flow-user-info-dynamic-github?update=true");
             assertEquals("alice@somecompany.com:alice:alice, cache size: 0, TenantConfigResolver: true", textPage.getContent());
+
+            // Dynamic `code-flow-user-info-dynamic-github` tenant, resource is `github`
+            checkResourceMetadata("github", "quarkus");
 
             htmlPage = webClient.getPage("http://localhost:8081/code-flow-user-info-dynamic-github?reconnect=true");
             htmlForm = htmlPage.getFormByName("form");
@@ -972,5 +981,20 @@ public class CodeFlowAuthorizationTest {
         return webClient.getCookieManager().getCookies().stream()
                 .filter(c -> c.getName().startsWith("q_auth" + (tenantId == null ? "" : "_" + tenantId))).findFirst()
                 .orElse(null);
+    }
+
+    private static void checkResourceMetadata(String resource, String realm) {
+        Response metadataResponse = RestAssured.when()
+                .get("http://localhost:8081" + OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH
+                        + (resource == null ? "" : "/" + resource));
+        JsonObject jsonMetadata = new JsonObject(metadataResponse.asString());
+        assertEquals("https://localhost:8081" + (resource == null ? "" : "/" + resource),
+                jsonMetadata.getString(OidcConstants.RESOURCE_METADATA_RESOURCE));
+        JsonArray jsonAuthorizationServers = jsonMetadata.getJsonArray(OidcConstants.RESOURCE_METADATA_AUTHORIZATION_SERVERS);
+        assertEquals(1, jsonAuthorizationServers.size());
+
+        String authorizationServer = jsonAuthorizationServers.getString(0);
+        assertTrue(authorizationServer.startsWith("http://localhost:"));
+        assertTrue(authorizationServer.endsWith("/realms/" + realm));
     }
 }

--- a/integration-tests/oidc/src/main/resources/application.properties
+++ b/integration-tests/oidc/src/main/resources/application.properties
@@ -6,6 +6,7 @@ quarkus.keycloak.devservices.resource-mappings.keystore=/etc/server-keystore.p12
 quarkus.keycloak.devservices.resource-mappings.truststore=/etc/server-truststore.p12
 
 quarkus.oidc.token.principal-claim=email
+quarkus.oidc.resource-metadata.enabled=true
 
 quarkus.oidc.tls.verification=certificate-validation
 quarkus.oidc.tls.trust-store-file=target/certificates/oidc-client-truststore.p12

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/AbstractBearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/AbstractBearerTokenAuthorizationTest.java
@@ -149,7 +149,7 @@ public abstract class AbstractBearerTokenAuthorizationTest {
         RestAssured.given().auth().oauth2("123")
                 .when().get("/api/users/me").then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("Bearer"));
+                .header("WWW-Authenticate", equalTo("Bearer resource_metadata=\"https://localhost:8081\""));
     }
 
     //see https://github.com/quarkusio/quarkus/issues/5809
@@ -187,7 +187,7 @@ public abstract class AbstractBearerTokenAuthorizationTest {
                 .when().get("/bearer-only")
                 .then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("Bearer"));
+                .header("WWW-Authenticate", equalTo("Bearer resource_metadata=\"https://localhost:8081\""));
     }
 
     @Test


### PR DESCRIPTION
Closes: #47317.

This PR provides an initial support for [RFC9728](https://datatracker.ietf.org/doc/rfc9728/).

[RFC9728](https://datatracker.ietf.org/doc/rfc9728/) metadata document may include a lot of properties but this PR starts with returning an `authorization_servers` property only, to support the [MCP authorization requirement](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#overview) and specifically, the [requirement to support authorization_servers ](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-server-location), to allow MCP clients bootstrap themselves with discovering how they can login users into MCP servers.

Going forward, more metadata may be included, given the specific requirements.

Right now, returning the resource metadata is disabled by default since this information can be considered sensitive. For example, `www.someservice.com` may not want to advertise on the web which authorization providers or endpoints and other related  metadata are supporting the user's logins... For example, with Keycloak or other production quality providers, by registering custom login pages, it can be hard to figure out what the actual provider is used to login users and therefore, it should be a deployment level decision whether to expose the protected resource metadata or not.
That might need to be relaxed though in some cases, may be in devmode.

`quarkus.oidc.resource-metadata.resource` property is optional.
If it is not configured then the handler path is calculated as follows: if it is a default tenant then it is just `/.well-known/oauth-protected-resource`, otherwise `/.well-known/oauth-protected-resource/${tenant-id}`.
If it is configured, then if it is an absolute URL then  it is either `/.well-known/oauth-protected-resource`, or `/.well-known/oauth-protected-resource/${url-path-component}`. If it is a relative URL, then it is `/.well-known/oauth-protected-resource`, otherwise `/.well-known/oauth-protected-resource/relative-url`.

I've added a few tests for static and dynamic tenants, and also confirmed with NGrok that configuring an absolute HTTPS based resource URL also works.

Right now I'm finalizing the spec option where the `WWW_Authenticate Bearer resource_metadata=...` is returned if no token is available when accessing the protected resource, which is also required by the MCP authorization; PR will be ready for review once it is done
