### PR TITLE
Make the ProcessBuilder calls intents a bit clearer

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -99,13 +99,15 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
         // todo: maybe this should just be logged or something?
         if (processInheritIODisabled) {
             pb.output().consumeLinesWith(8192, System.out::println);
-            pb.error().consumeLinesWith(8192, System.err::println);
+            // logOnSuccess(false) avoids WARNING from io.smallrye.common.process.Logging
+            pb.error().logOnSuccess(false).consumeLinesWith(8192, System.err::println);
         } else {
-            pb.output().inherited().error().inherited();
+            pb.output().inherited();
+            // logOnSuccess(false) avoids WARNING from io.smallrye.common.process.Logging
+            pb.error().logOnSuccess(false).inherited();
         }
         try {
-            // logOnSuccess(false) avoids WARNING from io.smallrye.common.process.Logging
-            pb.error().logOnSuccess(false).run();
+            pb.run();
         } catch (Exception e) {
             throw new RuntimeException("Failed to pull builder image '" + effectiveBuilderImage + "'", e);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -47,34 +47,34 @@ public abstract class NativeImageBuildRunner {
         try {
             final String[] buildCommand = getBuildCommand(outputDir, args);
             log.info(String.join(" ", buildCommand).replace("$", "\\$"));
-            ProcessBuilder.newBuilder(buildCommand[0])
+            ProcessBuilder<Void> pb = ProcessBuilder.newBuilder(buildCommand[0])
                     .arguments(Arrays.copyOfRange(buildCommand, 1, buildCommand.length))
-                    .directory(outputDir)
-                    .whileRunning(ph -> {
-                        if (!ph.isAlive()) {
-                            return;
-                        }
-                        // todo: maybe have a "destroy-on-shutdown" switch?
-                        Thread hook = new Thread(() -> {
-                            if (ph.supportsNormalTermination()) {
-                                // ask nicely (not supported on Windows)
-                                ph.destroy();
-                            }
-                            ph.waitUninterruptiblyFor(10, TimeUnit.SECONDS);
-                            ProcessUtil.destroyAllForcibly(ph);
-                        }, "GraalVM terminator");
-                        Runtime.getRuntime().addShutdownHook(hook);
-                        try {
-                            ph.waitUninterruptiblyFor();
-                        } finally {
-                            Runtime.getRuntime().removeShutdownHook(hook);
-                        }
-                    })
-                    .output().consumeLinesWith(8192, System.out::println)
-                    // Why logOnSuccess(false) and then consumeWith? Because we get the stdErr twice otherwise.
-                    .error().logOnSuccess(false)
-                    .consumeWith(br -> new ErrorReplacingProcessReader(br, outputDir.resolve("reports").toFile()).run())
-                    .run();
+                    .directory(outputDir);
+            pb.whileRunning(ph -> {
+                if (!ph.isAlive()) {
+                    return;
+                }
+                // todo: maybe have a "destroy-on-shutdown" switch?
+                Thread hook = new Thread(() -> {
+                    if (ph.supportsNormalTermination()) {
+                        // ask nicely (not supported on Windows)
+                        ph.destroy();
+                    }
+                    ph.waitUninterruptiblyFor(10, TimeUnit.SECONDS);
+                    ProcessUtil.destroyAllForcibly(ph);
+                }, "GraalVM terminator");
+                Runtime.getRuntime().addShutdownHook(hook);
+                try {
+                    ph.waitUninterruptiblyFor();
+                } finally {
+                    Runtime.getRuntime().removeShutdownHook(hook);
+                }
+            });
+            pb.output().consumeLinesWith(8192, System.out::println);
+            // Why logOnSuccess(false) and then consumeWith? Because we get the stdErr twice otherwise.
+            pb.error().logOnSuccess(false)
+                    .consumeWith(br -> new ErrorReplacingProcessReader(br, outputDir.resolve("reports").toFile()).run());
+            pb.run();
             boolean objcopyExists = objcopyExists();
 
             if (!debugSymbolsEnabled) {
@@ -129,7 +129,8 @@ public abstract class NativeImageBuildRunner {
                 pb.directory(workingDirectory.toPath());
             }
             // Without logOnSuccess(false) the error stream is printed twice and with a "WARNING".
-            pb.error().logOnSuccess(false).run();
+            pb.error().logOnSuccess(false);
+            pb.run();
         } catch (Exception e) {
             if (errorMsg != null) {
                 log.errorf(e, errorMsg);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -1,7 +1,6 @@
 package io.quarkus.deployment.pkg.steps;
 
 import static io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem.Arch.AMD64;
-import static io.smallrye.common.process.ProcessBuilder.newBuilder;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +59,7 @@ import io.quarkus.sbom.ApplicationComponent;
 import io.quarkus.sbom.ApplicationManifestConfig;
 import io.smallrye.common.os.OS;
 import io.smallrye.common.process.AbnormalExitException;
+import io.smallrye.common.process.ProcessBuilder;
 import io.smallrye.common.process.ProcessUtil;
 
 public class NativeImageBuildStep {
@@ -566,8 +566,9 @@ public class NativeImageBuildStep {
 
     private static String testGCCArgument(String argument) {
         try {
-            newBuilder("cc", "-v", "-E", argument, "-")
-                    .error().logOnSuccess(log.isTraceEnabled()).run();
+            ProcessBuilder<Void> pb = ProcessBuilder.newBuilder("cc", "-v", "-E", argument, "-");
+            pb.error().logOnSuccess(log.isTraceEnabled());
+            pb.run();
             return argument;
         } catch (Exception ignored) {
             return "";


### PR DESCRIPTION
This is just cosmetic but I was having a look at an issue and the intent wasn't exactly clear given the indent and how the calls were made.

This commit makes things a lot more explicit.
