### PR TITLE
Make sure RUN mode is correctly taken into account

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsNormal.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsNormal.java
@@ -8,7 +8,12 @@ import io.quarkus.runtime.LaunchMode;
 /**
  * boolean supplier that returns true if the application is running in normal
  * mode. Intended for use with {@link BuildStep#onlyIf()}
+ *
+ * @deprecated This class was marked as deprecated to raise awareness that the semantic you want is probably provided by
+ *             {@link IsProduction}. If you actually need this specific supplier, please open an issue so that we undeprecate
+ *             it.
  */
+@Deprecated(since = "3.25")
 public class IsNormal implements BooleanSupplier {
 
     private final LaunchMode launchMode;
@@ -19,6 +24,6 @@ public class IsNormal implements BooleanSupplier {
 
     @Override
     public boolean getAsBoolean() {
-        return launchMode == LaunchMode.NORMAL || launchMode == LaunchMode.RUN;
+        return launchMode == LaunchMode.NORMAL;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/IsProduction.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsProduction.java
@@ -1,0 +1,24 @@
+package io.quarkus.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * boolean supplier that returns true if the application is running in production
+ * mode i.e. either NORMAL or RUN. Intended for use with {@link BuildStep#onlyIf()}
+ */
+public class IsProduction implements BooleanSupplier {
+
+    private final LaunchMode launchMode;
+
+    public IsProduction(LaunchMode launchMode) {
+        this.launchMode = launchMode;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return launchMode == LaunchMode.NORMAL || launchMode == LaunchMode.RUN;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -160,7 +160,7 @@ public class QuarkusAugmentor {
             BuildResult buildResult = execBuilder.execute();
             String message = "Quarkus augmentation completed in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
                     + "ms";
-            if (launchMode == LaunchMode.NORMAL) {
+            if (launchMode.isProduction()) {
                 log.info(message);
                 if (Boolean.parseBoolean(System.getProperty("quarkus.debug.dump-build-metrics"))) {
                     buildResult.getMetrics().dumpTo(targetDir.resolve("build-metrics.json"));
@@ -170,7 +170,7 @@ public class QuarkusAugmentor {
                 log.debug(message);
 
                 // Dump the metrics in the dev mode but not remote-dev (as it could cause issues with container permissions)
-                if ((launchMode == LaunchMode.DEVELOPMENT) && !LaunchMode.isRemoteDev()) {
+                if (launchMode.isDev() && !launchMode.isRemoteDev()) {
                     buildResult.getMetrics().dumpTo(targetDir.resolve("build-metrics.json"));
                 }
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/SnapStartProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/SnapStartProcessor.java
@@ -25,7 +25,7 @@ import io.quarkus.runtime.SnapStartRecorder;
  */
 public class SnapStartProcessor {
 
-    @BuildStep(onlyIf = IsNormal.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = IsProduction.class, onlyIfNot = NativeBuild.class)
     @Record(ExecutionTime.STATIC_INIT)
     public void processSnapStart(BuildProducer<PreloadClassesEnabledBuildItem> preload,
             BuildProducer<SnapStartEnabledBuildItem> snapStartEnabled,
@@ -46,7 +46,7 @@ public class SnapStartProcessor {
         recorder.register(config.fullWarmup());
     }
 
-    @BuildStep(onlyIf = IsNormal.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = IsProduction.class, onlyIfNot = NativeBuild.class)
     public void generateClassListFromApplication(
             SnapStartConfig config,
             Optional<SnapStartDefaultValueBuildItem> defaultVal,

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/io/NioThreadPoolDevModeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/io/NioThreadPoolDevModeProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkus.deployment.dev.io;
 
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
@@ -12,7 +12,7 @@ import io.quarkus.runtime.dev.io.NioThreadPoolRecorder;
 public class NioThreadPoolDevModeProcessor {
 
     @Produce(TestSetupBuildItem.class)
-    @BuildStep(onlyIfNot = IsNormal.class)
+    @BuildStep(onlyIfNot = IsProduction.class)
     @Record(ExecutionTime.STATIC_INIT)
     void setupTCCL(NioThreadPoolRecorder recorder, ShutdownContextBuildItem shutdownContextBuildItem) {
         recorder.updateTccl(shutdownContextBuildItem);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -27,7 +27,7 @@ import org.objectweb.asm.Opcodes;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.IsDevelopment;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -56,7 +56,7 @@ import io.quarkus.gizmo.Gizmo;
  */
 public class TestTracingProcessor {
 
-    @BuildStep(onlyIfNot = IsNormal.class)
+    @BuildStep(onlyIfNot = IsProduction.class)
     LogCleanupFilterBuildItem handle() {
         return new LogCleanupFilterBuildItem("org.junit.platform.launcher.core.EngineDiscoveryOrchestrator", "0 containers");
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -60,7 +60,7 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -391,7 +391,7 @@ public final class LoggingResourceProcessor {
         return result;
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class)
+    @BuildStep(onlyIfNot = IsProduction.class)
     @Produce(TestSetupBuildItem.class)
     @Produce(LogConsoleFormatBuildItem.class)
     @Consume(ConsoleInstalledBuildItem.class)

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/FileSystemResourcesBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/FileSystemResourcesBuildStep.java
@@ -7,7 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedFileSystemResourceBuildItem;
@@ -19,7 +19,7 @@ import io.quarkus.runtime.LaunchMode;
 
 public class FileSystemResourcesBuildStep {
 
-    @BuildStep(onlyIfNot = IsNormal.class)
+    @BuildStep(onlyIfNot = IsProduction.class)
     public void notNormalMode(OutputTargetBuildItem outputTargetBuildItem,
             LaunchModeBuildItem launchMode,
             List<GeneratedFileSystemResourceBuildItem> generatedFileSystemResources,
@@ -30,7 +30,7 @@ public class FileSystemResourcesBuildStep {
         producer.produce(new GeneratedFileSystemResourceHandledBuildItem());
     }
 
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     public void normalMode(OutputTargetBuildItem outputTargetBuildItem,
             List<GeneratedFileSystemResourceBuildItem> generatedFileSystemResources,
             // this is added to ensure that the build step will be run

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -44,7 +44,7 @@ import org.objectweb.asm.Opcodes;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -185,7 +185,7 @@ public class ConfigGenerationBuildStep {
         runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(builderClassName));
     }
 
-    @BuildStep(onlyIfNot = { IsNormal.class }) // for dev or test
+    @BuildStep(onlyIfNot = { IsProduction.class }) // for dev or test
     void runtimeOverrideConfig(
             BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
             BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
@@ -425,7 +425,7 @@ public class ConfigGenerationBuildStep {
         recorder.handleConfigChange(values);
     }
 
-    @BuildStep(onlyIfNot = { IsNormal.class })
+    @BuildStep(onlyIfNot = { IsProduction.class })
     public void setupConfigOverride(
             BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer) {
 
@@ -548,7 +548,7 @@ public class ConfigGenerationBuildStep {
         configRecorder.handleNativeProfileChange(config.getProfiles());
     }
 
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     void persistReadConfigOptions(
             BuildProducer<ArtifactResultBuildItem> dummy,
             QuarkusBuildCloseablesBuildItem closeables,

--- a/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
@@ -24,17 +24,6 @@ public enum LaunchMode {
     public static final String PROD_PROFILE = "prod";
     public static final String TEST_PROFILE = "test";
 
-    public static boolean isDev() {
-        return current() == DEVELOPMENT;
-    }
-
-    /**
-     * Returns true if the current launch is the server side of remote dev.
-     */
-    public static boolean isRemoteDev() {
-        return (current() == DEVELOPMENT) && "true".equals(System.getenv("QUARKUS_LAUNCH_DEVMODE"));
-    }
-
     private final String defaultProfile;
     private final String profileKey;
     private final boolean devServicesSupported;
@@ -54,6 +43,17 @@ public enum LaunchMode {
 
     public String getProfileKey() {
         return profileKey;
+    }
+
+    public boolean isDev() {
+        return this == DEVELOPMENT;
+    }
+
+    /**
+     * Returns true if the current launch is the server side of remote dev.
+     */
+    public boolean isRemoteDev() {
+        return (this == DEVELOPMENT) && "true".equals(System.getenv("QUARKUS_LAUNCH_DEVMODE"));
     }
 
     public boolean isDevOrTest() {

--- a/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
@@ -24,10 +24,6 @@ public enum LaunchMode {
     public static final String PROD_PROFILE = "prod";
     public static final String TEST_PROFILE = "test";
 
-    public boolean isDevOrTest() {
-        return this != NORMAL;
-    }
-
     public static boolean isDev() {
         return current() == DEVELOPMENT;
     }
@@ -58,6 +54,17 @@ public enum LaunchMode {
 
     public String getProfileKey() {
         return profileKey;
+    }
+
+    public boolean isDevOrTest() {
+        return this == DEVELOPMENT || this == TEST;
+    }
+
+    /**
+     * Returns true if the current launch is a production mode, such as NORMAL or RUN.
+     */
+    public boolean isProduction() {
+        return LaunchMode.PROD_PROFILE.equals(getDefaultProfile());
     }
 
     public boolean isDevServicesSupported() {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -265,7 +265,7 @@ public class QuarkusBootstrapProvider implements Closeable {
 
             final ResolvedDependencyBuilder appArtifact = getApplicationArtifactBuilder(mojo);
             Set<ArtifactKey> reloadableModules = Set.of();
-            if (mode == LaunchMode.NORMAL) {
+            if (mode.isProduction()) {
                 // collect reloadable artifacts for remote-dev
                 final List<MavenProject> localProjects = mojo.mavenProject().getCollectedProjects();
                 final Set<ArtifactKey> localProjectKeys = new HashSet<>(localProjects.size());

--- a/extensions/agroal/runtime-dev/src/main/java/io/quarkus/agroal/runtime/dev/ui/DatabaseInspector.java
+++ b/extensions/agroal/runtime-dev/src/main/java/io/quarkus/agroal/runtime/dev/ui/DatabaseInspector.java
@@ -52,7 +52,7 @@ public final class DatabaseInspector {
 
     public DatabaseInspector() {
         LaunchMode currentMode = LaunchMode.current();
-        this.isDev = currentMode == LaunchMode.DEVELOPMENT && !LaunchMode.isRemoteDev();
+        this.isDev = currentMode.isDev() && !currentMode.isRemoteDev();
 
         Config config = ConfigProvider.getConfig();
         this.allowSql = config.getOptionalValue("quarkus.datasource.dev-ui.allow-sql", Boolean.class)

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -23,7 +23,7 @@ import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.amazon.lambda.http.model.MultiValuedTreeMap;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -95,7 +95,7 @@ public class AmazonLambdaHttpProcessor {
     /**
      * Lambda provides /tmp for temporary files. Set vertx cache dir
      */
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     void setTempDir(BuildProducer<SystemPropertyBuildItem> systemProperty) {
         systemProperty.produce(new SystemPropertyBuildItem(CACHE_DIR_BASE_PROP_NAME, "/tmp/quarkus"));
     }

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/DevServicesLambdaProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/DevServicesLambdaProcessor.java
@@ -13,7 +13,7 @@ import io.quarkus.amazon.lambda.runtime.LambdaHotReplacementRecorder;
 import io.quarkus.amazon.lambda.runtime.MockEventServer;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsLiveReloadSupportedByLaunchMode;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Produce;
@@ -49,7 +49,7 @@ public class DevServicesLambdaProcessor {
     }
 
     @Produce(ServiceStartBuildItem.class)
-    @BuildStep(onlyIfNot = IsNormal.class) // This is required for testing so run it even if devservices.enabled=false
+    @BuildStep(onlyIfNot = IsProduction.class) // This is required for testing so run it even if devservices.enabled=false
     public void startEventServer(LaunchModeBuildItem launchModeBuildItem,
             LambdaConfig config,
             Optional<EventServerOverrideBuildItem> override,

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
@@ -18,7 +18,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.jboss.logging.Logger;
 
 import io.quarkus.builder.BuildException;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.PackageConfig;
@@ -46,7 +46,7 @@ public class FunctionZipProcessor {
      * @param jar
      * @throws Exception
      */
-    @BuildStep(onlyIf = IsNormal.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = IsProduction.class, onlyIfNot = NativeBuild.class)
     public void jvmZip(OutputTargetBuildItem target,
             PackageConfig packageConfig,
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer,
@@ -110,7 +110,7 @@ public class FunctionZipProcessor {
      * @param nativeImage
      * @throws Exception
      */
-    @BuildStep(onlyIf = { IsNormal.class, NativeBuild.class })
+    @BuildStep(onlyIf = { IsProduction.class, NativeBuild.class })
     public void nativeZip(OutputTargetBuildItem target,
             Optional<UpxCompressedBuildItem> upxCompressed, // used to ensure that we work with the compressed native binary if compression was enabled
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer,

--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
@@ -62,7 +62,7 @@ public abstract class AbstractLambdaPollLoop {
             public void run() {
                 try {
                     if (!LambdaHotReplacementRecorder.enabled
-                            && (launchMode == LaunchMode.DEVELOPMENT || launchMode == LaunchMode.NORMAL)) {
+                            && (launchMode.isDev() || launchMode.isProduction())) {
                         // when running with continuous testing, this method fails
                         // because currentApplication is not set when running as an
                         // auxiliary application.  So, just skip it if hot replacement enabled.

--- a/extensions/azure-functions-http/deployment/src/main/java/io/quarkus/azure/functions/resteasy/deployment/AzureFunctionsHttpProcessor.java
+++ b/extensions/azure-functions-http/deployment/src/main/java/io/quarkus/azure/functions/resteasy/deployment/AzureFunctionsHttpProcessor.java
@@ -9,7 +9,6 @@ import io.quarkus.azure.functions.resteasy.runtime.Function;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 
 public class AzureFunctionsHttpProcessor {
@@ -17,7 +16,7 @@ public class AzureFunctionsHttpProcessor {
 
     @BuildStep
     public RequireVirtualHttpBuildItem requestVirtualHttp(LaunchModeBuildItem launchMode) {
-        return launchMode.getLaunchMode() == LaunchMode.NORMAL ? RequireVirtualHttpBuildItem.MARKER : null;
+        return launchMode.getLaunchMode().isProduction() ? RequireVirtualHttpBuildItem.MARKER : null;
     }
 
     @BuildStep

--- a/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsProcessor.java
+++ b/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsProcessor.java
@@ -48,7 +48,7 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Feature;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -77,7 +77,7 @@ public class AzureFunctionsProcessor {
         return new AzureFunctionsAppNameBuildItem(appName);
     }
 
-    @BuildStep(onlyIf = IsNormal.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = IsProduction.class, onlyIfNot = NativeBuild.class)
     public ArtifactResultBuildItem packageFunctions(List<AzureFunctionBuildItem> functions,
             OutputTargetBuildItem target,
             AzureFunctionsConfig functionsConfig,

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -63,7 +63,7 @@ import io.quarkus.container.spi.ContainerImageBuilderBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImageLabelBuildItem;
 import io.quarkus.container.spi.ContainerImagePushRequestBuildItem;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
@@ -142,7 +142,7 @@ public class JibProcessor {
     }
 
     @SuppressWarnings("deprecation") // legacy JAR
-    @BuildStep(onlyIf = { IsNormal.class, JibBuild.class }, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = { IsProduction.class, JibBuild.class }, onlyIfNot = NativeBuild.class)
     public void buildFromJar(ContainerImageConfig containerImageConfig, ContainerImageJibConfig jibConfig,
             PackageConfig packageConfig,
             ContainerImageInfoBuildItem containerImage,
@@ -191,7 +191,7 @@ public class JibProcessor {
         containerImageBuilder.produce(new ContainerImageBuilderBuildItem(JIB));
     }
 
-    @BuildStep(onlyIf = { IsNormal.class, JibBuild.class, NativeBuild.class })
+    @BuildStep(onlyIf = { IsProduction.class, JibBuild.class, NativeBuild.class })
     public void buildFromNative(ContainerImageConfig containerImageConfig, ContainerImageJibConfig jibConfig,
             ContainerImageInfoBuildItem containerImage,
             NativeImageBuildItem nativeImage,

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ComposeLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ComposeLocator.java
@@ -23,7 +23,7 @@ public class ComposeLocator {
 
     public static Optional<ContainerAddress> locateContainer(DevServicesComposeProjectBuildItem composeProject,
             List<String> images, int port, LaunchMode launchMode, boolean useSharedNetwork) {
-        if (launchMode != LaunchMode.NORMAL) {
+        if (launchMode.isDevServicesSupported()) {
             return composeProject.locate(images, port)
                     .map(runningContainer -> {
                         String serviceName = getServiceName(runningContainer);
@@ -48,7 +48,7 @@ public class ComposeLocator {
 
     public static List<RunningContainer> locateContainer(DevServicesComposeProjectBuildItem composeProject,
             List<String> images, LaunchMode launchMode) {
-        if (launchMode != LaunchMode.NORMAL) {
+        if (launchMode.isDevServicesSupported()) {
             return composeProject.locate(images);
         }
         return Collections.emptyList();

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -48,7 +48,7 @@ import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsLocalDevelopment;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -446,7 +446,7 @@ public class DevUIProcessor {
 
     }
 
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     void cleanProd(BuildProducer<RemovedResourceBuildItem> producer,
             List<JsonRPCProvidersBuildItem> jsonRPCProvidersBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {

--- a/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/CloudFunctionsDeploymentBuildStep.java
+++ b/extensions/funqy/funqy-google-cloud-functions/deployment/src/main/java/io/quarkus/funqy/gcp/functions/deployment/bindings/CloudFunctionsDeploymentBuildStep.java
@@ -6,7 +6,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 import io.quarkus.builder.BuildException;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
@@ -19,7 +19,7 @@ public class CloudFunctionsDeploymentBuildStep {
      * Creates a target/deployment dir and copy the uber jar in it.
      * This facilitates the usage of the 'gcloud' command.
      */
-    @BuildStep(onlyIf = IsNormal.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = IsProduction.class, onlyIfNot = NativeBuild.class)
     public ArtifactResultBuildItem functionDeployment(OutputTargetBuildItem target, JarBuildItem jar)
             throws BuildException, IOException {
         if (!jar.isUberJar()) {

--- a/extensions/google-cloud-functions-http/deployment/src/main/java/io/quarkus/gcp/functions/http/deployment/CloudFunctionsDeploymentBuildStep.java
+++ b/extensions/google-cloud-functions-http/deployment/src/main/java/io/quarkus/gcp/functions/http/deployment/CloudFunctionsDeploymentBuildStep.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.builder.BuildException;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
@@ -19,7 +19,7 @@ public class CloudFunctionsDeploymentBuildStep {
      * Creates a target/deployment dir and copy the uber jar in it.
      * This facilitates the usage of the 'gcloud' command.
      */
-    @BuildStep(onlyIf = IsNormal.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = IsProduction.class, onlyIfNot = NativeBuild.class)
     public ArtifactResultBuildItem functionDeployment(OutputTargetBuildItem target, JarBuildItem jar)
             throws BuildException, IOException {
         if (!jar.isUberJar()) {

--- a/extensions/google-cloud-functions-http/deployment/src/main/java/io/quarkus/gcp/functions/http/deployment/GoogleCloudFunctionsHttpProcessor.java
+++ b/extensions/google-cloud-functions-http/deployment/src/main/java/io/quarkus/gcp/functions/http/deployment/GoogleCloudFunctionsHttpProcessor.java
@@ -4,7 +4,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
-import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 
 public class GoogleCloudFunctionsHttpProcessor {
@@ -23,6 +22,6 @@ public class GoogleCloudFunctionsHttpProcessor {
 
     @BuildStep
     public RequireVirtualHttpBuildItem requestVirtualHttp(LaunchModeBuildItem launchMode) {
-        return launchMode.getLaunchMode() == LaunchMode.NORMAL ? RequireVirtualHttpBuildItem.MARKER : null;
+        return launchMode.getLaunchMode().isProduction() ? RequireVirtualHttpBuildItem.MARKER : null;
     }
 }

--- a/extensions/google-cloud-functions/deployment/src/main/java/io/quarkus/gcp/functions/deployment/CloudFunctionDeploymentBuildStep.java
+++ b/extensions/google-cloud-functions/deployment/src/main/java/io/quarkus/gcp/functions/deployment/CloudFunctionDeploymentBuildStep.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.builder.BuildException;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
@@ -27,7 +27,7 @@ public class CloudFunctionDeploymentBuildStep {
      * Creates a target/deployment dir and copy the uber jar in it.
      * This facilitates the usage of the 'gcloud' command.
      */
-    @BuildStep(onlyIf = IsNormal.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = IsProduction.class, onlyIfNot = NativeBuild.class)
     public ArtifactResultBuildItem functionDeployment(OutputTargetBuildItem target, JarBuildItem jar)
             throws BuildException, IOException {
         if (!jar.isUberJar()) {

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -58,7 +58,7 @@ import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsDevelopment;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -546,7 +546,7 @@ public class GrpcServerProcessor {
         }
     }
 
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     KubernetesPortBuildItem registerGrpcServiceInKubernetes(List<BindableServiceBuildItem> bindables) {
         if (!bindables.isEmpty()) {
             boolean useSeparateServer = ConfigProvider.getConfig().getOptionalValue("quarkus.grpc.server.use-separate-server",

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
@@ -254,7 +254,7 @@ public final class HibernateProcessorUtil {
                     .filter(s -> !NO_SQL_LOAD_SCRIPT_FILE.equalsIgnoreCase(s))
                     .collect(Collectors.toList());
         }
-        if (launchMode == LaunchMode.NORMAL) {
+        if (launchMode.isProduction()) {
             return Collections.emptyList();
         }
         return List.of("import.sql");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevJsonRpcService.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevJsonRpcService.java
@@ -36,7 +36,7 @@ public class HibernateOrmDevJsonRpcService {
     private String allowedHost;
 
     public HibernateOrmDevJsonRpcService() {
-        this.isDev = LaunchMode.current() == LaunchMode.DEVELOPMENT && !LaunchMode.isRemoteDev();
+        this.isDev = LaunchMode.current().isDev() && !LaunchMode.current().isRemoteDev();
         this.allowedHost = ConfigProvider.getConfig()
                 .getOptionalValue("quarkus.datasource.dev-ui.allowed-db-host", String.class)
                 .orElse(null);

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -61,7 +61,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsDevelopment;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -332,7 +332,7 @@ public class KafkaProcessor {
     }
 
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void checkBoostrapServers(KafkaRecorder recorder, Capabilities capabilities) {
         if (capabilities.isPresent(Capability.KUBERNETES_SERVICE_BINDING)) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -56,7 +56,6 @@ import io.quarkus.kubernetes.spi.GeneratedKubernetesResourceBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesOutputDirectoryBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesPortBuildItem;
-import io.quarkus.runtime.LaunchMode;
 
 class KubernetesProcessor {
 
@@ -148,7 +147,7 @@ class KubernetesProcessor {
                         project.getRoot().resolve("src").resolve("main").resolve("kubernetes"), targets);
                 sessionWriter.setProject(project);
 
-                if (launchMode.getLaunchMode() != LaunchMode.NORMAL) {
+                if (!launchMode.getLaunchMode().isProduction()) {
                     // needed for a fresh run
                     Session.clearSession();
                 }
@@ -248,7 +247,7 @@ class KubernetesProcessor {
                 log.warn("No project was detected, skipping generation of kubernetes manifests!");
             }
         } catch (Exception e) {
-            if (launchMode.getLaunchMode() == LaunchMode.NORMAL) {
+            if (launchMode.getLaunchMode().isProduction()) {
                 throw e;
             }
 

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -57,7 +57,7 @@ import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
@@ -678,7 +678,7 @@ public class MessageBundleProcessor {
         }
     }
 
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     void generateExamplePropertiesFiles(List<MessageBundleMethodBuildItem> messageBundleMethods,
             BuildSystemTargetBuildItem target, BuildProducer<GeneratedResourceBuildItem> dummy) throws IOException {
         if (messageBundleMethods.isEmpty()) {

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientProcessor.java
@@ -300,7 +300,7 @@ public class RedisClientProcessor {
             return scripts.get().stream()
                     .filter(s -> !NO_REDIS_SCRIPT_FILE.equalsIgnoreCase(s))
                     .collect(Collectors.toList());
-        } else if (launchMode == LaunchMode.NORMAL) {
+        } else if (launchMode.isProduction()) {
             return Collections.emptyList();
         } else {
             return List.of("import.redis");

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationCompletionExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationCompletionExceptionMapper.java
@@ -17,7 +17,7 @@ public class AuthenticationCompletionExceptionMapper implements ExceptionMapper<
     @Override
     public Response toResponse(AuthenticationCompletionException ex) {
         log.debug("Authentication has failed, returning HTTP status 401");
-        if (LaunchMode.isDev() && ex.getMessage() != null) {
+        if (LaunchMode.current().isDev() && ex.getMessage() != null) {
             return Response.status(401).entity(ex.getMessage()).build();
         }
         return Response.status(401).build();

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationFailedExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationFailedExceptionMapper.java
@@ -45,7 +45,7 @@ public class AuthenticationFailedExceptionMapper implements ExceptionMapper<Auth
                 if (challengeData != null && challengeData.headerName != null) {
                     responseBuilder.header(challengeData.headerName.toString(), challengeData.headerContent);
                 }
-                if (LaunchMode.isDev() && exception.getMessage() != null && statusCode == 401) {
+                if (LaunchMode.current().isDev() && exception.getMessage() != null && statusCode == 401) {
                     responseBuilder.entity(exception.getMessage());
                 }
                 log.debugf("Returning an authentication challenge, status code: %d", statusCode);
@@ -56,7 +56,7 @@ public class AuthenticationFailedExceptionMapper implements ExceptionMapper<Auth
         } else {
             log.error("RoutingContext is not found, returning HTTP status 401");
         }
-        if (LaunchMode.isDev() && exception.getMessage() != null) {
+        if (LaunchMode.current().isDev() && exception.getMessage() != null) {
             return Response.status(401).entity(exception.getMessage()).build();
         }
         return Response.status(401).entity("Not Authenticated").build();

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationCompletionExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationCompletionExceptionMapper.java
@@ -10,7 +10,7 @@ public class AuthenticationCompletionExceptionMapper implements ExceptionMapper<
 
     @Override
     public Response toResponse(AuthenticationCompletionException ex) {
-        if (LaunchMode.isDev() && ex.getMessage() != null) {
+        if (LaunchMode.current().isDev() && ex.getMessage() != null) {
             return Response.status(Response.Status.UNAUTHORIZED).entity(ex.getMessage()).build();
         }
         return Response.status(Response.Status.UNAUTHORIZED).build();

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationFailedExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationFailedExceptionMapper.java
@@ -18,6 +18,6 @@ public class AuthenticationFailedExceptionMapper {
     public Uni<Response> handle(RoutingContext routingContext, AuthenticationFailedException exception) {
         addAuthenticationFailureToEvent(exception, routingContext);
         return SecurityExceptionMapperUtil.handleWithAuthenticator(routingContext,
-                LaunchMode.isDev() ? exception.getMessage() : null);
+                LaunchMode.current().isDev() ? exception.getMessage() : null);
     }
 }

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -206,7 +206,7 @@ public class UndertowDeploymentRecorder {
             resourceManager = new DelegatingResourceManager(managers.toArray(new ResourceManager[0]));
         }
 
-        if (launchMode == LaunchMode.NORMAL) {
+        if (launchMode.isProduction()) {
             //todo: cache configuration
             resourceManager = new CachingResourceManager(1000, 0, null, resourceManager, 2000);
         }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/GeneratedStaticResourcesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/GeneratedStaticResourcesProcessor.java
@@ -16,7 +16,7 @@ import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.IsDevelopment;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -69,7 +69,7 @@ public class GeneratedStaticResourcesProcessor {
                 }
             }
             // We can't use the vert.x StaticHandler for tests as it doesn't support 'quarkus' protocol
-            if (launchModeBuildItem.getLaunchMode() == LaunchMode.NORMAL) {
+            if (launchModeBuildItem.getLaunchMode().isProduction()) {
                 additionalStaticResourcesProducer.produce(
                         new AdditionalStaticResourceBuildItem(generatedStaticResource.getEndpoint(), false));
                 nativeImageResourcesProducer.produce(new NativeImageResourceBuildItem(generatedStaticResourceLocation));
@@ -77,7 +77,7 @@ public class GeneratedStaticResourcesProcessor {
         }
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class)
+    @BuildStep(onlyIfNot = IsProduction.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     public void process(List<GeneratedStaticResourceBuildItem> generatedStaticResources,
             LaunchModeBuildItem launchModeBuildItem,

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -457,7 +457,7 @@ class VertxHttpProcessor {
                     .produce(ReflectiveClassBuildItem.builder(VirtualServerChannel.class).reason(getClass().getName()).build());
         }
         boolean startSocket = requireSocket.isPresent() ||
-                ((!startVirtual || launchMode.getLaunchMode() != LaunchMode.NORMAL)
+                ((!startVirtual || !launchMode.getLaunchMode().isProduction())
                         && (requireVirtual.isEmpty() || !requireVirtual.get().isAlwaysVirtual()));
         recorder.startServer(vertx.getVertx(), shutdown,
                 launchMode.getLaunchMode(), startVirtual, startSocket,

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarProcessor.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -25,7 +25,7 @@ import io.quarkus.vertx.http.runtime.webjar.WebJarRecorder;
 
 public class WebJarProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
-    @BuildStep(onlyIfNot = IsNormal.class)
+    @BuildStep(onlyIfNot = IsProduction.class)
     WebJarResultsBuildItem processWebJarDevMode(WebJarRecorder recorder, List<WebJarBuildItem> webJars,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             ShutdownContextBuildItem shutdownContext,
@@ -62,7 +62,7 @@ public class WebJarProcessor {
         return new WebJarResultsBuildItem(results);
     }
 
-    @BuildStep(onlyIf = IsNormal.class)
+    @BuildStep(onlyIf = IsProduction.class)
     WebJarResultsBuildItem processWebJarProdMode(List<WebJarBuildItem> webJars,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             BuildProducer<GeneratedResourceBuildItem> generatedResources,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -124,7 +124,7 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
                 if ((exception instanceof AuthenticationCompletionException
                         || (exception instanceof AuthenticationFailedException && event.response().getStatusCode() == 401))
                         && exception.getMessage() != null
-                        && LaunchMode.isDev()) {
+                        && LaunchMode.current().isDev()) {
                     event.response().end(exception.getMessage());
                 } else {
                     event.response().end();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxConfigBuilder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxConfigBuilder.java
@@ -25,7 +25,7 @@ public class VertxConfigBuilder implements ConfigBuilder {
         }
 
         // Sets the default host config value, depending on the launch mode
-        if (LaunchMode.isRemoteDev()) {
+        if (LaunchMode.current().isRemoteDev()) {
             // in remote dev mode, we want to listen on all interfaces
             // to make sure the application is accessible
             builder.withDefaultValue(configurationProperty, ALL_INTERFACES);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -218,7 +218,7 @@ public class HttpSecurityRecorder {
                 return;
             }
             throwable = extractRootCause(throwable);
-            if (LaunchMode.isDev() && throwable instanceof AuthenticationException
+            if (LaunchMode.current().isDev() && throwable instanceof AuthenticationException
                     && throwable.getMessage() != null) {
                 event.put(DEV_MODE_AUTHENTICATION_FAILURE_BODY, throwable.getMessage());
             }


### PR DESCRIPTION
The first commit is the actual fix.

For the second commit, I'm a bit torn. I was annoyed by the fact that part of the `is<Mode>` methods were static and part instance methods. It's not very clean, especially since we had a few cases where we had both on the same line of code. But this is a breaking chance (but from what I could see, it won't impact too many component but... it won't be possible to have an extension release support both at the same time if it's using it).
Let me know if I should just drop the second commit.

While I plan to backport the first commit to 3.25, the second commit would be 3.26 only.

@yrodiere if you could check I didn't break anything
@geoand interested in your opinion on the second commit


