### PR TITLE
Bump elasticsearch-opensource-components.version from 9.0.3 to 9.0.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -101,7 +101,7 @@
         <narayana-lra.version>1.0.1.Final</narayana-lra.version>
         <agroal.version>2.7.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-opensource-components.version>9.0.3</elasticsearch-opensource-components.version>
+        <elasticsearch-opensource-components.version>9.0.4</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl-java.version>2.2.5.Final</wildfly.openssl-java.version>
         <wildfly.openssl-linux.version>2.2.2.SP01</wildfly.openssl-linux.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -73,7 +73,7 @@
         <volume.access.modifier>:Z</volume.access.modifier>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>9.0.2</elasticsearch-server.version>
+        <elasticsearch-server.version>9.0.4</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>


### PR DESCRIPTION
The tests in Hiberante Search pass. The bug with number search queries that was in 9.0.3 is fixed in 9.0.4, hence we can update the server version now as well.

Supersedes:
* https://github.com/quarkusio/quarkus/pull/49054

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

