### PR TITLE
RedisRecorder receives redis runtime config as RuntimeValue

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
@@ -38,13 +38,13 @@ import io.vertx.mutiny.redis.client.Request;
 public class RedisClientRecorder {
 
     // Split client and DS recorders
-    private final RedisConfig config;
+    private final RuntimeValue<RedisConfig> config;
     private static final Map<String, RedisClientAndApi> clients = new HashMap<>();
     private static final Map<String, ReactiveRedisDataSourceImpl> dataSources = new HashMap<>();
     private Vertx vertx;
     private ObservableRedisMetrics metrics;
 
-    public RedisClientRecorder(RedisConfig rc) {
+    public RedisClientRecorder(RuntimeValue<RedisConfig> rc) {
         this.config = rc;
     }
 
@@ -78,7 +78,7 @@ public class RedisClientRecorder {
             // - if default -> Default
             // - if named -> Look for that config
             // - if not found -> ConfigurationException
-            Optional<RedisClientConfig> maybe = getConfigForName(config, name);
+            Optional<RedisClientConfig> maybe = getConfigForName(config.getValue(), name);
             if (!RedisConfig.isDefaultClient(name)) {
                 RedisClientConfig actualConfig = maybe
                         .orElseThrow(new Supplier<ConfigurationException>() {
@@ -195,9 +195,9 @@ public class RedisClientRecorder {
     private Duration getTimeoutForClient(String name) {
         Duration timeout;
         if (RedisConfig.isDefaultClient(name)) {
-            timeout = config.defaultRedisClient().timeout();
+            timeout = config.getValue().defaultRedisClient().timeout();
         } else {
-            timeout = config.namedRedisClients().get(name).timeout();
+            timeout = config.getValue().namedRedisClients().get(name).timeout();
         }
         return timeout;
     }


### PR DESCRIPTION
Removes warnings like 
```
2025-07-04 21:23:32,621 WARN  [io.qua.deployment] (main) Run time configuration io.quarkus.redis.runtime.client.config.RedisConfig should be injected in a @Recorder constructor as a RuntimeValue<io.quarkus.redis.runtime.client.config.RedisConfig> at io.quarkus.redis.runtime.client.RedisClientRecorder recorder of public void io.quarkus.redis.deployment.client.RedisClientProcessor.init(java.util.List,io.quarkus.redis.runtime.client.RedisClientRecorder,io.quarkus.redis.deployment.client.RedisBuildTimeConfig,io.quarkus.arc.deployment.BeanArchiveIndexBuildItem,io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem,io.quarkus.deployment.builditem.ShutdownContextBuildItem,io.quarkus.deployment.annotations.BuildProducer,io.quarkus.vertx.deployment.VertxBuildItem,io.quarkus.deployment.builditem.ApplicationArchivesBuildItem,io.quarkus.deployment.builditem.LaunchModeBuildItem,io.quarkus.deployment.annotations.BuildProducer,io.quarkus.deployment.annotations.BuildProducer,io.quarkus.tls.deployment.spi.TlsRegistryBuildItem) of class io.quarkus.redis.deployment.client.RedisClientProcessor
2025-07-04 21:23:32,624 WARN  [io.qua.deployment] (main) Run time configuration io.quarkus.redis.runtime.client.config.RedisConfig should be injected in a @Recorder constructor as a RuntimeValue<io.quarkus.redis.runtime.client.config.RedisConfig> at io.quarkus.redis.runtime.client.RedisClientRecorder recorder of public void io.quarkus.redis.deployment.client.RedisDatasourceProcessor.init(io.quarkus.redis.runtime.client.RedisClientRecorder,java.util.List,io.quarkus.deployment.builditem.ShutdownContextBuildItem,io.quarkus.deployment.annotations.BuildProducer,io.quarkus.vertx.deployment.VertxBuildItem,io.quarkus.tls.deployment.spi.TlsRegistryBuildItem) of class io.quarkus.redis.deployment.client.RedisDatasourceProcessor
```