### PR TITLE
Remove trace logs and bytecode dumping from PublicFieldAccessInheritanceTest

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessInheritanceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessInheritanceTest.java
@@ -34,16 +34,7 @@ public class PublicFieldAccessInheritanceTest {
                     .addClass(MyAbstractEntity.class)
                     .addClass(MyConcreteEntity.class)
                     .addClass(FieldAccessEnhancedDelegate.class))
-            .withConfigurationResource("application.properties")
-            // FIXME Temporary debug options for https://github.com/quarkusio/quarkus/issues/42479
-            .overrideConfigKey("quarkus.hibernate-orm.log.sql", "true")
-            // Not doing this because it has side effects on other tests for some reason;
-            // see https://github.com/quarkusio/quarkus/issues/43180
-            // It's not necessary anyway as the only effect of this config property is to change
-            // the logging level for a specific "org.hibernate.something" category, which we already do below.
-            //.overrideConfigKey("quarkus.hibernate-orm.log.bind-parameters", "true")
-            .debugBytecode(true)
-            .traceCategories("org.hibernate", "io.quarkus.hibernate", "io.quarkus.panache");
+            .withConfigurationResource("application.properties");
 
     @Inject
     EntityManager em;


### PR DESCRIPTION
It's been working great for months now, so we're confident the problems have been solved:

<img width="984" height="367" alt="Screenshot From 2025-07-23 16-30-51" src="https://github.com/user-attachments/assets/9cf37478-8f4b-4cbf-a294-b85e6aba0c33" />
