### PR TITLE
Use consistent ordering of bean info in toString()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -978,9 +978,13 @@ public class BeanInfo implements InjectionTargetInfo {
         StringBuilder builder = new StringBuilder();
         builder.append(getType());
         builder.append(" bean [types=");
-        builder.append(types);
+        List<Type> sortedTypes = new ArrayList<>(types);
+        sortedTypes.sort(ToStringComparator.INSTANCE);
+        builder.append(sortedTypes);
         builder.append(", qualifiers=");
-        builder.append(qualifiers);
+        List<AnnotationInstance> sortedQualifiers = new ArrayList<>(qualifiers);
+        sortedQualifiers.sort(ToStringComparator.INSTANCE);
+        builder.append(sortedQualifiers);
         builder.append(", target=");
         builder.append(target.isPresent() ? target.get() : "n/a");
         if (declaringBean != null) {
@@ -1295,6 +1299,16 @@ public class BeanInfo implements InjectionTargetInfo {
         public Builder forceApplicationClass(boolean forceApplicationClass) {
             this.forceApplicationClass = forceApplicationClass;
             return this;
+        }
+    }
+
+    private static class ToStringComparator implements Comparator<Object> {
+
+        private static final ToStringComparator INSTANCE = new ToStringComparator();
+
+        @Override
+        public int compare(Object o1, Object o2) {
+            return o1.toString().compareTo(o2.toString());
         }
     }
 


### PR DESCRIPTION
The only thing this does is make reading
information about CDI related failures easier

For example you go from this failure:

```
[ERROR] 	- available beans:
[ERROR] 		- SYNTHETIC bean [types=[dev.langchain4j.store.embedding.EmbeddingStore, dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore, dev.langchain4j.store.embedding.EmbeddingStore<dev.langchain4j.data.segment.TextSegment>, java.lang.Object], qualifiers=[@Default, @Any], target=n/a]
[ERROR] 		- SYNTHETIC bean [types=[dev.langchain4j.store.embedding.EmbeddingStore, dev.langchain4j.store.embedding.EmbeddingStore<dev.langchain4j.data.segment.TextSegment>, java.lang.Object, io.quarkiverse.langchain4j.redis.RedisEmbeddingStore], qualifiers=[@Default, @Any], target=n/a]
```

to this one:

```
[ERROR] 	- available beans:
[ERROR] 		- SYNTHETIC bean [types=[dev.langchain4j.store.embedding.EmbeddingStore, dev.langchain4j.store.embedding.EmbeddingStore<dev.langchain4j.data.segment.TextSegment>, dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore, java.lang.Object], qualifiers=[@Any, @Default], target=n/a]
[ERROR] 		- SYNTHETIC bean [types=[dev.langchain4j.store.embedding.EmbeddingStore, dev.langchain4j.store.embedding.EmbeddingStore<dev.langchain4j.data.segment.TextSegment>, io.quarkiverse.langchain4j.redis.RedisEmbeddingStore, java.lang.Object], qualifiers=[@Any, @Default], target=n/a]
```

which makes things slightly easier to understand as the eye can more easily spot the differences between the two conflicting beans