### PR TITLE
Change the database.generation to schema-management.strategy in the docs

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -127,7 +127,7 @@ quarkus.datasource.password = connor
 quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5432/mydatabase
 
 # drop and create the database at startup (use `update` to only update the schema)
-quarkus.hibernate-orm.database.generation = drop-and-create
+quarkus.hibernate-orm.schema-management.strategy = drop-and-create
 ----
 
 == Solution 1: using the active record pattern

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -792,7 +792,7 @@ Or if you use a database schema migration tool like xref:flyway.adoc[Flyway] or 
 With this approach when making changes to an entity, make sure to adapt the database schema accordingly;
 you could also use `validate` to have Hibernate verify the schema matches its expectations.
 
-WARNING: Do not use `quarkus.hibernate-orm.database.generation` `drop-and-create` and `update` in your production environment.
+WARNING: Do not use `quarkus.hibernate-orm.schema-management.strategy` `drop-and-create` and `update` in your production environment.
 
 
 These approaches become really powerful when combined with Quarkus configuration profiles.
@@ -803,13 +803,13 @@ This is great because you can define different combinations of Hibernate ORM pro
 [source,properties]
 .application.properties
 ----
-%dev.quarkus.hibernate-orm.database.generation = drop-and-create
+%dev.quarkus.hibernate-orm.schema-management.strategy = drop-and-create
 %dev.quarkus.hibernate-orm.sql-load-script = import-dev.sql
 
-%dev-with-data.quarkus.hibernate-orm.database.generation = update
+%dev-with-data.quarkus.hibernate-orm.schema-management.strategy = update
 %dev-with-data.quarkus.hibernate-orm.sql-load-script = no-file
 
-%prod.quarkus.hibernate-orm.database.generation = none
+%prod.quarkus.hibernate-orm.schema-management.strategy = none
 %prod.quarkus.hibernate-orm.sql-load-script = no-file
 ----
 
@@ -838,7 +838,7 @@ Add the following in your properties file.
 [source,properties]
 .application.properties
 ----
-%prod.quarkus.hibernate-orm.database.generation = none
+%prod.quarkus.hibernate-orm.schema-management.strategy = none
 %prod.quarkus.hibernate-orm.sql-load-script = no-file
 ----
 

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -125,7 +125,7 @@ quarkus.datasource.password = connor
 quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost:5432/mydatabase
 
 # drop and create the database at startup (use `update` to only update the schema)
-quarkus.hibernate-orm.database.generation = drop-and-create
+quarkus.hibernate-orm.schema-management.strategy = drop-and-create
 ----
 
 == Solution 1: using the active record pattern

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitSchemaManagerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/singlepersistenceunit/SinglePersistenceUnitSchemaManagerTest.java
@@ -25,7 +25,7 @@ public class SinglePersistenceUnitSchemaManagerTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(DefaultEntity.class)
                     .addAsResource("application.properties"))
-            .overrideConfigKey("quarkus.hibernate-orm.database.generation", "none");
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "none");
     @Inject
     SchemaManager schemaManager;
 


### PR DESCRIPTION
This is a small follow-up on the previous update. My thinking here is that since we are deprecating the old property, we probably shouldn't mention it in the docs. 
I noticed a few more usages in the tests, but left them unchanged, thinking that it would still be nice to test the old property while it's around. One test that I've updated uses `overrideConfigKey` to update the key that is not there (since the property file changed to the new property, so I've updated it)


* Follows up on https://github.com/quarkusio/quarkus/pull/47252

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

