### PR TITLE
Offering configuration in the registry client and support scope display in the CLI ext list command

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
@@ -21,6 +21,10 @@ public class ListFormatOptions {
             "--origins" }, order = 7, description = "Display extension artifactId, name, version, and platform origins.")
     boolean origins = false;
 
+    @CommandLine.Option(names = {
+            "--support-scope" }, order = 7, description = "Display extension artifactId, name, version, and support scope in case it's associated with an extension.")
+    boolean supportScope = false;
+
     /**
      * Check if any format has been specified on the command line.
      */
@@ -38,6 +42,8 @@ public class ListFormatOptions {
             formatString = "full";
         else if (origins)
             formatString = "origins";
+        else if (supportScope)
+            formatString = "support-scope";
         return formatString;
     }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import io.quarkus.devtools.project.extensions.ExtensionManager;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.platform.catalog.processor.ExtensionProcessor;
+import io.quarkus.registry.Constants;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionOrigin;
 
@@ -41,6 +43,7 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
     private static final String ID_FORMAT = "%-1s %s";
     private static final String CONCISE_FORMAT = "%-1s %-50s %s";
     private static final String ORIGINS_FORMAT = "%-1s %-50s %-50s %-25s %s";
+    private static final String SUPPORT_SCOPE_FORMAT = "%-1s %-50s %-50s %-25s %s";
     private static final String FULL_FORMAT = "%-1s %-50s %-60s %-25s %s";
 
     @Override
@@ -97,6 +100,10 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
             case "full":
                 currentFormatter = this::fullFormatter;
                 log.info(String.format(FULL_FORMAT, "✬", "ArtifactId", "Extension", "Version", "Guide"));
+                break;
+            case "support-scope":
+                currentFormatter = this::offeringsFormatter;
+                log.info(String.format(SUPPORT_SCOPE_FORMAT, "✬", "ArtifactId", "Extension Name", "Version", "Support scope"));
                 break;
         }
 
@@ -173,6 +180,26 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
                     "",
                     "",
                     origins.get(i)));
+        }
+    }
+
+    private void offeringsFormatter(MessageWriter writer, DisplayData data) {
+        List<String> supportScopes = data.getSupportScopes();
+        writer.info(String.format(SUPPORT_SCOPE_FORMAT,
+                data.isPlatform(),
+                data.trimToFit(50, data.getExtensionArtifactId()),
+                data.trimToFit(50, data.getExtensionName()),
+                data.getVersion(),
+                supportScopes.isEmpty() ? "" : supportScopes.get(0)));
+
+        // If there is more than one support scopes, list the others
+        for (int i = 1; i < supportScopes.size(); i++) {
+            writer.info(String.format(SUPPORT_SCOPE_FORMAT,
+                    "",
+                    "",
+                    "",
+                    "",
+                    supportScopes.get(i)));
         }
     }
 
@@ -263,6 +290,40 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
             } else {
                 return s;
             }
+        }
+
+        List<String> getSupportScopes() {
+            final String selectedSupportKey = getRegistryUserSelectedSupportKey();
+            if (selectedSupportKey == null) {
+                return List.of();
+            }
+            var value = e.getMetadata().get(selectedSupportKey);
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof Collection<?> col) {
+                if (col.isEmpty()) {
+                    return List.of();
+                }
+                if (col.size() == 1) {
+                    return List.of(String.valueOf(col.iterator().next()));
+                }
+                final List<String> result = new ArrayList<>(col.size());
+                for (var i : col) {
+                    result.add(String.valueOf(i));
+                }
+                Collections.sort(result);
+                return result;
+            }
+            return List.of(value.toString());
+        }
+
+        String getRegistryUserSelectedSupportKey() {
+            var supportKey = e.getMetadata().get(Constants.REGISTRY_USER_SELECTED_SUPPORT_KEY);
+            if (supportKey == null) {
+                return null;
+            }
+            return supportKey.toString();
         }
     }
 }

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
@@ -3,6 +3,7 @@ package io.quarkus.devtools.testing.registry.client;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
 import org.eclipse.aether.artifact.DefaultArtifact;
 
