### PR TITLE
Decouple OpenTelemetry bean initialization from `quarkus.otel.sdk.disabled` config value

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TracerAsBeanWhenOTelSDKDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TracerAsBeanWhenOTelSDKDisabledTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static io.restassured.RestAssured.when;
+
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TracerAsBeanWhenOTelSDKDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Resource.class))
+            .overrideRuntimeConfigKey("quarkus.otel.sdk.disabled", "true");
+
+    @Test
+    public void test() {
+        when().get("resource")
+                .then()
+                .statusCode(200);
+    }
+
+    @Path("resource")
+    public static class Resource {
+
+        private final Tracer tracer;
+
+        public Resource(Tracer tracer) {
+            this.tracer = tracer;
+        }
+
+        @GET
+        public String get() {
+            Span span = tracer.spanBuilder("dummy").startSpan();
+            try (Scope scope = span.makeCurrent()) {
+                var otel = CDI.current().select(OpenTelemetry.class).get();
+                return otel.toString();// we don't care about the string itself, all we care about is that OTel is initialized
+            } catch (Throwable t) {
+                span.recordException(t);
+                throw t;
+            } finally {
+                span.end();
+            }
+        }
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
@@ -54,12 +54,12 @@ public class InstrumentationRecorder {
     /* RUNTIME INIT */
     @RuntimeInit
     public void setupVertxTracer(BeanContainer beanContainer, boolean sqlClientAvailable, boolean redisClientAvailable) {
+        OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class); // always force initialization of OTel
 
         if (runtimeConfig.getValue().sdkDisabled()) {
             return;
         }
 
-        OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class);
         List<InstrumenterVertxTracer<?, ?>> tracers = new ArrayList<>(4);
         if (runtimeConfig.getValue().instrument().vertxHttp()) {
             tracers.add(new HttpInstrumenterVertxTracer(openTelemetry, runtimeConfig.getValue(), buildConfig));


### PR DESCRIPTION

This is a quick fix, but we should follow up with a fix that ensure that the recorder runs after the OTel recorder

- Relates to: https://github.com/quarkiverse/quarkus-langchain4j/issues/1607