### PR TITLE
First steps towards build reproducibility

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.pkg;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,6 +49,13 @@ public interface PackageConfig {
      * The name of the final artifact, excluding the suffix and file extension.
      */
     Optional<String> outputName();
+
+    /**
+     * The timestamp used as a reference for generating the packages (e.g. for the creation timestamp of ZIP entries).
+     * <p>
+     * The approach is similar to what is done by the maven-jar-plugin with `project.build.outputTimestamp`.
+     */
+    Optional<Instant> outputTimestamp();
 
     /**
      * Setting this switch to {@code true} will cause Quarkus to write the transformed application bytecode

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -22,11 +22,13 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 import jakarta.annotation.Priority;
 
@@ -268,13 +270,13 @@ public class ConfigGenerationBuildStep {
         Set<String> configCustomizers = discoverService(SmallRyeConfigBuilderCustomizer.class, reflectiveClass);
 
         // TODO - introduce a way to ignore mappings that are only used for documentation or to prevent warnings
-        Set<ConfigClass> ignoreMappings = new HashSet<>();
+        Set<ConfigClass> ignoreMappings = new LinkedHashSet<>();
         ignoreMappings.add(ConfigClass.configClass(BuildAnalyticsConfig.class, "quarkus.analytics"));
         ignoreMappings.add(ConfigClass.configClass(BuilderConfig.class, "quarkus.builder"));
         ignoreMappings.add(ConfigClass.configClass(CommandLineRuntimeConfig.class, "quarkus"));
         ignoreMappings.add(ConfigClass.configClass(DebugRuntimeConfig.class, "quarkus.debug"));
 
-        Set<ConfigClass> allMappings = new HashSet<>();
+        Set<ConfigClass> allMappings = new LinkedHashSet<>();
         allMappings.addAll(staticSafeConfigMappings(configMappings));
         allMappings.addAll(runtimeConfigMappings(configMappings));
         allMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
@@ -285,11 +287,11 @@ public class ConfigGenerationBuildStep {
         Map<Object, FieldDescriptor> sharedFields = generateSharedConfig(generatedClass, converters, allMappings);
 
         // For Static Init Config
-        Set<ConfigClass> staticMappings = new HashSet<>();
+        Set<ConfigClass> staticMappings = new LinkedHashSet<>();
         staticMappings.addAll(staticSafeConfigMappings(configMappings));
         staticMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
         staticMappings.removeAll(ignoreMappings);
-        Set<String> staticCustomizers = new HashSet<>(staticSafeServices(configCustomizers));
+        Set<String> staticCustomizers = new LinkedHashSet<>(staticSafeServices(configCustomizers));
         staticCustomizers.add(StaticInitConfigBuilder.class.getName());
 
         generateConfigBuilder(generatedClass, reflectiveClass, CONFIG_STATIC_NAME,
@@ -312,12 +314,12 @@ public class ConfigGenerationBuildStep {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(CONFIG_STATIC_NAME).build());
 
         // For RunTime Config
-        Set<ConfigClass> runTimeMappings = new HashSet<>();
+        Set<ConfigClass> runTimeMappings = new LinkedHashSet<>();
         runTimeMappings.addAll(runtimeConfigMappings(configMappings));
         runTimeMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
         runTimeMappings.addAll(configItem.getReadResult().getRunTimeMappings());
         runTimeMappings.removeAll(ignoreMappings);
-        Set<String> runtimeCustomizers = new HashSet<>(configCustomizers);
+        Set<String> runtimeCustomizers = new LinkedHashSet<>(configCustomizers);
         runtimeCustomizers.add(RuntimeConfigBuilder.class.getName());
 
         generateConfigBuilder(generatedClass, reflectiveClass, CONFIG_RUNTIME_NAME,
@@ -841,7 +843,7 @@ public class ConfigGenerationBuildStep {
             Class<?> serviceClass,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass) throws IOException {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        Set<String> services = new HashSet<>();
+        Set<String> services = new TreeSet<>();
         for (String service : classNamesNamedIn(classLoader, SERVICES_PREFIX + serviceClass.getName())) {
             // The discovery includes deployment modules, so we only include services available at runtime
             if (QuarkusClassLoader.isClassPresentAtRuntime(service)) {
@@ -854,7 +856,7 @@ public class ConfigGenerationBuildStep {
 
     private static Set<String> staticSafeServices(Set<String> services) {
         ClassLoader classloader = Thread.currentThread().getContextClassLoader();
-        Set<String> staticSafe = new HashSet<>();
+        Set<String> staticSafe = new LinkedHashSet<>();
         for (String service : services) {
             // SmallRye Config services are always safe, but they cannot be annotated with @StaticInitSafe
             if (service.startsWith("io.smallrye.config.")) {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -64,8 +64,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         List<ExtensionProcessor> extensionProcessors = new ArrayList<>();
         extensionProcessors.add(new ExtensionBuildProcessor());
 
-        boolean skipDocs = Boolean.getBoolean("skipDocs") || Boolean.getBoolean("quickly");
-        boolean generateDoc = !skipDocs && !"false".equals(processingEnv.getOptions().get(Options.GENERATE_DOC));
+        boolean generateDoc = !"false".equals(processingEnv.getOptions().get(Options.GENERATE_DOC));
 
         // for now, we generate the old config doc by default but we will change this behavior soon
         if (generateDoc) {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/merger/JavadocMerger.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/merger/JavadocMerger.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import io.quarkus.annotation.processor.Outputs;
 import io.quarkus.annotation.processor.documentation.config.model.JavadocElements;
@@ -19,7 +19,7 @@ public final class JavadocMerger {
     }
 
     public static JavadocRepository mergeJavadocElements(List<Path> buildOutputDirectories) {
-        Map<String, JavadocElement> javadocElementsMap = new HashMap<>();
+        Map<String, JavadocElement> javadocElementsMap = new TreeMap<>();
 
         for (Path buildOutputDirectory : buildOutputDirectories) {
             Path javadocPath = buildOutputDirectory.resolve(Outputs.QUARKUS_CONFIG_DOC_JAVADOC);

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigRoot.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigRoot.java
@@ -3,10 +3,10 @@ package io.quarkus.annotation.processor.documentation.config.model;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import io.quarkus.annotation.processor.documentation.config.util.Markers;
@@ -25,7 +25,7 @@ public class ConfigRoot implements ConfigItemCollection {
 
     private final String overriddenDocFileName;
     private final List<AbstractConfigItem> items = new ArrayList<>();
-    private final Set<String> qualifiedNames = new HashSet<>();
+    private final Set<String> qualifiedNames = new TreeSet<>();
 
     public ConfigRoot(Extension extension, String prefix, String overriddenDocPrefix, String overriddenDocFileName) {
         this.extension = extension;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
@@ -2,11 +2,11 @@ package io.quarkus.annotation.processor.documentation.config.resolver;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import javax.lang.model.element.TypeElement;
@@ -72,7 +72,7 @@ public class ConfigResolver {
         for (DiscoveryConfigRoot discoveryConfigRoot : configCollector.getConfigRoots()) {
             ConfigRoot configRoot = new ConfigRoot(discoveryConfigRoot.getExtension(), discoveryConfigRoot.getPrefix(),
                     discoveryConfigRoot.getOverriddenDocPrefix(), discoveryConfigRoot.getOverriddenDocFileName());
-            Map<String, ConfigSection> existingRootConfigSections = new HashMap<>();
+            Map<String, ConfigSection> existingRootConfigSections = new TreeMap<>();
 
             configRoot.addQualifiedName(discoveryConfigRoot.getQualifiedName());
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigCollector.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigCollector.java
@@ -2,8 +2,8 @@ package io.quarkus.annotation.processor.documentation.config.scanner;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import io.quarkus.annotation.processor.documentation.config.discovery.DiscoveryConfigGroup;
 import io.quarkus.annotation.processor.documentation.config.discovery.DiscoveryConfigRoot;
@@ -15,22 +15,22 @@ public class ConfigCollector {
     /**
      * Key is qualified name of the class + "." + element name (for instance field or method name)
      */
-    private Map<String, JavadocElement> javadocElements = new HashMap<>();
+    private final Map<String, JavadocElement> javadocElements = new TreeMap<>();
 
     /**
      * Key is the qualified name of the class.
      */
-    private Map<String, DiscoveryConfigRoot> configRoots = new HashMap<>();
+    private final Map<String, DiscoveryConfigRoot> configRoots = new TreeMap<>();
 
     /**
      * Key is the qualified name of the class.
      */
-    private Map<String, DiscoveryConfigGroup> resolvedConfigGroups = new HashMap<>();
+    private final Map<String, DiscoveryConfigGroup> resolvedConfigGroups = new TreeMap<>();
 
     /**
      * Key is the qualified name of the class.
      */
-    private Map<String, EnumDefinition> resolvedEnums = new HashMap<>();
+    private final Map<String, EnumDefinition> resolvedEnums = new TreeMap<>();
 
     public void addJavadocElement(String key, JavadocElement element) {
         javadocElements.put(key, element);

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/JacksonMappers.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/JacksonMappers.java
@@ -1,15 +1,24 @@
 package io.quarkus.annotation.processor.documentation.config.util;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 public final class JacksonMappers {
 
     private static final ObjectWriter JSON_OBJECT_WRITER = new ObjectMapper()
+            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+            .setLocale(Locale.US)
+            .setTimeZone(TimeZone.getTimeZone("UTC"))
             .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT).writerWithDefaultPrettyPrinter();
     private static final ObjectWriter YAML_OBJECT_WRITER = new ObjectMapper(new YAMLFactory())
             .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT).writer();

--- a/devtools/gradle/gradle-application-plugin/build.gradle.kts
+++ b/devtools/gradle/gradle-application-plugin/build.gradle.kts
@@ -25,3 +25,9 @@ gradlePlugin {
 tasks.test {
   systemProperty("kotlin_version", libs.versions.kotlin.get())
 }
+
+// to generate reproducible jars
+tasks.withType<Jar>().configureEach {
+    isPreserveFileTimestamps = false 
+    isReproducibleFileOrder = true   
+}

--- a/devtools/gradle/gradle-extension-plugin/build.gradle.kts
+++ b/devtools/gradle/gradle-extension-plugin/build.gradle.kts
@@ -22,3 +22,9 @@ gradlePlugin {
 tasks.withType<Test>().configureEach {
     environment("GITHUB_REPOSITORY", "some/repo")
 }
+
+// to generate reproducible jars
+tasks.withType<Jar>().configureEach {
+    isPreserveFileTimestamps = false 
+    isReproducibleFileOrder = true   
+}

--- a/devtools/gradle/gradle-model/build.gradle.kts
+++ b/devtools/gradle/gradle-model/build.gradle.kts
@@ -14,6 +14,12 @@ java {
     withJavadocJar()
 }
 
+// to generate reproducible jars
+tasks.withType<Jar>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
 publishing {
     publications.create<MavenPublication>("maven") {
         artifactId = "quarkus-gradle-model"

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -348,6 +348,11 @@ public class QuarkusBootstrapProvider implements Closeable {
 
             effectiveProperties.putIfAbsent("quarkus.application.name", mojo.mavenProject().getArtifactId());
             effectiveProperties.putIfAbsent("quarkus.application.version", mojo.mavenProject().getVersion());
+            // pass the project.build.outputTimestamp to Quarkus packaging subsystem
+            if (mojo.mavenProject().getProperties().containsKey("project.build.outputTimestamp")) {
+                effectiveProperties.putIfAbsent("quarkus.package.output-timestamp",
+                        mojo.mavenProject().getProperties().getProperty("project.build.outputTimestamp"));
+            }
 
             for (Map.Entry<String, String> attribute : mojo.manifestEntries().entrySet()) {
                 if (attribute.getValue() == null) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeVisit.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeVisit.java
@@ -17,7 +17,10 @@ class PathTreeVisit implements PathVisit {
             PathVisitor visitor) {
         final PathTreeVisit visit = new PathTreeVisit(root, rootDir, pathFilter, multiReleaseMapping);
         try (Stream<Path> files = Files.walk(walkDir)) {
-            final Iterator<Path> i = files.iterator();
+            final Iterator<Path> i = files
+                    // we sort the elements to be deterministic, we compare the toString() to make sure the order is the same on Linux and Windows
+                    .sorted((p1, p2) -> p1.toString().compareTo(p2.toString()))
+                    .iterator();
             while (i.hasNext()) {
                 if (!visit.setCurrent(i.next())) {
                     continue;

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/FilteredPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/FilteredPathTreeTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -35,45 +35,46 @@ public class FilteredPathTreeTest {
         createFile("org/toolbox/Saw.class");
         createFile("README.md");
         testJar = testDir.resolve("test.jar");
+        Files.deleteIfExists(testJar);
         ZipUtils.zip(testDir, testJar);
     }
 
     @Test
     public void unfilteredTestDir() {
         var pathTree = PathTree.ofDirectoryOrArchive(testDir);
-        assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(
+        assertThat(getAllPaths(pathTree)).containsExactly(
                 "",
                 "META-INF",
                 "META-INF/jandex.idx",
+                "README.md",
                 "org",
                 "org/toolbox",
                 "org/toolbox/Axe.class",
                 "org/toolbox/Hammer.class",
                 "org/toolbox/Saw.class",
-                "README.md",
                 "test.jar");
     }
 
     @Test
     public void unfilteredTestJar() {
         var pathTree = PathTree.ofDirectoryOrArchive(testJar);
-        assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(
+        assertThat(getAllPaths(pathTree)).containsExactly(
                 "",
                 "META-INF",
                 "META-INF/jandex.idx",
+                "README.md",
                 "org",
                 "org/toolbox",
                 "org/toolbox/Axe.class",
                 "org/toolbox/Hammer.class",
                 "org/toolbox/Saw.class",
-                "README.md",
                 "test.jar");
     }
 
     @Test
     public void dirIncludeToolbox() {
         var pathTree = PathTree.ofDirectoryOrArchive(testDir, PathFilter.forIncludes(List.of("*/toolbox/**")));
-        assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(
+        assertThat(getAllPaths(pathTree)).containsExactly(
                 "org/toolbox/Axe.class",
                 "org/toolbox/Hammer.class",
                 "org/toolbox/Saw.class");
@@ -82,7 +83,7 @@ public class FilteredPathTreeTest {
     @Test
     public void jarIncludeToolbox() {
         var pathTree = PathTree.ofDirectoryOrArchive(testJar, PathFilter.forIncludes(List.of("*/toolbox/**")));
-        assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(
+        assertThat(getAllPaths(pathTree)).containsExactly(
                 "org/toolbox/Axe.class",
                 "org/toolbox/Hammer.class",
                 "org/toolbox/Saw.class");
@@ -93,7 +94,7 @@ public class FilteredPathTreeTest {
         var pathTree = PathTree.ofDirectoryOrArchive(testDir, new PathFilter(
                 List.of("*/toolbox/**"),
                 List.of("**/Hammer.class")));
-        assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(
+        assertThat(getAllPaths(pathTree)).containsExactly(
                 "org/toolbox/Axe.class",
                 "org/toolbox/Saw.class");
     }
@@ -103,7 +104,7 @@ public class FilteredPathTreeTest {
         var pathTree = PathTree.ofDirectoryOrArchive(testJar, new PathFilter(
                 List.of("*/toolbox/**"),
                 List.of("**/Hammer.class")));
-        assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(
+        assertThat(getAllPaths(pathTree)).containsExactly(
                 "org/toolbox/Axe.class",
                 "org/toolbox/Saw.class");
     }
@@ -133,7 +134,7 @@ public class FilteredPathTreeTest {
     }
 
     private static void assertFilteredPathTree(PathTree pathTree) {
-        assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(
+        assertThat(getAllPaths(pathTree)).containsExactly(
                 "org/toolbox/Axe.class");
 
         assertThat(pathTree.isEmpty()).isFalse();
@@ -145,7 +146,7 @@ public class FilteredPathTreeTest {
     }
 
     private static Set<String> getAllPaths(PathTree pathTree) {
-        final Set<String> paths = new HashSet<>();
+        final Set<String> paths = new LinkedHashSet<>();
         pathTree.walk(visit -> paths.add(visit.getRelativePath("/")));
         return paths;
     }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/JarPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/JarPathTreeTest.java
@@ -9,7 +9,7 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -35,6 +35,7 @@ public class JarPathTreeTest {
         }
 
         root = rootDir.getParent().resolve("root.jar");
+        Files.deleteIfExists(root);
         ZipUtils.zip(rootDir, root);
     }
 
@@ -140,7 +141,7 @@ public class JarPathTreeTest {
     public void walk() throws Exception {
         final PathTree tree = PathTree.ofDirectoryOrArchive(root);
 
-        final Set<String> visited = new HashSet<>();
+        final Set<String> visited = new LinkedHashSet<>();
         final PathVisitor visitor = new PathVisitor() {
             @Override
             public void visitPath(PathVisit visit) {
@@ -149,12 +150,12 @@ public class JarPathTreeTest {
         };
         tree.walk(visitor);
 
-        assertThat(visited).isEqualTo(Set.of(
+        assertThat(visited).containsExactly(
                 "",
                 "README.md",
                 "src",
                 "src/main",
                 "src/main/java",
-                "src/main/java/Main.java"));
+                "src/main/java/Main.java");
     }
 }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/WalkSubtreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/WalkSubtreeTest.java
@@ -38,6 +38,7 @@ public class WalkSubtreeTest {
         createFile("b/aa/aaa/aaaa/1.txt");
 
         testZip = testDir.resolve("archive.zip");
+        Files.deleteIfExists(testZip);
         ZipUtils.zip(testDir, testZip);
     }
 
@@ -46,14 +47,14 @@ public class WalkSubtreeTest {
         var list = new ArrayList<String>();
         PathTree.ofDirectoryOrArchive(testDir)
                 .walkIfContains("a/aa", visit -> list.add(visit.getRelativePath()));
-        assertThat(list).containsExactlyInAnyOrder(
+        assertThat(list).containsExactly(
                 "a/aa",
                 "a/aa/1.txt",
                 "a/aa/aaa",
                 "a/aa/aaa/1.txt",
+                "a/aa/aaa/2.txt",
                 "a/aa/aaa/aaaa",
-                "a/aa/aaa/aaaa/1.txt",
-                "a/aa/aaa/2.txt");
+                "a/aa/aaa/aaaa/1.txt");
     }
 
     @Test
@@ -61,14 +62,14 @@ public class WalkSubtreeTest {
         var list = new ArrayList<String>();
         PathTree.ofDirectoryOrArchive(testZip)
                 .walkIfContains("a/aa", visit -> list.add(visit.getRelativePath()));
-        assertThat(list).containsExactlyInAnyOrder(
+        assertThat(list).containsExactly(
                 "a/aa",
                 "a/aa/1.txt",
                 "a/aa/aaa",
                 "a/aa/aaa/1.txt",
+                "a/aa/aaa/2.txt",
                 "a/aa/aaa/aaaa",
-                "a/aa/aaa/aaaa/1.txt",
-                "a/aa/aaa/2.txt");
+                "a/aa/aaa/aaaa/1.txt");
     }
 
     @Test
@@ -78,20 +79,20 @@ public class WalkSubtreeTest {
                 PathTree.ofDirectoryOrArchive(testDir.resolve("a/aa")),
                 PathTree.ofDirectoryOrArchive(testDir.resolve("b/aa")))
                 .walk(visit -> list.add(ensureForwardSlash(testDir.relativize(visit.getPath()).toString())));
-        assertThat(list).containsExactlyInAnyOrder(
+        assertThat(list).containsExactly(
                 "a/aa",
                 "a/aa/1.txt",
                 "a/aa/aaa",
                 "a/aa/aaa/1.txt",
+                "a/aa/aaa/2.txt",
                 "a/aa/aaa/aaaa",
                 "a/aa/aaa/aaaa/1.txt",
-                "a/aa/aaa/2.txt",
                 "b/aa",
                 "b/aa/aaa",
                 "b/aa/aaa/1.txt",
+                "b/aa/aaa/2.txt",
                 "b/aa/aaa/aaaa",
-                "b/aa/aaa/aaaa/1.txt",
-                "b/aa/aaa/2.txt");
+                "b/aa/aaa/aaaa/1.txt");
     }
 
     @Test
@@ -101,7 +102,7 @@ public class WalkSubtreeTest {
                 PathTree.ofDirectoryOrArchive(testDir.resolve("a/aa")),
                 PathTree.ofDirectoryOrArchive(testDir.resolve("b/aa")))
                 .walkIfContains("aaa", visit -> list.add(ensureForwardSlash(testDir.relativize(visit.getPath()).toString())));
-        assertThat(list).containsExactlyInAnyOrder(
+        assertThat(list).containsExactly(
                 "a/aa/aaa",
                 "a/aa/aaa/1.txt",
                 "a/aa/aaa/2.txt",

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/CatalogMapperHelper.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/CatalogMapperHelper.java
@@ -8,9 +8,12 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -43,6 +46,10 @@ public class CatalogMapperHelper {
         mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         mapper.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+        mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        mapper.setLocale(Locale.US);
+        mapper.setTimeZone(TimeZone.getTimeZone("UTC"));
         return mapper;
     }
 


### PR DESCRIPTION
About this work:
- I have been revisiting the work @ppalaga started a long time ago toward reproducibility. @ppalaga's focus was towards reproducibility of the build of a Quarkus application. I'm working on both this and the reproducibility of our own builds.
- This PR contains some work on both:
  - [Propagate project.build.outputTimestamp to our packaging](https://github.com/quarkusio/quarkus/commit/ae6a7670cbf58f4287bf2340d676cdeaace91785) is part of my work on the former
  - The rest of the commits are targeting our own build

There's a companion PR here: https://github.com/quarkusio/quarkus-platform-bom-generator/pull/375

Our builds is a lot better after these PRs: I was able to get a reproducible build for most of our own artifacts except for `quarkus-cli-runner` which is a Quarkus app and not yet reproducible and all the modules after it (mostly the ITs, which are also Quarkus apps).

Note that this is just a start, there are a lot of tricky issues to solve to get the build of a Quarkus app reproducible. I'll continue to iterate on this task, I already started extracting and rebasing some of @ppalaga 's old PRs - they definitely go in the right direction.