@@ -61,7 +62,15 @@ public class TestRegistryClient implements RegistryClient {
         if (clientConfig.getQuarkusVersions() != null) {
             registryConfig.setQuarkusVersions(clientConfig.getQuarkusVersions());
         }
-
+        if (!clientConfig.getExtra().isEmpty()) {
+            if (registryConfig.getExtra().isEmpty()) {
+                registryConfig.setExtra(clientConfig.getExtra());
+            } else {
+                for (Map.Entry<String, Object> e : clientConfig.getExtra().entrySet()) {
+                    registryConfig.getExtra().put(e.getKey(), e.getValue());
+                }
+            }
+        }
         final Object o = clientConfig.getExtra().get("enable-maven-resolver");
         enableMavenResolver = o == null ? false : Boolean.parseBoolean(o.toString());
         this.config = registryConfig;

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -336,6 +336,16 @@ public class TestRegistryClientBuilder {
             return this;
         }
 
+        public TestRegistryBuilder setOffering(String offering) {
+            var extra = config.getExtra();
+            if (extra == null || extra.isEmpty()) {
+                extra = new HashMap<>(1);
+                config.setExtra(extra);
+            }
+            extra.put(Constants.OFFERING, offering);
+            return this;
+        }
+
         public TestRegistryClientBuilder clientBuilder() {
             return parent;
         }
@@ -751,13 +761,20 @@ public class TestRegistryClientBuilder {
 
         public TestPlatformCatalogMemberBuilder addExtensionWithCodestart(String groupId, String artifactId, String version,
                 String codestart) {
+            return addExtensionWithMetadata(groupId, artifactId, version,
+                    codestart == null ? Map.of()
+                            : Map.of("codestart", Map.of("name", codestart, "languages", List.of("java"))));
+        }
+
+        public TestPlatformCatalogMemberBuilder addExtensionWithMetadata(String groupId, String artifactId, String version,
+                Map<String, Object> metadata) {
             final ArtifactCoords coords = ArtifactCoords.jar(groupId, artifactId, version);
             final Extension.Mutable e = Extension.builder()
                     .setArtifact(coords)
                     .setName(artifactId)
                     .setOrigins(Collections.singletonList(extensions));
-            if (codestart != null) {
-                e.getMetadata().put("codestart", Map.of("name", codestart, "languages", List.of("java")));
+            if (metadata != null) {
+                e.getMetadata().putAll(metadata);
             }
             extensions.addExtension(e);
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
@@ -131,7 +131,7 @@ public abstract class MultiplePlatformBomsTestBase {
     }
 
     protected List<ArtifactCoords> toPlatformBomCoords(String... artifactIds) {
-        return toPlatformBomCoords(Arrays.asList(artifactIds));
+        return toPlatformBomCoords(List.of(artifactIds));
     }
 
     protected List<ArtifactCoords> toPlatformBomCoords(final List<String> extraBoms) {

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig1Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig1Test.java
@@ -1,0 +1,106 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class RegistryOfferingFilteringConfig1Test extends MultiplePlatformBomsTestBase {
+
+    private static final String DOWNSTREAM_PLATFORM_KEY = "io.downstream.platform";
+    private static final String UPSTREAM_PLATFORM_KEY = "io.upstream.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("downstream.registry.test")
+                .recognizedQuarkusVersions("*downstream")
+                .setOffering("offering-a")
+                // platform key
+                .newPlatform(DOWNSTREAM_PLATFORM_KEY)
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1.downstream")
+                .quarkusVersion("1.1.1.downstream")
+                .upstreamQuarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom")
+                .addExtensionWithMetadata("io.acme", "ext-a", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .release()
+                .newMember("acme-b-bom")
+                .addExtensionWithMetadata("io.acme", "ext-b", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported")))
+                .release()
+                .newMember("acme-c-bom")
+                .addExtensionWithMetadata("io.acme", "ext-c", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported"),
+                                "offering-c-support", List.of("supported")))
+                .release()
+                .stream().platform().registry()
+                .clientBuilder()
+                .newRegistry("upstream.registry.test")
+                // platform key
+                .newPlatform(UPSTREAM_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.5 release
+                .newRelease("2.0.5")
+                .quarkusVersion("2.0.5")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "2.0.5").release().stream().platform()
+                // 1.0 STREAM
+                .newStream("1.1")
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "1.1.1")
+                .release()
+                .newMember("acme-b-bom").addExtension("io.acme", "ext-b", "1.1.1")
+                .release()
+                .newMember("acme-c-bom").addExtension("io.acme", "ext-c", "1.1.1")
+                .release()
+                .newMember("acme-d-bom").addExtension("io.acme", "ext-d", "1.1.1")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return DOWNSTREAM_PLATFORM_KEY;
+    }
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir("offering-a-based-project");
+        createProject(projectDir, List.of("ext-a", "ext-b", "ext-c", "ext-d"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom"),
+                        platformMemberBomCoords("acme-b-bom"),
+                        platformMemberBomCoords("acme-c-bom"),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-d-bom", "1.1.1")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null),
+                        ArtifactCoords.jar("io.acme", "ext-c", null),
+                        ArtifactCoords.jar("io.acme", "ext-d", null)),
+                "1.1.1.downstream");
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig2Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig2Test.java
@@ -1,0 +1,106 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class RegistryOfferingFilteringConfig2Test extends MultiplePlatformBomsTestBase {
+
+    private static final String DOWNSTREAM_PLATFORM_KEY = "io.downstream.platform";
+    private static final String UPSTREAM_PLATFORM_KEY = "io.upstream.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("downstream.registry.test")
+                .recognizedQuarkusVersions("*downstream")
+                .setOffering("offering-b")
+                // platform key
+                .newPlatform(DOWNSTREAM_PLATFORM_KEY)
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1.downstream")
+                .quarkusVersion("1.1.1.downstream")
+                .upstreamQuarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom")
+                .addExtensionWithMetadata("io.acme", "ext-a", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .release()
+                .newMember("acme-b-bom")
+                .addExtensionWithMetadata("io.acme", "ext-b", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported")))
+                .release()
+                .newMember("acme-c-bom")
+                .addExtensionWithMetadata("io.acme", "ext-c", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported"),
+                                "offering-c-support", List.of("supported")))
+                .release()
+                .stream().platform().registry()
+                .clientBuilder()
+                .newRegistry("upstream.registry.test")
+                // platform key
+                .newPlatform(UPSTREAM_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.5 release
+                .newRelease("2.0.5")
+                .quarkusVersion("2.0.5")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "2.0.5").release().stream().platform()
+                // 1.0 STREAM
+                .newStream("1.1")
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "1.1.1")
+                .release()
+                .newMember("acme-b-bom").addExtension("io.acme", "ext-b", "1.1.1")
+                .release()
+                .newMember("acme-c-bom").addExtension("io.acme", "ext-c", "1.1.1")
+                .release()
+                .newMember("acme-d-bom").addExtension("io.acme", "ext-d", "1.1.1")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return DOWNSTREAM_PLATFORM_KEY;
+    }
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir("offering-a-based-project");
+        createProject(projectDir, List.of("ext-a", "ext-b", "ext-c", "ext-d"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-a-bom", "1.1.1"),
+                        platformMemberBomCoords("acme-b-bom"),
+                        platformMemberBomCoords("acme-c-bom"),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-d-bom", "1.1.1")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null),
+                        ArtifactCoords.jar("io.acme", "ext-c", null),
+                        ArtifactCoords.jar("io.acme", "ext-d", null)),
+                "1.1.1.downstream");
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig3Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig3Test.java
@@ -1,0 +1,106 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class RegistryOfferingFilteringConfig3Test extends MultiplePlatformBomsTestBase {
+
+    private static final String DOWNSTREAM_PLATFORM_KEY = "io.downstream.platform";
+    private static final String UPSTREAM_PLATFORM_KEY = "io.upstream.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("downstream.registry.test")
+                .recognizedQuarkusVersions("*downstream")
+                .setOffering("offering-c")
+                // platform key
+                .newPlatform(DOWNSTREAM_PLATFORM_KEY)
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1.downstream")
+                .quarkusVersion("1.1.1.downstream")
+                .upstreamQuarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom")
+                .addExtensionWithMetadata("io.acme", "ext-a", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .release()
+                .newMember("acme-b-bom")
+                .addExtensionWithMetadata("io.acme", "ext-b", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported")))
+                .release()
+                .newMember("acme-c-bom")
+                .addExtensionWithMetadata("io.acme", "ext-c", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported"),
+                                "offering-c-support", List.of("supported")))
+                .release()
+                .stream().platform().registry()
+                .clientBuilder()
+                .newRegistry("upstream.registry.test")
+                // platform key
+                .newPlatform(UPSTREAM_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.5 release
+                .newRelease("2.0.5")
+                .quarkusVersion("2.0.5")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "2.0.5").release().stream().platform()
+                // 1.0 STREAM
+                .newStream("1.1")
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "1.1.1")
+                .release()
+                .newMember("acme-b-bom").addExtension("io.acme", "ext-b", "1.1.1")
+                .release()
+                .newMember("acme-c-bom").addExtension("io.acme", "ext-c", "1.1.1")
+                .release()
+                .newMember("acme-d-bom").addExtension("io.acme", "ext-d", "1.1.1")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return DOWNSTREAM_PLATFORM_KEY;
+    }
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir("offering-a-based-project");
+        createProject(projectDir, List.of("ext-a", "ext-b", "ext-c", "ext-d"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-a-bom", "1.1.1"),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-b-bom", "1.1.1"),
+                        platformMemberBomCoords("acme-c-bom"),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-d-bom", "1.1.1")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null),
+                        ArtifactCoords.jar("io.acme", "ext-c", null),
+                        ArtifactCoords.jar("io.acme", "ext-d", null)),
+                "1.1.1.downstream");
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingNoFilteringTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingNoFilteringTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class RegistryOfferingNoFilteringTest extends MultiplePlatformBomsTestBase {
+
+    private static final String DOWNSTREAM_PLATFORM_KEY = "io.downstream.platform";
+    private static final String UPSTREAM_PLATFORM_KEY = "io.upstream.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("downstream.registry.test")
+                .recognizedQuarkusVersions("*downstream")
+                // platform key
+                .newPlatform(DOWNSTREAM_PLATFORM_KEY)
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1.downstream")
+                .quarkusVersion("1.1.1.downstream")
+                .upstreamQuarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom")
+                .addExtensionWithMetadata("io.acme", "ext-a", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .release()
+                .newMember("acme-b-bom")
+                .addExtensionWithMetadata("io.acme", "ext-b", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported")))
+                .release()
+                .newMember("acme-c-bom")
+                .addExtensionWithMetadata("io.acme", "ext-c", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported"),
+                                "offering-b-support", List.of("supported"),
+                                "offering-c-support", List.of("supported")))
+                .release()
+                .stream().platform().registry()
+                .clientBuilder()
+                .newRegistry("upstream.registry.test")
+                // platform key
+                .newPlatform(UPSTREAM_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.5 release
+                .newRelease("2.0.5")
+                .quarkusVersion("2.0.5")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "2.0.5").release().stream().platform()
+                // 1.0 STREAM
+                .newStream("1.1")
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "1.1.1")
+                .release()
+                .newMember("acme-b-bom").addExtension("io.acme", "ext-b", "1.1.1")
+                .release()
+                .newMember("acme-c-bom").addExtension("io.acme", "ext-c", "1.1.1")
+                .release()
+                .newMember("acme-d-bom").addExtension("io.acme", "ext-d", "1.1.1")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return DOWNSTREAM_PLATFORM_KEY;
+    }
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir("offering-a-based-project");
+        createProject(projectDir, List.of("ext-a", "ext-b", "ext-c", "ext-d"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom"),
+                        platformMemberBomCoords("acme-b-bom"),
+                        platformMemberBomCoords("acme-c-bom"),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-d-bom", "1.1.1")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null),
+                        ArtifactCoords.jar("io.acme", "ext-c", null),
+                        ArtifactCoords.jar("io.acme", "ext-d", null)),
+                "1.1.1.downstream");
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
@@ -20,4 +20,15 @@ public interface Constants {
     String JSON = "json";
 
     String LAST_UPDATED = "last-updated";
+
+    /**
+     * Registry configuration option allowing users to limit the extension catalog from a registry to a specific offering
+     */
+    String OFFERING = "offering";
+
+    /**
+     * An internal metadata key optionally added to extension metadata by a registry client
+     * to indicate a user configured offering-based support key that should be displayed by extension listing commands
+     */
+    String REGISTRY_USER_SELECTED_SUPPORT_KEY = "registry-user-selected-support-key";
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -1,12 +1,17 @@
 package io.quarkus.registry;
 
+import static io.quarkus.registry.Constants.OFFERING;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.Platform;
 import io.quarkus.registry.catalog.PlatformCatalog;
@@ -21,12 +26,40 @@ class RegistryExtensionResolver {
     public static final int VERSION_RECOGNIZED = 1;
     public static final int VERSION_EXCLUSIVE_PROVIDER = 2;
 
+    private static final String DASH_SUPPORT = "-support";
+
+    /**
+     * Returns offering configured by the user in the registry configuration or null, in case
+     * no offering was configured.
+     *
+     * An offering would be the name part of the {@code <name>-support} in the extension metadata.
+     *
+     * @param config registry configuration
+     * @return user configured offering or null
+     */
+    private static String getConfiguredOfferingOrNull(RegistryConfig config) {
+        var offering = config.getExtra().get(OFFERING);
+        if (offering == null) {
+            return null;
+        }
+        if (!(offering instanceof String)) {
+            throw new IllegalArgumentException("Expected a string value for option " + OFFERING + " but got " + offering
+                    + " of type " + offering.getClass().getName());
+        }
+        final String str = offering.toString();
+        return str.isBlank() ? null : str;
+    }
+
     private final RegistryConfig config;
     private final RegistryClient extensionResolver;
     private final int index;
 
     private final Pattern recognizedQuarkusVersions;
     private final Collection<String> recognizedGroupIds;
+    /**
+     * {@code -support} extension metadata key that corresponds to the user selected offering, can be null
+     */
+    private final String offeringSupportKey;
 
     RegistryExtensionResolver(RegistryClient extensionResolver,
             MessageWriter log, int index) throws RegistryResolutionException {
@@ -39,6 +72,14 @@ class RegistryExtensionResolver {
         recognizedQuarkusVersions = versionExpr == null ? null : Pattern.compile(GlobUtil.toRegexPattern(versionExpr));
         this.recognizedGroupIds = config.getQuarkusVersions() == null ? Collections.emptyList()
                 : config.getQuarkusVersions().getRecognizedGroupIds();
+
+        final String offering = getConfiguredOfferingOrNull(config);
+        if (offering != null) {
+            log.info("Registry " + config.getId() + " is limited to offerings " + offering);
+            this.offeringSupportKey = offering + DASH_SUPPORT;
+        } else {
+            offeringSupportKey = null;
+        }
     }
 
     String getId() {
@@ -94,8 +135,38 @@ class RegistryExtensionResolver {
         return extensionResolver.resolveNonPlatformExtensions(quarkusCoreVersion);
     }
 
+    /**
+     * Resolves a platform extension catalog using a given JSON artifact.
+     *
+     * If a user did not configure an offering the the original catalog is returned.
+     *
+     * If an offering was configured, we filter out extensions that are not part of the selected offering
+     * {@link Constants#DEFAULT_REGISTRY_ARTIFACT_VERSION} to the metadata with the corresponding {@code <name>-support}
+     * as its value that will be used by the extension list commands later to display the relevant support scope.
+     *
+     * @param platform either a BOM or a JSON descriptor coordinates
+     * @return extension catalog
+     * @throws RegistryResolutionException in case of a failure
+     */
     ExtensionCatalog.Mutable resolvePlatformExtensions(ArtifactCoords platform) throws RegistryResolutionException {
-        return extensionResolver.resolvePlatformExtensions(platform);
+        ExtensionCatalog.Mutable catalog = extensionResolver.resolvePlatformExtensions(platform);
+        // if a user didn't select an offering, return the original catalog
+        if (offeringSupportKey == null) {
+            return catalog;
+        }
+        final Collection<Extension> originalCollection = catalog.getExtensions();
+        List<Extension> filteredCollection = new ArrayList<>(originalCollection.size());
+        for (Extension ext : originalCollection) {
+            if (ext.getMetadata().containsKey(offeringSupportKey)) {
+                ext.getMetadata().put(Constants.REGISTRY_USER_SELECTED_SUPPORT_KEY, offeringSupportKey);
+                filteredCollection.add(ext);
+            } else if (ext.getArtifact().getArtifactId().equals("quarkus-core")) {
+                // we need quarkus-core for proper quarkus-bom to become the primary platform when creating projects
+                filteredCollection.add(ext);
+            }
+        }
+        catalog.setExtensions(filteredCollection);
+        return catalog;
     }
 
     void clearCache() throws RegistryResolutionException {


### PR DESCRIPTION
This change supersedes https://github.com/quarkusio/quarkus/pull/34516

It adds an option for registry users to select an offering associated with extensions provided by a registry in `.quarkus/config.yaml` to limit the set of extensions provided by that registry to that specific offering.

For example:
```
registries:
  - registry.quarkus.acme.org:
      offering: acme-cloud
  - registry.quarkus.io
```

Assuming `registry.quarkus.acme.org` provides extensions associated with multiple offerings, only those extensions associated with `acme-cloud` will be returned by a registry client with that configuration.

The value of `offering` should match the name in the `<name>-support` field in extension metadata for an extension to be included in the resulting catalog.

In the current implementation a single offering is allowed to be selected in the configuration.

If an `offering` is not configured, all the extensions provided by a registry are returned by the client.