### PR TITLE
Revert the previous handling of Uni<Response> in REST Client

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client/deployment/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
             <scope>test</scope>

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ResponseConsumptionTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ResponseConsumptionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
+import java.util.Random;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -17,6 +18,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
 
 public class ResponseConsumptionTest {
 
@@ -28,12 +32,17 @@ public class ResponseConsumptionTest {
     URI uri;
 
     @Test
-    public void test() throws InterruptedException {
-        Client client = RestClientBuilder.newBuilder()
-                .baseUri(uri)
-                .build(Client.class);
+    public void testBlockingOk() {
+        Client client = createClient();
+        Response response200 = client.get200();
+        assertThat(response200.getStatus()).isEqualTo(200);
+        assertThat(response200.readEntity(byte[].class)).hasSize(Resource.OK_RESPONSE_SIZE);
+    }
 
-        assertThatThrownBy(client::get).isInstanceOfSatisfying(WebApplicationException.class, w -> {
+    @Test
+    public void testBlockingError() {
+        Client client = createClient();
+        assertThatThrownBy(client::get401).isInstanceOfSatisfying(WebApplicationException.class, w -> {
             Response response = w.getResponse();
             // the response should have the response code from the api call
             assertThat(response.getStatus()).isEqualTo(401);
@@ -42,19 +51,76 @@ public class ResponseConsumptionTest {
         });
     }
 
+    @Test
+    @RunOnVertxContext
+    public void testEventLoopOk(UniAsserter asserter) {
+        Client client = createClient();
+
+        asserter.assertThat(client::uniGet200, (res) -> {
+            assertThat(res.getStatus()).isEqualTo(200);
+            assertThat(res.readEntity(byte[].class)).hasSize(Resource.OK_RESPONSE_SIZE);
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testEventLoopError(UniAsserter asserter) {
+        Client client = createClient();
+
+        asserter.assertThat(() -> {
+            return client.uniGet401().onFailure(WebApplicationException.class).recoverWithItem(wae -> {
+                return ((WebApplicationException) wae).getResponse();
+            });
+        }, (res) -> {
+            assertThat(res.getStatus()).isEqualTo(401);
+            assertThat(res.readEntity(String.class)).isEqualTo("Unauthorized");
+        });
+    }
+
+    private Client createClient() {
+        return RestClientBuilder.newBuilder()
+                .baseUri(uri)
+                .build(Client.class);
+    }
+
     @Path("resource")
     public interface Client {
 
         @GET
-        Response get();
+        @Path("401")
+        Response get401();
+
+        @GET
+        @Path("401")
+        Uni<Response> uniGet401();
+
+        @GET
+        @Path("200")
+        Response get200();
+
+        @GET
+        @Path("200")
+        Uni<Response> uniGet200();
     }
 
     @Path("resource")
     public static class Resource {
 
+        public static final int OK_RESPONSE_SIZE = 2 * 1024 * 1024;
+
+        @Path("401")
         @GET
-        public RestResponse<String> get() throws InterruptedException {
+        public RestResponse<String> get401() {
             return RestResponse.status(RestResponse.Status.UNAUTHORIZED, "Unauthorized");
+        }
+
+        @Path("200")
+        @GET
+        public RestResponse<byte[]> get200() {
+            byte[] byteArray = new byte[OK_RESPONSE_SIZE];
+            Random random = new Random();
+            random.nextBytes(byteArray);
+            return RestResponse.ok(byteArray);
         }
     }
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -343,7 +343,12 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                                         }
                                     });
 
-                        } else if (requestContext.isInputStreamDownload() || requestContext.isJakartaResponseDownload()) {
+                        } else if (requestContext.isInputStreamDownload() ||
+                        // when returning Response (and not Uni<Response>) we don't buffer the result
+                        // but instead set up the proper InputStream
+                        // for Uni<Response> we can't buffer because setting up the InputSteam would result in blocking the event loop
+                                (requestContext.isJakartaResponseDownload()
+                                        && !requestContext.invokedMethodReturnsAsyncType())) {
                             if (loggingScope != LoggingScope.NONE) {
                                 clientLogger.logResponse(clientResponse, false);
                             }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -44,6 +45,7 @@ import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.stork.api.ServiceInstance;
 import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
@@ -172,6 +174,16 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
             return (Method) o;
         }
         return null;
+    }
+
+    public boolean invokedMethodReturnsAsyncType() {
+        Method invokedMethod = getInvokedMethod();
+        if (invokedMethod == null) {
+            return false;
+        }
+        Class<?> returnType = invokedMethod.getReturnType();
+        return Uni.class.isAssignableFrom(returnType) || Multi.class.isAssignableFrom(returnType)
+                || CompletionStage.class.isAssignableFrom(returnType);
     }
 
     public Annotation[] getMethodDeclaredAnnotationsSafe() {


### PR DESCRIPTION
Although this is an edge case, we should probably ensure that it continues to work.

- Closes: #48886
- Follows up on: #48807
