### PR TITLE
Simplify OIDC client exchange grant configuration

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -178,6 +178,11 @@ public class OidcClientRecorder {
                                         tokenGrantParams.addAll(grantOptions);
                                     }
                                 }
+                                if (oidcConfig.grant().type() == Grant.Type.EXCHANGE
+                                        && !tokenGrantParams.contains(OidcConstants.EXCHANGE_GRANT_SUBJECT_TOKEN_TYPE)) {
+                                    tokenGrantParams.add(OidcConstants.EXCHANGE_GRANT_SUBJECT_TOKEN_TYPE,
+                                            OidcConstants.EXCHANGE_GRANT_SUBJECT_ACCESS_TOKEN_TYPE);
+                                }
                             }
                         }
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -9,6 +9,9 @@ public final class OidcConstants {
     public static final String JWT_BEARER_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
     public static final String JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String JWT_BEARER_GRANT_ASSERTION = "assertion";
+    public static final String EXCHANGE_GRANT_SUBJECT_TOKEN = "subject_token";
+    public static final String EXCHANGE_GRANT_SUBJECT_TOKEN_TYPE = "subject_token_type";
+    public static final String EXCHANGE_GRANT_SUBJECT_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
     public static final String CLIENT_CREDENTIALS_GRANT = "client_credentials";
     public static final String PASSWORD_GRANT = "password";

--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
@@ -24,6 +24,7 @@ import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.runtime.DisabledOidcClientException;
 import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
@@ -59,9 +60,9 @@ public class AccessTokenRequestReactiveFilter implements ResteasyReactiveClientR
                                     + "grant.type",
                             Grant.Type.class);
             if (exchangeTokenGrantType == Grant.Type.EXCHANGE) {
-                exchangeTokenProperty = "subject_token";
+                exchangeTokenProperty = OidcConstants.EXCHANGE_GRANT_SUBJECT_TOKEN;
             } else if (exchangeTokenGrantType == Grant.Type.JWT) {
-                exchangeTokenProperty = "assertion";
+                exchangeTokenProperty = OidcConstants.JWT_BEARER_GRANT_ASSERTION;
             } else {
                 throw new ConfigurationException("Token exchange is required but OIDC client is configured "
                         + "to use the " + exchangeTokenGrantType.getGrantType() + " grantType");

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
@@ -53,7 +53,7 @@ public class AccessTokenRequestFilter extends AbstractTokenRequestFilter {
                                     + "grant.type",
                             Grant.Type.class);
             if (exchangeTokenGrantType == Grant.Type.EXCHANGE) {
-                exchangeTokenProperty = "subject_token";
+                exchangeTokenProperty = OidcConstants.EXCHANGE_GRANT_SUBJECT_TOKEN;
             } else if (exchangeTokenGrantType == Grant.Type.JWT) {
                 exchangeTokenProperty = OidcConstants.JWT_BEARER_GRANT_ASSERTION;
             } else {

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -17,6 +17,7 @@ import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.smallrye.mutiny.Uni;
 
 @Path("/frontend")
@@ -58,6 +59,10 @@ public class FrontendResource {
     OidcClient jwtBearerGrantClient;
 
     @Inject
+    @NamedOidcClient("exchange-grant")
+    OidcClient exchangeGrantClient;
+
+    @Inject
     @RestClient
     ProtectedResourceServiceRefreshIntervalTestClient tokenRefreshIntervalTestClient;
 
@@ -68,6 +73,13 @@ public class FrontendResource {
     @Path("echoToken")
     public String echoToken() {
         return protectedResourceServiceOidcClient.echoToken();
+    }
+
+    @GET
+    @Path("echoTokenExchangeGrant")
+    public String echoTokenExchangeGrant() {
+        return exchangeGrantClient.getTokens(Map.of(OidcConstants.EXCHANGE_GRANT_SUBJECT_TOKEN, "token_to_be_exchanged"))
+                .await().indefinitely().getAccessToken();
     }
 
     @GET

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -47,6 +47,14 @@ quarkus.oidc-client.password-grant-public-client.grant.type=password
 quarkus.oidc-client.password-grant-public-client.grant-options.password.username=alice
 quarkus.oidc-client.password-grant-public-client.grant-options.password.password=alice
 
+quarkus.oidc-client.exchange-grant.auth-server-url=${keycloak.url}
+quarkus.oidc-client.exchange-grant.discovery-enabled=false
+quarkus.oidc-client.exchange-grant.token-path=/tokens-exchange
+quarkus.oidc-client.exchange-grant.grant.type=exchange
+quarkus.oidc-client.exchange-grant.client-id=quarkus-app
+quarkus.oidc-client.exchange-grant.credentials.secret=secret
+
+
 quarkus.oidc-client.non-standard-response.token-path=${keycloak.url}/non-standard-tokens
 quarkus.oidc-client.non-standard-response.client-id=quarkus-app
 quarkus.oidc-client.non-standard-response.credentials.secret=secret

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -42,6 +42,15 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
                                 "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+        server.stubFor(WireMock.post("/tokens-exchange")
+                .withRequestBody(containing("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange"))
+                .withRequestBody(containing("subject_token=token_to_be_exchanged"))
+                .withRequestBody(containing("subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"access_token_exchanged\", \"expires_in\":4}")));
         server.stubFor(WireMock.post("/tokens-jwtbearer")
                 .withRequestBody(matching("grant_type=client_credentials&"
                         + "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&"

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -318,6 +318,15 @@ public class OidcClientTest {
         }
     }
 
+    @Order(15)
+    @Test
+    public void testEchoTokensExchangeGrant() {
+        RestAssured.when().get("/frontend/echoTokenExchangeGrant")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_exchanged"));
+    }
+
     private void checkLog() {
         final Path logDirectory = Paths.get(".", "target");
         given().await().pollInterval(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
I've been working on a demo that requires a use of the OIDC client exchange grant, and I realized I had to configure client like this: 

```
quarkus.oidc-client.auth-server-url=http://localhost:8081/realms/quarkus
quarkus.oidc-client.client-id=quarkus-mcp-server
quarkus.oidc-client.credentials.secret=secret
quarkus.oidc-client.scopes=quarkus-mcp-service-scope
quarkus.oidc-client.grant.type=exchange
quarkus.oidc-client.grant-options.exchange.subject_token_type=urn:ietf:params:oauth:token-type:access_token
```

Here, `quarkus.oidc-client.grant-options.exchange.subject_token_type=urn:ietf:params:oauth:token-type:access_token` can definitely be avoided, it is very technical, users will still be able to set this property if they want some different token type, but in 90% cases it will be this specific type, and users should not need to worry about having to add this property