### PR TITLE
Run compose-devservices tests in Native

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -51,7 +51,7 @@
         {
             "category": "Build tools and DevTools",
             "timeout": 75,
-            "test-modules": "maven, gradle, devtools-registry-client",
+            "test-modules": "maven, gradle, devtools-registry-client, compose-devservices",
             "os-name": "ubuntu-latest"
         },
         {


### PR DESCRIPTION
Run compose-devservices tests in Native

https://github.com/quarkusio/quarkus/tree/main/integration-tests/compose-devservices is currently executed only in JVM mode on GitHub Actions, there are also tests for Native mode in the module.