### PR TITLE
Allow users to turn off health probe in Dev UI

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
@@ -40,7 +40,7 @@ public class SmallRyeHealthDevUiProcessor {
                 .icon("font-awesome-solid:stethoscope")
                 .componentLink("qwc-smallrye-health-ui.js")
                 .dynamicLabelJsonRPCMethodName("getStatus")
-                .streamingLabelJsonRPCMethodName("streamStatus"));
+                .streamingLabelJsonRPCMethodName("streamStatus", "interval"));
 
         pageBuildItem.addPage(Page.externalPageBuilder("Raw")
                 .icon("font-awesome-solid:heart-circle-bolt")

--- a/extensions/smallrye-health/deployment/src/main/resources/dev-ui/qwc-smallrye-health-ui.js
+++ b/extensions/smallrye-health/deployment/src/main/resources/dev-ui/qwc-smallrye-health-ui.js
@@ -4,17 +4,23 @@ import 'qui-badge';
 import { JsonRpc } from 'jsonrpc';
 import '@qomponent/qui-card';
 import '@vaadin/icon';
+import '@vaadin/popover';
+import { popoverRenderer } from '@vaadin/popover/lit.js';
+import '@vaadin/item';
+import '@vaadin/list-box';
+import { StorageController } from 'storage-controller';
 
 /**
  * This component shows the health UI
  */
 export class QwcSmallryeHealthUi extends QwcHotReloadElement {
     jsonRpc = new JsonRpc(this);
-
+    storageControl = new StorageController(this);
+    
     static styles = css`
         :host {
             display: flex;
-            flex-direction: column;
+            justify-content: space-between;
             height: 100%;
             padding-left: 20px;
             padding-right: 20px;
@@ -57,6 +63,11 @@ export class QwcSmallryeHealthUi extends QwcHotReloadElement {
         .headingDown {
             color: var(--lumo-error-text-color);
         }
+        #configureIcon {
+            margin-top: 10px;
+            margin-right: 10px;
+            cursor:pointer;
+        }
         
     `;
 
@@ -71,10 +82,7 @@ export class QwcSmallryeHealthUi extends QwcHotReloadElement {
 
     connectedCallback() {
         super.connectedCallback();
-
-        if(!this._health){
-            this.hotReload();
-        }
+        this.hotReload();
     }
 
     disconnectedCallback() {
@@ -83,12 +91,27 @@ export class QwcSmallryeHealthUi extends QwcHotReloadElement {
     }
 
     hotReload(){
-        this._cancelObserver();
-        this._observer = this.jsonRpc.streamHealth().onNext(jsonRpcResponse => {
-            this._health = jsonRpcResponse.result;
-        });
+        let interval = this.storageControl.get("interval");
         this.jsonRpc.getHealth().then(jsonRpcResponse => { 
-           this._health = jsonRpcResponse.result; 
+           this._health = jsonRpcResponse.result;
+           this._startStreaming(interval);
+        });
+    }
+
+    _getIntervalIndex(){
+        const interval = this.storageControl.get("interval");
+        if(interval && interval ==="3s") return 0;
+        if(interval && interval ==="30s") return 2;
+        if(interval && interval ==="60s") return 3;
+        if(interval && interval ==="Off") return 4;
+        return 1; // default (10s)
+    }
+
+    _startStreaming(interval){
+        this._cancelObserver();
+        if(!interval)interval = "";
+        this._observer = this.jsonRpc.streamHealth({interval:interval}).onNext(jsonRpcResponse => {
+            this._health = jsonRpcResponse.result;
         });
     }
 
@@ -96,10 +119,38 @@ export class QwcSmallryeHealthUi extends QwcHotReloadElement {
         if(this._health && this._health.payload){
             return html`<div class="cards">${this._health.payload.checks.map((check) =>
                 html`${this._renderCard(check)}`
-            )}</div>`;
+            )}</div>
+            <vaadin-icon id="configureIcon" icon="font-awesome-solid:gear" title="Configure health status updates"></vaadin-icon>
+            <vaadin-popover
+                for="configureIcon"
+                .position="start-bottom"
+                ${popoverRenderer(this._configurePopoverRenderer)}
+            ></vaadin-popover>
+
+            `;
         }else {
             return html`<vaadin-progress-bar indeterminate></vaadin-progress-bar>`;
         }
+    }
+    
+    _configurePopoverRenderer(){
+        let i = this._getIntervalIndex();
+        return html`<vaadin-list-box selected="${i}" @selected-changed=${this._onSelectedChanged}>
+                        <vaadin-item>3s</vaadin-item>
+                        <vaadin-item>10s</vaadin-item>
+                        <vaadin-item>30s</vaadin-item>
+                        <vaadin-item>60s</vaadin-item>
+                        <vaadin-item>Off</vaadin-item>
+                    </vaadin-list-box>`;
+    }
+    
+    _onSelectedChanged(event) {
+        const listBox = event.target;
+        const selectedIndex = listBox.selected;
+        const selectedItem = listBox.children[selectedIndex];
+        this.storageControl.set('interval', selectedItem?.textContent?.trim());
+        
+        this.hotReload();
     }
     
     _renderCard(check){

--- a/extensions/smallrye-health/runtime-dev/src/main/java/io/quarkus/smallrye/health/runtime/dev/ui/HealthJsonRPCService.java
+++ b/extensions/smallrye-health/runtime-dev/src/main/java/io/quarkus/smallrye/health/runtime/dev/ui/HealthJsonRPCService.java
@@ -1,10 +1,11 @@
 package io.quarkus.smallrye.health.runtime.dev.ui;
 
 import java.time.Duration;
-import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -13,58 +14,123 @@ import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+import io.smallrye.mutiny.subscription.BackPressureStrategy;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.MultiEmitter;
 
 public class HealthJsonRPCService {
 
     @Inject
     SmallRyeHealthReporter smallRyeHealthReporter;
 
-    private final BroadcastProcessor<SmallRyeHealth> healthStream = BroadcastProcessor.create();
-    private final BroadcastProcessor<String> statusStream = BroadcastProcessor.create();
-    private final AtomicReference<String> lastPayload = new AtomicReference<>("");
+    private final Set<MultiEmitter<? super SmallRyeHealth>> healthEmitters = ConcurrentHashMap.newKeySet();
+    private final Set<MultiEmitter<? super String>> statusEmitters = ConcurrentHashMap.newKeySet();
 
-    @PostConstruct
-    void startPolling() {
-        Multi.createFrom().ticks().every(Duration.ofSeconds(3))
-                .onItem().transformToUniAndMerge(tick -> smallRyeHealthReporter.getHealthAsync())
-                .subscribe().with(smallRyeHealth -> {
-                    String jsonStr = smallRyeHealth.getPayload().toString();
-                    if (!Objects.equals(lastPayload.getAndSet(jsonStr), jsonStr)) {
-                        if (smallRyeHealth != null) {
-                            healthStream.onNext(smallRyeHealth);
-                            statusStream.onNext(getStatusIcon(smallRyeHealth));
+    private final AtomicInteger activeSubscribers = new AtomicInteger(0);
+    private final AtomicReference<SmallRyeHealth> latest = new AtomicReference<>();
+    private volatile Cancellable pollingCancellable;
+
+    private synchronized void startPollingIfNeeded(int interval) {
+        if (pollingCancellable == null) {
+            pollingCancellable = Multi.createFrom().ticks().every(Duration.ofSeconds(interval))
+                    .onItem().transformToUniAndMerge(tick -> smallRyeHealthReporter.getHealthAsync())
+                    .subscribe().with(smallRyeHealth -> {
+                        latest.set(smallRyeHealth);
+                        for (var emitter : healthEmitters) {
+                            emitter.emit(smallRyeHealth);
                         }
-                    }
-                }, failure -> {
-                    JsonObject errorPayload = Json.createObjectBuilder()
-                            .add("status", "DOWN")
-                            .add("checks", Json.createArrayBuilder()
-                                    .add(Json.createObjectBuilder()
-                                            .add("name", "Smallrye Health stream")
-                                            .add("status", "DOWN")
-                                            .add("data", Json.createObjectBuilder()
-                                                    .add("reason", failure.getMessage()))))
-                            .build();
-                    healthStream.onNext(new SmallRyeHealth(errorPayload));
-                    statusStream.onNext(DOWN_ICON);
-                });
+                        for (var emitter : statusEmitters) {
+                            emitter.emit(getStatusIcon(smallRyeHealth));
+                        }
+                    }, failure -> {
+                        JsonObject errorPayload = Json.createObjectBuilder()
+                                .add("status", "DOWN")
+                                .add("checks", Json.createArrayBuilder()
+                                        .add(Json.createObjectBuilder()
+                                                .add("name", "Smallrye Health stream")
+                                                .add("status", "DOWN")
+                                                .add("data", Json.createObjectBuilder()
+                                                        .add("reason", failure.getMessage()))))
+                                .build();
+                        SmallRyeHealth errorHealth = new SmallRyeHealth(errorPayload);
+                        latest.set(errorHealth);
+                        for (var emitter : healthEmitters) {
+                            emitter.emit(errorHealth);
+                        }
+                        for (var emitter : statusEmitters) {
+                            emitter.emit(getStatusIcon(errorHealth));
+                        }
+                    });
+        }
+    }
+
+    private synchronized void stopPolling() {
+        if (pollingCancellable != null) {
+            pollingCancellable.cancel();
+            pollingCancellable = null;
+            latest.set(null);
+        }
+    }
+
+    private synchronized void restartPolling(int interval) {
+        stopPolling();
+        if (interval > 0) {
+            startPollingIfNeeded(interval);
+        }
     }
 
     public Uni<SmallRyeHealth> getHealth() {
         return smallRyeHealthReporter.getHealthAsync();
     }
 
-    public Multi<SmallRyeHealth> streamHealth() {
-        return healthStream;
+    public Multi<SmallRyeHealth> streamHealth(String interval) {
+        int iv = getIntervalValue(interval);
+
+        return Multi.createFrom().emitter(emitter -> {
+            activeSubscribers.incrementAndGet();
+            healthEmitters.add(emitter);
+
+            SmallRyeHealth current = latest.get();
+            if (current != null) {
+                emitter.emit(current);
+            }
+
+            restartPolling(iv);
+
+            emitter.onTermination(() -> {
+                healthEmitters.remove(emitter);
+                if (activeSubscribers.decrementAndGet() == 0) {
+                    stopPolling();
+                }
+            });
+        }, BackPressureStrategy.LATEST);
     }
 
     public String getStatus() {
         return getStatusIcon(smallRyeHealthReporter.getHealth());
     }
 
-    public Multi<String> streamStatus() {
-        return statusStream;
+    public Multi<String> streamStatus(String interval) {
+        int iv = getIntervalValue(interval);
+
+        return Multi.createFrom().emitter(emitter -> {
+            activeSubscribers.incrementAndGet();
+            statusEmitters.add(emitter);
+
+            SmallRyeHealth current = latest.get();
+            if (current != null) {
+                emitter.emit(getStatusIcon(current));
+            }
+
+            restartPolling(iv);
+
+            emitter.onTermination(() -> {
+                statusEmitters.remove(emitter);
+                if (activeSubscribers.decrementAndGet() == 0) {
+                    stopPolling();
+                }
+            });
+        }, BackPressureStrategy.LATEST);
     }
 
     private String getStatusIcon(SmallRyeHealth smallRyeHealth) {
@@ -75,6 +141,17 @@ public class HealthJsonRPCService {
             }
         }
         return DOWN_ICON;
+    }
+
+    private int getIntervalValue(String interval) {
+        if (interval == null || interval.isBlank()) {
+            interval = "10s"; //default
+        }
+        if (interval.equalsIgnoreCase("Off")) {
+            return -1;
+        }
+
+        return Integer.parseInt(interval.substring(0, interval.length() - 1));
     }
 
     private static final String UP_ICON = "<vaadin-icon style='color:var(--lumo-success-text-color);' icon='font-awesome-solid:thumbs-up'></vaadin-icon>";

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/storage-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/storage-controller.js
@@ -6,8 +6,13 @@ export class StorageController {
     host;
     _pre;
     constructor(host) {
-        (this.host = host).addController(this);
-        this._pre = host.tagName.toLowerCase() + "-";
+        // First check if host is a String
+        if (typeof host === 'string' || host instanceof String){
+            this._pre = host + "-";
+        }else {
+            (this.host = host).addController(this);
+            this._pre = host.tagName.toLowerCase() + "-";
+        }
     }
 
     set(key, value){

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension-link.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension-link.js
@@ -3,6 +3,7 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import '@qomponent/qui-badge';
+import { StorageController } from 'storage-controller';
 
 /**
  * This component adds a custom link on the Extension card
@@ -48,20 +49,22 @@ export class QwcExtensionLink extends QwcHotReloadElement {
     `;
 
     static properties = {
+        streamingLabelParams: {type: String},
+        webcomponentTagName: {type: String},
         namespace: {type: String},
         extensionName: {type: String},
         iconName: {type: String},
         colorName: {type: String},
         tooltipContent: {type: String},
         displayName: {type: String},
-        staticLabel: {type: String},
-        dynamicLabel: {type: String},
-        streamingLabel: {type: String},
         path:  {type: String},
         webcomponent: {type: String},
         embed: {type: Boolean},
         externalUrl: {type: String},
         dynamicUrlMethodName: {type: String},
+        staticLabel: {type: String},
+        dynamicLabel: {type: String},
+        streamingLabel: {type: String},
         _effectiveLabel: {state: true},
         _effectiveExternalUrl: {state: true},
         _observer: {state: false},
@@ -134,11 +137,27 @@ export class QwcExtensionLink extends QwcHotReloadElement {
         this._effectiveLabel = null;
         if(this.streamingLabel){
             this.jsonRpc = new JsonRpc(this);
-            this._observer = this.jsonRpc[this.streamingLabel]().onNext(jsonRpcResponse => {
-                let oldVal = this._effectiveLabel;
-                this._effectiveLabel = jsonRpcResponse.result;
-                this.requestUpdate('_effectiveLabel', oldVal);
-            });
+            if(this.streamingLabelParams) {
+                let streamingLabelParamsArray = this.streamingLabelParams.split(',');
+                let storageController = new StorageController(this.webcomponentTagName);
+                let params = {};
+                for (const localParam of streamingLabelParamsArray){
+                    let val = storageController.get(localParam);
+                    if(!val)val="";
+                    params[localParam] = val;
+                }
+                this._observer = this.jsonRpc[this.streamingLabel](params).onNext(jsonRpcResponse => {
+                    let oldVal = this._effectiveLabel;
+                    this._effectiveLabel = jsonRpcResponse.result;
+                    this.requestUpdate('_effectiveLabel', oldVal);
+                });
+            }else {
+                this._observer = this.jsonRpc[this.streamingLabel]().onNext(jsonRpcResponse => {
+                    let oldVal = this._effectiveLabel;
+                    this._effectiveLabel = jsonRpcResponse.result;
+                    this.requestUpdate('_effectiveLabel', oldVal);
+                });
+            }
         }else if(this.dynamicLabel){
             this.jsonRpc = new JsonRpc(this);
             this.jsonRpc[this.dynamicLabel]().then(jsonRpcResponse => {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -357,20 +357,22 @@ export class QwcExtensions extends observeState(LitElement) {
     _renderCardLink(extension, page){
         if(!page.assistantPage || assistantState.current.isConfigured){
             return html`<qwc-extension-link slot="link"
+                                streamingLabelParams="${page.streamingLabelParams}"
+                                webcomponentTagName="${page.componentName}"
                                 namespace="${extension.namespace}"
                                 extensionName="${extension.name}"
                                 iconName="${page.icon}"
                                 tooltipContent="${page.tooltip}"
                                 colorName="${page.color}"
                                 displayName="${page.title}"
-                                staticLabel="${page.staticLabel}"
-                                dynamicLabel="${page.dynamicLabel}"
-                                streamingLabel="${page.streamingLabel}"
                                 path="${page.id}"
                                 ?embed=${page.embed}
                                 externalUrl="${page.metadata.externalUrl}"
                                 dynamicUrlMethodName="${page.metadata.dynamicUrlMethodName}"
-                                webcomponent="${page.componentLink}" 
+                                webcomponent="${page.componentLink}"
+                                staticLabel="${page.staticLabel}" 
+                                dynamicLabel="${page.dynamicLabel}"
+                                streamingLabel="${page.streamingLabel}"
                                 draggable="true" @dragstart="${this._handleDragStart}">
                             </qwc-extension-link>
                         `;

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
@@ -312,19 +312,21 @@ export class QwcHeader extends observeState(QwcHotReloadElement) {
         let relativePath = link.page.id.replace(link.page.namespace + "/", ""); 
 
         return html`<qwc-extension-link
+            streamingLabelParams="${link.page.streamingLabelParams}"
+            webcomponentTagName="${link.page.componentName}"
             namespace="${link.page.namespace}"
             extensionName="${link.page.extensionId}"
             iconName="${link.page.icon}"
             tooltipContent="${link.page.tooltip}"
             colorName="${link.page.color}"
             displayName="${link.page.title}"
-            staticLabel="${link.page.staticLabel}"
-            dynamicLabel="${link.page.dynamicLabel}"
-            streamingLabel="${link.page.streamingLabel}"
             path="${relativePath}"
             ?embed=${link.page.embed}
             externalUrl="${link.page.metadata.externalUrl}"
-            webcomponent="${link.page.componentLink}" >
+            webcomponent="${link.page.componentLink}"
+            staticLabel="${link.page.staticLabel}"
+            dynamicLabel="${link.page.dynamicLabel}"
+            streamingLabel="${link.page.streamingLabel}">
         </qwc-extension-link>`;
     }
 

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
@@ -20,7 +20,7 @@ public class Page {
     private final String staticLabel; // This is optional extra info that might be displayed next to the link
     private final String dynamicLabel; // This is optional extra info that might be displayed next to the link. This will override above static label. This expects a jsonRPC method name
     private final String streamingLabel; // This is optional extra info that might be displayed next to the link. This will override above dynamic label. This expects a jsonRPC Multi method name
-
+    private final String streamingLabelParams; // This is optional parameters (comma separated) that will be fetched from local storage and sent along with the streaming label jsonrpc request
     private final String componentName; // This is name of the component
     private final String componentLink; // This is a link to the component, excluding namespace
     private final Map<String, String> metadata; // Key value Metadata
@@ -42,6 +42,7 @@ public class Page {
             String staticLabel,
             String dynamicLabel,
             String streamingLabel,
+            String[] streamingLabelParams,
             String componentName,
             String componentLink,
             Map<String, String> metadata,
@@ -59,6 +60,11 @@ public class Page {
         this.staticLabel = staticLabel;
         this.dynamicLabel = dynamicLabel;
         this.streamingLabel = streamingLabel;
+        if (streamingLabelParams != null && streamingLabelParams.length > 0) {
+            this.streamingLabelParams = String.join(",", streamingLabelParams);
+        } else {
+            this.streamingLabelParams = null;
+        }
         this.componentName = componentName;
         this.componentLink = componentLink;
         this.metadata = metadata;
@@ -146,6 +152,10 @@ public class Page {
         return streamingLabel;
     }
 
+    public String getStreamingLabelParams() {
+        return streamingLabelParams;
+    }
+
     public String getComponentName() {
         return componentName;
     }
@@ -192,6 +202,7 @@ public class Page {
                 + ", \n\tstaticLabel=" + staticLabel
                 + ", \n\tdynamicLabel=" + dynamicLabel
                 + ", \n\tstreamingLabel=" + streamingLabel
+                + ", \n\tstreamingLabelParams=" + streamingLabelParams
                 + ", \n\tnamespace=" + namespace
                 + ", \n\tnamespaceLabel=" + namespaceLabel
                 + ", \n\tcomponentName=" + componentName

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
@@ -23,6 +23,7 @@ public abstract class PageBuilder<T> {
     protected String staticLabel = null;
     protected String dynamicLabel = null;
     protected String streamingLabel = null;
+    protected String[] streamingLabelParams = null;
     protected String componentName;
     protected String componentLink;
     protected Map<String, String> metadata = new HashMap<>();
@@ -103,6 +104,13 @@ public abstract class PageBuilder<T> {
     }
 
     @SuppressWarnings("unchecked")
+    public T streamingLabelJsonRPCMethodName(String methodName, String... params) {
+        this.streamingLabel = methodName;
+        this.streamingLabelParams = params;
+        return (T) this;
+    }
+
+    @SuppressWarnings("unchecked")
     public T metadata(String key, String value) {
         this.metadata.put(key, value);
         return (T) this;
@@ -176,6 +184,7 @@ public abstract class PageBuilder<T> {
                 staticLabel,
                 dynamicLabel,
                 streamingLabel,
+                streamingLabelParams,
                 componentName,
                 componentLink,
                 metadata,


### PR DESCRIPTION
Fix #48774

This PR introduce a new feature in Dev UI that allows local stored variables to be send with a streaming label. It also change the Health UI (Card and page) to use this new feature and allow the user to change the frequency of the health probe in Dev UI or to turn it off completely. It also fix a bug to stop probing if the health page or card is unloaded from the DOM.

![Screenshot_20250709_111910](https://github.com/user-attachments/assets/6475a31f-a0a1-42c5-a94f-92bee83a9bfa)
