### PR TITLE
Ensure codestarts pass spotbugs

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/java/src/main/java/org/acme/GreetingCommand.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/java/src/main/java/org/acme/GreetingCommand.java
@@ -13,7 +13,7 @@ public class GreetingCommand implements Runnable {
 
     @Override
     public void run() {
-        System.out.printf("Hello %s, go go commando!\n", name);
+        System.out.printf("Hello %s, go go commando!%n", name);
     }
 
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/kotlin/src/main/kotlin/org/acme/GreetingCommand.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/kotlin/src/main/kotlin/org/acme/GreetingCommand.kt
@@ -10,7 +10,7 @@ class GreetingCommand : Runnable {
     @Parameters(paramLabel = "<name>", defaultValue = "picocli", description = ["Your name."])
     var name: String? = null
     override fun run() {
-        System.out.printf("Hello %s, go go commando!\n", name)
+        System.out.printf("Hello %s, go go commando!%n", name)
     }
 
 }

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/code/jbang-picocli-code/java/src/{command.class-name}.tpl.qute.java
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/code/jbang-picocli-code/java/src/{command.class-name}.tpl.qute.java
@@ -19,6 +19,6 @@ public class {command.class-name} implements Runnable {
 
     @Override
     public void run() {
-        System.out.printf("Hello %s, go go commando!\n", name);
+        System.out.printf("Hello %s, go go commando!%n", name);
     }
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusJBangCodestartGenerationTest/generatePicocliProject/src_main.java
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusJBangCodestartGenerationTest/generatePicocliProject/src_main.java
@@ -17,6 +17,6 @@ public class main implements Runnable {
 
     @Override
     public void run() {
-        System.out.printf("Hello %s, go go commando!\n", name);
+        System.out.printf("Hello %s, go go commando!%n", name);
     }
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_main_java_ilove_quark_us_GreetingCommand.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_main_java_ilove_quark_us_GreetingCommand.java
@@ -13,7 +13,7 @@ public class GreetingCommand implements Runnable {
 
     @Override
     public void run() {
-        System.out.printf("Hello %s, go go commando!\n", name);
+        System.out.printf("Hello %s, go go commando!%n", name);
     }
 
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_main_kotlin_ilove_quark_us_GreetingCommand.kt
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_main_kotlin_ilove_quark_us_GreetingCommand.kt
@@ -10,7 +10,7 @@ class GreetingCommand : Runnable {
     @Parameters(paramLabel = "<name>", defaultValue = "picocli", description = ["Your name."])
     var name: String? = null
     override fun run() {
-        System.out.printf("Hello %s, go go commando!\n", name)
+        System.out.printf("Hello %s, go go commando!%n", name)
     }
 
 }


### PR DESCRIPTION
Various codestarts are generating code that will trigger the following spotbugs rule: [VA_FORMAT_STRING_USES_NEWLINE](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#fs-format-string-should-use-n-rather-than-n-va-format-string-uses-newline).

This change modifies the codestarts to comply with the rule.

Note: I found several other occurences of the `\n` pattern in the codeline but I didn't change them since they are not linked to codestarts.

Relevant discussion: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Samples.20trigger.20a.20spotbugs.20issue