### PR TITLE
DevUI HQL console redesign + Hibernate Assistant functionality

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -197,6 +197,7 @@ updates:
           - "org.hibernate.orm*"
           - "org.hibernate.reactive*"
           - "org.hibernate.search*"
+          - "org.hibernate.tool*"
       Mvnpm:
         patterns:
           - "org.mvnpm:*"

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5645,6 +5645,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.hibernate.tool</groupId>
+                <artifactId>hibernate-tools-language</artifactId>
+                <version>${hibernate-tools.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql-jdbc.version}</version>

--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
@@ -1,21 +1,25 @@
 import {css, html, QwcHotReloadElement} from 'qwc-hot-reload-element';
 import {RouterController} from 'router-controller';
 import {JsonRpc} from 'jsonrpc';
+import {StorageController} from 'storage-controller';
 import '@vaadin/icon';
 import '@vaadin/button';
 import '@vaadin/combo-box';
-import '@vaadin/grid';
+import '@vaadin/text-field';
+import '@vaadin/text-area';
 import '@vaadin/progress-bar';
 import '@vaadin/tabs';
 import '@vaadin/tabsheet';
-import {columnBodyRenderer} from '@vaadin/grid/lit.js';
 import {notifier} from 'notifier';
+import {assistantState} from 'assistant-state';
+import 'qui-assistant-warning';
+import {observeState} from 'lit-element-state';
 
