### PR TITLE
Always load properties and fields of recorded objects in the same order

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -1459,8 +1460,10 @@ public class BytecodeRecorderImpl implements RecorderContext {
             }
         }
 
-        //now handle accessible fields
-        for (Field field : param.getClass().getFields()) {
+        //now handle accessible fields, in a deterministic order
+        Field[] fields = param.getClass().getFields();
+        Arrays.sort(fields, Comparator.comparing(Field::getName));
+        for (Field field : fields) {
             // check if the field is ignored
             if (ignoreField(field)) {
                 continue;

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
@@ -6,10 +6,10 @@ import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -53,7 +53,8 @@ final class PropertyUtils {
                 }
             }
 
-            Set<String> names = new HashSet<>(getters.keySet());
+            // we want to return the properties in a deterministic order
+            Set<String> names = new TreeSet<>(getters.keySet());
             names.addAll(isGetters.keySet());
             names.addAll(setters.keySet());
             for (String i : names) {


### PR DESCRIPTION
This is part of the reproducible build work.

