### PR TITLE
Always return initialized TokenIntrospection from the CDI producer

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
@@ -111,12 +111,16 @@ public class OidcTokenCredentialProducer {
         if (codeFlowAccessTokenResult == null) {
             return tokenIntrospectionFromIdentityAttribute();
         } else {
-            return codeFlowAccessTokenResult.introspectionResult;
+            return tokenIntrospectionInstance(codeFlowAccessTokenResult.introspectionResult);
         }
     }
 
     TokenIntrospection tokenIntrospectionFromIdentityAttribute() {
         TokenIntrospection introspection = OidcUtils.getAttribute(identity, OidcUtils.INTROSPECTION_ATTRIBUTE);
+        return tokenIntrospectionInstance(introspection);
+    }
+
+    private static TokenIntrospection tokenIntrospectionInstance(TokenIntrospection introspection) {
         if (introspection == null) {
             LOG.trace("TokenIntrospection is null");
             introspection = new TokenIntrospection();


### PR DESCRIPTION
Avoid CDI producer exception when the token introspection is null, as [reported](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/OIDC.20Access.20token.20introspection) by @sschellh on Zulip

