### PR TITLE
Generate Netty's MachineId at runtime

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedRuntimeSystemPropertyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedRuntimeSystemPropertyBuildItem.java
@@ -1,0 +1,28 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.function.Supplier;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Represents a system property that will be set immediately on application startup,
+ * the system property will be generated when set.
+ */
+public final class GeneratedRuntimeSystemPropertyBuildItem extends MultiBuildItem {
+
+    private final String key;
+    private final String generatorClass;
+
+    public GeneratedRuntimeSystemPropertyBuildItem(String key, Class<? extends Supplier<String>> generatorClass) {
+        this.key = key;
+        this.generatorClass = generatorClass.getName();
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getGeneratorClass() {
+        return generatorClass;
+    }
+}

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Random;
 import java.util.function.Supplier;
 
 import jakarta.inject.Singleton;
@@ -23,6 +22,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.GeneratedRuntimeSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -35,6 +35,7 @@ import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.netty.BossEventLoopGroup;
 import io.quarkus.netty.MainEventLoopGroup;
 import io.quarkus.netty.runtime.EmptyByteBufStub;
+import io.quarkus.netty.runtime.MachineIdGenerator;
 import io.quarkus.netty.runtime.NettyRecorder;
 
 class NettyProcessor {
@@ -65,17 +66,11 @@ class NettyProcessor {
     }
 
     @BuildStep
-    public SystemPropertyBuildItem setNettyMachineId() {
+    public GeneratedRuntimeSystemPropertyBuildItem setNettyMachineId() {
         // we set the io.netty.machineId system property so to prevent potential
         // slowness when generating/inferring the default machine id in io.netty.channel.DefaultChannelId
         // implementation, which iterates over the NetworkInterfaces to determine the "best" machine id
-
-        // borrowed from io.netty.util.internal.MacAddressUtil.EUI64_MAC_ADDRESS_LENGTH
-        final int EUI64_MAC_ADDRESS_LENGTH = 8;
-        final byte[] machineIdBytes = new byte[EUI64_MAC_ADDRESS_LENGTH];
-        new Random().nextBytes(machineIdBytes);
-        final String nettyMachineId = io.netty.util.internal.MacAddressUtil.formatAddress(machineIdBytes);
-        return new SystemPropertyBuildItem("io.netty.machineId", nettyMachineId);
+        return new GeneratedRuntimeSystemPropertyBuildItem("io.netty.machineId", MachineIdGenerator.class);
     }
 
     @BuildStep

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/MachineIdGenerator.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/MachineIdGenerator.java
@@ -1,0 +1,20 @@
+package io.quarkus.netty.runtime;
+
+import java.util.Random;
+import java.util.function.Supplier;
+
+public final class MachineIdGenerator implements Supplier<String> {
+
+    /**
+     * We have our own implementation to generate the io.netty.machineId to prevent potential
+     * slowness when generating/inferring the default machine id in io.netty.channel.DefaultChannelId
+     * implementation, which iterates over the NetworkInterfaces to determine the "best" machine id
+     */
+    public String get() {
+        // borrowed from io.netty.util.internal.MacAddressUtil.EUI64_MAC_ADDRESS_LENGTH
+        final int EUI64_MAC_ADDRESS_LENGTH = 8;
+        final byte[] machineIdBytes = new byte[EUI64_MAC_ADDRESS_LENGTH];
+        new Random().nextBytes(machineIdBytes);
+        return io.netty.util.internal.MacAddressUtil.formatAddress(machineIdBytes);
+    }
+}


### PR DESCRIPTION
The way it was done, it was generated at build time and then embedded in the generated bytecode.
Which had 2 issues:
- the MachineId would be the same for every instance of the application on every machine.
- the MachineId was included in the generated bytecode thus breaking build reproducibility.

/cc @zakkak @franz1981 @galderz @cescoffier 

This is part of my work on build reproducibility and I have a few questions:
- is the MachineId useful at build time? Even if so, I don't think it's a problem to let it be generated by the default Netty mechanism at build time.
- is it a problem to have different MachineIds at build time and at runtime?