### PR TITLE
Tidy unneeded dependency

### DIFF
--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -31,14 +31,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--
-          This should be removed once we upgrade to commons-compress 1.26.1 (or similar).
-          See https://github.com/quarkusio/quarkus/issues/38990
-        -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit4-mock</artifactId>


### PR DESCRIPTION
I've checked with `gradle quarkusDev` and the error described in https://github.com/quarkusio/quarkus/issues/38990 no longer occurs. This is expected, since we've moved to commons-compress 1.27.1.