### PR TITLE
Support for customizing request and response body in OIDC filters

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -336,7 +336,7 @@ quarkus.oidc.introspection-credentials.secret=introspection-user-secret
 [[code-flow-oidc-request-filters]]
 === OIDC request filters
 
-You can filter OIDC requests made by Quarkus to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers and can also log requests.
+You can filter OIDC requests made by Quarkus to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers, customize a request body and can also log requests.
 
 For example:
 
@@ -401,6 +401,35 @@ public class OidcDiscoveryRequestCustomizer implements OidcRequestFilter {
 Currently, you can use a `tenand_id` key to access the OIDC tenant id and a `grant_type` key to access the grant type which the OIDC provider uses to acquire tokens.
 The `grant_type` can only be set to either `authorization_code` or `refresh_token` grant type, when requests are made to the token endpoint. It is `null` in all other cases.
 
+`OidcRequestFilter` can customize a request body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
+and setting it on a request context, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN)
+public class TokenRequestFilter implements OidcRequestFilter {
+
+    @Override
+    public void filter(OidcRequestContext rc) {
+        // Add more required properties to the token request
+        rc.requestBody(Buffer.buffer(rc.requestBody().toString() + "&opaque_token_param=opaque_token_value"));
+    }
+}
+----
+
 [[code-flow-oidc-response-filters]]
 === OIDC response filters
 
@@ -444,6 +473,40 @@ public class TokenEndpointResponseFilter implements OidcResponseFilter {
 <2> Check the response `Content-Type` header.
 <3> Use `OidcRequestContextProperties` request properties to check only an `authorization_code` token grant response for the `code-flow-user-info-cached-in-idtoken` tenant.
 <4> Confirm the response JSON contains an `id_token` property.
+
+`OidcResponseFilter` can customize a response body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
+and setting it on a response context, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN)
+public class TokenResponseFilter implements OidcResponseFilter {
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        JsonObject body = rc.responseBody().toJsonObject();
+        // JSON `scope` property has multiple values separated by a comma character.
+        // It must be replaced with a space character.
+        String scope = body.getString("scope");
+        body.put("scope", scope.replace(",", " "));
+        rc.responseBody(Buffer.buffer(body.toString()));
+    }
+}
+----
 
 === Redirecting to and from the OIDC provider
 

--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -1235,13 +1235,13 @@ You can also intercept OIDC redirect requests.
 
 ==== OIDC requests
 
-You can use OIDC request filters to observe requests, add additional headers, and set context properties for coordinating with OIDC response filters.
+You can use OIDC request filters to observe requests, add additional headers, customize a request body, and set context properties for coordinating with OIDC response filters.
 
 Use xref:security-oidc-code-flow-authentication.adoc#code-flow-oidc-request-filters[quarkus.oidc.common.OidcRequestFilter] to implement a request filter and if necessary, restrict it to the specific OIDC endpoint or endpoints only with the `quarkus.oidc.common.OidcEndpoint` annotation.
 
 ==== OIDC responses
 
-You can use OIDC response filters to observe responses, and use the context properties for coordinating with OIDC request filters.
+You can use OIDC response filters to observe responses, customize a response body, and use the context properties for coordinating with OIDC request filters.
 
 Use xref:security-oidc-code-flow-authentication.adoc#code-flow-oidc-response-filters[quarkus.oidc.common.OidcResponseFilter] to implement a response filter and if necessary, restrict it to the specific OIDC endpoint or endpoints only with the `quarkus.oidc.common.OidcEndpoint` annotation.
 

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1220,7 +1220,7 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-lev
 [[oidc-client-ref-oidc-request-filters]]
 == OIDC request filters
 
-You can filter OIDC requests made by OIDC client to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers, or analyze the request body.
+You can filter OIDC requests made by OIDC client to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers, customize or analyze the request body.
 
 You can have a single filter intercepting requests to all OIDC provider endpoints, or use an `@OidcEndpoint` annotation to apply this filter to requests to specific endpoints only. For example:
 
