### PR TITLE
Share RuntimeOverrideConfigSource between static init and runtime between tests

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeOverrideConfigSourceBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeOverrideConfigSourceBuilder.java
@@ -1,10 +1,15 @@
 package io.quarkus.runtime.configuration;
 
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
 import io.smallrye.config.SmallRyeConfigBuilder;
 
 public class RuntimeOverrideConfigSourceBuilder implements ConfigBuilder {
+    private static final ConfigSource RUNTIME_OVERRIDE_CONFIG_SOURCE = new RuntimeOverrideConfigSource(
+            Thread.currentThread().getContextClassLoader());
+
     @Override
     public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
-        return builder.withSources(new RuntimeOverrideConfigSource(builder.getClassLoader()));
+        return builder.withSources(RUNTIME_OVERRIDE_CONFIG_SOURCE);
     }
 }


### PR DESCRIPTION
Tests use `RuntimeOverrideConfigSource` to override configuration set via `io.quarkus.test.common.QuarkusTestResourceLifecycleManager#start`. A new instance of the source is set to both static init and runtime, but the static init source may leak configuration from previous tests.

The change makes a single source for both static and runtime to it is cleared and values set for both phases.

From https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/QuarkusTest.20failing.3A.20build-time.20vs.20runtime.20config.20mismatch/with/528649047