### PR TITLE
Dependabot - Group mvnpm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -197,6 +197,10 @@ updates:
           - "org.hibernate.orm*"
           - "org.hibernate.reactive*"
           - "org.hibernate.search*"
+      Mvnpm:
+        patterns:
+          - "org.mvnpm:*"
+          - "org.mvnpm.*:*"
     ignore:
       - dependency-name: org.eclipse.microprofile.config:microprofile-config-tck
         update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
There are lot of them and they are updated often, and usually you have to go trough the Dev UI to check it didn't break anything. So better group them and validate them in one go.

