### PR TITLE
Add profile for running CI builds against snapshot artifacts

### DIFF
--- a/.github/mvn-settings.xml
+++ b/.github/mvn-settings.xml
@@ -30,6 +30,41 @@
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    <profile>
+      <id>snapshots</id>
+      <repositories>
+        <repository>
+          <id>sonatype-maven-central</id>
+          <name>Sonatype Maven Central Snapshots</name>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>sonatype-maven-central</id>
+          <name>Sonatype Maven Central Snapshots</name>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
   </profiles>
   <activeProfiles>
     <activeProfile>google-mirror</activeProfile>

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1079,7 +1079,7 @@ jobs:
         run: |
           git clone --depth=1 -b ${{ steps.get-quickstarts-branch.outputs.result }} https://github.com/quarkusio/quarkus-quickstarts.git && cd quarkus-quickstarts
           QUARKUS_VERSION_ARGS="-Dquarkus.platform.version=${{ steps.get-quarkus-version.outputs.quarkus-version }}"
-          export LANG=en_US && ./mvnw -e -B -fae --settings .github/mvn-settings.xml clean verify -DskipTests -Dquarkus.platform.group-id=io.quarkus $QUARKUS_VERSION_ARGS
+          export LANG=en_US && ./mvnw -e -B -fae --global-settings ../.github/mvn-settings.xml --settings .github/mvn-settings.xml clean verify -DskipTests -Dquarkus.platform.group-id=io.quarkus $QUARKUS_VERSION_ARGS
       - name: Prepare build reports archive
         if: always()
         run: |


### PR DESCRIPTION
The profile is obviously disabled by default. To use it, I currently simply add a commit to my PR that enables the profile by default. See https://github.com/quarkusio/quarkus/pull/49140/files#diff-2b09b442cbc8cd64758ee20db29fe3da5f2f04460142d11d7c27a5ad08a65d7eR127

I suppose there could be better (safer) solutions to enable the profile -- like enabling the profile with a label on the PR, which would also add a failing check to the PR so that we don't mistakenly merge dependencies on snapshots. But that wouldn't work with fork builds, so IDK.

Anyway, this is what I have, and I think it's rather innocuous by itself, and worth merging?