### PR TITLE
Escape Cli Encrypt keys

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/config/Encrypt.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/Encrypt.java
@@ -51,6 +51,10 @@ public class Encrypt extends BaseConfigCommand implements Callable<Integer> {
             encryptionKey = encodeToString(generateEncryptionKey().getEncoded());
             generatedKey = true;
         } else {
+            if (encryptionKey.startsWith("\\\"") && encryptionKey.endsWith("\"\\")) {
+                encryptionKey = encryptionKey.substring(2, encryptionKey.length() - 2);
+            }
+
             if (encryptionKeyFormat.equals(KeyFormat.base64)) {
                 encryptionKey = encodeToString(encryptionKey.getBytes());
             }

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/SetConfig.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/SetConfig.java
@@ -46,14 +46,14 @@ public class SetConfig extends BaseConfigCommand implements Callable<Integer> {
                 value = findKey(lines, name).getValue();
             }
             args.add(value);
-            if (value == null || value.length() == 0) {
+            if (value == null || value.isEmpty()) {
                 output.error("Cannot encrypt an empty value");
                 return -1;
             }
 
             ConfigValue encryptionKey = findKey(lines, "smallrye.config.secret-handler.aes-gcm-nopadding.encryption-key");
             if (encryptionKey.getValue() != null) {
-                args.add("--key=" + encryptionKey.getValue());
+                args.add("--key=\\\"" + encryptionKey.getValue() + "\"\\");
             }
             ConfigValue encryptionDecode = findKey(lines,
                     "smallrye.config.secret-handler.aes-gcm-nopadding.encryption-key-decode");


### PR DESCRIPTION
Generated encryption keys may be generated starting with a `-` followed by a shorthand flag, which causes parse problems with Picocli: https://github.com/remkop/picocli/issues/2340

This should fix some of the random failures observed here: https://github.com/quarkusio/quarkus/pull/49397#issuecomment-3188012225
