### PR TITLE
OIDC Dev Service: Support 'client_secret_basic' client authentication

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/AbstractOidcClientDevServiceTest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/AbstractOidcClientDevServiceTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.oidc.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.client.runtime.OidcClientsConfig;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public abstract class AbstractOidcClientDevServiceTest {
+
+    protected static QuarkusUnitTest createQuarkusUnitTest(String applicationProperties) {
+        return new QuarkusUnitTest()
+                .withApplicationRoot((jar) -> jar
+                        .addClasses(NamedOidcClientResource.class)
+                        .addAsResource(applicationProperties, "application.properties"));
+    }
+
+    @Inject
+    OidcClientsConfig config;
+
+    @Test
+    public void testOidcClientDefaultIdIsSet() {
+        var defaultClientConfig = OidcClientsConfig.getDefaultClient(config);
+        // not set, so "Default" id should be set by Quarkus
+        assertEquals("Default", defaultClientConfig.id().orElse(null));
+        // not set, so named key "client1" should be set by Quarkus
+        assertEquals("client1", config.namedClients().get("client1").id().orElse(null));
+        // set to "client2" in application.properties
+        // we cannot set here any different value, because ATM OIDC client enforce that ID always equal named key anyway
+        assertEquals("client2", config.namedClients().get("client2").id().orElse(null));
+        // not set and named key "client3" is enclosed in double quotes, so named key "client3" should be set by Quarkus
+        assertEquals("client3", config.namedClients().get("client3").id().orElse(null));
+    }
+
+    @Test
+    public void testInjectedNamedOidcClients() {
+        String token1 = doTestGetTokenByNamedClient("client1");
+        String token2 = doTestGetTokenByNamedClient("client2");
+        validateTokens(token1, token2);
+    }
+
+    @Test
+    public void testInjectedNamedTokens() {
+        String token1 = doTestGetTokenByNamedTokensProvider("client1");
+        String token2 = doTestGetTokenByNamedTokensProvider("client2");
+        validateTokens(token1, token2);
+    }
+
+    private void validateTokens(String token1, String token2) {
+        assertThat(token1, is(not(equalTo(token2))));
+        assertThat(upn(token1), is("alice"));
+        assertThat(upn(token2), is("bob"));
+    }
+
+    private String upn(String token) {
+        return OidcCommonUtils.decodeJwtContent(token).getString("upn");
+    }
+
+    private String doTestGetTokenByNamedClient(String clientId) {
+        String token = RestAssured.given().get("/" + clientId + "/token").body().asString();
+        assertThat(token, is(notNullValue()));
+        return token;
+    }
+
+    private String doTestGetTokenByNamedTokensProvider(String clientId) {
+        String token = RestAssured.given().get("/" + clientId + "/token/singleton").body().asString();
+        assertThat(token, is(notNullValue()));
+        return token;
+    }
+}

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientKeycloakDevServiceTest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientKeycloakDevServiceTest.java
@@ -1,84 +1,17 @@
 package io.quarkus.oidc.client;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import jakarta.inject.Inject;
-
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.oidc.client.runtime.OidcClientsConfig;
-import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.test.QuarkusUnitTest;
-import io.restassured.RestAssured;
 
 /**
  * Test Keycloak Dev Service is started when OIDC extension is disabled (or not present, though indirectly).
  * OIDC client auth server URL and client id and secret must be automatically configured for this test to pass.
+ * This test uses Dev Services for Keycloak.
  */
-public class OidcClientKeycloakDevServiceTest {
+public class OidcClientKeycloakDevServiceTest extends AbstractOidcClientDevServiceTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
-                    .addClasses(NamedOidcClientResource.class)
-                    .addAsResource("oidc-client-dev-service-test.properties", "application.properties"));
+    static final QuarkusUnitTest test = createQuarkusUnitTest("oidc-client-dev-service-test.properties");
 
