### PR TITLE
Avoid using confusing "ITest" name for not-QuarkusIntegrationTests

### DIFF
--- a/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/DevServicesKubernetesTest.java
+++ b/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/DevServicesKubernetesTest.java
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(DevServiceKubernetes.class)
-public class DevServicesKubernetesITest {
+public class DevServicesKubernetesTest {
 
     @Inject
     KubernetesClient kubernetesClient;

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortReusableServiceTest.java
@@ -4,18 +4,19 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.redis.devservices.it.profiles.DevServicesCustomPortProfile;
+import io.quarkus.redis.devservices.it.profiles.DevServicesCustomPortReusableServiceProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.ports.SocketKit;
 
 @QuarkusTest
-@TestProfile(DevServicesCustomPortProfile.class)
-public class DevServicesRedisCustomPortITest {
+@TestProfile(DevServicesCustomPortReusableServiceProfile.class)
+public class DevServicesRedisCustomPortReusableServiceTest {
 
     @Test
     @DisplayName("should start redis container with the given custom port")
     public void shouldStartRedisContainer() {
+        // We could strengthen this test to make sure the container is the same as seen by other tests, but it's hard since we won't know the order
         Assertions.assertTrue(SocketKit.isPortAlreadyUsed(6371));
     }
 

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisCustomPortTest.java
@@ -4,19 +4,18 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.redis.devservices.it.profiles.DevServicesCustomPortReusableServiceProfile;
+import io.quarkus.redis.devservices.it.profiles.DevServicesCustomPortProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.ports.SocketKit;
 
 @QuarkusTest
-@TestProfile(DevServicesCustomPortReusableServiceProfile.class)
-public class DevServicesRedisCustomPortReusableServiceITest {
+@TestProfile(DevServicesCustomPortProfile.class)
+public class DevServicesRedisCustomPortTest {
 
     @Test
     @DisplayName("should start redis container with the given custom port")
     public void shouldStartRedisContainer() {
-        // We could strengthen this test to make sure the container is the same as seen by other tests, but it's hard since we won't know the order
         Assertions.assertTrue(SocketKit.isPortAlreadyUsed(6371));
     }
 

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisNonUniquePortTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisNonUniquePortTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.redis.devservices.it;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
@@ -8,13 +10,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.devservices.it.profiles.DevServicesRandomPortProfile;
+import io.quarkus.redis.devservices.it.profiles.DevServicesNonUniquePortProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@TestProfile(DevServicesRandomPortProfile.class)
-public class DevServicesRedisRandomPortITest {
+@TestProfile(DevServicesNonUniquePortProfile.class)
+public class DevServicesRedisNonUniquePortTest {
 
     @Inject
     RedisDataSource redisClient;
@@ -28,6 +30,16 @@ public class DevServicesRedisRandomPortITest {
     @DisplayName("given redis container must communicate with it and return value by key")
     public void shouldReturnAllKeys() {
         Assertions.assertEquals("anyvalue", redisClient.value(String.class).get("anykey").toString());
+    }
+
+    @Test
+    public void shouldHaveStack() {
+        // The entertainingly named lolwut command gives a version number but doesn't say if stack is available, so try using some of the commands
+        try {
+            redisClient.bloom(String.class).bfadd("key", "whatever");
+        } catch (Exception e) {
+            fail("Redis stack should be available on the connected back end (underlying error was  " + e + ")");
+        }
     }
 
 }

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisRandomPortTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisRandomPortTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.redis.devservices.it;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
@@ -10,13 +8,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.devservices.it.profiles.DevServicesNonUniquePortProfile;
+import io.quarkus.redis.devservices.it.profiles.DevServicesRandomPortProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@TestProfile(DevServicesNonUniquePortProfile.class)
-public class DevServicesRedisNonUniquePortITest {
+@TestProfile(DevServicesRandomPortProfile.class)
+public class DevServicesRedisRandomPortTest {
 
     @Inject
     RedisDataSource redisClient;
@@ -30,16 +28,6 @@ public class DevServicesRedisNonUniquePortITest {
     @DisplayName("given redis container must communicate with it and return value by key")
     public void shouldReturnAllKeys() {
         Assertions.assertEquals("anyvalue", redisClient.value(String.class).get("anykey").toString());
-    }
-
-    @Test
-    public void shouldHaveStack() {
-        // The entertainingly named lolwut command gives a version number but doesn't say if stack is available, so try using some of the commands
-        try {
-            redisClient.bloom(String.class).bfadd("key", "whatever");
-        } catch (Exception e) {
-            fail("Redis stack should be available on the connected back end (underlying error was  " + e + ")");
-        }
     }
 
 }

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisTest.java
@@ -17,7 +17,7 @@ import io.quarkus.test.ports.SocketKit;
 
 @QuarkusTest
 @TestProfile(DevServiceRedis.class)
-public class DevServicesRedisITest {
+public class DevServicesRedisTest {
 
     @Inject
     RedisClient redisClient;


### PR DESCRIPTION
These names are left over from before we had `QuarkusIntegrationTest` (I assume). The `ITest` naming convention overlaps in a confusing way with our usual convention of using `IT` endings for `QuarkusIntegrationTest`.