### PR TITLE
Hibernate ORM 7.1.0.CR2

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/H2CustomDialect.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/H2CustomDialect.java
@@ -5,8 +5,10 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
+import org.hibernate.query.sqm.mutation.spi.MultiTableHandlerBuildResult;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
+import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.query.sqm.tree.insert.SqmInsertStatement;
 import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
@@ -18,6 +20,12 @@ public class H2CustomDialect extends H2Dialect {
             EntityMappingType entityDescriptor,
             RuntimeModelCreationContext runtimeModelCreationContext) {
         return new SqmMultiTableMutationStrategy() {
+            @Override
+            public MultiTableHandlerBuildResult buildHandler(SqmDeleteOrUpdateStatement<?> sqmDeleteOrUpdateStatement,
+                    DomainParameterXref domainParameterXref, DomainQueryExecutionContext domainQueryExecutionContext) {
+                return null;
+            }
+
             @Override
             public int executeUpdate(
                     SqmUpdateStatement<?> sqmUpdateStatement,
@@ -41,6 +49,12 @@ public class H2CustomDialect extends H2Dialect {
             EntityMappingType entityDescriptor,
             RuntimeModelCreationContext runtimeModelCreationContext) {
         return new SqmMultiTableInsertStrategy() {
+            @Override
+            public MultiTableHandlerBuildResult buildHandler(SqmInsertStatement<?> sqmInsertStatement,
+                    DomainParameterXref domainParameterXref, DomainQueryExecutionContext context) {
+                return null;
+            }
+
             @Override
             public int executeInsert(
                     SqmInsertStatement<?> sqmInsertStatement,

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.loader.ast.internal.BatchLoaderFactoryInitiator;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
@@ -247,6 +248,9 @@ public class PreconfiguredServiceRegistryBuilder {
 
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);
+
+        // Default implementation -- TODO use Caffeine instead
+        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -20,7 +20,6 @@ import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
-import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.loader.ast.internal.BatchLoaderFactoryInitiator;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
@@ -50,6 +49,7 @@ import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRuntimeInitDialectFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRuntimeInitDialectResolverInitiator;
 import io.quarkus.hibernate.orm.runtime.service.bytecodeprovider.QuarkusRuntimeBytecodeProviderInitiator;
+import io.quarkus.hibernate.orm.runtime.service.internalcache.QuarkusInternalCacheFactoryInitiator;
 
 /**
  * Helps to instantiate a ServiceRegistryBuilder from a previous state. This
@@ -249,8 +249,8 @@ public class PreconfiguredServiceRegistryBuilder {
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);
 
-        // Default implementation -- TODO use Caffeine instead
-        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
+        // Custom Quarkus implementation: overrides the internal cache to leverage Caffeine
+        serviceInitiators.add(QuarkusInternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
@@ -14,7 +14,6 @@ import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
-import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.loader.ast.internal.BatchLoaderFactoryInitiator;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
@@ -30,6 +29,7 @@ import io.quarkus.hibernate.orm.runtime.cdi.QuarkusManagedBeanRegistryInitiator;
 import io.quarkus.hibernate.orm.runtime.customized.BootstrapOnlyProxyFactoryFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.customized.QuarkusJndiServiceInitiator;
 import io.quarkus.hibernate.orm.runtime.customized.QuarkusJtaPlatformInitiator;
+import io.quarkus.hibernate.orm.runtime.service.internalcache.QuarkusInternalCacheFactoryInitiator;
 
 /**
  * Here we define the list of standard Service Initiators to be used by
@@ -110,8 +110,8 @@ public final class StandardHibernateORMInitiatorListProvider implements InitialI
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);
 
-        // Default implementation -- TODO use Caffeine instead
-        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
+        // Custom Quarkus implementation: overrides the internal cache to leverage Caffeine
+        serviceInitiators.add(QuarkusInternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
@@ -14,6 +14,7 @@ import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
+import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.loader.ast.internal.BatchLoaderFactoryInitiator;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
@@ -108,6 +109,9 @@ public final class StandardHibernateORMInitiatorListProvider implements InitialI
 
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);
+
+        // Default implementation -- TODO use Caffeine instead
+        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/internalcache/QuarkusInternalCache.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/internalcache/QuarkusInternalCache.java
@@ -1,0 +1,43 @@
+package io.quarkus.hibernate.orm.runtime.service.internalcache;
+
+import java.util.function.Function;
+
+import org.hibernate.internal.util.cache.InternalCache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+final class QuarkusInternalCache<K, V> implements InternalCache<K, V> {
+
+    private final Cache<K, V> cache;
+
+    public QuarkusInternalCache(Cache<K, V> caffeineCache) {
+        this.cache = caffeineCache;
+    }
+
+    @Override
+    public int heldElementsEstimate() {
+        return Math.toIntExact(cache.estimatedSize());
+    }
+
+    @Override
+    public V get(K key) {
+        return cache.getIfPresent(key);
+    }
+
+    @Override
+    public void put(K key, V value) {
+        cache.put(key, value);
+    }
+
+    @Override
+    public void clear() {
+        cache.invalidateAll();
+        cache.cleanUp();
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        return cache.get(key, mappingFunction);
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/internalcache/QuarkusInternalCacheFactoryInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/internalcache/QuarkusInternalCacheFactoryInitiator.java
@@ -1,0 +1,49 @@
+package io.quarkus.hibernate.orm.runtime.service.internalcache;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.internal.util.cache.InternalCache;
+import org.hibernate.internal.util.cache.InternalCacheFactory;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+/**
+ * Override of {@link org.hibernate.internal.util.cache.InternalCacheFactoryInitiator}:
+ * this switches the internal cache implementation (currently used for some stats and, crucially, for the
+ * {@link org.hibernate.query.spi.QueryInterpretationCache}
+ * to use Caffeine rather than the legacy implementation Hibernate ORM normally uses, which is based on the excellent LIRS
+ * algorithm but which we
+ * plan to deprecate in favour of modern caching libraries.
+ * See also <a href="https://en.wikipedia.org/wiki/LIRS_caching_algorithm">LIRS</a> and
+ * <a href="https://github.com/ben-manes/caffeine/wiki/Efficiency">Caffeine, efficiency</a>.
+ */
+public final class QuarkusInternalCacheFactoryInitiator implements StandardServiceInitiator<InternalCacheFactory> {
+
+    public static final QuarkusInternalCacheFactoryInitiator INSTANCE = new QuarkusInternalCacheFactoryInitiator();
+
+    private QuarkusInternalCacheFactoryInitiator() {
+    }
+
+    @Override
+    public InternalCacheFactory initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
+        return new QuarkusInternalCacheFactory();
+    }
+
+    @Override
+    public Class<InternalCacheFactory> getServiceInitiated() {
+        return InternalCacheFactory.class;
+    }
+
+    private static class QuarkusInternalCacheFactory implements InternalCacheFactory {
+        @Override
+        public <K, V> InternalCache<K, V> createInternalCache(int intendedApproximateSize) {
+            final Cache<K, V> caffeineCache = Caffeine.newBuilder()
+                    .maximumSize(intendedApproximateSize)
+                    .build();
+            return new QuarkusInternalCache<>(caffeineCache);
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
@@ -199,6 +199,22 @@ public class TransactionScopedSession implements Session {
     }
 
     @Override
+    public Object find(String entityName, Object primaryKey) {
+        checkBlocking();
+        try (SessionResult emr = acquireSession()) {
+            return emr.session.find(entityName, primaryKey);
+        }
+    }
+
+    @Override
+    public Object find(String entityName, Object primaryKey, FindOption... options) {
+        checkBlocking();
+        try (SessionResult emr = acquireSession()) {
+            return emr.session.find(entityName, primaryKey, options);
+        }
+    }
+
+    @Override
     public <T> T find(Class<T> entityClass, Object primaryKey, Map<String, Object> properties) {
         checkBlocking();
         try (SessionResult emr = acquireSession()) {

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitPackageConfigurationTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitPackageConfigurationTest.java
@@ -60,7 +60,7 @@ public class SinglePersistenceUnitPackageConfigurationTest {
     public void testExcluded(UniAsserter asserter) {
         ExcludedEntity entity = new ExcludedEntity("gsmet");
         asserter.assertFailedWith(() -> persist(entity), t -> {
-            assertThat(t).hasMessageContaining("Unknown entity type:");
+            assertThat(t).hasMessageContaining("Unknown entity type");
         });
     }
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -19,6 +19,7 @@ import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorServiceInitiator;
@@ -249,6 +250,9 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
 
         // Custom for Hibernate Reactive: BatchLoaderFactory
         serviceInitiators.add(ReactiveBatchLoaderFactoryInitiator.INSTANCE);
+
+        // Default implementation -- TODO use Caffeine instead
+        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -19,7 +19,6 @@ import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
-import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorServiceInitiator;
@@ -53,6 +52,7 @@ import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRuntimeInitDialectFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRuntimeInitDialectResolverInitiator;
 import io.quarkus.hibernate.orm.runtime.service.bytecodeprovider.QuarkusRuntimeBytecodeProviderInitiator;
+import io.quarkus.hibernate.orm.runtime.service.internalcache.QuarkusInternalCacheFactoryInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.CheckingVertxContextInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcConnectionProviderInitiator;
 
@@ -251,8 +251,8 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
         // Custom for Hibernate Reactive: BatchLoaderFactory
         serviceInitiators.add(ReactiveBatchLoaderFactoryInitiator.INSTANCE);
 
-        // Default implementation -- TODO use Caffeine instead
-        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
+        // Custom Quarkus implementation: overrides the internal cache to leverage Caffeine
+        serviceInitiators.add(QuarkusInternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
@@ -14,6 +14,7 @@ import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
+import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.loader.ast.internal.ReactiveBatchLoaderFactoryInitiator;
@@ -122,6 +123,9 @@ public final class ReactiveHibernateInitiatorListProvider implements InitialInit
 
         // Custom for Hibernate Reactive: BatchLoaderFactory
         serviceInitiators.add(ReactiveBatchLoaderFactoryInitiator.INSTANCE);
+
+        // Default implementation -- TODO use Caffeine instead
+        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
@@ -14,7 +14,6 @@ import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
-import org.hibernate.internal.util.cache.InternalCacheFactoryInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.loader.ast.internal.ReactiveBatchLoaderFactoryInitiator;
@@ -37,6 +36,7 @@ import io.quarkus.hibernate.orm.runtime.service.QuarkusImportSqlCommandExtractor
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusStaticInitDialectFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.StandardHibernateORMInitiatorListProvider;
+import io.quarkus.hibernate.orm.runtime.service.internalcache.QuarkusInternalCacheFactoryInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcConnectionProviderInitiator;
 
 /**
@@ -124,8 +124,8 @@ public final class ReactiveHibernateInitiatorListProvider implements InitialInit
         // Custom for Hibernate Reactive: BatchLoaderFactory
         serviceInitiators.add(ReactiveBatchLoaderFactoryInitiator.INSTANCE);
 
-        // Default implementation -- TODO use Caffeine instead
-        serviceInitiators.add(InternalCacheFactoryInitiator.INSTANCE);
+        // Custom Quarkus implementation: overrides the internal cache to leverage Caffeine
+        serviceInitiators.add(QuarkusInternalCacheFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
@@ -30,7 +30,15 @@ import io.quarkus.test.junit.QuarkusTest;
 public class HibernateOrmNoWarningsTest {
     @Test
     public void testNoWarningsOnStartup() {
-        assertThat(LogCollectingTestResource.current().getRecords())
+        assertThat(LogCollectingTestResource.current().getRecords()
+                // Ignore logs about JDBC fetch size: Oracle's default is very wrong.
+                // See:
+                // https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/JDBC.20fetch.20size.20warning/with/532321427
+                // https://github.com/hibernate/hibernate-orm/pull/10633
+                // https://in.relation.to/2025/01/24/jdbc-fetch-size/
+                // https://github.com/hibernate/hibernate-orm/pull/10636
+                // Also, the Hibernate team is in talks with Oracle to get this fixed, so hopefully this will disappear soon.
+                .stream().filter(r -> !r.getMessage().contains("Low default JDBC fetch size")))
                 // There shouldn't be any warning or error
                 .as("Startup logs (warning or higher)")
                 .extracting(LogCollectingTestResource::format)

--- a/pom.xml
+++ b/pom.xml
@@ -71,14 +71,14 @@
         <jacoco.version>0.8.13</jacoco.version>
         <kubernetes-client.version>7.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.5</rest-assured.version>
-        <hibernate-orm.version>7.0.9.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.1.0.CR2</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
-        <bytebuddy.version>1.17.5</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-models.version>1.0.0</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>3.0.6.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <bytebuddy.version>1.17.6</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
+        <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
+        <hibernate-reactive.version>3.1.0.CR2</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.0.1.Final</hibernate-validator.version>
-        <hibernate-search.version>8.0.0.Final</hibernate-search.version>
+        <hibernate-search.version>8.1.0.CR2</hibernate-search.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.69.1</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->


### PR DESCRIPTION
I'm taking over from Yoann as he's on PTO, so continuing his work based on preview PR #49140 

* Fixes #49132 
* Fixes #47353  

Migration guide entry:

```
== Hibernate ORM

=== Upgrade to Hibernate ORM 7.1

The Quarkus extension for Hibernate ORM was upgraded to Hibernate ORM 7.1.

Hibernate ORM 7.1 is for the most part backwards-compatible with Hibernate ORM 7.0. However, a few breaking changes are to be expected. Below are the ones most likely to affect existing applications.

Refer to the https://docs.jboss.org/hibernate/orm/7.1/migration-guide/migration-guide.html[Hibernate ORM 7.1 migration guide] for more information.

=== API changes

* https://docs.jboss.org/hibernate/orm/7.1/migration-guide/migration-guide.html#lock-options[A few of the more problematic, deprecated features of `LockOptions` have been removed].
* https://docs.jboss.org/hibernate/orm/7.1/migration-guide/migration-guide.html#session-getLobHelper[`Session#getLobHelper` was deprecated in favor of `Hibernate#getLobHelper`].

[[orm-db-versions]]
=== Minimum database versions

As with every new version of Hibernate ORM, the minimum required version of databases was bumped to the *oldest version still supported* by their respective vendor. In particular:

* IBM DB2: bumped minimum version from 10.5 to 11.1
* MariaDB: bumped minimum version from 10.5 to 10.6
* Microsoft SQL Server: bumped minimum version from 11.0 (2012) to 12.0 (2014)

See https://docs.jboss.org/hibernate/orm/7.1/dialect/dialect.html[here] for details on the current minimum versions.

== Hibernate Reactive

=== Upgrade to Hibernate Reactive 3.1

The Quarkus extension for Hibernate Reactive was upgraded to Hibernate Reactive 3.1.

Hibernate Reactive 3.1 is backwards-compatible with Hibernate Reactive 3.0, with the exception of a few breaking changes inherited from Hibernate ORM and listed xref:#++hibernate-orm++[above].

== Hibernate Search

=== Upgrade to Hibernate Search 8.1

The Quarkus extensions for Hibernate Search were upgraded to Hibernate Search 8.1.

Hibernate Search 8.1 is backwards-compatible with Hibernate Search 8.0, apart from a few deprecations.

Refer to the the https://docs.jboss.org/hibernate/search/8.1/migration/html_single/[Hibernate Search 8.1 migration guide] for more information.

```