### PR TITLE
Log native build output to stdout

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -70,7 +70,7 @@ public abstract class NativeImageBuildRunner {
                             Runtime.getRuntime().removeShutdownHook(hook);
                         }
                     })
-                    .output().consumeLinesWith(8192, log::info)
+                    .output().consumeLinesWith(8192, System.out::println)
                     // Why logOnSuccess(false) and then consumeWith? Because we get the stdErr twice otherwise.
                     .error().logOnSuccess(false)
                     .consumeWith(br -> new ErrorReplacingProcessReader(br, outputDir.resolve("reports").toFile()).run())


### PR DESCRIPTION
We are going back to how it worked before David's patch to move to SmallRye Common Process.
I see no good reason to change that, at least not without a prior discussion.

Fixes #49452