### PR TITLE
Bump maven to 3.9.11

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,5 +16,5 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
-distributionSha256Sum=4ec3f26fb1a692473aea0235c300bd20f0f9fe741947c82c1234cefd76ac3a3c
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+distributionSha256Sum=0d7125e8c91097b36edb990ea5934e6c68b4440eef4ea96510a0f6815e7eeadb

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -61,7 +61,7 @@
         <supported-maven-versions>[3.8.6,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.9</proposed-maven-version>
+        <proposed-maven-version>3.9.11</proposed-maven-version>
         <maven-wrapper.version>3.3.2</maven-wrapper.version>
         <gradle-wrapper.version>9.0.0</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>

--- a/devtools/config-doc-maven-plugin/pom.xml
+++ b/devtools/config-doc-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <name>Quarkus - Config doc Maven plugin</name>
     <packaging>maven-plugin</packaging>
     <properties>
-        <maven-core.version>3.9.9</maven-core.version>
+        <maven-core.version>3.9.11</maven-core.version>
     </properties>
     <build>
         <pluginManagement>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -41,10 +41,10 @@
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <junit5.version>5.13.4</junit5.version>
-        <maven-core.version>3.9.9</maven-core.version><!-- Keep in sync with sisu.version -->
+        <maven-core.version>3.9.11</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.9.0.M4</sisu.version><!-- Keep in sync with maven-core.version -->
-        <maven-plugin-annotations.version>3.13.1</maven-plugin-annotations.version>
-        <maven-resolver.version>1.9.22</maven-resolver.version>
+        <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
+        <maven-resolver.version>1.9.24</maven-resolver.version>
         <maven-shared-utils.version>3.4.2</maven-shared-utils.version> <!-- Keep in sync with maven-core.version (force this version on maven-invoker) -->
         <maven-wagon.version>3.5.3</maven-wagon.version>
         <httpcore.version>4.4.16</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.5.3 brings in httpclient 4.5.14 which brings httpcore 4.4.16) -->

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -35,7 +35,7 @@
         <!-- Keeping 3.0.0.M3 because 3.2.1 requires class changes -->
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
         <maven-invoker-plugin.version>3.9.1</maven-invoker-plugin.version>
-        <maven-core.version>3.9.9</maven-core.version>
+        <maven-core.version>3.9.11</maven-core.version>
 
         <!--
            Supported Maven versions, interpreted as a version range (Also defined in build-parent)

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -36,7 +36,7 @@
         <!-- Not sure exactly why but the Maven plugins need to be compiled with Java 11 -->
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
-        <maven-core.version>3.9.9</maven-core.version>
+        <maven-core.version>3.9.11</maven-core.version>
         <jackson-bom.version>2.20.0</jackson-bom.version>
         <smallrye-beanbag.version>1.5.3</smallrye-beanbag.version>
         <junit5.version>5.13.4</junit5.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -47,7 +47,7 @@
         <jandex.version>3.4.0</jandex.version>
         <bytebuddy.version>1.15.11</bytebuddy.version>
         <junit5.version>5.13.4</junit5.version>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>3.9.11</maven.version>
         <assertj.version>3.27.4</assertj.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <jboss-logmanager.version>3.1.2.Final</jboss-logmanager.version>

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -451,7 +451,7 @@
         "supported-maven-versions": "[3.6.2,)",
         "minimum-java-version": "11",
         "recommended-java-version": "17",
-        "proposed-maven-version": "3.9.9",
+        "proposed-maven-version": "3.9.11",
         "maven-wrapper-version": "3.3.2",
         "gradle-wrapper-version": "9.0.0"
       }

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.9</proposed-maven-version>
+        <proposed-maven-version>3.9.11</proposed-maven-version>
         <maven-wrapper.version>3.3.2</maven-wrapper.version>
         <!-- When updating gradle-wrapper.version, make sure to also update files in
              independent-projects/tools/base-codestarts/src/main/resources/codestarts


### PR DESCRIPTION
Bumps maven to 3.9.11 and maven-plugin-annotations to 3.15.1.

Draft until;
-  ~~distribution is available so `distributionSha256Sum` can be updated in `.mvn/wrapper/maven-wrapper.properties`. Release is tagged, build not there yet.~~
- ~~mvnd 1.0.3 using maven 3.9.11 is available~~ see (https://github.com/quarkusio/quarkus/pull/48915#issuecomment-3258871494)

Fixes #49906
