### PR TITLE
ArC - Generate order-sensitive bytecode in reproducible order

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -8,6 +8,7 @@ import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -55,6 +57,8 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
     static final String ADD_OBSERVERS = "addObservers";
     static final String ADD_REMOVED_BEANS = "addRemovedBeans";
     static final String ADD_BEANS = "addBeans";
+    private static final Comparator<BeanInfo> BEAN_INFO_COMPARATOR = Comparator.comparing(BeanInfo::getIdentifier);
+    private static final Comparator<ObserverInfo> OBSERVER_INFO_COMPARATOR = Comparator.comparing(ObserverInfo::getIdentifier);
 
     private final AnnotationLiteralProcessor annotationLiterals;
     private final boolean detectUnusedFalsePositives;
@@ -264,7 +268,9 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             }
         }
         // Finally process beans and interceptors that are not dependencies
-        for (BeanInfo bean : beanDeployment.getBeans()) {
+        // We need to iterate in a deterministic order for build time reproducibility
+        for (BeanInfo bean : beanDeployment.getBeans().stream().sorted(BEAN_INFO_COMPARATOR)
+                .toList()) {
             if (!processed.contains(bean)) {
                 beanAdder.addComponent(bean);
             }
@@ -303,7 +309,8 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             ResultHandle beanIdToBeanHandle, ResultHandle observersHandle, Map<ObserverInfo, String> observerToGeneratedName) {
         try (ObserverAdder observerAdder = new ObserverAdder(componentsProvider, getComponents, observerToGeneratedName,
                 beanIdToBeanHandle, observersHandle)) {
-            for (ObserverInfo observer : beanDeployment.getObservers()) {
+            // We need to iterate in a deterministic order for build time reproducibility
+            for (ObserverInfo observer : beanDeployment.getObservers().stream().sorted(OBSERVER_INFO_COMPARATOR).toList()) {
                 observerAdder.addComponent(observer);
             }
         }
@@ -314,8 +321,10 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             ClassOutput classOutput) {
         try (RemovedBeanAdder removedBeanAdder = new RemovedBeanAdder(componentsProvider, targetMethod, removedBeansHandle,
                 typeCacheHandle, classOutput)) {
-            for (BeanInfo remnovedBean : beanDeployment.getRemovedBeans()) {
-                removedBeanAdder.addComponent(remnovedBean);
+            // We need to iterate in a deterministic order for build time reproducibility
+            for (BeanInfo removedBean : beanDeployment.getRemovedBeans().stream()
+                    .sorted(BEAN_INFO_COMPARATOR).toList()) {
+                removedBeanAdder.addComponent(removedBean);
             }
         }
     }
@@ -362,7 +371,8 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             }
         };
 
-        Map<BeanInfo, List<BeanInfo>> beanToInjections = new HashMap<>();
+        // We need to iterate in a deterministic order for build time reproducibility
+        Map<BeanInfo, List<BeanInfo>> beanToInjections = new TreeMap<>(BEAN_INFO_COMPARATOR);
         for (BeanInfo bean : beanDeployment.getBeans()) {
             if (bean.isProducer() && !bean.isStaticProducer()) {
                 // `static` producer doesn't depend on its declaring bean
@@ -706,7 +716,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             }
 
             List<InjectionPointInfo> injectionPoints = bean.getInjections().stream().flatMap(i -> i.injectionPoints.stream())
-                    .filter(ip -> !ip.isDelegate() && !BuiltinBean.resolvesTo(ip)).collect(toList());
+                    .filter(ip -> !ip.isDelegate() && !BuiltinBean.resolvesTo(ip)).toList();
             List<ResultHandle> params = new ArrayList<>();
             List<String> paramTypes = new ArrayList<>();
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -49,7 +49,6 @@ import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
-import io.smallrye.common.annotation.SuppressForbidden;
 
 /**
  *
@@ -95,7 +94,6 @@ public class ObserverGenerator extends AbstractGenerator {
      *
      * @param observer
      */
-    @SuppressForbidden(reason = "Using Type.toString() to build an informative message")
     void precomputeGeneratedName(ObserverInfo observer) {
         // The name of the generated class differs:
         // "org.acme.Foo_Observer_fooMethod_hash" for normal observer where hash represents the signature of the observer method
@@ -113,24 +111,6 @@ public class ObserverGenerator extends AbstractGenerator {
             }
         }
 
-        StringBuilder sigBuilder = new StringBuilder();
-        if (observer.isSynthetic()) {
-            // If a unique id is not specified then the signature is not unique but the best effort
-            if (observer.getUserId() != null) {
-                sigBuilder.append(observer.getUserId());
-            }
-            sigBuilder.append(observer.getObservedType().toString()).append(observer.getQualifiers().toString())
-                    .append(observer.isAsync()).append(observer.getPriority()).append(observer.getTransactionPhase());
-        } else {
-            sigBuilder.append(observer.getObserverMethod().name())
-                    .append(UNDERSCORE)
-                    .append(observer.getObserverMethod().returnType().name().toString());
-            for (org.jboss.jandex.Type paramType : observer.getObserverMethod().parameterTypes()) {
-                sigBuilder.append(paramType.name().toString());
-            }
-            sigBuilder.append(observer.getDeclaringBean().getIdentifier());
-        }
-
         StringBuilder baseNameBuilder = new StringBuilder();
         baseNameBuilder.append(classBase).append(OBSERVER_SUFFIX).append(UNDERSCORE);
         if (observer.isSynthetic()) {
@@ -138,7 +118,7 @@ public class ObserverGenerator extends AbstractGenerator {
         } else {
             baseNameBuilder.append(observer.getObserverMethod().name());
         }
-        baseNameBuilder.append(UNDERSCORE).append(Hashes.sha1_base64(sigBuilder.toString()));
+        baseNameBuilder.append(UNDERSCORE).append(observer.getIdentifier());
         String baseName = baseNameBuilder.toString();
         this.observerToGeneratedBaseName.put(observer, baseName);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -116,8 +116,8 @@ public class ObserverGenerator extends AbstractGenerator {
         StringBuilder sigBuilder = new StringBuilder();
         if (observer.isSynthetic()) {
             // If a unique id is not specified then the signature is not unique but the best effort
-            if (observer.getId() != null) {
-                sigBuilder.append(observer.getId());
+            if (observer.getUserId() != null) {
+                sigBuilder.append(observer.getUserId());
             }
             sigBuilder.append(observer.getObservedType().toString()).append(observer.getQualifiers().toString())
                     .append(observer.isAsync()).append(observer.getPriority()).append(observer.getTransactionPhase());
@@ -313,8 +313,8 @@ public class ObserverGenerator extends AbstractGenerator {
         StringBuilder val = new StringBuilder();
         if (observer.isSynthetic()) {
             val.append("Synthetic observer [");
-            if (observer.getId() != null) {
-                val.append("id=").append(observer.getId());
+            if (observer.getUserId() != null) {
+                val.append("id=").append(observer.getUserId());
             } else {
                 val.append("beanClass=").append(observer.getBeanClass());
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -57,7 +57,7 @@ import io.quarkus.gizmo.ResultHandle;
 public class ObserverGenerator extends AbstractGenerator {
 
     static final String OBSERVER_SUFFIX = "_Observer";
-    static final String OBSERVERVED_TYPE = "observedType";
+    static final String OBSERVED_TYPE = "observedType";
     static final String QUALIFIERS = "qualifiers";
     static final String DECLARING_PROVIDER_SUPPLIER = "declaringProviderSupplier";
 
@@ -177,7 +177,7 @@ public class ObserverGenerator extends AbstractGenerator {
                 .build();
 
         // Fields
-        FieldCreator observedType = observerCreator.getFieldCreator(OBSERVERVED_TYPE, Type.class)
+        FieldCreator observedType = observerCreator.getFieldCreator(OBSERVED_TYPE, Type.class)
                 .setModifiers(ACC_PRIVATE | ACC_FINAL);
         FieldCreator observedQualifiers = null;
         if (!observer.getQualifiers().isEmpty()) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -90,7 +90,7 @@ public class ObserverInfo implements InjectionTargetInfo {
                 buildContext, jtaCapabilities, null, Collections.emptyMap(), false);
     }
 
-    static ObserverInfo create(String id, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean,
+    static ObserverInfo create(String userId, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean,
             MethodInfo observerMethod, Injection injection,
             MethodParameterInfo eventParameter, Type observedType, Set<AnnotationInstance> qualifiers, Reception reception,
             TransactionPhase transactionPhase, boolean isAsync, int priority,
@@ -140,12 +140,12 @@ public class ObserverInfo implements InjectionTargetInfo {
                     "The observer %s makes use of %s transactional observers but no JTA capabilities were detected. Transactional observers will be notified at the same time as other observers.",
                     info, transactionPhase);
         }
-        return new ObserverInfo(id, beanDeployment, beanClass, declaringBean, observerMethod, injection, eventParameter,
+        return new ObserverInfo(userId, beanDeployment, beanClass, declaringBean, observerMethod, injection, eventParameter,
                 isAsync, priority, reception, transactionPhase, observedType, qualifiers, notify, params,
                 forceApplicationClass);
     }
 
-    private final String id;
+    private final String userId;
 
     private final BeanDeployment beanDeployment;
 
@@ -181,14 +181,14 @@ public class ObserverInfo implements InjectionTargetInfo {
 
     private final boolean forceApplicationClass;
 
-    private ObserverInfo(String id, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean,
+    private ObserverInfo(String userId, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean,
             MethodInfo observerMethod,
             Injection injection,
             MethodParameterInfo eventParameter,
             boolean isAsync, int priority, Reception reception, TransactionPhase transactionPhase,
             Type observedType, Set<AnnotationInstance> qualifiers, Consumer<MethodCreator> notify,
             Map<String, Object> params, boolean forceApplicationClass) {
-        this.id = id;
+        this.userId = userId;
         this.beanDeployment = beanDeployment;
         this.beanClass = beanClass;
         this.declaringBean = declaringBean;
@@ -222,9 +222,21 @@ public class ObserverInfo implements InjectionTargetInfo {
      * attributes (including the bean class).
      *
      * @return the optional identifier
+     * @deprecated use {@link #getUserId()} instead
      */
+    @Deprecated(since = "3.26", forRemoval = true)
     public String getId() {
-        return id;
+        return userId;
+    }
+
+    /**
+     * A unique identifier should be used for multiple synthetic observer methods with the same
+     * attributes (including the bean class).
+     *
+     * @return the optional identifier
+     */
+    public String getUserId() {
+        return userId;
     }
 
     BeanDeployment getBeanDeployment() {


### PR DESCRIPTION
This is an alternative to https://github.com/quarkusio/quarkus/pull/49097 that focuses on tuning the generation instead.

I'm interested in areas that I might have missed. I adjusted things mostly with trials/errors given I don't know this part of the codebase.

We don't have to enforce ordering on the generation of classes themselves as their names are deterministic but we need to make sure the glue code is properly ordered.

Commits are semantic and the first two are related to a discussion I had with @Ladicek .

