### PR TITLE
Fix Dev Services compose command when running on Windows

### DIFF
--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeRunner.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeRunner.java
@@ -12,6 +12,7 @@ import org.testcontainers.DockerClientFactory;
 import org.testcontainers.dockerclient.TransportConfig;
 import org.testcontainers.utility.CommandLine;
 
+import io.smallrye.common.os.OS;
 import io.smallrye.common.process.ProcessBuilder;
 
 /**
@@ -117,6 +118,7 @@ public class ComposeRunner {
                         env.put(COMPOSE_PROFILES_ENV, String.join(",", this.profiles));
                     }
                 })
+                .specialQuoting(OS.WINDOWS.isCurrent())
                 .output().consumeLinesWith(8192, LOG::info)
                 .error().logOnSuccess(false).consumeLinesWith(8192, LOG::info)
                 .run();


### PR DESCRIPTION
Fixes dev services compose feature on Windows. When using the dev services compose feature on Windows, it is failing because the command arguments are not properly quoted:

```
12:43:11,061 INFO  [app] 12:43:08,991 Failed to start quarkus: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
12:43:11,061 INFO  [app]        [error]: Build step io.quarkus.devservices.deployment.compose.ComposeDevServicesProcessor#config threw an exception: io.smallrye.common.process.AbnormalExitException: Process exited abnormally (pid 6628) with exit code 125 with error output:
12:43:11,061 INFO  [app]  > unknown shorthand flag: 'd' in -d
12:43:11,061 INFO  [app]  > See 'docker --help'.
12:43:11,061 INFO  [app]  >
12:43:11,061 INFO  [app]  > Usage:  docker [OPTIONS] COMMAND
12:43:11,061 INFO  [app]  >
12:43:11,061 INFO  [app]  > … (skipped 79 line(s)) …
12:43:11,061 INFO  [app]  >
12:43:11,061 INFO  [app]  > Run 'docker COMMAND --help' for more information on a command.
12:43:11,061 INFO  [app]  >
12:43:11,061 INFO  [app]  > For more help on how to use Docker, head to https://docs.docker.com/go/guides/
12:43:11,061 INFO  [app]  >
12:43:11,061 INFO  [app]        at io.smallrye.common.process.PipelineRunner.collectProblems(PipelineRunner.java:560)
12:43:11,061 INFO  [app]        at io.smallrye.common.process.ProcessRunner.complete(ProcessRunner.java:165)
12:43:11,061 INFO  [app]        at io.smallrye.common.process.ProcessRunner.run(ProcessRunner.java:95)
12:43:11,061 INFO  [app]        at io.smallrye.common.process.ProcessBuilderImpl.run(ProcessBuilderImpl.java:199)
12:43:11,061 INFO  [app]        at io.smallrye.common.process.ProcessBuilderImpl$ViewImpl.run(ProcessBuilderImpl.java:268)
12:43:11,062 INFO  [app]        at io.quarkus.devservices.deployment.compose.ComposeRunner.run(ComposeRunner.java:121)
12:43:11,062 INFO  [app]        at io.quarkus.devservices.deployment.compose.ComposeProject.runWithCompose(ComposeProject.java:389)
12:43:11,062 INFO  [app]        at io.quarkus.devservices.deployment.compose.ComposeProject.startServices(ComposeProject.java:277)
12:43:11,062 INFO  [app]        at io.quarkus.devservices.deployment.compose.ComposeProject.start(ComposeProject.java:177)
12:43:11,062 INFO  [app]        at io.quarkus.devservices.deployment.compose.ComposeDevServicesProcessor.startCompose(ComposeDevServicesProcessor.java:259)
12:43:11,062 INFO  [app]        at io.quarkus.devservices.deployment.compose.ComposeDevServicesProcessor.config(ComposeDevServicesProcessor.java:122)
12:43:11,062 INFO  [app]        at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
12:43:11,062 INFO  [app]        at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:889)
12:43:11,062 INFO  [app]        at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
12:43:11,062 INFO  [app]        at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
12:43:11,062 INFO  [app]        at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
12:43:11,062 INFO  [app]        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
12:43:11,062 INFO  [app]        at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1622)
12:43:11,062 INFO  [app]        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
12:43:11,062 INFO  [app]        at java.base/java.lang.Thread.run(Thread.java:1583)
12:43:11,062 INFO  [app]        at org.jboss.threads.JBossThread.run(JBossThread.java:501)
12:43:11,062 INFO  [app]        at io.quarkus.runner.bootstrap.AugmentActionImpl.runAugment(AugmentActionImpl.java:372)
12:43:11,062 INFO  [app]        at io.quarkus.runner.bootstrap.AugmentActionImpl.createInitialRuntimeApplication(AugmentActionImpl.java:289)
12:43:11,062 INFO  [app]        at io.quarkus.runner.bootstrap.AugmentActionImpl.createInitialRuntimeApplication(AugmentActionImpl.java:61)
12:43:11,062 INFO  [app]        at io.quarkus.deployment.dev.IsolatedDevModeMain.firstStart(IsolatedDevModeMain.java:89)
12:43:11,062 INFO  [app]        at io.quarkus.deployment.dev.IsolatedDevModeMain.accept(IsolatedDevModeMain.java:432)
12:43:11,062 INFO  [app]        at io.quarkus.deployment.dev.IsolatedDevModeMain.accept(IsolatedDevModeMain.java:55)
12:43:11,062 INFO  [app]        at io.quarkus.bootstrap.app.CuratedApplication.runInCl(CuratedApplication.java:143)
12:43:11,062 INFO  [app]        at io.quarkus.bootstrap.app.CuratedApplication.runInAugmentClassLoader(CuratedApplication.java:98)
12:43:11,062 INFO  [app]        at io.quarkus.deployment.dev.DevModeMain.start(DevModeMain.java:102)
12:43:11,062 INFO  [app]        at io.quarkus.deployment.dev.DevModeMain.main(DevModeMain.java:65)
12:43:11,062 INFO  [app] Caused by: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
12:43:11,062 INFO  [app]        [error]: Build step io.quarkus.devservices.deployment.compose.ComposeDevServicesProcessor#config threw an exception: io.smallrye.common.process.AbnormalExitException: Process exited abnormally (pid 6628) with exit code 125 with error output:
```

You can test it yourself, for example run one of these tests on Windows:

- https://github.com/quarkus-qe/quarkus-test-suite/blob/main/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMysqlComposeIT.java
- https://github.com/quarkus-qe/quarkus-test-suite/blob/main/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModeMariadbComposeIT.java
- https://github.com/quarkus-qe/quarkus-test-suite/blob/main/sql-db/sql-app/src/test/java/io/quarkus/ts/sqldb/sqlapp/DevModePostgresqlComposeIT.java