### PR TITLE
Composes Dev Services - Do not add wait strategies for ignored containers

### DIFF
--- a/extensions/devservices/deployment/pom.xml
+++ b/extensions/devservices/deployment/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
@@ -126,6 +126,11 @@ public class ComposeProject {
         for (ComposeServiceDefinition definition : composeFiles.getServiceDefinitions().values()) {
             String serviceName = definition.getServiceName();
             Map<String, Object> labels = definition.getLabels();
+
+            if (Boolean.TRUE.equals(labels.get(COMPOSE_IGNORE))) {
+                continue;
+            }
+
             // Skip the service if profiles doesn't match
             if (!definition.getProfiles().isEmpty() &&
                     definition.getProfiles().stream().noneMatch(profiles::contains)) {

--- a/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeProjectTest.java
+++ b/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeProjectTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.devservices.deployment.compose;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -87,9 +88,7 @@ public class ComposeProjectTest {
 
         // Verify only kafka service is selected (as it's in the kafka profile)
         Map<String, WaitAllStrategy> waitStrategies = composeProject.getWaitStrategies();
-        assertEquals(2, waitStrategies.size());
-        assertTrue(waitStrategies.containsKey("kafka"));
-        assertTrue(waitStrategies.containsKey("zookeeper"));
+        assertThat(waitStrategies).containsOnlyKeys("kafka");
 
         // Verify project name set in file
         assertEquals("devservices", composeProject.getProject());


### PR DESCRIPTION
Fixes #49219

What's a bit odd is that the test is checking a behavior that is different from the comment just above... so not completely sure which behavior you actually want there...

