### PR TITLE
Adjust the Hibernate ORM's JSON/XML formatter modification checks

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorJsonObjectMapperAdjustedPropertiesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorJsonObjectMapperAdjustedPropertiesTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorJsonObjectMapperAdjustedPropertiesTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyJsonEntity.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.jackson.write-dates-as-timestamps", "true") // to keep Jackson's defaults
+            .overrideConfigKey("quarkus.jackson.write-durations-as-timestamps", "true") // to keep Jackson's defaults
+            .overrideConfigKey("quarkus.jackson.accept-case-insensitive-enums", "false") // to keep Jackson's defaults
+    // .overrideConfigKey( "quarkus.jackson.timezone", "UTC" ) // to keep Jackson's defaults (this is already Quarkus' default)
+    ;
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    void smoke() {
+        // We really just care ot see if the SF is built successfully here or not;
+        assertThat(SchemaUtil.getColumnNames(sessionFactory, MyJsonEntity.class))
+                .contains("properties", "amount1", "amount2")
+                .doesNotContain("amountDifference");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorJsonObjectMapperCustomizerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorJsonObjectMapperCustomizerTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorJsonObjectMapperCustomizerTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyJsonEntity.class, MyObjectMapperCustomizer.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties")
+            .assertException(ex -> assertThat(ex).hasCauseInstanceOf(IllegalStateException.class)
+                    .cause()
+                    .hasMessageContaining("set \"quarkus.hibernate-orm.mapping.format.global=ignore\""));
+
+    @Test
+    void smoke() {
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorJsonObjectMapperCustomizerWithIgnoreTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorJsonObjectMapperCustomizerWithIgnoreTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorJsonObjectMapperCustomizerWithIgnoreTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyJsonEntity.class, MyObjectMapperCustomizer.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.mapping.format.global", "ignore");
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    void smoke() {
+        // We really just care ot see if the SF is built successfully here or not;
+        assertThat(SchemaUtil.getColumnNames(sessionFactory, MyJsonEntity.class))
+                .contains("properties", "amount1", "amount2")
+                .doesNotContain("amountDifference");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyJsonEntity.class, MyXmlEntity.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.mapping.format.global", "ignore");
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    void smoke() {
+        // We really just care ot see if the SF is built successfully here or not;
+        assertThat(SchemaUtil.getColumnNames(sessionFactory, MyJsonEntity.class))
+                .contains("properties", "amount1", "amount2")
+                .doesNotContain("amountDifference");
+        assertThat(SchemaUtil.getColumnNames(sessionFactory, MyXmlEntity.class))
+                .contains("properties", "amount1", "amount2")
+                .doesNotContain("amountDifference");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorWithFormatMapperTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorWithFormatMapperTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorWithFormatMapperTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyJsonEntity.class, MyJsonFormatMapper.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties");
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    void smoke() {
+        // We really just care ot see if the SF is built successfully here or not;
+        assertThat(SchemaUtil.getColumnNames(sessionFactory, MyJsonEntity.class))
+                .contains("properties", "amount1", "amount2")
+                .doesNotContain("amountDifference");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorXmlFailsByDefaultTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorXmlFailsByDefaultTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorXmlFailsByDefaultTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyXmlEntity.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties")
+            .assertException(ex -> assertThat(ex).hasCauseInstanceOf(IllegalStateException.class)
+                    .cause()
+                    .hasMessageContaining("set \"quarkus.hibernate-orm.mapping.format.global=ignore\""));
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    void smoke() {
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorXmlWorksWithUserDefinedMapperTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/FormatMapperBehaviorXmlWorksWithUserDefinedMapperTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SchemaUtil;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormatMapperBehaviorXmlWorksWithUserDefinedMapperTest {
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyXmlFormatMapper.class, MyXmlEntity.class)
+                    .addClasses(SchemaUtil.class, SmokeTestUtils.class))
+            .withConfigurationResource("application.properties");
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    void smoke() {
+        // We really just care ot see if the SF is built successfully here or not;
+        assertThat(SchemaUtil.getColumnNames(sessionFactory, MyXmlEntity.class))
+                .contains("properties", "amount1", "amount2")
+                .doesNotContain("amountDifference");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyJsonEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyJsonEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import java.util.Map;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+public class MyJsonEntity {
+
+    @Id
+    public Long id;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    public Map<String, String> properties;
+
+    public int amount1;
+    public int amount2;
+
+    @Formula("amount2 - amount1")
+    public int amountDifference;
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyJsonFormatMapper.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyJsonFormatMapper.java
@@ -1,0 +1,23 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.format.FormatMapper;
+
+import io.quarkus.hibernate.orm.JsonFormat;
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+
+@JsonFormat
+@PersistenceUnitExtension
+public class MyJsonFormatMapper implements FormatMapper {
+
+    @Override
+    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyObjectMapperCustomizer.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyObjectMapperCustomizer.java
@@ -1,0 +1,15 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class MyObjectMapperCustomizer implements ObjectMapperCustomizer {
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        // we don't really have to do anything here, it is enough that we have the customizer...
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyXmlEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyXmlEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import java.util.Map;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+public class MyXmlEntity {
+
+    @Id
+    public Long id;
+
+    @JdbcTypeCode(SqlTypes.SQLXML)
+    public Map<String, String> properties;
+
+    public int amount1;
+    public int amount2;
+
+    @Formula("amount2 - amount1")
+    public int amountDifference;
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyXmlFormatMapper.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/formatmapper/MyXmlFormatMapper.java
@@ -1,0 +1,23 @@
+package io.quarkus.hibernate.orm.formatmapper;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.format.FormatMapper;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.XmlFormat;
+
+@XmlFormat
+@PersistenceUnitExtension
+public class MyXmlFormatMapper implements FormatMapper {
+
+    @Override
+    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BuiltinFormatMapperBehaviour.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BuiltinFormatMapperBehaviour.java
@@ -4,6 +4,7 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.java.spi.JsonJavaType;
 import org.hibernate.type.descriptor.java.spi.XmlJavaType;
 import org.jboss.logging.Logger;
@@ -68,7 +69,12 @@ public enum BuiltinFormatMapperBehaviour {
                 hasJsonProperties.set(true);
             }
         });
-        return hasJsonProperties.get();
+        if (hasJsonProperties.get()) {
+            return true;
+        } else {
+            // for JSON_ARRAY we need to check the jdbc type registry instead
+            return metadata.getTypeConfiguration().getJdbcTypeRegistry().hasRegisteredDescriptor(SqlTypes.JSON_ARRAY);
+        }
     }
 
     public static boolean hasXmlProperties(MetadataImplementor metadata) {
@@ -78,7 +84,12 @@ public enum BuiltinFormatMapperBehaviour {
                 hasXmlProperties.set(true);
             }
         });
-        return hasXmlProperties.get();
+        if (hasXmlProperties.get()) {
+            return true;
+        } else {
+            // for XML_ARRAY we need to check the jdbc type registry instead
+            return metadata.getTypeConfiguration().getJdbcTypeRegistry().hasRegisteredDescriptor(SqlTypes.XML_ARRAY);
+        }
     }
 
     public void jsonApply(MetadataImplementor metadata, String puName, ArcContainer container,


### PR DESCRIPTION
Opening as a draft as it's based on Marco's PR: https://github.com/quarkusio/quarkus/pull/49271

I've added  "reasons" why the check is failing to help users identify what's been modified and hopefully help them.
Then for the checks themselves ... looking through the Jackson properties:

https://github.com/quarkusio/quarkus/blob/b7b742e637635fb24d642221f532343f4954d65a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ConfigurationCustomizer.java#L27-L56

I guess unless the user switched back to the defaults -- they are potentially in trouble, so I tried to include that and check the values. 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

