### PR TITLE
Upgrade to Gizmo 2.0.0.Beta4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <!-- GraalVM sdk 23.1.2 has a minimum JDK requirement of 17+ at runtime -->
         <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.9.0</gizmo.version>
-        <gizmo2.version>2.0.0.Beta3</gizmo2.version>
+        <gizmo2.version>2.0.0.Beta4</gizmo2.version>
         <jackson-bom.version>2.19.2</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>


### PR DESCRIPTION
Fixes `try`/`finally` in case the `try` body has nested blocks. The `finally_()` method is not used in Quarkus yet, but is very useful, so it better work :-)