### PR TITLE
Make ContainerRuntime detection less brittle

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -27,6 +27,10 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
     }
 
     public static List<String> getVolumeAccessArguments(ContainerRuntime containerRuntime) {
+        if (containerRuntime.isUnavailable()) {
+            return List.of();
+        }
+
         final List<String> result = new ArrayList<>();
         if (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) {
             if (containerRuntime.isDocker() && containerRuntime.isRootless()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
@@ -245,7 +245,7 @@ public final class ContainerRuntimeUtil {
         }
 
         public boolean isDocker() {
-            return this.executableName.equals("docker");
+            return this == DOCKER || this == DOCKER_ROOTLESS || this == WSL || this == WSL_ROOTLESS;
         }
 
         public boolean isPodman() {
@@ -258,6 +258,10 @@ public final class ContainerRuntimeUtil {
 
         public boolean isRootless() {
             return rootless;
+        }
+
+        public boolean isUnavailable() {
+            return this == UNAVAILABLE;
         }
 
         public static ContainerRuntime of(String value) {


### PR DESCRIPTION
In the case of unavailable, isDocker() was throwing a NPE.

Related to https://github.com/quarkusio/quarkus/issues/49465#issuecomment-3178086493