### PR TITLE
Fail by default if app is relying on global (REST) serialization settings for Hibernate ORM's XML/JSON serialization

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -234,7 +234,7 @@ public interface HibernateOrmConfig {
              * Only available to mitigate migration from the current Quarkus-preconfigured format mappers (that will be removed
              * in the future version).
              */
-            @WithDefault("warn")
+            @WithDefault("fail")
             BuiltinFormatMapperBehaviour global();
         }
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
@@ -41,6 +41,7 @@ import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
 import io.quarkus.hibernate.orm.runtime.customized.FormatMapperKind;
+import io.quarkus.hibernate.orm.runtime.customized.JsonFormatterCustomizationCheck;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
@@ -371,5 +372,12 @@ public final class HibernateProcessorUtil {
             descriptor.getProperties().setProperty(AvailableSettings.JAKARTA_HBM2DDL_LOAD_SCRIPT_SOURCE, "");
             descriptor.getProperties().setProperty(AvailableSettings.HBM2DDL_SKIP_DEFAULT_IMPORT_FILE, "true");
         }
+    }
+
+    public static JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck(Capabilities capabilities,
+            Optional<FormatMapperKind> jsonMapper) {
+        return jsonMapper.isEmpty() ? JsonFormatterCustomizationCheck.jsonFormatterCustomizationCheckSupplier(false, false)
+                : JsonFormatterCustomizationCheck.jsonFormatterCustomizationCheckSupplier(true,
+                        capabilities.isPresent(Capability.JACKSON));
     }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -218,7 +218,8 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                     runtimeSettings,
                     validatorFactory, cdiBeanManager, recordedState.getMultiTenancyStrategy(),
                     true,
-                    recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour());
+                    recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour(),
+                    recordedState.getBuildTimeSettings().getSource().getJsonFormatterCustomizationCheck());
         }
 
         log.debug("Found no matching persistence units");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BuiltinFormatMapperBehaviour.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BuiltinFormatMapperBehaviour.java
