### PR TITLE
Add Gradle repository to Bootstrap Core

### DIFF
--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -121,4 +121,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>gradle</id>
+            <name>Gradle releases repository</name>
+            <url>https://repo.gradle.org/artifactory/libs-releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
It should fix the issues we have in main with `go-offline`.