### PR TITLE
Keep variant info when using template locator

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/contents/TemplateContentsRecordTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/contents/TemplateContentsRecordTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute.deployment.contents;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.concurrent.ExecutionException;
 
@@ -13,6 +14,7 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.Engine;
 import io.quarkus.qute.TemplateContents;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.Variant;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class TemplateContentsRecordTest {
@@ -26,12 +28,18 @@ public class TemplateContentsRecordTest {
 
     @Test
     public void testTemplateContents() throws InterruptedException, ExecutionException {
+        // Clear preloaded templates to simulate quarkus.qute.dev-mode.no-restart-templates in the dev mode
+        engine.clearTemplates();
+
         assertEquals("Hello 42!", new helloInt(42).render());
         assertEquals("Hello 1!", engine.getTemplate("TemplateContentsRecordTest/helloInt").data("val", 1).render());
         assertEquals("Hello 42!", new helloLong(42).render());
         assertEquals("Hello 1!", engine.getTemplate("foo/helloLong").data("val", 1).render());
 
-        assertEquals("<p>Hello &quot;Martin&quot;!</p>", new helloHtml("\"Martin\"").render());
+        TemplateInstance helloHtml = new helloHtml("\"Martin\"");
+        assertNotNull(helloHtml.getTemplate().getVariant());
+        assertEquals(Variant.TEXT_HTML, helloHtml.getTemplate().getVariant().get().getContentType());
+        assertEquals("<p>Hello &quot;Martin&quot;!</p>", helloHtml.render());
         assertEquals("<p>Hello Lu!</p>",
                 engine.getTemplate("TemplateContentsRecordTest/helloHtml.html").data("name", "Lu").render());
     }


### PR DESCRIPTION
This fixes an issue after a change in dev-mode:
`QuteSetup ` is clearing the templates

The template locator is then used to locate the templates with the variant, but before this fix, the variant info was lost.

This will fix: https://github.com/quarkiverse/quarkus-roq/issues/587