### PR TITLE
Stabilize order of checkForBuildTimeConfigChange Map parameters

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 import jakarta.annotation.Priority;
 
@@ -404,7 +405,7 @@ public class ConfigGenerationBuildStep {
             excludedConfigKeys.add(item.getConfigKey());
         }
 
-        Map<String, ConfigValue> values = new HashMap<>();
+        Map<String, ConfigValue> values = new TreeMap<>();
         BuildTimeConfigurationReader.ReadResult readResult = configItem.getReadResult();
         for (final Map.Entry<String, ConfigValue> entry : readResult.getAllBuildTimeValues().entrySet()) {
             if (excludedConfigKeys.contains(entry.getKey())) {


### PR DESCRIPTION
This is important for build reproducibility.