### PR TITLE
Add devservices runtime module

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -921,6 +921,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devservices</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-devservices-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
@@ -220,6 +220,11 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
     }
 
     public static class OwnedServiceBuilder<T extends Startable> {
+
+        private static final String IO_QUARKUS_DEVSERVICES_CONFIG_BUILDER_CLASS = "io.quarkus.devservice.runtime.config.DevServicesConfigBuilder";
+        private static final boolean CONFIG_BUILDER_AVAILABLE = isClassAvailable(
+                IO_QUARKUS_DEVSERVICES_CONFIG_BUILDER_CLASS);
+
         private String name;
         private String description;
         private Map<String, String> config;
@@ -275,10 +280,23 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
         }
 
         public DevServicesResultBuildItem build() {
+            if (!CONFIG_BUILDER_AVAILABLE) {
+                throw new IllegalStateException(
+                        "Extension error. Please add the io.quarkus:quarkus-devservices runtime dependency to the extension's runtime module.");
+            }
             return new DevServicesResultBuildItem(name, description, serviceName, serviceConfig, config,
                     (Supplier<Startable>) startableSupplier,
                     (Consumer<Startable>) postStartAction,
                     applicationConfigProvider);
+        }
+
+        private static boolean isClassAvailable(String className) {
+            try {
+                Class.forName(className);
+                return true;
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -341,7 +341,9 @@ public class StartupActionImpl implements StartupAction {
 
             Method start = appClass.getMethod("start", String[].class);
             Object application = appClass.getDeclaredConstructor().newInstance();
+
             start.invoke(application, (Object) args);
+
             Closeable closeTask = (Closeable) application;
             return new RunningQuarkusApplicationImpl(new Closeable() {
                 @Override

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -507,6 +507,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-devservices</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-devui</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -497,6 +497,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devui-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/amazon-lambda/common-runtime/pom.xml
+++ b/extensions/amazon-lambda/common-runtime/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
@@ -9,6 +9,7 @@ import static io.quarkus.deployment.dev.testing.MessageFormat.RESET;
 import static io.quarkus.deployment.dev.testing.MessageFormat.UNDERLINE;
 import static io.quarkus.devservices.common.ConfigureUtil.configureLabels;
 import static io.quarkus.devservices.common.ConfigureUtil.shouldConfigureSharedServiceLabel;
+import static io.quarkus.devservices.deployment.IsRuntimeModuleAvailable.IO_QUARKUS_DEVSERVICES_CONFIG_BUILDER_CLASS;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -62,7 +63,6 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime;
 import io.quarkus.dev.spi.DevModeType;
-import io.quarkus.devservice.runtime.config.DevServicesConfigBuilder;
 import io.quarkus.devservices.common.ContainerUtil;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.StartableContainer;
@@ -152,11 +152,21 @@ public class DevServicesProcessor {
         return registryBuildItem;
     }
 
-    @BuildStep
+    // Because the devservices runtime module is new and the ecosystem needs time to catch up, don't die if the runtime module isn't available
+    @BuildStep(onlyIf = { IsRuntimeModuleAvailable.class })
     public RunTimeConfigBuilderBuildItem registerDevResourcesConfigSource(
             List<DevServicesResultBuildItem> devServicesRequestBuildItems) {
         // Once all the dev services are registered, we can share config
-        return new RunTimeConfigBuilderBuildItem(DevServicesConfigBuilder.class);
+        try {
+            // Use reflection, since we don't have an explicit dependency on the runtime module (because dependent extensions may not have that dependency)
+            Class<?> builderClass = Class
+                    .forName(IO_QUARKUS_DEVSERVICES_CONFIG_BUILDER_CLASS);
+            return new RunTimeConfigBuilderBuildItem(builderClass);
+        } catch (ClassNotFoundException e) {
+            // Should never happen, because of the guard, as long as the runtime module is not a direct dependency of this module
+            throw new RuntimeException(e);
+        }
+
     }
 
     @BuildStep(onlyIf = { IsDevelopment.class })

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/IsRuntimeModuleAvailable.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/IsRuntimeModuleAvailable.java
@@ -1,0 +1,23 @@
+package io.quarkus.devservices.deployment;
+
+import java.util.function.BooleanSupplier;
+
+public class IsRuntimeModuleAvailable implements BooleanSupplier {
+    static final String IO_QUARKUS_DEVSERVICES_CONFIG_BUILDER_CLASS = "io.quarkus.devservice.runtime.config.DevServicesConfigBuilder";
+    static final boolean CONFIG_BUILDER_AVAILABLE = isClassAvailable(
+            IO_QUARKUS_DEVSERVICES_CONFIG_BUILDER_CLASS);
+
+    @Override
+    public boolean getAsBoolean() {
+        return CONFIG_BUILDER_AVAILABLE;
+    }
+
+    private static boolean isClassAvailable(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/extensions/devservices/pom.xml
+++ b/extensions/devservices/pom.xml
@@ -28,6 +28,7 @@
         <module>oracle</module>
         <module>common</module>
         <module>deployment</module>
+        <module>runtime</module>
         <module>keycloak</module>
         <module>oidc</module>
     </modules>

--- a/extensions/devservices/runtime/pom.xml
+++ b/extensions/devservices/runtime/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>quarkus-devservices-parent</artifactId>
         <groupId>io.quarkus</groupId>
@@ -9,36 +9,35 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-devservices-deployment</artifactId>
-    <name>Quarkus - DevServices - Deployment</name>
-
+    <artifactId>quarkus-devservices</artifactId>
+    <name>Quarkus - DevServices - Runtime</name>
     <dependencies>
-        <!-- Do NOT add the devservices runtime module as a dependency, or it will cause execution-time failures in some modules that provide dev services.
-        See https://github.com/quarkusio/quarkus/pull/49025 for more details, and https://github.com/quarkusio/quarkus/pull/49026 for the remediation. -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices-common</artifactId>
+            <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
+            <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
@@ -58,4 +57,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigBuilder.java
+++ b/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigBuilder.java
@@ -4,7 +4,6 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
-// This should live in the devservices/runtime module, but that module doesn't exist, and adding it is a breaking change
 public class DevServicesConfigBuilder implements ConfigBuilder {
 
     @Override

--- a/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigSource.java
+++ b/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigSource.java
@@ -10,7 +10,6 @@ import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistr
 import io.quarkus.devservices.crossclassloader.runtime.RunningService;
 import io.quarkus.runtime.LaunchMode;
 
-// This should live in the devservices/runtime module, but that module doesn't exist, and adding it is a breaking change
 public class DevServicesConfigSource implements ConfigSource {
 
     private final LaunchMode launchMode;

--- a/extensions/devservices/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/devservices/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Dev services"
+description: "Infrastructure supporting extensions providing dev services."
+metadata:
+  keywords:
+  - "cache"
+  categories:
+  - "core"
+  status: "stable"
+  unlisted: "true"
+  config:
+  - "quarkus.devservices."

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -31,6 +31,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-redis-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -885,6 +885,25 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         final DependencyNode deploymentNode = collectDeploymentDeps().getRoot();
         visitDeploymentDeps(rootDeployment, deploymentNode);
 
+        if (!rootDeployment.riskyDeploymentDeps.isEmpty()) {
+            final Log log = getLog();
+            List<ArtifactKey> risks = new ArrayList<>(rootDeployment.riskyDeploymentDeps.size());
+            for (Map.Entry<ArtifactKey, org.eclipse.aether.artifact.Artifact> e : rootDeployment.unexpectedDeploymentDeps
+                    .entrySet()) {
+                // TODO this check doesn't make sense, if the second one isn't right it's worse?
+                if (rootDeployment.allDeploymentDeps.contains(e.getKey())) {
+                    risks.add(e.getKey());
+                } else {
+                    risks.add(toKey(e.getValue()));
+                }
+            }
+
+            log.warn("The deployment artifact " + rootDeploymentGact
+                    + " depends on the following Quarkus extension deployment artifacts whose corresponding runtime artifacts were not found among the dependencies of "
+                    + project.getArtifact() + ":");
+            highlightInTree(deploymentNode, risks);
+        }
+
         if (rootDeployment.hasErrors()) {
             final Log log = getLog();
             log.error("Quarkus Extension Dependency Verification Error");
@@ -892,7 +911,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             final StringBuilder buf = new StringBuilder();
 
             if (rootDeployment.deploymentDepsTotal != 0) {
-                log.error("Deployment artifact " + getDeploymentCoords() +
+                log.error(rootDeployment.deploymentDepsTotal + "Deployment artifact " + getDeploymentCoords() +
                         " was found to be missing dependencies on the Quarkus extension artifacts marked with '-' below:");
                 final List<ArtifactKey> missing = rootDeployment.collectMissingDeploymentDeps(log);
                 buf.append("Deployment artifact ");
@@ -1035,7 +1054,9 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         if (node != null) {
             if (!node.present) {
                 node.present = true;
-                --rootDeployment.deploymentDepsTotal;
+                if (!isExemptGact(node.gact)) {
+                    --rootDeployment.deploymentDepsTotal;
+                }
                 if (rootDeployment.allRtDeps.contains(key)) {
                     rootDeployment.deploymentsOnRtCp.add(key);
                 }
@@ -1043,7 +1064,12 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         } else if (!rootDeployment.allRtDeps.contains(key)) {
             final ArtifactKey deployment = getDeploymentKey(artifact);
             if (deployment != null) {
-                rootDeployment.unexpectedDeploymentDeps.put(deployment, artifact);
+                if (isExemptGact(deployment)) {
+                    rootDeployment.riskyDeploymentDeps.put(deployment, artifact);
+                } else {
+                    rootDeployment.unexpectedDeploymentDeps.put(deployment, artifact);
+
+                }
             }
         }
         visitDeploymentDeps(rootDeployment, dep);
@@ -1057,7 +1083,9 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         if (deployment != null) {
             currentNode = currentNode.newChild(deployment, ++currentId);
             root.expectedDeploymentNodes.put(currentNode.gact, currentNode);
-            ++root.deploymentDepsTotal;
+            if (!isExemptGact(currentNode.gact)) {
+                ++root.deploymentDepsTotal;
+            }
             if (root.allRtDeps.contains(deployment)) {
                 root.deploymentsOnRtCp.add(deployment);
                 if (root.directRuntimeDeps.contains(deployment)) {
@@ -1075,6 +1103,11 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             }
         }
         visitRuntimeDeps(root, currentNode, currentId, node);
+    }
+
+    private static boolean isExemptGact(ArtifactKey gact) {
+        return (gact.getArtifactId().equals("quarkus-devservices")
+                || gact.getArtifactId().equals("quarkus-devservices-deployment")) && gact.getGroupId().equals("io.quarkus");
     }
 
     private void visitRuntimeDeps(RootNode root, Node currentNode, int currentId, DependencyNode node)
@@ -1298,12 +1331,16 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         final Set<ArtifactKey> allRtDeps = new HashSet<>();
         final Set<ArtifactKey> allDeploymentDeps = new HashSet<>();
         final Map<ArtifactKey, org.eclipse.aether.artifact.Artifact> unexpectedDeploymentDeps = new HashMap<>(0);
+        final Map<ArtifactKey, org.eclipse.aether.artifact.Artifact> riskyDeploymentDeps = new HashMap<>(0);
 
         int deploymentDepsTotal = 1;
         List<ArtifactKey> deploymentsOnRtCp = new ArrayList<>(0);
 
         RootNode(ArtifactKey gact, int id) {
             super(null, gact, id);
+            if (isExemptGact(gact)) {
+                deploymentDepsTotal = 0;
+            }
         }
 
         boolean hasErrors() {


### PR DESCRIPTION
Historically, the dev services extension has a deployment module, but no runtime one. Adding a runtime module is non-trivial, because as soon as the runtime module exists, the quarkus extension maven plugin will insist that every extension which uses the deployment module has a dependency on the runtime module. Why not just do the one-time change and add the `runtime` dependency to the poms? That would work for quarkus core repo, but not for the ecosystem. A breaking change like that would be inconvenient for extension authors, but annoying for users, since extensions would only work with 3.26 or 3.25, and not both. 

Instead, we decided to special-case this module and tolerate missing dependencies. The new module isn't needed for old-style dev services, only new ones. So the goal is that if dev services on the new model are missing the dependency, they should fail with a clear message and early. Ideally, they'd fail at build time, but if not, quickly. Dev services not using the new model should continue to work. 

It's not visible in CI, because I fixed it (obviously), but I've confirmed that if I don't have the runtime dependency on a new-style devservice, I get this failure: 

```
[ERROR] TestEngine with ID 'junit-jupiter' encountered a critical issue during test discovery:
[ERROR] 
[ERROR] (1) [ERROR] ClassSelector [className = 'io.quarkus.redis.devservices.it.DevServicesRedisNonUniquePortTest', classLoader = null] resolution failed
[ERROR]     Source: ClassSource [className = 'io.quarkus.redis.devservices.it.DevServicesRedisNonUniquePortTest', filePosition = null]
[ERROR]             at io.quarkus.redis.devservices.it.DevServicesRedisNonUniquePortTest.<no-method>(SourceFile:0)
[ERROR]     Cause: org.junit.platform.commons.PreconditionViolationException: Could not load class with name: io.quarkus.redis.devservices.it.DevServicesRedisNonUniquePortTest
[ERROR]         at org.junit.platform.engine.discovery.ClassSelector.lambda$getJavaClass$0(ClassSelector.java:98)
...
[ERROR] Caused by: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]         [error]: Build step io.quarkus.redis.deployment.client.DevServicesRedisProcessor#startRedisContainers threw an exception: java.lang.RuntimeException: java.lang.IllegalStateException: Extension error. Please add the io.quarkus:quarkus-devservices runtime dependency to the extension's runtime module.
[ERROR]         at io.quarkus.redis.deployment.client.DevServicesRedisProcessor.startRedisContainers(DevServicesRedisProcessor.java:106)
[ERROR]         at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
[ERROR]         at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:873)
```

I moved some runtime classes over, but not all. I couldn’t move the `crossclassloader` classes over because the StartupImpl needs the registry build item, and the build item needs all the crossclassloader classes. We could switch to reflective access and some interfaces to allow them to move over if we think it’s worth it. That can be a follow-on PR, though, if we do want to do it. It reduces the runtime module size (yay), but adds reflection on the dev service path (boo). 

I didn’t do a `runtime-dev` module because dev services are used by integration and native tests, so I think it needs to be a full runtime module (annoyingly). 

So we don't lose track of it, I've raised https://github.com/quarkusio/quarkus/pull/49026 as follow-on PR to undo the exemption for Quarkus 4.

- Resolves: #47881