### PR TITLE
Exclude `bcprov-jdk15on` to avoid conflicts with `bcprov-jdk18on`

### DIFF
--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -115,6 +115,13 @@
             <artifactId>apacheds-protocol-dns</artifactId>
             <version>${apacheds-protocol-dns.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- exclude bcprov-jdk15on to avoid conflicts with bcprov-jdk18on -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This excludes the `org.bouncycastle:bcprov-jdk15on` JAR from the classpath to avoid potential conflicts

From:

<img width="361" height="194" alt="image" src="https://github.com/user-attachments/assets/c28685ef-1df4-4715-b276-1666df9e4cee" />


To: 

<img width="361" height="172" alt="image" src="https://github.com/user-attachments/assets/b1b9b3c8-a5bc-4cf0-acde-809a5cb3bc42" />
