### PR TITLE
Add the pull request template to remind about the format of linked issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+If this is your first time contributing to the project, 
+please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
+-->
+
+[Please describe here what your change is about]
+
+<!--
+Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:
+
+* Fixes #xxxxx
+* Fixes #yyyyy
+* Fixes #zzzzz
+* ....
+
+See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
+for more information about linking issues to the Pull Request.
+-->
+


### PR DESCRIPTION
So that there is a reminder about the format in which issues should be linked.

Let me know if you think we should phrase it differently or include something else in the template 😃 

* See: https://github.com/quarkusio/quarkus/issues/48698#issuecomment-3052616381