### PR TITLE
Update SmallRye Config to 3.13.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0.1</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.13.7</smallrye-common.version>
-        <smallrye-config.version>3.13.2</smallrye-config.version>
+        <smallrye-config.version>3.13.3</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.11</smallrye-open-api.version>


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.13.3</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1378">#1378</a> Sort matching properties with Env to prioritize specific names first</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1377">#1377</a> Bump com.typesafe:config from 1.4.3 to 1.4.4</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1376">#1376</a> Bump io.smallrye.common:smallrye-common-bom from 2.13.4 to 2.13.7</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1373">#1373</a> Bump io.smallrye.common:smallrye-common-bom from 2.12.0 to 2.13.4</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1369">#1369</a> Bump kotlin.version from 2.1.21 to 2.2.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1368">#1368</a> Warn when converting a boolean value that does not map to false or equivalent</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1367">#1367</a> Bump urllib3 from 2.4.0 to 2.5.0 in /documentation</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1363">#1363</a> Bump requests from 2.32.3 to 2.32.4 in /documentation</li>
    </ul>
</blockquote>
<br>

Quarkus:

- Fixes #48794