### PR TITLE
[3.25] Backport "QuarkusComponentTest: skip system config sources by default"

### DIFF
--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -297,6 +297,12 @@ NOTE: `@io.quarkus.test.component.TestConfigProperty` declared on a `@Nested` te
 
 CDI beans are also automatically registered for all injected https://smallrye.io/smallrye-config/Main/config/mappings/[Config Mappings]. The mappings are populated with the test configuration properties.
 
+=== Config sources
+
+By default, only the config properties from `application.properties` and properties set by the `@TestConfigProperty` annotation or with the `QuarkusComponentTestExtensionBuilder#configProperty(String, String)` method are included in the test config.
+System properties and ENV variables are _not_ included in the test config by default.
+However, you can use `@QuarkusComponentTest#useSystemConfigSources()` or `QuarkusComponentTestExtensionBuilder#useSystemConfigSources()` to configure this behavior.
+
 == Mocking CDI Interceptors
 
 If a tested component class declares an interceptor binding then you might need to mock the interception too.

--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -297,12 +297,6 @@ NOTE: `@io.quarkus.test.component.TestConfigProperty` declared on a `@Nested` te
 
 CDI beans are also automatically registered for all injected https://smallrye.io/smallrye-config/Main/config/mappings/[Config Mappings]. The mappings are populated with the test configuration properties.
 
-=== Config sources
-
-By default, only the config properties from `application.properties` and properties set by the `@TestConfigProperty` annotation or with the `QuarkusComponentTestExtensionBuilder#configProperty(String, String)` method are included in the test config.
-System properties and ENV variables are _not_ included in the test config by default.
-However, you can use `@QuarkusComponentTest#useSystemConfigSources()` or `QuarkusComponentTestExtensionBuilder#useSystemConfigSources()` to configure this behavior.
-
 == Mocking CDI Interceptors
 
 If a tested component class declares an interceptor binding then you might need to mock the interception too.

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
@@ -80,4 +80,11 @@ public @interface QuarkusComponentTest {
      */
     Class<? extends Converter<?>>[] configConverters() default {};
 
+    /**
+     * If set to {@code true} then config sources for system properties and ENV variables are included in the test config.
+     *
+     * @see QuarkusComponentTestExtensionBuilder#useSystemConfigSources(boolean)
+     */
+    boolean useSystemConfigSources() default false;
+
 }

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
@@ -82,9 +82,11 @@ public @interface QuarkusComponentTest {
 
     /**
      * If set to {@code true} then config sources for system properties and ENV variables are included in the test config.
+     * <p>
+     * This will default to {@code true} in Quarkus 3.26.0
      *
      * @see QuarkusComponentTestExtensionBuilder#useSystemConfigSources(boolean)
      */
-    boolean useSystemConfigSources() default false;
+    boolean useSystemConfigSources() default true;
 
 }

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
@@ -63,7 +63,7 @@ class QuarkusComponentTestConfiguration {
 
     static final QuarkusComponentTestConfiguration DEFAULT = new QuarkusComponentTestConfiguration(Map.of(), Set.of(),
             List.of(), false, true, QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL, List.of(),
-            DEFAULT_CONVERTERS, null);
+            DEFAULT_CONVERTERS, null, false);
 
     private static final Logger LOG = Logger.getLogger(QuarkusComponentTestConfiguration.class);
 
