### PR TITLE
Bump io.strimzi:strimzi-test-container from 0.109.1 to 0.109.2 to comply with Apache Licence

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -143,7 +143,7 @@
         <kafka3.version>4.0.0</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.10.5</snappy.version>
-        <strimzi-test-container.version>0.109.1</strimzi-test-container.version>
+        <strimzi-test-container.version>0.109.2</strimzi-test-container.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
         <scala.version>2.13.16</scala.version>
         <aws-lambda-java.version>1.3.0</aws-lambda-java.version>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -20,7 +20,7 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
 
         <rxjava1.version>1.3.8</rxjava1.version>
-        <strimzi-test-container.version>0.109.1</strimzi-test-container.version>
+        <strimzi-test-container.version>0.109.2</strimzi-test-container.version>
 
         <opentelemetry-proto.version>1.3.2-alpha</opentelemetry-proto.version>
     </properties>


### PR DESCRIPTION
Bump strimzi-test-container to 1.109.2 as older version depends on com.arcmutate:pitest-annotations:jar which is available under the Arcmutate License, which states that
`Usage requires the purchase (or grant) of a licence key`. 


