### PR TITLE
Always start dev services before getting the dev services properties

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -17,9 +17,15 @@ public interface StartupAction {
 
     QuarkusClassLoader getClassLoader();
 
-    Map<String, String> getDevServicesProperties();
+    /**
+     * This will start any dev services that were not started in the augmentation phase.
+     */
+    Map<String, String> getOrInitialiseDevServicesProperties();
 
-    String getDevServicesNetworkId();
+    /**
+     * This will start any dev services that were not started in the augmentation phase.
+     */
+    String getOrInitialiseDevServicesNetworkId();
 
     /**
      * Runs the application by running the main method of the main class. As this is a blocking method a new

--- a/integration-tests/kafka-avro-apicurio2/pom.xml
+++ b/integration-tests/kafka-avro-apicurio2/pom.xml
@@ -97,6 +97,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-kafka-companion</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>

--- a/integration-tests/kafka-avro-apicurio2/src/main/java/io/quarkus/it/kafka/avro/AvroEndpoint.java
+++ b/integration-tests/kafka-avro-apicurio2/src/main/java/io/quarkus/it/kafka/avro/AvroEndpoint.java
@@ -50,6 +50,20 @@ public class AvroEndpoint {
         send(p, pet, "test-avro-apicurio-producer");
     }
 
+    @GET
+    @Path("/companion")
+    public JsonObject getCompanion() {
+        return get(creator.createApicurioConsumer("test-avro-apicurio-companion-consumer",
+                "test-avro-apicurio-companion-consumer"));
+    }
+
+    @POST
+    @Path("/companion")
+    public void sendCompanion(Pet pet) {
+        KafkaProducer<Integer, Pet> p = creator.createApicurioProducer("test-avro-apicurio-companion");
+        send(p, pet, "test-avro-apicurio-companion-producer");
+    }
+
     private JsonObject get(KafkaConsumer<Integer, Pet> consumer) {
         final ConsumerRecords<Integer, Pet> records = consumer.poll(Duration.ofMillis(60000));
         if (records.isEmpty()) {

--- a/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroWithKafkaCompanionTest.java
+++ b/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroWithKafkaCompanionTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.kafka;
+
+import static io.apicurio.registry.serde.avro.AvroKafkaSerdeConfig.USE_SPECIFIC_AVRO_READER;
+import static io.restassured.RestAssured.given;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.quarkus.it.kafka.avro.Pet;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.restassured.http.ContentType;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+
+@QuarkusTest
+@WithTestResource(value = KafkaCompanionResource.class)
+public class KafkaAvroWithKafkaCompanionTest {
+
+    @InjectKafkaCompanion
+    KafkaCompanion kafkaCompanion;
+
+    @Test
+    public void consumeWithCompanion() {
+        kafkaCompanion.getCommonClientConfig().put(USE_SPECIFIC_AVRO_READER, "true");
+        Serde<Pet> avroSerde = Serdes.serdeFrom(new AvroKafkaSerializer<>(), new AvroKafkaDeserializer<>());
+        avroSerde.configure(kafkaCompanion.getCommonClientConfig(), false);
+        kafkaCompanion.registerSerde(Pet.class, avroSerde);
+
+        given().contentType(ContentType.JSON)
+                .body("{\"name\":\"Fluffy\",\"color\":\"ginger\"}")
+                .when()
+                .post("/avro/companion")
+                .then()
+                .statusCode(204);
+
+        given().contentType(ContentType.JSON)
+                .body("{\"name\":\"Fang\",\"color\":\"black\"}")
+                .when()
+                .post("/avro/companion")
+                .then()
+                .statusCode(204);
+
+        ConsumerTask<String, Pet> consumer = kafkaCompanion.consume(Pet.class)
+                .withGroupId("test-group-" + UUID.randomUUID())
+                .withOffsetReset(OffsetResetStrategy.EARLIEST)
+                .fromTopics("test-avro-apicurio-companion-producer");
+
+        List<ConsumerRecord<String, Pet>> received = consumer.awaitRecords(2, Duration.ofSeconds(5L)).getRecords();
+        // check if, after at most 5 seconds, we have at least 2 items collected, and they are what we expect
+        await().atMost(5, SECONDS).until(() -> received.size() >= 2);
+        List<String> pets = received.stream().map(r -> r.value().getName()).toList();
+        assertThat(pets, Matchers.hasItems("Fluffy", "Fang"));
+    }
+}

--- a/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroWithTestResourceTest.java
+++ b/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroWithTestResourceTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.kafka.avro.AvroKafkaCreator;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(value = KafkaResource.class, restrictToAnnotatedClass = true)
+public class KafkaAvroWithTestResourceTest extends KafkaAvroTestBase {
+
+    // This will be injected by the test resource, which is similar in operation to the KafkaCompanion
+    AvroKafkaCreator creator;
+
+    @Override
+    AvroKafkaCreator creator() {
+        return creator;
+    }
+
+    @Test
+    public void testConfluentAvroConsumer() {
+        // Hacky disabling; there's some cross-talk with the KafkaAvroTest causing socket timeouts, so just don't run this test for now
+    }
+
+    @Test
+    public void testApicurioAvroConsumer() {
+        // Hacky disabling; there's some cross-talk with the KafkaAvroTest causing socket timeouts, so just don't run this test for now
+    }
+
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -248,8 +248,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
                     profile,
                     copyEntriesFromProfile(profileInstance, startupAction.getClassLoader()),
                     profileInstance != null && profileInstance.disableGlobalTestResources(),
-                    startupAction.getDevServicesProperties(),
-                    Optional.ofNullable(startupAction.getDevServicesNetworkId()));
+                    startupAction.getOrInitialiseDevServicesProperties(),
+                    Optional.ofNullable(startupAction.getOrInitialiseDevServicesNetworkId()));
             TestResourceUtil.TestResourceManagerReflections.initReflectively(testResourceManager, profile);
             Map<String, String> properties = TestResourceUtil.TestResourceManagerReflections
                     .startReflectively(testResourceManager);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -213,8 +213,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     TestResourceUtil.TestResourceManagerReflections.copyEntriesFromProfile(profileInstance,
                             startupAction.getClassLoader()),
                     profileInstance != null && profileInstance.disableGlobalTestResources(),
-                    startupAction.getDevServicesProperties(),
-                    Optional.ofNullable(startupAction.getDevServicesNetworkId()),
+                    startupAction.getOrInitialiseDevServicesProperties(),
+                    Optional.ofNullable(startupAction.getOrInitialiseDevServicesNetworkId()),
                     testClassLocation);
             TestResourceUtil.TestResourceManagerReflections.initReflectively(testResourceManager, profile);
             Map<String, String> properties = TestResourceUtil.TestResourceManagerReflections


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/49208

This builds on @vonatzigenc's fix, and generalises it. When calling code asks for dev services properties, we should always make sure dev services are started by that point. If nothing asks for those properties, we should start dev services as the first step of the startup sequence. 

This does have the ickiness that the getter method has side effects, and it also means it's a bit loosely-defined when dev services start. The alternative was to have calling code explicitly request dev services be started before calling the getter. On balance, I decided that was more risky. 

I was surprised that we didn't catch this, since the original code broke a quickstart. I haven't investigated that yet, to see if there's anything we can do, but I did add a couple of tests in the main repo which show the problem. 
