### PR TITLE
Tidy up a few commented-out disabled annotations on tests

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleWithPackagePrivateParentTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleWithPackagePrivateParentTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 public class TestFixtureModuleWithPackagePrivateParentTest extends QuarkusGradleWrapperTestBase {
 
-    //@Disabled("See https://github.com/quarkusio/quarkus/issues/47760")
     @Test
     public void testTaskShouldUseTestFixtures() throws IOException, URISyntaxException, InterruptedException {
         final File projectDir = getProjectDir("test-fixtures-module-with-package-private-parent");

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
@@ -58,7 +58,6 @@ public class DevServicesRedisContinuousTestingTest {
         stopAllContainers();
     }
 
-    //    @Disabled("Not currently working")
     @Test
     public void testContinuousTestingDisablesDevServicesWhenPropertiesChange() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();


### PR DESCRIPTION
Trivial, but I noticed a few tests had been enabled but the disabled annotations hadn't been fully removed. 