### PR TITLE
Revert "Contain the use of reflection in amazon-lambda"

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -114,6 +114,8 @@ public final class AmazonLambdaProcessor {
             final DotName name = info.name();
             final String lambda = name.toString();
             builder.addBeanClass(lambda);
+            reflectiveClassBuildItemBuildProducer
+                    .produce(ReflectiveClassBuildItem.builder(lambda).methods().build());
 
             String cdiName = null;
             AnnotationInstance named = info.declaredAnnotation(NAMED);
@@ -148,18 +150,9 @@ public final class AmazonLambdaProcessor {
                         }
                     }
                 }
-                if (!done) {
-                    current = combinedIndexBuildItem.getIndex().getClassByName(current.superName());
-                }
+                current = combinedIndexBuildItem.getIndex().getClassByName(current.superName());
             }
-            if (done) {
-                String handlerClass = current.name().toString();
-                ret.add(new AmazonLambdaBuildItem(handlerClass, cdiName, streamHandler));
-                reflectiveClassBuildItemBuildProducer.produce(ReflectiveClassBuildItem.builder(handlerClass).methods()
-                        .reason(getClass().getName()
-                                + ": reflectively accessed in io.quarkus.amazon.lambda.runtime.AmazonLambdaRecorder.discoverHandlerMethod")
-                        .build());
-            }
+            ret.add(new AmazonLambdaBuildItem(lambda, cdiName, streamHandler));
         }
         additionalBeanBuildItemBuildProducer.produce(builder.build());
         reflectiveClassBuildItemBuildProducer

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -249,7 +249,7 @@ public final class AmazonLambdaProcessor {
             }
         } else if (lambdas == null || lambdas.isEmpty()) {
             String errorMessage = "Unable to find handler class, make sure your deployment includes a single "
-                    + RequestHandler.class.getName() + " or, " + RequestStreamHandler.class.getName() + " implementation";
+                    + RequestHandler.class.getName() + " or " + RequestStreamHandler.class.getName() + " implementation";
             throw new RuntimeException(errorMessage);
         }
     }

--- a/extensions/amazon-lambda/deployment/src/test/java/io/quarkus/amazon/lambda/deployment/testing/LambdaWithHierarchyTest.java
+++ b/extensions/amazon-lambda/deployment/src/test/java/io/quarkus/amazon/lambda/deployment/testing/LambdaWithHierarchyTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.amazon.lambda.deployment.testing;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class LambdaWithHierarchyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(GreetingLambda.class, AbstractRequestHandler.class, Person.class));
+
+    // https://github.com/quarkusio/quarkus/issues/49413
+    @Test
+    public void testLambdaWithHierarchy() throws Exception {
+        // you test your lambdas by invoking on http://localhost:8081
+        // this works in dev mode too
+
+        Person in = new Person("dagrammy");
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body(in)
+                .when()
+                .post()
+                .then()
+                .statusCode(200)
+                .body(containsString("Hello dagrammy"));
+    }
+
+    @ApplicationScoped
+    @Named("GreetingLambda")
+    public static class GreetingLambda extends AbstractRequestHandler<Person, String> {
+
+        public String getName(Person input) {
+            return "Hello " + input.getName();
+        }
+
+    }
+
+    public static class Person {
+
+        private final String name;
+
+        public Person(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static abstract class AbstractRequestHandler<T, R> implements RequestHandler<T, R> {
+
+        @Override
+        public R handleRequest(T input, Context context) {
+            return getName(input);
+        }
+
+        public abstract R getName(T input);
+    }
+}

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -88,7 +88,7 @@ public class AmazonLambdaRecorder {
     }
 
     private static Method discoverHandlerMethod(Class<? extends RequestHandler<?, ?>> handlerClass) {
-        final Method[] methods = handlerClass.getDeclaredMethods();
+        final Method[] methods = handlerClass.getMethods();
         Method method = null;
         for (int i = 0; i < methods.length && method == null; i++) {
             if (methods[i].getName().equals("handleRequest")) {


### PR DESCRIPTION
This reverts commit https://github.com/quarkusio/quarkus/commit/56470f288782a1f2647cef45f808c7691f03579a  (https://github.com/quarkusio/quarkus/pull/48425).

Fixes https://github.com/quarkusio/quarkus/issues/49413

The optimization is causing functional issues.
It might be possible to improve it but for now let's be safe and fix it in the next micro.

I added a test in a separate commit.

/cc @zakkak FYI.