### PR TITLE
Apply manifests from URL and await resources with readiness

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-dev-services.adoc
+++ b/docs/src/main/asciidoc/kubernetes-dev-services.adoc
@@ -90,8 +90,7 @@ quarkus.kubernetes-client.devservices.manifests=kubernetes/namespace.yaml
 
 When applying multiple properties, you can apply them as:
 ```
-quarkus.kubernetes-client.devservices.manifests[0]=kubernetes/first_manifest.yaml
-quarkus.kubernetes-client.devservices.manifests[1]=kubernetes/second_manifest.yaml
+quarkus.kubernetes-client.devservices.manifests=kubernetes/first_manifest.yaml,kubernetes/second_manifest.yaml
 ```
 
 It is also possible to apply manifests from a URL. So the following syntax would also be possible:

--- a/docs/src/main/asciidoc/kubernetes-dev-services.adoc
+++ b/docs/src/main/asciidoc/kubernetes-dev-services.adoc
@@ -88,6 +88,11 @@ And then add the following property to your `application.properties`:
 quarkus.kubernetes-client.devservices.manifests=kubernetes/namespace.yaml
 ```
 
+It is also possible to apply manifests from a URL. So the following syntax would also be possible:
+```
+quarkus.kubernetes-client.devservices.manifests=https://example.com/kubernetes/namespace.yaml
+```
+
 === Deploying helm charts
 `quarkus.kubernetes-client.devservices.manifests` only supports manifests. If you want to deploy a helm chart, you can use the `k3s` flavor and deploy a `HelmChart` manifest. See https://docs.k3s.io/helm for more information on how to use helm charts with k3s.
 

--- a/docs/src/main/asciidoc/kubernetes-dev-services.adoc
+++ b/docs/src/main/asciidoc/kubernetes-dev-services.adoc
@@ -88,10 +88,21 @@ And then add the following property to your `application.properties`:
 quarkus.kubernetes-client.devservices.manifests=kubernetes/namespace.yaml
 ```
 
+When applying multiple properties, you can apply them as:
+```
+quarkus.kubernetes-client.devservices.manifests[0]=kubernetes/first_manifest.yaml
+quarkus.kubernetes-client.devservices.manifests[1]=kubernetes/second_manifest.yaml
+```
+
 It is also possible to apply manifests from a URL. So the following syntax would also be possible:
 ```
 quarkus.kubernetes-client.devservices.manifests=https://example.com/kubernetes/namespace.yaml
 ```
+
+NOTE: Quarkus will apply the manifests in the order they are specified in the list.
+
+NOTE: Quarkus will await resources such as deployments to be ready before moving on to the next manifest.
+All applied resources are guaranteed to be ready by the time your application finishes startup.
 
 === Deploying helm charts
 `quarkus.kubernetes-client.devservices.manifests` only supports manifests. If you want to deploy a helm chart, you can use the `k3s` flavor and deploy a `HelmChart` manifest. See https://docs.k3s.io/helm for more information on how to use helm charts with k3s.

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -230,14 +230,14 @@ public class DevServicesKubernetesProcessor {
                             });
                         }
                     } catch (Exception ex) {
-                        log.errorf("Failed to deploy manifest %s: %s", manifestPath, ex.getMessage());
+                        log.errorf("Failed to apply manifest %s: %s", manifestPath, ex.getMessage());
                     }
                 }
 
                 log.infof("Applied manifest %s.", manifestPath);
             }
         } catch (Exception e) {
-            log.error("Failed to create Kubernetes client while trying to deploy manifests.", e);
+            log.error("Failed to create Kubernetes client while trying to apply manifests.", e);
         }
     }
 

--- a/integration-tests/kubernetes-client-devservices/src/main/resources/application.properties
+++ b/integration-tests/kubernetes-client-devservices/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-quarkus.kubernetes-client.devservices.manifests=kubernetes/namespace.yaml
+quarkus.kubernetes-client.devservices.manifests[0]=kubernetes/namespace.yaml
+quarkus.kubernetes-client.devservices.manifests[1]=https://k8s.io/examples/admin/namespace-dev.yaml

--- a/integration-tests/kubernetes-client-devservices/src/main/resources/application.properties
+++ b/integration-tests/kubernetes-client-devservices/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-quarkus.kubernetes-client.devservices.manifests[0]=kubernetes/namespace.yaml
-quarkus.kubernetes-client.devservices.manifests[1]=https://k8s.io/examples/admin/namespace-dev.yaml
+quarkus.kubernetes-client.devservices.manifests=kubernetes/namespace.yaml,https://k8s.io/examples/admin/namespace-dev.yaml

--- a/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/DevServicesKubernetesTest.java
+++ b/integration-tests/kubernetes-client-devservices/src/test/java/io/quarkus/kubernetes/client/devservices/it/DevServicesKubernetesTest.java
@@ -26,8 +26,15 @@ public class DevServicesKubernetesTest {
     }
 
     @Test
-    @DisplayName("specified manifest must be applied to the cluster by the dev service")
-    public void manifestIsApplied() {
+    @DisplayName("specified manifest in the resources folder must be applied to the cluster by the dev service")
+    public void resourceManifestIsApplied() {
         Assertions.assertNotNull(kubernetesClient.namespaces().withName("example-namespace").get());
+    }
+
+    @Test
+    @DisplayName("specified manifest from a URL must be applied to the cluster by the dev service")
+    public void urlManifestIsApplied() {
+        // Applied by https://k8s.io/examples/admin/namespace-dev.yaml
+        Assertions.assertNotNull(kubernetesClient.namespaces().withName("development").get());
     }
 }


### PR DESCRIPTION
This PR is a follow-up of https://github.com/quarkusio/quarkus/pull/48536 to include a few improvements I've noticed since experimenting with this new feature in Quarkus 3.25.0.CR1

The first is the ability to apply a manifest from a URL.. Often, one of the installation options for applications on Kubernetes is a single manifest that installs all related resources, e.g. https://kueue.sigs.k8s.io/docs/installation/#install-by-kubectl. You then don't want to add a 1MB YAML file to your resources folder and commit it to git, so it makes sense to apply directly from the URL.

Secondly is for startup to await resources that have readiness statuses (e.g. deployments). If you deploy, for example, a CRD controller (or any application for that fact), you often want it to be fully running before you start running tests or interact with it in dev mode. So it makes sense to delay startup until all manifests are ready. Besides that, there is another reason we want to do this that cannot be replaced by the user writing code themselves to await the deployments: Sometimes, manifests being deployed depend on it.

We, for example, have a setup where one of the manifests we deploy is a full CRD controller, and we then follow it up with a custom resource. This custom resource will, however, fail to apply until the deployment for the CRD controller is ready, and since both the CRD controller and custom resource are part of the Quarkus startup, you have no way to control this startup process as a user without Quarkus awaiting the CRD deployment.

The strategy for awaiting resources is as follows: We always deploy all resources within a single manifest without any await in between. We then await between manifest deployments for the resources of the manifest. This makes most sense as manifests may depend on each other, but the internal resources of a single manifest will never depend on a readiness await (since then `kubectl apply -f manifest.yaml` would naturally fail, which means the manifest itself is just broken).