### PR TITLE
[3.24] : Fix the http root bug in BackChannelLogoutHandler

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -11,7 +11,6 @@ import org.jose4j.jwt.consumer.InvalidJwtException;
 
 import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.SecurityEvent.Type;
-import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
 import io.vertx.core.Handler;
@@ -23,7 +22,6 @@ import io.vertx.ext.web.RoutingContext;
 
 public class BackChannelLogoutHandler {
     private static final Logger LOG = Logger.getLogger(BackChannelLogoutHandler.class);
-    private static final String SLASH = "/";
 
     void setup(@Observes Router router, DefaultTenantConfigResolver resolver) {
         final TenantConfigBean tenantConfigBean = resolver.getTenantConfigBean();
@@ -158,18 +156,9 @@ public class BackChannelLogoutHandler {
         private boolean isMatchingTenant(String requestPath, TenantConfigContext tenant) {
             return tenant.oidcConfig().tenantEnabled()
                     && tenant.oidcConfig().tenantId().get().equals(oidcTenantConfig.tenantId().get())
-                    && requestPath.equals(getRootPath() + tenant.oidcConfig().logout().backchannel().path().orElse(null));
+                    && requestPath.equals(OidcUtils.getRootPath(resolver.getRootPath())
+                            + tenant.oidcConfig().logout().backchannel().path().orElse(null));
         }
 
-        private String getRootPath() {
-            // Prepend '/' if it is not present
-            String rootPath = OidcCommonUtils.prependSlash(resolver.getRootPath());
-            // Strip trailing '/' if the length is > 1
-            if (rootPath.length() > 1 && rootPath.endsWith("/")) {
-                rootPath = rootPath.substring(rootPath.length() - 1);
-            }
-            // if it is only '/' then return an empty value
-            return SLASH.equals(rootPath) ? "" : rootPath;
-        }
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -938,4 +938,15 @@ public final class OidcUtils {
     public static boolean isDPoPScheme(String authorizationScheme) {
         return OidcConstants.DPOP_SCHEME.equalsIgnoreCase(authorizationScheme);
     }
+
+    public static String getRootPath(String configuredRootPath) {
+        // Prepend '/' if it is not present
+        String rootPath = OidcCommonUtils.prependSlash(configuredRootPath);
+        // Strip trailing '/' if the length is > 1
+        if (rootPath.length() > 1 && rootPath.endsWith("/")) {
+            rootPath = rootPath.substring(0, rootPath.length() - 1);
+        }
+        // if it is only '/' then return an empty value
+        return "/".equals(rootPath) ? "" : rootPath;
+    }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -34,6 +34,15 @@ import io.vertx.core.json.JsonObject;
 public class OidcUtilsTest {
 
     @Test
+    public void getRoorPath() throws Exception {
+
+        assertEquals("", OidcUtils.getRootPath("/"));
+        assertEquals("/root", OidcUtils.getRootPath("/root"));
+        assertEquals("/root", OidcUtils.getRootPath("root"));
+        assertEquals("/root", OidcUtils.getRootPath("/root/"));
+    }
+
+    @Test
     public void testDpopScheme() throws Exception {
 
         assertTrue(OidcUtils.isDPoPScheme("DPoP"));


### PR DESCRIPTION
This is a follow up to #48734 where the bug in `BackChannelLogoutHandler` http root related code to do with removing a trailing `/` was fixed in both  `BackChannelLogoutHandler` where I accidentally introduced the bug and in the `ResourceMetadataHandler` where it was copied/pasted to.