### PR TITLE
Improve assignment of interfaces / `PanacheEntity` to persistence units

### DIFF
--- a/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
+++ b/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.envers.deployment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -28,10 +29,18 @@ public final class HibernateEnversProcessor {
     @BuildStep
     List<AdditionalJpaModelBuildItem> addJpaModelClasses() {
         return Arrays.asList(
-                new AdditionalJpaModelBuildItem("org.hibernate.envers.DefaultRevisionEntity"),
-                new AdditionalJpaModelBuildItem("org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity"),
-                new AdditionalJpaModelBuildItem("org.hibernate.envers.RevisionMapping"),
-                new AdditionalJpaModelBuildItem("org.hibernate.envers.TrackingModifiedEntitiesRevisionMapping"));
+                new AdditionalJpaModelBuildItem("org.hibernate.envers.DefaultRevisionEntity",
+                        // Added to specific PUs at static init using org.hibernate.boot.spi.AdditionalMappingContributor
+                        Set.of()),
+                new AdditionalJpaModelBuildItem("org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity",
+                        // Added to specific PUs at static init using org.hibernate.boot.spi.AdditionalMappingContributor
+                        Set.of()),
+                new AdditionalJpaModelBuildItem("org.hibernate.envers.RevisionMapping",
+                        // Added to specific PUs at static init using org.hibernate.boot.spi.AdditionalMappingContributor
+                        Set.of()),
+                new AdditionalJpaModelBuildItem("org.hibernate.envers.TrackingModifiedEntitiesRevisionMapping",
+                        // Added to specific PUs at static init using org.hibernate.boot.spi.AdditionalMappingContributor
+                        Set.of()));
     }
 
     @BuildStep

--- a/extensions/hibernate-orm/deployment-spi/src/main/java/io/quarkus/hibernate/orm/deployment/spi/AdditionalJpaModelBuildItem.java
+++ b/extensions/hibernate-orm/deployment-spi/src/main/java/io/quarkus/hibernate/orm/deployment/spi/AdditionalJpaModelBuildItem.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.orm.deployment.spi;
 
 import java.util.Objects;
