### PR TITLE
Add a test for #49075

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistentUnitsWithSingleDatasourceAndMultipleLoadScriptsTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistentUnitsWithSingleDatasourceAndMultipleLoadScriptsTestCase.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.orm.multiplepersistenceunits;
+
+import static org.assertj.core.api.Assertions.*;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.inventory.Plane;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.shared.SharedEntity;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.user.User;
+import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.user.subpackage.OtherUserInSubPackage;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultiplePersistentUnitsWithSingleDatasourceAndMultipleLoadScriptsTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addPackage(Plane.class.getPackage().getName())
+                    .addPackage(SharedEntity.class.getPackage().getName())
+                    .addPackage(User.class.getPackage().getName())
+                    .addPackage(OtherUserInSubPackage.class.getPackage().getName())
+                    .addAsResource("application-multiple-persistence-units-with-load-scripts.properties",
+                            "application.properties")
+                    .addAsResource("import-sharedentity.sql", "import.sql")
+                    .addAsResource("import-users.sql", "import-users.sql"));
+
+    @Inject
+    EntityManager defaultEM;
+
+    @PersistenceUnit("users")
+    EntityManager usersEM;
+
+    @Test
+    @Transactional
+    public void testSharedEntity() {
+        SharedEntity sharedEntity = defaultEM.find(SharedEntity.class, 1L);
+        assertThat(sharedEntity).isNotNull();
+    }
+
+    @Test
+    @Transactional
+    public void testUser() {
+        User user = usersEM.find(User.class, 1L);
+        assertThat(user).isNotNull();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-with-load-scripts.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-with-load-scripts.properties
@@ -1,0 +1,12 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.max-size=1
+
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.hibernate-orm.datasource=<default>
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.shared
+
+quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
+quarkus.hibernate-orm."users".datasource=<default>
+quarkus.hibernate-orm."users".sql-load-script=import-users.sql
+quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.user

--- a/extensions/hibernate-orm/deployment/src/test/resources/import-users.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import-users.sql
@@ -1,0 +1,1 @@
+INSERT INTO User_(id, name) VALUES(1, 'test');


### PR DESCRIPTION
This is to be used to help the Hibernate folks debug #49075. That test doesn't fail, but you can see:

```posh
2025-07-24 11:52:41,643 WARN  [org.hib.too.sch.int.ExceptionHandlerLoggedImpl] (JPA Startup Thread: users) GenerationTarget encountered exception accepting command : Error executing DDL "INSERT INTO SharedEntity(id, name) VALUES(1, 'default sql load script entity')" via JDBC [Unique index or primary key
violation: "PRIMARY KEY ON PUBLIC.SHAREDENTITY(ID) ( /* key:1 */ CAST(1 AS BIGINT), 'default sql load script entity')";]: org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "INSERT INTO SharedEntity(id, name) VALUES(1, 'default sql load script entity')" via JDBC [Unique index or primary key violation: "PRIMARY KEY ON PUBLIC.SHAREDENTITY(ID) ( /* key:1 */ CAST(1 AS BIGINT), 'default sql load script entity')";]
        at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:93)
        at org.hibernate.tool.schema.internal.Helper.applySqlString(Helper.java:221)
        at org.hibernate.tool.schema.internal.Helper.applyScript(Helper.java:244)
        at org.hibernate.tool.schema.internal.AbstractSchemaPopulator.applyImportFiles(AbstractSchemaPopulator.java:150)
        at org.hibernate.tool.schema.internal.AbstractSchemaPopulator.applyImportSources(AbstractSchemaPopulator.java:58)
        at org.hibernate.tool.schema.internal.SchemaCreatorImpl.performCreation(SchemaCreatorImpl.java:172)
        at org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:130)
        at org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:106)
        at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.performDatabaseAction(SchemaManagementToolCoordinator.java:237)
        at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.lambda$process$5(SchemaManagementToolCoordinator.java:142)
        at java.base/java.util.HashMap.forEach(HashMap.java:1429)
        at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.process(SchemaManagementToolCoordinator.java:139)
        at io.quarkus.hibernate.orm.runtime.observers.SessionFactoryObserverForSchemaExport.sessionFactoryCreated(SessionFactoryObserverForSchemaExport.java:21)
        at org.hibernate.internal.SessionFactoryObserverChain.sessionFactoryCreated(SessionFactoryObserverChain.java:33)
        at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:350)
        at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:92)
        at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:74)
        at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:90)
        at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:66)
        at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:165)
        at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:61)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation: "PRIMARY KEY ON PUBLIC.SHAREDENTITY(ID) ( /* key:1 */ CAST(1 AS BIGINT), 'default sql load script entity')"; SQL statement:
INSERT INTO SharedEntity(id, name) VALUES(1, 'default sql load script entity') [23505-230]
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:520)
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:489)
        at org.h2.message.DbException.get(DbException.java:223)
        at org.h2.message.DbException.get(DbException.java:199)
        at org.h2.mvstore.db.MVPrimaryIndex.add(MVPrimaryIndex.java:121)
        at org.h2.mvstore.db.MVTable.addRow(MVTable.java:518)
        at org.h2.command.dml.Insert.insertRows(Insert.java:174)
        at org.h2.command.dml.Insert.update(Insert.java:135)
        at org.h2.command.dml.DataChangeStatement.update(DataChangeStatement.java:74)
        at org.h2.command.CommandContainer.update(CommandContainer.java:139)
        at org.h2.command.Command.executeUpdate(Command.java:304)
        at org.h2.command.Command.executeUpdate(Command.java:248)
        at org.h2.server.TcpServerThread.process(TcpServerThread.java:386)
        at org.h2.server.TcpServerThread.run(TcpServerThread.java:193)
        at java.base/java.lang.Thread.run(Thread.java:1583)

        at org.h2.message.DbException.getJdbcSQLException(DbException.java:520)
        at org.h2.engine.SessionRemote.readSQLException(SessionRemote.java:663)
        at org.h2.engine.SessionRemote.readException(SessionRemote.java:646)
        at org.h2.engine.SessionRemote.done(SessionRemote.java:620)
        at org.h2.command.CommandRemote.executeUpdate(CommandRemote.java:225)
        at org.h2.jdbc.JdbcStatement.executeInternal(JdbcStatement.java:262)
        at org.h2.jdbc.JdbcStatement.execute(JdbcStatement.java:231)
        at io.agroal.pool.wrapper.StatementWrapper.execute(StatementWrapper.java:220)
        at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:79)
        ... 21 more

2025-07-24 11:52:41,644 WARN  [org.hib.too.sch.int.ExceptionHandlerLoggedImpl] (JPA Startup Thread: users) GenerationTarget encountered exception accepting command : Error executing DDL "INSERT INTO SharedEntity(id, name) VALUES(2, 'import.sql load script entity')" via JDBC [Unique index or primary key violation: "PRIMARY KEY ON PUBLIC.SHAREDENTITY(ID) ( /* key:2 */ CAST(2 AS BIGINT), 'import.sql load script entity')";]: org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "INSERT INTO SharedEntity(id, name) VALUES(2, 'import.sql load script entity')" via JDBC [Unique index or primary key violation: "PRIMARY KEY ON PUBLIC.SHAREDENTITY(ID) ( /* key:2 */ CAST(2 AS BIGINT), 'import.sql load script entity')";]
        at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:93)
        at org.hibernate.tool.schema.internal.Helper.applySqlString(Helper.java:221)
        at org.hibernate.tool.schema.internal.Helper.applyScript(Helper.java:244)
        at org.hibernate.tool.schema.internal.AbstractSchemaPopulator.applyImportFiles(AbstractSchemaPopulator.java:150)
        at org.hibernate.tool.schema.internal.AbstractSchemaPopulator.applyImportSources(AbstractSchemaPopulator.java:58)
        at org.hibernate.tool.schema.internal.SchemaCreatorImpl.performCreation(SchemaCreatorImpl.java:172)
        at org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:130)
        at org.hibernate.tool.schema.internal.SchemaCreatorImpl.doCreation(SchemaCreatorImpl.java:106)
        at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.performDatabaseAction(SchemaManagementToolCoordinator.java:237)
        at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.lambda$process$5(SchemaManagementToolCoordinator.java:142)
        at java.base/java.util.HashMap.forEach(HashMap.java:1429)
        at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.process(SchemaManagementToolCoordinator.java:139)
        at io.quarkus.hibernate.orm.runtime.observers.SessionFactoryObserverForSchemaExport.sessionFactoryCreated(SessionFactoryObserverForSchemaExport.java:21)
        at org.hibernate.internal.SessionFactoryObserverChain.sessionFactoryCreated(SessionFactoryObserverChain.java:33)
        at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:350)
        at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:92)
        at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:74)
        at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:90)
        at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:66)
        at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:165)
        at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:61)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation: "PRIMARY KEY ON PUBLIC.SHAREDENTITY(ID) ( /* key:2 */ CAST(2 AS BIGINT), 'import.sql load script entity')"; SQL statement:
INSERT INTO SharedEntity(id, name) VALUES(2, 'import.sql load script entity') [23505-230]
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:520)
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:489)
        at org.h2.message.DbException.get(DbException.java:223)
        at org.h2.message.DbException.get(DbException.java:199)
        at org.h2.mvstore.db.MVPrimaryIndex.add(MVPrimaryIndex.java:121)
        at org.h2.mvstore.db.MVTable.addRow(MVTable.java:518)
        at org.h2.command.dml.Insert.insertRows(Insert.java:174)
        at org.h2.command.dml.Insert.update(Insert.java:135)
        at org.h2.command.dml.DataChangeStatement.update(DataChangeStatement.java:74)
        at org.h2.command.CommandContainer.update(CommandContainer.java:139)
        at org.h2.command.Command.executeUpdate(Command.java:304)
        at org.h2.command.Command.executeUpdate(Command.java:248)
        at org.h2.server.TcpServerThread.process(TcpServerThread.java:386)
        at org.h2.server.TcpServerThread.run(TcpServerThread.java:193)
        at java.base/java.lang.Thread.run(Thread.java:1583)

        at org.h2.message.DbException.getJdbcSQLException(DbException.java:520)
        at org.h2.engine.SessionRemote.readSQLException(SessionRemote.java:663)
        at org.h2.engine.SessionRemote.readException(SessionRemote.java:646)
        at org.h2.engine.SessionRemote.done(SessionRemote.java:620)
        at org.h2.command.CommandRemote.executeUpdate(CommandRemote.java:225)
        at org.h2.jdbc.JdbcStatement.executeInternal(JdbcStatement.java:262)
        at org.h2.jdbc.JdbcStatement.execute(JdbcStatement.java:231)
        at io.agroal.pool.wrapper.StatementWrapper.execute(StatementWrapper.java:220)
        at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:79)
        ... 21 more
```

which is essentially the same cause as the issue described in the original issue