@@ -1257,6 +1257,35 @@ public class OidcRequestCustomizer implements OidcRequestFilter {
 
 `OidcRequestContextProperties` can be used to access request properties.
 Currently, you can use a `client_id` key to access the client tenant id and a `grant_type` key to access the grant type which the OIDC client uses to acquire tokens.
+
+`OidcRequestFilter` can customize a request body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
+and setting it on a request context, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN)
+public class TokenRequestFilter implements OidcRequestFilter {
+
+    @Override
+    public void filter(OidcRequestContext rc) {
+        // Add more required properties to the token request
+        rc.requestBody(rc.requestBody().toString() + "&opaque_token_param=opaque_token_value"));
+    }
+}
+----
 
 [[oidc-client-ref-oidc-response-filters]]
 == OIDC response filters
@@ -1301,6 +1330,40 @@ public class TokenEndpointResponseFilter implements OidcResponseFilter {
 <2> Check the response `Content-Type` header.
 <3> Use `OidcRequestContextProperties` request properties to confirm it is a `refresh_grant` token grant response.
 <4> Confirm the response JSON contains a `refresh_token` property.
+
+`OidcResponseFilter` can customize a response body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
+and setting it as a property on a response context, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN)
+public class TokenResponseFilter implements OidcResponseFilter {
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        JsonObject body = rc.responseBody().toJsonObject();
+        // JSON `scope` property has multiple values separated by a comma character.
+        // It must be replaced with a space character.
+        String scope = body.getString("scope");
+        body.put("scope", scope.replace(",", " "));
+        rc.responseBody(Buffer.buffer(body.toString()));
+    }
+}
+----
 
 [[token-propagation-rest]]
 == Token Propagation for Quarkus REST

--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -505,7 +505,9 @@ You can persist the already registered client's registration URI and registratio
 [[oidc-client-registration-oidc-request-filters]]
 == OIDC request filters
 
-You can filter OIDC client registration and registered client requests registering one or more `OidcRequestFilter` implementations, which can update or add new request headers. For example, a filter can analyze the request body and add its digest as a new header value:
+You can filter OIDC client registration and registered client requests registering one or more `OidcRequestFilter` implementations, which can update or add new request headers, as well as customize a request body.
+
+For example, a filter can analyze the request body and add its digest as a new header value:
 
 You can have a single filter intercepting all the OIDC registration and registered client requests, or use an `@OidcEndpoint` annotation to apply this filter to either OIDC registration or registered client endpoint responses only. For example:
 
@@ -543,6 +545,40 @@ public class ClientRegistrationRequestFilter implements OidcRequestFilter {
 
 `OidcRequestContextProperties` can be used to access request properties.
 Currently, you can use a `client_id` key to access the client tenant id and a `grant_type` key to access the grant type which the OIDC client uses to acquire tokens.
+
+`OidcRequestFilter` can customize a request body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
+and setting it on a request context, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.CLIENT_REGISTRATION)
+public class ClientRegistrationReRequestFilter implements OidcRequestFilter {
+
+    @Override
+    public void filter(OidcRequestContext rc) {
+        // Update the client name
+        JsonObject body = rc.requestBody().toJsonObject();
+        if ("Dynamic Tenant Client".equals(body.getString("client_name"))) {
+            body.put("client_name", "Registered Dynamic Tenant Client");
+            rc.requestBody(Buffer.buffer(body.toString()));
+        }
+    }
+}
+----
 
 [[oidc-client-registration-oidc-response-filters]]
 == OIDC response filters
@@ -624,6 +660,42 @@ public class RegisteredClientResponseFilter implements OidcResponseFilter {
 <1> Restrict this filter to requests targeting the registered OIDC client endpoint only.
 <2> Check the response `Content-Type` header.
 <3> Confirm the client name property was updated.
+
+`OidcResponseFilter` can customize a response body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
+and setting it as a property on a response context, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.CLIENT_REGISTRATION)
+public class ClientRegistrationResponseFilter implements OidcResponseFilter {
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        // Update the client name
+        JsonObject body = rc.responseBody().toJsonObject();
+        if ("Registered Dynamic Tenant Client".equals(body.getString("client_name"))) {
+            body.put("client_name", "Registered Dynamically Tenant Client");
+            rc.responseContext(Buffer.buffer(body.toString()));
+        }
+    }
+}
+----
 
 [[configuration-reference]]
 == Configuration reference

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
@@ -162,7 +162,8 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Buffer buffer = Buffer.buffer(clientRegJson);
-        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, request, filters, buffer).sendBuffer(buffer)
+        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, request, filters, buffer)
+                .sendBuffer(OidcCommonUtils.getRequestBuffer(requestProps, buffer))
                 .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount())
