### PR TITLE
Remove Quarkus thread dumper. Support native mode thread dumps and jcmd

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -257,11 +257,13 @@ public interface NativeConfig {
      * Enable monitoring various monitoring options. The value should be comma separated.
      * <ul>
      * <li><code>jfr</code> for JDK flight recorder support</li>
+     * <li><code>jcmd</code> for JCMD support</li>
      * <li><code>jvmstat</code> for JVMStat support</li>
      * <li><code>heapdump</code> for heapdump support</li>
      * <li><code>jmxclient</code> for JMX client support (experimental)</li>
      * <li><code>jmxserver</code> for JMX server support (experimental)</li>
      * <li><code>nmt</code> for native memory tracking support</li>
+     * <li><code>threaddump</code> for thread dumping on SIGBREAK/SIGQUIT support</li>
      * <li><code>all</code> for all monitoring features</li>
      * <li><code>none</code> for explicitly turning off all monitoring features</li>
      * </ul>
@@ -515,6 +517,10 @@ public interface NativeConfig {
          */
         HEAPDUMP,
         /**
+         * JCMD support.
+         */
+        JCMD,
+        /**
          * JVMStat support.
          */
         JVMSTAT,
@@ -534,6 +540,10 @@ public interface NativeConfig {
          * Native memory tracking support.
          */
         NMT,
+        /**
+         * Thread dumping support.
+         */
+        THREADDUMP,
         /**
          * All monitoring features.
          */

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -954,6 +954,15 @@ public class NativeImageBuildStep {
                         // --enable-monitoring=heapdump is not supported on Windows
                         monitoringOptions.add(NativeConfig.MonitoringOption.HEAPDUMP);
                     }
+
+                    if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_2_0) >= 0) {
+                        /*
+                         * After GraalVM/Mandrel 24.2, JCMD becomes available. The Quarkus thread dumper handles
+                         * SIGQUIT which interferes with JCMD. To avoid this problem, Quarkus must use the GraalVM
+                         * built-in thread dumper instead for versions beyond 24.2.
+                         */
+                        monitoringOptions.add(NativeConfig.MonitoringOption.THREADDUMP);
+                    }
                 }
 
                 if (!monitoringOptions.isEmpty()) {

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -935,6 +935,10 @@ include at build time.
 |===
 |Monitoring Option |Description |Availability As Of
 
+|jcmd
+|Include JCMD support
+|GraalVM CE for JDK 24 Mandrel 24.2
+
 |jfr
 |Include JDK Flight Recorder support
 |GraalVM CE 21.3 Mandrel 21.3
@@ -958,6 +962,10 @@ include at build time.
 |nmt
 |Adds support for native memory tracking.
 |GraalVM for JDK 23 Mandrel 24.1
+
+|threaddump
+|Adds support for dumping thread stacks on SIGQUIT/SIGBREAK.
+|GraalVM for JDK 22 Mandrel 24.0
 
 |none
 |Disables support for all monitoring options that would be enabled by default in Quarkus


### PR DESCRIPTION
### Summary
This PR removes the Quarkus thread dumping on SIGQUIT/SIGBREAK code. It is no longer needed because GraalVM supports it's own built-in thread dumps. This change is necessary because the Quarkus SIGQUIT/SIGBREAK handler overwrites the GraalVM handler that is required for the AttachAPI to work, which causes `jcmd` support to fail. 

The `JCMD` and `THREADDUMP` monitoring options have also been added to NativeConfig.java.


-- -- 
Please see the related issue for more details: https://github.com/quarkusio/quarkus/issues/48871
