### PR TITLE
Handle `docker-compose` output more like we did before

### DIFF
--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeRunner.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeRunner.java
@@ -118,6 +118,7 @@ public class ComposeRunner {
                     }
                 })
                 .output().consumeLinesWith(8192, LOG::info)
+                .error().logOnSuccess(false).consumeLinesWith(8192, LOG::info)
                 .run();
 
         LOG.info("Compose has finished running");


### PR DESCRIPTION
Before, we redirected error to output and then logged the output. We do not want that now, because then we would not gather the error output on failure, but we can still log the same way we did before by capturing the error output and writing it to the log line-by-line.

See https://github.com/quarkusio/quarkus/pull/48354#issuecomment-3101423988 for more info.