### PR TITLE
Drop useless junit-platform-testkit version property

### DIFF
--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -45,7 +45,6 @@
         <smallrye-common.version>2.13.7</smallrye-common.version>
 
         <junit5.version>5.13.4</junit5.version>
-        <junit.testkit.version>1.13.3</junit.testkit.version>
         <assertj.version>3.27.3</assertj.version>
     </properties>
 


### PR DESCRIPTION
Follow-up of #48808, I dropped the version for the artifact but didn't remove the property.
