### PR TITLE
Fix checking for docker enviroment when `quarkus.devservices.enabled=false`

### DIFF
--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
@@ -159,7 +159,7 @@ public class DevServicesProcessor {
         return new RunTimeConfigBuilderBuildItem(DevServicesConfigBuilder.class);
     }
 
-    @BuildStep(onlyIf = { IsDevelopment.class })
+    @BuildStep(onlyIf = { IsDevelopment.class, DevServicesConfig.Enabled.class })
     public List<DevServiceDescriptionBuildItem> config(
             DockerStatusBuildItem dockerStatusBuildItem,
             BuildProducer<ConsoleCommandBuildItem> commandBuildItemBuildProducer,


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Fixes #49118 

Not sure if the whole `DevServicesProcessor` build steps should be skipped. Second option to fix the issue is adding `DevServicesConfig.Enabled.class` to https://github.com/quarkusio/quarkus/blob/main/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java#L162

But in general it seems this error is caused by https://github.com/quarkusio/quarkus/blob/main/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java#L172

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

