### PR TITLE
Attempt to reduce spurious linkage errors

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -147,7 +147,10 @@ public final class RunnerClassLoader extends ClassLoader {
     }
 
     private Class<?> defineClass(String name, byte[] data, ClassLoadingResource resource) {
-        Class<?> loaded;
+        Class<?> loaded = findLoadedClass(name);
+        if (loaded != null) {
+            return loaded;
+        }
         try {
             return defineClass(name, data, 0, data.length, resource.getProtectionDomain());
         } catch (LinkageError e) {


### PR DESCRIPTION
Since the `RunnerClassLoader` is (more or less) lockless, if a class is concurrently redefined, we can get a spurious `LinkageError` which is consumed and ignored. We can reduce this incidence by doing one last probe for the loaded class before we attempt to define it but after we have done all of the resource loader work.

Related to #39952.