### PR TITLE
Avoid failing when JaCoCo can't instrument a class

### DIFF
--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -90,7 +90,16 @@ public class JacocoProcessor {
                                             }
                                             return enhanced;
                                         } catch (IOException e) {
-                                            throw new RuntimeException(e);
+                                            if (!log.isDebugEnabled()) {
+                                                log.warnf(
+                                                        "Unable to instrument class %s with JaCoCo: %s, keeping the original class",
+                                                        className, e.getMessage());
+                                            } else {
+                                                log.warnf(e,
+                                                        "Unable to instrument class %s with JaCoCo, keeping the original class",
+                                                        className);
+                                            }
+                                            return bytes;
                                         }
                                     }
                                 }).build());


### PR DESCRIPTION
Fixes #49238

This is a follow-up of https://github.com/quarkusio/quarkus/pull/49304 as apparently the other PR is causing some issues. I'm not sure they are actually related to the change or if classes should be instrumented in other modules separately but let's work around the problem for now.
