### PR TITLE
Fix NPE in SnapshotTesting when src/test/resources/__snapshots__ directory isn't available

### DIFF
--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
@@ -85,7 +85,8 @@ public class SnapshotTesting {
             final String fileUrlStr = jarUrlStr.substring("jar:".length(),
                     jarUrlStr.length() - ("!/" + SNAPSHOTS_DIR_NAME).length());
             final Path p = Path.of(URI.create(fileUrlStr));
-            return snapshotsBaseRoot = new MultiRootPathTree(PathTree.ofDirectoryOrArchive(p), srcTree);
+            final PathTree jarPathTree = PathTree.ofDirectoryOrArchive(p);
+            return snapshotsBaseRoot = srcTree == null ? jarPathTree : new MultiRootPathTree(jarPathTree, srcTree);
         } else {
             throw new IllegalStateException("Unexpected URL protocol in " + url);
         }


### PR DESCRIPTION
@ia3andy this happens in the platform tests, where snapshots are found in JARs.