### PR TITLE
Use proper priority to deploy Vert.x Filter used for legacy websockets

### DIFF
--- a/extensions/websockets/server/deployment/src/main/java/io/quarkus/websockets/deployment/ServerWebSocketProcessor.java
+++ b/extensions/websockets/server/deployment/src/main/java/io/quarkus/websockets/deployment/ServerWebSocketProcessor.java
@@ -110,10 +110,11 @@ public class ServerWebSocketProcessor {
         final IndexView index = indexBuildItem.getIndex();
         WebsocketClientProcessor.registerCodersForReflection(reflection, index.getAnnotations(SERVER_ENDPOINT));
 
+        int priority = 1 + FilterBuildItem.AUTHORIZATION;
         return new FilterBuildItem(
                 recorder.createHandler(webSocketDeploymentInfoBuildItem.get().getInfo(),
                         serverWebSocketContainerBuildItem.get().getContainer()),
-                100);
+                priority);
     }
 
     @BuildStep


### PR DESCRIPTION
We should never use the same priority value that
Authorization or Authentication use as that can 
cause problems to other extensions 

- Fixes: #48812

