### PR TITLE
Ensure that `OpenTelemetry` bean is always initialized when obtaining `Meter`

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/metrics/cdi/MetricsProducer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/metrics/cdi/MetricsProducer.java
@@ -4,15 +4,22 @@ import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INST
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.common.Clock;
 import io.quarkus.arc.DefaultBean;
 
 @Singleton
 public class MetricsProducer {
+
+    @SuppressWarnings("unused")
+    @Inject
+    OpenTelemetry unused;
+
     @Produces
     @ApplicationScoped
     @DefaultBean


### PR DESCRIPTION
Attempts to fix flaky test reported at:
https://github.com/quarkusio/quarkus/pull/49203#issuecomment-3138849532