### PR TITLE
Only log manifests as applied if the process completes succesfully

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -229,13 +229,13 @@ public class DevServicesKubernetesProcessor {
                                         + " to be ready...");
                                 client.resource(resource).waitUntilReady(60, TimeUnit.SECONDS);
                             });
+
+                            log.infof("Applied manifest %s.", manifestPath);
                         }
                     } catch (Exception ex) {
                         log.errorf("Failed to apply manifest %s: %s", manifestPath, ex.getMessage());
                     }
                 }
-
-                log.infof("Applied manifest %s.", manifestPath);
             }
         } catch (Exception e) {
             log.error("Failed to create Kubernetes client while trying to apply manifests.", e);


### PR DESCRIPTION
This fix was originally included as an extra fix in https://github.com/quarkusio/quarkus/pull/49415, but since that PR has turned into an architecture discussion that may take some time (and likely won't be merged in its current state), I thought I'd extract this fix out into its own PR.

The log message would always state it applied a manifest, even if it ran into issues. This PR moves the log message such that it only states this if the manifest was applied succesfully. This prevents receiving messages such as:
```
<error message about manifest x>
Applied manifest x.
```