### PR TITLE
Docs: Fix spelling typo in the Deploying to OpenShift guide

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -483,7 +483,7 @@ quarkus.openshift.cron-job.schedule=0 * * * *
 ----
 
 IMPORTANT: CronJob resources require the https://en.wikipedia.org/wiki/Cron[Cron] expression to specify when to launch the job through the `quarkus.openshift.cron-job.schedule` property.
-If thet are not provided, the build fails.
+If they are not provided, the build fails.
 
 You can configure the rest of the Kubernetes CronJob configuration by using the properties under `quarkus.openshift.cron-job.xxx` (for more information, see xref:deploying-to-openshift.adoc#quarkus-kubernetes_quarkus-openshift-cron-job-parallelism[quarkus.openshift.cron-job.parallelism]).
 


### PR DESCRIPTION
Fix spelling typo in the Deploying Quarkus applications to OpenShift guide.


