### PR TITLE
Ban dynamic version ranges

### DIFF
--- a/extensions/web-dependency-locator/deployment/pom.xml
+++ b/extensions/web-dependency-locator/deployment/pom.xml
@@ -67,6 +67,12 @@
             <artifactId>dc.js</artifactId>
             <version>3.0.6</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mvnpm</groupId>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -168,6 +168,10 @@
                                     </message>
                                     <version>${maven.min.version}</version>
                                 </requireMavenVersion>
+                                <banDynamicVersions>
+                                    <!-- while we don't allow snapshots in the tree, it's handy to be able to use a snapshot for testing -->
+                                    <allowSnapshots>true</allowSnapshots>
+                                </banDynamicVersions>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This will prevent mvnpm version ranges to crawl in.

@phillip-kruger we can't merge it yet as it fails but let's merge it as soon as you have fixed the current Vaadin issue.

/cc @maxandersen 