### PR TITLE
Improve error message when trying to index class not in class loader

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -162,6 +162,11 @@ public class IndexingUtil {
         if (classInfo == null) {
             log.debugf("Index class: %s", className);
             try (InputStream stream = IoUtil.readClass(classLoader, className)) {
+                if (stream == null) {
+                    throw new IllegalStateException(
+                            "Failed to index: " + className + ", class not present in class loader: " + classLoader);
+                }
+
                 ClassSummary summary = indexer.indexWithSummary(stream);
                 additionalIndex.add(summary.name());
                 superclassName = summary.superclassName();


### PR DESCRIPTION
Related to some discussions in #48950

