### PR TITLE
Extracting baseconfig inputs from extensionview

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -14,11 +14,14 @@ import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.testing.Test;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.gradle.tasks.EffectiveConfigProvider;
 import io.quarkus.gradle.tasks.QuarkusPluginExtensionView;
 import io.quarkus.gradle.tooling.ToolingUtils;
 import io.smallrye.config.SmallRyeConfig;
@@ -31,17 +34,23 @@ public class BeforeTestAction implements Action<Task> {
     private final Provider<File> nativeRunnerPath;
     private final FileCollection mainSourceSetClassesDir;
     private final QuarkusPluginExtensionView extensionView;
+    private final MapProperty<String, Object> manifestAttributes;
+    private final MapProperty<String, Attributes> manifestSections;
 
     public BeforeTestAction(File projectDir, FileCollection combinedOutputSourceDirs,
             Provider<RegularFile> applicationModelPath, Provider<File> nativeRunnerPath,
             FileCollection mainSourceSetClassesDir,
-            QuarkusPluginExtensionView extensionView) {
+            QuarkusPluginExtensionView extensionView,
+            MapProperty<String, Object> manifestAttributes,
+            MapProperty<String, Attributes> manifestSections) {
         this.projectDir = projectDir;
         this.combinedOutputSourceDirs = combinedOutputSourceDirs;
         this.applicationModelPath = applicationModelPath;
         this.nativeRunnerPath = nativeRunnerPath;
         this.mainSourceSetClassesDir = mainSourceSetClassesDir;
         this.extensionView = extensionView;
+        this.manifestAttributes = manifestAttributes;
+        this.manifestSections = manifestSections;
 
     }
 
@@ -54,7 +63,8 @@ public class BeforeTestAction implements Action<Task> {
             ApplicationModel applicationModel = ToolingUtils
                     .deserializeAppModel(applicationModelPath.get().getAsFile().toPath());
 
-            SmallRyeConfig config = extensionView.buildEffectiveConfiguration(applicationModel, new HashMap<>()).getConfig();
+            SmallRyeConfig config = effectiveProvider().buildEffectiveConfiguration(applicationModel, new HashMap<>())
+                    .getConfig();
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));
 
@@ -87,5 +97,20 @@ public class BeforeTestAction implements Action<Task> {
         } catch (Exception e) {
             throw new IllegalStateException("Failed to resolve deployment classpath", e);
         }
