### PR TITLE
Remove BuildKit requirement from Dockerfile

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -605,7 +605,8 @@ Sample Dockerfile for building with Maven:
 ----
 ## Stage 1 : build with maven builder image with native capabilities
 FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
-COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
+COPY --chown=quarkus:quarkus mvnw /code/mvnw
+RUN chmod 0755 /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn
 COPY --chown=quarkus:quarkus pom.xml /code/
 USER quarkus


### PR DESCRIPTION
The --chmod flag within the COPY instruction is a feature of Docker's BuildKit engine. This dependency causes build failures in environments where BuildKit is not available or is disabled by default, such as Google Cloud Build. This change refactors the instruction into separate COPY and RUN chmod commands, achieving the same file permission outcome while removing the BuildKit requirement and ensuring the Dockerfile works universally across all build environments.

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

This pull request updates the Dockerfile to ensure compatibility with Docker environments that do not have BuildKit enabled. By replacing the --chmod flag in the COPY command with a separate RUN chmod instruction, the build process no longer implicitly depends on BuildKit. This prevents build failures on platforms like Google Cloud Build and in any other environment where BuildKit is not active, improving the reliability of the container build.