### PR TITLE
Avoid registering `Identifier` as a bean

### DIFF
--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/SmallRyeReactiveMessagingRabbitMQProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/SmallRyeReactiveMessagingRabbitMQProcessor.java
@@ -40,10 +40,7 @@ public class SmallRyeReactiveMessagingRabbitMQProcessor {
     public void dynamicCredentials(RabbitMQRecorder recorder,
             RabbitMQBuildTimeConfig rabbitMQBuildTimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> configDefaults) {
-
-        additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(Identifier.class).build());
 
         if (rabbitMQBuildTimeConfig.credentialsProvider().isPresent()) {
             String credentialsProvider = rabbitMQBuildTimeConfig.credentialsProvider().get();


### PR DESCRIPTION
Qualifiers are always recognized, even if not in "the bean archive"
