### PR TITLE
Make REST Client config suffice for request/response logging

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -72,13 +72,13 @@ public class ClientBuilderImpl extends ClientBuilder {
     // overridden security settings
     private TlsConfig tlsConfig;
 
-    private LoggingScope loggingScope;
+    private ClientLogger clientLogger = new DefaultClientLogger();
+    private LoggingScope loggingScope = LoggingScope.NONE;
     private Integer loggingBodySize = 100;
 
     private int maxChunkSize = 8096;
     private MultiQueryParamMode multiQueryParamMode;
 
-    private ClientLogger clientLogger = new DefaultClientLogger();
     private String userAgent = RestClientRequestContext.DEFAULT_USER_AGENT_VALUE;
 
     private Boolean enableCompression;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/logging/DefaultClientLogger.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/logging/DefaultClientLogger.java
@@ -23,13 +23,10 @@ public class DefaultClientLogger implements ClientLogger {
 
     @Override
     public void logResponse(HttpClientResponse response, boolean redirect) {
-        if (!log.isDebugEnabled()) {
-            return;
-        }
         response.bodyHandler(new Handler<>() {
             @Override
             public void handle(Buffer body) {
-                log.debugf("%s: %s %s, Status[%d %s], Headers[%s], Body:\n%s",
+                log.infof("%s: %s %s, Status[%d %s], Headers[%s], Body:\n%s",
                         redirect ? "Redirect" : "Response",
                         response.request().getMethod(), response.request().absoluteURI(), response.statusCode(),
                         response.statusMessage(), asString(response.headers()), bodyToString(body));
@@ -39,17 +36,14 @@ public class DefaultClientLogger implements ClientLogger {
 
     @Override
     public void logRequest(HttpClientRequest request, Buffer body, boolean omitBody) {
-        if (!log.isDebugEnabled()) {
-            return;
-        }
         if (omitBody) {
-            log.debugf("Request: %s %s Headers[%s], Body omitted",
+            log.infof("Request: %s %s Headers[%s], Body omitted",
                     request.getMethod(), request.absoluteURI(), asString(request.headers()));
         } else if (body == null || body.length() == 0) {
-            log.debugf("Request: %s %s Headers[%s], Empty body",
+            log.infof("Request: %s %s Headers[%s], Empty body",
                     request.getMethod(), request.absoluteURI(), asString(request.headers()));
         } else {
-            log.debugf("Request: %s %s Headers[%s], Body:\n%s",
+            log.infof("Request: %s %s Headers[%s], Body:\n%s",
                     request.getMethod(), request.absoluteURI(), asString(request.headers()), bodyToString(body));
         }
     }


### PR DESCRIPTION
With the previous behavior, one needed to both enable the REST Client specific properties while *also*
setting the proper category to INFO, which
amounted to a pretty bad user experience.

- Relates to: #48743