### PR TITLE
Dev services lifecycle close running disabled services

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -1,6 +1,5 @@
 package io.quarkus.devservices.common;
 
-import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 import static io.quarkus.devservices.common.Labels.QUARKUS_LAUNCH_MODE;
 import static io.quarkus.devservices.common.Labels.QUARKUS_PROCESS_UUID;
 
@@ -47,13 +46,16 @@ public final class ConfigureUtil {
         return container.getHost();
     }
 
-    public static void configureLabels(GenericContainer<?> container, LaunchMode launchMode, String serviceLabel,
-            String serviceName) {
-        if (serviceName != null) {
-            container.withLabel(serviceLabel, serviceName);
-            container.withLabel(QUARKUS_DEV_SERVICE, serviceName);
+    public static boolean shouldConfigureSharedServiceLabel(LaunchMode launchMode) {
+        return launchMode == LaunchMode.DEVELOPMENT;
+    }
+
+    public static <T extends GenericContainer<T>> T configureSharedServiceLabel(T container, LaunchMode launchMode,
+            String serviceLabel, String serviceName) {
+        if (shouldConfigureSharedServiceLabel(launchMode)) {
+            return container.withLabel(serviceLabel, serviceName);
         }
-        configureLabels(container, launchMode);
+        return container;
     }
 
     public static void configureLabels(GenericContainer<?> container, LaunchMode launchMode) {

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
@@ -1,5 +1,8 @@
 package io.quarkus.kafka.client.deployment;
 
+import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
+import static io.quarkus.kafka.client.deployment.DevServicesKafkaProcessor.DEV_SERVICE_LABEL;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,6 +14,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.runtime.LaunchMode;
 
 public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer> implements Startable {
 
@@ -33,6 +37,10 @@ public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer>
         withCommand("sh", "-c", cmd);
         waitingFor(Wait.forLogMessage(".*Kafka broker started.*", 1));
         this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "kafka");
+    }
+
+    public KafkaNativeContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {
+        return configureSharedServiceLabel(this, launchMode, DEV_SERVICE_LABEL, serviceName);
     }
 
     @Override

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
@@ -1,5 +1,8 @@
 package io.quarkus.kafka.client.deployment;
 
+import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
+import static io.quarkus.kafka.client.deployment.DevServicesKafkaProcessor.DEV_SERVICE_LABEL;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +16,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.runtime.LaunchMode;
 
 /**
  * Container configuring and starting the Redpanda broker.
@@ -45,6 +49,10 @@ final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContain
                 STARTER_SCRIPT);
         waitingFor(Wait.forLogMessage(".*Started Kafka API server.*", 1));
         this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "redpanda");
+    }
+
+    public RedpandaKafkaContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {
+        return configureSharedServiceLabel(this, launchMode, DEV_SERVICE_LABEL, serviceName);
     }
 
     @Override

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.deployment.client;
 
+import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 
 import java.util.HashMap;
@@ -95,7 +96,7 @@ public class DevServicesRedisProcessor {
                                             .withEnv(redisConfig.containerEnv())
                                             // Dev Service discovery works using a global dev service label applied in DevServicesCustomizerBuildItem
                                             // for backwards compatibility we still add the custom label
-                                            .withLabel(DEV_SERVICE_LABEL, redisConfig.serviceName()))
+                                            .withSharedServiceLabel(launchMode.getLaunchMode(), redisConfig.serviceName()))
                                     .configProvider(Map.of(configPrefix + RedisConfig.HOSTS_CONFIG_NAME,
                                             s -> REDIS_SCHEME + s.getConnectionInfo()))
                                     .build());
@@ -191,6 +192,10 @@ public class DevServicesRedisProcessor {
             this.useSharedNetwork = useSharedNetwork;
 
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "redis");
+        }
+
+        public QuarkusPortRedisContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {
+            return configureSharedServiceLabel(this, launchMode, DEV_SERVICE_LABEL, serviceName);
         }
 
         @Override

--- a/integration-tests/kafka-devservices/pom.xml
+++ b/integration-tests/kafka-devservices/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-kafka-companion</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaNonUniquePortSecondTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/DevServicesKafkaNonUniquePortSecondTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.kafka;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.kafka.devservices.profiles.DevServicesNonUniquePortProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.ports.SocketKit;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@TestProfile(DevServicesNonUniquePortProfile.class)
+public class DevServicesKafkaNonUniquePortSecondTest {
+
+    @Test
+    @DisplayName("should start kafka container with the given custom port")
+    public void shouldStartKafkaContainer() {
+        Assertions.assertTrue(SocketKit.isPortAlreadyUsed(5050));
+        RestAssured.when().get("/kafka/port").then().body(Matchers.is("5050"));
+    }
+
+    @Test
+    public void shouldBeCorrectImage() {
+        RestAssured.when().get("/kafka/image").then().body(Matchers.is("redpanda"));
+    }
+
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/BaseDevServiceTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/BaseDevServiceTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.it.kafka.continuoustesting;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.model.Container;
+
+import io.quarkus.devservices.common.Labels;
+import io.quarkus.runtime.LaunchMode;
+
+public abstract class BaseDevServiceTest {
+
+    static List<Container> getAllContainers() {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .toList();
+    }
+
+    static List<Container> getAllContainers(LaunchMode launchMode) {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(container -> getLaunchMode(container) == launchMode)
+                .toList();
+    }
+
+    static List<Container> getKafkaContainers() {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(BaseDevServiceTest::isKafkaContainer)
+                .toList();
+    }
+
+    static List<Container> getKafkaContainers(LaunchMode launchMode) {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(BaseDevServiceTest::isKafkaContainer)
+                .filter(container -> getLaunchMode(container) == launchMode)
+                .toList();
+    }
+
+    static void stopAllContainers() {
+        DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
+                .filter(BaseDevServiceTest::isKafkaContainer)
+                .forEach(c -> DockerClientFactory.lazyClient().stopContainerCmd(c.getId()).exec());
+    }
+
+    static List<Container> getKafkaContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getKafkaContainers().stream()
+                .filter(container -> existingContainers.stream().noneMatch(
+                        existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    static List<Container> getKafkaContainersExcludingExisting(LaunchMode launchMode,
+            Collection<Container> existingContainers) {
+        return getKafkaContainers(launchMode).stream()
+                .filter(container -> existingContainers.stream().noneMatch(
+                        existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    static List<Container> getAllContainersExcludingExisting(Collection<Container> existingContainers) {
+        return getAllContainers().stream().filter(
+                container -> existingContainers.stream().noneMatch(
+                        existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    static List<Container> getAllContainersExcludingExisting(LaunchMode launchMode, Collection<Container> existingContainers) {
+        return getAllContainers(launchMode).stream().filter(
+                container -> existingContainers.stream().noneMatch(
+                        existing -> existing.getId().equals(container.getId())))
+                .toList();
+    }
+
+    static LaunchMode getLaunchMode(Container container) {
+        String launchMode = container.getLabels().get(Labels.QUARKUS_LAUNCH_MODE);
+        return launchMode == null ? null : LaunchMode.valueOf(launchMode.toUpperCase());
+    }
+
+    static boolean isKafkaContainer(Container container) {
+        // This could be redpanda or kafka-native or other variants
+        return container.getImage().contains("kafka") || container.getImage().contains("redpanda");
+    }
+
+    static String prettyPrintContainerList(List<Container> newContainers) {
+        return newContainers.stream()
+                .map(c -> Arrays.toString(c.getPorts()) + " -- " + Arrays.toString(c.getNames()) + " -- " + c.getLabels())
+                .collect(Collectors.joining(", \n"));
+    }
+
+    static boolean hasPublicPort(Container newContainer, int newPort) {
+        return Arrays.stream(newContainer.getPorts()).anyMatch(p -> p.getPublicPort() == newPort);
+    }
+
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesContainerSharingTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesContainerSharingTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.it.kafka.continuoustesting;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.it.kafka.BundledEndpoint;
+import io.quarkus.it.kafka.KafkaAdminManager;
+import io.quarkus.it.kafka.KafkaAdminTest;
+import io.quarkus.it.kafka.KafkaEndpoint;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.strimzi.test.container.StrimziKafkaContainer;
+
+public class DevServicesContainerSharingTest extends BaseDevServiceTest {
+
+    @RegisterExtension
+    public static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .deleteClass(KafkaEndpoint.class)
+                    .addClass(BundledEndpoint.class)
+                    .addClass(KafkaAdminManager.class))
+            .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(KafkaAdminTest.class));
+
+    static StrimziKafkaContainer kafka;
+
+    @BeforeAll
+    static void beforeAll() {
+        kafka = new StrimziKafkaContainer().withKraft()
+                .withLabel("quarkus-dev-service-kafka", "kafka");
+        kafka.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (kafka != null) {
+            kafka.stop();
+            kafka = null;
+        }
+    }
+
+    @Test
+    void test() {
+        ping();
+        assertTrue(getKafkaContainers(LaunchMode.DEVELOPMENT).isEmpty());
+    }
+
+    void ping() {
+        when().get("/kafka/partitions/test").then()
+                .statusCode(200)
+                .body(is("2"));
+    }
+}

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesKafkaContinuousTestingTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesKafkaContinuousTestingTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,9 +18,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.DockerClientFactory;
 
-import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.ContainerPort;
 
@@ -37,16 +34,12 @@ import io.quarkus.test.QuarkusDevModeTest;
  * will override the maven executions and cause it to run twice.
  * That doesn't help debug anything.
  */
-public class DevServicesKafkaContinuousTestingTest {
+public class DevServicesKafkaContinuousTestingTest extends BaseDevServiceTest {
 
     static final String DEVSERVICES_DISABLED_PROPERTIES = ContinuousTestingTestUtils.appProperties(
             "quarkus.devservices.enabled=false");
 
-    static final String FIXED_PORT_PROPERTIES = ContinuousTestingTestUtils.appProperties(
-            "quarkus.kafka.devservices.port=6377");
-
-    static final String UPDATED_FIXED_PORT_PROPERTIES = ContinuousTestingTestUtils.appProperties(
-            "quarkus.kafka.devservices.port=6342");
+    static final String UPDATED_FIXED_PORT_PROPERTIES = "\nquarkus.kafka.devservices.port=6342\n";
 
     @RegisterExtension
     public static QuarkusDevModeTest test = new QuarkusDevModeTest()
@@ -139,16 +132,6 @@ public class DevServicesKafkaContinuousTestingTest {
 
     }
 
-    private static String prettyPrintContainerList(List<Container> newContainers) {
-        return newContainers.stream()
-                .map(c -> Arrays.toString(c.getPorts()) + " -- " + Arrays.toString(c.getNames()) + " -- " + c.getLabels())
-                .collect(Collectors.joining(", \n"));
-    }
-
-    private static boolean hasPublicPort(Container newContainer, int newPort) {
-        return Arrays.stream(newContainer.getPorts()).anyMatch(p -> p.getPublicPort() == newPort);
-    }
-
     void ping() {
         when().get("/kafka/partitions/test").then()
                 .statusCode(200)
@@ -179,7 +162,6 @@ public class DevServicesKafkaContinuousTestingTest {
     }
 
     @Test
-    @Disabled("This seems to work in dev mode with continuous testing mode, but not in tests")
     public void testContinuousTestingCreatesANewInstanceWhenPropertiesAreChanged() {
 
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
@@ -213,10 +195,10 @@ public class DevServicesKafkaContinuousTestingTest {
             assertFalse(ports.containsAll(existingPorts), "Container ports: " + ports);
             existingContainers.addAll(newContainers);
         }
-        test.modifyResourceFile("application.properties", s -> UPDATED_FIXED_PORT_PROPERTIES);
+        test.modifyResourceFile("application.properties", s -> s + UPDATED_FIXED_PORT_PROPERTIES);
 
         result = utils.waitForNextCompletion();
-        assertEquals(1, result.getTestsPassed());
+        assertEquals(2, result.getTestsPassed());
         assertEquals(0, result.getTestsFailed());
 
         // Another new container should have appeared
@@ -236,36 +218,4 @@ public class DevServicesKafkaContinuousTestingTest {
         }
     }
 
-    private static List<Container> getAllContainers() {
-        return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
-                .filter(container -> isKafkaContainer(container)).toList();
-    }
-
-    private static void stopAllContainers() {
-        DockerClient dockerClient = DockerClientFactory.lazyClient();
-        dockerClient.listContainersCmd().exec().stream()
-                .filter(DevServicesKafkaContinuousTestingTest::isKafkaContainer)
-                .forEach(c -> dockerClient.stopContainerCmd(c.getId()).exec());
-    }
-
-    private static List<Container> getKafkaContainers() {
-        return getAllContainers();
-    }
-
-    private static List<Container> getKafkaContainersExcludingExisting(Collection<Container> existingContainers) {
-        return getKafkaContainers().stream().filter(
-                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
-                .toList();
-    }
-
-    private static List<Container> getAllContainersExcludingExisting(Collection<Container> existingContainers) {
-        return getAllContainers().stream().filter(
-                container -> existingContainers.stream().noneMatch(existing -> existing.getId().equals(container.getId())))
-                .toList();
-    }
-
-    private static boolean isKafkaContainer(Container container) {
-        // The output of getCommand() seems to vary by host OS (it's different on CI and mac), but the image name should be reliable
-        return container.getImage().contains("kafka") || container.getImage().contains("redpanda");
-    }
 }

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
@@ -16,7 +16,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.DockerClientFactory;
@@ -59,7 +58,7 @@ public class DevServicesRedisContinuousTestingTest {
         stopAllContainers();
     }
 
-    @Disabled("Not currently working")
+    //    @Disabled("Not currently working")
     @Test
     public void testContinuousTestingDisablesDevServicesWhenPropertiesChange() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
@@ -73,7 +72,11 @@ public class DevServicesRedisContinuousTestingTest {
         assertEquals(0, result.getTotalTestsPassed());
         assertEquals(1, result.getTotalTestsFailed());
 
+        ping500();
+
         // We could check the container goes away, but we'd have to check slowly, because ryuk can be slow
+        List<Container> containers = getAllContainers();
+        assertTrue(containers.isEmpty(), "Expected no containers, but got: " + prettyPrintContainerList(containers));
     }
 
     @Test
@@ -212,6 +215,11 @@ public class DevServicesRedisContinuousTestingTest {
         when().get("/bundled/ping").then()
                 .statusCode(200)
                 .body(is("PONG"));
+    }
+
+    void ping500() {
+        when().get("/kafka/partitions/test").then()
+                .statusCode(500);
     }
 
     private static boolean hasPublicPort(Container newContainer, int newPort) {


### PR DESCRIPTION
When some devservices are already started, but a config refresh disables the dev service (for reasons like service config exists, devservice disabled etc.), the service needs to be closed. Before each extension has the code for closing the running service. 
The next dev services lifecycle not takes that into account.

Includes 
- a second fix after #48746, which adds labels only in dev mode.
- enable Kafka and Redis devservice tests related to container sharing and service closing.
-  **merged** ~Cherry-picks 9e063d07c14b3cacf2d594ae1cd9d3c0ec937820 from #48785 for fixing post start actions on native tests~
- **closed** ~Cherry-pick #48788~ 

