### PR TITLE
Still produce KubernetesDevServiceInfoBuildItem when a dev service already exists

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -184,8 +184,8 @@ public class DevServicesKubernetesProcessor {
             KubernetesDevServiceInfoBuildItem kubernetesDevServiceInfoBuildItem,
             KubernetesClientBuildConfig kubernetesClientBuildTimeConfig) {
         if (kubernetesDevServiceInfoBuildItem == null) {
-            // Gracefully return in case the Kubernetes dev service could not be spun up.
-            log.warn("Cannot apply manifests because the Kubernetes dev service is not running");
+            // Gracefully return in case the Kubernetes dev service could not be found
+            log.error("Cannot apply manifests because the Kubernetes dev service is not running");
             return;
         }
 
@@ -367,6 +367,13 @@ public class DevServicesKubernetesProcessor {
                     getKubernetesClientConfigFromKubeConfig(kubeConfig));
         };
 
+        maybeContainerAddress.ifPresent(containerAddress -> {
+            devServicesKube
+                    .produce(new KubernetesDevServiceInfoBuildItem(
+                            KubeConfigUtils.serializeKubeConfig(getKubeconfigFromRunningContainer(containerAddress)),
+                            containerAddress.getId()));
+        });
+
         return maybeContainerAddress
                 .map(containerAddress -> new RunningDevService(Feature.KUBERNETES_CLIENT.getName(),
                         containerAddress.getId(),
@@ -423,6 +430,13 @@ public class DevServicesKubernetesProcessor {
         var container = new RunningContainer(dockerClient, containerAddress);
 
         return container.getKubeconfig();
+    }
+
+    private KubeConfig getKubeconfigFromRunningContainer(ContainerAddress containerAddress) {
+        var dockerClient = DockerClientFactory.lazyClient();
+        var container = new RunningContainer(dockerClient, containerAddress);
+
+        return container.getKubeconfigFromContainer();
     }
 
     private KubernetesDevServiceCfg getConfiguration(KubernetesClientBuildConfig cfg) {
@@ -496,25 +510,29 @@ public class DevServicesKubernetesProcessor {
             this.containerInfo = dockerClient.inspectContainerCmd(getContainerId()).exec();
         }
 
-        public Map<String, String> getKubeconfig() {
+        private KubeConfig getKubeconfigFromContainer() {
             var image = getContainerInfo().getConfig().getImage();
             if (image.contains("rancher/k3s")) {
-                return getKubernetesClientConfigFromKubeConfig(
-                        KubeConfigUtils.parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig(containerAddress.getUrl(),
-                                getFileContentFromContainer(K3S_KUBECONFIG))));
+                return KubeConfigUtils
+                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + containerAddress.getUrl(),
+                                getFileContentFromContainer(K3S_KUBECONFIG)));
             } else if (image.contains("kindest/node")) {
-                return getKubernetesClientConfigFromKubeConfig(
-                        KubeConfigUtils.parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig(containerAddress.getUrl(),
-                                getFileContentFromContainer(KIND_KUBECONFIG))));
+                return KubeConfigUtils
+                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + containerAddress.getUrl(),
+                                getFileContentFromContainer(KIND_KUBECONFIG)));
             } else if (image.contains("k8s.gcr.io/kube-apiserver") ||
                     image.contains("registry.k8s.io/kube-apiserver")) {
-                return getKubernetesClientConfigFromKubeConfig(getKubeconfigFromApiContainer(containerAddress.getUrl()));
+                return getKubeconfigFromApiContainer(containerAddress.getUrl());
             }
 
             // this can happen only if the user manually start
             // a DEV_SERVICE_LABEL labeled container with an invalid image name
             throw new RuntimeException("The container with the label '" + DEV_SERVICE_LABEL
                     + "' is not compatible with Dev Services for Kubernetes. Stop it or disable Dev Services for Kubernetes.");
+        }
+
+        public Map<String, String> getKubeconfig() {
+            return getKubernetesClientConfigFromKubeConfig(getKubeconfigFromContainer());
         }
 
         protected KubeConfig getKubeconfigFromApiContainer(final String url) {


### PR DESCRIPTION
- Fixes #49381

It builds on top on https://github.com/quarkusio/quarkus/pull/48990, which has not been merged yet, so that PR must be merged first before this becomes reviewable. This PR currently contains the code for both PRs.

Applying manifests onto the Kubernetes dev service does not work if the application connects to an existing dev service. I originally thought this was an issue in the manifests feature, but it turns out to be an issue in the Kubernetes dev service setup. Basically, the producer was never called in the code path where a dev service already exists, so `KubernetesDevServiceInfoBuildItem` would be null in depending BuildSteps.

This is not code I originally contributed so I did my best to use the features I could easily find. Definitely let me know if some of this code can be cleaned up.

I also made a small change in the manifests application code I contributed earlier to make sure it wouldn't log `Applied manifest` if a failure did occur. It now only prints this if no failure has occurred.