### PR TITLE
Enable dependabot Hibernate updates for 3.20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: maven
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: daily
       time: "23:00"
@@ -232,6 +233,28 @@ updates:
       # Hence we update major/minor Expressly versions manually.
       - dependency-name: org.glassfish.expressly:expressly
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    rebase-strategy: disabled
+  - package-ecosystem: maven
+    directory: "/"
+    target-branch: "3.20"
+    schedule:
+      interval: daily
+      time: "23:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 10
+    labels:
+      - area/dependencies
+    allow:
+      # Hibernate
+      - dependency-name: org.hibernate.orm:*
+      - dependency-name: org.hibernate.reactive:*
+      - dependency-name: org.hibernate.validator:*
+      - dependency-name: org.hibernate.search:*
+    ignore:
+      # Major/minor upgrades require more work and synchronization, we do them manually.
+      # Only use dependabot for micros (patch versions).
+      - dependency-name: org.hibernate.*:*
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     rebase-strategy: disabled
   - package-ecosystem: gradle
     directory: "/devtools/gradle"


### PR DESCRIPTION
See:

- [#dev > Hibernate updates for 3.20](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Hibernate.20updates.20for.203.2E20)

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

