### PR TITLE
Add containerId to DevServicesContent

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -34,6 +34,12 @@ public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult>
             for (Map.Entry<String, String> entry : devServicesRegistry.getConfigForAllRunningServices().entrySet()) {
                 propertyConsumer.accept(entry.getKey(), entry.getValue());
             }
+            for (DevServicesResultBuildItem devService : devServices) {
+                if (devService.getContainerId() != null) {
+                    propertyConsumer.accept("quarkus.devservices." + devService.getName() + ".containerId",
+                            devService.getContainerId());
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
For example, for mongo the property could look like:

```
quarkus.devservices.mongodb-client.containerId=someId
```

This info could then be used by tests that need to actually interact with the container itself in some way.

- Relates to: #48963