### PR TITLE
Use MultiMap set method instead of add for client assertion parameters

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -194,7 +194,7 @@ public class OidcClientImpl implements OidcClient {
             if (clientAssertion == null && clientAssertionProvider != null) {
                 clientAssertion = clientAssertionProvider.getClientAssertion();
                 if (clientAssertion != null) {
-                    body.add(OidcConstants.CLIENT_ASSERTION, clientAssertion);
+                    body.set(OidcConstants.CLIENT_ASSERTION, clientAssertion);
                 }
             }
             if (clientAssertion == null) {
@@ -204,7 +204,7 @@ public class OidcClientImpl implements OidcClient {
                 LOG.error(errorMessage);
                 throw new OidcClientException(errorMessage);
             }
-            body.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
+            body.set(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
         } else if (clientJwtKey != null) {
             // if it is a refresh then a map has already been copied
             body = !refresh ? copyMultiMap(body) : body;

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -35,6 +35,10 @@ public class FrontendResource {
 
     @Inject
     @RestClient
+    JwtBearerAuthenticationOidcClientForceNewToken jwtBearerAuthenticationOidcClientForceNewToken;
+
+    @Inject
+    @RestClient
     JwtBearerFileAuthenticationOidcClient jwtBearerFileAuthenticationOidcClient;
 
     @Inject
@@ -88,6 +92,12 @@ public class FrontendResource {
     @Path("echoTokenJwtBearerAuthentication")
     public String echoTokenJwtBearerAuthentication() {
         return jwtBearerAuthenticationOidcClient.echoToken();
+    }
+
+    @GET
+    @Path("echoTokenJwtBearerAuthenticationForceNewToken")
+    public String echoTokenJwtBearerAuthenticationForceNewToken() {
+        return jwtBearerAuthenticationOidcClientForceNewToken.echoToken();
     }
 
     @GET

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/JwtBearerAuthenticationOidcClientForceNewToken.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/JwtBearerAuthenticationOidcClientForceNewToken.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@RegisterProvider(value = OidcClientRequestCustomJwtBearerForceNewTokenFilter.class)
+@Path("/")
+public interface JwtBearerAuthenticationOidcClientForceNewToken {
+
+    @GET
+    String echoToken();
+}

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/OidcClientRequestCustomJwtBearerForceNewTokenFilter.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/OidcClientRequestCustomJwtBearerForceNewTokenFilter.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+
+@Priority(Priorities.AUTHENTICATION)
+public class OidcClientRequestCustomJwtBearerForceNewTokenFilter extends AbstractOidcClientRequestFilter {
+
+    @Override
+    protected Map<String, String> additionalParameters() {
+        return Map.of(OidcConstants.CLIENT_ASSERTION, "123456");
+    }
+
+    @Override
+    protected boolean isForceNewTokens() {
+        // Easiest way to force requesting new tokens, instead of
+        // manipulating the token expiration time
+        return true;
+    }
+
+    @Override
+    protected Optional<String> clientId() {
+        return Optional.of("jwtbearer-forcenewtoken");
+    }
+}

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -20,6 +20,12 @@ quarkus.oidc-client.jwtbearer.token-path=/tokens-jwtbearer
 quarkus.oidc-client.jwtbearer.client-id=quarkus-app
 quarkus.oidc-client.jwtbearer.credentials.jwt.source=bearer
 
+quarkus.oidc-client.jwtbearer-forcenewtoken.auth-server-url=${keycloak.url}
+quarkus.oidc-client.jwtbearer-forcenewtoken.discovery-enabled=false
+quarkus.oidc-client.jwtbearer-forcenewtoken.token-path=/tokens-jwtbearer-forcenewtoken
+quarkus.oidc-client.jwtbearer-forcenewtoken.client-id=quarkus-app
+quarkus.oidc-client.jwtbearer-forcenewtoken.credentials.jwt.source=bearer
+
 quarkus.oidc-client.jwtbearer-file.auth-server-url=${keycloak.url}
 quarkus.oidc-client.jwtbearer-file.discovery-enabled=false
 quarkus.oidc-client.jwtbearer-file.token-path=/tokens-jwtbearer-file
@@ -97,6 +103,7 @@ quarkus.oidc-client.crash-test.early-tokens-acquisition=false
 
 io.quarkus.it.keycloak.ProtectedResourceServiceOidcClient/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.JwtBearerAuthenticationOidcClient/mp-rest/url=http://localhost:8081/protected
+io.quarkus.it.keycloak.JwtBearerAuthenticationOidcClientForceNewToken/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.JwtBearerFileAuthenticationOidcClient/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceCrashTestClient/mp-rest/url=http://localhost:8081/protected
 

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -51,6 +51,15 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
                                 "{\"access_token\":\"access_token_jwt_bearer\", \"expires_in\":4, \"refresh_token\":\"refresh_token_jwt_bearer\"}")));
+        server.stubFor(WireMock.post("/tokens-jwtbearer-forcenewtoken")
+                .withRequestBody(matching("grant_type=client_credentials&"
+                        + "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&"
+                        + "client_assertion=123456"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"access_token_jwt_bearer_always_new\", \"expires_in\":4, \"refresh_token\":\"refresh_token_jwt_bearer\"}")));
         server.stubFor(WireMock.post("/tokens-jwtbearer-grant")
                 .withRequestBody(containing("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&"
                         + "assertion="))

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -55,6 +55,25 @@ public class OidcClientTest {
                 .body(equalTo("access_token_jwt_bearer"));
     }
 
+    @Order(14)
+    @Test
+    public void testEchoTokensJwtBearerAuthenticationForceNewToken() {
+        // This test uses a custom filter that forces new tokens to be requested
+        // regardless of the token expiration time.
+        // The corresponding stub will only return the access token if the body
+        // exactly matches the expected request body. If for example
+        // multiple form parameters are sent, as it was the case with previous
+        // implementations, the stub will not match and the test will fail.
+        RestAssured.when().get("/frontend/echoTokenJwtBearerAuthenticationForceNewToken")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_jwt_bearer_always_new"));
+        RestAssured.when().get("/frontend/echoTokenJwtBearerAuthenticationForceNewToken")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_jwt_bearer_always_new"));
+    }
+
     @Order(8)
     @Test
     public void testEchoTokensJwtBearerAuthenticationFromFile() {


### PR DESCRIPTION
The issue is in OidcClientImpl.java, where `add()` is used instead of `set()` for JWT bearer authentication parameters. Other authentication methods correctly use `set()`.

This causes a mismatch between the expected behavior (replacing previous values) and the actual behavior (accumulating values).

Replaced the `add()` method calls with `set()` in the JWT bearer authentication code path:

```java
// Replace these lines:
body.add(OidcConstants.CLIENT_ASSERTION, clientAssertion);
body.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);

// With:
body.set(OidcConstants.CLIENT_ASSERTION, clientAssertion);
body.set(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
```

This would ensure only the newest key-value pairs are included in the request, eliminating the duplication problem.

- Fixes: #48879