### PR TITLE
Update cors origin default info

### DIFF
--- a/docs/src/main/asciidoc/security-cors.adoc
+++ b/docs/src/main/asciidoc/security-cors.adoc
@@ -54,7 +54,7 @@ quarkus.http.cors.access-control-allow-credentials=true <7>
 ----
 
 <1> Enables the CORS filter.
-<2> Specifies allowed origins, including a regular expression.
+<2> Specifies allowed origins, including a regular expression. When not specified, CORS is not permitted, and only same-origin requests are allowed.
 <3> Lists allowed HTTP methods for cross-origin requests.
 <4> Declares custom headers that clients can include in requests.
 <5> Identifies response headers that clients can access.


### PR DESCRIPTION
Based on QE feedback, we need to describe the default behavior of quarkus.http.cors.origins when a value is not specified.

Relates to https://github.com/quarkusio/quarkus/issues/49486

Open this preview, https://quarkus-pr-main-49489-preview.surge.sh/version/main/guides/security-cors#example-cors-configuration, and search for "Leaving this value empty blocks all origins."