### PR TITLE
Update quarkus-hibernate-orm-derby* project names to match the common pattern

### DIFF
--- a/extensions/hibernate-orm-derby/pom.xml
+++ b/extensions/hibernate-orm-derby/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-hibernate-orm-derby-parent</artifactId>
-    <name>Quarkus - Hibernate ORM - Derby - Deployment</name>
+    <name>Quarkus - Hibernate ORM - Derby</name>
     <packaging>pom</packaging>
     <modules>
         <module>runtime</module>

--- a/extensions/hibernate-orm-derby/runtime/pom.xml
+++ b/extensions/hibernate-orm-derby/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-hibernate-orm-derby</artifactId>
-    <name>Quarkus - Hibernate ORM - Derby - Deployment</name>
+    <name>Quarkus - Hibernate ORM - Derby - Runtime</name>
     <description>This extensions is added by Quarkus automatically when quarkus-hibernate-orm and quarkus-jdbc-derby are on the classpath</description>
 
     <dependencies>


### PR DESCRIPTION
It was a bit misleading when looking at the build log to have all 3 (parent, deployment, runtime) to have the same name

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

