### PR TITLE
Avoids some WARNINGs from io.smallrye.common.process.Logging

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -104,7 +104,8 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
             pb.output().inherited().error().inherited();
         }
         try {
-            pb.run();
+            // logOnSuccess(false) avoids WARNING from io.smallrye.common.process.Logging
+            pb.error().logOnSuccess(false).run();
         } catch (Exception e) {
             throw new RuntimeException("Failed to pull builder image '" + effectiveBuilderImage + "'", e);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.pkg.steps;
 
 import static io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem.Arch.AMD64;
+import static io.smallrye.common.process.ProcessBuilder.newBuilder;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,7 +60,6 @@ import io.quarkus.sbom.ApplicationComponent;
 import io.quarkus.sbom.ApplicationManifestConfig;
 import io.smallrye.common.os.OS;
 import io.smallrye.common.process.AbnormalExitException;
-import io.smallrye.common.process.ProcessBuilder;
 import io.smallrye.common.process.ProcessUtil;
 
 public class NativeImageBuildStep {
@@ -566,7 +566,8 @@ public class NativeImageBuildStep {
 
     private static String testGCCArgument(String argument) {
         try {
-            ProcessBuilder.exec("cc", "-v", "-E", argument, "-");
+            newBuilder("cc", "-v", "-E", argument, "-")
+                    .error().logOnSuccess(log.isTraceEnabled()).run();
             return argument;
         } catch (Exception ignored) {
             return "";


### PR DESCRIPTION
The problem is that io.smallrye.common.process treats *non empty* stdErr as something to print a WARNING about.
At best case it prints the stdErr twice. A worse scenario is a confusion caused for log scanning tools such as Mandrel integration testsuite that suddenly report benign things like:

```
[WARNING] [io.smallrye.common.process] SRCOM05000: Command podman (pid 2448670) completed but logged errors:
        Trying to pull quay.io/quarkus/ubi-quarkus-mandrel-builder-image:dev...
        Getting image source signatures
```
i.e. it makes a WARNING out of a perfectly fine podman output. 

This PR scratches the itch for some cases, but the Quarkus codebase seems riddled wit Smallrye process now, so perhaps a more general solution would be in order.

- Fixes #48946