### PR TITLE
[3.25] Account for Formula properties when detecting JSON/XML columns

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyJsonEntity.class, MyXmlEntity.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties");
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    void smoke() {
+        // We really just care ot see if the SF is built successfully here or not;
+        assertThat(SchemaUtil.getColumnNames(sessionFactory, MyJsonEntity.class))
+                .contains("properties", "amount1", "amount2")
+                .doesNotContain("amountDifference");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyJsonEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyJsonEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import java.util.Map;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+public class MyJsonEntity {
+
+    @Id
+    public Long id;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    public Map<String, String> properties;
+
+    public int amount1;
+    public int amount2;
+
+    @Formula("amount2 - amount1")
+    public int amountDifference;
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyXmlEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyXmlEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import java.util.Map;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+public class MyXmlEntity {
+
+    @Id
+    public Long id;
+
+    @JdbcTypeCode(SqlTypes.SQLXML)
+    public Map<String, String> properties;
+
+    public int amount1;
+    public int amount2;
+
+    @Formula("amount2 - amount1")
+    public int amountDifference;
+
+}


### PR DESCRIPTION
I'm opening this against a 3.25 branch to make it easier to apply. 
For the main branch, I'll have to add a bit more as we switched to a failing behavior there so the tests won't work the same +  there's that other issue discused here: [#dev > Change the ORM's XML/JSON built-in format mapper default @ 💬](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Change.20the.20ORM's.20XML.2FJSON.20built-in.20format.20mapper.20default/near/532082071), working on a fix for it and will comibne it all together 

* Fixes https://github.com/quarkusio/quarkus/issues/49258

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

