### PR TITLE
OIDC Client filter - allow to trigger token refresh when REST client request results in 401

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -592,6 +592,33 @@ public interface ProtectedResourceService {
 }
 ----
 
+If you also want to refresh the token every time the `ProtectedResourceService#getUserName` call results in a 401 Unauthorized error, use the `quarkus.rest-client-oidc-filter.refresh-on-unauthorized` configuration property like in the example below:
+
+[source,properties]
+----
+quarkus.rest-client-oidc-filter.refresh-on-unauthorized=true
+----
+
+Alternatively, if you only need to enable this feature for individual endpoints, create a custom filter like in the example below:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+@Priority(Priorities.AUTHENTICATION)
+public class OidcClientRequestCustomFilter extends AbstractOidcClientRequestReactiveFilter {
+
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return true;
+    }
+}
+----
+
 [[resteasy-client-oidc-filter]]
 === Use OidcClient in RestClient ClientFilter
 
@@ -670,6 +697,33 @@ public interface ProtectedResourceService {
 
     @GET
     String getUserName();
+}
+----
+
+If you also want to refresh the token every time the `ProtectedResourceService#getUserName` call results in a 401 Unauthorized error, use the `quarkus.resteasy-client-oidc-filter.refresh-on-unauthorized` configuration property like in the example below:
+
+[source,properties]
+----
+quarkus.resteasy-client-oidc-filter.refresh-on-unauthorized=true
+----
+
+Alternatively, if you only need to enable this feature for individual endpoints, create a custom filter like in the example below:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+@Priority(Priorities.AUTHENTICATION)
+public class OidcClientRequestCustomFilter extends AbstractOidcClientRequestFilter {
+
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return true;
+    }
 }
 ----
 

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/AbstractRevokedAccessTokenDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/AbstractRevokedAccessTokenDevModeTest.java
@@ -1,0 +1,225 @@
+package io.quarkus.oidc.client.filter;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.security.Authenticated;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public abstract class AbstractRevokedAccessTokenDevModeTest {
+
+    protected static final String NAMED_CLIENT = "named";
+    protected static final String RESPONSE = "Ho hey!";
+    protected static final String MY_CLIENT_RESOURCE_PATH = "/my-client-resource";
+    protected static final String MY_SERVER_RESOURCE_PATH = "/my-server-resource";
+    private static final Class<?>[] BASE_TEST_CLASSES = {
+            MyServerResource.class, MyClientResource.class, MyClient.class, MyClientCategory.class,
+            AbstractRevokedAccessTokenDevModeTest.class
+    };
+
+    protected static QuarkusDevModeTest createQuarkusDevModeTest(String additionalProperties,
+            Class<? extends MyClient> defaultClientClass,
+            Class<? extends MyClient> namedClientClass, Class<? extends MyClient> namedClientWithoutRefresh,
+            Class<? extends MyClient> defaultClientWithoutRefresh, Class<? extends MyClientResource> myClientResourceImpl,
+            Class<?>... additionalClasses) {
+        return new QuarkusDevModeTest().withApplicationRoot((jar) -> jar
+                .addAsResource(
+                        new StringAsset("""
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
+                                quarkus.oidc.client-id=quarkus-service-app
+                                quarkus.oidc.credentials.secret=secret
+                                quarkus.oidc.token.verify-access-token-with-user-info=true
+                                quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
+                                quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
+                                quarkus.oidc-client.credentials.client-secret.value=${quarkus.oidc.credentials.secret}
+                                quarkus.oidc-client.credentials.client-secret.method=POST
+                                quarkus.oidc-client.grant.type=password
+                                quarkus.oidc-client.grant-options.password.username=alice
+                                quarkus.oidc-client.grant-options.password.password=alice
+                                quarkus.oidc-client.named.auth-server-url=${quarkus.oidc.auth-server-url}
+                                quarkus.oidc-client.named.client-id=${quarkus.oidc.client-id}
+                                quarkus.oidc-client.named.credentials.client-secret.value=${quarkus.oidc.credentials.secret}
+                                quarkus.oidc-client.named.credentials.client-secret.method=POST
+                                quarkus.oidc-client.named.grant.type=password
+                                quarkus.oidc-client.named.grant-options.password.username=alice
+                                quarkus.oidc-client.named.grant-options.password.password=alice
+                                %s
+                                """.formatted(defaultClientClass.getName(), namedClientClass.getName(),
+                                namedClientWithoutRefresh.getName(), defaultClientWithoutRefresh.getName(),
+                                additionalProperties)),
+                        "application.properties")
+                .addClasses(defaultClientClass, namedClientClass, namedClientWithoutRefresh, defaultClientWithoutRefresh,
+                        myClientResourceImpl)
+                .addClasses(additionalClasses)
+                .addClasses(BASE_TEST_CLASSES));
+    }
+
+    @Test
+    void verifyNamedClientHasTokenRefreshedOn401() {
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // response filter recognized 401 and told the request token to refresh the token on next request
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+    }
+
+    @Test
+    void verifyDefaultClientHasTokenRefreshedOn401() {
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // response filter recognized 401 and told the request token to refresh the token on next request
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+    }
+
+    @Test
+    void verifyDefaultClientHasNotRefreshedTokenOnUnauthorized() {
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // there is no response filter, so our request filter still doesn't know that the token is revoked
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+    }
+
+    @Test
+    void verifyNamedClientHasNotRefreshedTokenOnUnauthorized() {
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // there is no response filter, so our request filter still doesn't know that the token is revoked
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+    }
+
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public static class MyServerResource {
+
+        private volatile String previousToken = null;
+
+        @Inject
+        OidcClient defaultOidcClient;
+
+        @NamedOidcClient(NAMED_CLIENT)
+        @Inject
+        OidcClient namedOidcClient;
+
+        @Authenticated
+        @POST
+        public String revokeAccessTokenAndRespond(@HeaderParam(AUTHORIZATION) String authorizationHeader, String named) {
+            String accessToken = authorizationHeader.substring("Bearer ".length());
+            if (accessToken.equals(previousToken)) {
+                // do not expect this to happen
+                throw new IllegalStateException("Quarkus OIDC should recognize this access token is revoked");
+            }
+            previousToken = accessToken;
+            OidcClient client = Boolean.parseBoolean(named) ? namedOidcClient : defaultOidcClient;
+            boolean tokenRevoked = client.revokeAccessToken(accessToken).await().indefinitely();
+            if (tokenRevoked) {
+                return RESPONSE;
+            }
+            // do not expect this to happen
+            throw new IllegalStateException("Token is not revoked");
+        }
+
+    }
+
+    @Path(MY_CLIENT_RESOURCE_PATH)
+    public abstract static class MyClientResource {
+
+        @POST
+        public String talkToServerAndRespond(MyClientCategory clientCategory) {
+            MyClient client = switch (clientCategory) {
+                case NAMED_CLIENT -> myNamedClient();
+                case DEFAULT_CLIENT -> myDefaultClient();
+                case DEFAULT_CLIENT_WITHOUT_REFRESH -> myDefaultClientWithoutRefresh();
+                case NAMED_CLIENT_WITHOUT_REFRESH -> myNamedClientWithoutRefresh();
+            };
+            return client.revokeAccessTokenAndRespond(clientCategory.named + "");
+        }
+
+        protected abstract MyClient myDefaultClient();
+
+        protected abstract MyClient myNamedClient();
+
+        protected abstract MyClient myDefaultClientWithoutRefresh();
+
+        protected abstract MyClient myNamedClientWithoutRefresh();
+
+    }
+
+    public interface MyClient {
+
+        @POST
+        String revokeAccessTokenAndRespond(String named);
+
+    }
+
+    public enum MyClientCategory {
+        DEFAULT_CLIENT(false),
+        NAMED_CLIENT(true),
+        DEFAULT_CLIENT_WITHOUT_REFRESH(false),
+        NAMED_CLIENT_WITHOUT_REFRESH(true);
+
+        public final boolean named;
+
+        MyClientCategory(boolean named) {
+            this.named = named;
+        }
+    }
+}

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterRevokedAccessTokenDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterRevokedAccessTokenDevModeTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.oidc.client.filter;
+
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class OidcClientFilterRevokedAccessTokenDevModeTest extends AbstractRevokedAccessTokenDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = createQuarkusDevModeTest(
+            "quarkus.resteasy-client-oidc-filter.refresh-on-unauthorized=true", MyDefaultClient.class, MyNamedClient.class,
+            MyNamedClientWithoutRefresh.class, MyDefaultClientWithoutRefresh.class, MyClientResourceImpl.class,
+            DefaultClientRefreshDisabled.class, NamedClientRefreshDisabled.class);
+
+    @RegisterRestClient
+    @OidcClientFilter
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClient extends MyClient {
+
+    }
+
+    @RegisterRestClient
+    @OidcClientFilter(NAMED_CLIENT)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClient extends MyClient {
+
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = DefaultClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class DefaultClientRefreshDisabled extends AbstractOidcClientRequestFilter {
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = NamedClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class NamedClientRefreshDisabled extends AbstractOidcClientRequestFilter {
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(NAMED_CLIENT);
+        }
+    }
+
+    public static class MyClientResourceImpl extends MyClientResource {
+
+        @Inject
+        @RestClient
+        MyDefaultClient myDefaultClient;
+
+        @Inject
+        @RestClient
+        MyNamedClient myNamedClient;
+
+        @Inject
+        @RestClient
+        MyDefaultClientWithoutRefresh myDefaultClientWithoutRefresh;
+
+        @Inject
+        @RestClient
+        MyNamedClientWithoutRefresh myNamedClientWithoutRefresh;
+
+        @Override
+        protected MyClient myDefaultClient() {
+            return myDefaultClient;
+        }
+
+        @Override
+        protected MyClient myNamedClient() {
+            return myNamedClient;
+        }
+
+        @Override
+        protected MyClient myDefaultClientWithoutRefresh() {
+            return myDefaultClientWithoutRefresh;
+        }
+
+        @Override
+        protected MyClient myNamedClientWithoutRefresh() {
+            return myNamedClientWithoutRefresh;
+        }
+    }
+
+}

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientRequestFilterRevokedTokenDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientRequestFilterRevokedTokenDevModeTest.java
@@ -1,0 +1,129 @@
+package io.quarkus.oidc.client.filter;
+
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class OidcClientRequestFilterRevokedTokenDevModeTest extends AbstractRevokedAccessTokenDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = createQuarkusDevModeTest("", MyDefaultClient.class, MyNamedClient.class,
+            MyNamedClientWithoutRefresh.class, MyDefaultClientWithoutRefresh.class, MyClientResourceImpl.class,
+            DefaultClientRefreshEnabled.class, NamedClientRefreshEnabled.class, DefaultClientRefreshDisabled.class,
+            NamedClientRefreshDisabled.class);
+
+    @RegisterRestClient
+    @RegisterProvider(value = DefaultClientRefreshEnabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClient extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class DefaultClientRefreshEnabled extends AbstractOidcClientRequestFilter {
+        @Override
+        protected boolean refreshOnUnauthorized() {
+            return true;
+        }
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = NamedClientRefreshEnabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClient extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class NamedClientRefreshEnabled extends AbstractOidcClientRequestFilter {
+        @Override
+        protected boolean refreshOnUnauthorized() {
+            return true;
+        }
+
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(NAMED_CLIENT);
+        }
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = DefaultClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class DefaultClientRefreshDisabled extends AbstractOidcClientRequestFilter {
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = NamedClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class NamedClientRefreshDisabled extends AbstractOidcClientRequestFilter {
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(NAMED_CLIENT);
+        }
+    }
+
+    public static class MyClientResourceImpl extends MyClientResource {
+
+        @Inject
+        @RestClient
+        MyDefaultClient myDefaultClient;
+
+        @Inject
+        @RestClient
+        MyNamedClient myNamedClient;
+
+        @Inject
+        @RestClient
+        MyDefaultClientWithoutRefresh myDefaultClientWithoutRefresh;
+
+        @Inject
+        @RestClient
+        MyNamedClientWithoutRefresh myNamedClientWithoutRefresh;
+
+        @Override
+        protected MyClient myDefaultClient() {
+            return myDefaultClient;
+        }
+
+        @Override
+        protected MyClient myNamedClient() {
+            return myNamedClient;
+        }
+
+        @Override
+        protected MyClient myDefaultClientWithoutRefresh() {
+            return myDefaultClientWithoutRefresh;
+        }
+
+        @Override
+        protected MyClient myNamedClientWithoutRefresh() {
+            return myNamedClientWithoutRefresh;
+        }
+    }
+
+}

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
@@ -22,4 +22,9 @@ public class OidcClientRequestFilter extends AbstractOidcClientRequestFilter {
     protected Optional<String> clientId() {
         return oidcClientFilterConfig.clientName();
     }
+
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return oidcClientFilterConfig.refreshOnUnauthorized();
+    }
 }

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
@@ -15,8 +15,11 @@ import io.quarkus.oidc.common.runtime.OidcConstants;
 public class AbstractOidcClientRequestFilter extends AbstractTokensProducer implements ClientRequestFilter {
     private static final Logger LOG = Logger.getLogger(AbstractOidcClientRequestFilter.class);
     private static final String BEARER_SCHEME_WITH_SPACE = OidcConstants.BEARER_SCHEME + " ";
+    static final String REQUEST_FILTER_KEY = "io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter#this";
+    private volatile boolean accessTokenNeedsRefresh;
 
     public AbstractOidcClientRequestFilter() {
+        this.accessTokenNeedsRefresh = false;
     }
 
     @Override
@@ -26,12 +29,13 @@ public class AbstractOidcClientRequestFilter extends AbstractTokensProducer impl
                     + "OIDC client is disabled with `quarkus.oidc-client.enabled=false`");
             return;
         }