@@ -25,7 +25,7 @@ public enum BuiltinFormatMapperBehaviour {
         }
     },
     /**
-     * Currently the default one, uses a Quarkus preconfigured format mappers. If a format mapper operation is invoked a
+     * Uses a Quarkus preconfigured format mappers. If a format mapper operation is invoked a
      * warning is logged.
      */
     WARN {
@@ -35,8 +35,7 @@ public enum BuiltinFormatMapperBehaviour {
         }
     },
     /**
-     * If there is no user provided format mapper, a Quarkus preconfigured one will fail at runtime.
-     * Will become the default in the future versions of Quarkus.
+     * Currently the default one. If there is no user provided format mapper, a Quarkus preconfigured one will fail at runtime.
      */
     FAIL {
         @Override
@@ -60,7 +59,7 @@ public enum BuiltinFormatMapperBehaviour {
                         + (TYPE_JSON.equals(type) ? "@JsonFormat" : "@XmlFormat")
                         + " and @PersistenceUnitExtension"
                         + (PersistenceUnitUtil.isDefaultPersistenceUnit(puName) ? "" : "(\"%1$s\")")
-                        + "to address your database serialization/deserialization needs."
+                        + " to address your database serialization/deserialization needs."
                         + "\nSee the migration guide for more details and how to proceed.",
                 puName, type);
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/JsonFormatterCustomizationCheck.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/JsonFormatterCustomizationCheck.java
@@ -1,0 +1,121 @@
+package io.quarkus.hibernate.orm.runtime.customized;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.json.bind.Jsonb;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.jsonb.JsonbConfigCustomizer;
+
+/**
+ * Test whether the underlying Jackson Object Mapper / JSON-B used to create the "built-in" format mapper
+ * were modified and cannot be safely replaced by the Hibernate ORM's default ones.
+ */
+public interface JsonFormatterCustomizationCheck extends Predicate<ArcContainer> {
+    @Override
+    boolean test(ArcContainer container);
+
+    static JsonFormatterCustomizationCheck jsonFormatterCustomizationCheckSupplier(boolean required, boolean isJackson) {
+        if (!required) {
+            return new NotModifiedJsonFormatterCustomizationCheck();
+        }
+
+        if (isJackson) {
+            return new JacksonJsonFormatterCustomizationCheck();
+        }
+        return new NotModifiedJsonFormatterCustomizationCheck();
+    }
+
+    class NotModifiedJsonFormatterCustomizationCheck implements JsonFormatterCustomizationCheck {
+        @Override
+        public boolean test(ArcContainer container) {
+            return false;
+        }
+    }
+
+    class JacksonJsonFormatterCustomizationCheck implements JsonFormatterCustomizationCheck {
+        @Override
+        public boolean test(ArcContainer container) {
+            InstanceHandle<ObjectMapper> objectMapperInstance = container.instance(ObjectMapper.class);
+            if (!objectMapperInstance.isAvailable()) {
+                // We have no mapper so it wasn't modified, and we've probably used the JSONB instead.
+                return false;
+            }
+            if (!objectMapperInstance.getBean().isDefaultBean()) {
+                // A bean producer was used and the ObjectMapper is a user custom bean...
+                return true;
+            }
+
+            Instance<ObjectMapperCustomizer> customizers = container.select(ObjectMapperCustomizer.class);
+            if (!customizers.isUnsatisfied()) {
+                // There most likely are the following customizer available:
+                //  - io.quarkus.jackson.customizer.RegisterSerializersAndDeserializersCustomizer  --- this one ... Do we need to check if any serializers were added?
+                //  - io.quarkus.jackson.runtime.ConfigurationCustomizer  --- applies the "config properties", we check for those later hence "safe to ignore"
+                //  - io.quarkus.jackson.runtime.VertxHybridPoolObjectMapperCustomizer  --- doesn't look like this one affects the serialization -- ignore it
+                Set<String> allowedCustomizers = Set.of(
+                        "io.quarkus.jackson.customizer.RegisterSerializersAndDeserializersCustomizer",
+                        "io.quarkus.jackson.runtime.ConfigurationCustomizer",
+                        "io.quarkus.jackson.runtime.VertxHybridPoolObjectMapperCustomizer");
+                for (Instance.Handle<ObjectMapperCustomizer> handle : customizers.handles()) {
+                    if (allowedCustomizers.contains(handle.getBean().getClass().getName())) {
+                        continue;
+                    }
+                    // ObjectMapper was potentially customized
+                    return true;
+                }
+            }
+
+            // these won't affect representation of the objects in the DB so it's probably somewhat "safe" to allow them:
+            Set<String> acceptableConfigs = Set.of("quarkus.jackson.fail-on-unknown-properties",
+                    "quarkus.jackson.fail-on-empty-beans");
+            for (String propertyName : ConfigProvider.getConfig().getPropertyNames()) {
+                if (propertyName.startsWith("quarkus.jackson.") && !acceptableConfigs.contains(propertyName)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    class JsonbJsonFormatterCustomizationCheck implements JsonFormatterCustomizationCheck {
+        @Override
+        public boolean test(ArcContainer container) {
+            InstanceHandle<Jsonb> jsonbInstance = container.instance(Jsonb.class);
+            if (!jsonbInstance.isAvailable()) {
+                // We have no JSON-B bean so it wasn't modified.
+                return false;
+            }
+            if (!jsonbInstance.getBean().isDefaultBean()) {
+                // A bean producer was used and the JSON-B is a user custom bean...
+                return true;
+            }
+
+            Instance<JsonbConfigCustomizer> customizers = container.select(JsonbConfigCustomizer.class);
+            // There most likely are the following customizer available:
+            //  - io.quarkus.jsonb.customizer.RegisterSerializersAndDeserializersCustomizer  --- this one ... Do we need to check if any serializers were added?
+            Set<String> allowedCustomizers = Set.of(
+                    "io.quarkus.jsonb.customizer.RegisterSerializersAndDeserializersCustomizer");
+            for (Instance.Handle<JsonbConfigCustomizer> handle : customizers.handles()) {
+                if (allowedCustomizers.contains(handle.getBean().getClass().getName())) {
+                    continue;
+                }
+
+                // JSON-B was potentially customized
+                return true;
+            }
+
+            // JSON-B does not have the config properties so nothing else to check..
+
+            return false;
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import io.quarkus.hibernate.orm.runtime.config.DatabaseOrmCompatibilityVersion;
 import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
+import io.quarkus.hibernate.orm.runtime.customized.JsonFormatterCustomizationCheck;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.runtime.annotations.RecordableConstructor;
 
@@ -21,6 +22,7 @@ public class RecordedConfig {
     private final Map<String, String> quarkusConfigUnsupportedProperties;
     private final DatabaseOrmCompatibilityVersion databaseOrmCompatibilityVersion;
     private final BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour;
+    private final JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck;
 
     @RecordableConstructor
     public RecordedConfig(Optional<String> dataSource, Optional<String> dbKind,
@@ -28,6 +30,7 @@ public class RecordedConfig {
             MultiTenancyStrategy multiTenancyStrategy,
             DatabaseOrmCompatibilityVersion databaseOrmCompatibilityVersion,
             BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour,
+            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck,
             Map<String, String> quarkusConfigUnsupportedProperties) {
         Objects.requireNonNull(dataSource);
         Objects.requireNonNull(dbKind);
@@ -40,6 +43,7 @@ public class RecordedConfig {
         this.multiTenancyStrategy = multiTenancyStrategy;
         this.databaseOrmCompatibilityVersion = databaseOrmCompatibilityVersion;
         this.builtinFormatMapperBehaviour = builtinFormatMapperBehaviour;
+        this.jsonFormatterCustomizationCheck = jsonFormatterCustomizationCheck;
         this.quarkusConfigUnsupportedProperties = quarkusConfigUnsupportedProperties;
     }
 
@@ -69,6 +73,10 @@ public class RecordedConfig {
 
     public BuiltinFormatMapperBehaviour getBuiltinFormatMapperBehaviour() {
         return builtinFormatMapperBehaviour;
+    }
+
+    public JsonFormatterCustomizationCheck getJsonFormatterCustomizationCheck() {
+        return jsonFormatterCustomizationCheck;
     }
 
     public Map<String, String> getQuarkusConfigUnsupportedProperties() {

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -6,6 +6,7 @@ import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.co
 import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.configureSqlLoadScript;
 import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.hasEntities;
 import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.isHibernateValidatorPresent;
+import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.jsonFormatterCustomizationCheck;
 import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.jsonMapperKind;
 import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.setDialectAndStorageEngine;
 import static io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil.xmlMapperKind;
@@ -60,6 +61,7 @@ import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 import io.quarkus.hibernate.orm.runtime.customized.FormatMapperKind;
+import io.quarkus.hibernate.orm.runtime.customized.JsonFormatterCustomizationCheck;
 import io.quarkus.hibernate.orm.runtime.recording.RecordedConfig;
 import io.quarkus.hibernate.reactive.runtime.FastBootHibernateReactivePersistenceProvider;
 import io.quarkus.hibernate.reactive.runtime.HibernateReactiveRecorder;
@@ -243,6 +245,8 @@ public final class HibernateReactiveProcessor {
                 .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
         xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
                 .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
+        JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck = jsonFormatterCustomizationCheck(capabilities,
+                jsonMapper);
 
         //Some constant arguments to the following method:
         // - this is Reactive
@@ -257,6 +261,7 @@ public final class HibernateReactiveProcessor {
                         io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy.NONE,
                         hibernateOrmConfig.database().ormCompatibilityVersion(),
                         hibernateOrmConfig.mapping().format().global(),
+                        jsonFormatterCustomizationCheck,
                         persistenceUnitConfig.unsupportedProperties()),
                 null,
                 jpaModel.getXmlMappings(reactivePU.getName()),

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -247,7 +247,8 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
                     runtimeSettings,
                     validatorFactory, cdiBeanManager, recordedState.getMultiTenancyStrategy(),
                     PersistenceUnitsHolder.getPersistenceUnitDescriptors().size() == 1,
-                    recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour());
+                    recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour(),
+                    recordedState.getBuildTimeSettings().getSource().getJsonFormatterCustomizationCheck());
         }
 
         log.debug("Found no matching persistence units");

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
@@ -12,6 +12,7 @@ import io.quarkus.hibernate.orm.runtime.RuntimeSettings;
 import io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
+import io.quarkus.hibernate.orm.runtime.customized.JsonFormatterCustomizationCheck;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.recording.PrevalidatedQuarkusMetadata;
 
@@ -22,9 +23,11 @@ public final class FastBootReactiveEntityManagerFactoryBuilder extends FastBootE
             StandardServiceRegistry standardServiceRegistry, RuntimeSettings runtimeSettings, Object validatorFactory,
             Object cdiBeanManager, MultiTenancyStrategy strategy,
             boolean shouldApplySchemaMigration,
-            BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour) {
+            BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour,
+            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck) {
         super(puDescriptor, metadata, standardServiceRegistry, runtimeSettings, validatorFactory,
-                cdiBeanManager, strategy, shouldApplySchemaMigration, builtinFormatMapperBehaviour);
+                cdiBeanManager, strategy, shouldApplySchemaMigration, builtinFormatMapperBehaviour,
+                jsonFormatterCustomizationCheck);
     }
 
     @Override

--- a/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
@@ -5,6 +5,8 @@ quarkus.datasource.jdbc.max-size=8
 
 quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql.defaultpu
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+#only set it for the default pu as the other one configures a custom mapper and should not fail:
+quarkus.hibernate-orm.mapping.format.global=ignore
 
 #Necessary for assertions in JPAFunctionalityInGraalITCase:
 quarkus.native.enable-reports=true

--- a/integration-tests/jpa-postgresql/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/main/resources/application.properties
@@ -6,6 +6,8 @@ quarkus.datasource.jdbc.max-size=8
 quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql.defaultpu
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.schema-management.create-schemas=true
+#only set it for the default pu as the other one configures a custom mapper and should not fail:
+quarkus.hibernate-orm.mapping.format.global=ignore
 # Define non-default PU so that we can configure a custom JSON format mapper. The default PU is using the default mapper.
 quarkus.hibernate-orm."other".datasource=<default>
 quarkus.hibernate-orm."other".packages=io.quarkus.it.jpa.postgresql.otherpu


### PR DESCRIPTION
This is the next step to get the ORM's format mappers more independent from the more broadly used default Quarkus object mappers (jsonb and so on).

I kept the `warn` option even though at this point it would seem a bit pointless.
 
It probably would require a migration note... if so, maybe something along the lines:

```md
The default value of `quarkus.hibernate-orm.mapping.format.global` has changed to `fail`. 
If the application relies on persisting JSON/XML in the database via Hibernate ORM/Reactive the users should review their serialization/deserialization configuration. If there is no customization to the Quarkus' JSON/XML formatting, 
it is possible to set `quarkus.hibernate-orm.mapping.format.global=ignore`, 
this will result in bypassing these formatting facilities and relying on Hibernate ORM to configure the default serialization. 
Otherwise, implement the custom `FromatMapper` bean as described (https://quarkus.io/guides/hibernate-orm#json_xml_serialization_deserialization)[here].
```

note: this is for 3.26, no backports required.

* Follows up on https://github.com/quarkusio/quarkus/pull/48177#issuecomment-2975651876

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

