### PR TITLE
Do not try and cache deployment classloaders that don't have the right test dependencies in continuous testing

### DIFF
--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/dependency/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/dependency/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <groupId>org.acme</groupId>
+    <artifactId>quarkus-quickstart-multimodule-dependency</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
@@ -20,6 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <modules>
+        <module>dependency</module>
         <module>rest</module>
         <module>html</module>
         <module>runner</module>
@@ -61,6 +62,11 @@
             <dependency>
                 <groupId>org.acme</groupId>
                 <artifactId>quarkus-quickstart-multimodule-rest</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.acme</groupId>
+                <artifactId>quarkus-quickstart-multimodule-dependency</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>
         </dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/rest/src/test/java/org/acme/test/SimpleTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/rest/src/test/java/org/acme/test/SimpleTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SimpleTest {
-    
+
     @Test
     public void testNothing() {
         Assertions.assertTrue(true);

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/runner/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>quarkus-quickstart-multimodule-rest</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>quarkus-quickstart-multimodule-dependency</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
@@ -117,6 +117,7 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
         this(parent, false, null, null, null, System.getProperty("java.class.path"));
     }
 
+    // Also called reflectively by JUnitTestRunner
     public FacadeClassLoader(ClassLoader parent, boolean isAuxiliaryApplication, CuratedApplication curatedApplication,
             final Map<String, String> profileNames,
             final Set<String> quarkusTestClasses, final String classesPath) {
@@ -550,6 +551,7 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
         // If the try block fails, this would be null, but there's no catch, so we'd never get to this code
         QuarkusClassLoader loader = startupAction.getClassLoader();
 
+        // Make sure that our new classloader has config on it; this is a bit of a scattergun approach to setting config, but it helps cover most paths
         Class<?> configProviderResolverClass = loader.loadClass(ConfigProviderResolver.class.getName());
 
         Class<?> testConfigProviderResolverClass = loader.loadClass(QuarkusTestConfigProviderResolver.class.getName());


### PR DESCRIPTION
Resolves #48503

The problem happens when the dependency module does not include `quarkus-junit5` on its dependencies. We use the first deployment class loader of the first module we find to load the `FacadeClassLoader`, and we assume that if loading didn’t work, there’s no call for the `FacadeClassLoader`. That usually works, but in the multi-module case, if not all modules depend on `quarkus-junit5`, the first module’s deployment class loader ‘poisons’ the class load for later modules. 

My fix only populates the cached variable when we start running tests. This fixes most of the problem cases, but we could have a similar problem if the first module has tests, but not Quarkus Tests. In that case we would populate the cache, so we need to de-populate the cache if we discover the deployment class loader is not useful. 

We didn’t have a test for this scenario (obviously) but we had a closely related one where all dependency modules depended on `quarkus-junit5 (even when they didn't need it). That unneeded dependency happens to works around the issue raised in https://github.com/quarkusio/quarkus/issues/48503. Rather than adding a whole new, slow, test for the very minor variant, I’ve adjusted the existing test to cover the problem case. I think this is a strengthening of the test, and doesn’t hurt coverage of the original scenario. The adjusted test fails without my fix and passes with it.