### PR TITLE
Bump smallrye-open-api.version from 4.0.11 to 4.0.12

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-config.version>3.13.4</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.0.11</smallrye-open-api.version>
+        <smallrye-open-api.version>4.0.12</smallrye-open-api.version>
         <smallrye-graphql.version>2.14.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.9.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.2</smallrye-jwt.version>
@@ -6719,7 +6719,7 @@
                 <artifactId>quarkus-webjars-locator-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>


### PR DESCRIPTION
Update smallrye-open-api to 4.0.12. This would be good for backport to 3.20.x LTS as well.

Release: https://github.com/smallrye/smallrye-open-api/releases/tag/4.0.12