### PR TITLE
Constrain order of ArC generation

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -279,7 +280,7 @@ public class BeanGenerator extends AbstractGenerator {
 
         Map<InjectionPointInfo, String> injectionPointToProviderSupplierField = Collections.emptyMap();
         if (bean.hasInjectionPoint()) {
-            injectionPointToProviderSupplierField = new HashMap<>();
+            injectionPointToProviderSupplierField = new LinkedHashMap<>();
             // Synthetic beans are not intercepted
             initMaps(bean, injectionPointToProviderSupplierField, null, null);
             createProviderFields(beanCreator, bean, injectionPointToProviderSupplierField, Collections.emptyMap(),
@@ -372,9 +373,9 @@ public class BeanGenerator extends AbstractGenerator {
             stereotypes = beanCreator.getFieldCreator(FIELD_NAME_STEREOTYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
 
-        Map<InjectionPointInfo, String> injectionPointToProviderSupplierField = new HashMap<>();
-        Map<InterceptorInfo, String> interceptorToProviderSupplierField = new HashMap<>();
-        Map<DecoratorInfo, String> decoratorToProviderSupplierField = new HashMap<>();
+        Map<InjectionPointInfo, String> injectionPointToProviderSupplierField = new LinkedHashMap<>();
+        Map<InterceptorInfo, String> interceptorToProviderSupplierField = new LinkedHashMap<>();
+        Map<DecoratorInfo, String> decoratorToProviderSupplierField = new LinkedHashMap<>();
         initMaps(bean, injectionPointToProviderSupplierField, interceptorToProviderSupplierField,
                 decoratorToProviderSupplierField);
 


### PR DESCRIPTION
This is part of the build reproducibility work I have been preparing for quite some time now.
Apart from making sure we generate the bytecode in a reproducible order, I think it helps making things a bit more deterministic.

I know the data structures used here are less efficient.
My understanding is that it should only affect build time and have no consequences on runtime.

Another option would be to track when the code is generated and order things there for each use case but I'm not sure it's actually be more readable and maintainable in the long run.

If the cost is not too high, I would favor this approach. @Ladicek @manovotn I don't know if you have a build time benchmark for ArC around?

The idea is to solve reproducibility issues such as:

<img width="2165" height="1229" alt="Screenshot From 2025-07-24 17-13-35" src="https://github.com/user-attachments/assets/878858e6-7f15-49fa-9f91-1f346dfb44cc" />
<img width="2165" height="1229" alt="Screenshot From 2025-07-24 17-13-42" src="https://github.com/user-attachments/assets/f3fab4f4-1a07-4b63-a6c2-f5e2022b8284" />
<img width="2165" height="1229" alt="Screenshot From 2025-07-24 17-13-51" src="https://github.com/user-attachments/assets/6a326c6a-a164-4af8-bd40-f74e92cd6ec2" />
