### PR TITLE
Fix container sharing for simple dev service model 

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -103,7 +103,10 @@ public class DevServicesKafkaProcessor {
                     config.port().orElse(0),
                     composeProjectBuildItem.getDefaultNetworkId(),
                     useSharedNetwork, config.redpanda())
-                    .withEnv(config.containerEnv());
+                    .withEnv(config.containerEnv())
+                    // Dev Service discovery works using a global dev service label applied in DevServicesCustomizerBuildItem
+                    // for backwards compatibility we still add the custom label
+                    .withLabel(DEV_SERVICE_LABEL, config.serviceName());
             case STRIMZI -> {
                 StrimziKafkaContainer strimzi = new StrimziKafkaContainer(config.effectiveImageName())
                         .withBrokerId(1)
@@ -118,12 +121,15 @@ public class DevServicesKafkaProcessor {
                     strimzi.withPort(config.port().get());
                 }
                 strimzi.withEnv(config.containerEnv());
+                strimzi.withLabel(DEV_SERVICE_LABEL, config.serviceName());
                 yield new StartableContainer<>(strimzi, StrimziKafkaContainer::getBootstrapServers);
             }
             case KAFKA_NATIVE -> new KafkaNativeContainer(DockerImageName.parse(config.effectiveImageName()),
                     config.port().orElse(0),
                     composeProjectBuildItem.getDefaultNetworkId(),
-                    useSharedNetwork).withEnv(config.containerEnv());
+                    useSharedNetwork)
+                    .withEnv(config.containerEnv())
+                    .withLabel(DEV_SERVICE_LABEL, config.serviceName());
         };
         return startable;
     }

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -92,7 +92,10 @@ public class DevServicesRedisProcessor {
                                             redisConfig.port(),
                                             composeProjectBuildItem.getDefaultNetworkId(),
                                             useSharedNetwork)
-                                            .withEnv(redisConfig.containerEnv()))
+                                            .withEnv(redisConfig.containerEnv())
+                                            // Dev Service discovery works using a global dev service label applied in DevServicesCustomizerBuildItem
+                                            // for backwards compatibility we still add the custom label
+                                            .withLabel(DEV_SERVICE_LABEL, redisConfig.serviceName()))
                                     .configProvider(Map.of(configPrefix + RedisConfig.HOSTS_CONFIG_NAME,
                                             s -> REDIS_SCHEME + s.getConnectionInfo()))
                                     .build());


### PR DESCRIPTION
Service Container discovery from different dev mode processes is applied using `DevServicesCustomizerBuildItem`.

Custom labels per dev service such as `quarkus-dev-service-redis` and `quarkus-dev-service-kafka` are kept there for backwards compatibility.