### PR TITLE
Allow users to turn off RestAssured logging

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -298,6 +298,14 @@ public interface TestConfig {
         Map<String, String> volumeMounts();
     }
 
+    interface RestAssured {
+        /**
+         * Enable logging of both the request and the response if REST Assureds test validation fails
+         */
+        @WithDefault("true")
+        boolean enableLoggingOnFailure();
+    }
+
     enum Mode {
         PAUSED,
         ENABLED,

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
@@ -122,7 +122,10 @@ public class RestAssuredURLManager {
         configureTimeouts(timeout);
 
         oldRequestSpecification = RestAssured.requestSpecification;
-        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        if (ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.test.rest-assured.enable-logging-on-failure", Boolean.class).orElse(true)) {
+            RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        }
     }
 
     private static void configureTimeouts(Duration d) {


### PR DESCRIPTION
This can now be done by using:

```
quarkus.test.rest-assured.enable-logging-on-failure=false
```

- Closes: #48885