### PR TITLE
Bump Elasticsearch/OpenSearch containers to latest-compatible with Hibernate Search

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -101,7 +101,7 @@
         <narayana-lra.version>1.0.1.Final</narayana-lra.version>
         <agroal.version>2.7.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-opensource-components.version>9.0.4</elasticsearch-opensource-components.version>
+        <elasticsearch-opensource-components.version>9.1.0</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl-java.version>2.2.5.Final</wildfly.openssl-java.version>
         <wildfly.openssl-linux.version>2.2.2.SP01</wildfly.openssl-linux.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -73,12 +73,12 @@
         <volume.access.modifier>:Z</volume.access.modifier>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>9.0.4</elasticsearch-server.version>
+        <elasticsearch-server.version>9.1.0</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
-        <opensearch-server.version>3.0.0</opensearch-server.version>
+        <opensearch-server.version>3.1.0</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
         <junit-pioneer.version>2.2.0</junit-pioneer.version>

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -820,7 +820,7 @@ as shown below.
 
 [source,properties]
 ----
-quarkus.hibernate-search-orm.elasticsearch.version=opensearch:3.0
+quarkus.hibernate-search-orm.elasticsearch.version=opensearch:3.1
 ----
 
 All other configuration options and APIs are exactly the same as with Elasticsearch.

--- a/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
@@ -738,7 +738,7 @@ as shown below.
 
 [source,properties]
 ----
-quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:3.0
+quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:3.1
 ----
 
 All other configuration options and APIs are exactly the same as with Elasticsearch.

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
@@ -17,11 +17,11 @@ quarkus.hibernate-orm."namedpu".schema-management.strategy=drop-and-create
 
 # Hibernate Search is inactive for the default PU
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=9.0
+quarkus.hibernate-search-orm.elasticsearch.version=9.1
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 
 # ... but it's (implicitly) active for a named PU
-quarkus.hibernate-search-orm."namedpu".elasticsearch.version=9.0
+quarkus.hibernate-search-orm."namedpu".elasticsearch.version=9.1
 quarkus.hibernate-search-orm."namedpu".elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm."namedpu".schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -7,6 +7,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=9.0
+quarkus.hibernate-search-orm.elasticsearch.version=9.1
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -6,6 +6,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=9.0
+quarkus.hibernate-search-orm.elasticsearch.version=9.1
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=9.0
+quarkus.hibernate-search-orm.elasticsearch.version=9.1
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-orm.schema-management.strategy=none

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -2,6 +2,6 @@
 quarkus.devservices.enabled=false
 
 quarkus.hibernate-search-standalone.active=false
-quarkus.hibernate-search-standalone.elasticsearch.version=9.0
+quarkus.hibernate-search-standalone.elasticsearch.version=9.1
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -1,6 +1,6 @@
 # We already start Elasticsearch with Maven
 quarkus.devservices.enabled=false
 
-quarkus.hibernate-search-standalone.elasticsearch.version=9.0
+quarkus.hibernate-search-standalone.elasticsearch.version=9.1
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -1,4 +1,4 @@
-quarkus.hibernate-search-standalone.elasticsearch.version=9.0
+quarkus.hibernate-search-standalone.elasticsearch.version=9.1
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-standalone.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-standalone.schema-management.strategy=none

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.0"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.1"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.0");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.1");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.0"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.1"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.0");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.1");
         }
 
         @Override

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.0"));
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.1"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.0");
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.1");
         }
 
         @Override

--- a/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.0"));
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.1"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.0");
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.1");
         }
 
         @Override


### PR DESCRIPTION
This one builds on top of ORM/Search/Reactive update (https://github.com/quarkusio/quarkus/pull/49344) and includes both client version update + update to the latest supported versions of Elasticsearch/Opensearch.

I think we also will need to bump the versions in the quickstarts. I'll double-check and open another PR over there if needed.

* Supersedes #49241

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