@@ -193,8 +194,8 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
             Map<Type, List<OidcRequestFilter>> requestFilters,
             Map<Type, List<OidcResponseFilter>> responseFilters,
             OidcRequestContextProperties requestProps) {
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, OidcEndpoint.Type.CLIENT_REGISTRATION);
+        Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters,
+                OidcEndpoint.Type.CLIENT_REGISTRATION);
         if (resp.statusCode() == 200 || resp.statusCode() == 201) {
             JsonObject json = buffer.toJsonObject();
             LOG.debugf("Client has been succesfully registered: %s", json.toString());

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
@@ -161,7 +161,8 @@ public class RegisteredClientImpl implements RegisteredClient {
             request.putHeader(AUTHORIZATION_HEADER, OidcConstants.BEARER_SCHEME + " " + registrationToken);
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
-        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, request, buffer).sendBuffer(buffer)
+        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, request, buffer)
+                .sendBuffer(OidcCommonUtils.getRequestBuffer(requestProps, buffer))
                 .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount())
@@ -186,8 +187,8 @@ public class RegisteredClientImpl implements RegisteredClient {
     }
 
     private RegisteredClient newRegisteredClient(HttpResponse<Buffer> resp, OidcRequestContextProperties requestProps) {
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, OidcEndpoint.Type.REGISTERED_CLIENT);
+        Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters,
+                OidcEndpoint.Type.REGISTERED_CLIENT);
         if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
             io.vertx.core.json.JsonObject json = buffer.toJsonObject();
             LOG.debugf("Client metadata has been succesfully updated: %s", json.toString());
@@ -208,8 +209,8 @@ public class RegisteredClientImpl implements RegisteredClient {
     }
 
     private Uni<Void> deleteResponse(HttpResponse<Buffer> resp, OidcRequestContextProperties requestProps) {
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, OidcEndpoint.Type.REGISTERED_CLIENT);
+        Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters,
+                OidcEndpoint.Type.REGISTERED_CLIENT);
         if (resp.statusCode() == 200) {
             LOG.debug("Client has been succesfully deleted");
             return Uni.createFrom().voidItem();

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -148,8 +148,7 @@ public class OidcClientImpl implements OidcClient {
         // invalid token, https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.
         // 503 is at least theoretically possible if the OIDC server declines and suggests to Retry-After some period of time.
         // However this period of time can be set to unpredictable value.
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, OidcEndpoint.Type.TOKEN_REVOCATION);
+        OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, OidcEndpoint.Type.TOKEN_REVOCATION);
         return resp.statusCode() == 503 ? false : true;
     }
 
@@ -243,7 +242,8 @@ public class OidcClientImpl implements OidcClient {
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Buffer buffer = OidcCommonUtils.encodeForm(body);
-        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, endpointType, request, buffer).sendBuffer(buffer)
+        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, endpointType, request, buffer)
+                .sendBuffer(OidcCommonUtils.getRequestBuffer(requestProps, buffer))
                 .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount())
