### PR TITLE
Switch to Gradle component variant-based approach to resolve conditional and deployment dependencies

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -5,12 +5,15 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -38,6 +41,13 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
     public static final String VALIDATE_EXTENSION_TASK_NAME = "validateExtension";
 
     public static final String QUARKUS_ANNOTATION_PROCESSOR = "io.quarkus:quarkus-extension-processor";
+
+    TaskDependencyFactory taskDepFactory;
+
+    @Inject
+    public QuarkusExtensionPlugin(TaskDependencyFactory taskDepFactory) {
+        this.taskDepFactory = taskDepFactory;
+    }
 
     @Override
     public void apply(Project project) {
@@ -93,7 +103,8 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
                     test.useJUnitPlatform();
                     test.doFirst(task -> {
                         final Map<String, Object> props = test.getSystemProperties();
-                        final ApplicationModel appModel = ToolingUtils.create(deploymentProject, LaunchMode.TEST);
+                        final ApplicationModel appModel = ToolingUtils.create(deploymentProject, LaunchMode.TEST,
+                                taskDepFactory);
                         try {
                             final Path serializedModel = ToolingUtils.serializeAppModel(appModel, task, true);
                             props.put(BootstrapConstants.SERIALIZED_TEST_APP_MODEL, serializedModel.toString());
@@ -111,10 +122,10 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
         DeploymentClasspathBuilder deploymentClasspathBuilder = new DeploymentClasspathBuilder(project);
         project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).getIncoming()
                 .beforeResolve((dependencies) -> deploymentClasspathBuilder
-                        .exportDeploymentClasspath(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
+                        .exportDeploymentClasspath(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, LaunchMode.NORMAL));
         project.getConfigurations().getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME).getIncoming()
                 .beforeResolve((testDependencies) -> deploymentClasspathBuilder
-                        .exportDeploymentClasspath(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME));
+                        .exportDeploymentClasspath(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, LaunchMode.TEST));
 
     }
 

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dependency/DeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dependency/DeploymentClasspathBuilder.java
@@ -12,9 +12,11 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 
+import io.quarkus.gradle.dependency.QuarkusComponentVariants;
 import io.quarkus.gradle.tooling.ToolingUtils;
 import io.quarkus.gradle.tooling.dependency.DependencyUtils;
 import io.quarkus.gradle.tooling.dependency.ExtensionDependency;
+import io.quarkus.runtime.LaunchMode;
 
 public class DeploymentClasspathBuilder {
 
@@ -25,12 +27,14 @@ public class DeploymentClasspathBuilder {
         this.project = project;
     }
 
-    public void exportDeploymentClasspath(String configurationName) {
+    public void exportDeploymentClasspath(String configurationName, LaunchMode mode) {
 
         String deploymentConfigurationName = ToolingUtils.toDeploymentConfigurationName(configurationName);
         project.getConfigurations().create(deploymentConfigurationName, config -> {
             Configuration configuration = DependencyUtils.duplicateConfiguration(project,
                     project.getConfigurations().getByName(configurationName));
+            QuarkusComponentVariants.setDeploymentAndConditionalAttributes(configuration, project, mode);
+
             Set<ExtensionDependency<?>> extensionDependencies = collectFirstMetQuarkusExtensions(configuration);
 
             DependencyHandler dependencies = project.getDependencies();
@@ -43,6 +47,7 @@ public class DeploymentClasspathBuilder {
                 dependencies.add(deploymentConfigurationName,
                         DependencyUtils.createDeploymentDependency(dependencies, extension));
             }
+            QuarkusComponentVariants.setDeploymentAndConditionalAttributes(config, project, mode);
         });
     }
 

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -20,6 +20,10 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.runtime.LaunchMode;
 
+/**
+ * @deprecated since 3.25.1 in favor of {@link QuarkusComponentVariants}
+ */
+@Deprecated(forRemoval = true)
 public class ConditionalDependenciesEnabler {
 
     /**

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/DeploymentConfigurationResolver.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/DeploymentConfigurationResolver.java
@@ -1,0 +1,199 @@
+package io.quarkus.gradle.dependency;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.provider.ListProperty;
+
+import io.quarkus.gradle.tooling.dependency.DependencyUtils;
+import io.quarkus.gradle.tooling.dependency.ExtensionDependency;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Registers and initializes project's build time (deployment) classpath configuration
+ */
+public class DeploymentConfigurationResolver {
+
+    private static final byte COLLECT_TOP_EXTENSIONS = 0b001;
+
+    /**
+     * Registers and initializes project's build time (deployment) classpath configuration for a given project
+     * and launch mode.
+     * <p/>
+     * The configuration will re-use component variants added previously by the {@link QuarkusComponentVariants}.
+     * <p/>
+     * Deployment dependencies that could not be added using variants, will be added as direct dependencies
+     * of the configuration.
+     *
+     * @param project project
+     * @param mode launch mode
+     * @param configurationName configuration name
+     * @param taskDependencyFactory task dependency factory
+     */
+    public static void registerDeploymentConfiguration(Project project, LaunchMode mode, String configurationName,
+            TaskDependencyFactory taskDependencyFactory) {
+        project.getConfigurations().register(configurationName,
+                config -> new DeploymentConfigurationResolver(project, config, mode, taskDependencyFactory));
+    }
+
+    private final Project project;
+    private final TaskDependencyFactory taskDependencyFactory;
+    private byte walkingFlags;
+
+    private DeploymentConfigurationResolver(Project project, Configuration deploymentConfig, LaunchMode mode,
+            TaskDependencyFactory taskDependencyFactory) {
+        this.project = project;
+        this.taskDependencyFactory = taskDependencyFactory;
+
+        final Configuration baseRuntimeConfig = project.getConfigurations()
+                .getByName(ApplicationDeploymentClasspathBuilder.getFinalRuntimeConfigName(mode));
+        deploymentConfig.setCanBeConsumed(false);
+        deploymentConfig.extendsFrom(baseRuntimeConfig);
+        deploymentConfig.shouldResolveConsistentlyWith(baseRuntimeConfig);
+
+        ListProperty<Dependency> dependencyListProperty = project.getObjects().listProperty(Dependency.class);
+        final AtomicReference<Collection<Dependency>> directDeploymentDeps = new AtomicReference<>();
+        // the following provider appears to be called 3 times for some reason,
+        // this is the reason for this atomic reference checks
+        deploymentConfig.getDependencies().addAllLater(dependencyListProperty.value(project.provider(() -> {
+            Collection<Dependency> directDeps = directDeploymentDeps.get();
+            if (directDeps == null) {
+                if (!baseRuntimeConfig.getIncoming().getDependencies().isEmpty()) {
+                    directDeps = collectDirectDeploymentDeps(baseRuntimeConfig.getResolvedConfiguration());
+                } else {
+                    directDeps = List.of();
+                }
+                directDeploymentDeps.set(directDeps);
+            }
+            return directDeps;
+        })));
+        QuarkusComponentVariants.setDeploymentAndConditionalAttributes(deploymentConfig, project, mode);
+    }
+
+    private Collection<Dependency> collectDirectDeploymentDeps(ResolvedConfiguration baseConfig) {
+        return collectDirectDeploymentDeps(processRuntimeDeps(baseConfig));
+    }
+
+    private Map<ArtifactKey, ProcessedDependency> processRuntimeDeps(ResolvedConfiguration baseConfig) {
+        final Map<ArtifactKey, ProcessedDependency> allDeps = new HashMap<>();
+        setWalkingFlags(COLLECT_TOP_EXTENSIONS);
+        for (var dep : baseConfig.getFirstLevelModuleDependencies()) {
+            processDependency(null, dep, allDeps);
+        }
+        walkingFlags = 0;
+        return allDeps;
+    }
+
+    private void processDependency(ProcessedDependency parent,
+            ResolvedDependency dep,
+            Map<ArtifactKey, ProcessedDependency> allDeps) {
+        boolean processChildren = false;
+        int depFlags = 0;
+        var artifacts = dep.getModuleArtifacts();
+        ProcessedDependency processedDep = null;
+        if (artifacts.isEmpty()) {
+            processChildren = true;
+        } else {
+            for (var artifact : artifacts) {
+                processedDep = allDeps.computeIfAbsent(DependencyUtils.getKey(artifact), key -> {
+                    final ProcessedDependency pd = new ProcessedDependency(parent, dep,
+                            artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier);
+                    if (isWalkingFlagsOn(COLLECT_TOP_EXTENSIONS)) {
+                        pd.ext = DependencyUtils.getExtensionInfoOrNull(project, artifact);
+                        if (pd.ext != null) {
+                            pd.setFlags(DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
+                        }
+                    }
+                    return pd;
+                });
+                if (processedDep.setFlags(DependencyFlags.VISITED)) {
+                    processChildren = true;
+                    depFlags |= processedDep.flags;
+                }
+            }
+        }
+        if (processChildren) {
+            boolean stopCollectingTopExt = isWalkingFlagsOn(COLLECT_TOP_EXTENSIONS)
+                    && (depFlags & DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT) > 0;
+            if (stopCollectingTopExt) {
+                clearWalkingFlags(COLLECT_TOP_EXTENSIONS);
+            }
+            for (var child : dep.getChildren()) {
+                processDependency(processedDep, child, allDeps);
+            }
+            if (stopCollectingTopExt) {
+                setWalkingFlags(COLLECT_TOP_EXTENSIONS);
+            }
+        }
+    }
+
+    private Collection<Dependency> collectDirectDeploymentDeps(Map<ArtifactKey, ProcessedDependency> allRuntimeDeps) {
+        final List<Dependency> directDeploymentDeps = new ArrayList<>();
+        for (var processedDep : allRuntimeDeps.values()) {
+            if (processedDep.ext != null &&
+                    processedDep.hasLocalParent() &&
+                    // if it's an extension and its deployment artifact is not a runtime dependency (e.g. deployment tests)
+                    !allRuntimeDeps.containsKey(
+                            ArtifactKey.of(processedDep.ext.getDeploymentGroup(), processedDep.ext.getDeploymentName(),
+                                    ArtifactCoords.DEFAULT_CLASSIFIER, ArtifactCoords.TYPE_JAR))) {
+                directDeploymentDeps.add(getDeploymentDependency(processedDep.ext));
+            }
+        }
+        return directDeploymentDeps;
+    }
+
+    private Dependency getDeploymentDependency(ExtensionDependency<?> ext) {
+        return ext.isProjectDependency()
+                ? DependencyUtils.createDeploymentProjectDependency((Project) ext.getDeploymentModule(), taskDependencyFactory)
+                : DependencyUtils.createDeploymentDependency(project.getDependencies(), ext);
+    }
+
+    private boolean isWalkingFlagsOn(byte flags) {
+        return (walkingFlags & flags) == flags;
+    }
+
+    private void clearWalkingFlags(byte flags) {
+        walkingFlags &= (byte) (walkingFlags ^ flags);
+    }
+
+    private boolean setWalkingFlags(byte flags) {
+        return walkingFlags != (walkingFlags |= flags);
+    }
+
+    private static class ProcessedDependency {
+
+        final ProcessedDependency parent;
+        final ResolvedDependency dep;
+        final boolean local;
+        int flags;
+        ExtensionDependency<?> ext;
+
+        private ProcessedDependency(ProcessedDependency parent, ResolvedDependency dep, boolean local) {
+            this.parent = parent;
+            this.dep = dep;
+            this.local = local;
+        }
+
+        private boolean setFlags(int flags) {
+            return this.flags != (this.flags |= flags);
+        }
+
+        private boolean hasLocalParent() {
+            return parent == null || parent.local;
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/QuarkusComponentVariants.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/QuarkusComponentVariants.java
@@ -1,0 +1,567 @@
+package io.quarkus.gradle.dependency;
+
+import static io.quarkus.gradle.tooling.dependency.DependencyUtils.getKey;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.attributes.java.TargetJvmEnvironment;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+
+import io.quarkus.gradle.tooling.dependency.DependencyUtils;
+import io.quarkus.gradle.tooling.dependency.ExtensionDependency;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Analyzes application configurations and adds the necessary component variants
+ * to enable conditional and deployment dependencies.
+ */
+public class QuarkusComponentVariants {
+
+    private static final String ON = "on";
+    private static final String RUNTIME_ELEMENTS = "runtimeElements";
+    private static final String RUNTIME = "runtime";
+
+    /**
+     * Makes sure the first character of the string is an upper-case one.
+     *
+     * @param s a string
+     * @return a string that starts with an upper-case character
+     */
+    private static String toUpperCaseName(String s) {
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    /**
+     * Returns a runtime classpath configuration name for a specific launch mode
+     * that includes satisfied conditional dependencies.
+     *
+     * @param mode launch mode
+     * @return conditional runtime classpath configuration name
+     */
+    public static String getConditionalConfigurationName(LaunchMode mode) {
+        return "quarkusConditional" + ApplicationDeploymentClasspathBuilder.getLaunchModeAlias(mode)
+                + "RuntimeClasspath";
+    }
+
+    /**
+     * Returns a conditional dependency attribute for a specific project and launch mode.
+     * A project name is included in the attribute name since the same dependency may end up being used
+     * in different subprojects of the same codebase.
+     *
+     * @param projectName project name
+     * @param mode launch mode
+     * @return conditional dependency attribute
+     */
+    private static Attribute<String> getConditionalDependencyAttribute(String projectName, LaunchMode mode) {
+        var sb = new StringBuilder()
+                .append("quarkus.")
+                .append(mode.getDefaultProfile())
+                .append(".conditional-dependency.")
+                .append(projectName);
+        return Attribute.of(sb.toString(), String.class);
+    }
+
+    /**
+     * Returns a deployment dependency attribute for a specific project and launch mode.
+     * A project name is included in the attribute name since the same dependency may end up being used
+     * in different subprojects of the same codebase.
+     *
+     * @param projectName project name
+     * @param mode launch mode
+     * @return deployment dependency attribute
+     */
+    private static Attribute<String> getDeploymentDependencyAttribute(String projectName, LaunchMode mode) {
+        var sb = new StringBuilder()
+                .append("quarkus.")
+                .append(mode.getDefaultProfile())
+                .append(".deployment-dependency.")
+                .append(projectName);
+        return Attribute.of(sb.toString(), String.class);
+    }
+
+    /**
+     * Sets conditional and other generally relevant attributes on a configuration for a given project and launch mode.
+     *
+     * @param config target configuration
+     * @param project project
+     * @param mode launch mode
+     */
+    public static void setConditionalAttributes(Configuration config, Project project, LaunchMode mode) {
+        config.attributes(attrs -> {
+            setCommonAttributes(attrs, project.getObjects());
+            attrs.attribute(getConditionalDependencyAttribute(project.getName(), mode), ON);
+        });
+    }
+
+    /**
+     * Sets deployment, conditional and other generally relevant attributes on a configuration for a given project
+     * and launch mode.
+     *
+     * @param config target configuration
+     * @param project project
+     * @param mode launch mode
+     */
+    public static void setDeploymentAndConditionalAttributes(Configuration config, Project project, LaunchMode mode) {
+        setConditionalAttributes(config, project, mode);
+        config.attributes(attrs -> attrs.attribute(getDeploymentDependencyAttribute(project.getName(), mode), ON));
+    }
+
+    /**
+     * Sets iterative (not yet final) conditional attributes on a configuration for a given project.
+     *
+     * @param config target configuration
+     * @param project project
+     * @param satisfiedExtDeps currently satisfied conditional dependencies
+     */
+    private static void setIterativeConditionalAttributes(Configuration config, Project project,
+            Collection<SatisfiedExtensionDeps> satisfiedExtDeps) {
+        config.attributes(attrs -> {
+            setCommonAttributes(attrs, project.getObjects());
+            for (var satisfiedDep : satisfiedExtDeps) {
+                satisfiedDep.setItrativeAttribute(attrs);
+            }
+        });
+    }
+
+    /**
+     * Sets generally relevant non-Quarkus attributes.
+     *
+     * @param attrs attributes container
+     * @param objectFactory object factory
+     */
+    public static void setCommonAttributes(AttributeContainer attrs, ObjectFactory objectFactory) {
+        attrs.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
+        attrs.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        attrs.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                objectFactory.named(LibraryElements.class, LibraryElements.JAR));
+        attrs.attribute(Bundling.BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
+        attrs.attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+                objectFactory.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM));
+    }
+
+    /**
+     * Analyzes project configurations and adds the necessary component attributes for a specific launch mode.
+     *
+     * @param project project
+     * @param mode launch mode
+     */
+    public static void addVariants(Project project, LaunchMode mode) {
+        new QuarkusComponentVariants(project, mode).configureAndAddVariants();
+    }
+
+    private final Attribute<String> quarkusDepAttr;
+    private final Project project;
+    private final Map<ArtifactKey, ProcessedDependency> processedDeps = new HashMap<>();
+    private final Map<ArtifactKey, ConditionalDependency> allConditionalDeps = new HashMap<>();
+    private final List<ConditionalDependencyVariant> dependencyVariantQueue = new ArrayList<>();
+    private final Map<String, SatisfiedExtensionDeps> satisfiedExtensionDeps = new HashMap<>();
+    private final LaunchMode mode;
+    private final AtomicInteger configCopyCounter = new AtomicInteger();
+
+    private QuarkusComponentVariants(Project project, LaunchMode mode) {
+        this.project = project;
+        this.mode = mode;
+        this.quarkusDepAttr = getConditionalDependencyAttribute(project.getName(), mode);
+        project.getDependencies().getAttributesSchema().attribute(quarkusDepAttr);
+        project.getDependencies().getAttributesSchema().attribute(getDeploymentDependencyAttribute(project.getName(), mode));
+    }
+
+    /**
+     * Configuration that should be used as the base for conditional and deployment dependency analysis.
+     *
+     * @return base configuration for dependency analysis
+     */
+    private Configuration getBaseConfiguration() {
+        return project.getConfigurations().getByName(ApplicationDeploymentClasspathBuilder.getBaseRuntimeConfigName(mode));
+    }
+
+    /**
+     * Registers a runtime configuration with enabled conditional dependencies.
+     * It also adds deployment variants to the corresponding components but does not select them in this configuration.
+     */
+    private void configureAndAddVariants() {
+        project.getConfigurations().resolvable(
+                getConditionalConfigurationName(mode),
+                config -> {
+                    config.setCanBeConsumed(false);
+                    config.extendsFrom(getBaseConfiguration());
+                    setConditionalAttributes(config, project, mode);
+                    final ListProperty<Dependency> dependencyProperty = project.getObjects().listProperty(Dependency.class);
+                    final AtomicInteger invocations = new AtomicInteger();
+                    config.getDependencies().addAllLater(dependencyProperty.value(project.provider(() -> {
+                        if (invocations.getAndIncrement() == 0) {
+                            addConditionalVariants(getBaseConfiguration());
+                            addDeploymentVariants();
+                        }
+                        return Set.of();
+                    })));
+                });
+    }
+
+    /**
+     * This is where the dependencies are being analyzed and component variants bein added.
+     *
+     * @param baseConfig base configuration for analysis
+     */
+    private void addConditionalVariants(Configuration baseConfig) {
+        processConfiguration(baseConfig);
+        while (!dependencyVariantQueue.isEmpty()) {
+            boolean satisfiedConditions = false;
+            var i = dependencyVariantQueue.iterator();
+            while (i.hasNext()) {
+                var conditionalVariant = i.next();
+                if (conditionalVariant.conditionalDep.isConditionSatisfied()) {
+                    satisfiedConditions = true;
+                    i.remove();
+                    satisfiedExtensionDeps.computeIfAbsent(conditionalVariant.parent.toModuleName(),
+                            key -> new SatisfiedExtensionDeps(conditionalVariant.parent, project.getName(), mode)).deps
+                            .add(conditionalVariant.conditionalDep);
+                }
+            }
+            if (!satisfiedConditions) {
+                break;
+            }
+            for (var satisfiedDeps : satisfiedExtensionDeps.values()) {
+                project.getDependencies().getComponents().withModule(
+                        satisfiedDeps.getModuleId(),
+                        satisfiedDeps::addIterativeConditionalVariants);
+            }
+            processConfiguration(baseConfig);
+        }
+    }
+
+    private void addConditionalVariant(String variantName, ComponentMetadataDetails compDetails,
+            Attribute<String> attr, List<ConditionalDependency> deps) {
+        addConditionalVariant(variantName, RUNTIME_ELEMENTS, compDetails, attr, deps);
+        addConditionalVariant(variantName, RUNTIME, compDetails, attr, deps);
+    }
+
+    private void addConditionalVariant(String variantName, String baseVariant,
+            ComponentMetadataDetails compDetails,
+            Attribute<String> attr,
+            List<ConditionalDependency> satisfiedDeps) {
+        compDetails.maybeAddVariant(
+                variantName,
+                baseVariant,
+                variant -> {
+                    final AtomicInteger selectCounter = new AtomicInteger();
+                    variant.attributes(attrs -> {
+                        if (selectCounter.getAndIncrement() == 0) {
+                            attrs.attribute(attr, ON);
+                        }
+                    });
+                    variant.withDependencies(directDeps -> {
+                        for (var satisfiedDep : satisfiedDeps) {
+                            boolean alreadyAdded = false;
+                            for (var directDep : directDeps) {
+                                if (directDep.getName().equals(satisfiedDep.key.getArtifactId())
+                                        && directDep.getGroup().equals(satisfiedDep.key.getGroupId())) {
+                                    alreadyAdded = true;
+                                    break;
+                                }
+                            }
+                            if (!alreadyAdded) {
+                                var a = satisfiedDep.artifact;
+                                directDeps.add(DependencyUtils.asDependencyNotation(project.getDependencyFactory().create(
+                                        a.getModuleVersion().getId().getGroup(),
+                                        a.getName(),
+                                        a.getModuleVersion().getId().getVersion(),
+                                        a.getClassifier(), a.getExtension())));
+                            }
+                        }
+                    });
+                });
+    }
+
+    private void addDeploymentVariants() {
+        final Map<String, List<ExtensionDependency<?>>> deploymentDeps = new HashMap<>();
+        for (var satisfiedDeps : satisfiedExtensionDeps.values()) {
+            project.getDependencies().getComponents().withModule(
+                    satisfiedDeps.getModuleId(),
+                    satisfiedDeps::addFinalConditionalVariants);
+            satisfiedDeps.collectExtensionDeps(deploymentDeps);
+        }
+
+        for (var pd : processedDeps.values()) {
+            pd.addDeploymentDependency(deploymentDeps);
+        }
+
+        for (var deployment : deploymentDeps.entrySet()) {
+            addDeploymentVariant(deployment.getKey(), deployment.getValue());
+        }
+    }
+
+    private void addDeploymentVariant(String parentModule, List<ExtensionDependency<?>> extDeps) {
+        project.getDependencies().getComponents().withModule(
+                parentModule,
+                compDetails -> addDeploymentVariant(
+                        getDeploymentDependencyAttribute(project.getName(), mode),
+                        compDetails, extDeps));
+    }
+
+    private static void addDeploymentVariant(Attribute<String> attribute,
+            ComponentMetadataDetails compDetails,
+            List<ExtensionDependency<?>> deploymentDeps) {
+        addDeploymentVariant(attribute, RUNTIME_ELEMENTS, compDetails, deploymentDeps);
+        addDeploymentVariant(attribute, RUNTIME, compDetails, deploymentDeps);
+    }
+
+    private static void addDeploymentVariant(Attribute<String> attribute, String baseVariant,
+            ComponentMetadataDetails compDetails,
+            List<ExtensionDependency<?>> deploymentDeps) {
+        compDetails.maybeAddVariant(attribute.getName(), baseVariant, variant -> {
+            variant.attributes(attrs -> {
+                attrs.attribute(attribute, ON);
+            });
+            variant.withDependencies(directDeps -> {
+                for (var deploymentDep : deploymentDeps) {
+                    boolean alreadyAdded = false;
+                    for (var directDep : directDeps) {
+                        if (directDep.getName().equals(deploymentDep.getDeploymentName()) &&
+                                directDep.getGroup().equals(deploymentDep.getDeploymentGroup())) {
+                            alreadyAdded = true;
+                            break;
+                        }
+                    }
+                    if (!alreadyAdded) {
+                        directDeps.add(deploymentDep.getDeploymentGroup() + ":" + deploymentDep.getDeploymentName() + ":"
+                                + deploymentDep.getDeploymentVersion());
+                    }
+                }
+            });
+        });
+    }
+
+    private Configuration copyBaseConfig(Configuration baseConfig) {
+        return project.getConfigurations()
+                .resolvable(baseConfig.getName() + "Copy" + configCopyCounter.incrementAndGet(), c -> {
+                    c.setCanBeConsumed(false);
+                    c.extendsFrom(baseConfig);
+                    setIterativeConditionalAttributes(c, project, satisfiedExtensionDeps.values());
+                }).get();
+    }
+
+    private void processConfiguration(Configuration baseConfig) {
+        var config = copyBaseConfig(baseConfig);
+        final Set<ModuleVersionIdentifier> visited = new HashSet<>();
+        for (var dep : config.getResolvedConfiguration().getFirstLevelModuleDependencies()) {
+            processDependency(null, dep, visited, true);
+        }
+    }
+
+    private void processDependency(ProcessedDependency parent,
+            ResolvedDependency dep,
+            Set<ModuleVersionIdentifier> visited,
+            boolean collectTopExtensions) {
+        if (!visited.add(dep.getModule().getId())) {
+            return;
+        }
+        var artifacts = dep.getModuleArtifacts();
+        ProcessedDependency nextParent = null;
+        if (!artifacts.isEmpty()) {
+            for (var a : artifacts) {
+                nextParent = processedDeps.computeIfAbsent(getKey(a), key -> {
+                    var processedDep = new ProcessedDependency(a, DependencyUtils.getExtensionInfoOrNull(project, a),
+                            a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier);
+                    processedDep.parent = parent;
+                    processedDep.queueConditionalDeps();
+                    return processedDep;
+                });
+                if (nextParent.extension != null) {
+                    if (collectTopExtensions) {
+                        nextParent.topLevelExt = true;
+                        nextParent.parent = parent;
+                        collectTopExtensions = false;
+                    }
+                }
+            }
+        }
+
+        for (var c : dep.getChildren()) {
+            processDependency(nextParent, c, visited, collectTopExtensions);
+        }
+    }
+
+    private void queueConditionalDependency(ProcessedDependency parent, Dependency dep) {
+        dependencyVariantQueue.add(new ConditionalDependencyVariant(parent.extension, getOrCreateConditionalDep(dep)));
+    }
+
+    private ConditionalDependency getOrCreateConditionalDep(Dependency dep) {
+        return allConditionalDeps.computeIfAbsent(
+                ArtifactKey.of(dep.getGroup(), dep.getName(), dep.getVersion(), ArtifactCoords.TYPE_JAR),
+                key -> newConditionalDep(dep));
+    }
+
+    private ConditionalDependency newConditionalDep(Dependency dep) {
+        final Configuration config = project.getConfigurations().detachedConfiguration(dep).setTransitive(false);
+        setConditionalAttributes(config, project, mode);
+        for (var a : config.getResolvedConfiguration().getResolvedArtifacts()) {
+            return new ConditionalDependency(getKey(a), a, DependencyUtils.getExtensionInfoOrNull(project, a));
+        }
+        throw new RuntimeException(dep + " did not resolve to any artifacts");
+    }
+
+    private class ProcessedDependency {
+        private final ResolvedArtifact artifact;
+        private final ExtensionDependency<?> extension;
+        private final boolean local;
+        private ProcessedDependency parent;
+        private boolean topLevelExt;
+
+        private ProcessedDependency(ResolvedArtifact artifact, ExtensionDependency<?> extension, boolean local) {
+            this.artifact = artifact;
+            this.extension = extension;
+            this.local = local;
+        }
+
+        private void queueConditionalDeps() {
+            if (extension == null) {
+                return;
+            }
+            for (var dep : extension.getConditionalDependencies()) {
+                queueConditionalDependency(this, dep);
+            }
+            if (mode == LaunchMode.DEVELOPMENT) {
+                for (var dep : extension.getConditionalDevDependencies()) {
+                    queueConditionalDependency(this, dep);
+                }
+            }
+        }
+
+        private void addDeploymentDependency(Map<String, List<ExtensionDependency<?>>> deploymentDeps) {
+            if (extension == null || parent == null || parent.local || parent.extension != null && !topLevelExt) {
+                return;
+            }
+            final String parentModule;
+            if (parent.extension == null) {
+                parentModule = parent.artifact.getModuleVersion().getId().getGroup() + ":"
+                        + parent.artifact.getModuleVersion().getId().getName();
+            } else {
+                parentModule = parent.extension.getDeploymentGroup() + ":" + parent.extension.getDeploymentName();
+            }
+            deploymentDeps.computeIfAbsent(parentModule, k -> new ArrayList<>(1)).add(extension);
+        }
+    }
+
+    private class ConditionalDependency {
+        private final ArtifactKey key;
+        private final ResolvedArtifact artifact;
+        private final ExtensionDependency<?> extension;
+
+        private ConditionalDependency(ArtifactKey key, ResolvedArtifact artifact, ExtensionDependency<?> extension) {
+            this.key = key;
+            this.artifact = artifact;
+            this.extension = extension;
+        }
+
+        private boolean isConditionSatisfied() {
+            if (extension == null || extension.getDependencyConditions().isEmpty()) {
+                return true;
+            }
+            for (var key : extension.getDependencyConditions()) {
+                if (!processedDeps.containsKey(key)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    private record ConditionalDependencyVariant(ExtensionDependency<?> parent, ConditionalDependency conditionalDep) {
+    }
+
+    private class SatisfiedExtensionDeps {
+
+        private final ExtensionDependency<?> parent;
+        private final List<ConditionalDependency> deps = new ArrayList<>(4);
+        private int depsInLastAddedVariant;
+        private String iterativeVariantName;
+        private int variantIteration;
+
+        private SatisfiedExtensionDeps(ExtensionDependency<?> parent, String projectName, LaunchMode mode) {
+            this.parent = parent;
+            iterativeVariantName = "quarkus" +
+                    ApplicationDeploymentClasspathBuilder.getLaunchModeAlias(mode) +
+                    "Iterative" +
+                    toUpperCaseName(projectName) +
+                    toUpperCaseName(parent.getName());
+        }
+
+        private String getModuleId() {
+            return parent.getGroup() + ":" + parent.getName();
+        }
+
+        private boolean hasNewDepsSinceLastAddedVariant() {
+            return deps.size() > depsInLastAddedVariant;
+        }
+
+        private void setItrativeAttribute(AttributeContainer attrs) {
+            /* @formatter:off
+            It appears we can't re-use a previously added variant and with attribute.
+            Somehow, it's not selected.
+
+            String attrName = null;
+            if (hasNewDepsSinceLastAddedVariant()) {
+                // this method is called before addIterativeConditionalVariants
+                attrName = iterativeVariantName + (variantIteration + 1);
+            } else if (variantIteration > 0) {
+                attrName = iterativeVariantName + variantIteration;
+            }
+            if (attrName != null) {
+                attrs.attribute(Attribute.of(attrName, String.class), ON);
+            }
+            @formatter:on */
+            // this method is called before addIterativeConditionalVariants
+            attrs.attribute(Attribute.of(iterativeVariantName + (variantIteration + 1), String.class), ON);
+        }
+
+        private void addIterativeConditionalVariants(ComponentMetadataDetails compDetails) {
+            // It appears we can't re-use a previously added variant and with attribute.
+            // Somehow, it's not selected.
+            //if (hasNewDepsSinceLastAddedVariant()) {
+            final String variantName = iterativeVariantName + ++variantIteration;
+            depsInLastAddedVariant = deps.size();
+            final Attribute<String> attr = Attribute.of(variantName, String.class);
+            project.getDependencies().getAttributesSchema().attribute(attr);
+            addConditionalVariant(variantName, compDetails, attr, deps);
+            //}
+        }
+
+        private void addFinalConditionalVariants(ComponentMetadataDetails compDetails) {
+            addConditionalVariant(quarkusDepAttr.getName(), compDetails, quarkusDepAttr, deps);
+        }
+
+        private void collectExtensionDeps(Map<String, List<ExtensionDependency<?>>> extMap) {
+            for (var dep : deps) {
+                if (dep.extension != null) {
+                    extMap.computeIfAbsent(parent.getDeploymentGroup() + ":" + parent.getDeploymentName(),
+                            k -> new ArrayList<>(4)).add(dep.extension);
+                }
+            }
+        }
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -15,6 +15,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.initialization.IncludedBuild;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.composite.internal.DefaultIncludedBuild;
 import org.gradle.internal.composite.IncludedBuildInternal;
@@ -179,13 +180,22 @@ public class ToolingUtils {
     }
 
     public static ApplicationModel create(Project project, LaunchMode mode) {
+        return create(project, mode, null);
+    }
+
+    public static ApplicationModel create(Project project, LaunchMode mode, TaskDependencyFactory taskDepFactory) {
         final ModelParameter params = new ModelParameterImpl();
         params.setMode(mode.toString());
-        return create(project, params);
+        return create(project, params, taskDepFactory);
     }
 
     public static ApplicationModel create(Project project, ModelParameter params) {
-        return (ApplicationModel) new GradleApplicationModelBuilder().buildAll(ApplicationModel.class.getName(), params,
+        return create(project, params, null);
+    }
+
+    public static ApplicationModel create(Project project, ModelParameter params, TaskDependencyFactory taskDepFactory) {
+        return (ApplicationModel) new GradleApplicationModelBuilder(taskDepFactory).buildAll(ApplicationModel.class.getName(),
+                params,
                 project);
     }
 

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/ArtifactExtensionDependency.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/ArtifactExtensionDependency.java
@@ -16,4 +16,24 @@ public class ArtifactExtensionDependency extends ExtensionDependency<ArtifactCoo
             List<ArtifactKey> dependencyConditions) {
         super(extensionId, deploymentModule, conditionalDependencies, conditionalDevDeps, dependencyConditions);
     }
+
+    @Override
+    public String getDeploymentGroup() {
+        return getDeploymentModule().getGroupId();
+    }
+
+    @Override
+    public String getDeploymentName() {
+        return getDeploymentModule().getArtifactId();
+    }
+
+    @Override
+    public String getDeploymentVersion() {
+        return getDeploymentModule().getVersion();
+    }
+
+    @Override
+    public boolean isProjectDependency() {
+        return false;
+    }
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/ExtensionDependency.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/ExtensionDependency.java
@@ -76,6 +76,14 @@ public abstract class ExtensionDependency<T> {
         return extensionId.getVersion();
     }
 
+    public abstract String getDeploymentGroup();
+
+    public abstract String getDeploymentName();
+
+    public abstract String getDeploymentVersion();
+
+    public abstract boolean isProjectDependency();
+
     public ModuleVersionIdentifier getExtensionId() {
         return extensionId;
     }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/ProjectExtensionDependency.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/ProjectExtensionDependency.java
@@ -33,4 +33,24 @@ public class ProjectExtensionDependency extends ExtensionDependency<Project> {
     public Boolean isIncludedBuild() {
         return isIncludedBuild;
     }
+
+    @Override
+    public String getDeploymentGroup() {
+        return String.valueOf(getDeploymentModule().getGroup());
+    }
+
+    @Override
+    public String getDeploymentName() {
+        return getDeploymentModule().getName();
+    }
+
+    @Override
+    public String getDeploymentVersion() {
+        return String.valueOf(getDeploymentModule().getVersion());
+    }
+
+    @Override
+    public boolean isProjectDependency() {
+        return true;
+    }
 }

--- a/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilderTest.java
+++ b/devtools/gradle/gradle-model/src/test/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilderTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.util.Files;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.junit.jupiter.api.Test;
@@ -14,8 +15,11 @@ public class GradleApplicationModelBuilderTest {
     @Test
     void testToAppDependency() {
         ResolvedArtifact artifact = mock(ResolvedArtifact.class);
+        when(artifact.getName()).thenReturn("commons-lang");
+        ModuleVersionIdentifier id = mock(ModuleVersionIdentifier.class);
         ResolvedModuleVersion version = mock(ResolvedModuleVersion.class);
-        when(version.toString()).thenReturn(":commons-lang3-3.9:");
+        when(version.getId()).thenReturn(id);
+        when(id.getGroup()).thenReturn("commons-lang");
         when(artifact.getModuleVersion()).thenReturn(version);
         when(artifact.getFile()).thenReturn(Files.currentFolder());
         assertThatCode(() -> GradleApplicationModelBuilder.toDependency(artifact)).doesNotThrowAnyException();

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -923,3 +923,14 @@ The current state of compatibility is shown in the following table:
 |`addExtension`|❌
 |`removeExtension`|❌
 |====
+
+== Dependency resolver options
+
+=== Quarkus component variants
+
+`disableQuarkusComponentVariants` project property was introduced in Quarkus 3.25.1 to control whether Quarkus component variants should be added to certain dependencies of a project to enable xref:conditional-extension-dependencies.adoc[Quarkus conditional] and build time (deployment) dependencies. Quarkus component variants are enabled by default since 3.25.1.
+
+The approach to enable Quarkus conditional and extension build time (deployment) dependencies has changed in Quarkus 3.25.1 due to a few issues with the previous implementation.
+Specifically, the previous implementation would not apply relevant dependency exclusions to enabled conditional and deployment dependencies. It would also appear to leak devmode-only dependencies into non-devmode classpaths (such as test and prod) in some cases. These issues couldn't be fixed in a reasonable way in the previous implementation, which is why the Quarkus dependency resolution had to be re-implemented based on a different approach using link:https://docs.gradle.org/current/userguide/variant_aware_resolution.html[Gradle component variants].
+
+The previous implementation still remains available for now in case the new one appears to introduce not yet detected regressions and can be enabled by setting `disableQuarkusComponentVariants` project property to `true`.

--- a/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
+    implementation 'io.quarkus:quarkus-rest'
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}

--- a/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformGroupId=io.quarkus
+quarkusPlatformArtifactId=quarkus-bom

--- a/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='quarkus-grade-dev-classpath'

--- a/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/src/main/java/org/acme/GreetingResource.java
+++ b/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Quarkus REST";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/src/test/java/org/acme/GreetingResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/dev-deps-leak-into-prod-48992/src/test/java/org/acme/GreetingResourceTest.java
@@ -1,0 +1,20 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+class GreetingResourceTest {
+    @Test
+    void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("Hello from Quarkus REST"));
+    }
+
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/DevDepsLeakIntoProdClaspathTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/DevDepsLeakIntoProdClaspathTest.java
@@ -1,0 +1,15 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class DevDepsLeakIntoProdClaspathTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void test() throws Exception {
+        final File projectDir = getProjectDir("dev-deps-leak-into-prod-48992");
+        runGradleWrapper(projectDir, "dependencies", "--write-locks");
+        runGradleWrapper(projectDir, "assemble");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/48992

Quoting the doc update added as part of this PR:

`disableQuarkusComponentVariants` project property was introduced in Quarkus 3.26.0 to control whether Quarkus component variants should be added to certain dependencies of a project to enable link:conditional-extension-dependencies.adoc[Quarkus conditional] and build time (deployment) dependencies. Quarkus component variants are enabled by default since 3.26.0.

The approach to enable Quarkus conditional and extension build time (deployment) dependencies has changed in Quarkus 3.26.0 due to a few issues with the previous implementation.
Specifically, the previous implementation would not apply relevant dependency exclusions to enabled conditional and deployment dependencies. It would also appear to leak devmode-only dependencies into non-devmode classpaths (such as test and prod) in some cases. These issues couldn't be fixed in a reasonable way in the previous implementation, which is why the Quarkus dependency resolution had to be re-implemented based on a different approach using link:https://docs.gradle.org/current/userguide/variant_attributes.html[Gradle component variants].

The previous implementation still remains available for now in case the new one appears to introduce not yet detected regressions and can be enabled by setting `disableQuarkusComponentVariants` project property to `true`.