### PR TITLE
Force reloadability of project dependencies in QuarkusApplicationModelTask

### DIFF
--- a/integration-tests/gradle/src/main/resources/test-with-sidecar-module/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/test-with-sidecar-module/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/test-with-sidecar-module/my-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-with-sidecar-module/my-module/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation "io.quarkus:quarkus-arc"
+
+    testImplementation project(":test-support")
+    testImplementation "io.quarkus:quarkus-junit5"
+}

--- a/integration-tests/gradle/src/main/resources/test-with-sidecar-module/my-module/src/main/java/com/module/Person.java
+++ b/integration-tests/gradle/src/main/resources/test-with-sidecar-module/my-module/src/main/java/com/module/Person.java
@@ -1,0 +1,4 @@
+package com.module;
+
+public record Person(String id) {
+}

--- a/integration-tests/gradle/src/main/resources/test-with-sidecar-module/my-module/src/test/java/com/module/PersonTest.java
+++ b/integration-tests/gradle/src/main/resources/test-with-sidecar-module/my-module/src/test/java/com/module/PersonTest.java
@@ -1,0 +1,16 @@
+package com.module;
+
+import org.junit.jupiter.api.Test;
+
+import com.module.test.PersonFactory;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class PersonTest {
+
+    @Test
+    void test() {
+        PersonFactory.newRandomPerson();
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-with-sidecar-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-with-sidecar-module/settings.gradle
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'test-with-sidecar-module'
+
+include "test-support"
+include "my-module"

--- a/integration-tests/gradle/src/main/resources/test-with-sidecar-module/test-support/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-with-sidecar-module/test-support/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation project(":my-module")
+}

--- a/integration-tests/gradle/src/main/resources/test-with-sidecar-module/test-support/src/main/java/com/module/test/PersonFactory.java
+++ b/integration-tests/gradle/src/main/resources/test-with-sidecar-module/test-support/src/main/java/com/module/test/PersonFactory.java
@@ -1,0 +1,12 @@
+package com.module.test;
+
+import java.util.UUID;
+
+import com.module.Person;
+
+public class PersonFactory {
+
+    public static Person newRandomPerson() {
+        return new Person(UUID.randomUUID().toString());
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestWithSidecarModule.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestWithSidecarModule.java
@@ -1,0 +1,18 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+// Reproduces https://github.com/quarkusio/quarkus/issues/48159
+public class TestWithSidecarModule extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void test() throws Exception {
+        final File projectDir = getProjectDir("test-with-sidecar-module");
+        final BuildResult build = runGradleWrapper(projectDir, "clean", ":my-module:test");
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":my-module:test"))).isTrue();
+    }
+}


### PR DESCRIPTION
This new Gradle task does not have proper means for workspace discovery, so for now we optimistically setWorkspaceModule() for project dependencies.

- Fixes: #48159.