### PR TITLE
Remove deprecated APIs that are removed from Gradle 9

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/DeploymentConfigurationResolver.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/DeploymentConfigurationResolver.java
@@ -150,16 +150,11 @@ public class DeploymentConfigurationResolver {
                     !allRuntimeDeps.containsKey(
                             ArtifactKey.of(processedDep.ext.getDeploymentGroup(), processedDep.ext.getDeploymentName(),
                                     ArtifactCoords.DEFAULT_CLASSIFIER, ArtifactCoords.TYPE_JAR))) {
-                directDeploymentDeps.add(getDeploymentDependency(processedDep.ext));
+                directDeploymentDeps
+                        .add(DependencyUtils.createDeploymentDependency(project.getDependencies(), processedDep.ext));
             }
         }
         return directDeploymentDeps;
-    }
-
-    private Dependency getDeploymentDependency(ExtensionDependency<?> ext) {
-        return ext.isProjectDependency()
-                ? DependencyUtils.createDeploymentProjectDependency((Project) ext.getDeploymentModule(), taskDependencyFactory)
-                : DependencyUtils.createDeploymentDependency(project.getDependencies(), ext);
     }
 
     private boolean isWalkingFlagsOn(byte flags) {

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -348,7 +348,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
             boolean workspaceDiscovery, Project project, ApplicationModelBuilder modelBuilder,
             WorkspaceModule.Mutable wsModule) {
 
-        final Set<File> artifactFiles = getArtifactFilesOrNull(configuration);
+        final Set<File> artifactFiles = getArtifactFilesOrNull(configuration, dependencies);
         for (ResolvedDependency d : configuration.getFirstLevelModuleDependencies()) {
             collectDependencies(d, workspaceDiscovery, project, artifactFiles, new HashSet<>(),
                     modelBuilder,
@@ -393,11 +393,11 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         }
     }
 
-    private static Set<File> getArtifactFilesOrNull(ResolvedConfiguration configuration) {
+    private static Set<File> getArtifactFilesOrNull(ResolvedConfiguration configuration, ResolvableDependencies dependencies) {
         final Set<ResolvedArtifact> resolvedArtifacts = configuration.getResolvedArtifacts();
         // if the number of artifacts is less than the number of files then probably
         // the project includes direct file dependencies
-        return resolvedArtifacts.size() < configuration.getFiles().size()
+        return resolvedArtifacts.size() < dependencies.getFiles().getFiles().size()
                 ? new HashSet<>(resolvedArtifacts.size())
                 : null;
     }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
@@ -26,9 +26,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
-import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -375,11 +372,6 @@ public class DependencyUtils {
         } else {
             return handler.create(handler.project(Map.of("path", ped.getDeploymentModule().getPath())));
         }
-    }
-
-    public static Dependency createDeploymentProjectDependency(Project project, TaskDependencyFactory taskDependencyFactory) {
-        return project.getDependencies().create(
-                new DefaultProjectDependency((ProjectInternal) project, true, taskDependencyFactory));
     }
 
     private static Dependency createArtifactDeploymentDependency(DependencyHandler handler,


### PR DESCRIPTION
This PR removes deprecated APIs that are removed from Gradle 9. They were added in #49224.
This PR is a prerequisite for #49256

@aloubyansky I am not quite sure if replacing `getDeploymentDependency` with `DependencyUtils.createDeploymentDependency` is valid, so I need your review here.