### PR TITLE
Drop junit-platform-testkit version

### DIFF
--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-testkit</artifactId>
-            <version>${junit.testkit.version}</version>
         </dependency>
         <dependency>
             <groupId>io.smallrye.common</groupId>


### PR DESCRIPTION
It is provided by the BOM so better let the BOM align the version.