### PR TITLE
Allow dev service `Startable`s to access config in native mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -77,7 +77,11 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
                 .filter(DevServicesResultBuildItem::isStartable)
                 .map(serv -> CompletableFuture.runAsync(() -> {
                     // We need to set the context classloader to the augment classloader, so that the dev services can be started with the right classloader
-                    Thread.currentThread().setContextClassLoader(augmentClassLoader);
+                    if (augmentClassLoader != null) {
+                        Thread.currentThread().setContextClassLoader(augmentClassLoader);
+                    } else {
+                        Thread.currentThread().setContextClassLoader(serv.getClass().getClassLoader());
+                    }
                     this.start(serv, customizers);
                 }))
                 .toArray(CompletableFuture[]::new)).join();

--- a/extensions/amazon-lambda/event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockEventServer.java
+++ b/extensions/amazon-lambda/event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockEventServer.java
@@ -75,18 +75,13 @@ public class MockEventServer implements Closeable {
         HttpServerOptions options = new HttpServerOptions();
         options.setPort(port == 0 ? -1 : port);
 
-        ClassLoader original = Thread.currentThread().getContextClassLoader();
-        try {
-            Thread.currentThread().setContextClassLoader(MockEventServer.class.getClassLoader());
-            Optional<MemorySize> maybeMaxHeadersSize = ConfigProvider.getConfig()
-                    .getOptionalValue("quarkus.http.limits.max-header-size", MemorySize.class);
+        Optional<MemorySize> maybeMaxHeadersSize = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.http.limits.max-header-size", MemorySize.class);
 
-            if (maybeMaxHeadersSize.isPresent()) {
-                options.setMaxHeaderSize(maybeMaxHeadersSize.get().asBigInteger().intValueExact());
-            }
-        } finally {
-            Thread.currentThread().setContextClassLoader(original);
+        if (maybeMaxHeadersSize.isPresent()) {
+            options.setMaxHeaderSize(maybeMaxHeadersSize.get().asBigInteger().intValueExact());
         }
+
         httpServer = vertx.createHttpServer(options);
         router = Router.router(vertx);
         setupRoutes();

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -30,7 +30,7 @@ public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult>
         DevServicesRegistryBuildItem devServicesRegistry = buildResult.consumeOptional(DevServicesRegistryBuildItem.class);
         List<DevServicesCustomizerBuildItem> customizers = buildResult.consumeMulti(DevServicesCustomizerBuildItem.class);
         if (devServicesRegistry != null) {
-            devServicesRegistry.startAll(devServices, customizers, Thread.currentThread().getContextClassLoader());
+            devServicesRegistry.startAll(devServices, customizers, null);
             for (Map.Entry<String, String> entry : devServicesRegistry.getConfigForAllRunningServices().entrySet()) {
                 propertyConsumer.accept(entry.getKey(), entry.getValue());
             }


### PR DESCRIPTION
This is a less tactical version of https://github.com/quarkusio/quarkus/pull/48753/files#diff-53bbc5c17c7f10a6cce6c0e51e3a27e20cd64cddc5cfb9a7da3e1cf1a8e5a945L77-R88. 

On the native path, the TCCL-setting in the dev service registry is a no-op, because the native method just passed it the current TCCL. I'm not totally sure what the optimum TCCL is, but I know that the TCCL of the class doing the starting works better than the current TCCL, which would be the app classloader. We can iterate on this in future PRs if we come up with something more considered.

