### PR TITLE
Add pseudo monitoring option 'none' to disable all monitoring options

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -334,6 +334,7 @@ public interface NativeConfig {
      * <li><code>jmxserver</code> for JMX server support (experimental)</li>
      * <li><code>nmt</code> for native memory tracking support</li>
      * <li><code>all</code> for all monitoring features</li>
+     * <li><code>none</code> for explicitly turning off all monitoring features</li>
      * </ul>
      */
     Optional<List<MonitoringOption>> monitoring();
@@ -590,7 +591,8 @@ public interface NativeConfig {
         JMXSERVER,
         JMXCLIENT,
         NMT,
-        ALL
+        ALL,
+        NONE
     }
 
     enum ImagePullStrategy {

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -957,6 +957,10 @@ include at build time.
 |Adds support for native memory tracking.
 |GraalVM for JDK 23 Mandrel 24.1
 
+|none
+|Disables support for all monitoring options that would be enabled by default in Quarkus
+|Pseudo option used by Quarkus
+
 |all
 |Adds all monitoring options.
 |GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)


### PR DESCRIPTION
This option isn't recognized by `native-image`, but it's a way to disable all monitoring options
that quarkus would otherwise add without that setting. For example, `--enable-monitoring=heapdump` is
added by default without the user doing anything for native builds. This patch doesn't change this behaviour,
but adds an option to turn it off by specifying `-Dquarkus.native.monitoring=none`

It would be a step to make some progress on #46890 since we aren't sure if the `heapdump` monitoring option is causing it. If it is, we'd know more.

Thoughts?

Related: #46890 