### PR TITLE
Skip the root application artifact and clear the reloadable flag properly when processing deployment dependencies

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -60,15 +60,14 @@ public class BeforeTestAction implements Action<Task> {
             Test task = (Test) t;
             final Map<String, Object> props = task.getSystemProperties();
 
-            ApplicationModel applicationModel = ToolingUtils
-                    .deserializeAppModel(applicationModelPath.get().getAsFile().toPath());
+            final Path serializedModel = applicationModelPath.get().getAsFile().toPath();
+            ApplicationModel applicationModel = ToolingUtils.deserializeAppModel(serializedModel);
 
             SmallRyeConfig config = effectiveProvider().buildEffectiveConfiguration(applicationModel, new HashMap<>())
                     .getConfig();
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));
 
-            final Path serializedModel = applicationModelPath.get().getAsFile().toPath();
             props.put(BootstrapConstants.SERIALIZED_TEST_APP_MODEL, serializedModel.toString());
 
             StringJoiner outputSourcesDir = new StringJoiner(",");


### PR DESCRIPTION
This fixes an issue that appears when using test fixtures but in some particular situations. I wasn't able to create a minimal reproducer that creates that particular situation in a dependency graph.

The change is about skipping processing the root application artifact in case it appears among the dependencies (deployment in particular) and properly passing reloadable flag to the children of a processed dependency.

Fixes #49462, #49463, #49464