### PR TITLE
Go back to Ubuntu 22 on AWS runners for now

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -181,6 +181,7 @@ jobs:
           main-repository: quarkusio/quarkus
           runs-on: true
           magic-cache: true
+          ubuntu-latest: family=m7i.xlarge/image=ubuntu22-full-x64
       - name: Determines if GIB should be disabled
         id: gib-status
         run: |


### PR DESCRIPTION
This is related to an issue with the old Keycloak image. It might be a workaround if CI works fine with this image.