### PR TITLE
Set default to `true` for `quarkus.hibernate-orm.schema-management.halt-on-error`

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -159,7 +159,7 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
         /**
          * Whether we should stop on the first error when applying the schema.
          */
-        @WithDefault("false")
+        @WithDefault("true")
         boolean haltOnError();
     }
 


### PR DESCRIPTION
Because why would we continue running scripts and -- worse -- application startup when something is clearly wrong?

It would only be reasonable to issue a warning and continue running scripts if:

1. The developer is debugging their app, but in that case they can just set `halt-on-error=false`
2. We at least fail application startup after running all scripts, but that's not currently implemented.