### PR TITLE
Do not create GeoIP downloader when starting Elasticsearch container

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
@@ -170,6 +170,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/pom.xml
@@ -179,6 +179,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/pom.xml
@@ -156,6 +156,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/elasticsearch-java-client/pom.xml
+++ b/integration-tests/elasticsearch-java-client/pom.xml
@@ -193,6 +193,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -193,6 +193,7 @@
                       <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                       <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                       <slm.history_index_enabled>false</slm.history_index_enabled>
+                      <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                     </env>
                     <ports>
                       <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
@@ -224,6 +224,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -240,6 +240,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -202,6 +202,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-standalone-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/pom.xml
@@ -180,6 +180,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -175,6 +175,7 @@
                                             <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
                                             <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
                                             <slm.history_index_enabled>false</slm.history_index_enabled>
+                                            <ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
                                         </env>
                                         <log>
                                             <prefix>Elasticsearch:</prefix>


### PR DESCRIPTION
I noticed this a couple times locally, and also Christian found it in Hibernate ORM's Quarkus test run:

> 10:49:19.329 Elasticsearch:{"@timestamp":"2025-07-18T10:49:19.326Z", "log.level":"ERROR", "message":"failed to create geoip downloader task", "ecs.version": "1.2.0","service.name":"ES_ECS","event.dataset":"elasticsearch.server","process.thread.name":"elasticsearch[69a292e680cc][cluster_coordination][T#1]","log.logger":"org.elasticsearch.ingest.geoip.GeoIpDownloader","elasticsearch.cluster.uuid":"Um8MJ0PBS8OxCpcDxgjbdA","elasticsearch.node.id":"ayZf-rgvSja8fV_BP1G5ig","elasticsearch.node.name":"69a292e680cc","elasticsearch.cluster.name":"docker-cluster","error.type":"org.elasticsearch.node.NodeClosedException","error.message":"node closed {69a292e680cc}{ayZf-rgvSja8fV_BP1G5ig}{5ZfTqBogSvSreBoHUb2hUg}{69a292e680cc}{172.17.0.3}{172.17.0.3:9300}{cdfhilmrstw}{8.15.0}{7000099-8512000}{transform.config_version=10.0.0, xpack.installed=true, ml.config_version=12.0.0}","error.stack_trace":"org.elasticsearch.node.NodeClosedException: node closed {69a292e680cc}{ayZf-rgvSja8fV_BP1G5ig}{5ZfTqBogSvSreBoHUb2hUg}{69a292e680cc}{172.17.0.3}{172.17.0.3:9300}{cdfhilmrstw}{8.15.0}{7000099-8512000}{transform.config_version=10.0.0, xpack.installed=true, ml.config_version=12.0.0}\n\tat

We don't really use the geoip stuff in the tests we have, so maybe let's just disable the feature and don't let it even try downloading things? 
I kept the dev service unchanged as users may actually benefit from it in their apps.

See:
* https://www.elastic.co/docs/reference/enrich-processor/geoip-processor#:~:text=poll.interval.-,Manually%20update%20your%20IP%20geolocation%20databases,-Use%20the%20cluster

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