@@ -256,8 +256,7 @@ public class OidcClientImpl implements OidcClient {
     }
 
     private Tokens emitGrantTokens(OidcRequestContextProperties requestProps, HttpResponse<Buffer> resp, boolean refresh) {
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, OidcEndpoint.Type.TOKEN);
+        Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, OidcEndpoint.Type.TOKEN);
         if (resp.statusCode() == 200) {
             LOG.debugf("%s OidcClient has %s the tokens", oidcConfig.id().get(), (refresh ? "refreshed" : "acquired"));
             JsonObject json = buffer.toJsonObject();

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestContextProperties.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestContextProperties.java
@@ -9,6 +9,8 @@ public class OidcRequestContextProperties {
     public static String TOKEN = "token";
     public static String TOKEN_CREDENTIAL = "token_credential";
     public static String DISCOVERY_ENDPOINT = "discovery_endpoint";
+    public static String REQUEST_BODY = "request_body";
+    public static String RESPONSE_BODY = "response_body";
 
     private final Map<String, Object> properties;
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestFilter.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestFilter.java
@@ -14,7 +14,35 @@ public interface OidcRequestFilter {
     /**
      * OIDC request context which provides access to the HTTP request headers and body, as well as context properties.
      */
-    record OidcRequestContext(HttpRequest<Buffer> request, Buffer requestBody, OidcRequestContextProperties contextProperties) {
+    class OidcRequestContext {
+        final HttpRequest<Buffer> request;
+        final OidcRequestContextProperties contextProperties;
+        Buffer requestBody;
+
+        public OidcRequestContext(HttpRequest<Buffer> request, Buffer requestBody,
+                OidcRequestContextProperties contextProperties) {
+            this.request = request;
+            this.requestBody = requestBody;
+            this.contextProperties = contextProperties;
+        }
+
+        public HttpRequest<Buffer> request() {
+            return request;
+        }
+
+        public Buffer requestBody() {
+            return requestBody;
+        }
+
+        public OidcRequestContextProperties contextProperties() {
+            return contextProperties;
+        }
+
+        public void requestBody(Buffer buffer) {
+            requestBody = buffer;
+            contextProperties.put(OidcRequestContextProperties.REQUEST_BODY, buffer);
+        }
+
     }
 
     /**

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcResponseFilter.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcResponseFilter.java
@@ -13,8 +13,40 @@ public interface OidcResponseFilter {
     /**
      * OIDC response context which provides access to the HTTP response status code, headers and body.
      */
-    record OidcResponseContext(OidcRequestContextProperties requestProperties,
-            int statusCode, MultiMap responseHeaders, Buffer responseBody) {
+    class OidcResponseContext {
+        final OidcRequestContextProperties requestProperties;
+        final int statusCode;
+        final MultiMap responseHeaders;
+        Buffer responseBody;
+
+        public OidcResponseContext(OidcRequestContextProperties requestProperties, int statusCode,
+                MultiMap responseHeaders, Buffer responseBody) {
+            this.requestProperties = requestProperties;
+            this.statusCode = statusCode;
+            this.responseHeaders = responseHeaders;
+            this.responseBody = responseBody;
+        }
+
+        public OidcRequestContextProperties requestProperties() {
+            return requestProperties;
+        }
+
+        public int statusCode() {
+            return statusCode;
+        }
+
+        public MultiMap responseHeaders() {
+            return responseHeaders;
+        }
+
+        public Buffer responseBody() {
+            return responseBody;
+        }
+
+        public void responseBody(Buffer buffer) {
+            responseBody = buffer;
+            requestProperties.put(OidcRequestContextProperties.RESPONSE_BODY, buffer);
+        }
     }
 
     /**

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -277,8 +277,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         // invalid token, https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.
         // 503 is at least theoretically possible if the OIDC server declines and suggests to Retry-After some period of time.
         // However this period of time can be set to unpredictable value.
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, OidcEndpoint.Type.TOKEN_REVOCATION);
+        OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, OidcEndpoint.Type.TOKEN_REVOCATION);
         return resp.statusCode() == 503 ? false : true;
     }
 
@@ -345,7 +344,8 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         // Retry up to three times with a one-second delay between the retries if the connection is closed.
 
         OidcEndpoint.Type endpoint = introspect ? OidcEndpoint.Type.INTROSPECTION : OidcEndpoint.Type.TOKEN;
-        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, endpoint, request, buffer).sendBuffer(buffer)
+        Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, endpoint, request, buffer)
+                .sendBuffer(OidcCommonUtils.getRequestBuffer(requestProps, buffer))
                 .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount()).onFailure().transform(Throwable::getCause);
@@ -381,8 +381,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
 
     private JsonObject getJsonObject(OidcRequestContextProperties requestProps, String requestUri, HttpResponse<Buffer> resp,
             OidcEndpoint.Type endpoint) {
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, endpoint);
+        Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, endpoint);
         if (resp.statusCode() == 200) {
             LOG.debugf("Request succeeded: %s", resp.bodyAsJsonObject());
             return buffer.toJsonObject();
@@ -395,8 +394,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
 
     private String getString(final OidcRequestContextProperties requestProps, String requestUri, HttpResponse<Buffer> resp,
             OidcEndpoint.Type endpoint) {
-        Buffer buffer = resp.body();
-        OidcCommonUtils.filterHttpResponse(requestProps, resp, buffer, responseFilters, endpoint);
+        Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, endpoint);
         if (resp.statusCode() == 200) {
             LOG.debugf("Request succeeded: %s", resp.bodyAsString());
             return buffer.toString();

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationRequestFilter.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationRequestFilter.java
@@ -9,6 +9,7 @@ import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
 
 @ApplicationScoped
 @Unremovable
@@ -21,6 +22,9 @@ public class ClientRegistrationRequestFilter implements OidcRequestFilter {
         JsonObject body = rc.requestBody().toJsonObject();
         if ("Default Client".equals(body.getString("client_name"))) {
             LOG.debug("'Default Client' registration request");
+        } else if ("Dynamic Tenant Client".equals(body.getString("client_name"))) {
+            body.put("client_name", "Registered Dynamic Tenant Client");
+            rc.requestBody(Buffer.buffer(body.toString()));
         }
     }
 

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationResponseFilter.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationResponseFilter.java
@@ -9,6 +9,7 @@ import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcResponseFilter;
 import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
 
 @ApplicationScoped
 @Unremovable
@@ -20,9 +21,13 @@ public class ClientRegistrationResponseFilter implements OidcResponseFilter {
     public void filter(OidcResponseContext rc) {
         String contentType = rc.responseHeaders().get("Content-Type");
         JsonObject body = rc.responseBody().toJsonObject();
-        if (contentType.startsWith("application/json")
-                && "Default Client".equals(body.getString("client_name"))) {
-            LOG.debug("'Default Client' has been registered");
+        if (contentType.startsWith("application/json")) {
+            if ("Default Client".equals(body.getString("client_name"))) {
+                LOG.debug("'Default Client' has been registered");
+            } else if ("Registered Dynamic Tenant Client".equals(body.getString("client_name"))) {
+                body.put("client_name", "Registered Dynamically Tenant Client");
+                rc.responseBody(Buffer.buffer(body.toString()));
+            }
         }
     }
 

--- a/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationTest.java
+++ b/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationTest.java
@@ -97,7 +97,7 @@ public class OidcClientRegistrationTest {
 
             TextPage textPage = loginForm.getButtonByName("login").click();
 
-            assertEquals("registered-client-dynamic-tenant:Dynamic Tenant Client:alice", textPage.getContent());
+            assertEquals("registered-client-dynamic-tenant:Registered Dynamically Tenant Client:alice", textPage.getContent());
         }
     }
 

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -109,7 +109,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                 .withHeader("GrantType", matching("password"))
                 .withHeader("client-id", containing("non-standard-response"))
                 .withRequestBody(matching(
-                        "grant_type=password&audience=audience1&username=alice&password=alice&extra_param=extra_param_value"))
+                        "grant_type=password&audience=audience1&username=alice&password=alice&extra_param=extra_param_value&custom_prop=custom_value"))
                 .willReturn(WireMock
                         .aResponse()
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -211,7 +211,7 @@ public class OidcClientTest {
         RestAssured.when().get("/frontend/echoTokenNonStandardResponse")
                 .then()
                 .statusCode(200)
-                .body(equalTo("access_token_n refresh_token_n"));
+                .body(equalTo("access_token_n refresh_token_non_standard"));
     }
 
     @Order(4)

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -872,11 +872,12 @@ public class CodeFlowAuthorizationTest {
     private void defineCodeFlowOpaqueAccessTokenStub() {
         wireMockServer
                 .stubFor(WireMock.post(urlPathMatching("/auth/realms/quarkus/opaque-access-token"))
+                        .withRequestBody(containing("&opaque_token_param=opaque_token_value"))
                         .willReturn(WireMock.aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +
                                         "  \"access_token\": \"alice\","
-                                        + "  \"scope\": \"laptop phone\","
+                                        + "  \"scope\": \"laptop,phone\","
                                         + "\"expires_in\": 299}")));
     }
 


### PR DESCRIPTION
Fixes #49041.
Fixes #40258.

This PR provides a simple option for `OidcRequestFilter` implementations to customize a request body and for `OidcResponseFilter` implementations to customize a response body, by depending on a shared `OidcRequestContextProperties` map as a medium to pass the updated content back to the runtime 