### PR TITLE
Add Vertx Kotlin Dispatchers

### DIFF
--- a/extensions/vertx/kotlin/deployment/pom.xml
+++ b/extensions/vertx/kotlin/deployment/pom.xml
@@ -39,18 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-test-supplement</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-test-supplement-decorator</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-test</artifactId>
             <scope>test</scope>

--- a/extensions/vertx/kotlin/deployment/pom.xml
+++ b/extensions/vertx/kotlin/deployment/pom.xml
@@ -20,11 +20,40 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-deployment-spi</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-test-supplement</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-test-supplement-decorator</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -46,6 +75,33 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <source>src/test/kotlin</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>${maven.compiler.target}</jvmTarget>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>de.thetaphi</groupId>

--- a/extensions/vertx/kotlin/deployment/src/main/java/io/quarkus/vertx/kotlin/deployment/VertxKotlinProcessor.java
+++ b/extensions/vertx/kotlin/deployment/src/main/java/io/quarkus/vertx/kotlin/deployment/VertxKotlinProcessor.java
@@ -13,9 +13,22 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.vertx.deployment.spi.EventConsumerInvokerCustomizerBuildItem;
 import io.quarkus.vertx.kotlin.runtime.ApplicationCoroutineScope;
 import io.quarkus.vertx.kotlin.runtime.CoroutineInvoker;
