### PR TITLE
Datagrid support in Compose Dev Services, example for guide

### DIFF
--- a/docs/src/main/asciidoc/compose-dev-services.adoc
+++ b/docs/src/main/asciidoc/compose-dev-services.adoc
@@ -234,7 +234,7 @@ The following is the list of platform extensions with dev services support:
 | 6379
 
 | Infinispan
-| infinispan
+| infinispan, datagrid
 | 11222
 
 | Elasticsearch

--- a/docs/src/main/asciidoc/infinispan-dev-services.adoc
+++ b/docs/src/main/asciidoc/infinispan-dev-services.adoc
@@ -204,6 +204,24 @@ The default service name is `infinispan`.
 Sharing is enabled by default in dev mode, but disabled in test mode.
 You can disable the sharing with `quarkus.infinispan-client.devservices.shared=false`
 
+== Compose
+
+Dev Services for Infinispan supports xref:compose-dev-services.adoc[Compose Dev Services].
+It relies on a `compose-devservices.yml`, such as:
+
+[source,yaml]
+----
+name: test-project
+services:
+  infinispan:
+    image: quay.io/infinispan/server:15.0.18.Final
+    ports:
+      - '11222'
+    environment:
+      - USER=quarkus
+      - PASS=quarkus
+----
+
 == Configuration reference
 
 include::{generated-dir}/config/quarkus-infinispan-client_quarkus.infinispan-client.devservices.adoc[opts=optional, leveloffset=+1]

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -240,7 +240,7 @@ public class InfinispanDevServiceProcessor {
                 .map(containerAddress -> getRunningDevService(clientName, containerAddress.getId(), null,
                         containerAddress.getUrl(), DEFAULT_USERNAME, DEFAULT_PASSWORD, properties)) // TODO can this be always right ?
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
-                        List.of(devServicesConfig.imageName().orElse(IMAGE_BASENAME), "infinispan"),
+                        List.of(devServicesConfig.imageName().orElse(IMAGE_BASENAME), "infinispan", "datagrid"),
                         DEFAULT_INFINISPAN_PORT, launchMode, useSharedNetwork)
                         .map(address -> getRunningDevService(clientName, address, properties)))
                 .orElseGet(infinispanServerSupplier);


### PR DESCRIPTION
* Datagrid support in Compose Dev Services
  * This allows usage of images like registry.redhat.io/datagrid/datagrid-8-rhel9:latest
* Compose Dev Services example for inginispan-dev-services guide
  * Extending https://github.com/quarkusio/quarkus/pull/48472