+    }
+
+    private EffectiveConfigProvider effectiveProvider() {
+        return new EffectiveConfigProvider(
+                extensionView.getIgnoredEntries(),
+                extensionView.getMainResources(),
+                extensionView.getForcedProperties(),
+                extensionView.getProjectProperties(),
+                extensionView.getQuarkusBuildProperties(),
+                extensionView.getQuarkusRelevantProjectProperties(),
+                manifestAttributes,
+                manifestSections,
+                extensionView.getNativeBuild(),
+                extensionView.getQuarkusProfileSystemVariable(),
+                extensionView.getQuarkusProfileEnvVariable());
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -28,6 +28,8 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.process.JavaForkOptions;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.gradle.dsl.Manifest;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.smallrye.common.expression.Expression;
@@ -97,7 +99,7 @@ public abstract class AbstractQuarkusExtension {
         return new BaseConfig(effectiveConfig);
     }
 
-    protected BaseConfig baseConfig() {
+    public BaseConfig baseConfig() {
         this.baseConfig.finalizeValue();
         return this.baseConfig.get();
     }
@@ -114,8 +116,24 @@ public abstract class AbstractQuarkusExtension {
         return classpath;
     }
 
-    protected Manifest manifest() {
+    public Manifest manifest() {
         return baseConfig().manifest();
+    }
+
+    public Map<String, Attributes> getAttributes() {
+        return manifest().getSections();
+    }
+
+    public PackageConfig packageConfig() {
+        return baseConfig().packageConfig();
+    }
+
+    public Map<String, String> cachingRelevantProperties(List<String> propertyPatterns) {
+        return baseConfig().cachingRelevantProperties(propertyPatterns);
+    }
+
+    public NativeConfig nativeConfig() {
+        return baseConfig().nativeConfig();
     }
 
     protected EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
@@ -1,7 +1,8 @@
 package io.quarkus.gradle.tasks;
 
-import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.*;
 import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.QUARKUS_PROFILE;
+import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.toManifestAttributeKey;
+import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.toManifestSectionAttributeKey;
 
 import java.io.File;
 import java.util.HashMap;

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
@@ -1,0 +1,130 @@
+package io.quarkus.gradle.tasks;
+
+import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.*;
+import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.QUARKUS_PROFILE;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+public class EffectiveConfigProvider {
+    final ListProperty<String> ignoredEntries;
+    final ConfigurableFileCollection mainResources;
+    final MapProperty<String, String> forcedProperties;
+    final MapProperty<String, Object> projectProperties;
+    final MapProperty<String, String> quarkusBuildProperties;
+    final MapProperty<String, String> quarkusRelevantProjectProperties;
+    final MapProperty<String, Object> manifestAttributes;
+    final MapProperty<String, Attributes> manifestSections;
+    final Property<Boolean> nativeBuild;
+    final Property<String> quarkusProfileSystemVariable;
+    final Property<String> quarkusProfileEnvVariable;
+
+    public EffectiveConfigProvider(ListProperty<String> ignoredEntries,
+            ConfigurableFileCollection mainResources,
+            MapProperty<String, String> forcedProperties,
+            MapProperty<String, Object> projectProperties,
+            MapProperty<String, String> quarkusBuildProperties,
+            MapProperty<String, String> quarkusRelevantProjectProperties,
+            MapProperty<String, Object> manifestAttributes,
+            MapProperty<String, Attributes> manifestSections,
+            Property<Boolean> nativeBuild,
+            Property<String> quarkusProfileSystemVariable,
+            Property<String> quarkusProfileEnvVariable) {
+        this.ignoredEntries = ignoredEntries;
+        this.mainResources = mainResources;
+        this.forcedProperties = forcedProperties;
+        this.projectProperties = projectProperties;
+        this.quarkusBuildProperties = quarkusBuildProperties;
+        this.quarkusRelevantProjectProperties = quarkusRelevantProjectProperties;
+        this.manifestAttributes = manifestAttributes;
+        this.manifestSections = manifestSections;
+        this.nativeBuild = nativeBuild;
+        this.quarkusProfileSystemVariable = quarkusProfileSystemVariable;
+        this.quarkusProfileEnvVariable = quarkusProfileEnvVariable;
+    }
+
+    public EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel,
+            Map<String, ?> additionalForcedProperties) {
+        ResolvedDependency appArtifact = appModel.getAppArtifact();
+
+        Map<String, Object> properties = new HashMap<>();
+        exportCustomManifestProperties(properties);
+
+        Map<String, String> defaultProperties = new HashMap<>();
+        String userIgnoredEntries = String.join(",", ignoredEntries.get());
+        if (!userIgnoredEntries.isEmpty()) {
+            defaultProperties.put("quarkus.package.jar.user-configured-ignored-entries", userIgnoredEntries);
+        }
+        Set<File> resourcesDirs = mainResources.getFiles();
+        defaultProperties.putIfAbsent("quarkus.application.name", appArtifact.getArtifactId());
+        defaultProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
+
+        Map<String, String> forced = new HashMap<>(forcedProperties.get());
+        projectProperties.get().forEach((k, v) -> {
+            forced.put(k, v.toString());
+
+        });
+        additionalForcedProperties.forEach((k, v) -> {
+            forced.put(k, v.toString());
+        });
+        if (nativeBuild.get()) {
+            forced.put("quarkus.native.enabled", "true");
+        }
+        return EffectiveConfig.builder()
+                .withPlatformProperties(appModel.getPlatformProperties())
+                .withForcedProperties(forced)
+                .withTaskProperties(properties)
+                .withBuildProperties(quarkusBuildProperties.get())
+                .withProjectProperties(quarkusRelevantProjectProperties.get())
+                .withDefaultProperties(defaultProperties)
+                .withSourceDirectories(resourcesDirs)
+                .withProfile(getQuarkusProfile())
+                .build();
+    }
+
+    private void exportCustomManifestProperties(Map<String, Object> properties) {
+        for (Map.Entry<String, Object> attribute : manifestAttributes.get().entrySet()) {
+            properties.put(toManifestAttributeKey(attribute.getKey()),
+                    attribute.getValue());
+        }
+
+        for (Map.Entry<String, Attributes> section : manifestSections.get().entrySet()) {
+            for (Map.Entry<String, Object> attribute : section.getValue().entrySet()) {
+                properties
+                        .put(toManifestSectionAttributeKey(section.getKey(), attribute.getKey()), attribute.getValue());
+            }
+        }
+    }
+
+    private String getQuarkusProfile() {
+        String profile = quarkusProfileSystemVariable.getOrNull();
+        if (profile == null) {
+            profile = quarkusProfileEnvVariable.getOrNull();
+        }
+        if (profile == null) {
+            profile = quarkusBuildProperties.get().get(QUARKUS_PROFILE);
+        }
+        if (profile == null) {
+            Object p = quarkusRelevantProjectProperties.get().get(QUARKUS_PROFILE);
+            if (p != null) {
+                profile = p.toString();
+            }
+        }
+        if (profile == null) {
+            profile = "prod";
+        }
+        return profile;
+    }
+
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
@@ -144,7 +144,7 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
         }
 
         ApplicationModel appModel = resolveAppModelForBuild();
-        SmallRyeConfig config = getExtensionView()
+        SmallRyeConfig config = effectiveProvider()
                 .buildEffectiveConfiguration(appModel, new HashMap<>())
                 .getConfig();
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -24,7 +24,6 @@ import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -38,7 +37,7 @@ import io.quarkus.gradle.tooling.ToolingUtils;
 import io.quarkus.runtime.LaunchMode;
 
 @CacheableTask
-public abstract class QuarkusGenerateCode extends QuarkusTask {
+public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
 
     public static final String QUARKUS_GENERATED_SOURCES = "quarkus-generated-sources";
     public static final String QUARKUS_TEST_GENERATED_SOURCES = "quarkus-test-generated-sources";
@@ -49,7 +48,6 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
     private final LaunchMode launchMode;
     private final String inputSourceSetName;
 
-    private final QuarkusPluginExtensionView extensionView;
     private final List<String> codeGenInput;
 
     @Inject
@@ -57,14 +55,8 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
         super("Performs Quarkus pre-build preparations, such as sources generation", true);
         this.launchMode = launchMode;
         this.inputSourceSetName = inputSourceSetName;
-        this.extensionView = getProject().getObjects().newInstance(QuarkusPluginExtensionView.class, extension());
         this.codeGenInput = codeGenInput;
 
-    }
-
-    @Nested
-    protected QuarkusPluginExtensionView getExtensionView() {
-        return extensionView;
     }
 
     /**
@@ -118,7 +110,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
     @TaskAction
     public void generateCode() throws IOException {
         ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
-        Map<String, String> configMap = getExtensionView()
+        Map<String, String> configMap = effectiveProvider()
                 .buildEffectiveConfiguration(appModel, new HashMap<>()).getValues();
 
         File outputPath = getGeneratedOutputDirectory().get().getAsFile();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -3,20 +3,10 @@ package io.quarkus.gradle.tasks;
 import static io.quarkus.gradle.QuarkusPlugin.BUILD_NATIVE_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.TEST_NATIVE_TASK_NAME;
 import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.QUARKUS_PROFILE;
-import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.toManifestAttributeKey;
-import static io.quarkus.gradle.tasks.AbstractQuarkusExtension.toManifestSectionAttributeKey;
-import static io.smallrye.common.expression.Expression.Flag.DOUBLE_COLON;
-import static io.smallrye.common.expression.Expression.Flag.LENIENT_SYNTAX;
-import static io.smallrye.common.expression.Expression.Flag.NO_SMART_BRACES;
-import static io.smallrye.common.expression.Expression.Flag.NO_TRIM;
 import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -24,7 +14,6 @@ import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -38,13 +27,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.GradleVersion;
 
-import io.quarkus.bootstrap.model.ApplicationModel;
-import io.quarkus.deployment.pkg.PackageConfig;
-import io.quarkus.gradle.QuarkusPlugin;
-import io.quarkus.gradle.dsl.Manifest;
 import io.quarkus.gradle.extension.QuarkusPluginExtension;
-import io.quarkus.maven.dependency.ResolvedDependency;
-import io.smallrye.common.expression.Expression;
 
 /**
  * Configuration cache compatible view of Quarkus extension
@@ -73,8 +56,7 @@ public abstract class QuarkusPluginExtensionView {
         getQuarkusRelevantProjectProperties().set(getQuarkusRelevantProjectProperties(project));
         getQuarkusProfileSystemVariable().set(getProviderFactory().systemProperty(QUARKUS_PROFILE));
         getQuarkusProfileEnvVariable().set(getProviderFactory().environmentVariable("QUARKUS_PROFILE"));
-        getCachingRelevantInput()
-                .set(extension.baseConfig().cachingRelevantProperties(extension.getCachingRelevantProperties().get()));
+        getCachingRelevantProperties().set(extension.getCachingRelevantProperties());
         getForcedProperties().set(extension.forcedPropertiesProperty());
         Map<String, Object> projectProperties = new HashMap<>();
         for (Map.Entry<String, ?> entry : project.getProperties().entrySet()) {
@@ -83,16 +65,6 @@ public abstract class QuarkusPluginExtensionView {
             }
         }
         getProjectProperties().set(projectProperties);
-        getJarEnabled().set(extension.baseConfig().packageConfig().jar().enabled());
-        getManifestAttributes().set(extension.manifest().getAttributes());
-        getManifestSections().set(extension.manifest().getSections());
-        getNativeEnabled().set(extension.baseConfig().nativeConfig().enabled());
-        getNativeSourcesOnly().set(extension.baseConfig().nativeConfig().sourcesOnly());
-        getRunnerSuffix().set(extension.baseConfig().packageConfig().computedRunnerSuffix());
-        getRunnerName().set(extension.baseConfig().packageConfig().outputName().orElseGet(extension::finalName));
-        getOutputDirectory().set(Path.of(extension.baseConfig().packageConfig().outputDirectory().map(Path::toString)
-                .orElse(QuarkusPlugin.DEFAULT_OUTPUT_DIRECTORY)));
-        getJarType().set(extension.baseConfig().jarType());
     }
 
     private Provider<Map<String, String>> getQuarkusRelevantProjectProperties(Project project) {
@@ -118,6 +90,9 @@ public abstract class QuarkusPluginExtensionView {
     public abstract Property<Boolean> getCacheLargeArtifacts();
 
     @Input
+    public abstract ListProperty<String> getCachingRelevantProperties();
+
+    @Input
     public abstract Property<Boolean> getCleanupBuildOutput();
 
     @Input
@@ -133,22 +108,6 @@ public abstract class QuarkusPluginExtensionView {
     public abstract ListProperty<Action<? super JavaForkOptions>> getBuildForkOptions();
 
     @Input
-    @Optional
-    public abstract Property<Boolean> getJarEnabled();
-
-    @Input
-    @Optional
-    public abstract Property<Boolean> getNativeEnabled();
-
-    @Input
-    @Optional
-    public abstract Property<Manifest> getManifest();
-
-    @Input
-    @Optional
-    public abstract Property<Boolean> getNativeSourcesOnly();
-
-    @Input
     public abstract ListProperty<String> getIgnoredEntries();
 
     @Input
@@ -160,18 +119,6 @@ public abstract class QuarkusPluginExtensionView {
     @Internal
     public abstract ConfigurableFileCollection getMainResources();
 
-    @Internal
-    public abstract Property<String> getRunnerSuffix();
-
-    @Internal
-    public abstract Property<String> getRunnerName();
-
-    @Internal
-    public abstract Property<Path> getOutputDirectory();
-
-    @Input
-    public abstract Property<PackageConfig.JarConfig.JarType> getJarType();
-
     @Input
     @Optional
     public abstract Property<String> getQuarkusProfileSystemVariable();
@@ -182,139 +129,6 @@ public abstract class QuarkusPluginExtensionView {
 
     @Input
     @Optional
-    public abstract MapProperty<String, String> getCachingRelevantInput();
-
-    @Input
-    @Optional
     public abstract MapProperty<String, String> getForcedProperties();
 
-    @Input
-    @Optional
-    public abstract MapProperty<String, Object> getManifestAttributes();
-
-    @Input
-    @Optional
-    public abstract MapProperty<String, Attributes> getManifestSections();
-
-    private void exportCustomManifestProperties(Map<String, Object> properties) {
-        for (Map.Entry<String, Object> attribute : getManifestAttributes().get().entrySet()) {
-            properties.put(toManifestAttributeKey(attribute.getKey()),
-                    attribute.getValue());
-        }
-
-        for (Map.Entry<String, Attributes> section : getManifestSections().get().entrySet()) {
-            for (Map.Entry<String, Object> attribute : section.getValue().entrySet()) {
-                properties
-                        .put(toManifestSectionAttributeKey(section.getKey(), attribute.getKey()), attribute.getValue());
-            }
-        }
-    }
-
-    public EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel,
-            Map<String, ?> additionalForcedProperties) {
-        ResolvedDependency appArtifact = appModel.getAppArtifact();
-
-        Map<String, Object> properties = new HashMap<>();
-        exportCustomManifestProperties(properties);
-
-        Map<String, String> defaultProperties = new HashMap<>();
-        String userIgnoredEntries = String.join(",", getIgnoredEntries().get());
-        if (!userIgnoredEntries.isEmpty()) {
-            defaultProperties.put("quarkus.package.jar.user-configured-ignored-entries", userIgnoredEntries);
-        }
-        Set<File> resourcesDirs = getMainResources().getFiles();
-        defaultProperties.putIfAbsent("quarkus.application.name", appArtifact.getArtifactId());
-        defaultProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
-
-        Map<String, String> forced = new HashMap<>(getForcedProperties().get());
-        getProjectProperties().get().forEach((k, v) -> {
-            forced.put(k, v.toString());
-
-        });
-        additionalForcedProperties.forEach((k, v) -> {
-            forced.put(k, v.toString());
-        });
-        if (getNativeBuild().get()) {
-            forced.put("quarkus.native.enabled", "true");
-        }
-        return EffectiveConfig.builder()
-                .withPlatformProperties(appModel.getPlatformProperties())
-                .withForcedProperties(forced)
-                .withTaskProperties(properties)
-                .withBuildProperties(getQuarkusBuildProperties().get())
-                .withProjectProperties(getQuarkusRelevantProjectProperties().get())
-                .withDefaultProperties(defaultProperties)
-                .withSourceDirectories(resourcesDirs)
-                .withProfile(getQuarkusProfile())
-                .build();
-    }
-
-    protected Map<String, String> buildSystemProperties(ResolvedDependency appArtifact, Map<String, String> quarkusProperties) {
-        Map<String, String> buildSystemProperties = new HashMap<>();
-        buildSystemProperties.putIfAbsent("quarkus.application.name", appArtifact.getArtifactId());
-        buildSystemProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
-
-        for (Map.Entry<String, String> entry : getForcedProperties().get().entrySet()) {
-            if (entry.getKey().startsWith("quarkus.") || entry.getKey().startsWith("platform.quarkus.")) {
-                buildSystemProperties.put(entry.getKey(), entry.getValue());
-            }
-        }
-        for (Map.Entry<String, String> entry : getQuarkusBuildProperties().get().entrySet()) {
-            if (entry.getKey().startsWith("quarkus.") || entry.getKey().startsWith("platform.quarkus.")) {
-                buildSystemProperties.put(entry.getKey(), entry.getValue());
-            }
-        }
-        for (Map.Entry<String, ?> entry : getProjectProperties().get().entrySet()) {
-            if ((entry.getKey().startsWith("quarkus.") || entry.getKey().startsWith("platform.quarkus."))
-                    && entry.getValue() != null) {
-                buildSystemProperties.put(entry.getKey(), entry.getValue().toString());
-            }
-        }
-
-        Set<String> quarkusValues = new HashSet<>();
-        quarkusValues.addAll(quarkusProperties.values());
-        quarkusValues.addAll(buildSystemProperties.values());
-
-        for (String value : quarkusValues) {
-            Expression expression = Expression.compile(value, LENIENT_SYNTAX, NO_TRIM, NO_SMART_BRACES, DOUBLE_COLON);
-            for (String reference : expression.getReferencedStrings()) {
-                String expanded = getForcedProperties().get().get(reference);
-                if (expanded != null) {
-                    buildSystemProperties.put(reference, expanded);
-                    continue;
-                }
-
-                expanded = getQuarkusBuildProperties().get().get(reference);
-                if (expanded != null) {
-                    buildSystemProperties.put(reference, expanded);
-                    continue;
-                }
-                expanded = (String) getProjectProperties().get().get(reference);
-                if (expanded != null) {
-                    buildSystemProperties.put(reference, expanded);
-                }
-            }
-        }
-        return buildSystemProperties;
-    }
-
-    private String getQuarkusProfile() {
-        String profile = getQuarkusProfileSystemVariable().getOrNull();
-        if (profile == null) {
-            profile = getQuarkusProfileEnvVariable().getOrNull();
-        }
-        if (profile == null) {
-            profile = getQuarkusBuildProperties().get().get(QUARKUS_PROFILE);
-        }
-        if (profile == null) {
-            Object p = getQuarkusRelevantProjectProperties().get().get(QUARKUS_PROFILE);
-            if (p != null) {
-                profile = p.toString();
-            }
-        }
-        if (profile == null) {
-            profile = "prod";
-        }
-        return profile;
-    }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
@@ -48,7 +48,7 @@ public abstract class QuarkusShowEffectiveConfig extends QuarkusBuildTask {
     public void dumpEffectiveConfiguration() {
         try {
             ApplicationModel appModel = resolveAppModelForBuild();
-            EffectiveConfig effectiveConfig = getExtensionView()
+            EffectiveConfig effectiveConfig = effectiveProvider()
                     .buildEffectiveConfiguration(appModel,
                             getAdditionalForcedProperties().get().getProperties());
             SmallRyeConfig config = effectiveConfig.getConfig();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -1,0 +1,63 @@
+package io.quarkus.gradle.tasks;
+
+import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+
+/**
+ * Quarkus task providing inputs compatible with the configuration cache, used by the {@link QuarkusGenerateCode}
+ * and {@link QuarkusBuildTask} tasks.
+ * <p>
+ * Most inputs are provided by the {@link QuarkusPluginExtensionView}. This includes those required by both tasks,
+ * and additional inputs that require initialization of the {@link BaseConfig} object.
+ * </p>
+ * <p>
+ * Additionally, this class provides an {@link EffectiveConfigProvider}, which is used by dependent tasks
+ * to access the inputs defined in this task.
+ * </p>
+ */
+public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
+
+    private final QuarkusPluginExtensionView extensionView;
+
+    @Input
+    @Optional
+    public abstract MapProperty<String, Object> getManifestAttributes();
+
+    @Input
+    @Optional
+    public abstract MapProperty<String, Attributes> getManifestSections();
+
+    @Input
+    public abstract MapProperty<String, String> getCachingRelevantInput();
+
+    public QuarkusTaskWithExtensionView(String description, boolean compatible) {
+        super(description, compatible);
+        this.extensionView = getProject().getObjects().newInstance(QuarkusPluginExtensionView.class, extension());
+    }
+
+    public EffectiveConfigProvider effectiveProvider() {
+        return new EffectiveConfigProvider(
+                getExtensionView().getIgnoredEntries(),
+                getExtensionView().getMainResources(),
+                getExtensionView().getForcedProperties(),
+                getExtensionView().getProjectProperties(),
+                getExtensionView().getQuarkusBuildProperties(),
+                getExtensionView().getQuarkusRelevantProjectProperties(),
+                getManifestAttributes(),
+                getManifestSections(),
+                getExtensionView().getNativeBuild(),
+                getExtensionView().getQuarkusProfileSystemVariable(),
+                getExtensionView().getQuarkusProfileEnvVariable());
+    }
+
+    /**
+     * Returns a view of the Quarkus extension that is compatible with the configuration cache.
+     */
+    @Nested
+    protected QuarkusPluginExtensionView getExtensionView() {
+        return extensionView;
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
@@ -26,7 +26,7 @@ public class EagerResolutionTaskTest {
     @TempDir
     Path testProjectDir;
 
-    private static Stream<String> compatibleTasks() {
+    private static Stream<String> tasksToTest() {
         return Stream.of(
                 QUARKUS_GENERATE_CODE_TASK_NAME,
                 QUARKUS_BUILD_TASK_NAME,
@@ -35,8 +35,8 @@ public class EagerResolutionTaskTest {
     }
 
     @ParameterizedTest
-    @MethodSource("compatibleTasks")
-    public void configurationCacheIsReusedTest(String taskName) throws IOException, URISyntaxException {
+    @MethodSource("tasksToTest")
+    public void eagerResolutionConfigurationBuildsSuccessfully(String taskName) throws IOException, URISyntaxException {
         URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/crypto/main");
         FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
         FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.gradle.tasks;
+
+import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_TASK_NAME;
+import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_GENERATE_CODE_TASK_NAME;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class EagerResolutionTaskTest {
+
+    @TempDir
+    Path testProjectDir;
+
+    private static Stream<String> compatibleTasks() {
+        return Stream.of(
+                QUARKUS_GENERATE_CODE_TASK_NAME,
+                QUARKUS_BUILD_TASK_NAME,
+                "build",
+                "classes");
+    }
+
+    @ParameterizedTest
+    @MethodSource("compatibleTasks")
+    public void configurationCacheIsReusedTest(String taskName) throws IOException, URISyntaxException {
+        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/crypto/main");
+        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
+        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+
+        File projectDir = new File(testProjectDir + "/build.gradle.kts");
+
+        String addingQuarkusExtension = """
+                quarkus {
+                  cachingRelevantProperties.add("FOO_ENV_VAR")
+                  quarkusBuildProperties.put("quarkus.package.type", "fast-jar")
+                  quarkusBuildProperties.putAll(
+                    provider {
+                      tasks
+                        .named("jar", Jar::class.java)
+                        .get()
+                        .manifest
+                        .attributes
+                        .map { e -> "quarkus.package.jar.manifest.attributes.\\"${e.key}\\"" to e.value.toString() }
+                        .toMap()
+                    }
+                  )
+                }
+
+                """;
+        try {
+            Files.write(projectDir.toPath(), addingQuarkusExtension.getBytes(), StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        BuildResult firstBuild = buildResult(taskName);
+        assertEquals(SUCCESS, firstBuild.task(":quarkusGenerateCode").getOutcome());
+
+    }
+
+    private BuildResult buildResult(String task) {
+        return GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(task, "--info", "--stacktrace", "--build-cache")
+                .build();
+    }
+}


### PR DESCRIPTION
Issue #48651 describes a build failure when executing the classes task:
```
Some problems were found with the configuration of task ':project:quarkusGenerateCodeDev' (type 'QuarkusGenerateCode').

- In plugin 'io.quarkus' type 'io.quarkus.gradle.tasks.QuarkusGenerateCode' property 'applicationModel' doesn't have a configured value.

  Reason: This property isn't marked as optional and no value has been configured.

  Possible solutions:
    1. Assign a value to 'applicationModel'.
    2. Mark property 'applicationModel' as optional.

  For more information, please refer to https://docs.gradle.org/8.14.2/userguide/validation_problems.html#value_not_set

- In plugin 'io.quarkus' type 'io.quarkus.gradle.tasks.QuarkusGenerateCode' property 'classpath' doesn't have a configured value.

  Reason: This property isn't marked as optional and no value has been configured.

  Possible solutions:
    1. Assign a value to 'classpath'.
    2. Mark property 'classpath' as optional.
```
Initially, the failure didn’t make much sense because there is a known relationship between the `ApplicationModel` task and the generated tasks. Something was breaking the task dependency hierarchy.

### Investigation Summary
We observed:

* The issue did not occur when executing assemble, build, or other typical Quarkus tasks.

* It could be reproduced in Quarkus projects if the extension configuration triggered eager task resolution, for example:
```kotlin
quarkus {
  quarkusBuildProperties.putAll(
    provider {
      tasks
        .named("jar", Jar::class.java)
        .get() // <- eager resolution
        .manifest
        .attributes
        .map { e -> "quarkus.package.jar.manifest.attributes.\"${e.key}\"" to e.value.toString() }
        .toMap()
    }
  )
}

```
In contrast, replacing .get() with .flatMap avoided the resolution but did not fix the issue on the client side.

User reports confirm the issue occurs on Quarkus 3.23.1 but not in 3.23.0, although we could not directly link the behavior to the [project descriptor rework](https://github.com/quarkusio/quarkus/commit/bc13138b82ee09dad2945d3f252b88bc1f214d1a).

We also verified that in a non-Quarkus project, we could not reproduce the issue using the same structure as the Quarkus plugin. Even with eager resolution in place, task dependencies were respected as expected.

### Root Cause
Deeper investigation revealed that the issue was triggered by the initialization of `QuarkusPluginExtensionView`, specifically due to inputs that rely on the instantiation of the BaseConfig object:
```java
getCachingRelevantInput()
    .set(extension.baseConfig().cachingRelevantProperties(extension.getCachingRelevantProperties().get()));
```
It’s unclear why this initialization disrupts the task graph, but it causes a failure when tasks like `classes` are executed in isolation.

### Fix Summary (this PR)
* Extracted inputs requiring BaseConfig from `QuarkusPluginExtensionView`.

* Decoupled inputs specific to `QuarkusBuildTask` and moved them out of the shared extension view, keeping only common inputs.

* Introduced a new base task class to hold common inputs and `QuarkusPluginExtensionView`.

* Inputs depending on baseConfig are now set during task configuration time (not during extension instantiation).

* Added a new `EffectiveConfigProvider` in the base task to abstract effective configuration.

* Added a regression test to cover the issue reported.

### Motivation
Given the unexpected side effects caused by the early instantiation of BaseConfig inside the extension, especially since it is injected into both `QuarkusGenerateCode` and `QuarkusBuildTask`, we chose to restructure the task input declaration.

Previously, QuarkusPluginExtensionView held all inputs for both tasks, including those not required for `QuarkusGenerateCode`. We split these inputs into their respective tasks and delegated common ones to a shared base task.

This change ensures that only the required inputs are declared eagerly, and those dependent on BaseConfig are delayed until configuration time, improving configuration cache compatibility and fixing the task failure issue.

### CI checks
https://github.com/cdsap/quarkus/actions/runs/16061544644

- Fixes: #48651