### PR TITLE
Make error message about needing a DataSource for a PersistenceUnit actionable

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -989,10 +989,11 @@ public final class HibernateOrmProcessor {
         Optional<String> dbKind = jdbcDataSource.map(JdbcDataSourceBuildItem::getDbKind);
         Optional<String> explicitDbMinVersion = jdbcDataSource.flatMap(JdbcDataSourceBuildItem::getDbVersion);
         if (multiTenancyStrategy != MultiTenancyStrategy.DATABASE && jdbcDataSource.isEmpty()) {
+            String dsConfigProperty = HibernateOrmRuntimeConfig.puPropertyKey(persistenceUnitName, "datasource");
             throw new ConfigurationException(String.format(Locale.ROOT,
-                    "Datasource must be defined for persistence unit '%s'."
+                    "Datasource must be defined for persistence unit '%s'. Setting the datasource for the persistence unit can be done via the '%s' property. "
                             + " Refer to https://quarkus.io/guides/datasource for guidance.",
-                    persistenceUnitName),
+                    persistenceUnitName, dsConfigProperty),
                     new HashSet<>(Arrays.asList("quarkus.datasource.db-kind", "quarkus.datasource.username",
                             "quarkus.datasource.password", "quarkus.datasource.jdbc.url")));
         }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/EntitiesInNamedPUWithoutDatasourceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/datasource/EntitiesInNamedPUWithoutDatasourceTest.java
@@ -23,7 +23,8 @@ public class EntitiesInNamedPUWithoutDatasourceTest {
             .overrideConfigKey("quarkus.hibernate-orm.pu-1.schema-management.strategy", "drop-and-create")
             .assertException(t -> assertThat(t)
                     .isInstanceOf(ConfigurationException.class)
-                    .hasMessageContainingAll("Datasource must be defined for persistence unit 'pu-1'."));;
+                    .hasMessageContainingAll("Datasource must be defined for persistence unit 'pu-1'.")
+                    .hasMessageContainingAll("'quarkus.hibernate-orm.\"pu-1\".datasource'"));
 
     @Test
     public void testInvalidConfiguration() {


### PR DESCRIPTION
This is done by giving the exact configuration property that the user needs to set.

- Closes: #49159