### PR TITLE
Upgrade bcfips and bctls to 2.x

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -17,8 +17,8 @@
         <angus-activation.version>2.0.2</angus-activation.version>
         <angus-mail.version>2.0.4</angus-mail.version> <!-- keep in sync with angus-activation (mail depends on activation) -->
         <bouncycastle.version>1.81</bouncycastle.version>
-        <bouncycastle.fips.version>1.0.2.5</bouncycastle.fips.version>
-        <bouncycastle.tls.fips.version>1.0.19</bouncycastle.tls.fips.version>
+        <bouncycastle.fips.version>2.1.1</bouncycastle.fips.version>
+        <bouncycastle.tls.fips.version>2.1.20</bouncycastle.tls.fips.version>
         <cyclonedx.version>9.0.5</cyclonedx.version>
         <expressly.version>6.0.0</expressly.version>
         <findbugs.version>3.0.2</findbugs.version>

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -288,6 +288,15 @@ public class SecurityProcessor {
             runtimeReInitialized
                     .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves"));
             runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.jcajce.spec.ECUtil"));
+            // start of BCFIPS 2.0
+            // started thread during initialization
+            runtimeReInitialized
+                    .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.crypto.util.dispose.DisposalDaemon"));
+            // secure randoms
+            runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.crypto.fips.FipsDRBG"));
+            runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.crypto.fips.Utils"));
+            // re-detect JNI library availability
+            runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.crypto.fips.NativeLoader"));
         }
 
         // Reinitialize class because it embeds a java.lang.ref.Cleaner instance in the image heap

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/graal/BouncyCastleSubstitutions.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/graal/BouncyCastleSubstitutions.java
@@ -94,14 +94,8 @@ final class Target_org_bouncycastle_crypto_fips_RsaBlindedEngine {
 final class Target_org_bouncycastle_jcajce_provider_BouncyCastleFipsProvider {
     @Alias
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
-    private SecureRandom entropySource;
-}
-
-@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.math.ec.ECPoint", onlyWith = BouncyCastleCryptoFips.class)
-final class Target_org_bouncycastle_math_ec_ECPoint {
-    @Alias //
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
-    private static SecureRandom testRandom;
+    // yes, typo on bcfips side.
+    private SecureRandom entopySource;
 }
 
 class BouncyCastleCryptoFips implements BooleanSupplier {


### PR DESCRIPTION
### What

Fixes #46151 

Upgrade bcfips and bctls libraries to 2.x. This is necessary since bcfips 1.x is out of maintenance and as of Aug 12, 2025, a new CVE has been revealed for latest 1.x version: https://mvnrepository.com/artifact/org.bouncycastle/bc-fips/1.0.2.5.

### Test

As a first-time contributor to quarkus, I'm not familiar how the existing BCFips integration is verified in Quarkus project. But on my side I've tried my best to verify it in a few ways:

- Followed CONTRIBUTION.md to build the project, and verify that my existing Quarkus service which has bcfips enabled is working fine. 
- The diffs (extra substitutions and runtime reinitialization) are also verified in a few GraalVM native image projects outside of Quarkus (springboot).

If there are other guidelines of adding unit/integration test to cover this change, I would be happy to work on those. Thank you.