### PR TITLE
QuarkusTestExtension flag curated application not eligible for reuse 

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -1172,7 +1172,9 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         protected void doClose() {
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             if (runningQuarkusApplication != null) {
-                Thread.currentThread().setContextClassLoader(runningQuarkusApplication.getClassLoader());
+                QuarkusClassLoader classLoader = (QuarkusClassLoader) runningQuarkusApplication.getClassLoader();
+                classLoader.getCuratedApplication().setEligibleForReuse(false);
+                Thread.currentThread().setContextClassLoader(classLoader);
             }
             try {
                 // this will close the application, the test resources, the class loader...


### PR DESCRIPTION
..when the extension state is being closed

As far as I can observe, 
- With the current test extension, once the curated application is flagged as eligible for reuse, it never gets closed.
- When a curated application is eligible for reuse, it doesn't get closed.
- In the test extension, the extension state close triggers the running application close. However, the extension state close is never triggered when there is a running application.

This change has the effect of closing the curated application only when the test suite is terminated and junit cleans the state stored in the extension store. 

Because the dev service lifecycle (#47683 ) is linked to the curated application, if no curated applications are not closed in a test suite, it may have the effect of never removing some services during tests.