### PR TITLE
Redis Client: fix *SCAN cursor handling

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/Cursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/Cursor.java
@@ -4,12 +4,24 @@ public interface Cursor<T> {
 
     /**
      * The cursor id when no operations have been emitted yet.
+     *
+     * @deprecated Previously, this value was -1, assuming that this value is never produced by Redis as an actual cursor.
+     *             However, Redis uses unsigned 64-bit integers as cursor values, so the assumption was wrong
+     *             (-1 as 64-bit signed integer is 0xFFFF_FFFF_FFFF_FFFF, which is the biggest unsigned 64-bit integer).
+     *             This should have never been exposed publicly and should not be relied upon.
+     *             <p>
+     *             The current value is 0, which is the correct initial <em>and</em> final cursor value in Redis.
      */
+    @Deprecated(forRemoval = true, since = "3.26")
     long INITIAL_CURSOR_ID = ReactiveCursor.INITIAL_CURSOR_ID;
 
     boolean hasNext();
 
     T next();
 
+    /**
+     * @deprecated see {@link #INITIAL_CURSOR_ID}
+     */
+    @Deprecated(forRemoval = true, since = "3.26")
     long cursorId();
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveCursor.java
@@ -6,12 +6,24 @@ public interface ReactiveCursor<T> {
 
     /**
      * The cursor id when no operations have been emitted yet.
+     *
+     * @deprecated Previously, this value was -1, assuming that this value is never produced by Redis as an actual cursor.
+     *             However, Redis uses unsigned 64-bit integers as cursor values, so the assumption was wrong
+     *             (-1 as 64-bit signed integer is 0xFFFF_FFFF_FFFF_FFFF, which is the biggest unsigned 64-bit integer).
+     *             This should have never been exposed publicly and should not be relied upon.
+     *             <p>
+     *             The current value is 0, which is the correct initial <em>and</em> final cursor value in Redis.
      */
-    long INITIAL_CURSOR_ID = -1L;
+    @Deprecated(forRemoval = true, since = "3.26")
+    long INITIAL_CURSOR_ID = 0L;
 
     boolean hasNext();
 
     Uni<T> next();
 
+    /**
+     * @deprecated see {@link #INITIAL_CURSOR_ID}
+     */
+    @Deprecated(forRemoval = true, since = "3.26")
     long cursorId();
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
@@ -284,11 +284,9 @@ public class HashCommandsTest extends DatasourceTestBase {
         hash.hset(key, "one", Person.person0);
         HashScanCursor<String, Person> cursor = hash.hscan(key);
 
-        assertThat(cursor.cursorId()).isEqualTo(-1L);
         assertThat(cursor.hasNext()).isTrue();
         Map<String, Person> next = cursor.next();
 
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(next).containsExactly(entry("one", Person.person0));
         assertThat(cursor.hasNext()).isFalse();
     }
@@ -297,11 +295,10 @@ public class HashCommandsTest extends DatasourceTestBase {
     void hscanEmpty() {
         HashScanCursor<String, Person> cursor = hash.hscan(key);
 
-        assertThat(cursor.cursorId()).isEqualTo(-1L);
         assertThat(cursor.hasNext()).isTrue();
         Map<String, Person> next = cursor.next();
 
-        assertThat(cursor.cursorId()).isEqualTo(0);
+        assertThat(cursor.hasNext()).isFalse();
         assertThat(next).isEmpty();
     }
 
@@ -324,11 +321,9 @@ public class HashCommandsTest extends DatasourceTestBase {
         hash.hset(key, "three", Person.person2);
         HashScanCursor<String, Person> cursor = hash.hscan(key, new ScanArgs().count(3));
 
-        assertThat(cursor.cursorId()).isEqualTo(-1L);
         assertThat(cursor.hasNext()).isTrue();
         Map<String, Person> next = cursor.next();
 
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(next).containsExactly(entry("one", Person.person0), entry("two", Person.person1),
                 entry("three", Person.person2));
         assertThat(cursor.hasNext()).isFalse();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
@@ -392,38 +392,34 @@ public class KeyCommandsTest extends DatasourceTestBase {
     void scan() {
         values.set(key, Person.person7);
         KeyScanCursor<String> cursor = keys.scan();
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
         assertThat(cursor.next()).containsExactly(key);
         assertThat(cursor.hasNext()).isFalse();
-        assertThat(cursor.cursorId()).isEqualTo(0);
     }
 
     @Test
     void scanEmpty() {
         KeyScanCursor<String> cursor = keys.scan();
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
         assertThat(cursor.next()).isEmpty();
         assertThat(cursor.hasNext()).isFalse();
-        assertThat(cursor.cursorId()).isEqualTo(0);
     }
 
     @Test
     void scanIterableEmpty() {
         KeyScanCursor<String> cursor = keys.scan();
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
         assertThat(cursor.toIterable()).isEmpty();
         assertThat(cursor.hasNext()).isFalse();
-        assertThat(cursor.cursorId()).isEqualTo(0);
     }
 
     @Test
     void scanWithArgs() {
         values.set(key, Person.person7);
         KeyScanCursor<String> cursor = keys.scan(new KeyScanArgs().count(10));
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
         assertThat(cursor.next()).containsExactly(key);
         assertThat(cursor.hasNext()).isFalse();
-        assertThat(cursor.cursorId()).isEqualTo(0);
     }
 
     @Test
@@ -446,7 +442,6 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
         KeyScanCursor<String> cursor = keys.scan(new KeyScanArgs().count(12));
 
-        assertThat(cursor.cursorId()).isNotEqualTo(0);
         assertThat(cursor.hasNext()).isTrue();
 
         Set<String> check = new HashSet<>(cursor.next());
@@ -481,10 +476,9 @@ public class KeyCommandsTest extends DatasourceTestBase {
         Set<String> expect = new HashSet<>();
         populateMany(expect);
         KeyScanCursor<String> cursor = keys.scan(new KeyScanArgs().count(200).match(key + "*"));
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
         assertThat(cursor.next()).hasSize(expect.size());
         assertThat(cursor.hasNext()).isFalse();
-        assertThat(cursor.cursorId()).isEqualTo(0);
     }
 
     void populateMany(Set<String> expect) {

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
@@ -199,12 +199,10 @@ public class SetCommandsTest extends DatasourceTestBase {
         sets.sadd(key, person1);
         SScanCursor<Person> cursor = sets.sscan(key);
 
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
 
         List<Person> list = cursor.next();
 
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(list).hasSize(1).containsExactly(person1);
     }
@@ -213,12 +211,10 @@ public class SetCommandsTest extends DatasourceTestBase {
     void sscanEmpty() {
         SScanCursor<Person> cursor = sets.sscan(key);
 
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
 
         List<Person> list = cursor.next();
 
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(list).isEmpty();
     }
@@ -227,7 +223,6 @@ public class SetCommandsTest extends DatasourceTestBase {
     void sscanEmptyAsIterable() {
         SScanCursor<Person> cursor = sets.sscan(key);
 
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
 
         Iterable<Person> iterable = cursor.toIterable();
@@ -240,12 +235,10 @@ public class SetCommandsTest extends DatasourceTestBase {
         sets.sadd(key, person1);
         SScanCursor<Person> cursor = sets.sscan(key, new ScanArgs().count(3));
 
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
 
         List<Person> list = cursor.next();
 
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(list).hasSize(1).containsExactly(person1);
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
@@ -654,10 +654,8 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     void zsscan() {
         setOfPlaces.zadd(key, 1.0, Place.crussol);
         ZScanCursor<Place> cursor = setOfPlaces.zscan(key);
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
         List<ScoredValue<Place>> values = cursor.next();
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(values.get(0)).isEqualTo(new ScoredValue<>(Place.crussol, 1.0));
     }
@@ -665,10 +663,8 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     @Test
     void zsscanEmpty() {
         ZScanCursor<Place> cursor = setOfPlaces.zscan(key);
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
         List<ScoredValue<Place>> values = cursor.next();
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(values).isEmpty();
     }
@@ -676,11 +672,9 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     @Test
     void zsscanEmptyAsIterable() {
         ZScanCursor<Place> cursor = setOfPlaces.zscan(key);
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
         Iterable<ScoredValue<Place>> iterable = cursor.toIterable();
         assertThat(iterable).isEmpty();
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(cursor.hasNext()).isFalse();
     }
 
@@ -690,10 +684,8 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
         setOfPlaces.zadd(key, 2.0, Place.grignan);
         setOfPlaces.zadd(key, 3.0, Place.adhemar);
         ZScanCursor<Place> cursor = setOfPlaces.zscan(key, new ScanArgs().count(2));
-        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.hasNext()).isTrue();
         List<ScoredValue<Place>> values = cursor.next();
-        assertThat(cursor.cursorId()).isEqualTo(0);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(values.get(0)).isEqualTo(new ScoredValue<>(Place.crussol, 1.0));
     }
@@ -710,7 +702,6 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
         while (cursor.hasNext()) {
             values.addAll(cursor.next());
         }
-        assertThat(cursor.cursorId()).isEqualTo(0L);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(values).hasSize(100);
     }
@@ -727,7 +718,6 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
         for (ScoredValue<String> scoredValue : cursor.toIterable()) {
             values.add(scoredValue);
         }
-        assertThat(cursor.cursorId()).isEqualTo(0L);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(values).hasSize(100);
     }
@@ -741,7 +731,6 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
         while (cursor.hasNext()) {
             values.addAll(cursor.next());
         }
-        assertThat(cursor.cursorId()).isEqualTo(0L);
         assertThat(cursor.hasNext()).isFalse();
         assertThat(values).hasSize(100);
     }


### PR DESCRIPTION
`*SCAN` cursors in Redis are strings that contain _unsigned_ 64-bit integers. Until this commit, we ignored that and treated cursors as _signed_ integers, which may lead to an exception when parsing the number. Further, this allowed us to devise a sentinel value, `-1`, to mark the "not yet started" situation.

Since this commit, we parse and serialize cursors as unsigned integers. This disallows using -1 as a special value, so we add a special flag `initial` to mark the "not yet started" situation instead.

This commit also deprecates (for removal) the access to cursor values. This is specifically:

- `Cursor.INITIAL_CURSOR_ID`
- `Cursor.cursorId()`
- `ReactiveCursor.INITIAL_CURSOR_ID`
- `ReactiveCursor.cursorId()`

The `INITIAL_CURSOR_ID` value used to be `-1`, which is incorrect. The initial _and_ final value of a cursor is always `0`.

The `cursorId()` returns the cursor value as `long`, which makes it super easy to treat it as a signed integer, which is wrong.

We would be able to add a `cursor()`/`cursorValue()`/`cursorString()` method that returns the cursor value as a `String`, but I'm not sure there's any actual need for access to the underlying value, so I'm refraining from this for now.

Fixes #49492