### PR TITLE
Add MongoDriverInformation to identify Quarkus client connections

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -42,6 +42,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoConfigurationException;
 import com.mongodb.MongoCredential;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.MongoException;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadConcernLevel;
@@ -82,7 +83,8 @@ import io.vertx.core.buffer.impl.VertxByteBufAllocator;
 public class MongoClients {
 
     private static final Pattern COLON_PATTERN = Pattern.compile(":");
-
+    private static final MongoDriverInformation DRIVER_INFORMATION = MongoDriverInformation
+            .builder(MongoDriverInformation.builder().build()).driverName("quarkus").build();
     private final MongodbConfig mongodbConfig;
     private final MongoClientSupport mongoClientSupport;
     private final Instance<CodecProvider> codecProviders;
@@ -126,7 +128,7 @@ public class MongoClients {
     public MongoClient createMongoClient(String clientName) throws MongoException {
         MongoClientSettings mongoConfiguration = createMongoConfiguration(clientName, getMatchingMongoClientConfig(clientName),
                 false);
-        MongoClient client = com.mongodb.client.MongoClients.create(mongoConfiguration);
+        MongoClient client = com.mongodb.client.MongoClients.create(mongoConfiguration, DRIVER_INFORMATION);
         mongoclients.put(clientName, client);
         return client;
     }
@@ -136,7 +138,7 @@ public class MongoClients {
         MongoClientSettings mongoConfiguration = createMongoConfiguration(clientName, getMatchingMongoClientConfig(clientName),
                 true);
         com.mongodb.reactivestreams.client.MongoClient client = com.mongodb.reactivestreams.client.MongoClients
-                .create(mongoConfiguration);
+                .create(mongoConfiguration, DRIVER_INFORMATION);
         ReactiveMongoClientImpl reactive = new ReactiveMongoClientImpl(client);
         reactiveMongoClients.put(clientName, reactive);
         return reactive;


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2025-07-26T11:33:05.688+00:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn70990","msg":"client metadata","attr":{"remote":"192.168.0.1:34567","client":"conn70990","negotiatedCompressors":["zstd"],"doc":{"application":{"name":"quarkus-test"},`"driver":{"name":"mongo-java-driver|reactive-streams|quarkus"`,"version":"5.2.1"},"os":{"type":"Linux","name":"Linux","architecture":"amd64","version":"6.1.119-129.201.amzn2023.x86_64"},"platform":"Java/Amazon.com Inc./21.0.8+9-LTS"}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.

This is effectively the same approach taken by Spring Data MongoDB (see [SpringDataMongoDB.java](https://github.com/spring-projects/spring-data-mongodb/blob/main/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/SpringDataMongoDB.java#L37-L47), [AbstractMongoClientConfiguration.java](https://github.com/spring-projects/spring-data-mongodb/blob/024d49d4df7cba4eb970cbbd651416742fe1bebf/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoClientConfiguration.java#L107-L109))