### PR TITLE
Add jackson-databind as a dependency of core-deployment

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>asm-commons</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-development-mode-spi</artifactId>
         </dependency>


### PR DESCRIPTION
There is a need to provide a JSON reader / writer (possible with data binding) to our deployment phase.

We do have internal implementations sitting here:
- https://github.com/quarkusio/quarkus/blob/7493ab4ab24c7277067a0755354bb634bcdd5b5d/core/builder/src/main/java/io/quarkus/builder/Json.java
- https://github.com/quarkusio/quarkus/blob/7493ab4ab24c7277067a0755354bb634bcdd5b5d/core/builder/src/main/java/io/quarkus/builder/JsonReader.java

Mostly used to handle native image resources and build time metrics.

We now also have a json file that describes our configuration metadata (for tooling), but that we would benefit if consumed by our own build.

The proposal is to pick a popular JSON library to handle these uses cases instead of maintaining our own implementation. Since this is for the `deployment` phase only, it shouldn't leak to the runtime application, but it will be available in the `test` class path due to `core-deployment` being included in `quarkus-junit5`.

Additional discussion from Zulip: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/JSON.20dependency.20in.20the.20core.20deployment.3F/with/526854010