### PR TITLE
Update runtime container images (UBI and OpenJDK)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -9,7 +9,7 @@ import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
  * <p>
  * - {@code x_IMAGE_NAME} - the name of the image without the version (e.g. {@code registry.access.redhat.com/ubi9/ubi-minimal})
  * - {@code x_VERSION} - the version of the image (e.g. {@code 9.5})
- * - {@code x} - the full image name (e.g. {@code registry.access.redhat.com/ubi9/ubi-minimal:9.5})
+ * - {@code x} - the full image name (e.g. {@code registry.access.redhat.com/ubi9/ubi-minimal:9.6})
  */
 public class ContainerImages {
 
@@ -23,17 +23,17 @@ public class ContainerImages {
     /**
      * UBI 9 version
      */
-    public static final String UBI9_VERSION = "9.5";
+    public static final String UBI9_VERSION = "9.6";
 
     /**
      * Version used for more UBI8 Java images.
      */
-    public static final String UBI8_JAVA_VERSION = "1.21";
+    public static final String UBI8_JAVA_VERSION = "1.23";
 
     /**
      * Version used for more UBI9 Java images.
      */
-    public static final String UBI9_JAVA_VERSION = "1.21";
+    public static final String UBI9_JAVA_VERSION = "1.23";
 
     /**
      * Version uses for the native builder image.

--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -146,9 +146,9 @@
     "project": {
       "default-codestart": "rest",
       "codestart-data": {
-        "tooling-dockerfiles.dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21",
-        "tooling-dockerfiles.dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.21",
-        "tooling-dockerfiles.dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.5",
+        "tooling-dockerfiles.dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.23",
+        "tooling-dockerfiles.dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.23",
+        "tooling-dockerfiles.dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.6",
         "tooling-dockerfiles.dockerfile.native-micro.from": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
       },
       "properties": {

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -564,7 +564,7 @@ The project generation has also provided a `Dockerfile.native` in the `src/main/
 
 [source,dockerfile]
 ----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -38,7 +38,7 @@ In this case, you need to use a multi-stage `dockerfile` to copy the required li
 [source, dockerfile]
 ----
 # First stage - install the dependencies in an intermediate container
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 as BUILD
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 as BUILD
 RUN microdnf install freetype -y
 
 # Second stage - copy the dependencies
@@ -60,7 +60,7 @@ If you need to have access to the full AWT support, you need more than just `lib
 [source, dockerfile]
 ----
 # First stage - install the dependencies in an intermediate container
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 as BUILD
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 as BUILD
 RUN microdnf install freetype fontconfig -y
 
 # Second stage - copy the dependencies
@@ -109,7 +109,7 @@ To use this base image, use the following `Dockerfile`:
 
 [source, dockerfile]
 ----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-17-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-17-runtime
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.23
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-21-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-21-runtime
@@ -1,5 +1,5 @@
 # Use Java 21 base image
-FROM registry.access.redhat.com/ubi8/openjdk-21-runtime:1.21
+FROM registry.access.redhat.com/ubi8/openjdk-21-runtime:1.23
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java17
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java17
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
 ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java21
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java21
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
 ARG JAVA_PACKAGE=java-21-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-17-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-17-runtime
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.23
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-21-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-21-runtime
@@ -1,5 +1,5 @@
 # Use Java 21 base image
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
@@ -21,9 +21,9 @@ public interface ContainerImageJibConfig {
     /**
      * The base image to be used when a container image is being produced for the jar build.
      *
-     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21}
+     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23}
      * is used as the default.
-     * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17-runtime:1.21} is used as the default.
+     * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17-runtime:1.23} is used as the default.
      */
     Optional<String> baseJvmImage();
 

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
@@ -46,9 +46,9 @@ public interface ContainerImageOpenshiftConfig {
      * The value of this property is used to create an ImageStream for the builder image used in the Openshift build.
      * When it references images already available in the internal Openshift registry, the corresponding streams are used
      * instead.
-     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi9/openjdk-21:1.21}
+     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi9/openjdk-21:1.23}
      * is used as the default.
-     * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17:1.21} is used as the default.
+     * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17:1.23} is used as the default.
      */
     Optional<String> baseJvmImage();
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -83,7 +83,7 @@ FROM {#eval dockerfile.jvm.from-template /}
 {#else if dockerfile.jvm.from}
 FROM {dockerfile.jvm.from}
 {#else}
-FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.21
+FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.23
 {/if}
 
 ENV LANGUAGE='en_US:en'

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -429,9 +429,9 @@
     "project": {
       "default-codestart": "resteasy-reactive",
       "codestart-data": {
-        "dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21",
-        "dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.21",
-        "dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.5",
+        "dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.23",
+        "dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.23",
+        "dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.6",
         "dockerfile.native-micro": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
       },
       "properties": {

--- a/integration-tests/awt/src/main/docker/Dockerfile.native
+++ b/integration-tests/awt/src/main/docker/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 # Dependencies for AWT
 RUN microdnf install freetype fontconfig -y \
     && microdnf clean all -y

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/rest-client-quickstart-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
 ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.native
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
 #
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy-deploymentconfig/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy-deploymentconfig/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.legacy-jar
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/49476, but also updates the UBI base images.
