### PR TITLE
Gizmo 2 rewrites

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.Opcodes;
  * A collection of ASM and Jandex utilities.
  */
 public class AsmUtil {
+    public static final int ASM_API_VERSION = Opcodes.ASM9;
 
     public static final List<org.objectweb.asm.Type> PRIMITIVES = asList(
             VOID_TYPE,

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.web.deployment;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
@@ -97,26 +98,17 @@ class HandlerDescriptor {
 
     boolean isPayloadString() {
         Type type = getPayloadType();
-        if (type == null) {
-            return false;
-        }
-        return type.name().equals(io.quarkus.arc.processor.DotNames.STRING);
+        return type != null && type.name().equals(DotName.STRING_NAME);
     }
 
-    boolean isPayloadTypeBuffer() {
+    boolean isPayloadBuffer() {
         Type type = getPayloadType();
-        if (type == null) {
-            return false;
-        }
-        return type.name().equals(DotNames.BUFFER);
+        return type != null && type.name().equals(DotNames.BUFFER);
     }
 
     boolean isPayloadMutinyBuffer() {
         Type type = getPayloadType();
-        if (type == null) {
-            return false;
-        }
-        return type.name().equals(DotNames.MUTINY_BUFFER);
+        return type != null && type.name().equals(DotNames.MUTINY_BUFFER);
     }
 
     boolean isFailureHandler() {

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
@@ -1,7 +1,11 @@
 package io.quarkus.vertx.web.deployment;
 
-import java.util.Collection;
-import java.util.Iterator;
+import static io.quarkus.gizmo2.Reflection2Gizmo.classDescOf;
+import static java.lang.constant.ConstantDescs.CD_boolean;
+import static java.lang.constant.ConstantDescs.CD_void;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -20,12 +24,17 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.InjectableReferenceProvider;
-import io.quarkus.gizmo.AssignableResultHandle;
-import io.quarkus.gizmo.BranchResult;
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.FieldCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.arc.impl.CreationalContextImpl;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.FieldVar;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.Var;
+import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.vertx.web.runtime.MultiJsonArraySupport;
 import io.quarkus.vertx.web.runtime.MultiNdjsonSupport;
 import io.quarkus.vertx.web.runtime.MultiSseSupport;
@@ -49,257 +58,196 @@ import io.vertx.ext.web.RoutingContext;
 
 class Methods {
 
-    static final MethodDescriptor GET_HEADERS = MethodDescriptor
-            .ofMethod(HttpServerResponse.class, "headers", MultiMap.class);
-    static final MethodDescriptor MULTIMAP_GET = MethodDescriptor
-            .ofMethod(MultiMap.class, "get", String.class, String.class);
-    static final MethodDescriptor MULTIMAP_SET = MethodDescriptor
-            .ofMethod(MultiMap.class, "set", MultiMap.class, String.class, String.class);
-    static final MethodDescriptor MULTIMAP_GET_ALL = MethodDescriptor
-            .ofMethod(MultiMap.class, "getAll", List.class, String.class);
+    static final MethodDesc GET_HEADERS = MethodDesc.of(HttpServerResponse.class, "headers", MultiMap.class);
+    static final MethodDesc MULTIMAP_GET = MethodDesc.of(MultiMap.class, "get", String.class, String.class);
+    static final MethodDesc MULTIMAP_SET = MethodDesc.of(MultiMap.class, "set", MultiMap.class, String.class, String.class);
+    static final MethodDesc MULTIMAP_GET_ALL = MethodDesc.of(MultiMap.class, "getAll", List.class, String.class);
 
-    static final MethodDescriptor REQUEST = MethodDescriptor
-            .ofMethod(RoutingContext.class, "request", HttpServerRequest.class);
-    static final MethodDescriptor REQUEST_GET_PARAM = MethodDescriptor
-            .ofMethod(HttpServerRequest.class, "getParam", String.class, String.class);
-    static final MethodDescriptor REQUEST_GET_HEADER = MethodDescriptor
-            .ofMethod(HttpServerRequest.class, "getHeader", String.class, String.class);
-    static final MethodDescriptor GET_BODY = MethodDescriptor
-            .ofMethod(RoutingContext.class, "getBody", Buffer.class);
-    static final MethodDescriptor GET_BODY_AS_STRING = MethodDescriptor
-            .ofMethod(RoutingContext.class, "getBodyAsString", String.class);
-    static final MethodDescriptor GET_BODY_AS_JSON = MethodDescriptor
-            .ofMethod(RoutingContext.class, "getBodyAsJson", JsonObject.class);
-    static final MethodDescriptor GET_BODY_AS_JSON_ARRAY = MethodDescriptor
-            .ofMethod(RoutingContext.class, "getBodyAsJsonArray", JsonArray.class);
-    static final MethodDescriptor JSON_OBJECT_MAP_TO = MethodDescriptor
-            .ofMethod(JsonObject.class, "mapTo", Object.class, Class.class);
-    static final MethodDescriptor REQUEST_PARAMS = MethodDescriptor
-            .ofMethod(HttpServerRequest.class, "params", MultiMap.class);
-    static final MethodDescriptor REQUEST_HEADERS = MethodDescriptor
-            .ofMethod(HttpServerRequest.class, "headers", MultiMap.class);
-    static final MethodDescriptor RESPONSE = MethodDescriptor
-            .ofMethod(RoutingContext.class, "response", HttpServerResponse.class);
-    static final MethodDescriptor FAIL = MethodDescriptor
-            .ofMethod(RoutingContext.class, "fail", Void.TYPE, Throwable.class);
-    static final MethodDescriptor FAILURE = MethodDescriptor
-            .ofMethod(RoutingContext.class, "failure", Throwable.class);
-    static final MethodDescriptor NEXT = MethodDescriptor
-            .ofMethod(RoutingContext.class, "next", void.class);
+    static final MethodDesc REQUEST = MethodDesc.of(RoutingContext.class, "request", HttpServerRequest.class);
+    static final MethodDesc REQUEST_GET_PARAM = MethodDesc.of(HttpServerRequest.class, "getParam", String.class, String.class);
+    static final MethodDesc REQUEST_GET_HEADER = MethodDesc.of(HttpServerRequest.class, "getHeader",
+            String.class, String.class);
+    static final MethodDesc GET_BODY = MethodDesc.of(RoutingContext.class, "getBody", Buffer.class);
+    static final MethodDesc GET_BODY_AS_STRING = MethodDesc.of(RoutingContext.class, "getBodyAsString", String.class);
+    static final MethodDesc GET_BODY_AS_JSON = MethodDesc.of(RoutingContext.class, "getBodyAsJson", JsonObject.class);
+    static final MethodDesc GET_BODY_AS_JSON_ARRAY = MethodDesc.of(RoutingContext.class, "getBodyAsJsonArray", JsonArray.class);
+    static final MethodDesc JSON_OBJECT_MAP_TO = MethodDesc.of(JsonObject.class, "mapTo", Object.class, Class.class);
+    static final MethodDesc REQUEST_PARAMS = MethodDesc.of(HttpServerRequest.class, "params", MultiMap.class);
+    static final MethodDesc REQUEST_HEADERS = MethodDesc.of(HttpServerRequest.class, "headers", MultiMap.class);
+    static final MethodDesc RESPONSE = MethodDesc.of(RoutingContext.class, "response", HttpServerResponse.class);
+    static final MethodDesc FAIL = MethodDesc.of(RoutingContext.class, "fail", void.class, Throwable.class);
+    static final MethodDesc FAILURE = MethodDesc.of(RoutingContext.class, "failure", Throwable.class);
+    static final MethodDesc NEXT = MethodDesc.of(RoutingContext.class, "next", void.class);
 
-    static final MethodDescriptor UNI_SUBSCRIBE = MethodDescriptor.ofMethod(Uni.class, "subscribe", UniSubscribe.class);
-    static final MethodDescriptor UNI_SUBSCRIBE_WITH = MethodDescriptor
-            .ofMethod(UniSubscribe.class, "with", Cancellable.class, Consumer.class, Consumer.class);
+    static final MethodDesc UNI_SUBSCRIBE = MethodDesc.of(Uni.class, "subscribe", UniSubscribe.class);
+    static final MethodDesc UNI_SUBSCRIBE_WITH = MethodDesc.of(UniSubscribe.class, "with",
+            Cancellable.class, Consumer.class, Consumer.class);
 
-    static final MethodDescriptor MULTI_SUBSCRIBE_VOID = MethodDescriptor.ofMethod(MultiSupport.class, "subscribeVoid",
-            Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_SUBSCRIBE_STRING = MethodDescriptor.ofMethod(MultiSupport.class, "subscribeString",
-            Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_SUBSCRIBE_BUFFER = MethodDescriptor.ofMethod(MultiSupport.class, "subscribeBuffer",
-            Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_SUBSCRIBE_MUTINY_BUFFER = MethodDescriptor.ofMethod(MultiSupport.class,
-            "subscribeMutinyBuffer", Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_SUBSCRIBE_OBJECT = MethodDescriptor.ofMethod(MultiSupport.class, "subscribeObject",
-            Void.TYPE, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SUBSCRIBE_VOID = MethodDesc.of(MultiSupport.class, "subscribeVoid",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SUBSCRIBE_STRING = MethodDesc.of(MultiSupport.class, "subscribeString",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SUBSCRIBE_BUFFER = MethodDesc.of(MultiSupport.class, "subscribeBuffer",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SUBSCRIBE_MUTINY_BUFFER = MethodDesc.of(MultiSupport.class, "subscribeMutinyBuffer",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SUBSCRIBE_OBJECT = MethodDesc.of(MultiSupport.class, "subscribeObject",
+            void.class, Multi.class, RoutingContext.class);
 
-    static final MethodDescriptor IS_SSE = MethodDescriptor.ofMethod(MultiSseSupport.class, "isSSE", Boolean.TYPE, Multi.class);
-    static final MethodDescriptor MULTI_SSE_SUBSCRIBE_STRING = MethodDescriptor.ofMethod(MultiSseSupport.class,
-            "subscribeString",
-            Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_SSE_SUBSCRIBE_BUFFER = MethodDescriptor.ofMethod(MultiSseSupport.class,
-            "subscribeBuffer",
-            Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_SSE_SUBSCRIBE_MUTINY_BUFFER = MethodDescriptor.ofMethod(MultiSseSupport.class,
-            "subscribeMutinyBuffer", Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_SSE_SUBSCRIBE_OBJECT = MethodDescriptor.ofMethod(MultiSseSupport.class,
-            "subscribeObject",
-            Void.TYPE, Multi.class, RoutingContext.class);
+    static final MethodDesc IS_SSE = MethodDesc.of(MultiSseSupport.class, "isSSE", boolean.class, Multi.class);
+    static final MethodDesc MULTI_SSE_SUBSCRIBE_STRING = MethodDesc.of(MultiSseSupport.class, "subscribeString",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SSE_SUBSCRIBE_BUFFER = MethodDesc.of(MultiSseSupport.class, "subscribeBuffer",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SSE_SUBSCRIBE_MUTINY_BUFFER = MethodDesc.of(MultiSseSupport.class, "subscribeMutinyBuffer",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_SSE_SUBSCRIBE_OBJECT = MethodDesc.of(MultiSseSupport.class, "subscribeObject",
+            void.class, Multi.class, RoutingContext.class);
 
-    static final MethodDescriptor IS_NDJSON = MethodDescriptor.ofMethod(MultiNdjsonSupport.class, "isNdjson", Boolean.TYPE,
-            Multi.class);
-    static final MethodDescriptor MULTI_NDJSON_SUBSCRIBE_STRING = MethodDescriptor.ofMethod(MultiNdjsonSupport.class,
-            "subscribeString",
-            Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_NDJSON_SUBSCRIBE_OBJECT = MethodDescriptor.ofMethod(MultiNdjsonSupport.class,
-            "subscribeObject",
-            Void.TYPE, Multi.class, RoutingContext.class);
+    static final MethodDesc IS_NDJSON = MethodDesc.of(MultiNdjsonSupport.class, "isNdjson",
+            boolean.class, Multi.class);
+    static final MethodDesc MULTI_NDJSON_SUBSCRIBE_STRING = MethodDesc.of(MultiNdjsonSupport.class, "subscribeString",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_NDJSON_SUBSCRIBE_OBJECT = MethodDesc.of(MultiNdjsonSupport.class, "subscribeObject",
+            void.class, Multi.class, RoutingContext.class);
 
-    static final MethodDescriptor IS_JSON_ARRAY = MethodDescriptor.ofMethod(MultiJsonArraySupport.class, "isJsonArray",
-            Boolean.TYPE, Multi.class);
-    static final MethodDescriptor MULTI_JSON_SUBSCRIBE_VOID = MethodDescriptor.ofMethod(MultiJsonArraySupport.class,
-            "subscribeVoid", Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_JSON_SUBSCRIBE_STRING = MethodDescriptor.ofMethod(MultiJsonArraySupport.class,
-            "subscribeString", Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_JSON_SUBSCRIBE_BUFFER = MethodDescriptor.ofMethod(MultiJsonArraySupport.class,
-            "subscribeBuffer", Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_JSON_SUBSCRIBE_MUTINY_BUFFER = MethodDescriptor.ofMethod(MultiJsonArraySupport.class,
-            "subscribeMutinyBuffer", Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_JSON_SUBSCRIBE_OBJECT = MethodDescriptor.ofMethod(MultiJsonArraySupport.class,
-            "subscribeObject", Void.TYPE, Multi.class, RoutingContext.class);
-    static final MethodDescriptor MULTI_JSON_FAIL = MethodDescriptor.ofMethod(MultiJsonArraySupport.class,
-            "fail", Void.TYPE, RoutingContext.class);
+    static final MethodDesc IS_JSON_ARRAY = MethodDesc.of(MultiJsonArraySupport.class, "isJsonArray",
+            boolean.class, Multi.class);
+    static final MethodDesc MULTI_JSON_SUBSCRIBE_VOID = MethodDesc.of(MultiJsonArraySupport.class, "subscribeVoid",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_JSON_SUBSCRIBE_STRING = MethodDesc.of(MultiJsonArraySupport.class, "subscribeString",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_JSON_SUBSCRIBE_OBJECT = MethodDesc.of(MultiJsonArraySupport.class, "subscribeObject",
+            void.class, Multi.class, RoutingContext.class);
+    static final MethodDesc MULTI_JSON_FAIL = MethodDesc.of(MultiJsonArraySupport.class, "fail",
+            void.class, RoutingContext.class);
 
-    static final MethodDescriptor END = MethodDescriptor.ofMethod(HttpServerResponse.class, "end", Future.class);
-    static final MethodDescriptor END_WITH_STRING = MethodDescriptor
-            .ofMethod(HttpServerResponse.class, "end", Future.class, String.class);
-    static final MethodDescriptor END_WITH_BUFFER = MethodDescriptor
-            .ofMethod(HttpServerResponse.class, "end", Future.class, Buffer.class);
-    static final MethodDescriptor SET_STATUS = MethodDescriptor
-            .ofMethod(HttpServerResponse.class, "setStatusCode", HttpServerResponse.class, Integer.TYPE);
-    static final MethodDescriptor MUTINY_GET_DELEGATE = MethodDescriptor
-            .ofMethod(io.vertx.mutiny.core.buffer.Buffer.class, "getDelegate", Buffer.class);
-    static final MethodDescriptor JSON_ENCODE = MethodDescriptor
-            .ofMethod(Json.class, "encode", String.class, Object.class);
-    static final MethodDescriptor ARC_CONTAINER = MethodDescriptor
-            .ofMethod(Arc.class, "container", ArcContainer.class);
-    static final MethodDescriptor ARC_CONTAINER_GET_ACTIVE_CONTEXT = MethodDescriptor
-            .ofMethod(ArcContainer.class,
-                    "getActiveContext", InjectableContext.class, Class.class);
-    static final MethodDescriptor ARC_CONTAINER_BEAN = MethodDescriptor.ofMethod(ArcContainer.class, "bean",
+    static final MethodDesc END = MethodDesc.of(HttpServerResponse.class, "end", Future.class);
+    static final MethodDesc END_WITH_STRING = MethodDesc.of(HttpServerResponse.class, "end", Future.class, String.class);
+    static final MethodDesc END_WITH_BUFFER = MethodDesc.of(HttpServerResponse.class, "end", Future.class, Buffer.class);
+    static final MethodDesc SET_STATUS = MethodDesc.of(HttpServerResponse.class, "setStatusCode",
+            HttpServerResponse.class, Integer.TYPE);
+    static final MethodDesc MUTINY_GET_DELEGATE = MethodDesc.of(io.vertx.mutiny.core.buffer.Buffer.class, "getDelegate",
+            Buffer.class);
+
+    static final MethodDesc JSON_ENCODE = MethodDesc.of(Json.class, "encode", String.class, Object.class);
+
+    static final MethodDesc ARC_CONTAINER = MethodDesc.of(Arc.class, "container", ArcContainer.class);
+    static final MethodDesc ARC_CONTAINER_GET_ACTIVE_CONTEXT = MethodDesc.of(ArcContainer.class, "getActiveContext",
+            InjectableContext.class, Class.class);
+    static final MethodDesc ARC_CONTAINER_BEAN = MethodDesc.of(ArcContainer.class, "bean",
             InjectableBean.class, String.class);
-    static final MethodDescriptor BEAN_GET_SCOPE = MethodDescriptor.ofMethod(InjectableBean.class, "getScope",
-            Class.class);
-    static final MethodDescriptor CONTEXT_GET = MethodDescriptor.ofMethod(Context.class, "get", Object.class,
-            Contextual.class,
-            CreationalContext.class);
-    static final MethodDescriptor CONTEXT_GET_IF_PRESENT = MethodDescriptor
-            .ofMethod(Context.class, "get", Object.class,
-                    Contextual.class);
-    static final MethodDescriptor INJECTABLE_REF_PROVIDER_GET = MethodDescriptor.ofMethod(
-            InjectableReferenceProvider.class,
-            "get", Object.class,
-            CreationalContext.class);
-    static final MethodDescriptor INJECTABLE_BEAN_DESTROY = MethodDescriptor
-            .ofMethod(InjectableBean.class, "destroy",
-                    void.class, Object.class,
-                    CreationalContext.class);
-    static final MethodDescriptor ROUTE_HANDLER_CONSTRUCTOR = MethodDescriptor.ofConstructor(RouteHandler.class);
+    static final MethodDesc BEAN_GET_SCOPE = MethodDesc.of(InjectableBean.class, "getScope", Class.class);
+    static final MethodDesc CONTEXT_GET = MethodDesc.of(Context.class, "get",
+            Object.class, Contextual.class, CreationalContext.class);
+    static final MethodDesc CONTEXT_GET_IF_PRESENT = MethodDesc.of(Context.class, "get",
+            Object.class, Contextual.class);
+    static final MethodDesc INJECTABLE_REF_PROVIDER_GET = MethodDesc.of(InjectableReferenceProvider.class, "get",
+            Object.class, CreationalContext.class);
+    static final MethodDesc INJECTABLE_BEAN_DESTROY = MethodDesc.of(InjectableBean.class, "destroy",
+            void.class, Object.class, CreationalContext.class);
+    static final ConstructorDesc CREATIONAL_CONTEXT_IMPL_CTOR = ConstructorDesc.of(CreationalContextImpl.class,
+            Contextual.class);
 
-    static final MethodDescriptor ROUTE_HANDLERS_SET_CONTENT_TYPE = MethodDescriptor
-            .ofMethod(RouteHandlers.class, "setContentType", void.class, RoutingContext.class, String.class);
+    static final ConstructorDesc ROUTE_HANDLER_CTOR = ConstructorDesc.of(RouteHandler.class);
 
-    static final MethodDescriptor OPTIONAL_OF_NULLABLE = MethodDescriptor
-            .ofMethod(Optional.class, "ofNullable", Optional.class, Object.class);
+    static final MethodDesc ROUTE_HANDLERS_SET_CONTENT_TYPE = MethodDesc.of(RouteHandlers.class, "setContentType",
+            void.class, RoutingContext.class, String.class);
 
-    static final String VALIDATION_VALIDATOR = "jakarta.validation.Validator";
-    static final String VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION = "jakarta.validation.ConstraintViolationException";
+    static final MethodDesc OPTIONAL_OF_NULLABLE = MethodDesc.of(Optional.class, "ofNullable", Optional.class, Object.class);
 
-    static final MethodDescriptor VALIDATION_GET_VALIDATOR = MethodDescriptor.ofMethod(ValidationSupport.class, "getValidator",
-            "jakarta.validation.Validator", ArcContainer.class);
-    static final MethodDescriptor VALIDATION_MAP_VIOLATIONS_TO_JSON = MethodDescriptor
-            .ofMethod(ValidationSupport.class, "mapViolationsToJson", String.class, Set.class,
-                    HttpServerResponse.class);
-    static final MethodDescriptor VALIDATION_HANDLE_VIOLATION_EXCEPTION = MethodDescriptor
-            .ofMethod(ValidationSupport.class.getName(), "handleViolationException",
-                    Void.TYPE.getName(), Methods.VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION,
-                    RoutingContext.class.getName(), Boolean.TYPE.getName());
+    private static final String VALIDATOR = "jakarta.validation.Validator";
+    private static final String CONSTRAINT_VIOLATION_EXCEPTION = "jakarta.validation.ConstraintViolationException";
+    static final ClassDesc VALIDATION_VALIDATOR = ClassDesc.of(VALIDATOR);
+    static final ClassDesc VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION = ClassDesc.of(CONSTRAINT_VIOLATION_EXCEPTION);
 
-    static final MethodDescriptor VALIDATOR_VALIDATE = MethodDescriptor
-            .ofMethod("jakarta.validation.Validator", "validate", "java.util.Set",
-                    Object.class, Class[].class);
-    static final MethodDescriptor SET_IS_EMPTY = MethodDescriptor.ofMethod(Set.class, "isEmpty", Boolean.TYPE);
+    static final MethodDesc VALIDATOR_VALIDATE = InterfaceMethodDesc.of(VALIDATION_VALIDATOR, "validate",
+            Set.class, Object.class, Class[].class);
 
-    static final MethodDescriptor IS_ASSIGNABLE_FROM = MethodDescriptor.ofMethod(Class.class, "isAssignableFrom",
-            boolean.class, Class.class);
-    static final MethodDescriptor GET_CLASS = MethodDescriptor.ofMethod(Object.class, "getClass", Class.class);
+    static final MethodDesc VALIDATION_GET_VALIDATOR = MethodDesc.of(ValidationSupport.class, "getValidator",
+            MethodTypeDesc.of(VALIDATION_VALIDATOR, classDescOf(ArcContainer.class)));
+    static final MethodDesc VALIDATION_MAP_VIOLATIONS_TO_JSON = MethodDesc.of(ValidationSupport.class, "mapViolationsToJson",
+            String.class, Set.class, HttpServerResponse.class);
+    static final MethodDesc VALIDATION_HANDLE_VIOLATION = MethodDesc.of(ValidationSupport.class, "handleViolationException",
+            MethodTypeDesc.of(CD_void, VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION, classDescOf(RoutingContext.class),
+                    CD_boolean));
 
-    static final MethodDescriptor STRING_CHAR_AT = MethodDescriptor.ofMethod(String.class, "charAt", int.class);
-    static final MethodDescriptor INTEGER_VALUE_OF = MethodDescriptor.ofMethod(Integer.class, "valueOf", Integer.class,
-            String.class);
-    static final MethodDescriptor LONG_VALUE_OF = MethodDescriptor.ofMethod(Long.class, "valueOf", Long.class, String.class);
-    static final MethodDescriptor BOOLEAN_VALUE_OF = MethodDescriptor.ofMethod(Boolean.class, "valueOf", Boolean.class,
-            String.class);
-    static final MethodDescriptor CHARACTER_VALUE_OF = MethodDescriptor.ofMethod(Character.class, "valueOf", Character.class,
-            char.class);
-    static final MethodDescriptor FLOAT_VALUE_OF = MethodDescriptor.ofMethod(Float.class, "valueOf", Float.class, String.class);
-    static final MethodDescriptor DOUBLE_VALUE_OF = MethodDescriptor.ofMethod(Double.class, "valueOf", Double.class,
-            String.class);
-    static final MethodDescriptor SHORT_VALUE_OF = MethodDescriptor.ofMethod(Short.class, "valueOf", Short.class, String.class);
-    static final MethodDescriptor BYTE_VALUE_OF = MethodDescriptor.ofMethod(Byte.class, "valueOf", Byte.class, String.class);
+    static final MethodDesc IS_ASSIGNABLE_FROM = MethodDesc.of(Class.class, "isAssignableFrom", boolean.class, Class.class);
 
-    static final MethodDescriptor COLLECTION_SIZE = MethodDescriptor.ofMethod(Collection.class, "size", int.class);
-    static final MethodDescriptor COLLECTION_ITERATOR = MethodDescriptor.ofMethod(Collection.class, "iterator", Iterator.class);
-    static final MethodDescriptor COLLECTION_ADD = MethodDescriptor.ofMethod(Collection.class, "add", boolean.class,
-            Object.class);
-    static final MethodDescriptor ITERATOR_NEXT = MethodDescriptor.ofMethod(Iterator.class, "next", Object.class);
-    static final MethodDescriptor ITERATOR_HAS_NEXT = MethodDescriptor.ofMethod(Iterator.class, "hasNext", boolean.class);
+    static final MethodDesc INTEGER_VALUE_OF = MethodDesc.of(Integer.class, "valueOf", Integer.class, String.class);
+    static final MethodDesc LONG_VALUE_OF = MethodDesc.of(Long.class, "valueOf", Long.class, String.class);
+    static final MethodDesc BOOLEAN_VALUE_OF = MethodDesc.of(Boolean.class, "valueOf", Boolean.class, String.class);
+    static final MethodDesc CHARACTER_VALUE_OF = MethodDesc.of(Character.class, "valueOf", Character.class, char.class);
+    static final MethodDesc FLOAT_VALUE_OF = MethodDesc.of(Float.class, "valueOf", Float.class, String.class);
+    static final MethodDesc DOUBLE_VALUE_OF = MethodDesc.of(Double.class, "valueOf", Double.class, String.class);
+    static final MethodDesc SHORT_VALUE_OF = MethodDesc.of(Short.class, "valueOf", Short.class, String.class);
+    static final MethodDesc BYTE_VALUE_OF = MethodDesc.of(Byte.class, "valueOf", Byte.class, String.class);
 
-    public static final MethodDescriptor CS_WHEN_COMPLETE = MethodDescriptor.ofMethod(CompletionStage.class,
-            "whenComplete",
+    public static final MethodDesc CS_WHEN_COMPLETE = MethodDesc.of(CompletionStage.class, "whenComplete",
             CompletionStage.class, BiConsumer.class);
 
     private Methods() {
         // Avoid direct instantiation
     }
 
-    static void returnAndClose(BytecodeCreator creator) {
-        creator.returnValue(null);
-        creator.close();
-    }
-
     static boolean isNoContent(HandlerDescriptor descriptor) {
-        return descriptor.getPayloadType().name()
-                .equals(DotName.createSimple(Void.class.getName()));
+        return descriptor.getPayloadType().name().equals(DotName.createSimple(Void.class));
     }
 
-    static ResultHandle createNpeBecauseItemIfNull(BytecodeCreator writer) {
-        return writer.newInstance(
-                MethodDescriptor.ofConstructor(NullPointerException.class, String.class),
-                writer.load("Invalid value returned by Uni: `null`"));
+    static Expr createNpeItemIsNull(BlockCreator bc) {
+        return bc.new_(ConstructorDesc.of(NullPointerException.class, String.class),
+                Const.of("Invalid value returned by Uni: `null`"));
     }
 
-    static MethodDescriptor getEndMethodForContentType(HandlerDescriptor descriptor) {
-        if (descriptor.isPayloadTypeBuffer() || descriptor.isPayloadMutinyBuffer()) {
+    static MethodDesc getEndMethodForContentType(HandlerDescriptor descriptor) {
+        if (descriptor.isPayloadBuffer() || descriptor.isPayloadMutinyBuffer()) {
             return END_WITH_BUFFER;
         }
         return END_WITH_STRING;
     }
 
-    static void setContentTypeToJson(ResultHandle response, BytecodeCreator invoke) {
-        ResultHandle ct = invoke.load("Content-Type");
-        ResultHandle headers = invoke.invokeInterfaceMethod(GET_HEADERS, response);
-        ResultHandle current = invoke.invokeInterfaceMethod(MULTIMAP_GET, headers, ct);
-        BytecodeCreator branch = invoke.ifNull(current).trueBranch();
-        branch.invokeInterfaceMethod(MULTIMAP_SET, headers, ct, branch.load("application/json"));
-        branch.close();
+    static void setContentTypeToJson(Var response, BlockCreator b0) {
+        Const contentType = Const.of("Content-Type");
+        LocalVar headers = b0.localVar("headers", b0.invokeInterface(GET_HEADERS, response));
+        Expr current = b0.invokeInterface(MULTIMAP_GET, headers, contentType);
+        b0.ifNull(current, b1 -> {
+            b1.invokeInterface(MULTIMAP_SET, headers, contentType, Const.of("application/json"));
+        });
     }
 
     /**
      * Generate the following code:
      *
      * <pre>
-     * String s = null;
-     * Set<ConstraintViolation<Object>> violations = validator.validate(res);
-     * if (!violations.isEmpty()) {
-     *    s = ValidationSupport.mapViolationsToJson(violations, response);
+     * String result = null;
+     * Set&lt;ConstraintViolation&lt;Object>> violations = validator.validate(res);
+     * if (violations.isEmpty()) {
+     *    result = res.encode()
      * } else {
-     *    s = res.encode()
+     *    result = ValidationSupport.mapViolationsToJson(violations, response);
      * }
      * </pre>
+     *
+     * Note that {@code this_} is always either {@code This} or a captured {@code Var}.
+     *
      */
-    public static ResultHandle validateProducedItem(ResultHandle response, BytecodeCreator writer, ResultHandle res,
-            FieldCreator validatorField, ResultHandle owner) {
+    public static Var validateProducedItem(Var response, BlockCreator b0, Var res,
+            Expr this_, FieldDesc validatorField) {
 
-        AssignableResultHandle result = writer.createVariable(String.class);
-        writer.assign(result, writer.loadNull());
+        FieldVar validator = this_.field(validatorField);
+        LocalVar violations = b0.localVar("violations",
+                b0.invokeInterface(VALIDATOR_VALIDATE, validator, res, b0.newArray(Class.class)));
 
-        ResultHandle validator = writer.readInstanceField(validatorField.getFieldDescriptor(), owner);
-        ResultHandle violations = writer.invokeInterfaceMethod(
-                VALIDATOR_VALIDATE, validator, res, writer.newArray(Class.class, 0));
+        LocalVar result = b0.localVar("result", Const.ofDefault(String.class));
 
-        ResultHandle isEmpty = writer.invokeInterfaceMethod(SET_IS_EMPTY, violations);
-        BranchResult ifNoViolations = writer.ifTrue(isEmpty);
-
-        ResultHandle encoded = ifNoViolations.trueBranch().invokeStaticMethod(JSON_ENCODE, res);
-        ifNoViolations.trueBranch().assign(result, encoded);
-        ifNoViolations.trueBranch().close();
-
-        ResultHandle json = ifNoViolations.falseBranch().invokeStaticMethod(VALIDATION_MAP_VIOLATIONS_TO_JSON, violations,
-                response);
-        ifNoViolations.falseBranch().assign(result, json);
-        ifNoViolations.falseBranch().close();
+        b0.ifElse(b0.withSet(violations).isEmpty(), b1 -> {
+            Expr json = b1.invokeStatic(JSON_ENCODE, res);
+            b1.set(result, json);
+        }, b1 -> {
+            Expr json = b1.invokeStatic(VALIDATION_MAP_VIOLATIONS_TO_JSON, violations, response);
+            b1.set(result, json);
+        });
 
         return result;
-
     }
 }

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
@@ -7,8 +7,9 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.Type;
 
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Var;
+import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnOpen;
@@ -36,17 +37,17 @@ interface CallbackArgument {
      * @param context
      * @return the result handle to be passed as an argument to a callback method
      */
-    ResultHandle get(InvocationBytecodeContext context);
+    Expr get(InvocationBytecodeContext context);
 
     /**
      *
      * @return the priority
      */
-    default int priotity() {
+    default int priority() {
         return DEFAULT_PRIORITY;
     }
 
-    static final int DEFAULT_PRIORITY = 1;
+    int DEFAULT_PRIORITY = 1;
 
     interface ParameterContext {
 
@@ -101,14 +102,14 @@ interface CallbackArgument {
          *
          * @return the bytecode
          */
-        BytecodeCreator bytecode();
+        BlockCreator bytecode();
 
         /**
          * Obtains the message or error directly in the bytecode.
          *
          * @return the message/error object or {@code null} for {@link OnOpen} and {@link OnClose} callbacks
          */
-        ResultHandle getPayload();
+        Var getPayload();
 
         /**
          * Attempts to obtain the decoded message directly in the bytecode.
@@ -116,14 +117,14 @@ interface CallbackArgument {
          * @param parameterType
          * @return the decoded message object or {@code null} for {@link OnOpen}, {@link OnClose} and {@link OnError} callbacks
          */
-        ResultHandle getDecodedMessage(Type parameterType);
+        Expr getDecodedMessage(Type parameterType);
 
         /**
          * Obtains the current connection directly in the bytecode.
          *
          * @return the current {@link WebSocketConnection}, never {@code null}
          */
-        ResultHandle getConnection();
+        Var getConnection();
 
     }
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/CloseReasonCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/CloseReasonCallbackArgument.java
@@ -1,7 +1,7 @@
 package io.quarkus.websockets.next.deployment;
 
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.websockets.next.CloseReason;
 import io.quarkus.websockets.next.runtime.WebSocketConnectionBase;
 
@@ -14,9 +14,9 @@ class CloseReasonCallbackArgument implements CallbackArgument {
     }
 
     @Override
-    public ResultHandle get(InvocationBytecodeContext context) {
-        return context.bytecode().invokeVirtualMethod(
-                MethodDescriptor.ofMethod(WebSocketConnectionBase.class, "closeReason", CloseReason.class),
+    public Expr get(InvocationBytecodeContext context) {
+        return context.bytecode().invokeVirtual(
+                MethodDesc.of(WebSocketConnectionBase.class, "closeReason", CloseReason.class),
                 context.getConnection());
     }
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
@@ -2,7 +2,7 @@ package io.quarkus.websockets.next.deployment;
 
 import org.jboss.jandex.DotName;
 
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Expr;
 import io.quarkus.websockets.next.WebSocketException;
 import io.quarkus.websockets.next.deployment.Callback.Target;
 
@@ -30,7 +30,7 @@ class ConnectionCallbackArgument implements CallbackArgument {
     }
 
     @Override
-    public ResultHandle get(InvocationBytecodeContext context) {
+    public Expr get(InvocationBytecodeContext context) {
         return context.getConnection();
     }
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/ErrorCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/ErrorCallbackArgument.java
@@ -4,7 +4,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Expr;
 
 class ErrorCallbackArgument implements CallbackArgument {
 
@@ -15,7 +15,7 @@ class ErrorCallbackArgument implements CallbackArgument {
     }
 
     @Override
-    public ResultHandle get(InvocationBytecodeContext context) {
+    public Expr get(InvocationBytecodeContext context) {
         return context.getPayload();
     }
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/HandshakeRequestCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/HandshakeRequestCallbackArgument.java
@@ -1,7 +1,7 @@
 package io.quarkus.websockets.next.deployment;
 
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.websockets.next.HandshakeRequest;
 import io.quarkus.websockets.next.runtime.WebSocketConnectionBase;
 
@@ -13,10 +13,10 @@ class HandshakeRequestCallbackArgument implements CallbackArgument {
     }
 
     @Override
-    public ResultHandle get(InvocationBytecodeContext context) {
-        return context.bytecode()
-                .invokeVirtualMethod(MethodDescriptor.ofMethod(WebSocketConnectionBase.class, "handshakeRequest",
-                        HandshakeRequest.class), context.getConnection());
+    public Expr get(InvocationBytecodeContext context) {
+        return context.bytecode().invokeVirtual(
+                MethodDesc.of(WebSocketConnectionBase.class, "handshakeRequest", HandshakeRequest.class),
+                context.getConnection());
     }
 
 }

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/KotlinContinuationCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/KotlinContinuationCallbackArgument.java
@@ -1,7 +1,11 @@
 package io.quarkus.websockets.next.deployment;
 
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
+
+import io.quarkus.arc.processor.KotlinDotNames;
 import io.quarkus.arc.processor.KotlinUtils;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
 
 public class KotlinContinuationCallbackArgument implements CallbackArgument {
     @Override
@@ -10,8 +14,8 @@ public class KotlinContinuationCallbackArgument implements CallbackArgument {
     }
 
     @Override
-    public ResultHandle get(InvocationBytecodeContext context) {
+    public Expr get(InvocationBytecodeContext context) {
         // the actual value is provided by the invoker
-        return context.bytecode().loadNull();
+        return Const.ofNull(classDescOf(KotlinDotNames.CONTINUATION));
     }
 }

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/MessageCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/MessageCallbackArgument.java
@@ -1,6 +1,6 @@
 package io.quarkus.websockets.next.deployment;
 
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Expr;
 
 class MessageCallbackArgument implements CallbackArgument {
 
@@ -10,12 +10,12 @@ class MessageCallbackArgument implements CallbackArgument {
     }
 
     @Override
-    public ResultHandle get(InvocationBytecodeContext context) {
+    public Expr get(InvocationBytecodeContext context) {
         return context.getDecodedMessage(context.parameter().type());
     }
 
     @Override
-    public int priotity() {
+    public int priority() {
         return DEFAULT_PRIORITY - 1;
     }
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/PathParamCallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/PathParamCallbackArgument.java
@@ -8,8 +8,9 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 
 import io.quarkus.arc.processor.Annotations;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.websockets.next.WebSocketException;
 import io.quarkus.websockets.next.runtime.WebSocketConnectionBase;
 
@@ -41,12 +42,11 @@ class PathParamCallbackArgument implements CallbackArgument {
     }
 
     @Override
-    public ResultHandle get(InvocationBytecodeContext context) {
+    public Expr get(InvocationBytecodeContext context) {
         String paramName = getParamName(context);
-        return context.bytecode().invokeVirtualMethod(
-                MethodDescriptor.ofMethod(WebSocketConnectionBase.class, "pathParam", String.class, String.class),
-                context.getConnection(),
-                context.bytecode().load(paramName));
+        return context.bytecode().invokeVirtual(
+                MethodDesc.of(WebSocketConnectionBase.class, "pathParam", String.class, String.class),
+                context.getConnection(), Const.of(paramName));
     }
 
     private String getParamName(ParameterContext context) {

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/RuntimeTypeCreator.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/RuntimeTypeCreator.java
@@ -1,0 +1,359 @@
+package io.quarkus.websockets.next.deployment;
+
+import java.lang.constant.ClassDesc;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.WildcardType;
+
+import io.quarkus.arc.impl.GenericArrayTypeImpl;
+import io.quarkus.arc.impl.ParameterizedTypeImpl;
+import io.quarkus.arc.impl.TypeVariableImpl;
+import io.quarkus.arc.impl.TypeVariableReferenceImpl;
+import io.quarkus.arc.impl.WildcardTypeImpl;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+
+// TODO only present here because ArC rewrite to Gizmo 2 hasn't been merged yet
+//  ArC rewrite to Gizmo 2 includes this class as a public API
+/**
+ * Utility to create runtime representation of Jandex {@link Type}s. In the code,
+ * the runtime values are Gizmo 2 {@link LocalVar}s and at actual runtime, they
+ * implement {@link java.lang.reflect.Type} (often, they're simply {@link Class}es).
+ * <p>
+ * The creator is created using {@link #of(BlockCreator)} for the given Gizmo 2
+ * {@link BlockCreator} and must be used only in that block.
+ * <p>
+ * The creator supports optional caching of type values (call {@link #withCache(Cache)})
+ * and optional usage of a Jandex index to look up enclosing classes (call
+ * {@link #withIndex(IndexView)}).
+ */
+class RuntimeTypeCreator {
+    /**
+     * Supports caching of types in case many are created. The implementation is supposed
+     * to exist only for the block in which the backing data structure is in scope,
+     * but the backing data structure may span multiple separate blocks or even methods.
+     */
+    public interface Cache {
+        /**
+         * Returns a local variable that contains a runtime representation of given type.
+         * The result contains {@code null} if {@link #put(BlockCreator, Type, LocalVar)}
+         * wasn't previously called with the same type.
+         */
+        LocalVar get(BlockCreator bc, Type type);
+
+        /**
+         * Puts a local variable that contains a runtime representation of given type
+         * into the cache. It can later be retrieved using {@link #get(BlockCreator, Type)}.
+         */
+        void put(BlockCreator bc, Type type, LocalVar value);
+    }
+
+    private static final class TypeVariables {
+        private final Map<String, LocalVar> typeVariables = new HashMap<>();
+        private final Map<String, LocalVar> typeVariableReferences = new HashMap<>();
+
+        LocalVar getTypeVariable(String identifier) {
+            return typeVariables.get(identifier);
+        }
+
+        void setTypeVariable(String identifier, LocalVar localVar) {
+            typeVariables.put(identifier, localVar);
+        }
+
+        LocalVar getTypeVariableReference(String identifier) {
+            return typeVariableReferences.get(identifier);
+        }
+
+        void setTypeVariableReference(String identifier, LocalVar localVar) {
+            typeVariableReferences.put(identifier, localVar);
+        }
+
+        void patchTypeVariableReferences(BlockCreator bc) {
+            typeVariableReferences.forEach((identifier, reference) -> {
+                LocalVar typeVar = typeVariables.get(identifier);
+                if (typeVar != null) {
+                    bc.invokeVirtual(MethodDesc.of(TypeVariableReferenceImpl.class,
+                            "setDelegate", void.class, TypeVariableImpl.class), reference, typeVar);
+                }
+            });
+        }
+    }
+
+    private final BlockCreator bc;
+
+    // these fields are optional (possibly `null`)
+    private final IndexView index;
+    private final Cache cache;
+    private final LocalVar tccl;
+
+    /**
+     * Returns a {@code RuntimeTypeCreator} for the given {@linkplain BlockCreator block}.
+     * It may not be used outside of that block creator.
+     *
+     * @param bc the block creator, must not be {@code null}
+     * @return a new runtime type creator
+     */
+    public static RuntimeTypeCreator of(BlockCreator bc) {
+        Objects.requireNonNull(bc);
+        return new RuntimeTypeCreator(bc, null, null, null);
+    }
+
+    /**
+     * Returns a new {@code RuntimeTypeCreator} with the given {@link IndexView}
+     * <p>
+     * The other properties are taken from this instance.
+     *
+     * @param index the index, must not be {@code null}
+     * @return a new runtime type creator
+     */
+    public RuntimeTypeCreator withIndex(IndexView index) {
+        Objects.requireNonNull(index);
+        return new RuntimeTypeCreator(bc, index, cache, tccl);
+    }
+
+    /**
+     * Returns a new {@code RuntimeTypeCreator} with the given {@link Cache}.
+     * <p>
+     * The other properties are taken from this instance.
+     *
+     * @param cache the type cache, must not be {@code null}
+     * @return a new runtime type creator
+     */
+    public RuntimeTypeCreator withCache(Cache cache) {
+        Objects.requireNonNull(cache);
+        return new RuntimeTypeCreator(bc, index, cache, tccl);
+    }
+
+    /**
+     * Returns a new {@code RuntimeTypeCreator} with the given {@code tccl}.
+     * The local variable {@code tccl} must be in scope in the block for which
+     * this {@code RuntimeTypeCreator} was created.
+     * <p>
+     * The other properties are taken from this instance.
+     *
+     * @param tccl the current thread's context class loader, must not be {@code null}
+     * @return a new runtime type creator
+     */
+    public RuntimeTypeCreator withTCCL(LocalVar tccl) {
+        Objects.requireNonNull(tccl);
+        return new RuntimeTypeCreator(bc, index, cache, tccl);
+    }
+
+    private RuntimeTypeCreator(BlockCreator bc, IndexView index, Cache cache, LocalVar tccl) {
+        this.bc = bc;
+        this.index = index;
+        this.cache = cache;
+        this.tccl = tccl;
+    }
+
+    /**
+     * Returns a runtime representation of the given build-time type.
+     *
+     * @param type the Jandex type, must not be {@code null}
+     * @return the runtime type as a Gizmo 2 local variable, never {@code null}
+     */
+    public LocalVar create(Type type) {
+        Objects.requireNonNull(type);
+
+        LocalVar result = bc.localVar("type", Const.ofNull(java.lang.reflect.Type.class));
+        TypeVariables typeVariables = new TypeVariables();
+        create(type, result, bc, typeVariables);
+        typeVariables.patchTypeVariableReferences(bc);
+        return result;
+    }
+
+    // bt* -- build time, Jandex representation
+    // rt* -- runtime, Gizmo representation
+    private void create(Type btType, LocalVar rtType, BlockCreator bc, TypeVariables typeVariables) {
+        if (cache != null) {
+            LocalVar rtCachedType = cache.get(bc, btType);
+            bc.ifElse(bc.eq(rtCachedType, Const.ofNull(java.lang.reflect.Type.class)), b1 -> {
+                doCreate(btType, rtType, b1, typeVariables);
+            }, b1 -> {
+                b1.set(rtType, rtCachedType);
+            });
+        } else {
+            doCreate(btType, rtType, bc, typeVariables);
+        }
+    }
+
+    private void doCreate(Type btType, LocalVar rtType, BlockCreator bc, TypeVariables typeVariables) {
+        if (Type.Kind.VOID.equals(btType.kind())) {
+            bc.set(rtType, Const.of(void.class));
+        } else if (Type.Kind.PRIMITIVE.equals(btType.kind())) {
+            bc.set(rtType, switch (btType.asPrimitiveType().primitive()) {
+                case BOOLEAN -> Const.of(boolean.class);
+                case BYTE -> Const.of(byte.class);
+                case SHORT -> Const.of(short.class);
+                case INT -> Const.of(int.class);
+                case LONG -> Const.of(long.class);
+                case FLOAT -> Const.of(float.class);
+                case DOUBLE -> Const.of(double.class);
+                case CHAR -> Const.of(char.class);
+            });
+        } else if (Type.Kind.CLASS.equals(btType.kind())) {
+            ClassType btClass = btType.asClassType();
+            LocalVar rtClass = bc.localVar("clazz", doLoadClass(btClass.name().toString(), bc));
+            if (cache != null) {
+                cache.put(bc, btType, rtClass);
+            }
+            bc.set(rtType, rtClass);
+        } else if (Type.Kind.ARRAY.equals(btType.kind())) {
+            ArrayType btArray = btType.asArrayType();
+
+            // only used to figure out if the target should be `Class` or `GenericArrayType`
+            Type btElementType = btArray.elementType();
+
+            LocalVar rtArray;
+            if (btElementType.kind() == Type.Kind.PRIMITIVE || btElementType.kind() == Type.Kind.CLASS) {
+                // can produce a java.lang.Class representation of the array type
+                // E.g. String[] -> String[].class
+                rtArray = bc.localVar("array", doLoadClass(btArray.name().toString(), bc));
+            } else {
+                // E.g. List<String>[] -> new GenericArrayTypeImpl(new ParameterizedTypeImpl(List.class, String.class))
+                Type btComponentType = btType.asArrayType().componentType();
+                LocalVar rtComponentType = bc.localVar("component", Const.ofNull(java.lang.reflect.Type.class));
+                create(btComponentType, rtComponentType, bc, typeVariables);
+                rtArray = bc.localVar("array", bc.new_(
+                        ConstructorDesc.of(GenericArrayTypeImpl.class, java.lang.reflect.Type.class),
+                        rtComponentType));
+            }
+            if (cache != null) {
+                cache.put(bc, btType, rtArray);
+            }
+            bc.set(rtType, rtArray);
+        } else if (Type.Kind.PARAMETERIZED_TYPE.equals(btType.kind())) {
+            // E.g. List<String> -> new ParameterizedTypeImpl(List.class, String.class)
+            ParameterizedType btParamType = btType.asParameterizedType();
+            LocalVar rtTypeArgs = bc.localVar("typeArgs", bc.newArray(java.lang.reflect.Type.class, btParamType.arguments()
+                    .stream()
+                    .map(btTypeArg -> {
+                        LocalVar rtTypeArg = bc.localVar("typeArg", Const.ofNull(java.lang.reflect.Type.class));
+                        create(btTypeArg, rtTypeArg, bc, typeVariables);
+                        return rtTypeArg;
+                    })
+                    .toList()));
+            ClassType btGenericType = ClassType.create(btParamType.name());
+            LocalVar rtGenericType = null;
+            if (cache != null) {
+                rtGenericType = cache.get(bc, btGenericType);
+            }
+            if (rtGenericType == null) {
+                rtGenericType = bc.localVar("genericType", doLoadClass(btGenericType.name().toString(), bc));
+                if (cache != null) {
+                    cache.put(bc, btGenericType, rtGenericType);
+                }
+            }
+            LocalVar rtOwner = bc.localVar("owner", Const.ofNull(java.lang.reflect.Type.class));
+            if (btParamType.owner() != null) {
+                create(btParamType.owner(), rtOwner, bc, typeVariables);
+            } else if (index != null) {
+                ClassInfo btGenericClass = index.getClassByName(btParamType.name());
+                if (btGenericClass != null && btGenericClass.enclosingClass() != null) {
+                    // this is not entirely precise, but generic classes with more than 1 level of nesting are very rare
+                    ClassType btOwner = ClassType.create(btGenericClass.enclosingClass());
+                    create(btOwner, rtOwner, bc, typeVariables);
+                }
+            }
+            LocalVar rtParamType = bc.localVar("parameterizedType", bc.new_(
+                    ConstructorDesc.of(ParameterizedTypeImpl.class, java.lang.reflect.Type.class,
+                            java.lang.reflect.Type[].class, java.lang.reflect.Type.class),
+                    rtGenericType, rtTypeArgs, rtOwner));
+            if (cache != null) {
+                cache.put(bc, btParamType, rtParamType);
+            }
+            bc.set(rtType, rtParamType);
+        } else if (Type.Kind.TYPE_VARIABLE.equals(btType.kind())) {
+            // E.g. T -> new TypeVariableImpl("T")
+            TypeVariable btTypeVar = btType.asTypeVariable();
+            String btIdentifier = btTypeVar.identifier();
+
+            LocalVar rtTypeVar = typeVariables.getTypeVariable(btIdentifier);
+            if (rtTypeVar == null) {
+                List<Type> btBounds = btTypeVar.bounds();
+                LocalVar rtBounds = bc.localVar("bounds", bc.newArray(java.lang.reflect.Type.class,
+                        btBounds.stream().map(btBound -> {
+                            LocalVar rtBound = bc.localVar("bound", Const.ofNull(java.lang.reflect.Type.class));
+                            create(btBound, rtBound, bc, typeVariables);
+                            return rtBound;
+                        }).toList()));
+                rtTypeVar = bc.localVar("typeVariable", bc.new_(
+                        ConstructorDesc.of(TypeVariableImpl.class, String.class, java.lang.reflect.Type[].class),
+                        Const.of(btIdentifier), rtBounds));
+                if (cache != null) {
+                    cache.put(bc, btTypeVar, rtTypeVar);
+                }
+                typeVariables.setTypeVariable(btIdentifier, rtTypeVar);
+            }
+            bc.set(rtType, rtTypeVar);
+        } else if (Type.Kind.TYPE_VARIABLE_REFERENCE.equals(btType.kind())) {
+            String btIdentifier = btType.asTypeVariableReference().identifier();
+
+            LocalVar rtTypeVarRef = typeVariables.getTypeVariableReference(btIdentifier);
+            if (rtTypeVarRef == null) {
+                rtTypeVarRef = bc.localVar("typeVariableReference", bc.new_(
+                        ConstructorDesc.of(TypeVariableReferenceImpl.class, String.class),
+                        Const.of(btIdentifier)));
+                typeVariables.setTypeVariableReference(btIdentifier, rtTypeVarRef);
+            }
+
+            bc.set(rtType, rtTypeVarRef);
+        } else if (Type.Kind.WILDCARD_TYPE.equals(btType.kind())) {
+            // E.g. ? extends Number -> WildcardTypeImpl.withUpperBound(Number.class)
+            WildcardType btWildcard = btType.asWildcardType();
+            LocalVar rtWildcard;
+            if (btWildcard.superBound() == null) {
+                Type btUpperBound = btWildcard.extendsBound();
+                LocalVar rtUpperBound = bc.localVar("upperBound", Const.ofNull(java.lang.reflect.Type.class));
+                create(btUpperBound, rtUpperBound, bc, typeVariables);
+                rtWildcard = bc.localVar("wildcard", bc.invokeStatic(
+                        MethodDesc.of(WildcardTypeImpl.class, "withUpperBound",
+                                java.lang.reflect.WildcardType.class, java.lang.reflect.Type.class),
+                        rtUpperBound));
+            } else {
+                Type btLowerBound = btWildcard.superBound();
+                LocalVar rtLowerBound = bc.localVar("lowerBound", Const.ofNull(java.lang.reflect.Type.class));
+                create(btLowerBound, rtLowerBound, bc, typeVariables);
+                rtWildcard = bc.localVar("wildcard", bc.invokeStatic(
+                        MethodDesc.of(WildcardTypeImpl.class, "withLowerBound",
+                                java.lang.reflect.WildcardType.class, java.lang.reflect.Type.class),
+                        rtLowerBound));
+            }
+            if (cache != null) {
+                cache.put(bc, btWildcard, rtWildcard);
+            }
+            bc.set(rtType, rtWildcard);
+        } else {
+            throw new IllegalArgumentException("Unsupported type: " + btType.kind() + ", " + btType);
+        }
+    }
+
+    private Expr doLoadClass(String className, BlockCreator bc) {
+        if (className.startsWith("java.")) {
+            return Const.of(ClassDesc.of(className));
+        } else {
+            MethodDesc THREAD_GET_TCCL = MethodDesc.of(Thread.class, "getContextClassLoader", ClassLoader.class);
+            MethodDesc CL_FOR_NAME = MethodDesc.of(Class.class, "forName", Class.class, String.class, boolean.class,
+                    ClassLoader.class);
+
+            Expr cl = tccl != null ? tccl : bc.invokeVirtual(THREAD_GET_TCCL, bc.currentThread());
+
+            // we need to use Class.forName as the class may be package private
+            return bc.invokeStatic(CL_FOR_NAME, Const.of(className), Const.of(false), cl);
+        }
+    }
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/ClientErrorHandlerOnServerEndpointTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/ClientErrorHandlerOnServerEndpointTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.websockets.next.test.errors;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketException;
+
+public class ClientErrorHandlerOnServerEndpointTest {
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Echo.class);
+            })
+            .assertException(e -> {
+                assertInstanceOf(WebSocketException.class, e);
+                assertTrue(e.getMessage().contains(
+                        "@OnError callback on @WebSocket must not accept WebSocketClientConnection"));
+            });
+
+    @Test
+    void trigger() {
+    }
+
+    @WebSocket(path = "/echo")
+    public static class Echo {
+        @OnTextMessage
+        void echo(String msg) {
+        }
+
+        @OnError
+        String handle(Exception e, WebSocketClientConnection clientConnection) {
+            return "error";
+        }
+    }
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MixedErrorHandlersTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MixedErrorHandlersTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.websockets.next.test.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class MixedErrorHandlersTest {
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Echo.class, GlobalErrorHandlers.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo")
+    URI testUri;
+
+    @Test
+    void test() {
+        WSClient client = WSClient.create(vertx).connect(testUri);
+
+        client.send("0");
+        assertEquals("OK", client.waitForNextMessage().toString());
+
+        client.send("1");
+        assertEquals("IAE", client.waitForNextMessage().toString());
+
+        client.send("2");
+        assertEquals("ISE", client.waitForNextMessage().toString());
+
+        client.send("3");
+        assertEquals("RE", client.waitForNextMessage().toString());
+
+        client.send("4");
+        assertEquals("E", client.waitForNextMessage().toString());
+
+        client.send("5");
+        assertEquals("OK", client.waitForNextMessage().toString());
+    }
+
+    @WebSocket(path = "/echo")
+    public static class Echo {
+        @OnTextMessage
+        String echo(String msg) throws Exception {
+            if ("1".equals(msg)) {
+                throw new IllegalArgumentException();
+            } else if ("2".equals(msg)) {
+                throw new IllegalStateException();
+            } else if ("3".equals(msg)) {
+                throw new RuntimeException();
+            } else if ("4".equals(msg)) {
+                throw new Exception();
+            } else {
+                return "OK";
+            }
+        }
+
+        @OnError
+        String handle(IllegalArgumentException e) {
+            return "IAE";
+        }
+
+        @OnError
+        String handle(RuntimeException e) {
+            return "RE";
+        }
+    }
+
+    @ApplicationScoped
+    public static class GlobalErrorHandlers {
+        @OnError
+        String handle(IllegalStateException e) {
+            return "ISE";
+        }
+
+        @OnError
+        String handle(Exception e) {
+            return "E";
+        }
+    }
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MultipleAmbiguousGlobalErrorHandlersTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MultipleAmbiguousGlobalErrorHandlersTest.java
@@ -7,7 +7,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.arc.Unremovable;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.WebSocketException;
@@ -26,7 +25,6 @@ public class MultipleAmbiguousGlobalErrorHandlersTest {
         fail();
     }
 
-    @Unremovable
     @ApplicationScoped
     public static class GlobalErrorHandlers {
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/ServerErrorHandlerOnClientEndpointTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/ServerErrorHandlerOnClientEndpointTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.websockets.next.test.errors;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.WebSocketException;
+
+public class ServerErrorHandlerOnClientEndpointTest {
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Echo.class);
+            })
+            .assertException(e -> {
+                assertInstanceOf(WebSocketException.class, e);
+                assertTrue(e.getMessage().contains(
+                        "@OnError callback on @WebSocketClient must not accept WebSocketConnection"));
+            });
+
+    @Test
+    void trigger() {
+    }
+
+    @WebSocketClient(path = "/echo")
+    public static class Echo {
+        @OnTextMessage
+        void echo(String msg) {
+        }
+
+        @OnError
+        String handle(Exception e, WebSocketConnection serverConnection) {
+            return "error";
+        }
+    }
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/telemetry/endpoints/onerror/GlobalErrorHandler.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/telemetry/endpoints/onerror/GlobalErrorHandler.java
@@ -4,10 +4,8 @@ import java.util.concurrent.CountDownLatch;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
-import io.quarkus.arc.Unremovable;
 import io.quarkus.websockets.next.OnError;
 
-@Unremovable
 @ApplicationScoped
 public class GlobalErrorHandler {
 

--- a/extensions/websockets-next/deployment/src/test/kotlin/io/quarkus/websockets/next/test/kotlin/MixedErrorHandlersSuspendTest.kt
+++ b/extensions/websockets-next/deployment/src/test/kotlin/io/quarkus/websockets/next/test/kotlin/MixedErrorHandlersSuspendTest.kt
@@ -1,0 +1,101 @@
+package io.quarkus.websockets.next.test.kotlin
+
+import io.quarkus.test.QuarkusUnitTest
+import io.quarkus.test.common.http.TestHTTPResource
+import io.quarkus.websockets.next.OnError
+import io.quarkus.websockets.next.OnTextMessage
+import io.quarkus.websockets.next.WebSocket
+import io.quarkus.websockets.next.test.utils.WSClient
+import io.vertx.core.Vertx
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.net.URI
+
+class MixedErrorHandlersSuspendTest {
+    companion object {
+        @RegisterExtension
+        val test: QuarkusUnitTest? = QuarkusUnitTest()
+            .withApplicationRoot { jar ->
+                jar.addClasses(Echo::class.java, GlobalErrorHandlers::class.java, WSClient::class.java)
+            }
+    }
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    @TestHTTPResource("echo")
+    lateinit var testUri: URI
+
+    @Test
+    fun test() {
+        val client = WSClient.create(vertx).connect(testUri)
+
+        client.send("0")
+        assertEquals("OK", client.waitForNextMessage().toString())
+
+        client.send("1")
+        assertEquals("IAE", client.waitForNextMessage().toString())
+
+        client.send("2")
+        assertEquals("ISE", client.waitForNextMessage().toString())
+
+        client.send("3")
+        assertEquals("RE", client.waitForNextMessage().toString())
+
+        client.send("4")
+        assertEquals("E", client.waitForNextMessage().toString())
+
+        client.send("5")
+        assertEquals("OK", client.waitForNextMessage().toString())
+    }
+
+    @WebSocket(path = "/echo")
+    class Echo {
+        @OnTextMessage
+        suspend fun echo(msg: String): String {
+            delay(100)
+            if ("1" == msg) {
+                throw IllegalArgumentException()
+            } else if ("2" == msg) {
+                throw IllegalStateException()
+            } else if ("3" == msg) {
+                throw RuntimeException()
+            } else if ("4" == msg) {
+                throw Exception()
+            } else {
+                return "OK"
+            }
+        }
+
+        @OnError
+        suspend fun handle(e: IllegalArgumentException): String {
+            delay(100)
+            return "IAE"
+        }
+
+        @OnError
+        suspend fun handle(e: RuntimeException): String {
+            delay(100)
+            return "RE"
+        }
+    }
+
+    @ApplicationScoped
+    class GlobalErrorHandlers {
+        @OnError
+        suspend fun handle(e: IllegalStateException): String {
+            delay(100)
+            return "ISE"
+        }
+
+        @OnError
+        suspend fun handle(e: Exception): String {
+            delay(100)
+            return "E"
+        }
+    }
+}


### PR DESCRIPTION
This PR rewrites the following extensions from Gizmo 1 to Gizmo 2:

- Hibernate Validator (@gsmet)
- WebSockets Next (@mkouba)
- Reactive Routes (@mkouba)

2 small WebSockets Next improvements are included as well:

- validate `@OnError` callbacks accepting the connection object
- make beans that carry global `@OnError` callbacks unremovable