### PR TITLE
Clean up security fluent API configuration on shutdown

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -60,6 +60,7 @@ import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.DescriptorUtils;
@@ -292,9 +293,10 @@ public class HttpSecurityProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     void initializeHttpSecurity(Optional<HttpAuthenticationHandlerBuildItem> authenticationHandler,
-            HttpSecurityRecorder recorder, BeanContainerBuildItem beanContainerBuildItem) {
+            HttpSecurityRecorder recorder, BeanContainerBuildItem beanContainerBuildItem,
+            ShutdownContextBuildItem shutdown) {
         if (authenticationHandler.isPresent()) {
-            recorder.prepareHttpSecurityConfiguration();
+            recorder.prepareHttpSecurityConfiguration(shutdown);
             recorder.initializeHttpAuthenticatorHandler(authenticationHandler.get().handler,
                     beanContainerBuildItem.getValue());
         }


### PR DESCRIPTION
This refactoring comes from stuff I hit with the https://github.com/quarkusio/quarkus/pull/48900 and it will make its review easier (so this PR is probably not vital). We have DEV mode tests and they are passing, but I think we need to add a shutdown task to cover all scenarios. The rest of refactoring is also something I have experienced during https://github.com/quarkusio/quarkus/pull/48900, I'd like to propagate config from the recorder instead of querying the SR Config over and over again. The record is turned into a public class because we will need to expose at least one static method and I don't want to expose field accessors publicly.