### PR TITLE
Reflect top-level name attribute in Compose file for test execution

### DIFF
--- a/docs/src/main/asciidoc/compose-dev-services.adoc
+++ b/docs/src/main/asciidoc/compose-dev-services.adoc
@@ -645,6 +645,8 @@ Compose Dev Services won't try to discover any services and will be disabled.
 === Compose Dev Services used for tests
 
 For Quarkus tests, a generated project name in the format `quarkus-devservices-<application-name>-<random-suffix>` is used by default to ensure isolation between test runs and running dev mode services.
+If the top-level name attribute is specified in the Compose file, the project name in the format `<compose-name>-<random-suffix>` is used.
+
 This way, Quarkus tests start a separate copy of the services defined in the compose files.
 For example, when running continuous testing in development mode, tests will have their own isolated set of services.
 

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
@@ -196,6 +196,9 @@ public class ComposeDevServicesProcessor {
         ComposeFiles composeFiles = new ComposeFiles(cfg.files);
         String projectName = (PROJECT_PREFIX + "-" + appName).toLowerCase();
         if (launchMode.getLaunchMode() != LaunchMode.DEVELOPMENT && !cfg.reuseProjectForTests) {
+            if (composeFiles.getProjectName() != null) {
+                projectName = composeFiles.getProjectName();
+            }
             projectName = projectName + "-" + RandomStringUtils.insecure().nextAlphabetic(6).toLowerCase();
         } else {
             if (cfg.project != null) {


### PR DESCRIPTION
Reflect top-level name attribute in Compose file for test execution

- Fixes: https://github.com/quarkusio/quarkus/issues/49031