+import io.quarkus.vertx.kotlin.runtime.VertxKotlinCoroutinesDispatchers;
 
 public class VertxKotlinProcessor {
     private static final String KOTLIN_COROUTINE_SCOPE = "kotlinx.coroutines.CoroutineScope";
+
+    @BuildStep
+    void produceCoroutineDispatchers(BuildProducer<AdditionalBeanBuildItem> additionalBean) {
+        if (!QuarkusClassLoader.isClassPresentAtRuntime(KOTLIN_COROUTINE_SCOPE)) {
+            return;
+        }
+
+        additionalBean.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClass(VertxKotlinCoroutinesDispatchers.class)
+                .setUnremovable()
+                .build());
+    }
 
     @BuildStep
     void produceCoroutineScope(BuildProducer<AdditionalBeanBuildItem> additionalBean) {

--- a/extensions/vertx/kotlin/deployment/src/test/kotlin/io.quarkus.vertx.kotlin.runtime/VertxKotlinCoroutinesDispatchersTest.kt
+++ b/extensions/vertx/kotlin/deployment/src/test/kotlin/io.quarkus.vertx.kotlin.runtime/VertxKotlinCoroutinesDispatchersTest.kt
@@ -1,0 +1,505 @@
+package io.quarkus.vertx.kotlin.runtime
+
+import io.quarkus.arc.Arc
+import io.quarkus.test.QuarkusUnitTest
+import jakarta.enterprise.context.RequestScoped
+import jakarta.inject.Inject
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class VertxKotlinCoroutinesDispatchersTest {
+
+    companion object {
+        @RegisterExtension
+        @JvmStatic
+        val TEST =
+            QuarkusUnitTest().withApplicationRoot { jar ->
+                jar.addClasses(RequestData::class.java)
+            }
+    }
+
+    enum class DispatcherType(
+        val dispatcherProvider: (VertxKotlinCoroutinesDispatchers) -> CoroutineDispatcher
+    ) {
+        BLOCKING({ it.contextualBlockingDispatcher() }),
+        NON_BLOCKING({ it.contextualNonBlockingDispatcher() })
+        ;
+
+
+    }
+
+    @Inject
+    lateinit var requestData: RequestData
+
+    @Inject
+    lateinit var dispatchers: VertxKotlinCoroutinesDispatchers
+
+    lateinit var expectedClassLoader: ClassLoader
+
+    @BeforeEach
+    @AfterEach
+    fun setUp() {
+        if (Arc.container().requestContext().isActive) {
+            Arc.container().requestContext().terminate()
+        }
+        expectedClassLoader = Thread.currentThread().contextClassLoader
+    }
+
+    private fun assertThatCallersClassLoaderIsExpected() {
+        assertEquals(
+            expectedClassLoader,
+            Thread.currentThread().contextClassLoader,
+            "Thread context class loader should be the expected one"
+        )
+    }
+
+    private fun testDispatcher(displayerType: String): CoroutineDispatcher {
+        return DispatcherType.valueOf(displayerType).dispatcherProvider(dispatchers)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `without an active request scope on withContext`(dispatcherType: String) {
+        // GIVEN no active request context
+        assertFalse(Arc.container().requestContext().isActive, "Request context should not be active")
+
+        // WHEN we run a block
+        runTest {
+            withContext(testDispatcher(dispatcherType)) {
+                // THEN the request context should not be active
+                assertFalse(Arc.container().requestContext().isActive, "Request context should not be active")
+
+                assertThatCallersClassLoaderIsExpected()
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `without an active request scope on async`(dispatcherType: String) {
+        // GIVEN no active request context
+        assertFalse(Arc.container().requestContext().isActive, "Request context should not be active")
+
+        // WHEN we run a block with async
+        runTest {
+            coroutineScope {
+                async(testDispatcher(dispatcherType)) {
+                    // THEN the request context should not be active
+                    assertFalse(Arc.container().requestContext().isActive, "Request context should not be active")
+
+                    assertThatCallersClassLoaderIsExpected()
+                }.await()
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `with an active request scope on withContext`(dispatcherType: String) {
+        // GIVEN an active request context
+        Arc.container().requestContext().activate()
+        assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+        // AND a given number and an expected post-async number
+        val givenNumber = 1234L
+        val expectedPostAsyncNumber = 5432L
+
+        // AND we set the number value in the request data
+        requestData.numberValue = givenNumber
+
+        // WHEN we run a block with the request context
+        runTest {
+            withContext(testDispatcher(dispatcherType)) {
+                // THEN the request context should be active
+                assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                // AND the number value should match the given number
+                assertEquals(givenNumber, requestData.numberValue)
+
+                assertThatCallersClassLoaderIsExpected()
+
+                // AND the number value should match the given number after a short delay
+                delay(10)
+                assertEquals(givenNumber, requestData.numberValue)
+
+                assertThatCallersClassLoaderIsExpected()
+
+                // WHEN we set the number value to the expected post-async number
+                requestData.numberValue = expectedPostAsyncNumber
+
+                // THEN the number value should match the expected post-async number after a short delay
+                delay(10)
+                assertEquals(expectedPostAsyncNumber, requestData.numberValue)
+
+                assertThatCallersClassLoaderIsExpected()
+            }
+        }
+
+        // THEN the number value should match the expected post-async number after the block execution
+        assertEquals(expectedPostAsyncNumber, requestData.numberValue)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `with an active request scope on async`(dispatcherType: String) {
+        // GIVEN an active request context
+        Arc.container().requestContext().activate()
+        assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+        // AND a given number and an expected post-async number
+        val givenNumber = 1234L
+        val expectedPostAsyncNumber = 5432L
+
+        // AND we set the number value in the request data
+        requestData.numberValue = givenNumber
+
+        // WHEN we run a block with async
+        runTest {
+            coroutineScope {
+                async(testDispatcher(dispatcherType)) {
+                    // THEN the request context should be active
+                    assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                    // AND the number value should match the given number
+                    assertEquals(givenNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+
+                    // AND the number value should match the given number after a short delay
+                    delay(10)
+                    assertEquals(givenNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+
+                    // WHEN we set the number value to the expected post-async number
+                    requestData.numberValue = expectedPostAsyncNumber
+
+                    // THEN the number value should match the expected post-async number after a short delay
+                    delay(10)
+                    assertEquals(expectedPostAsyncNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+                }.await()
+            }
+        }
+
+        // THEN the number value should match the expected post-async number after the block execution
+        assertEquals(expectedPostAsyncNumber, requestData.numberValue)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `with an active request scope on inner coroutine scope in async`(dispatcherType: String) {
+        // GIVEN an active request context
+        Arc.container().requestContext().activate()
+        assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+        // AND a given number and an expected post-async number
+        val givenNumber = 1234L
+        val expectedPostAsyncNumber = 5432L
+
+        // AND we set the number value in the request data
+        requestData.numberValue = givenNumber
+
+        // WHEN we run a block with async
+        runTest {
+            coroutineScope {
+                async(testDispatcher(dispatcherType)) {
+                    coroutineScope {
+                        // THEN the request context should be active
+                        assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                        // AND the number value should match the given number
+                        assertEquals(givenNumber, requestData.numberValue)
+
+                        assertThatCallersClassLoaderIsExpected()
+
+                        // AND the number value should match the given number after a short delay
+                        delay(10)
+                        assertEquals(givenNumber, requestData.numberValue)
+
+                        assertThatCallersClassLoaderIsExpected()
+
+                        // WHEN we set the number value to the expected post-async number
+                        requestData.numberValue = expectedPostAsyncNumber
+
+                        // THEN the number value should match the expected post-async number after a short delay
+                        delay(10)
+                        assertEquals(expectedPostAsyncNumber, requestData.numberValue)
+
+                        assertThatCallersClassLoaderIsExpected()
+                    }
+                }.await()
+            }
+        }
+
+        // THEN the number value should match the expected post-async number after the block execution
+        assertEquals(expectedPostAsyncNumber, requestData.numberValue)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `with a terminated request scope while on async (undefined behavior)`(dispatcherType: String) {
+        // GIVEN an active request context
+        Arc.container().requestContext().activate()
+        assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+        // AND a given number
+        val givenNumber = 1234L
+
+        // AND we set the number value in the request data
+        requestData.numberValue = givenNumber
+
+        val asyncStarted = CompletableDeferred<Unit>()
+        val requestScopeTerminated = CompletableDeferred<Unit>()
+
+        // WHEN we run a block with async
+        runTest {
+            val job = launch {
+                async(testDispatcher(dispatcherType)) {
+                    // THEN the request context should be active
+                    assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                    // AND the number value should match the given number
+                    assertEquals(givenNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+
+                    asyncStarted.complete(Unit)
+
+                    // WHEN we wait for the request context to be terminated by another thread
+                    requestScopeTerminated.await()
+
+                    // THEN the request context should not be active (undefined behavior)
+                    assertFalse(Arc.container().requestContext().isActive, "Request context should not be active")
+                }.await()
+
+            }
+
+            launch {
+                asyncStarted.await()
+
+                assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+                assertEquals(givenNumber, requestData.numberValue)
+                Arc.container().requestContext().terminate()
+                assertFalse(Arc.container().requestContext().isActive, "Request context should be active")
+
+                requestScopeTerminated.complete(Unit)
+            }
+
+            job.join()
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `with two active request scope on async on same coroutine`(dispatcherType: String) {
+        // GIVEN two active request contexts with different giveNumbers
+        Arc.container().requestContext().activate()
+
+        val firstRequestState = Arc.container().requestContext().stateIfActive
+        assertNotNull(firstRequestState)
+
+        val firstGivenNumber = 1234L
+        val expectedFirstGivenNumber = 91234L
+        requestData.numberValue = firstGivenNumber
+
+        Arc.container().requestContext().activate()
+
+        val secondRequestState = Arc.container().requestContext().stateIfActive
+        assertNotNull(secondRequestState)
+        assertNotEquals(firstGivenNumber, requestData.numberValue)
+
+        val secondGivenNumber = 5432L
+        val expectedSecondGivenNumber = 95432L
+        requestData.numberValue = secondGivenNumber
+
+        assertNotEquals(firstRequestState, secondRequestState)
+
+        val waitForFirstEnd = CompletableDeferred<Unit>()
+        val waitForSecondMiddle = CompletableDeferred<Unit>()
+        val waitForSecondEnd = CompletableDeferred<Unit>()
+
+        // WHEN we run a block with async
+        runTest {
+
+            val jobFirstRequest = launch {
+                Arc.container().requestContext().activate(firstRequestState)
+                async(testDispatcher(dispatcherType)) {
+                    // THEN the request context should be active
+                    assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                    // AND the number value should match the given number
+                    assertEquals(firstGivenNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+
+                    waitForSecondMiddle.await()
+
+                    // THEN the request context should be active
+                    assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                    // AND the number value should match the given number
+                    assertEquals(firstGivenNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+
+                    requestData.numberValue = expectedFirstGivenNumber
+
+                    waitForFirstEnd.complete(Unit)
+
+                }.await()
+            }
+
+            val jobSecondRequest = launch {
+                Arc.container().requestContext().activate(secondRequestState)
+                async(testDispatcher(dispatcherType)) {
+                    // THEN the request context should be active
+                    assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                    // AND the number value should match the given number
+                    assertEquals(secondGivenNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+
+                    waitForSecondMiddle.complete(Unit)
+
+                    waitForFirstEnd.await()
+
+                    // THEN the request context should be active
+                    assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+                    // AND the number value should match the given number
+                    assertEquals(secondGivenNumber, requestData.numberValue)
+
+                    assertThatCallersClassLoaderIsExpected()
+
+                    requestData.numberValue = expectedSecondGivenNumber
+
+                    waitForSecondEnd.complete(Unit)
+
+                }.await()
+            }
+
+
+            jobSecondRequest.join()
+            jobFirstRequest.join()
+        }
+
+        Arc.container().requestContext().activate(secondRequestState)
+        assertEquals(expectedSecondGivenNumber, requestData.numberValue)
+        Arc.container().requestContext().terminate()
+
+        Arc.container().requestContext().activate(firstRequestState)
+        assertEquals(expectedFirstGivenNumber, requestData.numberValue)
+        Arc.container().requestContext().terminate()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `exception on withContext`(dispatcherType: String) {
+        runTest {
+            val message = "Some Error Message"
+
+            val ex = assertThrows<IllegalArgumentException> {
+                withContext(testDispatcher(dispatcherType)) {
+                    throw IllegalArgumentException(message)
+                }
+            }
+            assertEquals(message, ex.message)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `exception on async`(dispatcherType: String) {
+        val message = "Some Error Message"
+        val ex = assertThrows<IllegalArgumentException> {
+            runTest {
+                val deferred = async(testDispatcher(dispatcherType)) {
+                    throw IllegalArgumentException(message)
+                }
+
+                val ex = assertThrows<IllegalArgumentException> { deferred.await() }
+                assertEquals(message, ex.message)
+            }
+        }
+        assertEquals(message, ex.message)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["BLOCKING", "NON_BLOCKING"])
+    fun `call method that requires active request context (45441 reproducer)`(dispatcherType: String) {
+        runTest {
+            // GIVEN an active request context
+            Arc.container().requestContext().activate()
+            assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+
+            // AND a given number and
+            val givenNumber = 1234L
+
+            requestData.numberValue = givenNumber
+
+            // WHEN we call a method that requires an active request context and that suspends the coroutine
+            requestData.sleep()
+
+            // THEN the request context should still be active
+            assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+            // AND the number value should match the given number
+            assertEquals(givenNumber, requestData.numberValue)
+
+            // WHEN we switch to a different dispatcher
+            withContext(testDispatcher(dispatcherType)) {
+
+                // THEN the request context should still be active
+                assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+                // AND the number value should match the given number
+                assertEquals(givenNumber, requestData.numberValue)
+
+                // WHEN we call a method that requires an active request context and that suspends the coroutine
+                // THEN it should not throw an exception
+                assertDoesNotThrow { requestData.sleep() }
+
+                // AND the request context should still be active
+                assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+                // AND the number value should match the given number
+                assertEquals(givenNumber, requestData.numberValue)
+            }
+
+            // WHEN we return to the call dispatcher
+            // THEN the request context should still be active
+            assertTrue(Arc.container().requestContext().isActive, "Request context should be active")
+            // AND the number value should match the given number
+            assertEquals(givenNumber, requestData.numberValue)
+        }
+    }
+
+
+    @RequestScoped
+    class RequestData {
+        var numberValue = 0L
+
+        suspend fun sleep() {
+            delay(10)
+        }
+    }
+
+}

--- a/extensions/vertx/kotlin/runtime/pom.xml
+++ b/extensions/vertx/kotlin/runtime/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
         </dependency>

--- a/extensions/vertx/kotlin/runtime/src/main/kotlin/io/quarkus/vertx/kotlin/runtime/VertxKotlinCoroutinesDispatchers.kt
+++ b/extensions/vertx/kotlin/runtime/src/main/kotlin/io/quarkus/vertx/kotlin/runtime/VertxKotlinCoroutinesDispatchers.kt
@@ -1,0 +1,80 @@
+package io.quarkus.vertx.kotlin.runtime
+
+import io.quarkus.arc.Arc
+import io.quarkus.arc.InjectableContext
+import io.vertx.core.Vertx
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.util.concurrent.Callable
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Runnable
+
+@Singleton
+class VertxKotlinCoroutinesDispatchers @Inject constructor(private val vertx: Vertx) {
+
+    /**
+     * Creates a [CoroutineDispatcher] that dispatches code on the Vert.x blocking context.
+     *
+     * Dispatches to this dispatcher will execute with context that is captured from the thread that
+     * invokes `contextualBlockingDispatcher`
+     */
+    fun contextualBlockingDispatcher(): CoroutineDispatcher {
+        val vertxContext = vertx.orCreateContext
+        return VertxDispatcher { exec ->
+            vertxContext.executeBlocking(Callable { exec.run() }, false)
+        }
+    }
+
+    /**
+     * Creates a [CoroutineDispatcher] that dispatches code on the Vert.x event loop (current
+     * context if it exists).
+     *
+     * Dispatches to this dispatcher will execute with context that is captured from the thread that
+     * invokes `contextualBlockingDispatcher`
+     */
+    fun contextualNonBlockingDispatcher(): CoroutineDispatcher {
+        val vertxContext = vertx.orCreateContext
+        return VertxDispatcher { exec -> vertxContext.runOnContext { exec.run() } }
+    }
+
+    private class VertxDispatcher(private val execution: (Runnable) -> Unit) :
+        CoroutineDispatcher() {
+
+        // capture context state at the time of dispatcher creation NOT at dispatch time
+        private val requestContext = Arc.container().requestContext()
+        private val state = requestContext.stateIfActive
+        private val classLoader = Thread.currentThread().contextClassLoader
+
+        fun InjectableContext.ContextState?.isNullOrInvalid(): Boolean {
+            return this == null || !this.isValid
+        }
+
+        private fun replaceContext(
+            nextState: InjectableContext.ContextState?,
+            nextClassLoader: ClassLoader,
+        ) {
+            Thread.currentThread().contextClassLoader = nextClassLoader
+
+            if (nextState.isNullOrInvalid()) {
+                requestContext.deactivate()
+            } else {
+                requestContext.activate(nextState)
+            }
+        }
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            execution {
+                val previousState = requestContext.stateIfActive
+                val previousClassLoader = Thread.currentThread().contextClassLoader
+
+                replaceContext(state, classLoader)
+                try {
+                    block.run()
+                } finally {
+                    replaceContext(previousState, previousClassLoader)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provides a way to create contextualized blocking and non-blocking dispatchers that are fired in vertx context.

* Fixes: https://github.com/quarkusio/quarkus/issues/45441

Documentation missing but the basic gist is

```
@Inject
lateinit var dispatcher: VertxKotlinCoroutinesDispatchers

fun suspend doBlockingWork() {
  withContext(dispatcher.contextualBlockingDispatcher())

}

```

The prefix `contextualize` was chosen to be similar to the methods in MP Context Propagation's `ThreadContext`

Not sure if this was added to the correct modules (`vertx-kotlin`). Had to add `quarkus-vertx` as a dependency of `quarkus-vertx-kotlin` which might raise some flags.

Previous attempt at solving this
https://github.com/quarkusio/quarkus/pull/49057

