### PR TITLE
Restore another DevServiceDescriptionBuildItem constructor

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
@@ -17,6 +17,11 @@ public final class DevServiceDescriptionBuildItem extends MultiBuildItem {
         this(name, null, (Supplier<ContainerInfo>) null, configs);
     }
 
+    public DevServiceDescriptionBuildItem(String name, ContainerInfo containerInfo,
+            Map<String, String> configs) {
+        this(name, null, () -> containerInfo, configs);
+    }
+
     public DevServiceDescriptionBuildItem(String name, String description, ContainerInfo containerInfo,
             Map<String, String> configs) {
         this(name, description, () -> containerInfo, configs);


### PR DESCRIPTION
This is used in the Wiremock extension in the quarkiverse

- See: https://github.com/quarkusio/quarkus/pull/48849#issuecomment-3068606842