### PR TITLE
Offline startup and dialect configuration for Hibernate ORM

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -54,6 +54,7 @@
 :quickstarts-tree-url: ${quickstarts-base-url}/tree/main
 // .
 :hibernate-orm-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/userguide/html_single/Hibernate_User_Guide.html
+:hibernate-orm-javadocs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/javadocs/
 :hibernate-orm-dialect-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/dialect/dialect.html
 :hibernate-search-docs-url: https://docs.jboss.org/hibernate/search/{hibernate-search-version-major-minor}/reference/en-US/html_single/
 :hibernate-validator-docs-url: https://docs.jboss.org/hibernate/validator/{hibernate-validator-version-major-minor}/reference/en-US/html_single/

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -864,6 +864,46 @@ link in the Flyway pane. Hit the `Create Initial Migration` button and the follo
 WARNING: This button is simply a convenience to quickly get you started with Flyway, it is up to you to determine how you want to
 manage your database schemas in production. In particular the `migrate-at-start` setting may not be right for all environments.
 
+[[offline]]
+== Offline startup
+
+By default, Hibernate attempts to connect to the database at startup to fetch metadata. This is useful, for example, to validate the schema or create some temporary tables, making the startup process smoother and more user-friendly.
+
+However, in certain environments, such as when running a Quarkus application in a container within a Kubernetes
+cluster, this connection might not be possible. For example, if the application runs in one pod and the database
+in another, the database may not be reachable at startup time.
+To address this, Quarkus provides an _offline startup_ mode, which allows Hibernate to skip connecting to the database
+during application startup.
+
+When using offline startup, it's important to ensure that the database schema has already been created correctly before
+the application starts.
+
+You can rely on xref:flyway.adoc[Flyway], xref:liquibase.adoc[Liquibase] or custom setups to create/migrate your database schema,
+though obviously at a time where the database _is_ accessible --
+Flyway's `migrate-at-start` option in particular will just fail at application startup
+if the database is not reachable.
+
+To enable offline startup, set the following configuration property:
+
+[source,properties]
+.application.properties
+----
+quarkus.hibernate-orm.database.start-offline=true
+----
+
+
+You can also fine-tune dialect behavior for specific databases using additional properties, such as:
+
+[source,properties]
+.application.properties
+----
+quarkus.hibernate-orm."offline".dialect.mariadb.bytes-per-character=1
+quarkus.hibernate-orm."offline".dialect.mariadb.no-backslash-escapes=true
+----
+
+Refer to the <<hibernate-configuration-properties,Hibernate ORM configuration properties>> section for more details on the available properties.
+
+
 [[caching]]
 == Caching
 