+import java.util.Set;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
@@ -12,13 +13,38 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class AdditionalJpaModelBuildItem extends MultiBuildItem {
 
     private final String className;
+    private final Set<String> persistenceUnits;
 
+    /**
+     * @deprecated Use {@link AdditionalJpaModelBuildItem#AdditionalJpaModelBuildItem(String, Set)} instead,
+     *             which should fit the use case of JBeret better.
+     */
+    @Deprecated(since = "3.26", forRemoval = true)
     public AdditionalJpaModelBuildItem(String className) {
         Objects.requireNonNull(className);
         this.className = className;
+        this.persistenceUnits = null;
+    }
+
+    /**
+     * @param className The name of the additional class.
+     * @param persistenceUnits The name of persistence units to which this class should be added
+     *        even if the application does not request it explicitly (e.g. using `quarkus.hibernate-orm.packages`).
+     *        Note the class can still be added to a persistence unit at static init through other means --
+     *        for example Hibernate Envers and Hibernate Search use {@link org.hibernate.boot.spi.AdditionalMappingContributor}.
+     */
+    public AdditionalJpaModelBuildItem(String className, Set<String> persistenceUnits) {
+        Objects.requireNonNull(className);
+        Objects.requireNonNull(persistenceUnits);
+        this.className = className;
+        this.persistenceUnits = persistenceUnits;
     }
 
     public String getClassName() {
         return className;
+    }
+
+    public Set<String> getPersistenceUnits() {
+        return persistenceUnits;
     }
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -327,6 +327,7 @@ public final class HibernateOrmProcessor {
             List<JdbcDataSourceBuildItem> jdbcDataSources,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             LaunchModeBuildItem launchMode,
+            List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems,
             JpaModelBuildItem jpaModel,
             Capabilities capabilities,
             BuildProducer<SystemPropertyBuildItem> systemProperties,
@@ -383,7 +384,8 @@ public final class HibernateOrmProcessor {
 
         if (impliedPU.shouldGenerateImpliedBlockingPersistenceUnit()) {
             handleHibernateORMWithNoPersistenceXml(hibernateOrmConfig, index, persistenceXmlDescriptors,
-                    jdbcDataSources, applicationArchivesBuildItem, launchMode.getLaunchMode(), jpaModel, capabilities,
+                    jdbcDataSources, applicationArchivesBuildItem, launchMode.getLaunchMode(), additionalJpaModelBuildItems,
+                    jpaModel, capabilities,
                     systemProperties, nativeImageResources, hotDeploymentWatchedFiles, persistenceUnitDescriptors,
                     reflectiveMethods, unremovableBeans, dbKindMetadataBuildItems);
         }
@@ -843,6 +845,7 @@ public final class HibernateOrmProcessor {
             List<JdbcDataSourceBuildItem> jdbcDataSources,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             LaunchMode launchMode,
+            List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems,
             JpaModelBuildItem jpaModel,
             Capabilities capabilities,
             BuildProducer<SystemPropertyBuildItem> systemProperties,
@@ -891,7 +894,7 @@ public final class HibernateOrmProcessor {
                 || hibernateOrmConfig.defaultPersistenceUnit().isAnyPropertySet();
 
         Map<String, Set<String>> modelClassesAndPackagesPerPersistencesUnits = getModelClassesAndPackagesPerPersistenceUnits(
-                hibernateOrmConfig, jpaModel, index.getIndex(), enableDefaultPersistenceUnit);
+                hibernateOrmConfig, additionalJpaModelBuildItems, jpaModel, index.getIndex(), enableDefaultPersistenceUnit);
         Set<String> modelClassesAndPackagesForDefaultPersistenceUnit = modelClassesAndPackagesPerPersistencesUnits
                 .getOrDefault(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, Collections.emptySet());
 
@@ -1135,7 +1138,8 @@ public final class HibernateOrmProcessor {
     }
 
     public static Map<String, Set<String>> getModelClassesAndPackagesPerPersistenceUnits(HibernateOrmConfig hibernateOrmConfig,
-            JpaModelBuildItem jpaModel, IndexView index, boolean enableDefaultPersistenceUnit) {
+            List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems, JpaModelBuildItem jpaModel,
+            IndexView index, boolean enableDefaultPersistenceUnit) {
         Map<String, Set<String>> modelClassesAndPackagesPerPersistenceUnits = new HashMap<>();
 
         boolean hasPackagesInQuarkusConfig = hasPackagesInQuarkusConfig(hibernateOrmConfig);
@@ -1234,14 +1238,28 @@ public final class HibernateOrmProcessor {
             }
         }
 
+        Set<String> affectedModelClasses = new HashSet<>();
+        for (AdditionalJpaModelBuildItem additionalJpaModel : additionalJpaModelBuildItems) {
+            var className = additionalJpaModel.getClassName();
+            var persistenceUnits = additionalJpaModel.getPersistenceUnits();
+            if (persistenceUnits == null) {
+                // Legacy behavior -- remove when the deprecated one-argument constructor of AdditionalJpaModelBuildItem gets removed.
+                continue;
+            }
+            affectedModelClasses.add(className); // Even if persistenceUnits is empty, the class is still affected (to nothing)
+            for (String persistenceUnitName : persistenceUnits) {
+                modelClassesAndPackagesPerPersistenceUnits.putIfAbsent(persistenceUnitName, new HashSet<>());
+                modelClassesAndPackagesPerPersistenceUnits.get(persistenceUnitName).add(className);
+            }
+        }
+
         if (!modelClassesWithPersistenceUnitAnnotations.isEmpty()) {
             throw new IllegalStateException(String.format(Locale.ROOT,
                     "@PersistenceUnit annotations are not supported at the class level on model classes:\n\t- %s\nUse the `.packages` configuration property or package-level annotations instead.",
                     String.join("\n\t- ", modelClassesWithPersistenceUnitAnnotations)));
         }
 
-        Set<String> affectedModelClasses = modelClassesAndPackagesPerPersistenceUnits.values().stream().flatMap(Set::stream)
-                .collect(Collectors.toSet());
+        affectedModelClasses.addAll(modelClassesAndPackagesPerPersistenceUnits.values().stream().flatMap(Set::stream).toList());
         Set<String> unaffectedModelClasses = jpaModel.getAllModelClassNames().stream()
                 .filter(c -> !affectedModelClasses.contains(c))
                 .collect(Collectors.toCollection(TreeSet::new));

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/differentpackage/INamedEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/differentpackage/INamedEntity.java
@@ -1,0 +1,12 @@
+package io.quarkus.hibernate.orm.config.differentpackage;
+
+import io.quarkus.hibernate.orm.config.packages.ConfigEntityPUAssigmentUsingInterfaceTest;
+
+/**
+ * This must be located in a different package than the entity that implements it.
+ * In particular, it must not be located in a subpackage of that entity's package.
+ * Otherwise {@link ConfigEntityPUAssigmentUsingInterfaceTest} would not reproduce the problem correctly.
+ */
+public interface INamedEntity {
+    String getName();
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/packages/ConfigEntityPUAssigmentUsingInterfaceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/packages/ConfigEntityPUAssigmentUsingInterfaceTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.hibernate.orm.config.packages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.hibernate.Session;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.config.differentpackage.INamedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Reproducer for https://github.com/quarkusio/quarkus/issues/22183
+ */
+public class ConfigEntityPUAssigmentUsingInterfaceTest {
+
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(EntityImplementingInterface.class, INamedEntity.class))
+            // In a real-world scenario, this would be used only if there are multiple PUs,
+            // but this is simpler and enough to reproduce the issue.
+            .overrideConfigKey("quarkus.hibernate-orm.packages", EntityImplementingInterface.class.getPackageName())
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            // We don't expect any warning, in particular not:
+            // "Could not find a suitable persistence unit for model classes:"
+            .assertLogRecords(records -> assertThat(records).extracting(LOG_FORMATTER::format).isEmpty());
+
+    @Inject
+    Session session;
+
+    @Test
+    @ActivateRequestContext
+    void smoke() {
+        // We just want to check the lack of warnings... but let's at least check the entity works correctly.
+        assertThatCode(() -> session.createSelectionQuery("select count(*) from EntityImplementingInterface", Long.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Entity(name = "EntityImplementingInterface")
+    public static class EntityImplementingInterface implements INamedEntity {
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String name;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -58,6 +58,7 @@ import io.quarkus.hibernate.orm.deployment.PersistenceProviderSetUpBuildItem;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
+import io.quarkus.hibernate.orm.deployment.spi.AdditionalJpaModelBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
@@ -114,6 +115,7 @@ public final class HibernateReactiveProcessor {
             List<JdbcDataSourceBuildItem> jdbcDataSources,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             LaunchModeBuildItem launchMode,
+            List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems,
             JpaModelBuildItem jpaModel,
             Capabilities capabilities,
             BuildProducer<SystemPropertyBuildItem> systemProperties,
@@ -157,7 +159,7 @@ public final class HibernateReactiveProcessor {
                     enableDefaultPersistenceUnit,
                     reactiveDataSources,
                     jdbcDataSources,
-                    applicationArchivesBuildItem, jpaModel, launchMode, capabilities,
+                    applicationArchivesBuildItem, additionalJpaModelBuildItems, jpaModel, launchMode, capabilities,
                     systemProperties, nativeImageResources,
                     hotDeploymentWatchedFiles, persistenceUnitDescriptors,
                     unremovableBeans, dbKindDialectBuildItems);
@@ -173,7 +175,7 @@ public final class HibernateReactiveProcessor {
 
             producePersistenceUnitFromConfig(hibernateOrmConfig, namedPersistenceUnitName, persistenceUnitConfig, index,
                     enableDefaultPersistenceUnit, reactiveDataSources, jdbcDataSources,
-                    applicationArchivesBuildItem, jpaModel, launchMode, capabilities,
+                    applicationArchivesBuildItem, additionalJpaModelBuildItems, jpaModel, launchMode, capabilities,
                     systemProperties, nativeImageResources,
                     hotDeploymentWatchedFiles, persistenceUnitDescriptors,
                     unremovableBeans, dbKindDialectBuildItems);
@@ -186,6 +188,7 @@ public final class HibernateReactiveProcessor {
             List<ReactiveDataSourceBuildItem> reactiveDataSources,
             List<JdbcDataSourceBuildItem> jdbcDataSources,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
+            List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems,
             JpaModelBuildItem jpaModel, LaunchModeBuildItem launchMode,
             Capabilities capabilities,
             BuildProducer<SystemPropertyBuildItem> systemProperties,
@@ -234,7 +237,7 @@ public final class HibernateReactiveProcessor {
         }
 
         QuarkusPersistenceUnitDescriptorWithSupportedDBKind reactivePUWithDBKind = generateReactivePersistenceUnit(
-                hibernateOrmConfig, persistenceUnitName, index, persistenceUnitConfig, jpaModel,
+                hibernateOrmConfig, persistenceUnitName, index, persistenceUnitConfig, additionalJpaModelBuildItems, jpaModel,
                 dbKindOptional, explicitDialect, explicitDbMinVersion, applicationArchivesBuildItem,
                 launchMode.getLaunchMode(),
                 systemProperties, nativeImageResources, hotDeploymentWatchedFiles, dbKindDialectBuildItems,
@@ -345,6 +348,7 @@ public final class HibernateReactiveProcessor {
             String persistenceUnitName,
             CombinedIndexBuildItem index,
             HibernateOrmConfigPersistenceUnit persistenceUnitConfig,
+            List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems,
             JpaModelBuildItem jpaModel,
             Optional<String> dbKindOptional,
             Optional<String> explicitDialect,
@@ -357,7 +361,8 @@ public final class HibernateReactiveProcessor {
             List<DatabaseKindDialectBuildItem> dbKindDialectBuildItems, boolean enableDefaultPersistenceUnit) {
 
         Map<String, Set<String>> modelClassesAndPackagesPerPersistencesUnits = HibernateOrmProcessor
-                .getModelClassesAndPackagesPerPersistenceUnits(hibernateOrmConfig, jpaModel, index.getIndex(),
+                .getModelClassesAndPackagesPerPersistenceUnits(hibernateOrmConfig, additionalJpaModelBuildItems, jpaModel,
+                        index.getIndex(),
                         enableDefaultPersistenceUnit);
 
         Set<String> modelClassesAndPackages = modelClassesAndPackagesPerPersistencesUnits

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.search.orm.outboxpolling.deployment;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.hibernate.search.mapper.orm.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
 import org.hibernate.search.mapper.orm.outboxpolling.mapping.spi.HibernateOrmMapperOutboxPollingClasses;
@@ -37,7 +38,9 @@ class HibernateSearchOutboxPollingProcessor {
                 .reason(getClass().getName())
                 .methods().fields().build());
         for (String className : hibernateOrmTypes) {
-            additionalJpaModel.produce(new AdditionalJpaModelBuildItem(className));
+            additionalJpaModel.produce(new AdditionalJpaModelBuildItem(className,
+                    // Added to specific PUs at static init using org.hibernate.boot.spi.AdditionalMappingContributor
+                    Set.of()));
         }
     }
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
@@ -211,7 +211,9 @@ public final class KotlinPanacheResourceProcessor {
     AdditionalJpaModelBuildItem produceModel() {
         // only useful for the index resolution: hibernate will register it to be transformed, but BuildMojo
         // only transforms classes from the application jar, so we do our own transforming
-        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.orm.panache.kotlin.PanacheEntity");
+        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.orm.panache.kotlin.PanacheEntity",
+                // Only added to persistence units actually using this class, using Jandex-based discovery
+                Set.of());
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -65,7 +65,9 @@ public final class PanacheHibernateResourceProcessor {
     AdditionalJpaModelBuildItem produceModel() {
         // only useful for the index resolution: hibernate will register it to be transformed, but BuildMojo
         // only transforms classes from the application jar, so we do our own transforming
-        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.orm.panache.PanacheEntity");
+        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.orm.panache.PanacheEntity",
+                // Only added to persistence units actually using this class, using Jandex-based discovery
+                Set.of());
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.orm.panache.deployment.test.config.packages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Reproducer for https://github.com/quarkusio/quarkus/issues/22183
+ */
+public class ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest {
+
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(EntityExtendingOnlyPanacheEntityBase.class))
+            // In a real-world scenario, this would be used only if there are multiple PUs,
+            // but this is simpler and enough to reproduce the issue.
+            .overrideConfigKey("quarkus.hibernate-orm.packages", EntityExtendingOnlyPanacheEntityBase.class.getPackageName())
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            // We don't expect any warning, in particular not:
+            // "Could not find a suitable persistence unit for model classes:"
+            .assertLogRecords(records -> assertThat(records).extracting(LOG_FORMATTER::format).isEmpty());
+
+    @Test
+    @ActivateRequestContext
+    void smoke() {
+        // We just want to check the lack of warnings... but let's at least check the entity works correctly.
+        assertThatCode(() -> EntityExtendingOnlyPanacheEntityBase.count())
+                .doesNotThrowAnyException();
+    }
+
+    @Entity
+    public static class EntityExtendingOnlyPanacheEntityBase extends PanacheEntityBase {
+        @Id
+        @GeneratedValue
+        public Long id;
+
+        public String name;
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/kotlin/deployment/HibernateReactivePanacheKotlinProcessor.java
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/kotlin/deployment/HibernateReactivePanacheKotlinProcessor.java
@@ -53,7 +53,9 @@ public class HibernateReactivePanacheKotlinProcessor {
     public AdditionalJpaModelBuildItem produceModel() {
         // only useful for the index resolution: hibernate will register it to be transformed, but BuildMojo
         // only transforms classes from the application jar, so we do our own transforming
-        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity");
+        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity",
+                // Only added to persistence units actually using this class, using Jandex-based discovery
+                Set.of());
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -64,7 +64,9 @@ public final class PanacheHibernateResourceProcessor {
     AdditionalJpaModelBuildItem produceModel() {
         // only useful for the index resolution: hibernate will register it to be transformed, but BuildMojo
         // only transforms classes from the application jar, so we do our own transforming
-        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.reactive.panache.PanacheEntity");
+        return new AdditionalJpaModelBuildItem("io.quarkus.hibernate.reactive.panache.PanacheEntity",
+                // Only added to persistence units actually using this class, using Jandex-based discovery
+                Set.of());
     }
 
     @BuildStep

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -169,8 +170,12 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
     @BuildStep
     public void additionalJpaModel(BuildProducer<AdditionalJpaModelBuildItem> additionalJpaModel) {
-        additionalJpaModel.produce(new AdditionalJpaModelBuildItem(CHECKPOINT_ENTITY_NAME));
-        additionalJpaModel.produce(new AdditionalJpaModelBuildItem(CHECKPOINT_ENTITY_ID_NAME));
+        additionalJpaModel.produce(new AdditionalJpaModelBuildItem(CHECKPOINT_ENTITY_NAME,
+                // Only added to persistence units actually using this class, using Jandex-based discovery
+                Set.of()));
+        additionalJpaModel.produce(new AdditionalJpaModelBuildItem(CHECKPOINT_ENTITY_ID_NAME,
+                // Only added to persistence units actually using this class, using Jandex-based discovery
+                Set.of()));
     }
 
     /**


### PR DESCRIPTION
This should hopefully fix #22183, which is actually two separate problems:

1. When assigning an entity to a persistence unit, we automatically add superclasses as well. But we ignore interfaces.,resulting in a warning because that interface is not found in any PU.
2. When using Panache, it's technically possible to only use `PanacheEntityBase`, and never use `PanacheEntity`. This results in a warning because `PanacheEntity` is not found in any PU -- but that's actually fine, because `PanacheEntity` is not needed in any PU.

These problems only ever happen in applications with multiple persistence units -- when there is a single persistence unit, everything is assigned to it anyway.

* Fixes #22183
