### PR TITLE
Prevent theoretically possible NPE in HttpSecurity API

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -155,8 +155,10 @@ public class HttpSecurityProcessor {
     @Consume(HttpSecurityConfigSetupCompleteBuildItem.class)
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void setMtlsCertificateRoleProperties(HttpSecurityRecorder recorder) {
-        recorder.setMtlsCertificateRoleProperties();
+    void setMtlsCertificateRoleProperties(HttpSecurityRecorder recorder, Capabilities capabilities) {
+        if (capabilities.isPresent(Capability.SECURITY)) {
+            recorder.setMtlsCertificateRoleProperties();
+        }
     }
 
     @BuildStep(onlyIf = IsApplicationBasicAuthRequired.class)

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityConfiguration.java
@@ -228,7 +228,8 @@ public final class HttpSecurityConfiguration {
             }
 
             instance = new HttpSecurityConfiguration(httpSecurity.getRolesMapping(), httpSecurity.getHttpPermissions(),
-                    basicAuthEnabled, formAuthEnabled, formPostLocation, mechanisms, httpConfig, httpBuildTimeConfig);
+                    basicAuthEnabled, formAuthEnabled, formPostLocation, mechanisms, vertxHttpConfig,
+                    vertxHttpBuildTimeConfig);
             HttpServerTlsConfig.setConfiguration(
                     new ProgrammaticTlsConfig(httpSecurity.getClientAuth(), httpSecurity.getHttpServerTlsConfigName()));
         }


### PR DESCRIPTION
This PR is tiny refactoring I have mentioned last week when working on the fluent API for CORS:

- HttpSecurity is initialized with runtime and build-time config passed from recorder and there is order to things enforced by build items, but I added fallback mechanism in case something goes wrong and this mechanism wasn't used in all cases, hence fixing it
- mTLS certificate role mapping only happens when Quarkus Security extension is present, so it is unnecessarily runs some code if it isn't around (newly) in 3.26, therefore I am adding the capability check

I'd like this to get to 3.26 and Sergey is not around, so I am asking others to review.