### PR TITLE
Move aws-lambda to new dev services model, starting services after augmentation

### DIFF
--- a/extensions/amazon-lambda/common-deployment/pom.xml
+++ b/extensions/amazon-lambda/common-deployment/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaEphemeralPortTestCase.java
+++ b/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaEphemeralPortTestCase.java
@@ -10,7 +10,7 @@ import io.quarkus.it.amazon.lambda.profiles.EphemeralPortProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
-@Disabled("Failing since 3.22, should be fixed by by https://github.com/quarkusio/quarkus/issues/48006")
+@Disabled("Tracked by https://github.com/quarkusio/quarkus/issues/48784")
 @TestProfile(EphemeralPortProfile.class)
 @QuarkusTest
 public class AmazonLambdaEphemeralPortTestCase {

--- a/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaWithProfileSimpleTestCase.java
+++ b/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaWithProfileSimpleTestCase.java
@@ -3,14 +3,12 @@ package io.quarkus.it.amazon.lambda;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.it.amazon.lambda.profiles.TrivialProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
-@Disabled("Failing, tracked by https://github.com/quarkusio/quarkus/issues/48006")
 @TestProfile(TrivialProfile.class)
 @QuarkusTest
 public class AmazonLambdaWithProfileSimpleTestCase {


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/48006

This doesn't fully get the lambda dev service to how it was before the test classloading rewrite, because ephemeral ports still don't work. Fixing that needs some dev service infra changes and some fussing with config priorities, so I've moved it to its own issue: https://github.com/quarkusio/quarkus/issues/48784