### PR TITLE
AMQ Broker support in Compose Dev Services, example for guide

### DIFF
--- a/docs/src/main/asciidoc/amqp-dev-services.adoc
+++ b/docs/src/main/asciidoc/amqp-dev-services.adoc
@@ -59,6 +59,27 @@ IMPORTANT: The configured image must be _compatible_ with the `activemq-artemis-
 The container is launched with the `AMQ_USER`, `AMQ_PASSWORD` and `AMQ_EXTRA_ARGS` environment variables.
 The ports 5672 and 8161 (web console) are exposed.
 
+[[Compose]]
+== Compose
+
+Dev Services for AMQP supports xref:compose-dev-services.adoc[Compose Dev Services].
+It relies on a `compose-devservices.yml`, such as:
+
+[source,yaml]
+----
+name: <application name>
+services:
+  artemis:
+    image: quay.io/artemiscloud/activemq-artemis-broker:1.0.28
+    ports:
+      - "5672"
+      - "8161"
+    environment:
+      AMQ_USER: quarkus
+      AMQ_PASSWORD: quarkus
+      AMQ_EXTRA_ARGS: --no-autotune --mapped --no-fsync --relax-jolokia
+----
+
 [[configuration-reference-devservices]]
 == Configuration reference
 

--- a/docs/src/main/asciidoc/compose-dev-services.adoc
+++ b/docs/src/main/asciidoc/compose-dev-services.adoc
@@ -170,7 +170,7 @@ The following is the list of platform extensions with dev services support:
 |Exposed Port
 
 | AMQP
-| amqp, activemq-artemis, rabbitmq
+| amqp, activemq-artemis, amq-broker, rabbitmq
 | 5672
 
 | Apicurio Registry

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -211,7 +211,7 @@ public class AmqpDevServicesProcessor {
         return amqpContainerLocator.locateContainer(config.serviceName, config.shared, launchMode.getLaunchMode())
                 .map(containerAddress -> getRunningService(config, launchMode, containerAddress))
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
-                        List.of(config.imageName, "amqp", "activemq-artemis", "rabbitmq"),
+                        List.of(config.imageName, "amqp", "activemq-artemis", "amq-broker", "rabbitmq"),
                         AMQP_PORT,
                         launchMode.getLaunchMode(), useSharedNetwork)
                         .map(this::getRunningService))


### PR DESCRIPTION
* AMQ Broker support in Compose Dev Services
  * This allows usage of images like `registry.redhat.io/amq7/amq-broker-rhel8:7.12`
* Compose Dev Services example for amqp-dev-services guide
  * Extending https://github.com/quarkusio/quarkus/pull/48472  
