### PR TITLE
Do not apply config provider if not set

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
@@ -178,8 +178,10 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
         if (config != null && !config.isEmpty()) {
             map.putAll(config);
         }
-        for (Map.Entry<String, Function<Startable, String>> entry : applicationConfigProvider.entrySet()) {
-            map.put(entry.getKey(), () -> entry.getValue().apply(startable));
+        if (applicationConfigProvider != null) {
+            for (Map.Entry<String, Function<Startable, String>> entry : applicationConfigProvider.entrySet()) {
+                map.put(entry.getKey(), () -> entry.getValue().apply(startable));
+            }
         }
         return map;
     }
@@ -263,6 +265,7 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
             return this;
         }
 
+        @SuppressWarnings("unchecked")
         public <S extends Startable> OwnedServiceBuilder<S> startable(Supplier<S> startableSupplier) {
             this.startableSupplier = startableSupplier;
             return (OwnedServiceBuilder<S>) this;
@@ -273,11 +276,13 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
             return this;
         }
 
+        @SuppressWarnings({ "unchecked", "rawtypes" })
         public OwnedServiceBuilder<T> configProvider(Map<String, Function<T, String>> applicationConfigProvider) {
             this.applicationConfigProvider = (Map<String, Function<Startable, String>>) (Map) applicationConfigProvider;
             return this;
         }
 
+        @SuppressWarnings("unchecked")
         public DevServicesResultBuildItem build() {
             return new DevServicesResultBuildItem(name, description, serviceName, serviceConfig, config,
                     (Supplier<Startable>) startableSupplier,


### PR DESCRIPTION
`DevServicesResultBuildItem` doesn't make `applicationConfigProvider` mandatory so not setting it could lead to an NPE at runtime. This addresses this particular issue. If, on the other hand, providing a provider is mandatory, then it should be reflected in the builder somehow.
/cc @holly-cummins 