### PR TITLE
[3.15] Install Java 17 for Gradle plugin build

### DIFF
--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -8,7 +8,7 @@
 , {
   "name": "21",
   "java-version": 21,
-  "java-version-gradle": 20,
+  "java-version-gradle": 17,
   "maven_args": "$JVM_TEST_MAVEN_ARGS",
   "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
   "os-name": "ubuntu-22.04"


### PR DESCRIPTION
Gradle requires Java 17 for the build.