-export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
+export class HibernateOrmHqlConsoleComponent extends observeState(QwcHotReloadElement) {
     jsonRpc = new JsonRpc(this);
     configJsonRpc = new JsonRpc("devui-configuration");
-
     routerController = new RouterController(this);
+    storageControl = new StorageController(this);
 
     static styles = css`
         .bordered {
@@ -32,120 +36,247 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
             padding-left: 10px;
         }
 
-        .tablesAndData {
+        .chat-container {
             display: flex;
             height: 100%;
-            gap: 20px;
+            flex-direction: column;
             padding-right: 20px;
         }
 
-        .tables {
+        .selector-section {
             display: flex;
             flex-direction: column;
-            gap: 20px;
+            gap: 10px;
+            margin-bottom: 15px;
         }
 
-        .tableData {
+        .selector-row {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            align-items: flex-end;
+        }
+
+        .pu-selector, .entity-selector {
+            min-width: 200px;
+        }
+
+        .entity-suggestions {
             display: flex;
             flex-direction: column;
-            width: 100%;
+            gap: 5px;
         }
 
-        .tablesCard {
-            min-width: 192px;
+        .suggestion-chips {
             display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            margin-bottom: 5px;
         }
 
-        .fill {
-            width: 100%;
-            height: 100%;
+        .chat-area {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            overflow-y: auto;
+            gap: 10px;
+            padding: 15px;
+            background-color: var(--lumo-contrast-5pct);
+            border-radius: var(--lumo-border-radius-l);
+            margin-bottom: 10px;
         }
 
+        .message {
+            max-width: 80%;
+            padding: 10px 15px;
+            border-radius: var(--lumo-border-radius-m);
+            margin-bottom: 10px;
+        }
+
+        .user-message {
+            align-self: flex-end;
+            background-color: var(--lumo-primary-color-10pct);
+            color: var(--lumo-body-text-color);
+        }
+
+        .system-message {
+            align-self: flex-start;
+            background-color: var(--lumo-contrast-10pct);
+            color: var(--lumo-body-text-color);
+        }
+
+        .error-message {
+            align-self: flex-start;
+            background-color: var(--lumo-error-color-10pct);
+            color: var(--lumo-error-text-color);
+        }
+
+        .chat-input {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+
+        .chat-text-area {
+            flex: 1;
+        }
+
+        .results-card {
+            background-color: var(--lumo-base-color);
+            padding: 10px;
+            border-radius: var(--lumo-border-radius-m);
+            margin-top: 5px;
+            border: 1px solid var(--lumo-contrast-20pct);
+            display: inline-block;
+        }
+
+        .pagination {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding-top: 10px;
+            font-size: var(--lumo-font-size-s);
+        }
+
+        .result-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 5px;
+            padding: 5px 5px 0 5px;
+            font-size: var(--lumo-font-size-s);
+            border-top: 1px solid var(--lumo-contrast-10pct);
+        }
+
+        .result-count {
+            color: var(--lumo-secondary-text-color);
+        }
+
+        .copy-button {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+        
         .small-icon {
             height: var(--lumo-icon-size-s);
             width: var(--lumo-icon-size-s);
         }
 
-        .hqlInput {
-            display: flex;
-            justify-content: space-between;
-            gap: 10px;
-            align-items: center;
-            padding-bottom: 20px;
-            border-bottom-style: dotted;
-            border-bottom-color: var(--lumo-contrast-10pct);
+        .spinner {
+            animation: spin 1s linear infinite;
+            font-size: var(--lumo-font-size-xl);
+            color: var(--lumo-primary-color);
         }
 
-        #hql {
-            width: 100%;
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
         }
 
-        .data {
+        .expandable-json {
             display: flex;
             flex-direction: column;
-            gap: 10px;
-            width: 100%;
-            height: 100%;
         }
 
-        .pager {
-            display: flex;
-            justify-content: space-between;
+        .json-preview {
+            color: var(--lumo-secondary-text-color);
+            cursor: pointer;
+            padding: 2px 4px;
+            border-radius: var(--lumo-border-radius-s);
+            width: fit-content;
         }
 
-        .hidden {
-            visibility: hidden;
-        }
-
-        a, a:visited, a:focus, a:active {
-            text-decoration: none;
+        .json-preview:hover {
             color: var(--lumo-body-text-color);
         }
 
-        a:hover {
-            text-decoration: none;
-            color: var(--lumo-primary-text-color);
+        .table-container table {
+            border-collapse: collapse;
+            border-spacing: 0;
+            width: 100%;
         }
 
-        .font-large {
-            font-size: var(--lumo-font-size-l);
+        .table-container th {
+            text-align: left;
+            padding: 8px 12px;
+            font-weight: bold;
+            background-color: var(--lumo-contrast-5pct);
+            border-bottom: 1px solid var(--lumo-contrast-20pct);
+            white-space: nowrap;
         }
 
-        .cursor-text {
-            cursor: text;
+        .table-container td {
+            padding: 8px 12px;
+            vertical-align: top;
         }
 
-        .no-margin {
-            margin: 0;
+        .table-container tbody tr:nth-child(even) {
+            background-color: var(--lumo-contrast-5pct);
+        }
+
+        .nested-table {
+            width: 100%;
+            margin-top: 8px;
+            border-left: 2px solid var(--lumo-contrast-10pct);
+            padding: 0 10px;
+        }
+        
+        .nested-table table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .nested-table th {
+            text-align: left;
+            padding: 4px 8px;
+            font-weight: bold;
+            background-color: var(--lumo-contrast-5pct);
+            border-bottom: 1px solid var(--lumo-contrast-20pct);
+        }
+
+        .nested-table td {
+            padding: 4px 8px;
+            vertical-align: top;
+        }
+
+        .vertical-separator {
+            width: 1px;
+            height: 24px;
+            background-color: var(--lumo-contrast-20pct);
+            margin: 0 8px;
+            align-self: center;
         }
     `;
-
 
     static properties = {
         _persistenceUnits: {state: true, type: Array},
         _selectedPersistenceUnit: {state: true},
-        _selectedEntity: {state: true},
-        _selectedEntityIndex: {state: true},
-        _currentHQL: {state: true},
-        _currentDataSet: {state: true},
-        _currentMessage: {state: true},
+        _entityTypes: {state: true, type: Array},
+        _messages: {state: true, type: Array},
         _currentPageNumber: {state: true},
         _currentNumberOfPages: {state: true},
         _allowHql: {state: true},
+        _assistantEnabled: {state: true},
+        _assistantInteractive: {state: true},
+        _loading: {state: true, type: Boolean},
+        _expandCounter: {state: true, type: Number},
     }
 
     constructor() {
         super();
         this._persistenceUnits = [];
         this._selectedPersistenceUnit = null;
-        this._selectedEntity = null;
-        this._selectedEntityIndex = 0;
-        this._currentHQL = null;
-        this._currentDataSet = null;
-        this._currentMessage = null;
+        this._entityTypes = [];
+        this._messages = [];
         this._currentPageNumber = 1;
         this._currentNumberOfPages = 1;
         this._pageSize = 15;
+        this._allowHql = false;
+        this._assistantEnabled = this.storageControl.get('assistant-enabled') === 'true';
+        this._assistantInteractive = this.storageControl.get('assistant-interactive') === 'true';
+        this._loading = false;
+        this._expandCounter = 0;
     }
 
     connectedCallback() {
@@ -162,21 +293,29 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
     }
 
     hotReload() {
+        this._loading = true;
         this.jsonRpc.getInfo().then(response => {
             this._persistenceUnits = response.result.persistenceUnits;
-            this._selectPersistenceUnit(this._persistenceUnits[0])
+            this._selectPersistenceUnit(this._persistenceUnits[0]);
+            this._loading = false;
         }).catch(error => {
             console.error("Failed to fetch persistence units:", error);
             this._persistenceUnits = [];
+            this._loading = false;
             notifier.showErrorMessage("Failed to fetch persistence units: " + error, "bottom-start", 30);
         });
     }
 
     render() {
-        if (this._persistenceUnits) {
-            return this._renderAllPUs();
-        } else {
+        if (this._loading) {
             return this._renderFetchingProgress();
+        } else if (this._persistenceUnits && this._persistenceUnits.length > 0) {
+            return this._renderChatInterface();
+        } else {
+            return html`
+                <p>No persistence units were found.
+                    <vaadin-button @click="${this.hotReload}" theme="small">Check again</vaadin-button>
+                </p>`;
         }
     }
 
@@ -188,16 +327,323 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
             </div>`;
     }
 
-    _renderAllPUs() {
-        return this._persistenceUnits.length === 0
-            ? html`
-                    <p>No persistence units were found.
-                        <vaadin-button @click="${this.hotReload}" theme="small">Check again</vaadin-button>
-                    </p>`
-            : html`
-                    <div class="dataSources">
-                        ${this._renderTablesAndData()}
-                    </div>`;
+    _renderChatInterface() {
+        return html`
+            <div class="dataSources">
+                <div class="chat-container bordered">
+                    <div class="selector-section">
+                        <div class="selector-row">
+                            <div class="pu-selector">
+                                ${this._renderDatasourcesComboBox()}
+                            </div>
+                            <div class="entity-selector">
+                                ${this._renderEntityTypes()}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="chat-area" id="chat-area">
+                        ${this._messages.map(msg => this._renderMessage(msg))}
+                    </div>
+                    ${this._allowHql ? html`
+                        <div class="chat-input">
+                            <vaadin-text-field class="chat-text-area" placeholder="${this._assistantEnabled ? 'Enter natural language request' : 'Enter an HQL query'}"
+                                              id="hql-input"
+                                              @keydown="${this._handleKeyDown}"
+                                              style="height: 40px;" 
+                                              clear-button-visible>
+                                <vaadin-tooltip slot="tooltip"
+                                                text="${this._assistantEnabled ? 'Enter natural language request' : 'Enter an HQL query'}">
+                                </vaadin-tooltip>
+                            </vaadin-text-field>
+                            ${assistantState.current.isConfigured ? html`
+                                <vaadin-button theme="secondary" @click="${this._toggleAssistant}"
+                                               style="color: ${this._assistantEnabled ? 'var(--quarkus-assistant)' : 'var(--lumo-secondary-text-color)'}">
+                                    <vaadin-icon icon="font-awesome-solid:robot" slot="prefix"></vaadin-icon>
+                                    <vaadin-tooltip slot="tooltip" 
+                                                    text="${this._assistantEnabled ? 'Disable Hibernate Assistant' : 'Enable Hibernate Assistant'}">
+                                    </vaadin-tooltip>
+                                    ${this._assistantEnabled ? 'Assistant enabled' : 'Assistant disabled'}
+                                </vaadin-button>
+                                <vaadin-checkbox 
+                                        label="Interactive"
+                                        ?disabled="${!this._assistantEnabled}"
+                                        ?checked="${this._assistantInteractive}"
+                                        @change="${this._onInteractiveChanged}">
+                                    <vaadin-tooltip slot="tooltip"
+                                                    text="Interactive mode generates a natural language response based on the extracted data"></vaadin-tooltip>
+                                </vaadin-checkbox>
+                            ` : ''}
+                            <div class="vertical-separator"></div>
+                            <vaadin-button theme="contrast" @click="${this._clearChat}">
+                                <vaadin-icon icon="font-awesome-solid:trash"></vaadin-icon>
+                                <vaadin-tooltip slot="tooltip" text="Clear History"></vaadin-tooltip>
+                            </vaadin-button>
+                            <vaadin-button theme="primary" @click="${this._sendQuery}"
+                                           ?disabled="${this._selectedPersistenceUnit?.reactive}">
+                                <vaadin-icon icon="font-awesome-solid:play"></vaadin-icon>
+                                <vaadin-tooltip slot="tooltip" text="Execute query"></vaadin-tooltip>
+                            </vaadin-button>
+                        </div>` : ''}
+                </div>
+            </div>`;
+    }
+
+    _clearChat() {
+        this._messages = [];
+        this._expandCounter = 0;
+        this._welcomeMessage(this._selectedPersistenceUnit);
+    }
+
+    _toggleAssistant() {
+        this._assistantEnabled = !this._assistantEnabled;
+        this.storageControl.set('assistant-enabled', this._assistantEnabled);
+    }
+
+    _onInteractiveChanged(event) {
+        this._assistantInteractive = event.target.checked;
+        this.storageControl.set('assistant-interactive', this._assistantInteractive);
+    }
+
+    _renderMessage(message) {
+        if (message.type === 'loading') {
+            return html`
+            <div class="message system-message">
+                <div style="display: flex; justify-content: center; align-items: center;">
+                    <vaadin-icon icon="font-awesome-solid:circle-notch" class="spinner"></vaadin-icon>
+                </div>
+            </div>`;
+        } else if (message.type === 'user') {
+            return html`
+            <div class="message user-message">
+                <div>${message.content}</div>
+            </div>`;
+        } else if (message.type === 'error') {
+            return html`
+            <div class="message error-message">
+                <div><strong>Error:</strong> ${message.content}</div>
+            </div>`;
+        } else if (message.type === 'result') {
+            return html`
+                <div class="message system-message">
+                    ${message.message ? html`
+                        <div>${message.message}</div>
+                        ${this._renderResultsFooter(message)}
+                    ` : message.data ? html`
+                        ${this._renderResultsWithPagination(message)}
+                    ` : ''}
+                </div>`;
+        } else {
+            return html`
+            <div class="message system-message">
+                <div>${message.content}</div>
+            </div>`;
+        }
+    }
+
+    _renderResultsFooter(message) {
+        if (message.results <= 0) {
+            return;
+        }
+
+        const results = `${message.message ? 'Using ' : ''}${message.results} result${message.results === 1 ? '' : 's'}`;
+        return html`
+            <div class="result-footer">
+                <span class="result-count">${results}</span>
+                ${message.assistant ? html`<qui-assistant-warning style="display: inline-block;padding-right: 20px;"/>` : ''}
+                <vaadin-button theme="tertiary-inline" class="copy-button"
+                               data-query="${message.query}"
+                               @click="${(e) => this._copyQueryToClipboard(e, message.query)}">
+                    HQL
+                    <vaadin-icon class="small-icon" icon="font-awesome-regular:copy"></vaadin-icon>
+                    <vaadin-tooltip slot="tooltip" text="${message.query}"></vaadin-tooltip>
+                </vaadin-button>
+            </div>`;
+    }
+
+    _renderResultsWithPagination(message) {
+        return html`
+            <div class="results-card">
+                ${this._renderResultsData(message.data)}
+                ${this._renderResultsFooter(message)}
+            </div>
+            ${message.totalPages > 1 ? html`
+                <div class="pagination">
+                    <vaadin-button theme="icon tertiary" ?disabled="${message.page === 1}"
+                                   @click="${() => this._paginateResults(message.query, message.page - 1)}">
+                        <vaadin-icon class="small-icon" icon="font-awesome-solid:chevron-left"></vaadin-icon>
+                    </vaadin-button>
+                    <span>Page ${message.page} of ${message.totalPages}</span>
+                    <vaadin-button theme="icon tertiary" ?disabled="${message.page >= message.totalPages}"
+                                   @click="${() => this._paginateResults(message.query, message.page + 1)}">
+                        <vaadin-icon class="small-icon" icon="font-awesome-solid:chevron-right"></vaadin-icon>
+                    </vaadin-button>
+                </div>` : ''}`;
+    }
+
+    _copyQueryToClipboard(e, query) {
+        e.stopPropagation();
+        const targetButton = e.currentTarget;
+        navigator.clipboard.writeText(query).then(() => {
+            if (targetButton) {
+                const icon = targetButton.querySelector('vaadin-icon');
+                icon.setAttribute('icon', 'font-awesome-solid:check');
+                setTimeout(() => {
+                    icon.setAttribute('icon', 'font-awesome-regular:copy');
+                }, 2000);
+            }
+        }).catch(err => {
+            console.error('Failed to copy query: ', err);
+        });
+    }
+
+    _renderResultsData(data) {
+        if (!data || data.length === 0) {
+            return html`<div>No results found.</div>`;
+        }
+
+        return this._renderArrayTable(data, false);
+    }
+
+    _formatValue(value) {
+        if (value === true) {
+            return html`<vaadin-icon style="color: var(--lumo-contrast-50pct);" title="true" icon="font-awesome-regular:square-check"></vaadin-icon>`;
+        } else if (value === false) {
+            return html`<vaadin-icon style="color: var(--lumo-contrast-50pct);" title="false" icon="font-awesome-regular:square"></vaadin-icon>`;
+        } else if (value === null || value === undefined) {
+            return html`<span>null</span>`;
+        } else if (typeof value === 'object') {
+            return this._renderExpandableJson(value);
+        } else if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+            return html`<a href="${value}" target="_blank">${value}</a>`;
+        } else {
+            return html`<span>${value}</span>`;
+        }
+    }
+
+    _renderExpandableJson(value) {
+        const isArray = Array.isArray(value);
+        const preview = isArray
+            ? `Array[${value.length}]`
+            : `Object{${Object.keys(value).length} properties}`;
+
+        const expandId = `expand-${++this._expandCounter}`;
+        return html`
+            <div class="expandable-json">
+                <span class="json-preview" @click="${(e) => this._toggleExpand(e, expandId)}">[+] ${preview}</span>
+                <div id="${expandId}" class="nested-table" style="display: none">
+                    ${isArray
+                            ? this._renderArrayTable(value, true) // true means this is nested
+                            : this._renderObjectTable(value)}
+                </div>
+            </div>
+        `;
+    }
+
+    _toggleExpand(e, expandId) {
+        e.stopPropagation();
+        const element = this.renderRoot.querySelector(`#${expandId}`);
+        const previewEl = e.currentTarget;
+        if (element.style.display === 'none') {
+            element.style.display = 'block';
+            previewEl.textContent = previewEl.textContent.replace('[+]', '[-]');
+        } else {
+            element.style.display = 'none';
+            previewEl.textContent = previewEl.textContent.replace('[-]', '[+]');
+        }
+    }
+
+    _renderArrayTable(array, isNested = false) {
+        if (array.length === 0) {
+            return html`<div style="font-style: italic; color: var(--lumo-tertiary-text-color);">[empty array]</div>`;
+        }
+
+        // Check if we need a complex table (objects) or a simple list
+        const isComplexArray = array.some(item => typeof item === 'object' && item !== null);
+
+        if (isComplexArray) {
+            // Get all possible keys from objects in the array
+            const keys = new Set();
+            array.forEach(item => {
+                if (typeof item === 'object' && item !== null) {
+                    Object.keys(item).forEach(key => keys.add(key));
+                }
+            });
+
+            return html`
+                <div class="table-container">
+                    <table>
+                        <thead>
+                        <tr>
+                            ${[...keys].map(key => html`<th>${key}</th>`)}
+                        </tr>
+                        </thead>
+                        <tbody>
+                        ${array.map(item => {
+                            if (typeof item === 'object' && item !== null) {
+                                return html`
+                                    <tr>
+                                        ${[...keys].map(key => html`
+                                            <td>${this._formatValue(item[key])}</td>
+                                        `)}
+                                    </tr>
+                                `;
+                            }
+                            return '';
+                        })}
+                        </tbody>
+                    </table>
+                </div>
+            `;
+        } else {
+            // Simple table for primitive values
+            return html`
+                <div class="table-container">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Index</th>
+                            <th>Value</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        ${array.map((item, index) => html`
+                            <tr>
+                                <td style="width: 50px;">${index}</td>
+                                <td>${this._formatValue(item)}</td>
+                            </tr>
+                        `)}
+                        </tbody>
+                    </table>
+                </div>
+            `;
+        }
+    }
+
+    _renderObjectTable(obj) {
+        return html`
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Property</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${Object.entries(obj).map(([key, value]) => html`
+                        <tr>
+                            <td style="width: 30%;">${key}</td>
+                            <td>${this._formatValue(value)}</td>
+                        </tr>
+                    `)}
+                </tbody>
+            </table>
+        </div>
+    `;
+    }
+
+    _capitalize(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
     }
 
     _renderDatasourcesComboBox() {
@@ -214,6 +660,30 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
         `;
     }
 
+    _renderEntityTypes() {
+        return html`
+            <div class="entity-suggestions">
+                <vaadin-combo-box
+                        label="Entity Types"
+                        .items="${this._entityTypes}"
+                        placeholder="Select entity to use..."
+                        @value-changed="${(e) => this._insertEntityName(e.detail.value)}"
+                        clear-button-visible
+                ></vaadin-combo-box>
+            </div>
+        `;
+    }
+
+    _insertEntityName(entityName) {
+        if (entityName) {
+            const input = this.renderRoot.querySelector('#hql-input');
+            if (input) {
+                input.value = `from ${entityName}`;
+                input.focus();
+            }
+        }
+    }
+
     _onPersistenceUnitChanged(event) {
         const selectedValue = event.detail.value;
         this._selectPersistenceUnit(this._persistenceUnits.find(unit => unit.name === selectedValue))
@@ -221,129 +691,36 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
 
     _selectPersistenceUnit(pu) {
         this._selectedPersistenceUnit = pu;
-        this._selectedEntityIndex = 0;
-        this._selectedEntity = pu && pu.managedEntities[0] || null;
-    }
 
-    _renderTablesAndData() {
-        return html`
-            <div class="tablesAndData">
-                <div class="tables">
-                    ${this._renderDatasourcesComboBox()}
-                    ${this._renderTables()}
-                </div>
-                <div class="tableData bordered">
-                    ${this._renderDataAndInput()}
-                </div>
-            </div>`;
-    }
-
-    _renderTables() {
-        if (this._selectedPersistenceUnit) {
-            if (this._selectedPersistenceUnit.reactive) {
-                return; // Reactive persistence units are not supported
-            }
-            return html`
-                <qui-card class="tablesCard" header="Entities">
-                    <div slot="content">
-                        <vaadin-list-box selected="${this._selectedEntityIndex}"
-                                         @selected-changed="${this._onEntityChanged}">
-                            ${this._selectedPersistenceUnit.managedEntities.map((entity) =>
-                                    html`
-                                        <vaadin-item>${entity.name}</vaadin-item>`
-                            )}
-                        </vaadin-list-box>
-                    </div>
-                </qui-card>`;
+        if (pu && !pu.reactive) {
+            this._entityTypes = pu.managedEntities ? pu.managedEntities.map(entity => entity.name) : [];
         } else {
-            return this._renderFetchingProgress();
+            this._entityTypes = [];
         }
+        this._clearChat();
     }
 
-    _onEntityChanged(event) {
-        this._selectedEntityIndex = event.detail.value;
-        this._selectedEntity = this._selectedPersistenceUnit.managedEntities[this._selectedEntityIndex];
-        this._clearHqlInput();
-    }
-
-    _clearHqlInput() {
-        if (this._selectedEntity) {
-            this._executeHQL("from " + this._selectedEntity.name);
-        } else {
-            this._currentDataSet = [];
-        }
-    }
-
-    _executeHQL(hql) {
-        this._currentPageNumber = 1;
-        this._currentHQL = hql.trim();
-        this._executeCurrentHQL();
-    }
-
-    _executeClicked() {
-        let newValue = this.shadowRoot.getElementById('hql').getAttribute('value');
-        this._executeHQL(newValue);
-    }
-
-    _executeCurrentHQL() {
-        if (this._currentHQL) {
-            this._currentDataSet = null; // indicates loading
-            this._currentMessage = null;
-
-            this.jsonRpc.executeHQL({
-                persistenceUnit: this._selectedPersistenceUnit.name,
-                hql: this._currentHQL,
-                pageNumber: this._currentPageNumber,
-                pageSize: this._pageSize
-            }).then(jsonRpcResponse => {
-                const error = jsonRpcResponse.error && jsonRpcResponse.error.message || jsonRpcResponse.result.error;
-                if (error) {
-                    this._currentDataSet = [];
-                    notifier.showErrorMessage("Error executing query: " + error, "bottom-start");
-                } else if (jsonRpcResponse.result.message) {
-                    this._currentMessage = jsonRpcResponse.result.message;
+    _welcomeMessage(pu) {
+        if ( pu ) {
+            if (pu.reactive) {
+                this._addErrorMessage("Reactive persistence units are not supported in this console, please use a blocking one.");
+            } else {
+                // Add initialization welcome message
+                if (this._allowHql) {
+                    this._addSystemMessage(`Welcome to the HQL Console! Enter your queries below.`);
                 } else {
-                    this._currentDataSet = jsonRpcResponse.result;
-                    this._currentNumberOfPages = this._getNumberOfPages();
+                    this._addSystemMessage(html`
+                        Welcome to the HQL Console!
+                        <a href="#" @click="${this._handleAllowHqlChange}"
+                           style="color: var(--lumo-primary-color); text-decoration: underline; font-weight: bold;">
+                            Enable HQL execution in <code>application.properties</code>
+                        </a>.
+                    `);
                 }
-            });
+            }
         }
-    }
-
-    // *** data table and HQL input ***
-
-    _renderDataAndInput() {
-        if (this._selectedPersistenceUnit.reactive) {
-            return html`
-                <span style="padding-top:20px;padding-left:20px;">Reactive persistence units are not supported in this console, please use a blocking one.</span>`;
-        }
-        return html`
-            ${this._renderHqlInput()}
-            <div tab="data-tab" style="height:100%;">${this._renderTableData()}</div>`;
-    }
-
-    _renderHqlInput() {
-        if (this._allowHql) {
-            return html`
-                <div class="hqlInput">
-                    <qui-code-block @shiftEnter=${this._shiftEnterPressed} class="font-large cursor-text"
-                                    content="${this._currentHQL}" id="hql"
-                                    mode="sql" theme="dark" value='${this._currentHQL}' editable></qui-code-block>
-                    <vaadin-button class="no-margin" slot="suffix" theme="icon" aria-label="Clear">
-                        <vaadin-tooltip .hoverDelay=${500} slot="tooltip" text="Clear"></vaadin-tooltip>
-                        <vaadin-icon class="small-icon" @click=${this._clearHqlInput}
-                                     icon="font-awesome-solid:trash"></vaadin-icon>
-                    </vaadin-button>
-                    <vaadin-button class="no-margin" slot="suffix" theme="icon" aria-label="Run">
-                        <vaadin-tooltip .hoverDelay=${500} slot="tooltip" text="Run"></vaadin-tooltip>
-                        <vaadin-icon class="small-icon" @click=${this._executeClicked}
-                                     icon="font-awesome-solid:play"></vaadin-icon>
-                    </vaadin-button>
-                </div>`;
-        } else {
-            return html`
-                <vaadin-button theme="small" @click="${this._handleAllowHqlChange}">Allow HQL execution from here
-                </vaadin-button>`;
+        else {
+            this._addErrorMessage("No persistence unit is available.");
         }
     }
 
@@ -353,136 +730,126 @@ export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
             'value': 'true'
         }).then(e => {
             this._allowHql = true;
+            this._addSystemMessage("HQL execution is now enabled. Enter your queries below.");
         });
     }
 
-    _shiftEnterPressed(event) {
-        this._executeHQL(event.detail.content);
-    }
-
-    _renderTableData() {
-        if (this._selectedEntity) {
-            if (this._currentMessage) {
-                return html`
-                    <div class="data"><span style="padding-top:20px;">${this._currentMessage}</span></div>`;
-            } else if (this._currentDataSet) {
-                return html`
-                    <div class="data">
-                        <vaadin-grid id="data-grid" .items="${this._currentDataSet.data}" theme="row-stripes no-border"
-                                     class="fill" column-reordering-allowed>
-                            ${this._renderTableRows(this._currentDataSet.data)}
-                            <span slot="empty-state">No data.</span>
-                        </vaadin-grid>
-                        ${this._renderPager()}
-                    </div>`;
-            }
-        }
-
-        return html`
-            <div style="color: var(--lumo-secondary-text-color);width: 95%;padding-top:20px;">
-                <div>Fetching data...</div>
-                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
-            </div>`;
-    }
-
-    _renderTableRows(data) {
-        if (!data || data.length === 0) {
-            return html``;
-        }
-
-        const firstResult = data.find(e => !!e); // first non-null element
-        if (typeof firstResult === 'object') {
-            return Object.keys(this._currentDataSet.data[0]).map((col) => {
-                return html`
-                    <vaadin-grid-sort-column path="${col}" header="${col}" auto-width resizable ${columnBodyRenderer(
-                            (item) => this._cellRenderer(item[col]),
-                            []
-                    )}></vaadin-grid-sort-column>`;
-            });
-        } else {
-            return html`
-                <vaadin-grid-sort-column header="0" auto-width resizable ${columnBodyRenderer(
-                        (value) => this._cellRenderer(value),
-                        []
-                )}></vaadin-grid-sort-column>`;
+    _handleKeyDown(event) {
+        if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+            event.preventDefault();
+            this._sendQuery();
         }
     }
 
-    _cellRenderer(value) {
-        if ( value === true ) {
-            return html`
-                <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
-                             icon="font-awesome-regular:square-check"></vaadin-icon>`;
-        }
-        else if ( value === false ) {
-            return html`
-                <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
-                             icon="font-awesome-regular:square"></vaadin-icon>`;
-        }
-        else if ( value ) {
-            if ( typeof value === 'string' && (value.startsWith( 'http://' ) || value.startsWith( 'https://' )) ) {
-                return html`<a href="${value}" target="_blank">${value}</a>`;
-            }
-            else {
-                const s = typeof value === 'object' ? JSON.stringify( value ) : value;
-                return html`<span>${s}</span>`;
-            }
-        }
+    _sendQuery() {
+        const input = this.renderRoot.querySelector('#hql-input');
+        const query = input.value.trim();
+
+        if (!query) return;
+
+        this._addUserMessage(html`<strong>${this._assistantEnabled ? 'Message' : 'Query'}: </strong>${query}`);
+
+        this._executeHQL(query, 1, this._assistantEnabled, this._assistantInteractive);
     }
 
-    // *** pager and page handling ***
+    _executeHQL(query, pageNumber, assistant = false, interactive = false) {
+        if (!query || !this._selectedPersistenceUnit) return;
 
-    _renderPager() {
-        return html`
-            <div class="pager">
-                ${this._renderPreviousPageButton()}
-                <span>${this._currentPageNumber} of ${this._currentNumberOfPages}</span>
-                ${this._renderNextPageButton()}
-            </div>`;
-    }
+        // Create a loading message instead of setting global loading state
+        const loadingMessageIndex = this._messages.length;
+        this._messages = [...this._messages, {
+            type: 'loading',
+            query: query
+        }];
 
-    _renderPreviousPageButton() {
-        let klas = "pageButton";
-        if (this._currentPageNumber === 1) {
-            klas = "hidden";
-        }
-        return html`
-            <vaadin-button theme="icon tertiary" aria-label="Previous" @click=${this._previousPage} class="${klas}">
-                <vaadin-icon icon="font-awesome-solid:circle-chevron-left"></vaadin-icon>
-            </vaadin-button>`;
-    }
+        this.jsonRpc.executeHQL({
+            persistenceUnit: this._selectedPersistenceUnit.name,
+            query: query,
+            pageNumber: pageNumber,
+            pageSize: this._pageSize,
+            assistant: assistant,
+            interactive: interactive,
+        }).then(response => {
+            // Clone the messages array to modify it
+            const updatedMessages = [...this._messages];
 
-    _renderNextPageButton() {
-        let klas = "pageButton";
-        if (this._currentPageNumber === this._currentNumberOfPages) {
-            klas = "hidden";
-        }
-        return html`
-            <vaadin-button theme="icon tertiary" aria-label="Next" @click=${this._nextPage} class="${klas}">
-                <vaadin-icon icon="font-awesome-solid:circle-chevron-right"></vaadin-icon>
-            </vaadin-button>`;
-    }
+            const result = response.result;
+            const error = response.error && response.error.message ||
+                (result && result.error);
 
-    _previousPage() {
-        if (this._currentPageNumber !== 1) {
-            this._currentPageNumber = this._currentPageNumber - 1;
-            this._executeCurrentHQL();
-        }
-    }
-
-    _nextPage() {
-        this._currentPageNumber = this._currentPageNumber + 1;
-        this._executeCurrentHQL();
-    }
-
-    _getNumberOfPages() {
-        if (this._currentDataSet) {
-            if (this._currentDataSet.totalNumberOfElements > this._pageSize) {
-                return Math.ceil(this._currentDataSet.totalNumberOfElements / this._pageSize);
+            if (error) {
+                updatedMessages[loadingMessageIndex] = {
+                    type: 'error',
+                    content: error
+                };
             } else {
-                return 1;
+                updatedMessages[loadingMessageIndex] = {
+                    type: 'result',
+                    message: result.message,
+                    data: result.data,
+                    query: result.query,
+                    page: pageNumber,
+                    results: result.resultCount,
+                    assistant: assistant,
+                    totalPages: Math.ceil(result.resultCount / this._pageSize) || 1
+                };
             }
-        }
+
+            this._messages = updatedMessages;
+            this._scrollToBottom();
+        }).catch(response => {
+            // Replace loading message with error on exception
+            const updatedMessages = [...this._messages];
+            updatedMessages[loadingMessageIndex] = {
+                type: 'error',
+                content: response.error && response.error.message || "Failed to execute query."
+            };
+            this._messages = updatedMessages;
+        });
+    }
+
+    _paginateResults(query, pageNumber) {
+        this._executeHQL(query, pageNumber);
+    }
+
+    _addUserMessage(content) {
+        this._messages = [...this._messages, {
+            type: 'user',
+            content
+        }];
+        this._scrollToBottom();
+    }
+
+    _scrollToBottom() {
+        setTimeout(() => {
+            const chatArea = this.renderRoot.querySelector('#chat-area');
+            chatArea.scrollTop = chatArea.scrollHeight;
+        }, 100);
+    }
+
+    _addSystemMessage(content) {
+        this._messages = [...this._messages, {
+            type: 'system',
+            content
+        }];
+    }
+
+    _addErrorMessage(content) {
+        this._messages = [...this._messages, {
+            type: 'error',
+            content
+        }];
+    }
+
+    _addResultMessage(result) {
+        this._messages = [...this._messages, {
+            type: 'result',
+            ...result
+        }];
+    }
+
+    _getCurrentTime() {
+        return new Date().toLocaleTimeString();
     }
 }
 

--- a/extensions/hibernate-orm/runtime-dev/pom.xml
+++ b/extensions/hibernate-orm/runtime-dev/pom.xml
@@ -26,5 +26,9 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.tool</groupId>
+            <artifactId>hibernate-tools-language</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/AbstractDevUIHibernateOrmTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/AbstractDevUIHibernateOrmTest.java
@@ -107,7 +107,7 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
     public void testExecuteHQL() throws Exception {
         String entityName = expectedTableName != null ? expectedTableName : "MyEntity";
         Map<String, Object> arguments = Map.of(
-                "hql", "select e from " + entityName + " e where e.id = 1",
+                "query", "select e from " + entityName + " e where e.id = 1",
                 "persistenceUnit", expectedPersistenceUnitName != null ? expectedPersistenceUnitName : "",
                 "pageNumber", 1,
                 "pageSize", 15);
@@ -117,11 +117,11 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
         if (expectedResults != null) {
             // Expect number of results
             assertNotNull(dataSet);
-            assertTrue(dataSet.has("totalNumberOfElements"));
+            assertTrue(dataSet.has("resultCount"));
             assertTrue(dataSet.has("data"));
             assertFalse(dataSet.has("error"));
 
-            JsonNode elements = dataSet.get("totalNumberOfElements");
+            JsonNode elements = dataSet.get("resultCount");
             assertTrue(elements.isNumber());
             assertEquals(expectedResults, elements.intValue());
 
@@ -136,11 +136,11 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
         } else if (expectedPersistenceUnitName != null) {
             // Expecting an empty result set
             assertNotNull(dataSet);
-            assertTrue(dataSet.has("totalNumberOfElements"));
+            assertTrue(dataSet.has("resultCount"));
             assertTrue(dataSet.has("data"));
             assertFalse(dataSet.has("error"));
 
-            JsonNode elements = dataSet.get("totalNumberOfElements");
+            JsonNode elements = dataSet.get("resultCount");
             assertTrue(elements.isNumber());
             assertEquals(0, elements.intValue());
 
@@ -150,11 +150,11 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
         } else {
             // Expecting an error
             assertNotNull(dataSet);
-            assertTrue(dataSet.has("totalNumberOfElements"));
+            assertTrue(dataSet.has("resultCount"));
             assertFalse(dataSet.has("data"));
             assertTrue(dataSet.has("error"));
 
-            JsonNode elements = dataSet.get("totalNumberOfElements");
+            JsonNode elements = dataSet.get("resultCount");
             assertTrue(elements.isNumber());
             assertEquals(-1, elements.intValue());
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <hibernate-reactive.version>3.1.0.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.0.1.Final</hibernate-validator.version>
         <hibernate-search.version>8.1.0.Final</hibernate-search.version>
+        <hibernate-tools.version>7.1.0.Final</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.69.1</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->


### PR DESCRIPTION
Fixes #49144 

This PR provides a re-design of the Hibernate ORM query console (Dev UI interface that allows querying the underlying datasources through Hibernate's query language), taking advantage of the functionality introduced in the new [hibernate-tools-language](https://github.com/hibernate/hibernate-tools/tree/main/language) module.

The changes are:

- re-designed the console to a "chat-like" interface that preserves the history of the executed queries
- improved the query results serialization, that now handles lazy and circular associations correctly
- introduced new AI features, based on @phillip-kruger's work and the new `Assistant` interface, like LLM-assisted query execution and also data interpretation via the interactive mode

Here's a small demo of the new interface:

https://github.com/user-attachments/assets/7b8e83fa-21ca-447f-bb66-533f55195837

