### PR TITLE
Fix OIDC token propagation doc typo

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1305,7 +1305,7 @@ quarkus.oidc-client.credentials.secret=secret
 quarkus.oidc-client.grant.type=exchange
 quarkus.oidc-client.grant-options.exchange.audience=quarkus-app-exchange
 
-quarkus.resteasy-client-oidc-token-propagation.exchange-token=true <1>
+quarkus.rest-client-oidc-token-propagation.exchange-token=true <1>
 ----
 <1> Please note that the `exchange-token` configuration property is ignored when the OidcClient name is set with the `io.quarkus.oidc.token.propagation.common.AccessToken#exchangeTokenClient` annotation attribute.
 


### PR DESCRIPTION
REST client OIDC token propagation section documents a wrong exchange property name 