### PR TITLE
Add support for reading in memory file to string in multipart

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/FormDataWithAllUploads.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/FormDataWithAllUploads.java
@@ -18,6 +18,9 @@ public class FormDataWithAllUploads extends FormDataBase {
     @PartType(MediaType.TEXT_PLAIN)
     private Status status;
 
+    @RestForm
+    private String stringWithFilename;
+
     @RestForm(FileUpload.ALL)
     private List<FileUpload> uploads;
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartInputWithAllUploadsTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartInputWithAllUploadsTest.java
@@ -64,6 +64,7 @@ public class MultipartInputWithAllUploadsTest extends AbstractMultipartTest {
         RestAssured.given()
                 .multiPart("name", "Alice")
                 .multiPart("active", "true")
+                .multiPart("stringWithFilename", "a-string", "application/xfdf")
                 .multiPart("num", "25")
                 .multiPart("status", "WORKING")
                 .multiPart("htmlFile", HTML_FILE, "text/html")
@@ -74,7 +75,7 @@ public class MultipartInputWithAllUploadsTest extends AbstractMultipartTest {
                 .post("/multipart-all/simple/2")
                 .then()
                 .statusCode(200)
-                .body(equalTo("Alice - true - 50 - WORKING - 3 - text/plain"));
+                .body(equalTo("Alice - true - 50 - WORKING - 4 - text/plain"));
 
         // ensure that the 3 uploaded files where created on disk
         Assertions.assertEquals(3, uploadDir.toFile().listFiles().length);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
@@ -201,7 +201,7 @@ public final class MultipartSupport {
         // this is only for the TCK and regular form params
         if (value.isFileItem()) {
             try {
-                return Files.readString(value.getFileItem().getFile(), Charset.defaultCharset());
+                return new String(value.getFileItem().getInputStream().readAllBytes());
             } catch (IOException e) {
                 throw new MultipartPartReadingException(e);
             }


### PR DESCRIPTION
When `FileItem.isInMemory` is `true`, `value.getFileItem().getFile()` throws a NullPointerException. This MR fixes the problem by using the independent `FileItem.getInputStream`-Method which works for in memory and not in memory FileItems.