@@ -71,6 +71,7 @@ class QuarkusComponentTestConfiguration {
     final Set<Class<?>> componentClasses;
     final List<MockBeanConfiguratorImpl<?>> mockConfigurators;
     final boolean useDefaultConfigProperties;
+    final boolean useSystemConfigSources;
     final boolean addNestedClassesAsComponents;
     final int configSourceOrdinal;
     final List<AnnotationsTransformer> annotationsTransformers;
@@ -81,11 +82,12 @@ class QuarkusComponentTestConfiguration {
             List<MockBeanConfiguratorImpl<?>> mockConfigurators, boolean useDefaultConfigProperties,
             boolean addNestedClassesAsComponents, int configSourceOrdinal,
             List<AnnotationsTransformer> annotationsTransformers, List<Converter<?>> configConverters,
-            Consumer<SmallRyeConfigBuilder> configBuilderCustomizer) {
+            Consumer<SmallRyeConfigBuilder> configBuilderCustomizer, boolean useSystemConfigSources) {
         this.configProperties = configProperties;
         this.componentClasses = componentClasses;
         this.mockConfigurators = mockConfigurators;
         this.useDefaultConfigProperties = useDefaultConfigProperties;
+        this.useSystemConfigSources = useSystemConfigSources;
         this.addNestedClassesAsComponents = addNestedClassesAsComponents;
         this.configSourceOrdinal = configSourceOrdinal;
         this.annotationsTransformers = annotationsTransformers;
@@ -97,6 +99,7 @@ class QuarkusComponentTestConfiguration {
         Map<String, String> configProperties = new HashMap<>(this.configProperties);
         List<Class<?>> componentClasses = new ArrayList<>(this.componentClasses);
         boolean useDefaultConfigProperties = this.useDefaultConfigProperties;
+        boolean useSystemConfigSources = this.useSystemConfigSources;
         boolean addNestedClassesAsComponents = this.addNestedClassesAsComponents;
         int configSourceOrdinal = this.configSourceOrdinal;
         List<AnnotationsTransformer> annotationsTransformers = new ArrayList<>(this.annotationsTransformers);
@@ -112,6 +115,7 @@ class QuarkusComponentTestConfiguration {
         if (testAnnotation != null) {
             Collections.addAll(componentClasses, testAnnotation.value());
             useDefaultConfigProperties = testAnnotation.useDefaultConfigProperties();
+            useSystemConfigSources = testAnnotation.useSystemConfigSources();
             addNestedClassesAsComponents = testAnnotation.addNestedClassesAsComponents();
             configSourceOrdinal = testAnnotation.configSourceOrdinal();
             Class<? extends AnnotationsTransformer>[] transformers = testAnnotation.annotationsTransformers();
@@ -148,7 +152,8 @@ class QuarkusComponentTestConfiguration {
 
         return new QuarkusComponentTestConfiguration(Map.copyOf(configProperties), Set.copyOf(componentClasses),
                 this.mockConfigurators, useDefaultConfigProperties, addNestedClassesAsComponents, configSourceOrdinal,
-                List.copyOf(annotationsTransformers), List.copyOf(configConverters), configBuilderCustomizer);
+                List.copyOf(annotationsTransformers), List.copyOf(configConverters), configBuilderCustomizer,
+                useSystemConfigSources);
     }
 
     private static void collectComponents(Class<?> testClass, boolean addNestedClassesAsComponents,
@@ -220,7 +225,7 @@ class QuarkusComponentTestConfiguration {
         }
         return new QuarkusComponentTestConfiguration(configProperties, componentClasses,
                 mockConfigurators, useDefaultConfigProperties, addNestedClassesAsComponents, configSourceOrdinal,
-                annotationsTransformers, configConverters, configBuilderCustomizer);
+                annotationsTransformers, configConverters, configBuilderCustomizer, useSystemConfigSources);
     }
 
     private static boolean resolvesToBuiltinBean(Class<?> rawType) {

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
@@ -63,7 +63,7 @@ class QuarkusComponentTestConfiguration {
 
     static final QuarkusComponentTestConfiguration DEFAULT = new QuarkusComponentTestConfiguration(Map.of(), Set.of(),
             List.of(), false, true, QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL, List.of(),
-            DEFAULT_CONVERTERS, null, false);
+            DEFAULT_CONVERTERS, null, true);
 
     private static final Logger LOG = Logger.getLogger(QuarkusComponentTestConfiguration.class);
 

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -212,7 +212,7 @@ public class QuarkusComponentTestExtension
     public QuarkusComponentTestExtension(Class<?>... additionalComponentClasses) {
         this(new QuarkusComponentTestConfiguration(Map.of(), Set.of(additionalComponentClasses),
                 List.of(), false, true, QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL,
-                List.of(), List.of(), null, false), false);
+                List.of(), List.of(), null, true), false);
     }
 
     QuarkusComponentTestExtension(QuarkusComponentTestConfiguration baseConfiguration, boolean startShouldFail) {

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
@@ -34,6 +34,7 @@ public class QuarkusComponentTestExtensionBuilder {
     private final List<AnnotationsTransformer> annotationsTransformers = new ArrayList<>();
     private final List<Converter<?>> configConverters = new ArrayList<>();
     private boolean useDefaultConfigProperties = false;
+    private boolean useSystemConfigSources = false;
     private boolean addNestedClassesAsComponents = true;
     private int configSourceOrdinal = QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL;
     private Consumer<SmallRyeConfigBuilder> configBuilderCustomizer;
@@ -140,6 +141,16 @@ public class QuarkusComponentTestExtensionBuilder {
     }
 
     /**
+     * Use config sources for system properties and ENV variables in the test config.
+     *
+     * @return self
+     */
+    public QuarkusComponentTestExtensionBuilder useSystemConfigSources(boolean value) {
+        this.useSystemConfigSources = value;
+        return this;
+    }
+
+    /**
      * Configure a new mock of a bean.
      * <p>
      * Note that a mock is created automatically for all unsatisfied dependencies in the test. This API provides full control
@@ -174,7 +185,8 @@ public class QuarkusComponentTestExtensionBuilder {
         return new QuarkusComponentTestExtension(new QuarkusComponentTestConfiguration(Map.copyOf(configProperties),
                 Set.copyOf(componentClasses), List.copyOf(mockConfigurators), useDefaultConfigProperties,
                 addNestedClassesAsComponents, configSourceOrdinal,
-                List.copyOf(annotationsTransformers), converters, configBuilderCustomizer), buildShouldFail);
+                List.copyOf(annotationsTransformers), converters, configBuilderCustomizer, useSystemConfigSources),
+                buildShouldFail);
     }
 
     void registerMockBean(MockBeanConfiguratorImpl<?> mock) {

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/config/ConfigSourceOrdinalTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/config/ConfigSourceOrdinalTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.component.QuarkusComponentTest;
 import io.quarkus.test.component.TestConfigProperty;
 
-@QuarkusComponentTest(configSourceOrdinal = 275)
+@QuarkusComponentTest(configSourceOrdinal = 275, useSystemConfigSources = true)
 @TestConfigProperty(key = "foo", value = "baz")
 public class ConfigSourceOrdinalTest {
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Backports change #48942 as described in #48899

We keep this property disabled by default to avoid the brekaing change with component tests in 3.25 and await enabling by default in 3.26

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....
Fixes #48899

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