+        if (refreshOnUnauthorized() && !accessTokenNeedsRefresh) {
+            requestContext.setProperty(REQUEST_FILTER_KEY, this);
+        }
         try {
-            final String accessToken = getAccessToken();
-            requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + accessToken);
+            requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + getAccessToken());
         } catch (DisabledOidcClientException ex) {
             LOG.debug("Client is disabled, acquiring and propagating the token is not necessary");
-            return;
         } catch (Exception ex) {
             LOG.debugf("Access token is not available, cause: %s, aborting the request", ex.getMessage());
             throw (ex instanceof RuntimeException) ? (RuntimeException) ex : new RuntimeException(ex);
@@ -42,4 +46,27 @@ public class AbstractOidcClientRequestFilter extends AbstractTokensProducer impl
         return awaitTokens().getAccessToken();
     }
 
+    @Override
+    protected boolean isForceNewTokens() {
+        if (accessTokenNeedsRefresh()) {
+            this.accessTokenNeedsRefresh = false;
+            return true;
+        }
+        return super.isForceNewTokens();
+    }
+
+    /**
+     * @return true if token that appears valid should be refreshed the next time this filter is applied
+     */
+    protected boolean refreshOnUnauthorized() {
+        return false;
+    }
+
+    void refreshAccessToken() {
+        this.accessTokenNeedsRefresh = true;
+    }
+
+    private boolean accessTokenNeedsRefresh() {
+        return refreshOnUnauthorized() && accessTokenNeedsRefresh;
+    }
 }

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/DetectUnauthorizedClientResponseFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/DetectUnauthorizedClientResponseFilter.java
@@ -1,0 +1,24 @@
+package io.quarkus.oidc.client.filter.runtime;
+
+import static io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter.REQUEST_FILTER_KEY;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.ClientResponseFilter;
+
+public final class DetectUnauthorizedClientResponseFilter implements ClientResponseFilter {
+
+    public DetectUnauthorizedClientResponseFilter() {
+    }
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext, ClientResponseContext clientResponseContext)
+            throws IOException {
+        if (clientResponseContext.getStatus() == 401 &&
+                clientRequestContext.getProperty(REQUEST_FILTER_KEY) instanceof AbstractOidcClientRequestFilter requestFilter) {
+            requestFilter.refreshAccessToken();
+        }
+    }
+}

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfig.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfig.java
@@ -22,4 +22,12 @@ public interface OidcClientFilterConfig {
      * individual MP RestClient with the `io.quarkus.oidc.client.filter.OidcClientFilter` annotation.
      */
     Optional<String> clientName();
+
+    /**
+     * If Quarkus should refresh the access token after the MP REST client request results in 401 Unauthorized error.
+     * The refresh can be useful when the access token can be revoked by other services while the access token
+     * still appears valid locally.
+     */
+    @WithDefault("false")
+    boolean refreshOnUnauthorized();
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -1,10 +1,13 @@
 package io.quarkus.oidc.client.reactive.filter.deployment;
 
+import static io.quarkus.oidc.client.deployment.OidcClientFilterDeploymentHelper.detectCustomFiltersThatRequireResponseFilter;
+
 import java.util.Collection;
 import java.util.List;
 
 import jakarta.ws.rs.Priorities;
 
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
@@ -23,6 +26,7 @@ import io.quarkus.oidc.client.deployment.OidcClientFilterDeploymentHelper;
 import io.quarkus.oidc.client.filter.OidcClientFilter;
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter;
 import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
+import io.quarkus.oidc.client.reactive.filter.runtime.DetectUnauthorizedClientResponseFilter;
 import io.quarkus.oidc.client.reactive.filter.runtime.OidcClientReactiveFilterConfig;
 import io.quarkus.rest.client.reactive.deployment.DotNames;
 import io.quarkus.rest.client.reactive.deployment.RegisterProviderAnnotationInstanceBuildItem;
@@ -34,12 +38,15 @@ public class OidcClientReactiveFilterBuildStep {
     private static final DotName OIDC_CLIENT_REQUEST_REACTIVE_FILTER = DotName
             .createSimple(OidcClientRequestReactiveFilter.class.getName());
     OidcClientReactiveFilterConfig oidcClientReactiveFilterConfig;
+    private static final DotName DETECT_401_RESPONSE_FILTER = DotName
+            .createSimple(DetectUnauthorizedClientResponseFilter.class.getName());
 
     // we simply pretend that @OidcClientFilter means @RegisterProvider(OidcClientRequestReactiveFilter.class)
     @BuildStep
     void oidcClientFilterSupport(CombinedIndexBuildItem indexBuildItem, BuildProducer<GeneratedBeanBuildItem> generatedBean,
             BuildProducer<RegisterProviderAnnotationInstanceBuildItem> producer) {
-        final var helper = new OidcClientFilterDeploymentHelper<>(AbstractOidcClientRequestReactiveFilter.class, generatedBean);
+        final var helper = new OidcClientFilterDeploymentHelper<>(AbstractOidcClientRequestReactiveFilter.class, generatedBean,
+                oidcClientReactiveFilterConfig.refreshOnUnauthorized());
 
         Collection<AnnotationInstance> instances = indexBuildItem.getIndex().getAnnotations(OIDC_CLIENT_FILTER);
         for (AnnotationInstance instance : instances) {
@@ -60,6 +67,15 @@ public class OidcClientReactiveFilterBuildStep {
             String targetClass = instance.target().asClass().name().toString();
             producer.produce(new RegisterProviderAnnotationInstanceBuildItem(targetClass, AnnotationInstance.create(
                     DotNames.REGISTER_PROVIDER, instance.target(), List.of(valueAttr, priorityAttr))));
+
+            if (oidcClientReactiveFilterConfig.refreshOnUnauthorized()) {
+                var valueAttribute = createClassValue(DETECT_401_RESPONSE_FILTER);
+                // client filter responsibility must be the other way around for response because
+                // currently the MicroProfileRestClientResponseFilter which handles failures runs with priority USER
+                var priority = AnnotationValue.createIntegerValue("priority", Priorities.USER + 100);
+                producer.produce(new RegisterProviderAnnotationInstanceBuildItem(targetClass, AnnotationInstance
+                        .create(DotNames.REGISTER_PROVIDER, instance.target(), List.of(valueAttribute, priority))));
+            }
         }
     }
 
@@ -78,5 +94,28 @@ public class OidcClientReactiveFilterBuildStep {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(OidcClientRequestReactiveFilter.class)
                 .reason(getClass().getName())
                 .methods().fields().build());
+    }
+
+    @BuildStep
+    void registerDetectUnauthorizedResponseFilterForCustomFilters(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<RegisterProviderAnnotationInstanceBuildItem> producer, CombinedIndexBuildItem indexBuildItem) {
+        var annotatedRestClientNames = detectCustomFiltersThatRequireResponseFilter(
+                AbstractOidcClientRequestReactiveFilter.class, RegisterProvider.class, indexBuildItem.getIndex());
+        boolean detectionEnabledForCustomFilters = !annotatedRestClientNames.isEmpty();
+        if (detectionEnabledForCustomFilters) {
+            // client filter responsibility must be the other way around for response because
+            // currently the MicroProfileRestClientResponseFilter which handles failures runs with priority USER
+            final var priority = AnnotationValue.createIntegerValue("priority", Priorities.USER + 100);
+            final var annotationValues = List.of(createClassValue(DETECT_401_RESPONSE_FILTER), priority);
+            annotatedRestClientNames.forEach(restClientName -> {
+                String targetClass = restClientName.name().toString();
+                producer.produce(new RegisterProviderAnnotationInstanceBuildItem(targetClass, AnnotationInstance
+                        .create(DotNames.REGISTER_PROVIDER, restClientName, annotationValues)));
+            });
+        }
+        if (oidcClientReactiveFilterConfig.refreshOnUnauthorized() || detectionEnabledForCustomFilters) {
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(DETECT_401_RESPONSE_FILTER.toString())
+                    .constructors().methods().reason(getClass().getName()).serialization(true).build());
+        }
     }
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/AbstractRevokedAccessTokenDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/AbstractRevokedAccessTokenDevModeTest.java
@@ -1,0 +1,233 @@
+package io.quarkus.oidc.client.reactive.filter;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.security.Authenticated;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public abstract class AbstractRevokedAccessTokenDevModeTest {
+
+    protected static final String NAMED_CLIENT = "named";
+    protected static final String RESPONSE = "Ho hey!";
+    protected static final String MY_CLIENT_RESOURCE_PATH = "/my-client-resource";
+    protected static final String MY_SERVER_RESOURCE_PATH = "/my-server-resource";
+    private static final Class<?>[] BASE_TEST_CLASSES = {
+            MyServerResource.class, MyClientResource.class, MyClient.class, MyClientCategory.class,
+            AbstractRevokedAccessTokenDevModeTest.class
+    };
+
+    protected static QuarkusDevModeTest createQuarkusDevModeTest(String additionalProperties,
+            Class<? extends MyClient> defaultClientClass,
+            Class<? extends MyClient> namedClientClass, Class<? extends MyClient> namedClientWithoutRefresh,
+            Class<? extends MyClient> defaultClientWithoutRefresh, Class<? extends MyClientResource> myClientResourceImpl,
+            Class<?>... additionalClasses) {
+        return new QuarkusDevModeTest().withApplicationRoot((jar) -> jar
+                .addAsResource(
+                        new StringAsset("""
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                                quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
+                                quarkus.oidc.client-id=quarkus-service-app
+                                quarkus.oidc.credentials.secret=secret
+                                quarkus.oidc.token.verify-access-token-with-user-info=true
+                                quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
+                                quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
+                                quarkus.oidc-client.credentials.client-secret.value=${quarkus.oidc.credentials.secret}
+                                quarkus.oidc-client.credentials.client-secret.method=POST
+                                quarkus.oidc-client.grant.type=password
+                                quarkus.oidc-client.grant-options.password.username=alice
+                                quarkus.oidc-client.grant-options.password.password=alice
+                                quarkus.oidc-client.named.auth-server-url=${quarkus.oidc.auth-server-url}
+                                quarkus.oidc-client.named.client-id=${quarkus.oidc.client-id}
+                                quarkus.oidc-client.named.credentials.client-secret.value=${quarkus.oidc.credentials.secret}
+                                quarkus.oidc-client.named.credentials.client-secret.method=POST
+                                quarkus.oidc-client.named.grant.type=password
+                                quarkus.oidc-client.named.grant-options.password.username=alice
+                                quarkus.oidc-client.named.grant-options.password.password=alice
+                                %s
+                                """.formatted(defaultClientClass.getName(), namedClientClass.getName(),
+                                namedClientWithoutRefresh.getName(), defaultClientWithoutRefresh.getName(),
+                                additionalProperties)),
+                        "application.properties")
+                .addClasses(defaultClientClass, namedClientClass, namedClientWithoutRefresh, defaultClientWithoutRefresh,
+                        myClientResourceImpl)
+                .addClasses(additionalClasses)
+                .addClasses(BASE_TEST_CLASSES));
+    }
+
+    @Test
+    void verifyNamedClientHasTokenRefreshedOn401() {
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // response filter recognized 401 and told the request token to refresh the token on next request
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+    }
+
+    @Test
+    void verifyDefaultClientHasTokenRefreshedOn401() {
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // response filter recognized 401 and told the request token to refresh the token on next request
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+    }
+
+    @Test
+    void verifyDefaultClientHasNotRefreshedTokenOnUnauthorized() {
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // there is no response filter, so our request filter still doesn't know that the token is revoked
+        RestAssured.given()
+                .body(MyClientCategory.DEFAULT_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+    }
+
+    @Test
+    void verifyNamedClientHasNotRefreshedTokenOnUnauthorized() {
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(200)
+                .body(Matchers.is(RESPONSE));
+        // access token is revoked now
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+        // there is no response filter, so our request filter still doesn't know that the token is revoked
+        RestAssured.given()
+                .body(MyClientCategory.NAMED_CLIENT_WITHOUT_REFRESH)
+                .post(MY_CLIENT_RESOURCE_PATH)
+                .then().statusCode(401);
+    }
+
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public static class MyServerResource {
+
+        private volatile String previousToken = null;
+
+        @Inject
+        OidcClient defaultOidcClient;
+
+        @NamedOidcClient(NAMED_CLIENT)
+        @Inject
+        OidcClient namedOidcClient;
+
+        @Authenticated
+        @POST
+        public String revokeAccessTokenAndRespond(@HeaderParam(AUTHORIZATION) String authorizationHeader, String named) {
+            String accessToken = authorizationHeader.substring("Bearer ".length());
+            if (accessToken.equals(previousToken)) {
+                // do not expect this to happen
+                throw new IllegalStateException("Quarkus OIDC should recognize this access token is revoked");
+            }
+            previousToken = accessToken;
+            OidcClient client = Boolean.parseBoolean(named) ? namedOidcClient : defaultOidcClient;
+            boolean tokenRevoked = client.revokeAccessToken(accessToken).await().indefinitely();
+            if (tokenRevoked) {
+                return RESPONSE;
+            }
+            // do not expect this to happen
+            throw new IllegalStateException("Token is not revoked");
+        }
+
+    }
+
+    public abstract static class MyClientResource {
+
+        @POST
+        public String talkToServerAndRespond(MyClientCategory clientCategory) {
+            MyClient client = switch (clientCategory) {
+                case NAMED_CLIENT -> myNamedClient();
+                case DEFAULT_CLIENT -> myDefaultClient();
+                case DEFAULT_CLIENT_WITHOUT_REFRESH -> myDefaultClientWithoutRefresh();
+                case NAMED_CLIENT_WITHOUT_REFRESH -> myNamedClientWithoutRefresh();
+            };
+            return client.revokeAccessTokenAndRespond(clientCategory.named + "");
+        }
+
+        protected abstract MyClient myDefaultClient();
+
+        protected abstract MyClient myNamedClient();
+
+        protected abstract MyClient myDefaultClientWithoutRefresh();
+
+        protected abstract MyClient myNamedClientWithoutRefresh();
+
+        @ServerExceptionMapper(value = WebApplicationException.class)
+        public RestResponse<Response> mapExceptions(WebApplicationException exception) {
+            return RestResponse.status(exception.getResponse().getStatus());
+        }
+
+    }
+
+    public interface MyClient {
+
+        @POST
+        String revokeAccessTokenAndRespond(String named);
+
+    }
+
+    public enum MyClientCategory {
+        DEFAULT_CLIENT(false),
+        NAMED_CLIENT(true),
+        DEFAULT_CLIENT_WITHOUT_REFRESH(false),
+        NAMED_CLIENT_WITHOUT_REFRESH(true);
+
+        public final boolean named;
+
+        MyClientCategory(boolean named) {
+            this.named = named;
+        }
+    }
+}

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientFilterRevokedAccessTokenDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientFilterRevokedAccessTokenDevModeTest.java
@@ -1,0 +1,110 @@
+package io.quarkus.oidc.client.reactive.filter;
+
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class OidcClientFilterRevokedAccessTokenDevModeTest extends AbstractRevokedAccessTokenDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = createQuarkusDevModeTest(
+            "quarkus.rest-client-oidc-filter.refresh-on-unauthorized=true",
+            MyDefaultClient.class, MyNamedClient.class, MyNamedClientWithoutRefresh.class, MyDefaultClientWithoutRefresh.class,
+            MyClientResourceImpl.class, NamedClientRefreshDisabled.class, DefaultClientRefreshDisabled.class);
+
+    @RegisterRestClient
+    @OidcClientFilter
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClient extends MyClient {
+
+    }
+
+    @RegisterRestClient
+    @OidcClientFilter(NAMED_CLIENT)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClient extends MyClient {
+
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = DefaultClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class DefaultClientRefreshDisabled extends AbstractOidcClientRequestReactiveFilter {
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = NamedClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class NamedClientRefreshDisabled extends AbstractOidcClientRequestReactiveFilter {
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(NAMED_CLIENT);
+        }
+    }
+
+    @Path(MY_CLIENT_RESOURCE_PATH)
+    public static class MyClientResourceImpl extends MyClientResource {
+
+        @Inject
+        @RestClient
+        MyDefaultClient myDefaultClient;
+
+        @Inject
+        @RestClient
+        MyNamedClient myNamedClient;
+
+        @Inject
+        @RestClient
+        MyDefaultClientWithoutRefresh myDefaultClientWithoutRefresh;
+
+        @Inject
+        @RestClient
+        MyNamedClientWithoutRefresh myNamedClientWithoutRefresh;
+
+        @Override
+        protected MyClient myDefaultClient() {
+            return myDefaultClient;
+        }
+
+        @Override
+        protected MyClient myNamedClient() {
+            return myNamedClient;
+        }
+
+        @Override
+        protected MyClient myDefaultClientWithoutRefresh() {
+            return myDefaultClientWithoutRefresh;
+        }
+
+        @Override
+        protected MyClient myNamedClientWithoutRefresh() {
+            return myNamedClientWithoutRefresh;
+        }
+    }
+
+}

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestFilterRevokedTokenDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestFilterRevokedTokenDevModeTest.java
@@ -1,0 +1,127 @@
+package io.quarkus.oidc.client.reactive.filter;
+
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class OidcClientRequestFilterRevokedTokenDevModeTest extends AbstractRevokedAccessTokenDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = createQuarkusDevModeTest("", MyDefaultClient.class, MyNamedClient.class,
+            MyNamedClientWithoutRefresh.class, MyDefaultClientWithoutRefresh.class, MyClientResourceImpl.class,
+            DefaultClientRefreshEnabled.class, NamedClientRefreshEnabled.class, DefaultClientRefreshDisabled.class,
+            NamedClientRefreshDisabled.class);
+
+    @RegisterRestClient
+    @RegisterProvider(value = DefaultClientRefreshEnabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClient extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class DefaultClientRefreshEnabled extends AbstractOidcClientRequestReactiveFilter {
+        @Override
+        protected boolean refreshOnUnauthorized() {
+            return true;
+        }
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = NamedClientRefreshEnabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClient extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class NamedClientRefreshEnabled extends AbstractOidcClientRequestReactiveFilter {
+        @Override
+        protected boolean refreshOnUnauthorized() {
+            return true;
+        }
+
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(NAMED_CLIENT);
+        }
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = DefaultClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class DefaultClientRefreshDisabled extends AbstractOidcClientRequestReactiveFilter {
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = NamedClientRefreshDisabled.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClientWithoutRefresh extends MyClient {
+
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    public static class NamedClientRefreshDisabled extends AbstractOidcClientRequestReactiveFilter {
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(NAMED_CLIENT);
+        }
+    }
+
+    @Path(MY_CLIENT_RESOURCE_PATH)
+    public static class MyClientResourceImpl extends MyClientResource {
+
+        private final MyDefaultClient myDefaultClient;
+        private final MyNamedClient myNamedClient;
+        private final MyDefaultClientWithoutRefresh myDefaultClientWithoutRefresh;
+        private final MyNamedClientWithoutRefresh myNamedClientWithoutRefresh;
+
+        public MyClientResourceImpl(@RestClient MyDefaultClient myDefaultClient, @RestClient MyNamedClient myNamedClient,
+                @RestClient MyDefaultClientWithoutRefresh myDefaultClientWithoutRefresh,
+                @RestClient MyNamedClientWithoutRefresh myNamedClientWithoutRefresh) {
+            this.myDefaultClient = myDefaultClient;
+            this.myNamedClient = myNamedClient;
+            this.myDefaultClientWithoutRefresh = myDefaultClientWithoutRefresh;
+            this.myNamedClientWithoutRefresh = myNamedClientWithoutRefresh;
+        }
+
+        @Override
+        protected MyClient myDefaultClient() {
+            return myDefaultClient;
+        }
+
+        @Override
+        protected MyClient myNamedClient() {
+            return myNamedClient;
+        }
+
+        @Override
+        protected MyClient myDefaultClientWithoutRefresh() {
+            return myDefaultClientWithoutRefresh;
+        }
+
+        @Override
+        protected MyClient myNamedClientWithoutRefresh() {
+            return myNamedClientWithoutRefresh;
+        }
+    }
+
+}

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
@@ -19,4 +19,9 @@ public class OidcClientRequestReactiveFilter extends AbstractOidcClientRequestRe
     protected Optional<String> clientId() {
         return config.clientName();
     }
+
+    @Override
+    protected boolean refreshOnUnauthorized() {
+        return config.refreshOnUnauthorized();
+    }
 }

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/DetectUnauthorizedClientResponseFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/DetectUnauthorizedClientResponseFilter.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc.client.reactive.filter.runtime;
+
+import static io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter.REQUEST_FILTER_KEY;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.ClientResponseFilter;
+
+public final class DetectUnauthorizedClientResponseFilter implements ClientResponseFilter {
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
+        if (responseContext.getStatus() == 401 &&
+                requestContext
+                        .getProperty(REQUEST_FILTER_KEY) instanceof AbstractOidcClientRequestReactiveFilter requestFilter) {
+            requestFilter.refreshAccessToken();
+        }
+    }
+}

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfig.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfig.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigMapping(prefix = "quarkus.rest-client-oidc-filter")
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
@@ -15,4 +16,12 @@ public interface OidcClientReactiveFilterConfig {
      * for individual MP RestClients with the `io.quarkus.oidc.client.filter.OidcClientFilter` annotation.
      */
     Optional<String> clientName();
+
+    /**
+     * If Quarkus should refresh the access token after the MP REST client request results in 401 Unauthorized error.
+     * The refresh can be useful when the access token can be revoked by other services while the access token
+     * still appears valid locally.
+     */
+    @WithDefault("false")
+    boolean refreshOnUnauthorized();
 }


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/44037
- it can happen that an access token that appears valid to Quarkus is rejected because it was revoked and users can't use `@Retry` because the revoked token would still be used to next request as well, this PR will help by detecting 401 and forcing refresh on next call