### PR TITLE
Fail the build if runtime Config objects are used during deployment time

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoaderConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoaderConfig.java
@@ -10,7 +10,7 @@ public interface ExtensionLoaderConfig {
     /**
      * Report runtime Config objects used during deployment time.
      */
-    @WithDefault("warn")
+    @WithDefault("fail")
     ReportRuntimeConfigAtDeployment reportRuntimeConfigAtDeployment();
 
     enum ReportRuntimeConfigAtDeployment {

--- a/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>io.quarkiverse.artemis</groupId>
                 <artifactId>quarkus-artemis-bom</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
In 3.25 we added a warning if extensions use runtime config objects during deployment time: https://github.com/quarkusio/quarkus/pull/48500

This changes the warning to fail instead.

- Fixes #39431

**Do not Merge - This is to give us a view on how the ecosystem behaves so we can fix the issues**:
- https://github.com/quarkiverse/quarkus-artemis/pull/864
- https://github.com/quarkiverse/quarkus-amazon-services/pull/1789
- https://github.com/apache/camel-quarkus/pull/7524
- https://github.com/quarkiverse/quarkus-jberet/pull/413
- https://github.com/quarkiverse/quarkus-langchain4j/pull/1623
- https://github.com/quarkiverse/quarkus-neo4j/pull/379
- https://github.com/quarkiverse/quarkus-mcp-server/pull/392