### PR TITLE
Always generate the Config doc as it's now embedded in the jars

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -58,8 +58,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         List<ExtensionProcessor> extensionProcessors = new ArrayList<>();
         extensionProcessors.add(new ExtensionBuildProcessor());
 
-        boolean skipDocs = Boolean.getBoolean("skipDocs") || Boolean.getBoolean("quickly");
-        boolean generateDoc = !skipDocs && !"false".equals(processingEnv.getOptions().get(Options.GENERATE_DOC));
+        boolean generateDoc = !"false".equals(processingEnv.getOptions().get(Options.GENERATE_DOC));
 
         // for now, we generate the old config doc by default but we will change this behavior soon
         if (generateDoc) {


### PR DESCRIPTION
We used to skip it when doing `-Dquickly` but it's a problem now as we want the JSON files to always be embedded in the Jar.