### PR TITLE
Do not include default values when passing Gradle build configuration to Quarkus

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -42,8 +42,6 @@ import io.quarkus.gradle.tasks.worker.BuildWorker;
 import io.quarkus.gradle.tooling.ToolingUtils;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.smallrye.common.expression.Expression;
-import io.smallrye.config.Expressions;
-import io.smallrye.config.SmallRyeConfig;
 
 /**
  * Base class for the {@link QuarkusBuildDependencies}, {@link QuarkusBuildCacheableAppParts}, {@link QuarkusBuild} tasks
@@ -261,19 +259,9 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
         });
 
         ApplicationModel appModel = resolveAppModelForBuild();
-        SmallRyeConfig config = effectiveProvider()
+        Map<String, String> quarkusProperties = effectiveProvider()
                 .buildEffectiveConfiguration(appModel, getAdditionalForcedProperties().get().getProperties())
-                .getConfig();
-        Map<String, String> quarkusProperties = Expressions.withoutExpansion(() -> {
-            Map<String, String> values = new HashMap<>();
-            for (String key : config.getMapKeys("quarkus").values()) {
-                values.put(key, config.getConfigValue(key).getValue());
-            }
-            for (String key : config.getMapKeys("platform.quarkus").values()) {
-                values.put(key, config.getConfigValue(key).getValue());
-            }
-            return values;
-        });
+                .getOnlyQuarkusValues();
 
         if (nativeEnabled()) {
             if (nativeSourcesOnly()) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -111,7 +111,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
     public void generateCode() throws IOException {
         ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
         Map<String, String> configMap = effectiveProvider()
-                .buildEffectiveConfiguration(appModel, new HashMap<>()).getValues();
+                .buildEffectiveConfiguration(appModel, new HashMap<>()).getOnlyQuarkusValues();
 
         File outputPath = getGeneratedOutputDirectory().get().getAsFile();
 


### PR DESCRIPTION
The Gradle plugin uses a separate worker process to execute Quarkus tasks. It copies all `quarkus.*` configuration from the main process and hands it over to the worker as system properties. This means that every `quarkus.*` configuration is set as a system property.

To warn about deprecated configuration names, we check if the value is coming from the defaults. However, due to the Gradle plugin's behavior, every deprecated name will be reported because the value is set as a system property in the worker process.

This PRs removes all `quarkus.*` values coming from the default source, since they are not required, and the values will be available in the Quarkus tasks.

- Fixes #49174 

