### PR TITLE
Add Gizmo 2 variant of `AnnotationProxyProvider.build()`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/AnnotationProxyProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/AnnotationProxyProvider.java
@@ -1,14 +1,17 @@
 package io.quarkus.deployment.recording;
 
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
+import java.lang.constant.ClassDesc;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -32,6 +35,12 @@ import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.TypeArgument;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
 
 public class AnnotationProxyProvider {
 
@@ -70,9 +79,9 @@ public class AnnotationProxyProvider {
             }
             return clazz;
         });
-        String annotationLiteral = annotationLiterals.computeIfAbsent(annotationInstance.name(), name ->
-        // com.foo.MyAnnotation -> com.foo.MyAnnotation_Proxy_AnnotationLiteral
-        name.toString().replace('.', '/') + "_Proxy_AnnotationLiteral");
+        String annotationLiteral = annotationLiterals.computeIfAbsent(annotationInstance.name(),
+                // com.foo.MyAnnotation -> com.foo.MyAnnotation_Proxy_AnnotationLiteral
+                name -> name + "_Proxy_AnnotationLiteral");
 
         return new AnnotationProxyBuilder<>(annotationInstance, annotationType, annotationLiteral, annotationClass);
     }
@@ -134,7 +143,6 @@ public class AnnotationProxyProvider {
             return this;
         }
 
-        @SuppressWarnings("unchecked")
         public A build(ClassOutput classOutput) {
 
             // Generate literal class if needed
@@ -178,6 +186,11 @@ public class AnnotationProxyProvider {
                 return Boolean.TRUE;
             });
 
+            return proxy();
+        }
+
+        @SuppressWarnings("unchecked")
+        private A proxy() {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             if (classLoader == null) {
                 classLoader = AnnotationProxy.class.getClassLoader();
@@ -215,6 +228,58 @@ public class AnnotationProxyProvider {
                             };
                         }
                     });
+        }
+
+        public A build(io.quarkus.gizmo2.ClassOutput classOutput) {
+            generatedLiterals.computeIfAbsent(annotationLiteral, generatedName -> {
+                Gizmo.create(classOutput).class_(generatedName, cc -> {
+                    ClassDesc annotationClassDesc = classDescOf(annotationInstance.name());
+                    cc.extends_(GenericType.ofClass(AnnotationLiteral.class, TypeArgument.of(annotationClassDesc)));
+                    cc.implements_(annotationClassDesc);
+
+                    List<MethodInfo> members = annotationClass.methods()
+                            .stream()
+                            .filter(m -> !m.isStaticInitializer() && !m.isConstructor())
+                            .toList();
+
+                    List<FieldDesc> fields = new ArrayList<>(members.size());
+                    for (MethodInfo member : members) {
+                        fields.add(cc.field(member.name(), fc -> {
+                            fc.private_();
+                            fc.final_();
+                            fc.setType(classDescOf(member.returnType()));
+                        }));
+                    }
+
+                    cc.constructor(mc -> {
+                        List<ParamVar> params = new ArrayList<>(members.size());
+                        for (MethodInfo member : members) {
+                            params.add(mc.parameter(member.name(), classDescOf(member.returnType())));
+                        }
+
+                        mc.body(bc -> {
+                            bc.invokeSpecial(ConstructorDesc.of(AnnotationLiteral.class), cc.this_());
+                            for (int i = 0; i < members.size(); i++) {
+                                bc.set(cc.this_().field(fields.get(i)), params.get(i));
+                            }
+                            bc.return_();
+                        });
+                    });
+
+                    for (int i = 0; i < members.size(); i++) {
+                        MethodInfo member = members.get(i);
+                        FieldDesc field = fields.get(i);
+                        cc.method(member.name(), mc -> {
+                            mc.returning(classDescOf(member.returnType()));
+                            mc.body(bc -> bc.return_(cc.this_().field(field)));
+                        });
+                    }
+                });
+
+                return Boolean.TRUE;
+            });
+
+            return proxy();
         }
     }
 

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -5,9 +5,9 @@ import static org.jboss.jandex.AnnotationTarget.Kind.METHOD;
 import static org.jboss.jandex.AnnotationValue.createArrayValue;
 import static org.jboss.jandex.AnnotationValue.createBooleanValue;
 import static org.jboss.jandex.AnnotationValue.createStringValue;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.methodDescOf;
 
-import java.lang.constant.ClassDesc;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.ZoneId;
@@ -64,7 +64,6 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
@@ -74,6 +73,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
+import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.Gizmo;
@@ -393,9 +393,8 @@ public class SchedulerProcessor {
             }
         };
 