--- a/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DatabaseKind.java
+++ b/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DatabaseKind.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -97,7 +98,7 @@ public final class DatabaseKind {
     private DatabaseKind() {
     }
 
-    private enum SupportedDatabaseKind {
+    public enum SupportedDatabaseKind {
         DB2(DatabaseKind.DB2),
         DERBY(DatabaseKind.DERBY),
         H2(DatabaseKind.H2),
@@ -110,16 +111,30 @@ public final class DatabaseKind {
         private final String mainName;
         private final Set<String> aliases;
 
-        private SupportedDatabaseKind(String mainName) {
+        SupportedDatabaseKind(String mainName) {
             this.mainName = mainName;
             this.aliases = Collections.singleton(mainName);
         }
 
-        private SupportedDatabaseKind(String mainName, String... aliases) {
+        SupportedDatabaseKind(String mainName, String... aliases) {
             this.mainName = mainName;
             this.aliases = new HashSet<>();
             this.aliases.add(mainName);
             this.aliases.addAll(Arrays.asList(aliases));
+        }
+
+        public String getMainName() {
+            return mainName;
+        }
+
+        public static Optional<SupportedDatabaseKind> from(String name) {
+            String normalizedName = normalize(name);
+            for (SupportedDatabaseKind kind : values()) {
+                if (kind.getMainName().equals(normalizedName)) {
+                    return Optional.of(kind);
+                }
+            }
+            return Optional.empty();
         }
     }
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -304,12 +304,41 @@ public interface HibernateOrmConfigPersistenceUnit {
          *
          * E.g. `MyISAM` or `InnoDB` for MySQL.
          *
+         * @deprecated Use {@code mysql.}{@linkplain MySQLDialectConfig#storageEngine storage-engine}
+         *             or {@code mariadb.}{@linkplain MySQLDialectConfig#storageEngine storage-engine} instead
+         *
          * @asciidoclet
          */
-        Optional<@WithConverter(TrimmedStringConverter.class) String> storageEngine();
+        @WithConverter(TrimmedStringConverter.class)
+        @Deprecated
+        Optional<String> storageEngine();
+
+        /**
+         * Configuration specific to Hibernate's Dialect for MariaDB
+         */
+        MySQLDialectConfig mariadb();
+
+        /**
+         * Configuration specific to Hibernate's Dialect for MySQL
+         */
+        MySQLDialectConfig mysql();
+
+        /**
+         * Configuration specific to Hibernate's Dialect for Oracle
+         */
+        OracleDialectConfig oracle();
+
+        /**
+         * Configuration specific to Hibernate's Dialect for Microsoft SQLServer
+         */
+        SqlServerDialectConfig mssql();
 
         default boolean isAnyPropertySet() {
-            return dialect().isPresent() || storageEngine().isPresent();
+            return dialect().isPresent() || storageEngine().isPresent()
+                    || mysql().isAnyPropertySet()
+                    || oracle().isAnyPropertySet()
+                    || mssql().isAnyPropertySet()
+                    || mariadb().isAnyPropertySet();
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/MySQLDialectConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/MySQLDialectConfig.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.orm.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
+
+/**
+ * Configuration specific to the Hibernate ORM {@linkplain org.hibernate.dialect.MySQLDialect},
+ * though may also affect other dialects such as {@linkplain org.hibernate.dialect.MariaDBDialect}.
+ *
+ * @author Steve Ebersole
+ */
+@ConfigGroup
+public interface MySQLDialectConfig {
+    /**
+     * Specifies the bytes per character to use based on the database's configured
+     * <a href="https://dev.mysql.com/doc/refman/8.0/en/charset-charsets.html">charset</a>.
+     *
+     * @see org.hibernate.cfg.DialectSpecificSettings#MYSQL_BYTES_PER_CHARACTER
+     */
+    @ConfigDocDefault("4")
+    Optional<Integer> bytesPerCharacter();
+
+    /**
+     * Specifies whether the {@code NO_BACKSLASH_ESCAPES} sql mode is enabled.
+     *
+     * @see org.hibernate.cfg.DialectSpecificSettings#MYSQL_NO_BACKSLASH_ESCAPES
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> noBackslashEscapes();
+
+    /**
+     * The storage engine to use.
+     */
+    @WithConverter(TrimmedStringConverter.class)
+    Optional<String> storageEngine();
+
+    default boolean isAnyPropertySet() {
+        return bytesPerCharacter().isPresent()
+                || noBackslashEscapes().isPresent()
+                || storageEngine().isPresent();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/OracleDialectConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/OracleDialectConfig.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.orm.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+/**
+ * Configuration specific to the Hibernate ORM {@linkplain org.hibernate.dialect.OracleDialect}
+ *
+ * @author Steve Ebersole
+ */
+@ConfigGroup
+public interface OracleDialectConfig {
+
+    /**
+     * Support for Oracle's MAX_STRING_SIZE = EXTENDED.
+     *
+     * @see org.hibernate.cfg.DialectSpecificSettings#ORACLE_EXTENDED_STRING_SIZE
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> extended();
+
+    /**
+     * Specifies whether this database is running on an Autonomous Database Cloud Service.
+     *
+     * @see org.hibernate.cfg.DialectSpecificSettings#ORACLE_AUTONOMOUS_DATABASE
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> autonomous();
+
+    /**
+     * Specifies whether this database is accessed using a database service protected by Application Continuity.
+     *
+     * @see org.hibernate.cfg.DialectSpecificSettings#ORACLE_APPLICATION_CONTINUITY
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> applicationContinuity();
+
+    default boolean isAnyPropertySet() {
+        return extended().isPresent()
+                || autonomous().isPresent()
+                || applicationContinuity().isPresent();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/SqlServerDialectConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/SqlServerDialectConfig.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
+
+/**
+ * Configuration specific to the Hibernate ORM {@linkplain org.hibernate.dialect.SQLServerDialect}
+ *
+ * @author Steve Ebersole
+ */
+@ConfigGroup
+public interface SqlServerDialectConfig {
+    /**
+     * The {@code compatibility_level} as defined in {@code sys.databases}.
+     *
+     * @see org.hibernate.cfg.DialectSpecificSettings#SQL_SERVER_COMPATIBILITY_LEVEL
+     */
+    @WithConverter(TrimmedStringConverter.class)
+    Optional<String> compatibilityLevel();
+
+    default boolean isAnyPropertySet() {
+        return compatibilityLevel().isPresent();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/DevServicesSchemaManagementStrategyTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/DevServicesSchemaManagementStrategyTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.hibernate.orm.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DevServicesSchemaManagementStrategyTest {
+
+    // A simple runner like this will trigger Dev Services
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withEmptyApplication();
+
+    @Test
+    public void testDevServices() {
+        String value = ConfigProvider.getConfig()
+                .getValue("quarkus.hibernate-orm.schema-management.strategy", String.class);
+        assertThat(value).isEqualTo("drop-and-create");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMariaDBIgnoredTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMariaDBIgnoredTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DialectSpecificSettingsMariaDBIgnoredTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mariadb-dialect.properties", "application.properties"))
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .overrideConfigKey("quarkus.datasource.db-kind", "") // This will override to default which is H2
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.storage-engine", "")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mariadb.bytes-per-character", "8") // This will be ignored
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mariadb.no-backslash-escapes", "true") // This will be ignored
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(
+                                l -> l.contains("MariaDB specific settings being ignored because the database is not MariaDB"));
+            });
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.bytes_per_character"))
+                .isEqualTo(null);
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.no_backslash_escapes"))
+                .isEqualTo(null);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMariaDBTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMariaDBTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test Maria DB Dialect specific settings with MariaDB DBKind
+ */
+public class DialectSpecificSettingsMariaDBTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mariadb-dialect.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mariadb-deployment", Version.getVersion())))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mariadb.bytes-per-character", "8")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mariadb.no-backslash-escapes", "true");
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.bytes_per_character"))
+                .isEqualTo("8");
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.no_backslash_escapes"))
+                .isEqualTo("true");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMySQLIgnoredTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMySQLIgnoredTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DialectSpecificSettingsMySQLIgnoredTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mysql-dialect.properties", "application.properties"))
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .overrideConfigKey("quarkus.datasource.db-kind", "") // This will override to default which is H2
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.storage-engine", "")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mysql.bytes-per-character", "8") // This will be ignored
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mysql.no-backslash-escapes", "true") // This will be ignored
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(l -> l.contains("MySQL specific settings being ignored because the database is not MySQL"));
+            });
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.bytes_per_character"))
+                .isEqualTo(null);
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.no_backslash_escapes"))
+                .isEqualTo(null);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMySQLTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsMySQLTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test MySQL Dialect specific settings with MySQL DBKind
+ */
+public class DialectSpecificSettingsMySQLTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mysql-dialect.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mysql-deployment", Version.getVersion())))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mysql.no-backslash-escapes", "true")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mysql.bytes-per-character", "8");
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.bytes_per_character"))
+                .isEqualTo("8");
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.mysql.no_backslash_escapes"))
+                .isEqualTo("true");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsOracleIgnoredTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsOracleIgnoredTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DialectSpecificSettingsOracleIgnoredTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-oracle-dialect.properties", "application.properties"))
+            .overrideConfigKey("quarkus.datasource.db-kind", "") // This will override to default which is H2
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.oracle.application-continuity", "true") // this will be ignored
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.oracle.autonomous", "true") // this will be ignored
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.oracle.extended", "true") // this will be ignored
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(l -> l.contains("Oracle specific settings being ignored because the database is not Oracle"));
+            });
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.oracle.application_continuity"))
+                .isEqualTo(null);
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.oracle.is_autonomous"))
+                .isEqualTo(null);
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.oracle.extended_string_size"))
+                .isEqualTo(null);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsOracleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsOracleTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test Oracle Dialect specific settings with Oracle DBKind
+ */
+public class DialectSpecificSettingsOracleTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-oracle-dialect.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-oracle-deployment", Version.getVersion())))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.oracle.application-continuity", "true")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.oracle.autonomous", "true")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.oracle.extended", "true");
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.oracle.application_continuity"))
+                .isEqualTo("true");
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.oracle.is_autonomous"))
+                .isEqualTo("true");
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.oracle.extended_string_size"))
+                .isEqualTo("true");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsSQLServerIgnoredTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsSQLServerIgnoredTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DialectSpecificSettingsSQLServerIgnoredTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mssql-dialect.properties", "application.properties"))
+            .overrideConfigKey("quarkus.datasource.db-kind", "") // This will override to default which is H2
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mssql.compatibility-level", "170") // this will be ignored
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(l -> l.contains(
+                                "SQL Server specific settings being ignored because the database is not SQL Server."));
+            });
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.sqlserver.compatibility_level"))
+                .isEqualTo(null);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsSQLServerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DialectSpecificSettingsSQLServerTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test SQL Server Dialect specific settings with MSSQL DBKind
+ */
+public class DialectSpecificSettingsSQLServerTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mssql-dialect.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mssql-deployment", Version.getVersion())))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mssql.compatibility-level", "170");
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory.getProperties().get("hibernate.dialect.sqlserver.compatibility_level"))
+                .isEqualTo("170");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageBaseDeprecatedTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageBaseDeprecatedTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test dialects specifics values can be configured
+ */
+public class StorageBaseDeprecatedTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mysql-dialect.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mysql-deployment", Version.getVersion())))
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(l -> l.contains("The storage engine set through configuration property "));
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(l -> l.contains("is deprecated;"));
+            });
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory).isNotNull();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageSpecificMariaDBTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageSpecificMariaDBTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test Maria DB storage engine with MySql dialect
+ */
+public class StorageSpecificMariaDBTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mysql-dialect.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mysql-deployment", Version.getVersion())))
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.storage-engine", "")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mariadb.storage-engine", "innodb");
+
+    @Test
+    public void applicationStarts() {
+        assertThat(System.getProperty("hibernate.dialect.storage_engine")).isEqualTo("innodb");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageSpecificMysqlDBIgnoredTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageSpecificMysqlDBIgnoredTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test MySQL storage engine with H2
+ */
+public class StorageSpecificMysqlDBIgnoredTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mariadb-dialect.properties", "application.properties"))
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .overrideConfigKey("quarkus.datasource.db-kind", "") // This will override to default which is H2
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.storage-engine", "")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mysql.storage-engine", "innodb") // This will be ignored
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(l -> l.contains("The storage engine set through configuration property"));
+                assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .anyMatch(l -> l.contains("is being ignored because the database is neither MySQL nor MariaDB."));
+            });
+
+    @Test
+    public void applicationStarts() {
+        // Application starts successfuly
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageSpecificMysqlDBTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/StorageSpecificMysqlDBTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.deployment.util.HibernateProcessorUtil;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test Mysql DB storage engine with MariaDB dialect
+ */
+public class StorageSpecificMysqlDBTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline-mariadb-dialect.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mariadb-deployment", Version.getVersion())))
+            .setLogRecordPredicate(record -> HibernateProcessorUtil.class.getName().equals(record.getLoggerName()))
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.storage-engine", "")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect.mysql.storage-engine", "innodb");
+
+    @Test
+    public void applicationStarts() {
+        assertThat(System.getProperty("hibernate.dialect.storage_engine")).isEqualTo("innodb");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsInconsistentStorageEnginesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsInconsistentStorageEnginesTest.java
@@ -1,13 +1,18 @@
 package io.quarkus.hibernate.orm.multiplepersistenceunits;
 
-import org.hibernate.dialect.H2Dialect;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.builder.Version;
 import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.DefaultEntity;
 import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.inventory.Plane;
 import io.quarkus.hibernate.orm.multiplepersistenceunits.model.config.user.User;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -15,24 +20,23 @@ public class MultiplePersistenceUnitsInconsistentStorageEnginesTest {
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
-            .setExpectedException(ConfigurationException.class)
             .withApplicationRoot((jar) -> jar
                     .addClass(User.class)
                     .addClass(DefaultEntity.class)
                     .addClass(User.class)
                     .addClass(Plane.class)
                     .addAsResource("application-multiple-persistence-units-inconsistent-storage-engines.properties",
-                            "application.properties"));
+                            "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mysql-deployment", Version.getVersion())))
+            .assertException(throwable -> assertThat(throwable)
+                    .isInstanceOf(ConfigurationException.class)
+                    .hasMessageContaining(
+                            "The dialect storage engine is a global configuration property: it must be consistent across all persistence units."));
 
     @Test
     public void testInvalidConfiguration() {
         // deployment exception should happen first
         Assertions.fail();
-    }
-
-    /**
-     * This is just to have the dialect matching MySQL and trigger the MySQL + storage engines check.
-     */
-    public static class H2DialectWithMySQLInTheName extends H2Dialect {
     }
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/DevServicesOfflineStartDisabledTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/DevServicesOfflineStartDisabledTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DevServicesOfflineStartDisabledTest {
+
+    // A simple runner like this will trigger Dev Services
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.hibernate-orm.database.start-offline", "false")
+            .withEmptyApplication()
+            .setLogRecordPredicate(record -> "io.quarkus.config".equals(record.getLoggerName()));
+
+    @Test
+    public void testOfflineDisabledStrategyDropCreate() {
+        String value = ConfigProvider.getConfig()
+                .getValue("quarkus.hibernate-orm.schema-management.strategy", String.class);
+        assertThat(value).isEqualTo("drop-and-create");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/DevServicesOfflineStartTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/DevServicesOfflineStartTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.hibernate.orm.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DevServicesOfflineStartTest {
+
+    // A simple runner like this will trigger Dev Services
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.hibernate-orm.database.start-offline", "true")
+            .withEmptyApplication()
+            .setLogRecordPredicate(record -> "io.quarkus.config".equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records) // Configuration keys mispelled
+                        .extracting(LogRecord::getMessage)
+                        .noneMatch(msg -> msg.contains("Unrecognized configuration key"));
+            });
+
+    @Test
+    public void testDevServices() {
+        String value = ConfigProvider.getConfig()
+                .getValue("quarkus.hibernate-orm.schema-management.strategy", String.class);
+        assertThat(value).isEqualTo("none");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineSchemaManagementTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineSchemaManagementTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.hibernate.orm.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.tool.schema.Action.CREATE_DROP;
+
+import java.util.logging.LogRecord;
+
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that if enable quarkus.hibernate-orm.schema-management.strategy during offline mode,
+ * application start will fail
+ */
+public class StartOfflineSchemaManagementTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline.properties", "application.properties"))
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", CREATE_DROP.getExternalHbm2ddlName())
+            .setLogRecordPredicate(record -> "io.quarkus.config".equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                assertThat(records) // Configuration keys mispelled
+                        .extracting(LogRecord::getMessage)
+                        .noneMatch(msg -> msg.contains("Unrecognized configuration key"));
+            })
+            .assertException(
+                    throwable -> assertThat(throwable)
+                            .hasNoSuppressedExceptions()
+                            .hasMessageContaining(
+                                    "When using offline mode with `quarkus.hibernate-orm.database.start-offline=true`, the schema management strategy `quarkus.hibernate-orm.schema-management.strategy` must be unset or set to `none`"));
+
+    @Test
+    @Transactional
+    public void applicationStarts() {
+        Assertions.fail("Startup has failed");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.hibernate.orm.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.config.internal.ConfigurationServiceImpl;
+import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableStrategy;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.runtime.service.QuarkusRuntimeInitDialectFactory;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that an application can be configured to start successfully
+ * even if the database is offline when the application starts.
+ */
+public class StartOfflineTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline.properties", "application.properties"))
+            .setLogRecordPredicate(record -> GlobalTemporaryTableStrategy.class.getName().equals(record.getLoggerName())
+                    || record.getLoggerName().contains("JdbcEnvironmentInitiator"))
+            .assertLogRecords(records -> {
+                assertThat(records) // JdbcSettings.ALLOW_METADATA_ON_BOOT
+                        .extracting(LogRecord::getMessage)
+                        .doesNotContain("HHH000342: Could not obtain connection to query JDBC database metadata");
+                assertThat(records) // Local TemporaryTable Strategy
+                        .extracting(LogRecord::getMessage).doesNotContain("Unable obtain JDBC Connection");
+            });
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(entityManagerFactory).isNotNull();
+    }
+
+    @Test
+    public void testVersionCheckShouldBeDisabledWhenOffline() {
+        SessionFactoryImplementor sfi = (SessionFactoryImplementor) entityManagerFactory.unwrap(SessionFactory.class);
+        ServiceRegistryImplementor registry = sfi.getServiceRegistry();
+
+        QuarkusRuntimeInitDialectFactory service = (QuarkusRuntimeInitDialectFactory) registry.getService(DialectFactory.class);
+        assertThat(service.isVersionCheckEnabled()).isFalse();
+    }
+
+    @Test
+    public void testUnitSchemaManagementStrategyIsNone() {
+        Object strategy = entityManagerFactory.unwrap(SessionFactoryImplementor.class)
+                .getServiceRegistry()
+                .getService(ConfigurationServiceImpl.class)
+                .getSettings()
+                .get(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION);
+        assertThat(strategy).isEqualTo("none");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineVersionCheckTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/offline/StartOfflineVersionCheckTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that if enable versionCheckEnabled during offline mode,
+ * application start will fail
+ */
+public class StartOfflineVersionCheckTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class)
+                    .addAsResource("application-start-offline.properties", "application.properties"))
+            .overrideConfigKey("quarkus.hibernate-orm.database.version-check.enabled", "true")
+            .assertException(
+                    throwable -> assertThat(throwable)
+                            .hasNoSuppressedExceptions()
+                            .hasMessageContaining(
+                                    "When using offline mode `quarkus.hibernate-orm.database.start-offline=true`, version check `quarkus.hibernate-orm.database.version-check.enabled` must be unset or set to `false`"));
+
+    @Test
+    @Transactional
+    public void applicationStarts() {
+        Assertions.fail("Startup has failed");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-inconsistent-storage-engines.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-inconsistent-storage-engines.properties
@@ -1,24 +1,21 @@
-quarkus.datasource.db-kind=h2
+quarkus.datasource.db-kind=mysql
 quarkus.datasource.jdbc.url=jdbc:h2:mem:default
 
-quarkus.datasource.users.db-kind=h2
+quarkus.datasource.users.db-kind=mysql
 quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
 
-quarkus.datasource.inventory.db-kind=h2
+quarkus.datasource.inventory.db-kind=mysql
 quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
-quarkus.hibernate-orm.dialect=io.quarkus.hibernate.orm.multiplepersistenceunits.MultiplePersistenceUnitsInconsistentStorageEnginesTest$H2DialectWithMySQLInTheName
-quarkus.hibernate-orm.dialect.storage-engine=engine1
+quarkus.hibernate-orm.dialect.mysql.storage-engine=engine1
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model
 
-quarkus.hibernate-orm."users".dialect=io.quarkus.hibernate.orm.multiplepersistenceunits.MultiplePersistenceUnitsInconsistentStorageEnginesTest$H2DialectWithMySQLInTheName
-quarkus.hibernate-orm."users".dialect.storage-engine=engine2
+quarkus.hibernate-orm."users".dialect.mysql.storage-engine=engine2
 quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users
 quarkus.hibernate-orm."users".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.user
 
-quarkus.hibernate-orm."inventory".dialect=io.quarkus.hibernate.orm.multiplepersistenceunits.MultiplePersistenceUnitsInconsistentStorageEnginesTest$H2DialectWithMySQLInTheName
 quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."inventory".datasource=inventory
 quarkus.hibernate-orm."inventory".packages=io.quarkus.hibernate.orm.multiplepersistenceunits.model.inventory

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-mariadb-dialect.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-mariadb-dialect.properties
@@ -1,0 +1,10 @@
+quarkus.datasource.db-kind=mariadb
+
+# Simulate an offline database by pointing to a non-existing database
+# The option IFEXISTS is required to avoid creating the database
+quarkus.datasource.jdbc.url=jdbc:h2:/non/existing/database;IFEXISTS=TRUE
+
+# we start offline so we won't check if the DB actually exists
+quarkus.hibernate-orm.database.start-offline=true
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
+quarkus.hibernate-orm.dialect.storage-engine=innodb

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-mssql-dialect.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-mssql-dialect.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.db-kind=mssql
+
+# Simulate an offline database by pointing to a non-existing database
+# The option IFEXISTS is required to avoid creating the database
+quarkus.datasource.jdbc.url=jdbc:h2:/non/existing/database;IFEXISTS=TRUE
+
+# we start offline so we won't check if the DB actually exists
+quarkus.hibernate-orm.database.start-offline=true
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServerDialect

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-mysql-dialect.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-mysql-dialect.properties
@@ -1,0 +1,10 @@
+quarkus.datasource.db-kind=mysql
+
+# Simulate an offline database by pointing to a non-existing database
+# The option IFEXISTS is required to avoid creating the database
+quarkus.datasource.jdbc.url=jdbc:h2:/non/existing/database;IFEXISTS=TRUE
+
+# we start offline so we won't check if the DB actually exists
+quarkus.hibernate-orm.database.start-offline=true
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MySQLDialect
+quarkus.hibernate-orm.dialect.storage-engine=innodb

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-oracle-dialect.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline-oracle-dialect.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.db-kind=oracle
+
+# Simulate an offline database by pointing to a non-existing database
+# The option IFEXISTS is required to avoid creating the database
+quarkus.datasource.jdbc.url=jdbc:h2:/non/existing/database;IFEXISTS=TRUE
+
+# we start offline so we won't check if the DB actually exists
+quarkus.hibernate-orm.database.start-offline=true
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.OracleDialect

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-start-offline.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.db-kind=h2
+
+# Simulate an offline database by pointing to a non-existing database
+# The option IFEXISTS is required to avoid creating the database
+quarkus.datasource.jdbc.url=jdbc:h2:/non/existing/database;IFEXISTS=TRUE
+
+# we start offline so we won't check if the DB actually exists
+quarkus.hibernate-orm.database.start-offline=true

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -112,11 +112,22 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        // TODO disable the check by default when offline startup is opted in
-        //   See https://github.com/quarkusio/quarkus/issues/13522
         @WithName("version-check.enabled")
-        @ConfigDocDefault("`true`")
+        @ConfigDocDefault("`false` if starting offline (see `start-offline`), `true` otherwise")
         Optional<Boolean> versionCheckEnabled();
+
+        /**
+         * Instructs Hibernate ORM to avoid connecting to the database on startup.
+         *
+         * When starting offline:
+         * * Hibernate ORM will not attempt to create a schema automatically, so it must already be created when the application
+         * hits the database for the first time.
+         * * Quarkus will not check that the database version matches the one configured at build time.
+         *
+         * @asciidoclet
+         */
+        @WithDefault("false")
+        boolean startOffline();
     }
 
     @ConfigGroup

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedConfig.java
@@ -16,6 +16,7 @@ import io.quarkus.runtime.annotations.RecordableConstructor;
 public class RecordedConfig {
     private final Optional<String> dataSource;
     private final Optional<String> dbKind;
+    private final Optional<String> supportedDBkind;
     private final Optional<String> dbVersion;
     private final Optional<String> explicitDialect;
     private final MultiTenancyStrategy multiTenancyStrategy;
@@ -26,6 +27,7 @@ public class RecordedConfig {
 
     @RecordableConstructor
     public RecordedConfig(Optional<String> dataSource, Optional<String> dbKind,
+            Optional<String> supportedDBkind,
             Optional<String> dbVersion, Optional<String> explicitDialect,
             MultiTenancyStrategy multiTenancyStrategy,
             DatabaseOrmCompatibilityVersion databaseOrmCompatibilityVersion,
@@ -34,10 +36,12 @@ public class RecordedConfig {
             Map<String, String> quarkusConfigUnsupportedProperties) {
         Objects.requireNonNull(dataSource);
         Objects.requireNonNull(dbKind);
+        Objects.requireNonNull(supportedDBkind);
         Objects.requireNonNull(dbVersion);
         Objects.requireNonNull(multiTenancyStrategy);
         this.dataSource = dataSource;
         this.dbKind = dbKind;
+        this.supportedDBkind = supportedDBkind;
         this.dbVersion = dbVersion;
         this.explicitDialect = explicitDialect;
         this.multiTenancyStrategy = multiTenancyStrategy;
@@ -53,6 +57,10 @@ public class RecordedConfig {
 
     public Optional<String> getDbKind() {
         return dbKind;
+    }
+
+    public Optional<String> getSupportedDBkind() {
+        return supportedDBkind;
     }
 
     public Optional<String> getDbVersion() {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactory.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactory.java
@@ -113,4 +113,9 @@ public class QuarkusRuntimeInitDialectFactory implements DialectFactory {
             return Optional.empty();
         }
     }
+
+    // Used for testing purposes
+    public boolean isVersionCheckEnabled() {
+        return versionCheckEnabled;
+    }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactoryInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactoryInitiator.java
@@ -3,6 +3,8 @@ package io.quarkus.hibernate.orm.runtime.service;
 import java.util.Map;
 import java.util.Optional;
 
+import jakarta.persistence.PersistenceException;
+
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
@@ -32,10 +34,16 @@ public class QuarkusRuntimeInitDialectFactoryInitiator implements StandardServic
         // We set the version from the dialect since if it wasn't provided explicitly through the `recordedConfig.getDbVersion()`
         // then the version from `DialectVersions.Defaults` will be used:
         this.buildTimeDbVersion = dialect.getVersion();
+        HibernateOrmRuntimeConfigPersistenceUnit.HibernateOrmConfigPersistenceUnitDatabase database = runtimePuConfig
+                .database();
+
+        if (database.startOffline() && database.versionCheckEnabled().filter(v -> v.booleanValue()).isPresent()) {
+            throw new PersistenceException(
+                    "When using offline mode `quarkus.hibernate-orm.database.start-offline=true`, version check `quarkus.hibernate-orm.database.version-check.enabled` must be unset or set to `false`");
+        }
+
         this.versionCheckEnabled = runtimePuConfig.database().versionCheckEnabled()
-                // TODO disable the check by default when offline startup is opted in
-                //   See https://github.com/quarkusio/quarkus/issues/13522
-                .orElse(true);
+                .orElse(!database.startOffline());
     }
 
     @Override

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/offline/StartOfflineSchemaManagementTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/offline/StartOfflineSchemaManagementTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.hibernate.reactive.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.tool.schema.Action.CREATE_DROP;
+
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.entities.Hero;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that if enable quarkus.hibernate-orm.schema-management.strategy during offline mode,
+ * application start will fail
+ */
+public class StartOfflineSchemaManagementTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(Hero.class)
+                    .addAsResource("application-start-offline.properties", "application.properties"))
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", CREATE_DROP.getExternalHbm2ddlName())
+            .assertException(
+                    throwable -> assertThat(throwable)
+                            .hasNoSuppressedExceptions()
+                            .hasMessageContaining(
+                                    "When using offline mode with `quarkus.hibernate-orm.database.start-offline=true`, the schema management strategy `quarkus.hibernate-orm.schema-management.strategy` must be unset or set to `none`"));
+
+    @Test
+    @Transactional
+    public void applicationStarts() {
+        Assertions.fail("Startup has failed");
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/offline/StartOfflineTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/offline/StartOfflineTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.hibernate.reactive.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.config.internal.ConfigurationServiceImpl;
+import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
+import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableStrategy;
+import org.hibernate.reactive.common.spi.Implementor;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.hibernate.orm.runtime.service.QuarkusRuntimeInitDialectFactory;
+import io.quarkus.hibernate.reactive.entities.Hero;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that an application can be configured to start successfully
+ * even if the database is offline when the application starts.
+ */
+public class StartOfflineTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(Hero.class)
+                    .addAsResource("application-start-offline.properties", "application.properties"))
+            .setLogRecordPredicate(record -> GlobalTemporaryTableStrategy.class.getName().equals(record.getLoggerName())
+                    || record.getLoggerName().contains("JdbcEnvironmentInitiator"))
+            .assertLogRecords(records -> {
+                assertThat(records) // JdbcSettings.ALLOW_METADATA_ON_BOOT
+                        .extracting(LogRecord::getMessage)
+                        .doesNotContain("HHH000342: Could not obtain connection to query JDBC database metadata");
+                assertThat(records) // GlobalTemporaryTableStrategy.CREATE_ID_TABLES
+                        .extracting(LogRecord::getMessage).doesNotContain("Unable obtain JDBC Connection");
+            });
+
+    @Inject
+    Mutiny.SessionFactory factory;
+
+    @Test
+    public void applicationStarts() {
+        assertThat(factory).isNotNull();
+    }
+
+    @Test
+    public void testVersionCheckShouldBeDisabledWhenOffline() {
+        Implementor sfi = (Implementor) ClientProxy.unwrap(factory);
+        ServiceRegistry registry = sfi.getServiceRegistry();
+
+        QuarkusRuntimeInitDialectFactory service = (QuarkusRuntimeInitDialectFactory) registry.getService(DialectFactory.class);
+        assertThat(service.isVersionCheckEnabled()).isFalse();
+    }
+
+    @Test
+    public void testUnitSchemaManagementStrategyIsNone() {
+        Object strategy = ((Implementor) ClientProxy.unwrap(factory))
+                .getServiceRegistry()
+                .getService(ConfigurationServiceImpl.class)
+                .getSettings()
+                .get(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION);
+        assertThat(strategy).isEqualTo("none");
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/offline/StartOfflineVersionCheckTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/offline/StartOfflineVersionCheckTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.reactive.offline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.transaction.Transactional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.entities.Hero;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that if enable versionCheckEnabled during offline mode,
+ * application start will fail
+ */
+public class StartOfflineVersionCheckTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(Hero.class)
+                    .addAsResource("application-start-offline.properties", "application.properties"))
+            .overrideConfigKey("quarkus.hibernate-orm.database.version-check.enabled", "true")
+            .assertException(
+                    throwable -> assertThat(throwable)
+                            .hasNoSuppressedExceptions()
+                            .hasMessageContaining(
+                                    "When using offline mode `quarkus.hibernate-orm.database.start-offline=true`, version check `quarkus.hibernate-orm.database.version-check.enabled` must be unset or set to `false`"));
+
+    @Test
+    @Transactional
+    public void applicationStarts() {
+        Assertions.fail("Startup has failed");
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-start-offline.properties
@@ -1,0 +1,13 @@
+
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.reactive=true
+
+# Simulate an offline database by pointing to a non-existing database
+quarkus.datasource.reactive.url=vertx-reactive:postgresql://nonexisting:5431/hibernate_orm_test
+
+quarkus.hibernate-orm.database.start-offline=true
+
+# Hibernate config
+quarkus.hibernate-orm.schema-management.strategy=none
+
+

--- a/integration-tests/jpa-mariadb/src/main/java/io/quarkus/it/jpa/mariadb/OfflineDialectDescriptor.java
+++ b/integration-tests/jpa-mariadb/src/main/java/io/quarkus/it/jpa/mariadb/OfflineDialectDescriptor.java
@@ -1,0 +1,68 @@
+package io.quarkus.it.jpa.mariadb;
+
+import org.hibernate.dialect.MariaDBDialect;
+
+public class OfflineDialectDescriptor {
+    private Integer bytesPerCharacter;
+    private Boolean noBackslashEscapes;
+    private String storageEngine;
+
+    public OfflineDialectDescriptor(MariaDBDialect dialect, String storageEngine) {
+        this(
+                determineBytesPerCharacter(dialect),
+                dialect.isNoBackslashEscapesEnabled(),
+                storageEngine);
+    }
+
+    private static Integer determineBytesPerCharacter(MariaDBDialect dialect) {
+        if (dialect.getMaxVarcharLength() == 65_535) {
+            return 1;
+        }
+        if (dialect.getMaxVarcharLength() == 32_767) {
+            return 2;
+        }
+        if (dialect.getMaxVarcharLength() == 21_844) {
+            return 3;
+        }
+        return 4;
+    }
+
+    public OfflineDialectDescriptor(Integer bytesPerCharacter, Boolean noBackslashEscapes, String storageEngine) {
+        this.bytesPerCharacter = bytesPerCharacter;
+        this.noBackslashEscapes = noBackslashEscapes;
+        this.storageEngine = storageEngine;
+    }
+
+    public Integer getBytesPerCharacter() {
+        return bytesPerCharacter;
+    }
+
+    public void setBytesPerCharacter(Integer bytesPerCharacter) {
+        this.bytesPerCharacter = bytesPerCharacter;
+    }
+
+    public Boolean getNoBackslashEscapes() {
+        return noBackslashEscapes;
+    }
+
+    public void setNoBackslashEscapes(Boolean noBackslashEscapes) {
+        this.noBackslashEscapes = noBackslashEscapes;
+    }
+
+    public String getStorageEngine() {
+        return storageEngine;
+    }
+
+    public void setStorageEngine(String storageEngine) {
+        this.storageEngine = storageEngine;
+    }
+
+    @Override
+    public String toString() {
+        return "OfflineDialectDescriptor{" +
+                "bytesPerCharacter=" + bytesPerCharacter +
+                ", noBackslashEscapes=" + noBackslashEscapes +
+                ", storageEngine='" + storageEngine + '\'' +
+                '}';
+    }
+}

--- a/integration-tests/jpa-mariadb/src/main/java/io/quarkus/it/jpa/mariadb/OfflineDialectEndpoint.java
+++ b/integration-tests/jpa-mariadb/src/main/java/io/quarkus/it/jpa/mariadb/OfflineDialectEndpoint.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.jpa.mariadb;
+
+import java.io.IOException;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+
+@Path("/offline/dialect")
+@Produces(MediaType.APPLICATION_JSON)
+public class OfflineDialectEndpoint {
+    @Inject
+    @PersistenceUnit("offline")
+    SessionFactory sessionFactory;
+
+    @GET
+    public OfflineDialectDescriptor test() throws IOException {
+        return new OfflineDialectDescriptor(
+                (MariaDBDialect) sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect(),
+                (String) sessionFactory.unwrap(SessionFactoryImplementor.class)
+                        .getProperties()
+                        .get(AvailableSettings.STORAGE_ENGINE));
+    }
+}

--- a/integration-tests/jpa-mariadb/src/main/resources/application.properties
+++ b/integration-tests/jpa-mariadb/src/main/resources/application.properties
@@ -4,3 +4,13 @@ quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.jdbc.url=${mariadb.url}
 quarkus.datasource.jdbc.max-size=2
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.hibernate-orm.packages=io.quarkus.it.jpa.mariadb
+
+quarkus.datasource."offline".db-kind=mariadb
+quarkus.datasource."offline".db-version=10.11
+quarkus.hibernate-orm."offline".database.start-offline=true
+quarkus.hibernate-orm."offline".dialect.mariadb.bytes-per-character=1
+quarkus.hibernate-orm."offline".dialect.mariadb.no-backslash-escapes=true
+#quarkus.hibernate-orm."offline".dialect.mariadb.storage-engine=MY_CUSTOM_ENGINE // this fails with  Unable to determine Dialect for MariaDB 10.6 (please set 'hibernate.dialect' or register a Dialect resolver
+quarkus.hibernate-orm."offline".datasource=offline
+quarkus.hibernate-orm."offline".packages=io.quarkus.it.jpa.mariadb

--- a/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/OfflineInGraalITCase.java
+++ b/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/OfflineInGraalITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.jpa.mariadb;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class OfflineInGraalITCase extends OfflineTest {
+}

--- a/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/OfflineTest.java
+++ b/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/OfflineTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.jpa.mariadb;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class OfflineTest {
+
+    @Test
+    public void testJPAFunctionalityFromServlet() throws Exception {
+        RestAssured.when().get("/offline/dialect").then().body(
+                containsString("bytesPerCharacter=1"),
+                containsString("noBackslashEscapes=true")
+        //                containsString("storageEngine: MY_CUSTOM_ENGINE"))
+        );
+    }
+}


### PR DESCRIPTION
This is only a rebase of @lucamolteni's work in https://github.com/quarkusio/quarkus/pull/48130 now that Hibernate has been upgraded to 7.1 via https://github.com/quarkusio/quarkus/pull/49344.

- Fixes #30002
- Fixes #13522

# To be added in the Migration Guide:
## Hibernate ORM
### MySQL/MariaDB storage engine
Setting the MySQL/MariaDB storage engine through property `quarkus.hibernate-orm.dialect.storage-engine` has been deprecated. Use one of these configuration keys instead:

```
quarkus.hibernate-orm.dialect.mariadb.storage-engine=...
quarkus.hibernate-orm.dialect.dialect.mysql.storage-engine=...
```