### PR TITLE
Use SmallRye Common library for OS and CPU detection

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsupportedOSBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsupportedOSBuildItem.java
@@ -5,6 +5,8 @@ import static io.quarkus.dev.console.QuarkusConsole.IS_MAC;
 import static io.quarkus.dev.console.QuarkusConsole.IS_WINDOWS;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.smallrye.common.cpu.CPU;
+import io.smallrye.common.os.OS;
 
 /**
  * Native-image might not be supported for a particular
@@ -12,8 +14,13 @@ import io.quarkus.builder.item.MultiBuildItem;
  */
 public final class UnsupportedOSBuildItem extends MultiBuildItem {
 
+    @Deprecated(forRemoval = true, since = "3.26.0")
     public static String ARCH = System.getProperty("os.arch");
 
+    /**
+     * @deprecated Use {@link OS} instead
+     */
+    @Deprecated(forRemoval = true, since = "3.26.0")
     public enum Os {
         WINDOWS(IS_WINDOWS),
         MAC(IS_MAC),
@@ -27,6 +34,10 @@ public final class UnsupportedOSBuildItem extends MultiBuildItem {
         }
     }
 
+    /**
+     * @deprecated Use {@link CPU} instead
+     */
+    @Deprecated(forRemoval = true, since = "3.26.0")
     public enum Arch {
         AMD64("amd64".equalsIgnoreCase(ARCH)),
         AARCH64("aarch64".equalsIgnoreCase(ARCH)),
@@ -39,25 +50,72 @@ public final class UnsupportedOSBuildItem extends MultiBuildItem {
         }
     }
 
-    public final Os os;
-    public final Arch arch;
-    public final String error;
+    private final OS os;
+    private final CPU cpu;
+    private final String error;
 
+    /**
+     * @deprecated Use {@link UnsupportedOSBuildItem#UnsupportedOSBuildItem(io.smallrye.common.os.OS, java.lang.String)} instead
+     */
+    @Deprecated(forRemoval = true, since = "3.26.0")
     public UnsupportedOSBuildItem(Os os, String error) {
-        this.os = os;
-        this.arch = Arch.NONE;
+        this.os = switch (os) {
+            case WINDOWS -> OS.WINDOWS;
+            case MAC -> OS.MAC;
+            case LINUX -> OS.LINUX;
+            case NONE -> null;
+        };
+        this.cpu = null;
         this.error = error;
     }
 
+    /**
+     * @deprecated Use {@link UnsupportedOSBuildItem#UnsupportedOSBuildItem(io.smallrye.common.cpu.CPU, java.lang.String)}
+     *             instead
+     */
+    @Deprecated(forRemoval = true, since = "3.26.0")
     public UnsupportedOSBuildItem(Arch arch, String error) {
-        this.os = Os.NONE;
-        this.arch = arch;
+        this.os = null;
+        this.cpu = switch (arch) {
+            case AMD64 -> CPU.x64;
+            case AARCH64 -> CPU.aarch64;
+            case NONE -> null;
+        };
         this.error = error;
     }
 
+    /**
+     * @deprecated Use
+     *             {@link UnsupportedOSBuildItem#UnsupportedOSBuildItem(io.smallrye.common.os.OS, io.smallrye.common.cpu.CPU, java.lang.String)}
+     *             instead
+     */
+    @Deprecated(forRemoval = true, since = "3.26.0")
     public UnsupportedOSBuildItem(Os os, Arch arch, String error) {
+        this.os = switch (os) {
+            case WINDOWS -> OS.WINDOWS;
+            case MAC -> OS.MAC;
+            case LINUX -> OS.LINUX;
+            case NONE -> null;
+        };
+        this.cpu = switch (arch) {
+            case AMD64 -> CPU.x64;
+            case AARCH64 -> CPU.aarch64;
+            case NONE -> null;
+        };
+        this.error = error;
+    }
+
+    public UnsupportedOSBuildItem(OS os, String error) {
+        this(os, null, error);
+    }
+
+    public UnsupportedOSBuildItem(CPU cpu, String error) {
+        this(null, cpu, error);
+    }
+
+    public UnsupportedOSBuildItem(OS os, CPU cpu, String error) {
         this.os = os;
-        this.arch = arch;
+        this.cpu = cpu;
         this.error = error;
     }
 
@@ -65,14 +123,18 @@ public final class UnsupportedOSBuildItem extends MultiBuildItem {
         return
         // When the host OS is unsupported, it could have helped to
         // run in a Linux builder image (e.g. an extension unsupported on Windows).
-        ((os.active && !isContainerBuild) ||
+        ((os != null && os == OS.current() && !isContainerBuild) ||
         // If Linux is the OS the extension does not support,
         // it fails in a container build regardless the host OS,
         // because we have only Linux based builder images.
-                (isContainerBuild && os == Os.LINUX)) ||
+                (isContainerBuild && os == OS.LINUX)) ||
         // We don't do cross-compilation, even builder images have to be
         // of the same arch, e.g. aarch64 Mac using aarch64 Linux builder image.
         // So if the arch is unsupported, it fails.
-                arch.active;
+                cpu != null && cpu == CPU.host();
+    }
+
+    public String error() {
+        return error;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -1046,7 +1046,7 @@ public class NativeImageBuildStep {
                 if (unsupportedOSes != null && !unsupportedOSes.isEmpty()) {
                     final String errs = unsupportedOSes.stream()
                             .filter(o -> o.triggerError(containerBuild))
-                            .map(o -> o.error)
+                            .map(UnsupportedOSBuildItem::error)
                             .collect(Collectors.joining(", "));
                     if (!errs.isEmpty()) {
                         throw new UnsupportedOperationException(errs);

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -1,8 +1,5 @@
 package io.quarkus.awt.deployment;
 
-import static io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem.Arch.AARCH64;
-import static io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem.Os.MAC;
-import static io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem.Os.WINDOWS;
 import static io.quarkus.runtime.graal.GraalVM.Version.CURRENT;
 
 import java.util.ArrayList;
@@ -32,6 +29,8 @@ import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabledBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.pkg.steps.NoopNativeImageBuildRunner;
 import io.quarkus.runtime.graal.GraalVM;
+import io.smallrye.common.cpu.CPU;
+import io.smallrye.common.os.OS;
 
 class AwtProcessor {
 
@@ -51,10 +50,10 @@ class AwtProcessor {
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     void supportCheck(BuildProducer<UnsupportedOSBuildItem> unsupported,
             NativeImageRunnerBuildItem nativeImageRunnerBuildItem) {
-        unsupported.produce(new UnsupportedOSBuildItem(WINDOWS,
+        unsupported.produce(new UnsupportedOSBuildItem(OS.WINDOWS,
                 "Windows AWT integration is not ready in Quarkus native-image and would result in " +
                         "java.lang.UnsatisfiedLinkError: no awt in java.library.path."));
-        unsupported.produce(new UnsupportedOSBuildItem(MAC,
+        unsupported.produce(new UnsupportedOSBuildItem(OS.MAC,
                 "MacOS AWT integration is not ready in Quarkus native-image and would result in " +
                         "java.lang.UnsatisfiedLinkError: Can't load library: awt | java.library.path = [.]."));
         final GraalVM.Version v;
@@ -68,7 +67,7 @@ class AwtProcessor {
 
         if (v.compareTo(io.quarkus.deployment.pkg.steps.GraalVM.Version.VERSION_24_2_0) >= 0
                 && v.compareTo(GraalVM.Version.VERSION_25_0_0) < 0) {
-            unsupported.produce(new UnsupportedOSBuildItem(AARCH64,
+            unsupported.produce(new UnsupportedOSBuildItem(CPU.aarch64,
                     "AWT needs JDK's JEP 454 FFI/FFM support and that is not available for AArch64 with " +
                             "GraalVM's native-image prior to JDK 25, see: " +
                             "https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions"));


### PR DESCRIPTION
This prevents us from having to maintain separate OS and CPU detection algorithms
