### PR TITLE
Set priority for form auth handler

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -81,13 +81,13 @@ import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.qute.Qute;
 import io.quarkus.runtime.util.ClassPathUtils;
-import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
@@ -157,13 +157,13 @@ public class DevUIProcessor {
         }
 
         routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .orderedRoute(DEVUI + SLASH_ALL, -2 * FilterBuildItem.CORS)
+                .orderedRoute(DEVUI + SLASH_ALL, -2 * SecurityHandlerPriorities.CORS)
                 .handler(recorder.createLocalHostOnlyFilter(devUIConfig.hosts().orElse(null)))
                 .build());
 
         if (devUIConfig.cors().enabled()) {
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                    .orderedRoute(DEVUI + SLASH_ALL, -1 * FilterBuildItem.CORS)
+                    .orderedRoute(DEVUI + SLASH_ALL, -1 * SecurityHandlerPriorities.CORS)
                     .handler(recorder.createDevUICorsFilter(devUIConfig.hosts().orElse(null)))
                     .build());
         }

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -97,6 +97,7 @@ import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -729,8 +730,8 @@ public class GrpcServerProcessor {
                 if (capabilities.isPresent(Capability.SECURITY)) {
                     securityHandlers = filterBuildItems
                             .stream()
-                            .filter(filter -> filter.getPriority() == FilterBuildItem.AUTHENTICATION
-                                    || filter.getPriority() == FilterBuildItem.AUTHORIZATION)
+                            .filter(filter -> filter.getPriority() == SecurityHandlerPriorities.AUTHENTICATION
+                                    || filter.getPriority() == SecurityHandlerPriorities.AUTHORIZATION)
                             .collect(Collectors.toMap(f -> f.getPriority() * -1, FilterBuildItem::getHandler));
                     // for the moment being, the main router doesn't have QuarkusErrorHandler, but we need to make
                     // sure that exceptions raised during proactive authentication or HTTP authorization are handled

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -117,6 +117,7 @@ import io.quarkus.vertx.http.deployment.HttpSecurityUtils;
 import io.quarkus.vertx.http.deployment.PreRouterFinalizationBuildItem;
 import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
@@ -489,7 +490,7 @@ public class OidcBuildStep {
     @BuildStep
     FilterBuildItem registerBackChannelLogoutHandler(BeanContainerBuildItem beanContainerBuildItem, OidcRecorder recorder) {
         Handler<RoutingContext> handler = recorder.getBackChannelLogoutHandler(beanContainerBuildItem.getValue());
-        return new FilterBuildItem(handler, FilterBuildItem.AUTHORIZATION - 50);
+        return new FilterBuildItem(handler, SecurityHandlerPriorities.AUTHORIZATION - 50);
     }
 
     @BuildStep
@@ -504,7 +505,7 @@ public class OidcBuildStep {
     @BuildStep
     FilterBuildItem registerResourceMetadataHandler(BeanContainerBuildItem beanContainerBuildItem, OidcRecorder recorder) {
         Handler<RoutingContext> handler = recorder.getResourceMetadataHandler(beanContainerBuildItem.getValue());
-        return new FilterBuildItem(handler, FilterBuildItem.AUTHORIZATION - 50);
+        return new FilterBuildItem(handler, SecurityHandlerPriorities.AUTHORIZATION - 50);
     }
 
     private static boolean areEagerSecInterceptorsSupported(Capabilities capabilities,

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -101,6 +101,7 @@ import io.quarkus.vertx.http.deployment.devmode.RouteDescriptionBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
 import io.quarkus.vertx.http.runtime.HttpCompression;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.Route.HttpMethod;
@@ -264,7 +265,8 @@ class ReactiveRoutesProcessor {
         if (capabilities.isMissing(Capability.RESTEASY_REACTIVE)) {
             // replace default auth failure handler added by vertx-http so that route failure handlers can customize response
             filterBuildItemBuildProducer
-                    .produce(new FilterBuildItem(recorder.addAuthFailureHandler(), FilterBuildItem.AUTHENTICATION - 1));
+                    .produce(new FilterBuildItem(recorder.addAuthFailureHandler(),
+                            SecurityHandlerPriorities.AUTHENTICATION - 1));
         }
     }
 

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -43,6 +43,7 @@ import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.RouteConstants;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -177,6 +178,6 @@ public class ResteasyStandaloneBuildStep {
     @Record(value = ExecutionTime.STATIC_INIT)
     public FilterBuildItem addDefaultAuthFailureHandler(ResteasyStandaloneRecorder recorder) {
         // replace default auth failure handler added by vertx-http so that our exception mappers can customize response
-        return new FilterBuildItem(recorder.defaultAuthFailureHandler(), FilterBuildItem.AUTHENTICATION - 1);
+        return new FilterBuildItem(recorder.defaultAuthFailureHandler(), SecurityHandlerPriorities.AUTHENTICATION - 1);
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -226,6 +226,7 @@ import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.RouteConstants;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.JaxRsPathMatchingHttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -1621,7 +1622,7 @@ public class ResteasyReactiveProcessor {
         // replace default auth failure handler added by vertx-http so that our exception mappers can customize response
         return new FilterBuildItem(
                 recorder.defaultAuthFailureHandler(deployment.getDeployment(), observabilityIntegrationBuildItem.isPresent()),
-                FilterBuildItem.AUTHENTICATION - 1);
+                SecurityHandlerPriorities.AUTHENTICATION - 1);
     }
 
     private void checkForDuplicateEndpoint(ResteasyReactiveConfig config, Map<String, List<EndpointConfig>> allMethods) {

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -70,7 +70,6 @@ import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLConfigMapping;
 import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLLocaleResolver;
 import io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLRecorder;
 import io.quarkus.vertx.http.deployment.BodyHandlerBuildItem;
-import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
@@ -79,6 +78,7 @@ import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.smallrye.config.Converters;
 import io.smallrye.graphql.api.AdaptWith;
 import io.smallrye.graphql.api.Deprecated;
@@ -170,7 +170,7 @@ public class SmallRyeGraphQLProcessor {
     private static final List<String> SUPPORTED_WEBSOCKET_SUBPROTOCOLS = List.of(SUBPROTOCOL_GRAPHQL_WS,
             SUBPROTOCOL_GRAPHQL_TRANSPORT_WS);
 
-    private static final int GRAPHQL_WEBSOCKET_HANDLER_ORDER = (-1 * FilterBuildItem.AUTHORIZATION) + 1;
+    private static final int GRAPHQL_WEBSOCKET_HANDLER_ORDER = (-1 * SecurityHandlerPriorities.AUTHORIZATION) + 1;
 
     private static final String GRAPHQL_MEDIA_TYPE = "application/graphql+json";
 

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -118,6 +118,7 @@ import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiDocument;
 import io.smallrye.openapi.api.SmallRyeOpenAPI;
@@ -280,7 +281,7 @@ public class SmallRyeOpenApiProcessor {
         // as 'http-vertx' only adds CORS filter to http route path
         if (!nonApplicationRootPathBuildItem.isAttachedToMainRouter()) {
             for (FilterBuildItem filterBuildItem : filterBuildItems) {
-                if (filterBuildItem.getPriority() == FilterBuildItem.CORS) {
+                if (filterBuildItem.getPriority() == SecurityHandlerPriorities.CORS) {
                     corsFilter = recorder.corsFilter(filterBuildItem.toFilter());
                     break;
                 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkus.vertx.http.deployment;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.vertx.http.runtime.filters.Filter;
 import io.quarkus.vertx.http.runtime.filters.Filters;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -10,12 +11,6 @@ import io.vertx.ext.web.RoutingContext;
  * A handler that is applied to every route
  */
 public final class FilterBuildItem extends MultiBuildItem {
-
-    //predefined system priorities
-    public static final int CORS = 300;
-    public static final int AUTHENTICATION = 200;
-    public static final int AUTHORIZATION = 100;
-    private static final int AUTH_FAILURE_HANDLER = Integer.MIN_VALUE + 1;
 
     private final Handler<RoutingContext> handler;
     private final int priority;
@@ -52,7 +47,7 @@ public final class FilterBuildItem extends MultiBuildItem {
     private FilterBuildItem(Handler<RoutingContext> authFailureHandler) {
         this.handler = authFailureHandler;
         this.isFailureHandler = true;
-        this.priority = AUTH_FAILURE_HANDLER;
+        this.priority = SecurityHandlerPriorities.AUTH_FAILURE_HANDLER;
     }
 
     /**
@@ -69,7 +64,7 @@ public final class FilterBuildItem extends MultiBuildItem {
      * {@link FilterBuildItem#ofAuthenticationFailureHandler(Handler)}
      */
     public static FilterBuildItem ofPreAuthenticationFailureHandler(Handler<RoutingContext> authFailureHandler) {
-        return new FilterBuildItem(authFailureHandler, AUTH_FAILURE_HANDLER + 1, false, true);
+        return new FilterBuildItem(authFailureHandler, SecurityHandlerPriorities.AUTH_FAILURE_HANDLER + 1, false, true);
     }
 
     private void checkPriority(int priority) {
@@ -94,10 +89,10 @@ public final class FilterBuildItem extends MultiBuildItem {
      * @return a filter object wrapping the handler and priority.
      */
     public Filter toFilter() {
-        if (isFailureHandler && priority == AUTH_FAILURE_HANDLER) {
+        if (isFailureHandler && priority == SecurityHandlerPriorities.AUTH_FAILURE_HANDLER) {
             // create filter for penultimate auth failure handler
             final Filters.SimpleFilter filter = new Filters.SimpleFilter();
-            filter.setPriority(AUTH_FAILURE_HANDLER);
+            filter.setPriority(SecurityHandlerPriorities.AUTH_FAILURE_HANDLER);
             filter.setFailureHandler(true);
             filter.setHandler(handler);
             return filter;

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -88,6 +88,7 @@ import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.AuthenticationHandler;
 import io.quarkus.vertx.http.runtime.security.MtlsAuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.PathMatchingHttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.quarkus.vertx.http.runtime.security.VertxBlockingSecurityExecutor;
 import io.quarkus.vertx.http.runtime.security.VertxSecurityIdentityAssociation;
 import io.quarkus.vertx.http.runtime.security.annotation.BasicAuthentication;
@@ -267,9 +268,9 @@ public class HttpSecurityProcessor {
             filterBuildItemBuildProducer
                     .produce(new FilterBuildItem(
                             recorder.getHttpAuthenticatorHandler(authenticationHandlerBuildItem.get().handler),
-                            FilterBuildItem.AUTHENTICATION));
+                            SecurityHandlerPriorities.AUTHENTICATION));
             filterBuildItemBuildProducer
-                    .produce(new FilterBuildItem(recorder.permissionCheckHandler(), FilterBuildItem.AUTHORIZATION));
+                    .produce(new FilterBuildItem(recorder.permissionCheckHandler(), SecurityHandlerPriorities.AUTHORIZATION));
         }
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -77,6 +77,7 @@ import io.quarkus.vertx.http.runtime.filters.Filter;
 import io.quarkus.vertx.http.runtime.filters.GracefulShutdownFilter;
 import io.quarkus.vertx.http.runtime.graal.Brotli4jFeature;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.vertx.core.http.impl.Http1xServerRequest;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.ext.web.Router;
@@ -148,7 +149,7 @@ class VertxHttpProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     FilterBuildItem cors(CORSRecorder recorder) {
-        return new FilterBuildItem(recorder.corsHandler(), FilterBuildItem.CORS);
+        return new FilterBuildItem(recorder.corsHandler(), SecurityHandlerPriorities.CORS);
     }
 
     @BuildStep

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -110,6 +110,7 @@ public class HttpSecurityRecorder {
         if (config.formAuthEnabled()) {
             httpRouter.getValue()
                     .post(config.formPostLocation())
+                    .order(-1 * SecurityHandlerPriorities.FORM_AUTHENTICATION)
                     .handler(new Handler<RoutingContext>() {
                         @Override
                         public void handle(RoutingContext event) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/SecurityHandlerPriorities.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/SecurityHandlerPriorities.java
@@ -1,0 +1,10 @@
+package io.quarkus.vertx.http.runtime.security;
+
+public class SecurityHandlerPriorities {
+
+    public static final int CORS = 300;
+    public static final int AUTHENTICATION = 200;
+    public static final int FORM_AUTHENTICATION = 150;
+    public static final int AUTHORIZATION = 100;
+    public static final int AUTH_FAILURE_HANDLER = Integer.MIN_VALUE + 1;
+}

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
@@ -112,6 +112,7 @@ import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
 import io.quarkus.vertx.http.runtime.security.EagerSecurityInterceptorStorage;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.quarkus.websockets.next.HttpUpgradeCheck;
 import io.quarkus.websockets.next.InboundProcessingMode;
 import io.quarkus.websockets.next.WebSocketClientConnection;
@@ -758,7 +759,7 @@ public class WebSocketProcessor {
         if (buildConfig.propagateSubprotocolHeaders()) {
             Handler<RoutingContext> handler = new WebSocketHeaderPropagationHandler();
             // must run after the CORS filter but before the authentication filter
-            int priority = 20 + FilterBuildItem.AUTHENTICATION;
+            int priority = 20 + SecurityHandlerPriorities.AUTHENTICATION;
             filterProducer.produce(new FilterBuildItem(handler, priority));
         }
     }

--- a/extensions/websockets/server/deployment/src/main/java/io/quarkus/websockets/deployment/ServerWebSocketProcessor.java
+++ b/extensions/websockets/server/deployment/src/main/java/io/quarkus/websockets/deployment/ServerWebSocketProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.quarkus.websockets.client.deployment.AnnotatedWebsocketEndpointBuildItem;
 import io.quarkus.websockets.client.deployment.ServerWebSocketContainerBuildItem;
 import io.quarkus.websockets.client.deployment.ServerWebSocketContainerFactoryBuildItem;
@@ -110,7 +111,7 @@ public class ServerWebSocketProcessor {
         final IndexView index = indexBuildItem.getIndex();
         WebsocketClientProcessor.registerCodersForReflection(reflection, index.getAnnotations(SERVER_ENDPOINT));
 
-        int priority = 1 + FilterBuildItem.AUTHORIZATION;
+        int priority = 1 + SecurityHandlerPriorities.AUTHORIZATION;
         return new FilterBuildItem(
                 recorder.createHandler(webSocketDeploymentInfoBuildItem.get().getInfo(),
                         serverWebSocketContainerBuildItem.get().getContainer()),


### PR DESCRIPTION
It used to be more or less randomly defined depending on the order of execution of the build steps, which made it work until we started playing with the order for build reproducibility.

The patch is large because I moved the priorities to the runtime module so that I could use them in the recorder.

This issue was detected by the patch here: https://github.com/quarkusio/quarkus/pull/49096 .