### PR TITLE
Dev Assistant: Agroal - allow data creation when table is empty

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
@@ -43,16 +43,18 @@ class AgroalDevUIProcessor {
     void createBuildTimeActions(BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer) {
         BuildTimeActionBuildItem bta = new BuildTimeActionBuildItem();
 
-        // TODO: If currentInsertScript is empty, maybe send tables schema. This might mean we need to move this to runtime
+        bta.actionBuilder()
+                .methodName("generateMoreData")
+                .assistantFunction((a, p) -> {
+                    Assistant assistant = (Assistant) a;
+                    return assistant.assistBuilder()
+                            .userMessage(ADD_DATA_MESSAGE)
+                            .variables(p)
+                            .assist();
+                }).build();
 
-        bta.addAssistantAction("generateMoreData", (a, p) -> {
-            Assistant assistant = (Assistant) a;
-            return assistant.assistBuilder()
-                    .userMessage(USER_MESSAGE)
-                    .variables(p)
-                    .assist();
-        });
         buildTimeActionProducer.produce(bta);
+
     }
 
     @BuildStep
@@ -60,7 +62,7 @@ class AgroalDevUIProcessor {
         return new JsonRPCProvidersBuildItem(DatabaseInspector.class);
     }
 
-    private static final String USER_MESSAGE = """
+    private static final String ADD_DATA_MESSAGE = """
             Given the provided sql script:
             {{currentInsertScript}}
             Can you add 10 more inserts into the script and return the result

--- a/extensions/agroal/runtime-dev/pom.xml
+++ b/extensions/agroal/runtime-dev/pom.xml
@@ -18,5 +18,9 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>quarkus-agroal</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-assistant-dev</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This PR allows AI data generation in Agroal even if the database / table is empty.

This fix a TODO in the code:

> `// TODO: If currentInsertScript is empty, maybe send tables schema. This might mean we need to move this to runtime`

https://github.com/user-attachments/assets/576d85db-b84a-4df4-a35a-b1a30a327950

