### PR TITLE
[3.20] Install Java 17 for Gradle plugin build

### DIFF
--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -9,7 +9,7 @@
     {
         "name": "JVM Tests - JDK 21",
         "java-version": 21,
-        "java-version-gradle": 20,
+        "java-version-gradle": 17,
         "maven_args": "$JVM_TEST_MAVEN_ARGS",
         "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
         "os-name": "ubuntu-latest"


### PR DESCRIPTION
Gradle requires Java 17 for the build.

(cherry picked from commit 382aa5ddd7d1fa6ca32953a47edb31fd58dcf286)