-        Gizmo gizmo = Gizmo
-                .create(new GeneratedClassGizmo2Adaptor(generatedClasses, generatedResources, generatedToBaseNameFun));
-        io.quarkus.gizmo.ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, generatedToBaseNameFun);
+        ClassOutput classOutput = new GeneratedClassGizmo2Adaptor(generatedClasses, generatedResources, generatedToBaseNameFun);
+        Gizmo gizmo = Gizmo.create(classOutput);
 
         for (ScheduledBusinessMethodItem scheduledMethod : scheduledMethods) {
             MutableScheduledMethod metadata = new MutableScheduledMethod();
@@ -502,7 +501,7 @@ public class SchedulerProcessor {
                 if (isSuspendMethod) {
                     mc.returning(Object.class);
                     execution = mc.parameter("execution", ScheduledExecution.class);
-                    continuation = mc.parameter("continuation", ClassDesc.of(SchedulerDotNames.CONTINUATION.toString()));
+                    continuation = mc.parameter("continuation", classDescOf(SchedulerDotNames.CONTINUATION));
                 } else {
                     // The descriptor is: CompletionStage invoke(ScheduledExecution execution)
                     mc.returning(CompletionStage.class);
@@ -572,7 +571,7 @@ public class SchedulerProcessor {
                             } else if (method.returnType().name().equals(SchedulerDotNames.UNI)) {
                                 // Subscribe to the returned Uni
                                 tryBlock.return_(tryBlock.invokeInterface(
-                                        InterfaceMethodDesc.of(ClassDesc.of(SchedulerDotNames.UNI.toString()),
+                                        InterfaceMethodDesc.of(classDescOf(SchedulerDotNames.UNI),
                                                 "subscribeAsCompletionStage", CompletableFuture.class),
                                         ret));
                             } else {

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
@@ -28,7 +28,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.AnnotationProxyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo2.ClassOutput;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.faulttolerance.api.ApplyFaultTolerance;

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -33,7 +33,7 @@ import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.Feature;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -42,6 +42,7 @@ import io.quarkus.deployment.builditem.AnnotationProxyBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -50,7 +51,7 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildI
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.smallrye.faulttolerance.deployment.devui.FaultToleranceInfoBuildItem;
 import io.quarkus.smallrye.faulttolerance.runtime.QuarkusAsyncExecutorProvider;
@@ -247,6 +248,7 @@ public class SmallRyeFaultToleranceProcessor {
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,
             AnnotationProxyBuildItem annotationProxy,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
             BuildProducer<ValidationPhaseBuildItem.ValidationErrorBuildItem> errors,
@@ -269,7 +271,7 @@ public class SmallRyeFaultToleranceProcessor {
         IndexView index = beanArchiveIndexBuildItem.getIndex();
         // only generating annotation literal classes for MicroProfile/SmallRye Fault Tolerance annotations,
         // none of them are application classes
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, false);
+        ClassOutput classOutput = new GeneratedClassGizmo2Adaptor(generatedClasses, generatedResources, false);
 
         FaultToleranceScanner scanner = new FaultToleranceScanner(index, annotationStore, annotationProxy, classOutput,
                 recorderContext, reflectiveMethod);

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -40,7 +40,7 @@ import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -50,6 +50,7 @@ import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
@@ -59,7 +60,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.vertx.ConsumeEvent;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.deployment.spi.EventConsumerInvokerCustomizerBuildItem;
@@ -89,12 +90,13 @@ class VertxProcessor {
     VertxBuildItem build(CoreVertxBuildItem vertx, VertxEventBusConsumerRecorder recorder,
             List<EventConsumerBusinessMethodItem> messageConsumerBusinessMethods,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResource,
             AnnotationProxyBuildItem annotationProxy, LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown,
             BuildProducer<ServiceStartBuildItem> serviceStart,
             List<MessageCodecBuildItem> codecs, LocalCodecSelectorTypesBuildItem localCodecSelectorTypes,
             RecorderContext recorderContext) {
         List<EventConsumerInfo> messageConsumerConfigurations = new ArrayList<>();
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
+        ClassOutput classOutput = new GeneratedClassGizmo2Adaptor(generatedClass, generatedResource, true);
         for (EventConsumerBusinessMethodItem businessMethod : messageConsumerBusinessMethods) {
             ConsumeEvent annotation = annotationProxy.builder(businessMethod.getConsumeEvent(), ConsumeEvent.class)
                     .withDefaultValue("value", businessMethod.getBean().getBeanClass().toString())


### PR DESCRIPTION
This PR also migrates all existing usages of `AnnotationProxyProvider`: Scheduler, SmallRye Fault Tolerance and Vert.x.