### PR TITLE
Move our tests to a recent Keycloak version

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -98,9 +98,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <keycloak.server.version>26.4.0</keycloak.server.version>
-        <keycloak.wildfly.version>19.0.3</keycloak.wildfly.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.server.version}</keycloak.docker.image>
-        <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.wildfly.version}-legacy</keycloak.docker.legacy.image>
 
         <unboundid-ldap.version>7.0.3</unboundid-ldap.version>
 

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -859,6 +859,7 @@ public class KeycloakDevServicesProcessor {
         realm.setAccessTokenLifespan(600);
         realm.setSsoSessionMaxLifespan(600);
         realm.setRefreshTokenMaxReuse(10);
+        realm.setRequiredActions(List.of());
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();
@@ -907,6 +908,8 @@ public class KeycloakDevServicesProcessor {
         user.setEnabled(true);
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(realmRoles);
+        user.setEmailVerified(true);
+        user.setRequiredActions(List.of());
 
         CredentialRepresentation credential = new CredentialRepresentation();
 

--- a/extensions/oidc-client-filter/deployment/pom.xml
+++ b/extensions/oidc-client-filter/deployment/pom.xml
@@ -112,7 +112,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.docker.image>${keycloak.docker.legacy.image}</keycloak.docker.image>
+                                <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
                                 <keycloak.use.https>false</keycloak.use.https>
                             </systemPropertyVariables>
                         </configuration>

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/AbstractRevokedAccessTokenDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/AbstractRevokedAccessTokenDevModeTest.java
@@ -51,6 +51,8 @@ public abstract class AbstractRevokedAccessTokenDevModeTest {
                                 quarkus.oidc-client.grant.type=password
                                 quarkus.oidc-client.grant-options.password.username=alice
                                 quarkus.oidc-client.grant-options.password.password=alice
+                                quarkus.oidc-client.scopes=openid
+                                quarkus.oidc-client.named.scopes=openid
                                 quarkus.oidc-client.named.auth-server-url=${quarkus.oidc.auth-server-url}
                                 quarkus.oidc-client.named.client-id=${quarkus.oidc.client-id}
                                 quarkus.oidc-client.named.credentials.client-secret.value=${quarkus.oidc.credentials.secret}

--- a/extensions/oidc-client-graphql/deployment/pom.xml
+++ b/extensions/oidc-client-graphql/deployment/pom.xml
@@ -120,7 +120,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.docker.image>${keycloak.docker.legacy.image}</keycloak.docker.image>
+                                <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
                                 <keycloak.use.https>false</keycloak.use.https>
                             </systemPropertyVariables>
                         </configuration>

--- a/extensions/oidc-client-reactive-filter/deployment/pom.xml
+++ b/extensions/oidc-client-reactive-filter/deployment/pom.xml
@@ -111,7 +111,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.docker.image>${keycloak.docker.legacy.image}</keycloak.docker.image>
+                                <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
                                 <keycloak.use.https>false</keycloak.use.https>
                             </systemPropertyVariables>
                         </configuration>

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/AbstractRevokedAccessTokenDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/AbstractRevokedAccessTokenDevModeTest.java
@@ -55,6 +55,8 @@ public abstract class AbstractRevokedAccessTokenDevModeTest {
                                 quarkus.oidc-client.grant.type=password
                                 quarkus.oidc-client.grant-options.password.username=alice
                                 quarkus.oidc-client.grant-options.password.password=alice
+                                quarkus.oidc-client.scopes=openid
+                                quarkus.oidc-client.named.scopes=openid
                                 quarkus.oidc-client.named.auth-server-url=${quarkus.oidc.auth-server-url}
                                 quarkus.oidc-client.named.client-id=${quarkus.oidc.client-id}
                                 quarkus.oidc-client.named.credentials.client-secret.value=${quarkus.oidc.credentials.secret}

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -13,7 +13,7 @@
     <name>Quarkus - OpenID Connect Client - Deployment</name>
 
     <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
+        <keycloak.url>http://localhost:8180</keycloak.url>
     </properties>
 
     <dependencies>
@@ -147,7 +147,6 @@
                 </plugins>
             </build>
         </profile>
-
         <profile>
             <id>docker-keycloak</id>
             <activation>
@@ -155,6 +154,9 @@
                     <name>start-containers</name>
                 </property>
             </activation>
+            <properties>
+                <keycloak.url>http://localhost:8180</keycloak.url>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -163,16 +165,19 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${keycloak.docker.legacy.image}</name>
+                                    <name>${keycloak.docker.image}</name>
                                     <alias>quarkus-test-keycloak</alias>
                                     <run>
                                         <ports>
                                             <port>8180:8080</port>
                                         </ports>
                                         <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
+                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
                                         </env>
+                                        <cmd>
+                                            <arg>start-dev</arg>
+                                        </cmd>
                                         <log>
                                             <prefix>Keycloak:</prefix>
                                             <date>default</date>

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsJwtPrivateKeyManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsJwtPrivateKeyManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.keycloak.representations.AccessTokenResponse;
@@ -64,6 +65,7 @@ public class KeycloakRealmClientCredentialsJwtPrivateKeyManager implements Quark
         realm.setRefreshTokenMaxReuse(0);
         realm.setDefaultGroups(Arrays.asList("user"));
         realm.setDefaultRoles(Arrays.asList("user"));
+        realm.setRequiredActions(List.of());
 
         return realm;
     }

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsJwtPrivateKeyStoreManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsJwtPrivateKeyStoreManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.keycloak.representations.AccessTokenResponse;
@@ -64,6 +65,7 @@ public class KeycloakRealmClientCredentialsJwtPrivateKeyStoreManager implements 
         realm.setRefreshTokenMaxReuse(0);
         realm.setDefaultGroups(Arrays.asList("user"));
         realm.setDefaultRoles(Arrays.asList("user"));
+        realm.setRequiredActions(List.of());
 
         return realm;
     }

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsJwtSecretManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsJwtSecretManager.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.keycloak.representations.AccessTokenResponse;
@@ -61,6 +62,7 @@ public class KeycloakRealmClientCredentialsJwtSecretManager implements QuarkusTe
         realm.setAccessTokenLifespan(3);
         realm.setRevokeRefreshToken(true);
         realm.setRefreshTokenMaxReuse(0);
+        realm.setRequiredActions(List.of());
 
         realm.setDefaultGroups(Arrays.asList("user"));
         realm.setDefaultRoles(Arrays.asList("user"));

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmClientCredentialsManager.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.keycloak.representations.AccessTokenResponse;
@@ -64,6 +65,7 @@ public class KeycloakRealmClientCredentialsManager implements QuarkusTestResourc
 
         realm.setDefaultGroups(Arrays.asList("user"));
         realm.setDefaultRoles(Arrays.asList("user"));
+        realm.setRequiredActions(List.of());
 
         return realm;
     }

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordCustomFilterManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordCustomFilterManager.java
@@ -69,6 +69,7 @@ public class KeycloakRealmUserPasswordCustomFilterManager implements QuarkusTest
         realm.setRevokeRefreshToken(true);
         realm.setRefreshTokenMaxReuse(0);
         realm.setDefaultRoles(Arrays.asList("user"));
+        realm.setRequiredActions(List.of());
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();
@@ -101,6 +102,8 @@ public class KeycloakRealmUserPasswordCustomFilterManager implements QuarkusTest
         user.setEnabled(true);
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(Arrays.asList(realmRoles));
+        user.setEmailVerified(true);
+        user.setRequiredActions(List.of());
 
         CredentialRepresentation credential = new CredentialRepresentation();
 

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordManager.java
@@ -71,6 +71,7 @@ public class KeycloakRealmUserPasswordManager implements QuarkusTestResourceLife
         realm.setRevokeRefreshToken(true);
         realm.setRefreshTokenMaxReuse(0);
         realm.setDefaultRoles(Arrays.asList("user"));
+        realm.setRequiredActions(List.of());
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();
@@ -114,6 +115,8 @@ public class KeycloakRealmUserPasswordManager implements QuarkusTestResourceLife
         user.setEnabled(true);
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(Arrays.asList(realmRoles));
+        user.setEmailVerified(true);
+        user.setRequiredActions(List.of());
 
         CredentialRepresentation credential = new CredentialRepresentation();
 

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientKeycloakDevServiceStartupTest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientKeycloakDevServiceStartupTest.java
@@ -18,6 +18,9 @@ public class OidcClientKeycloakDevServiceStartupTest {
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar
                     .addAsResource(new StringAsset("""
+                            # Disable Dev Services, Keycloak is started by a Maven plugin
+                            quarkus.keycloak.devservices.enabled=false
+
                             quarkus.oidc.provider=slack
                             quarkus.oidc.client-id=irrelevant-client-id
                             """), "application.properties"))

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientPasswordGrantSecretIsMissingTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientPasswordGrantSecretIsMissingTestCase.java
@@ -17,7 +17,9 @@ public class OidcClientPasswordGrantSecretIsMissingTestCase {
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset(
-                            "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
+                            "# Disable Dev Services, Keycloak is started by a Maven plugin\n"
+                                    + "quarkus.keycloak.devservices.enabled=false\n"
+                                    + "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
                                     + "quarkus.oidc-client.client-id=quarkus\n"
                                     + "quarkus.oidc-client.credentials.secret=secret\n"
                                     + "quarkus.oidc-client.grant.type=password\n"

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientTooManyJwtCredentialKeyPropsTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientTooManyJwtCredentialKeyPropsTestCase.java
@@ -17,7 +17,9 @@ public class OidcClientTooManyJwtCredentialKeyPropsTestCase {
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset(
-                            "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
+                            "# Disable Dev Services, Keycloak is started by a Maven plugin\n"
+                                    + "quarkus.keycloak.devservices.enabled=false\n"
+                                    + "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
                                     + "quarkus.oidc-client.client-id=quarkus\n"
                                     + "quarkus.oidc-client.credentials.jwt.secret=secret\n"
                                     + "quarkus.oidc-client.credentials.jwt.key=base64encPrivateKey\n"

--- a/extensions/oidc-client/deployment/src/test/resources/application-named-oidc-client-credentials.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-named-oidc-client-credentials.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-key-store.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-key-store.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus6/
 quarkus.oidc.client-id=quarkus-app
 

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-key.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-key.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus5/
 quarkus.oidc.client-id=quarkus-app
 

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-p12-key-store.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-p12-key-store.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus6/
 quarkus.oidc.client-id=quarkus-app
 

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus4/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc-client.client-enabled=false

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus2/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-custom-filter.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-custom-filter.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus3/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-user-password.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-user-password.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
 
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}

--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -165,7 +165,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.docker.image>${keycloak.docker.legacy.image}</keycloak.docker.image>
+                                <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
                                 <keycloak.use.https>false</keycloak.use.https>
                             </systemPropertyVariables>
                         </configuration>

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
@@ -57,7 +57,7 @@ public class CodeFlowDevModeDefaultTenantTestCase {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowManagementInterfaceDevModeTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowManagementInterfaceDevModeTest.java
@@ -58,7 +58,7 @@ public class CodeFlowManagementInterfaceDevModeTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", textPage.getContent());
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowRuntimeCredentialsProviderTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowRuntimeCredentialsProviderTest.java
@@ -56,7 +56,7 @@ public class CodeFlowRuntimeCredentialsProviderTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
         }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabledTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabledTest.java
@@ -37,7 +37,7 @@ public class CodeFlowVerifyAccessTokenDisabledTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice:false", page.getBody().asNormalizedText());
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyInjectedAccessTokenDisabledTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyInjectedAccessTokenDisabledTest.java
@@ -37,7 +37,7 @@ public class CodeFlowVerifyInjectedAccessTokenDisabledTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice:false", page.getBody().asNormalizedText());
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
@@ -3,9 +3,6 @@ package io.quarkus.oidc.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.util.List;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.TextPage;
@@ -147,7 +144,7 @@ public class CodeTenantReauthenticateTestCase {
         loginForm.getInputByName("username").setValueAttribute("alice");
         loginForm.getInputByName("password").setValueAttribute("alice");
 
-        page = loginForm.getInputByName("login").click();
+        page = loginForm.getButtonByName("login").click();
 
         assertEquals(expectedResponse, page.getBody().asNormalizedText());
         assertNotNull(getSessionCookie(webClient, tenant));
@@ -169,26 +166,9 @@ public class CodeTenantReauthenticateTestCase {
         return webClient;
     }
 
-    private static List<Cookie> getSessionCookie(WebClient webClient, String tenantId) {
-        Cookie sessionCookieChunk1 = null;
-        Cookie sessionCookieChunk2 = null;
+    private static Cookie getSessionCookie(WebClient webClient, String tenantId) {
+        String sessionCookie = "q_session" + (tenantId == null ? "" : "_" + tenantId);
 
-        String sessionCookieSuffix = "q_session" + (tenantId == null ? "" : "_" + tenantId);
-        String sessionCookieChunk1Name = sessionCookieSuffix + "_chunk_1";
-        String sessionCookieChunk2Name = sessionCookieSuffix + "_chunk_2";
-        for (Cookie c : webClient.getCookieManager().getCookies()) {
-            if (c.getName().startsWith(sessionCookieSuffix)) {
-                if (c.getName().equals(sessionCookieChunk1Name)) {
-                    sessionCookieChunk1 = c;
-                } else if (c.getName().equals(sessionCookieChunk2Name)) {
-                    sessionCookieChunk2 = c;
-                } else {
-                    fail("Unexpected session cookie chunk: " + c.getName());
-                }
-            }
-        }
-        return sessionCookieChunk1 != null && sessionCookieChunk2 != null
-                ? List.of(sessionCookieChunk1, sessionCookieChunk2)
-                : null;
+        return webClient.getCookieManager().getCookie(sessionCookie);
     }
 }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProviderTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProviderTestCase.java
@@ -44,7 +44,7 @@ public class CustomIdentityProviderTestCase {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
 
@@ -67,7 +67,7 @@ public class CustomIdentityProviderTestCase {
             loginForm.getInputByName("password").setValueAttribute("jdoe");
 
             try {
-                loginForm.getInputByName("login").click();
+                loginForm.getButtonByName("login").click();
                 fail("Exception is expected because `jdoe` is not allowed to access the service");
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(401, ex.getStatusCode());

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndBearerAuthCombinationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndBearerAuthCombinationTest.java
@@ -28,6 +28,9 @@ public class ImplicitBasicAuthAndBearerAuthCombinationTest {
                     .addClasses(BasicBearerResource.class, BearerPathBasedResource.class)
                     .addAsResource(
                             new StringAsset("""
+                                    # Disable Dev Services, we use a test resource manager
+                                    quarkus.keycloak.devservices.enabled=false
+
                                     quarkus.security.users.embedded.enabled=true
                                     quarkus.security.users.embedded.plain-text=true
                                     quarkus.security.users.embedded.users.alice=alice

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndCodeFlowAuthCombinationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndCodeFlowAuthCombinationTest.java
@@ -34,6 +34,9 @@ public class ImplicitBasicAuthAndCodeFlowAuthCombinationTest {
                     .addClasses(BasicCodeFlowResource.class)
                     .addAsResource(
                             new StringAsset("""
+                                    # Disable Dev Services, we use a test resource manager
+                                    quarkus.keycloak.devservices.enabled=false
+
                                     quarkus.security.users.embedded.enabled=true
                                     quarkus.security.users.embedded.plain-text=true
                                     quarkus.security.users.embedded.users.alice=alice
@@ -76,7 +79,7 @@ public class ImplicitBasicAuthAndCodeFlowAuthCombinationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcMtlsDisabledInclusiveAuthTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcMtlsDisabledInclusiveAuthTest.java
@@ -35,6 +35,9 @@ public class OidcMtlsDisabledInclusiveAuthTest {
 
     private static final String BASE_URL = "https://localhost:8443/mtls-bearer/";
     private static final String CONFIGURATION = """
+            # Disable Dev Services, we use a test resource manager
+            quarkus.keycloak.devservices.enabled=false
+
             quarkus.tls.key-store.pem.0.cert=server.crt
             quarkus.tls.key-store.pem.0.key=server.key
             quarkus.tls.trust-store.pem.certs=ca.crt

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcRequestAndResponseFilterTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcRequestAndResponseFilterTest.java
@@ -182,7 +182,7 @@ public class OidcRequestAndResponseFilterTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
 
@@ -239,7 +239,7 @@ public class OidcRequestAndResponseFilterTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
 
@@ -296,7 +296,7 @@ public class OidcRequestAndResponseFilterTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
 
@@ -353,7 +353,7 @@ public class OidcRequestAndResponseFilterTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OpaqueTokenVerificationWithUserInfoValidationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OpaqueTokenVerificationWithUserInfoValidationTest.java
@@ -17,7 +17,9 @@ public class OpaqueTokenVerificationWithUserInfoValidationTest {
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset(
-                            "quarkus.oidc.token.verify-access-token-with-user-info=true\n"
+                            "# Disable Dev Services, we use a test resource manager\n" +
+                                    "quarkus.keycloak.devservices.enabled=false\n" +
+                                    "quarkus.oidc.token.verify-access-token-with-user-info=true\n"
                                     + "quarkus.oidc.authentication.user-info-required=false\n"),
                             "application.properties"))
             .assertException(t -> {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/UserInfoRequiredDetectionTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/UserInfoRequiredDetectionTest.java
@@ -38,6 +38,9 @@ public class UserInfoRequiredDetectionTest {
                     .addAsResource(
                             new StringAsset(
                                     """
+                                            # Disable Dev Services, we use a test resource manager
+                                            quarkus.keycloak.devservices.enabled=false
+
                                             quarkus.oidc.tenant-paths=/user-info/default-tenant-random
                                             quarkus.oidc.user-info-path=http://${quarkus.http.host}:${quarkus.http.port}/user-info-endpoint
                                             quarkus.oidc.named-2.auth-server-url=${quarkus.oidc.auth-server-url}

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode-default-tenant.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode-default-tenant.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.secret=secret
 #quarkus.oidc.application-type=web-app

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-enabled=false
 quarkus.oidc.client-id=${oidc.client-id}

--- a/extensions/oidc/deployment/src/test/resources/application-introspection-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-introspection-disabled.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.application-type=web-app
 quarkus.oidc.client-id=quarkus-web-app

--- a/extensions/oidc/deployment/src/test/resources/application-runtime-cred-provider.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-runtime-cred-provider.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.client-secret.provider.name=runtime-vault-secret-provider

--- a/extensions/oidc/deployment/src/test/resources/application-security-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-security-disabled.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.tenant-enabled=false
 quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=permit

--- a/extensions/oidc/deployment/src/test/resources/application-tenant-reauthenticate.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-tenant-reauthenticate.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.secret=secret

--- a/extensions/oidc/deployment/src/test/resources/application-verify-access-token-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-verify-access-token-disabled.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.secret=secret

--- a/extensions/oidc/deployment/src/test/resources/application-verify-injected-access-token-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-verify-injected-access-token-disabled.properties
@@ -1,3 +1,6 @@
+# Disable Dev Services, we use a test resource manager
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.secret=secret

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -408,7 +408,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     }
 
     private static OIDCException responseException(String requestUri, HttpResponse<Buffer> resp, Buffer buffer) {
-        String errorMessage = buffer.toString();
+        String errorMessage = buffer == null ? null : buffer.toString();
 
         if (errorMessage != null && !errorMessage.isEmpty()) {
             LOG.errorf("Request %s has failed: status: %d, error message: %s", requestUri, resp.statusCode(), errorMessage);

--- a/integration-tests/oidc-client/pom.xml
+++ b/integration-tests/oidc-client/pom.xml
@@ -15,8 +15,8 @@
     <description>Module that contains OpenID Connect Client tests</description>
 
     <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
-        <keycloak.ssl.url>https://localhost:8543/auth</keycloak.ssl.url>
+        <keycloak.url>http://localhost:8180</keycloak.url>
+        <keycloak.ssl.url>https://localhost:8543</keycloak.ssl.url>
     </properties>
 
     <dependencies>
@@ -148,7 +148,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.url>${keycloak.ssl.url}</keycloak.url>
+                                <keycloak.url>${keycloak.url}</keycloak.url>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -157,7 +157,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.url>${keycloak.ssl.url}</keycloak.url>
+                                <keycloak.url>${keycloak.url}</keycloak.url>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -191,7 +191,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${keycloak.docker.legacy.image}</name>
+                                    <name>${keycloak.docker.image}</name>
                                     <alias>quarkus-test-keycloak</alias>
                                     <run>
                                         <ports>
@@ -199,9 +199,12 @@
                                             <port>8543:8443</port>
                                         </ports>
                                         <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
+                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
                                         </env>
+                                        <cmd>
+                                            <arg>start-dev</arg>
+                                        </cmd>
                                         <log>
                                             <prefix>Keycloak:</prefix>
                                             <date>default</date>

--- a/integration-tests/oidc-client/src/main/resources/application.properties
+++ b/integration-tests/oidc-client/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.oidc.auth-server-url=${keycloak.ssl.url}/realms/quarkus/
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 

--- a/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -21,7 +21,7 @@ import io.restassured.RestAssured;
 
 public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.ssl.url", "https://localhost:8543/auth");
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180");
     private static final String KEYCLOAK_REALM = "quarkus";
 
     static {
@@ -35,6 +35,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setRevokeRefreshToken(true);
         realm.setRefreshTokenMaxReuse(0);
         realm.setAccessTokenLifespan(3);
+        realm.setRequiredActions(List.of());
 
         realm.getClients().add(createClient("quarkus-app"));
         realm.getUsers().add(createUser("alice", "user"));
@@ -75,6 +76,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setUsers(new ArrayList<>());
         realm.setClients(new ArrayList<>());
         realm.setAccessTokenLifespan(3);
+        realm.setRequiredActions(List.of());
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();
@@ -109,6 +111,8 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(Arrays.asList(realmRoles));
         user.setEmail(username + "@gmail.com");
+        user.setEmailVerified(true);
+        user.setRequiredActions(List.of());
 
         CredentialRepresentation credential = new CredentialRepresentation();
 

--- a/integration-tests/smallrye-graphql-client-keycloak/pom.xml
+++ b/integration-tests/smallrye-graphql-client-keycloak/pom.xml
@@ -13,7 +13,7 @@
     <name>Quarkus - Integration Tests - SmallRye GraphQL Client with Keycloak</name>
 
     <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
+        <keycloak.url>http://localhost:8180</keycloak.url>
     </properties>
 
     <dependencies>
@@ -207,7 +207,7 @@
                 </property>
             </activation>
             <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
+                <keycloak.url>http://localhost:8180</keycloak.url>
             </properties>
             <build>
                 <plugins>
@@ -217,16 +217,19 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${keycloak.docker.legacy.image}</name>
+                                    <name>${keycloak.docker.image}</name>
                                     <alias>quarkus-test-keycloak</alias>
                                     <run>
                                         <ports>
                                             <port>8180:8080</port>
                                         </ports>
                                         <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
+                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
                                         </env>
+                                        <cmd>
+                                            <arg>start-dev</arg>
+                                        </cmd>
                                         <log>
                                             <prefix>Keycloak:</prefix>
                                             <date>default</date>

--- a/integration-tests/smallrye-graphql-client-keycloak/src/main/resources/application.properties
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/main/resources/application.properties
@@ -1,5 +1,7 @@
+# Disable Dev Services, Keycloak is started by a Maven plugin
+quarkus.keycloak.devservices.enabled=false
+
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.smallrye-graphql.log-payload=queryAndVariables
-quarkus.keycloak.devservices.enabled=false
 quarkus.smallrye-graphql.authorization-client-init-payload-name=Authorization

--- a/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/KeycloakRealmResourceManager.java
@@ -23,7 +23,7 @@ import io.restassured.response.Response;
 
 public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180");
     //private static String KEYCLOAK_SERVER_URL;
     private static final String KEYCLOAK_REALM = "quarkus";
     //private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:22.0.5";
@@ -36,6 +36,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setRevokeRefreshToken(true);
         realm.setRefreshTokenMaxReuse(0);
         realm.setAccessTokenLifespan(3);
+        realm.setRequiredActions(List.of());
 
         realm.getClients().add(createClient("quarkus-app"));
         realm.getUsers().add(createUser("alice", "user"));
@@ -50,7 +51,6 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                     .post(KEYCLOAK_SERVER_URL + "/admin/realms");
             response.then()
                     .statusCode(201);
-
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -80,10 +80,13 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
 
         realm.setRealm(name);
         realm.setEnabled(true);
+        realm.setRequiredActions(List.of());
         realm.setUsers(new ArrayList<>());
         realm.setClients(new ArrayList<>());
         realm.setAccessTokenLifespan(3);
         realm.setSsoSessionMaxLifespan(3);
+        realm.setRequiredActions(List.of());
+
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();
 
@@ -116,9 +119,10 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
 
         user.setUsername(username);
         user.setEnabled(true);
-        user.setCredentials(new ArrayList<>());
         user.setRealmRoles(Arrays.asList(realmRoles));
         user.setEmail(username + "@gmail.com");
+        user.setRequiredActions(List.of());
+        user.setEmailVerified(true);
 
         CredentialRepresentation credential = new CredentialRepresentation();
 
@@ -126,7 +130,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         credential.setValue(username);
         credential.setTemporary(false);
 
-        user.getCredentials().add(credential);
+        user.setCredentials(List.of(credential));
 
         return user;
     }

--- a/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
+++ b/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
@@ -15,7 +15,7 @@
     <description>Module that tests that Smallrye JWT and OIDC WebApp authentication can be combined</description>
 
     <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
+        <keycloak.url>http://localhost:8180</keycloak.url>
         <reactive-postgres.url>vertx-reactive:postgresql://:5431/oidc_db_token_state_manager_test</reactive-postgres.url>
     </properties>
 
@@ -225,16 +225,19 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${keycloak.docker.legacy.image}</name>
+                                    <name>${keycloak.docker.image}</name>
                                     <alias>quarkus-test-keycloak</alias>
                                     <run>
                                         <ports>
                                             <port>8180:8080</port>
                                         </ports>
                                         <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
+                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
                                         </env>
+                                        <cmd>
+                                            <arg>start-dev</arg>
+                                        </cmd>
                                         <log>
                                             <prefix>Keycloak:</prefix>
                                             <date>default</date>

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -21,7 +21,7 @@ import io.restassured.RestAssured;
 
 public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180");
     private static final String KEYCLOAK_REALM = "quarkus";
 
     @Override
@@ -31,6 +31,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setRevokeRefreshToken(true);
         realm.setRefreshTokenMaxReuse(0);
         realm.setAccessTokenLifespan(3);
+        realm.setRequiredActions(List.of());
 
         realm.getClients().add(createClient("quarkus-app"));
         realm.getUsers().add(createUser("alice", "user"));
@@ -73,6 +74,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setClients(new ArrayList<>());
         realm.setAccessTokenLifespan(3);
         realm.setSsoSessionMaxLifespan(3);
+        realm.setRequiredActions(List.of());
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();
 
@@ -107,6 +109,8 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(Arrays.asList(realmRoles));
         user.setEmail(username + "@gmail.com");
+        user.setEmailVerified(true);
+        user.setRequiredActions(List.of());
 
         CredentialRepresentation credential = new CredentialRepresentation();
 

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
@@ -74,7 +74,7 @@ public class SmallRyeJwtOidcWebAppTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();

--- a/integration-tests/smallrye-jwt-token-propagation/pom.xml
+++ b/integration-tests/smallrye-jwt-token-propagation/pom.xml
@@ -15,7 +15,7 @@
     <description>Module that contains Smallrye JWT Token Propagation tests</description>
 
     <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
+        <keycloak.url>http://localhost:8180</keycloak.url>
     </properties>
 
     <dependencies>
@@ -219,7 +219,7 @@
                 </property>
             </activation>
             <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
+                <keycloak.url>http://localhost:8180</keycloak.url>
             </properties>
             <build>
                 <plugins>
@@ -229,16 +229,19 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${keycloak.docker.legacy.image}</name>
+                                    <name>${keycloak.docker.image}</name>
                                     <alias>quarkus-test-keycloak</alias>
                                     <run>
                                         <ports>
                                             <port>8180:8080</port>
                                         </ports>
                                         <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
+                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
                                         </env>
+                                        <cmd>
+                                            <arg>start-dev</arg>
+                                        </cmd>
                                         <log>
                                             <prefix>Keycloak:</prefix>
                                             <date>default</date>

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -21,7 +21,7 @@ import io.restassured.RestAssured;
 
 public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180");
     private static final String KEYCLOAK_REALM = "quarkus";
 
     @Override
@@ -31,6 +31,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setRevokeRefreshToken(true);
         realm.setRefreshTokenMaxReuse(0);
         realm.setAccessTokenLifespan(3);
+        realm.setRequiredActions(List.of());
 
         realm.getClients().add(createClient("quarkus-app"));
         realm.getUsers().add(createUser("alice", "user"));
@@ -72,6 +73,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setUsers(new ArrayList<>());
         realm.setClients(new ArrayList<>());
         realm.setAccessTokenLifespan(3);
+        realm.setRequiredActions(List.of());
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();
@@ -106,6 +108,8 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(Arrays.asList(realmRoles));
         user.setEmail(username + "@gmail.com");
+        user.setEmailVerified(true);
+        user.setRequiredActions(List.of());
 
         CredentialRepresentation credential = new CredentialRepresentation();
 

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestResourceLifecycleManager.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestResourceLifecycleManager.java
@@ -112,6 +112,7 @@ public class KeycloakTestResourceLifecycleManager implements QuarkusTestResource
         client.setDirectAccessGrantsEnabled(true);
         client.setServiceAccountsEnabled(true);
         client.setEnabled(true);
+        client.setDefaultClientScopes(List.of("microprofile-jwt", "basic"));
 
         return client;
     }
@@ -124,6 +125,7 @@ public class KeycloakTestResourceLifecycleManager implements QuarkusTestResource
         client.setSecret("secret");
         client.setRedirectUris(Arrays.asList("*"));
         client.setEnabled(true);
+        client.setDefaultClientScopes(List.of("microprofile-jwt", "basic"));
 
         return client;
     }
@@ -136,6 +138,9 @@ public class KeycloakTestResourceLifecycleManager implements QuarkusTestResource
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(realmRoles);
         user.setEmail(username + "@gmail.com");
+        user.setEmailVerified(true);
+        user.setFirstName(username);
+        user.setLastName(username);
 
         CredentialRepresentation credential = new CredentialRepresentation();
 
@@ -154,6 +159,7 @@ public class KeycloakTestResourceLifecycleManager implements QuarkusTestResource
                 .param("password", userName)
                 .param("client_id", KEYCLOAK_SERVICE_CLIENT)
                 .param("client_secret", "secret")
+                .param("scope", "openid")
                 .when()
                 .post(keycloak.getServerUrl() + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class).getToken();


### PR DESCRIPTION
We are running a very old legacy version for testing which is a bad idea.
Especially since this version is using a very old JDK, which unfortunately is plagued by a bug that prevents it to start on recent Ubuntu runners (https://bugs.openjdk.org/browse/JDK-8287073, thanks to @Ladicek for tracking it).

I have no problem with us having to test this version with our stuff, but I don't think it should be the default in the community and we probably need QE testing on specific machines that will be able to run this old JDK.