### PR TITLE
Improve readability by replacing numeric literals with named constants

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
@@ -12,6 +12,8 @@ import io.quarkus.deployment.TestClassLoader;
 
 public class SimpleClassProxyTest {
 
+    private static final int EXPECTED_INVOCATION_COUNT = 4;
+
     @Test
     public void testProxyCreation() throws InstantiationException, IllegalAccessException {
         SimpleInvocationHandler invocationHandler = new SimpleInvocationHandler();
@@ -27,7 +29,7 @@ public class SimpleClassProxyTest {
         assertMethod3(instance);
         assertMethod4(instance);
 
-        assertThat(invocationHandler.invocationCount).isEqualTo(4);
+        assertThat(invocationHandler.invocationCount).isEqualTo(EXPECTED_INVOCATION_COUNT);
     }
 
     private void assertMethod1(SimpleClass instance) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
@@ -8,6 +8,8 @@ import io.quarkus.deployment.TestClassLoader;
 
 public class SimpleInterfaceProxyTest {
 
+    private static final int EXPECTED_INVOCATION_COUNT = 2;
+
     @Test
     public void testProxyCreation() throws InstantiationException, IllegalAccessException {
         FirstArgInvocationHandler invocationHandler = new FirstArgInvocationHandler();
@@ -24,7 +26,7 @@ public class SimpleInterfaceProxyTest {
 
         instance.doNothing();
 
-        assertThat(invocationHandler.invocationCount).isEqualTo(2);
+        assertThat(invocationHandler.invocationCount).isEqualTo(EXPECTED_INVOCATION_COUNT);
     }
 
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Replaced inline numeric literals in test assertions with descriptive named constants.  
This improves readability and clarifies the intent of the expected values in assertions.  
Only test files were modified; no changes to production code.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
