### PR TITLE
Add wait_for.logs for Oracle DB Compose Dev Services example

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -321,6 +321,8 @@ services:
       ORACLE_DATABASE: quarkus
       APP_USER: quarkus
       APP_USER_PASSWORD: quarkus
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: .*DATABASE IS READY TO USE.*
   mssql:
     image: mcr.microsoft.com/mssql/server:2022-latest
     ports:


### PR DESCRIPTION
Add `wait_for.logs` for Oracle DB Compose Dev Services example

This was needed to make https://github.com/quarkus-qe/quarkus-test-suite/pull/2552 test runs work, ports check was not enough.