-    @Inject
-    OidcClientsConfig config;
-
-    @Test
-    public void testOidcClientDefaultIdIsSet() {
-        var defaultClientConfig = OidcClientsConfig.getDefaultClient(config);
-        // not set, so "Default" id should be set by Quarkus
-        assertEquals("Default", defaultClientConfig.id().orElse(null));
-        // not set, so named key "client1" should be set by Quarkus
-        assertEquals("client1", config.namedClients().get("client1").id().orElse(null));
-        // set to "client2" in application.properties
-        // we cannot set here any different value, because ATM OIDC client enforce that ID always equal named key anyway
-        assertEquals("client2", config.namedClients().get("client2").id().orElse(null));
-        // not set and named key "client3" is enclosed in double quotes, so named key "client3" should be set by Quarkus
-        assertEquals("client3", config.namedClients().get("client3").id().orElse(null));
-    }
-
-    @Test
-    public void testInjectedNamedOidcClients() {
-        String token1 = doTestGetTokenByNamedClient("client1");
-        String token2 = doTestGetTokenByNamedClient("client2");
-        validateTokens(token1, token2);
-    }
-
-    @Test
-    public void testInjectedNamedTokens() {
-        String token1 = doTestGetTokenByNamedTokensProvider("client1");
-        String token2 = doTestGetTokenByNamedTokensProvider("client2");
-        validateTokens(token1, token2);
-    }
-
-    private void validateTokens(String token1, String token2) {
-        assertThat(token1, is(not(equalTo(token2))));
-        assertThat(upn(token1), is("alice"));
-        assertThat(upn(token2), is("bob"));
-    }
-
-    private String upn(String token) {
-        return OidcCommonUtils.decodeJwtContent(token).getString("upn");
-    }
-
-    private String doTestGetTokenByNamedClient(String clientId) {
-        String token = RestAssured.given().get("/" + clientId + "/token").body().asString();
-        assertThat(token, is(notNullValue()));
-        return token;
-    }
-
-    private String doTestGetTokenByNamedTokensProvider(String clientId) {
-        String token = RestAssured.given().get("/" + clientId + "/token/singleton").body().asString();
-        assertThat(token, is(notNullValue()));
-        return token;
-    }
 }

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientOidcDevServiceTest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientOidcDevServiceTest.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.client;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * This test uses OIDC Client extension with Dev Services for OIDC.
+ */
+public class OidcClientOidcDevServiceTest extends AbstractOidcClientDevServiceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = createQuarkusUnitTest("oidc-client-oidc-dev-service-test.properties");
+
+}

--- a/extensions/oidc-client/deployment/src/test/resources/oidc-client-oidc-dev-service-test.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/oidc-client-oidc-dev-service-test.properties
@@ -1,0 +1,25 @@
+# quarkus.oidc.enabled=false TODO: this shouldn't be necessary in the future!
+quarkus.keycloak.devservices.enabled=false
+quarkus.oidc.devservices.enabled=true
+
+quarkus.oidc-client.client1.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.client1.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.client1.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.client1.grant.type=password
+quarkus.oidc-client.client1.grant-options.password.username=alice
+quarkus.oidc-client.client1.grant-options.password.password=alice
+
+quarkus.oidc-client.client2.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.client2.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.client2.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.client2.grant.type=password
+quarkus.oidc-client.client2.grant-options.password.username=bob
+quarkus.oidc-client.client2.grant-options.password.password=bob
+quarkus.oidc-client.client2.id=client2
+
+quarkus.oidc-client."client3".auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client."client3".client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client."client3".credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client."client3".grant.type=password
+quarkus.oidc-client."client3".grant-options.password.username=bob
+quarkus.oidc-client."client3".grant-options.password.password=bob


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/47301
- please note that I didn't document the support, this PR fixes the reported issue (support for the `client_secret_basic`), but I think more work needs to be done before we declare support for using OIDC Dev Service with OIDC Client and I plan to do that work very soon