### PR TITLE
Docs & codestart: update couple of DEV UI component deeplinks to avoid extra redirect

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/grpc-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/grpc-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
@@ -1,3 +1,3 @@
 {#include index-entry}
-{#body}<br />&rsaquo; It can be tested in the <a href="/q/dev-ui/io.quarkus.quarkus-grpc/services">Dev UI</a> (available in dev mode only).
+{#body}<br />&rsaquo; It can be tested in the <a href="/q/dev-ui/quarkus-grpc/services">Dev UI</a> (available in dev mode only).
 {/include}

--- a/docs/src/main/asciidoc/rest-migration.adoc
+++ b/docs/src/main/asciidoc/rest-migration.adoc
@@ -103,7 +103,7 @@ Users are instead encouraged to use the Jakarta REST standard `jakarta.ws.rs.Bea
 
 Although Quarkus REST provides the same spec compliant behavior as RESTEasy Classic does, it does not include the same exact provider implementations at runtime.
 
-The most common case where the difference in providers might result in different behavior, is the included `jakarta.ws.rs.ext.ExceptionMapper` implementations. To see what classes are included in the application, launch the application in dev mode and navigate to http://localhost:8080/q/dev-ui/io.quarkus.quarkus-rest/exception-mappers.
+The most common case where the difference in providers might result in different behavior, is the included `jakarta.ws.rs.ext.ExceptionMapper` implementations. To see what classes are included in the application, launch the application in dev mode and navigate to http://localhost:8080/q/dev-ui/quarkus-rest/exception-mappers.
 
 ==== Service Loading
 

--- a/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
@@ -190,7 +190,7 @@ Typically, Quarkus must be configured with `quarkus.oidc.application-type=servic
 You also need to configure the Auth0 application to allow the callbacks to the OIDC Dev UI.
 Use the following URL format:
 
-`http://localhost:8080/q/dev-ui/io.quarkus.quarkus-oidc/${provider-name}-provider`
+`http://localhost:8080/q/dev-ui/quarkus-oidc/${provider-name}-provider`
 
 * Where in this example, the `${provider-name}` is `auth0`
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -178,7 +178,7 @@ It is recommended to do this in production to avoid the users being redirected t
 
 If Keycloak enforces it, you see an authentication error informing you that the `redirect_uri` value is wrong.
 
-In this case, select the *Keycloak Admin* option in the top right corner, login as `admin:admin`, select the test realm and the client which Dev UI for Keycloak is configured with, and add `http://localhost:8080/q/dev-ui/io.quarkus.quarkus-oidc/keycloak-provider` to `Valid Redirect URIs`.
+In this case, select the *Keycloak Admin* option in the top right corner, login as `admin:admin`, select the test realm and the client which Dev UI for Keycloak is configured with, and add `http://localhost:8080/q/dev-ui/quarkus-oidc/keycloak-provider` to `Valid Redirect URIs`.
 If you used `-Dquarkus.http.port` when starting Quarkus, then change `8080` to the value of `quarkus.http.port`
 
 If the container is shared between multiple applications running on different ports, you must register `redirect_uri` values for each application.
@@ -364,7 +364,7 @@ Follow the link to log in to your provider, get the tokens, and test the applica
 The experience is the same as described in the <<keycloak-authorization-code-grant,Authorization code grant for Keycloak>> section, where the Dev Services for Keycloak container has been started, especially if you work with Keycloak.
 
 You likely need to configure your OpenID Connect provider to support redirecting back to the `Dev Console`.
-You add `http://localhost:8080/q/dev-ui/io.quarkus.quarkus-oidc/<providerName>-provider` as one of the supported redirect and logout URLs, where `<providerName>` must be replaced by the name of the provider shown in the Dev UI, for example, `auth0`.
+You add `http://localhost:8080/q/dev-ui/quarkus-oidc/<providerName>-provider` as one of the supported redirect and logout URLs, where `<providerName>` must be replaced by the name of the provider shown in the Dev UI, for example, `auth0`.
 
 The Dev UI experience described in the <<keycloak-authorization-code-grant,Authorization code grant for Keycloak>> section might differ slightly if you work with other providers.
 For example, an access token might not be in JWT format, so it would not be possible to show its internal content.

--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
@@ -915,7 +915,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
     }
 
     _getEncodedPath() {
-        // this is the last part of this path: /q/dev-ui/io.quarkus.quarkus-oidc/keycloak-provider -> keycloak-provider
+        // this is the last part of this path: /q/dev-ui/quarkus-oidc/keycloak-provider -> keycloak-provider
         const subPath = window.location.pathname.substring(window.location.pathname.lastIndexOf('/') + 1);
         return QwcOidcProvider._getEncodedCurrentBaseUrl() + this._devRoot + "%2Fio.quarkus.quarkus-oidc%2F" + subPath;
     }


### PR DESCRIPTION
There is extra redirect when you use the old component address, so let's avoid that.
