### PR TITLE
Allow BOM overrides with the defined maven properties in list-extensions goal

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -59,13 +59,13 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
     protected List<RemoteRepository> repos;
 
     @Parameter(property = "bomGroupId", required = false)
-    private String bomGroupId;
+    protected String bomGroupId;
 
     @Parameter(property = "bomArtifactId", required = false)
-    private String bomArtifactId;
+    protected String bomArtifactId;
 
     @Parameter(property = "bomVersion", required = false)
-    private String bomVersion;
+    protected String bomVersion;
 
     @Component
     QuarkusWorkspaceProvider workspaceProvider;
@@ -213,6 +213,10 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
             }
         }
         return descriptors;
+    }
+
+    protected static ArtifactCoords getPrimaryBom(ExtensionCatalog c) {
+        return c.getDerivedFrom().isEmpty() ? c.getBom() : c.getDerivedFrom().get(0).getBom();
     }
 
     protected void validateParameters() throws MojoExecutionException {

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -157,8 +157,4 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
             throw new MojoExecutionException("Failed to apply the updates", e);
         }
     }
-
-    private static ArtifactCoords getPrimaryBom(ExtensionCatalog c) {
-        return c.getDerivedFrom().isEmpty() ? c.getBom() : c.getDerivedFrom().get(0).getBom();
-    }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/ListExtensions.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/ListExtensions.java
@@ -11,6 +11,7 @@ import io.quarkus.devtools.commands.handlers.ListExtensionsCommandHandler;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.extensions.ExtensionManager;
+import io.quarkus.registry.catalog.ExtensionCatalog;
 
 /**
  * Instances of this class are not thread-safe. They are created per single invocation.
@@ -25,6 +26,7 @@ public class ListExtensions {
     public static final String CATEGORY = "quarkus.list-extensions.category";
     public static final String BATCH_MODE = "quarkus.list-extensions.batch-mode";
     public static final String EXTENSION_MANAGER = "quarkus.list-extensions.extension-manager";
+    public static final String TARGET_CATALOG = "quarkus.list-extensions.target-catalog";
 
     public static final String MORE_INFO_HINT = "To get more information, append `%s` to your command line.";
     public static final String FILTER_HINT = "To list only extensions from specific category, append " +
@@ -80,6 +82,11 @@ public class ListExtensions {
 
     public ListExtensions batchMode(boolean batchMode) {
         invocation.setValue(BATCH_MODE, batchMode);
+        return this;
+    }
+
+    public ListExtensions targetCatalog(ExtensionCatalog targetCatalog) {
+        invocation.setValue(TARGET_CATALOG, targetCatalog);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
@@ -26,6 +26,7 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.ExtensionOrigin;
 
 /**
@@ -55,9 +56,11 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
         final boolean batchMode = invocation.getValue(ListExtensions.BATCH_MODE, false);
         final ExtensionManager extensionManager = invocation.getValue(ListExtensions.EXTENSION_MANAGER,
                 invocation.getQuarkusProject().getExtensionManager());
+        final ExtensionCatalog extensionCatalog = invocation.getValue(ListExtensions.TARGET_CATALOG,
+                invocation.getQuarkusProject().getExtensionsCatalog());
 
-        final Collection<Extension> extensions = search == null ? invocation.getExtensionsCatalog().getExtensions()
-                : QuarkusCommandHandlers.listExtensions(search, invocation.getExtensionsCatalog().getExtensions(), true)
+        final Collection<Extension> extensions = search == null ? extensionCatalog.getExtensions()
+                : QuarkusCommandHandlers.listExtensions(search, extensionCatalog.getExtensions(), true)
                         .getExtensions();
 
         if (extensions.isEmpty()) {


### PR DESCRIPTION
Not sure how to write a test for this if someone can point me to an example.

Let me know if this should work for other commands as well but I noticed this only in `quarkus:list-extensions`. 