### PR TITLE
Fix ResponseExceptionMapper example in rest-client.adoc

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1382,7 +1382,7 @@ public class MyResponseExceptionMapper implements ResponseExceptionMapper<Runtim
     @Override
     public RuntimeException toThrowable(Response response) {
         if (response.getStatus() == 500) {
-            throw new RuntimeException("The remote service responded with HTTP 500");
+            return new RuntimeException("The remote service responded with HTTP 500");
         }
         return null;
     }
@@ -1392,7 +1392,7 @@ public class MyResponseExceptionMapper implements ResponseExceptionMapper<Runtim
 `ResponseExceptionMapper` also defines the `getPriority` method which is used in order to determine the priority with which `ResponseExceptionMapper` implementations will be called (implementations with a lower value for `getPriority` will be invoked first).
 If `toThrowable` returns an exception, then that exception will be thrown. If `null` is returned, the next implementation of `ResponseExceptionMapper` in the chain will be called (if there is any).
 
-The class as written above, would not be automatically be used by any REST Client. To make it available to every REST Client of the application, the class needs to be annotated with `@Provider` (as long as `quarkus.rest-client.provider-autodiscovery` is not set to `false`).
+The class as written above, would not be automatically used by any REST Client. To make it available to every REST Client of the application, the class needs to be annotated with `@Provider` (as long as `quarkus.rest-client.provider-autodiscovery` is not set to `false`).
 Alternatively, if the exception handling class should only apply to specific REST Client interfaces, you can either annotate the interfaces with `@RegisterProvider(MyResponseExceptionMapper.class)`, or register it using configuration using the `providers` property of the proper `quarkus.rest-client` configuration group.
 
 === Using @ClientExceptionMapper


### PR DESCRIPTION
This is a documentation change. I believe we are supposed to __return__ the exception, not throw it. As throwing circumvents whatever may happen after `toThrowable` returns to the framework.

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

