### PR TITLE
Dev UI: Allow headless components

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -1295,6 +1295,68 @@ There might be cases where you develop an extension outside of Quarkus core (lik
 
 image::dev-ui-jsonrpc-log-v2.png[alt=Dev UI Json RPC Log,role="center"]
 
+=== Advanced: Headless Components
+
+In rare cases, an extension might need to execute logic *even when its main component is not added to the DOM*. This is typically useful for setting global state or triggering background tasks without displaying any UI.
+
+To support this, extensions can declare a *headless component* — a web component with no visual representation that runs automatically on page load.
+
+Declare the headless component in your extension:
+
+[source,java]
+----
+CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
+cardPageBuildItem.setHeadlessComponentLink("qwc-chappie-init.js"); // <1>
+----
+<1> Set the path to the headless component JavaScript file (relative to the extension resources).
+
+Then create the component alongside your other Dev UI pages:
+
+[source,javascript]
+----
+import { LitElement } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import { assistantState } from 'assistant-state';
+
+/**
+ * This load on browser load (headless components) to set the initial assistant state
+ */
+class QwcChappieInit extends LitElement {
+
+    static properties = {
+        namespace: {attribute: true}, // <1>
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._init().then(() => this.remove()); // <2>
+    }
+
+    async _init() {
+        const jsonRpc = new JsonRpc(this.namespace); // <3>
+
+        jsonRpc.loadConfiguration().then(jsonRpcResponse => { 
+            if(jsonRpcResponse.result && jsonRpcResponse.result.name){
+                assistantState.ready();
+            }else{
+                assistantState.available();
+            }
+        });
+    }
+
+    // prevent rendering anything
+    createRenderRoot() { // <3>
+        return this;
+    }
+}
+customElements.define('qwc-chappie-init', QwcChappieInit); // <4>
+----
+<1> The `namespace` attribute will always be provided automatically by Dev UI.
+<2> Perform your logic in `connectedCallback`, then remove the element if no longer needed.
+<3> When using JsonRPC, pass in the provided namespace (instead of `this`, as in normal components).
+<4> Your tag definition have to be the filename without the `.js`
+
+
 === Testing
 
 You can add tests to your extension that test:

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -621,6 +621,12 @@ public class DevUIProcessor {
                                         extension.setCard(card);
                                     });
 
+                                    // See if there is a headless component
+                                    String headlessJs = cardPageBuildItem.getHeadlessComponentLink();
+                                    if (headlessJs != null) {
+                                        extension.setHeadlessComponent(headlessJs);
+                                    }
+
                                     addLogo(extension, cardPageBuildItem, metaData);
                                     addLibraryLinks(extension, cardPageBuildItem, curateOutcomeBuildItem, metaData);
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
@@ -19,6 +19,7 @@ public final class InternalPageBuildItem extends MultiBuildItem {
     private final List<Page> pages = new ArrayList<>();
     private final Map<String, Object> buildTimeData = new HashMap<>();
     private final String menuActionComponent;
+    private String headlessComponentLink = null;
 
     public InternalPageBuildItem(String namespaceLabel, int position) {
         this(namespaceLabel, position, null);
@@ -57,5 +58,13 @@ public final class InternalPageBuildItem extends MultiBuildItem {
 
     public Map<String, Object> getBuildTimeData() {
         return buildTimeData;
+    }
+
+    public void setHeadlessComponentLink(String headlessComponentLink) {
+        this.headlessComponentLink = headlessComponentLink;
+    }
+
+    public String getHeadlessComponentLink() {
+        return this.headlessComponentLink;
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/extension/Extension.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/extension/Extension.java
@@ -32,6 +32,7 @@ public class Extension {
     private List<LibraryLink> libraryLinks = null;
     private String darkLogo = null;
     private String lightLogo = null;
+    private String headlessComponent = null;
 
     public Extension() {
 
@@ -232,6 +233,21 @@ public class Extension {
         return this.card != null;
     }
 
+    public void setHeadlessComponent(String headlessComponent) {
+        this.headlessComponent = headlessComponent;
+    }
+
+    public String getHeadlessComponent() {
+        return this.headlessComponent;
+    }
+
+    public String getHeadlessComponentRef() {
+        if (headlessComponent != null) {
+            return DOT + SLASH + DOT + DOT + SLASH + this.namespace + SLASH + this.headlessComponent;
+        }
+        return null;
+    }
+
     @Override
     public String toString() {
         return "Extension{" + "namespace=" + namespace + ", artifact=" + artifact + ", name=" + name + ", shortName="
@@ -241,4 +257,6 @@ public class Extension {
                 + extensionDependencies + ", codestart=" + codestart + '}';
     }
 
+    private static final String SLASH = "/";
+    private static final String DOT = ".";
 }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
@@ -15,6 +15,7 @@ public abstract class AbstractPageBuildItem extends AbstractDevUIBuildItem {
 
     protected final Map<String, Object> buildTimeData;
     protected final List<PageBuilder> pageBuilders;
+    protected String headlessComponentLink = null;
 
     public AbstractPageBuildItem() {
         super();
@@ -62,5 +63,13 @@ public abstract class AbstractPageBuildItem extends AbstractDevUIBuildItem {
 
     public boolean hasBuildTimeData() {
         return this.buildTimeData != null && !this.buildTimeData.isEmpty();
+    }
+
+    public void setHeadlessComponentLink(String headlessComponentLink) {
+        this.headlessComponentLink = headlessComponentLink;
+    }
+
+    public String getHeadlessComponentLink() {
+        return this.headlessComponentLink;
     }
 }


### PR DESCRIPTION
This PR adds support for Headless components in Dev UI. This came about from a need in the new assistant where the assistant state needs to be set by the chappie extension.