### PR TITLE
Improve `Awaiting thread pool shutdown` message

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -116,8 +116,13 @@ public class ExecutorRecorder {
                                 // do some probing
                                 final int queueSize = executor.getQueueSize();
                                 final Thread[] runningThreads = executor.getRunningThreads();
-                                log.infof("Awaiting thread pool shutdown; %d thread(s) running with %d task(s) waiting",
-                                        runningThreads.length, queueSize);
+                                if (queueSize <= 0) {
+                                    log.infof("Awaiting thread pool shutdown; %d thread(s) running",
+                                            runningThreads.length);
+                                } else {
+                                    log.infof("Awaiting thread pool shutdown; %d thread(s) running with %d task(s) waiting",
+                                            runningThreads.length, queueSize);
+                                }
                                 // make sure no threads are stuck in {@code exit()}
                                 int realWaiting = runningThreads.length;
                                 for (Thread thr : runningThreads) {
@@ -137,7 +142,7 @@ public class ExecutorRecorder {
                                         }
                                     }
                                 }
-                                if (realWaiting == 0 && queueSize == 0) {
+                                if (realWaiting == 0) {
                                     // just exit
                                     executor.shutdownNow();
                                     break;


### PR DESCRIPTION
The queue size part is removed from that message if the queue is unbounded
