### PR TITLE
Add tests for keycloak dev services when there is no test resource

### DIFF
--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.keycloak;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -29,6 +30,29 @@ public class AdminClientResource {
     @Path("realm")
     public String getRealm() {
         return keycloak.realm("quarkus").toRepresentation().getRealm();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("realms")
+    public String getRealms() {
+        return keycloak.realms().findAll().stream().map(r -> r.getRealm()).sorted().collect(Collectors.joining("-"));
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("roles")
+    public String getRoles() {
+        return keycloak.realm("quarkus").roles().list().stream().map(r -> r.getName()).sorted()
+                .collect(Collectors.joining("-"));
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("users")
+    public String getUsers() {
+        return keycloak.realm("quarkus").users().list().stream().map(r -> r.getUsername()).sorted()
+                .collect(Collectors.joining("-"));
     }
 
     @GET

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -17,11 +17,14 @@ import jakarta.ws.rs.core.Context;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.representations.idm.authorization.Permission;
 
+import io.quarkus.arc.profile.UnlessBuildProfile;
 import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpServerRequest;
 
+// This needs policy enforcement to be true, or the Authzclient can't be injected
+@UnlessBuildProfile("no-test-resource")
 @Path("/api/permission")
 public class ProtectedResource {
 

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/NoTestResourceAdminClientTestCase.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/NoTestResourceAdminClientTestCase.java
@@ -1,0 +1,51 @@
+package io.quarkus.it.keycloak;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/*
+ * Exercises behaviour in the case where there isn't a test resource to make
+ * all the realms and roles.
+ */
+@TestProfile(NoTestResourceProfile.class)
+@QuarkusTest
+public class NoTestResourceAdminClientTestCase {
+
+    @Test
+    public void testGetRoles() {
+        when().get("/admin-client/roles")
+                .then()
+                .statusCode(200)
+                .body(containsString("scratcher-sniffer"));
+    }
+
+    @Test
+    public void testGetUsers() {
+        when().get("/admin-client/users")
+                .then()
+                .statusCode(200)
+                .body(containsString("leia-luke"));
+    }
+
+    @Test
+    public void testGetExistingRealm() {
+        when().get("/admin-client/realm")
+                .then()
+                .statusCode(200)
+                .body(equalTo("quarkus"));
+    }
+
+    @Test
+    public void testGetNewRealm() {
+        when().get("/admin-client/newrealm")
+                .then()
+                .statusCode(200)
+                .body(equalTo("quarkus2"));
+    }
+}

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/NoTestResourceProfile.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/NoTestResourceProfile.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class NoTestResourceProfile implements QuarkusTestProfile {
+
+    public String getConfigProfile() {
+        return "no-test-resource";
+    }
+
+    // This profile is supposed to exercise defauly behaviour, but the application.properties changes a lot of defaults, so undo some of those changes
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.keycloak.devservices.create-realm", "true",
+                "quarkus.keycloak.policy-enforcer.enabled", "false",
+                "quarkus.keycloak.devservices.roles.quarkus", "scratcher,sniffer",
+                "quarkus.keycloak.devservices.users.luke", "force1",
+                "quarkus.keycloak.devservices.users.leia", "force2");
+    }
+
+    @Override
+    public boolean disableGlobalTestResources() {
+        return true;
+    }
+}


### PR DESCRIPTION
I'm currently working on #49542, and I noticed that the tests were all green, even when my implementation had problems. The current test uses a test resource to do a lot of the heavy lifting of creating realms, so I thought I'd add a test to exercise how we handle the default path of config initialisation a bit more. 