### PR TITLE
Add quarkus-extension-processor to quarkus-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -682,6 +682,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-processor</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-jacoco</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/extension/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/extension/runtime/pom.xml
@@ -60,9 +60,9 @@
             <path>
               <groupId>io.quarkus</groupId>
               <artifactId>quarkus-extension-processor</artifactId>
-              <version>\${quarkus.platform.version}</version>
             </path>
           </annotationProcessorPaths>
+          <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This can help avoid configuring the version of the Quarkus annotation processor in the compiler plugin in extension projects.

FYI @vsevel 