### PR TITLE
Create chunked OIDC session access token cookies

### DIFF
--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantRefreshTokenResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantRefreshTokenResource.java
@@ -30,6 +30,7 @@ public class TenantRefreshTokenResource {
         return "userName: " + idToken.getName()
                 + ", idToken: " + (idToken.getRawToken() != null)
                 + ", accessToken: " + (accessToken.getRawToken() != null)
+                + ", accessTokenLongStringClaim: " + accessToken.getClaim("longstring")
                 + ", refreshToken: " + (refreshToken.getToken() != null);
     }
 


### PR DESCRIPTION
Fixes #49469.

When the user logs with Quarkus OIDC, using the authorization code flow, by default, all the tokens (ID, access, and refresh tokens) acquired as part of this flow are stored in the encrypted session cookie named `q_session`.

If the final session cookie size (which also includes the session cookie name with the tenant id, and profile) is close to 4K, Quarkus OIDC, splits this single session cookie into multiple chunks to avoid browser losing it: `q_session_chunk_1`, `q_session_chunk_2`, etc. When the logged in user  returns to Quarkus, all these chunks are assembled back into a single session cookie value and then those ID, access and refresh tokens are extracted out of it.

Instead of keeping ID, access and refresh tokens in a single cookie, Quarkus OIDC supports a `split-tokens` option. In this case, instead of keeping all the tokens in a single session cookie, each token gets its own session cookie. ID token is still kept in the `q_session`, access token goes into `q_session_at`, and refresh token into `q_session_rt` cookies.

This `split-tokens` option was added before Quarkus OIDC started supporting creating chunked `q_session` cookies when all 3 tokens combined in a single cookiewere leading to a large cookie size. The idea was to make sure individual cookies could be of less size than a single one combining all cookies.

Today, the `split-tokens` options can be used to avoid chunking a single cookie, or when users prefer to keep each token in a dedicated cookie, possibly for security reasons (if one cookie is leaked, the other one may not be, etc).

As mentioned above, the `split-tokens` option ID token is still kept in the `q_session`, access token goes into `q_session_at`, and refresh token into `q_session_rt` cookies.

If the ID token is too large, its `q_session` cookie is still chunked.
But if the access token is too large as in #49469, then no chunking is applied and the `q_session_at` cookie is lost.

So this PR simply refactors the code a little bit to make sure that the same code that deals with chunking large `q_session` cookies and re-assembling the chunks is used for managing large `q_session_at` cookies which keep large access tokens.

In theory, the same code should be applied for managing `q_session_rt` cookies that hold refresh tokens, but I honestly don't expect refresh tokens ever getting too large. If that ever happens, we'll tune the code a bit more.

The test has been updated to produce large access tokens that in turn produces chunked `q_session_at` cookies and to verify that the access token can be correctly assembled on the Quarkus endpoint side - it is done by assembling the chunks in the client test code and verifying the returned `longstring` claim matches the same value extracted from the re-assembled cookie value on the client test side