### PR TITLE
Ignore the default import.sql when specifying a different file

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/DefaultSqlLoadScriptAbsentTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/DefaultSqlLoadScriptAbsentTestCase.java
@@ -1,0 +1,30 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultSqlLoadScriptAbsentTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class, SqlLoadScriptTestResource.class)
+                    .addAsResource("application.properties"))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            // In particular, we don't want Hibernate ORM to log
+            // "Specified schema generation script file [import.sql] did not exist for reading"
+            // when "import.sql" is just the Quarkus default.
+            .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage).isEmpty());
+
+    @Test
+    public void testImportSqlLoadScriptTest() {
+        // No startup failure, so we're already good.
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/DefaultSqlLoadScriptUnusedTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/DefaultSqlLoadScriptUnusedTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test that import.sql is not executed when a different file is specified in quarkus.hibernate-orm.sql-load-file.
+ *
+ * This could happen if 'import.sql' is used for a different persistence unit, for example.
+ *
+ * See https://github.com/quarkusio/quarkus/issues/49075
+ */
+public class DefaultSqlLoadScriptUnusedTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class, SqlLoadScriptTestResource.class)
+                    .addAsResource("application.properties")
+                    // If both these files get executed, a constraint failure will occur due to duplicate PKs.
+                    .addAsResource("import.sql")
+                    .addAsResource("import.sql", "import-different-name.sql"))
+            .overrideConfigKey("quarkus.hibernate-orm.sql-load-script", "import-different-name.sql")
+            // Fail startup if schema management has errors (like... executing the load script multiple times)
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.halt-on-error", "true");
+
+    @Test
+    public void testImportSqlLoadScriptTest() {
+        // No startup failure, so we're already good.
+
+        // Let's just check the script _was_ executed.
+        String name = "import.sql load script entity";
+        RestAssured.when().get("/orm-sql-load-script/2").then().body(Matchers.is(name));
+    }
+}


### PR DESCRIPTION
This fixes a regression caused by the switch from `hibernate.hbm2ddl.import_files` to `jakarta.persistence.sql-load-script-source` #46789 

* Fixes #49075 
