### PR TITLE
WIP - Avoid using a counter for recorded proxies identifier

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
@@ -57,11 +57,27 @@ public interface RecorderContext {
     /**
      * Creates a RuntimeValue object that represents an object created via the default constructor.
      * <p>
-     * This object can be passed into recorders, but must not be used directly at deployment time
+     * This object can be passed into recorders, but must not be used directly at deployment time.
+     * <p>
+     * The default identifier is {@code HashUtil.sha1(className)}.
+     * If this identifier is not unique in your codebase, use {@link #newInstance(String, String)}
+     * to define a more specific identifier.
      *
-     * @param name The name of the class
+     * @param className The name of the class
      * @param <T> The type of the class
      * @return The class instance proxy
      */
-    <T> RuntimeValue<T> newInstance(String name);
+    <T> RuntimeValue<T> newInstance(String className);
+
+    /**
+     * Creates a RuntimeValue object that represents an object created via the default constructor.
+     * <p>
+     * This object can be passed into recorders, but must not be used directly at deployment time
+     *
+     * @param className The name of the class
+     * @param identifier An identifier for the instance, must be unique to the codebase
+     * @param <T> The type of the class
+     * @return The class instance proxy
+     */
+    <T> RuntimeValue<T> newInstance(String className, String identifier);
 }


### PR DESCRIPTION
Using a counter is problematic as we run a lot of things in parallel and the proxies might not be created exactly in the same order for each run.

> [!NOTE]
> This approach is highly experimental and I created the PR to gather feedback and get a CI run.