### PR TITLE
Sync naming convention for file dependency JARs

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.TaskAction;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.gradle.QuarkusPlugin;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -184,7 +185,7 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
                     ResolvedDependency dep = depAndTarget.getValue();
                     Path targetDir = depAndTarget.getKey();
                     dep.getResolvedPaths().forEach(p -> {
-                        String file = dep.getGroupId() + '.' + p.getFileName();
+                        String file = JarResultBuildStep.getJarFileName(dep, p);
                         Path target = targetDir.resolve(file);
                         if (!Files.exists(target)) {
                             getLogger().debug("Dependency {} : copying {} to {}",

--- a/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+sourceSets {
+    additional {
+        java {
+            srcDir "src/gen/java"
+        }
+    }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation sourceSets.additional.output
+    implementation 'io.quarkus:quarkus-arc'
+    implementation 'io.quarkus:quarkus-rest'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'additional-source-set-as-dependency'

--- a/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/src/gen/java/io/reproducer/GreetApi.java
+++ b/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/src/gen/java/io/reproducer/GreetApi.java
@@ -1,0 +1,6 @@
+package io.reproducer;
+
+public interface GreetApi {
+
+  public String hello();
+}

--- a/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/src/main/java/org/acme/GreetingResource.java
+++ b/integration-tests/gradle/src/main/resources/additional-source-set-as-dependency/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,17 @@
+package org.acme;
+
+import io.reproducer.GreetApi;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource implements GreetApi {
+
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  public String hello() {
+    return "Hello from Quarkus REST...";
+  }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/run/AdditionalSourceSetAsDependencyTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/run/AdditionalSourceSetAsDependencyTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.gradle.run;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.gradle.devmode.QuarkusDevGradleTestBase;
+
+// Reproduces https://github.com/quarkusio/quarkus/issues/48768.
+// Despite extending QuarkusDevGradleTestBase, this test does not use the dev mode,
+// but rather runs the application in a production mode using `quarkusRun` task.
+// At this point it's the only test that does so, but if more such tests are added,
+// perhaps it would make sense to create a separate base class for them.
+public class AdditionalSourceSetAsDependencyTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "additional-source-set-as-dependency";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] { "clean", "quarkusRun" };
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("Hello from Quarkus REST...");
+    }
+}


### PR DESCRIPTION
This makes Gradle's 'quarkusDependenciesBuild' task use same naming convention when producing jars for directory dependencies as JarResultBuildStep.

- Closes: #48768.