### PR TITLE
Rewrite JarResultBuildStep and enable parallel compression of jars

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>
@@ -215,8 +219,6 @@
                                         <exclude>com.google.code.findbugs:jsr305</exclude>
                                         <!-- com.google.guava:listenablefuture is empty and the ListenableFuture class is available in Guava -->
                                         <exclude>com.google.guava:listenablefuture</exclude>
-                                        <!-- let's avoid having commons-io crawling into quarkus-core -->
-                                        <exclude>commons-io:commons-io</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
@@ -1,7 +1,7 @@
 package io.quarkus.deployment.cmd;
 
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.QUARKUS_RUN_JAR;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.QUARKUS_RUN_JAR;
 
 import java.io.File;
 import java.nio.file.Path;

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
@@ -38,7 +38,7 @@ import io.quarkus.deployment.dev.remote.DefaultRemoteDevClient;
 import io.quarkus.deployment.dev.remote.RemoteDevClient;
 import io.quarkus.deployment.dev.remote.RemoteDevClientProvider;
 import io.quarkus.deployment.mutability.DevModeTask;
-import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
+import io.quarkus.deployment.pkg.jar.FastJarFormat;
 import io.quarkus.deployment.steps.ClassTransformingBuildStep;
 import io.quarkus.dev.spi.DeploymentFailedStartHandler;
 import io.quarkus.dev.spi.DevModeType;
@@ -330,7 +330,7 @@ public class IsolatedRemoteDevModeMain implements BiConsumer<CuratedApplication,
     }
 
     static Map<String, String> createHashes(Path appRoot) throws IOException {
-        Path quarkus = appRoot.resolve(JarResultBuildStep.QUARKUS); //we filter this jar, it has no relevance for remote dev
+        Path quarkus = appRoot.resolve(FastJarFormat.QUARKUS); //we filter this jar, it has no relevance for remote dev
         Map<String, String> hashes = new HashMap<>();
         Files.walkFileTree(appRoot, new FileVisitor<Path>() {
             @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
@@ -1,9 +1,10 @@
 package io.quarkus.deployment.mutability;
 
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.BUILD_SYSTEM_PROPERTIES;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.DEPLOYMENT_LIB;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.LIB;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.QUARKUS;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.APPMODEL_DAT;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.BUILD_SYSTEM_PROPERTIES;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEPLOYMENT_LIB;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.LIB;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.QUARKUS;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -28,7 +29,6 @@ import io.quarkus.bootstrap.model.MutableJarApplicationModel;
 import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.IsolatedDevModeMain;
-import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedArtifactDependency;
@@ -40,7 +40,7 @@ public class DevModeTask {
     public static Closeable main(Path appRoot) throws Exception {
 
         try (ObjectInputStream in = new ObjectInputStream(
-                Files.newInputStream(appRoot.resolve(LIB).resolve(DEPLOYMENT_LIB).resolve(JarResultBuildStep.APPMODEL_DAT)))) {
+                Files.newInputStream(appRoot.resolve(LIB).resolve(DEPLOYMENT_LIB).resolve(APPMODEL_DAT)))) {
             Properties buildSystemProperties = new Properties();
             try (InputStream buildIn = Files
                     .newInputStream(appRoot.resolve(QUARKUS).resolve(BUILD_SYSTEM_PROPERTIES))) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/mutability/ReaugmentTask.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/mutability/ReaugmentTask.java
@@ -1,9 +1,10 @@
 package io.quarkus.deployment.mutability;
 
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.BUILD_SYSTEM_PROPERTIES;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.DEPLOYMENT_LIB;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.LIB;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.QUARKUS;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.APPMODEL_DAT;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.BUILD_SYSTEM_PROPERTIES;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEPLOYMENT_LIB;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.LIB;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.QUARKUS;
 
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -20,7 +21,6 @@ import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.MutableJarApplicationModel;
-import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
 
 public class ReaugmentTask {
 
@@ -29,7 +29,7 @@ public class ReaugmentTask {
         Path deploymentLib = appRoot.resolve(LIB).resolve(DEPLOYMENT_LIB);
         Path buildSystemProps = appRoot.resolve(QUARKUS).resolve(BUILD_SYSTEM_PROPERTIES);
         try (ObjectInputStream in = new ObjectInputStream(
-                Files.newInputStream(deploymentLib.resolve(JarResultBuildStep.APPMODEL_DAT)))) {
+                Files.newInputStream(deploymentLib.resolve(APPMODEL_DAT)))) {
             Properties buildSystemProperties = new Properties();
             try (InputStream buildIn = Files
                     .newInputStream(buildSystemProps)) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
@@ -1,0 +1,323 @@
+package io.quarkus.deployment.pkg.jar;
+
+import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.builder.item.BuildItem;
+import io.quarkus.deployment.ApplicationArchive;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.paths.PathVisit;
+import io.quarkus.paths.PathVisitor;
+
+public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuilder<T> {
+
+    private static final Logger LOG = Logger.getLogger(AbstractJarBuilder.class);
+
+    protected static FileSystem createNewZip(Path runnerJar, PackageConfig config) throws IOException {
+        boolean useUncompressedJar = !config.jar().compress();
+        if (useUncompressedJar) {
+            return ZipUtils.newZip(runnerJar, Map.of("compressionMethod", "STORED"));
+        }
+        return ZipUtils.newZip(runnerJar);
+    }
+
+    /**
+     * Copy files from {@code archive} to {@code fs}, filtering out service providers into the given map.
+     *
+     * @param archive the root application archive
+     * @param fs the destination filesystem
+     * @param services the services map
+     * @throws IOException if an error occurs
+     */
+    protected static void copyFiles(ApplicationArchive archive, FileSystem fs, Map<String, List<byte[]>> services,
+            Predicate<String> ignoredEntriesPredicate) throws IOException {
+        try {
+            archive.accept(tree -> {
+                tree.walk(new PathVisitor() {
+                    @Override
+                    public void visitPath(PathVisit visit) {
+                        final Path file = visit.getRoot().relativize(visit.getPath());
+                        final String relativePath = toUri(file);
+                        if (relativePath.isEmpty() || ignoredEntriesPredicate.test(relativePath)) {
+                            return;
+                        }
+                        try {
+                            if (Files.isDirectory(visit.getPath())) {
+                                addDirectory(fs, relativePath);
+                            } else {
+                                if (relativePath.startsWith("META-INF/services/") && relativePath.length() > 18
+                                        && services != null) {
+                                    final byte[] content;
+                                    try {
+                                        content = Files.readAllBytes(visit.getPath());
+                                    } catch (IOException e) {
+                                        throw new UncheckedIOException(e);
+                                    }
+                                    services.computeIfAbsent(relativePath, (u) -> new ArrayList<>()).add(content);
+                                } else if (!relativePath.equals("META-INF/INDEX.LIST")) {
+                                    //TODO: auto generate INDEX.LIST
+                                    //this may have implications for Camel though, as they change the layout
+                                    //also this is only really relevant for the thin jar layout
+                                    Path target = fs.getPath(relativePath);
+                                    if (!Files.exists(target)) {
+                                        Files.copy(visit.getPath(), target, StandardCopyOption.REPLACE_EXISTING);
+                                    }
+                                }
+                            }
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
+                });
+            });
+        } catch (RuntimeException re) {
+            final Throwable cause = re.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            throw re;
+        }
+    }
+
+    protected static void copyCommonContent(FileSystem runnerZipFs, Map<String, List<byte[]>> concatenatedEntries,
+            ApplicationArchivesBuildItem appArchives, TransformedClassesBuildItem transformedClassesBuildItem,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources, Map<String, String> seen,
+            Predicate<String> ignoredEntriesPredicate)
+            throws IOException {
+
+        //TODO: this is probably broken in gradle
+        //        if (Files.exists(augmentOutcome.getConfigDir())) {
+        //            copyFiles(augmentOutcome.getConfigDir(), runnerZipFs, services);
+        //        }
+        for (Set<TransformedClassesBuildItem.TransformedClass> transformed : transformedClassesBuildItem
+                .getTransformedClassesByJar().values()) {
+            for (TransformedClassesBuildItem.TransformedClass i : transformed) {
+                if (i.getData() != null) {
+                    Path target = runnerZipFs.getPath(i.getFileName());
+                    handleParent(runnerZipFs, i.getFileName(), seen);
+                    try (final OutputStream out = Files.newOutputStream(target)) {
+                        out.write(i.getData());
+                    }
+                    seen.put(i.getFileName(), "Current Application");
+                }
+            }
+        }
+        for (GeneratedClassBuildItem i : generatedClasses) {
+            String fileName = fromClassNameToResourceName(i.getName());
+            seen.put(fileName, "Current Application");
+            Path target = runnerZipFs.getPath(fileName);
+            handleParent(runnerZipFs, fileName, seen);
+            if (Files.exists(target)) {
+                continue;
+            }
+            try (final OutputStream os = Files.newOutputStream(target)) {
+                os.write(i.getClassData());
+            }
+        }
+
+        for (GeneratedResourceBuildItem i : generatedResources) {
+            if (ignoredEntriesPredicate.test(i.getName())) {
+                continue;
+            }
+            Path target = runnerZipFs.getPath(i.getName());
+            handleParent(runnerZipFs, i.getName(), seen);
+            if (Files.exists(target)) {
+                continue;
+            }
+            if (i.getName().startsWith("META-INF/services/")) {
+                concatenatedEntries.computeIfAbsent(i.getName(), (u) -> new ArrayList<>()).add(i.getData());
+            } else {
+                try (final OutputStream os = Files.newOutputStream(target)) {
+                    os.write(i.getData());
+                }
+            }
+        }
+
+        copyFiles(appArchives.getRootArchive(), runnerZipFs, concatenatedEntries, ignoredEntriesPredicate);
+
+        for (Map.Entry<String, List<byte[]>> entry : concatenatedEntries.entrySet()) {
+            try (final OutputStream os = Files.newOutputStream(runnerZipFs.getPath(entry.getKey()))) {
+                // TODO: Handle merging of XMLs
+                for (byte[] i : entry.getValue()) {
+                    os.write(i);
+                    os.write('\n');
+                }
+            }
+        }
+    }
+
+    /**
+     * Manifest generation is quite simple : we just have to push some attributes in manifest.
+     * However, it gets a little more complex if the manifest preexists.
+     * So we first try to see if a manifest exists, and otherwise create a new one.
+     *
+     * <b>BEWARE</b> this method should be invoked after file copy from target/classes and so on.
+     * Otherwise, this manifest manipulation will be useless.
+     */
+    protected static void generateManifest(FileSystem runnerZipFs, final String classPath, PackageConfig config,
+            ResolvedDependency appArtifact,
+            String mainClassName,
+            ApplicationInfoBuildItem applicationInfo)
+            throws IOException {
+        final Path manifestPath = runnerZipFs.getPath("META-INF", "MANIFEST.MF");
+        final Manifest manifest = new Manifest();
+        if (Files.exists(manifestPath)) {
+            try (InputStream is = Files.newInputStream(manifestPath)) {
+                manifest.read(is);
+            }
+            Files.delete(manifestPath);
+        } else {
+            Files.createDirectories(runnerZipFs.getPath("META-INF"));
+        }
+        Files.createDirectories(manifestPath.getParent());
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        // JDK 24+ needs --add-opens=java.base/java.lang=ALL-UNNAMED for org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals()
+        attributes.put(new Attributes.Name("Add-Opens"), "java.base/java.lang");
+
+        for (Map.Entry<String, String> attribute : config.jar().manifest().attributes().entrySet()) {
+            attributes.putValue(attribute.getKey(), attribute.getValue());
+        }
+        if (attributes.containsKey(Attributes.Name.CLASS_PATH)) {
+            LOG.warn(
+                    "A CLASS_PATH entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Class-Path\". Quarkus has overwritten this existing entry.");
+        }
+        attributes.put(Attributes.Name.CLASS_PATH, classPath);
+        if (attributes.containsKey(Attributes.Name.MAIN_CLASS)) {
+            String existingMainClass = attributes.getValue(Attributes.Name.MAIN_CLASS);
+            if (!mainClassName.equals(existingMainClass)) {
+                LOG.warn(
+                        "A MAIN_CLASS entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Main-Class\". Quarkus has overwritten your existing entry.");
+            }
+        }
+        attributes.put(Attributes.Name.MAIN_CLASS, mainClassName);
+        if (config.jar().manifest().addImplementationEntries()
+                && !attributes.containsKey(Attributes.Name.IMPLEMENTATION_TITLE)) {
+            String name = ApplicationInfoBuildItem.UNSET_VALUE.equals(applicationInfo.getName())
+                    ? appArtifact.getArtifactId()
+                    : applicationInfo.getName();
+            attributes.put(Attributes.Name.IMPLEMENTATION_TITLE, name);
+        }
+        if (config.jar().manifest().addImplementationEntries()
+                && !attributes.containsKey(Attributes.Name.IMPLEMENTATION_VERSION)) {
+            String version = ApplicationInfoBuildItem.UNSET_VALUE.equals(applicationInfo.getVersion())
+                    ? appArtifact.getVersion()
+                    : applicationInfo.getVersion();
+            attributes.put(Attributes.Name.IMPLEMENTATION_VERSION, version);
+        }
+        for (String sectionName : config.jar().manifest().sections().keySet()) {
+            for (Map.Entry<String, String> entry : config.jar().manifest().sections().get(sectionName).entrySet()) {
+                Attributes attribs = manifest.getEntries().computeIfAbsent(sectionName, k -> new Attributes());
+                attribs.putValue(entry.getKey(), entry.getValue());
+            }
+        }
+        try (final OutputStream os = Files.newOutputStream(manifestPath)) {
+            manifest.write(os);
+        }
+    }
+
+    /**
+     * Indicates whether the given dependency should be included or not.
+     * <p>
+     * A dependency should be included if it is a jar file and:
+     * <p>
+     * <ul>
+     * <li>The dependency is not optional or</li>
+     * <li>The dependency is part of the optional dependencies to include or</li>
+     * <li>The optional dependencies to include are absent</li>
+     * </ul>
+     *
+     * @param appDep the dependency to test.
+     * @param optionalDependencies the optional dependencies to include into the final package.
+     * @return {@code true} if the dependency should be included, {@code false} otherwise.
+     */
+    protected static boolean includeAppDependency(ResolvedDependency appDep, Optional<Set<ArtifactKey>> optionalDependencies,
+            Set<ArtifactKey> removedArtifacts) {
+        if (!appDep.isJar()) {
+            return false;
+        }
+        if (appDep.isOptional()) {
+            return optionalDependencies.map(appArtifactKeys -> appArtifactKeys.contains(appDep.getKey()))
+                    .orElse(true);
+        }
+        if (removedArtifacts.contains(appDep.getKey())) {
+            return false;
+        }
+        return true;
+    }
+
+    protected static String suffixToClassifier(String suffix) {
+        return suffix.startsWith("-") ? suffix.substring(1) : suffix;
+    }
+
+    protected static void addDirectory(FileSystem fs, final String relativePath)
+            throws IOException {
+        final Path targetDir = fs.getPath(relativePath);
+        try {
+            Files.createDirectory(targetDir);
+        } catch (FileAlreadyExistsException e) {
+            if (!Files.isDirectory(targetDir)) {
+                throw e;
+            }
+        }
+    }
+
+    protected static String toUri(Path path) {
+        if (path.isAbsolute()) {
+            return path.toUri().getPath();
+        }
+        if (path.getNameCount() == 0) {
+            return "";
+        }
+        return toUri(new StringBuilder(), path, 0).toString();
+    }
+
+    private static void handleParent(FileSystem runnerZipFs, String fileName, Map<String, String> seen) throws IOException {
+        for (int i = 0; i < fileName.length(); ++i) {
+            if (fileName.charAt(i) == '/') {
+                String dir = fileName.substring(0, i);
+                if (!seen.containsKey(dir)) {
+                    seen.put(dir, "Current Application");
+                    Files.createDirectories(runnerZipFs.getPath(dir));
+                }
+            }
+        }
+    }
+
+    private static StringBuilder toUri(StringBuilder b, Path path, int seg) {
+        b.append(path.getName(seg));
+        if (seg < path.getNameCount() - 1) {
+            b.append('/');
+            toUri(b, path, seg + 1);
+        }
+        return b;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -72,7 +72,8 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
     public abstract T build() throws IOException;
 
     protected void doBuild(Path runnerJar, Path libDir) throws IOException {
-        try (ArchiveCreator archiveCreator = new ZipFileSystemArchiveCreator(runnerJar, packageConfig.jar().compress())) {
+        try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
+                packageConfig.jar().compress(), outputTarget.getOutputDirectory())) {
             final Map<String, String> seen = new HashMap<>();
             final StringBuilder classPath = new StringBuilder();
             final Map<String, List<byte[]>> services = new HashMap<>();

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -1,0 +1,166 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.builder.item.BuildItem;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.pkg.JarUnsigner;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends AbstractJarBuilder<T> {
+
+    private static final Logger LOG = Logger.getLogger(AbstractLegacyThinJarBuilder.class);
+
+    protected final CurateOutcomeBuildItem curateOutcome;
+    protected final OutputTargetBuildItem outputTarget;
+    protected final ApplicationInfoBuildItem applicationInfo;
+    protected final PackageConfig packageConfig;
+    protected final MainClassBuildItem mainClass;
+    protected final ApplicationArchivesBuildItem applicationArchives;
+    protected final TransformedClassesBuildItem transformedClasses;
+    protected final List<GeneratedClassBuildItem> generatedClasses;
+    protected final List<GeneratedResourceBuildItem> generatedResources;
+    protected final Set<ArtifactKey> removedArtifactKeys;
+
+    public AbstractLegacyThinJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            Set<ArtifactKey> removedArtifactKeys) {
+        this.curateOutcome = curateOutcome;
+        this.outputTarget = outputTarget;
+        this.applicationInfo = applicationInfo;
+        this.packageConfig = packageConfig;
+        this.mainClass = mainClass;
+        this.applicationArchives = applicationArchives;
+        this.transformedClasses = transformedClasses;
+        this.generatedClasses = generatedClasses;
+        this.generatedResources = generatedResources;
+        this.removedArtifactKeys = removedArtifactKeys;
+    }
+
+    public abstract T build() throws IOException;
+
+    protected void doBuild(Path runnerJar, Path libDir) throws IOException {
+        try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
+            final Map<String, String> seen = new HashMap<>();
+            final StringBuilder classPath = new StringBuilder();
+            final Map<String, List<byte[]>> services = new HashMap<>();
+
+            final Collection<ResolvedDependency> appDeps = curateOutcome.getApplicationModel()
+                    .getRuntimeDependencies();
+
+            Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
+
+            copyLibraryJars(runnerZipFs, outputTarget, transformedClasses, libDir, classPath, appDeps, services,
+                    ignoredEntriesPredicate, removedArtifactKeys);
+
+            ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
+            // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
+            // see https://bugs.openjdk.java.net/browse/JDK-8031748
+            generateManifest(runnerZipFs, classPath.toString(), packageConfig, appArtifact, mainClass.getClassName(),
+                    applicationInfo);
+
+            copyCommonContent(runnerZipFs, services, applicationArchives, transformedClasses, generatedClasses,
+                    generatedResources, seen, ignoredEntriesPredicate);
+        }
+        runnerJar.toFile().setReadable(true, false);
+    }
+
+    private static void copyLibraryJars(FileSystem runnerZipFs, OutputTargetBuildItem outputTargetBuildItem,
+            TransformedClassesBuildItem transformedClasses, Path libDir,
+            StringBuilder classPath, Collection<ResolvedDependency> appDeps, Map<String, List<byte[]>> services,
+            Predicate<String> ignoredEntriesPredicate, Set<ArtifactKey> removedDependencies) throws IOException {
+        for (ResolvedDependency appDep : appDeps) {
+
+            // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
+            // and are not part of the optional dependencies to include
+            if (!includeAppDependency(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDependencies)) {
+                continue;
+            }
+
+            for (Path resolvedDep : appDep.getResolvedPaths()) {
+                if (!Files.isDirectory(resolvedDep)) {
+                    Set<String> transformedFromThisArchive = transformedClasses.getTransformedFilesByJar().get(resolvedDep);
+                    if (transformedFromThisArchive == null || transformedFromThisArchive.isEmpty()) {
+                        final String fileName = appDep.getGroupId() + "." + resolvedDep.getFileName();
+                        final Path targetPath = libDir.resolve(fileName);
+                        // Unsign the jar before copying it
+                        JarUnsigner.unsignJar(resolvedDep, targetPath);
+                        classPath.append(" lib/").append(fileName);
+                    } else {
+                        //we have transformed classes, we need to handle them correctly
+                        final String fileName = "modified-" + appDep.getGroupId() + "."
+                                + resolvedDep.getFileName();
+                        final Path targetPath = libDir.resolve(fileName);
+                        classPath.append(" lib/").append(fileName);
+                        JarUnsigner.unsignJar(resolvedDep, targetPath, Predicate.not(transformedFromThisArchive::contains));
+                    }
+                } else {
+                    // This case can happen when we are building a jar from inside the Quarkus repository
+                    // and Quarkus Bootstrap's localProjectDiscovery has been set to true. In such a case
+                    // the non-jar dependencies are the Quarkus dependencies picked up on the file system
+                    Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                            new SimpleFileVisitor<Path>() {
+                                @Override
+                                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                                        throws IOException {
+                                    final Path relativePath = resolvedDep.relativize(file);
+                                    final String relativeUri = toUri(relativePath);
+                                    if (ignoredEntriesPredicate.test(relativeUri)) {
+                                        return FileVisitResult.CONTINUE;
+                                    }
+                                    if (relativeUri.startsWith("META-INF/services/") && relativeUri.length() > 18) {
+                                        services.computeIfAbsent(relativeUri, (u) -> new ArrayList<>())
+                                                .add(Files.readAllBytes(file));
+                                    } else if (file.getFileName().toString().endsWith(".class")) {
+                                        final Path targetPath = runnerZipFs.getPath(relativePath.toString());
+                                        if (targetPath.getParent() != null) {
+                                            Files.createDirectories(targetPath.getParent());
+                                        }
+                                        Files.copy(file, targetPath, StandardCopyOption.REPLACE_EXISTING); //replace only needed for testing
+                                    }
+                                    return FileVisitResult.CONTINUE;
+                                }
+                            });
+                }
+            }
+        }
+    }
+
+    private static Predicate<String> getThinJarIgnoredEntriesPredicate(PackageConfig packageConfig) {
+        return packageConfig.jar().userConfiguredIgnoredEntries().map(Set::copyOf).orElse(Set.of())::contains;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -36,17 +36,6 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
 
     private static final Logger LOG = Logger.getLogger(AbstractLegacyThinJarBuilder.class);
 
-    protected final CurateOutcomeBuildItem curateOutcome;
-    protected final OutputTargetBuildItem outputTarget;
-    protected final ApplicationInfoBuildItem applicationInfo;
-    protected final PackageConfig packageConfig;
-    protected final MainClassBuildItem mainClass;
-    protected final ApplicationArchivesBuildItem applicationArchives;
-    protected final TransformedClassesBuildItem transformedClasses;
-    protected final List<GeneratedClassBuildItem> generatedClasses;
-    protected final List<GeneratedResourceBuildItem> generatedResources;
-    protected final Set<ArtifactKey> removedArtifactKeys;
-
     public AbstractLegacyThinJarBuilder(CurateOutcomeBuildItem curateOutcome,
             OutputTargetBuildItem outputTarget,
             ApplicationInfoBuildItem applicationInfo,
@@ -57,16 +46,8 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
             Set<ArtifactKey> removedArtifactKeys) {
-        this.curateOutcome = curateOutcome;
-        this.outputTarget = outputTarget;
-        this.applicationInfo = applicationInfo;
-        this.packageConfig = packageConfig;
-        this.mainClass = mainClass;
-        this.applicationArchives = applicationArchives;
-        this.transformedClasses = transformedClasses;
-        this.generatedClasses = generatedClasses;
-        this.generatedResources = generatedResources;
-        this.removedArtifactKeys = removedArtifactKeys;
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
+                generatedClasses, generatedResources, removedArtifactKeys);
     }
 
     public abstract T build() throws IOException;
@@ -92,8 +73,7 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
             generateManifest(archiveCreator, classPath.toString(), packageConfig, appArtifact, mainClass.getClassName(),
                     applicationInfo);
 
-            copyCommonContent(archiveCreator, services, applicationArchives, transformedClasses, generatedClasses,
-                    generatedResources, seen, ignoredEntriesPredicate);
+            copyCommonContent(archiveCreator, services, ignoredEntriesPredicate);
         }
         runnerJar.toFile().setReadable(true, false);
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ArchiveCreator.java
@@ -1,0 +1,53 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.Manifest;
+
+public interface ArchiveCreator extends AutoCloseable {
+
+    static final String UNKNOWN_SOURCE = "Unknown source";
+    static final String CURRENT_APPLICATION = "Current application";
+
+    void addManifest(Manifest manifest) throws IOException;
+
+    void addDirectory(String directory, String source) throws IOException;
+
+    void addFile(Path origin, String target, String source) throws IOException;
+
+    void addFile(byte[] bytes, String target, String source) throws IOException;
+
+    void addFileIfNotExists(Path origin, String target, String source) throws IOException;
+
+    void addFileIfNotExists(byte[] bytes, String target, String source) throws IOException;
+
+    void addFile(List<byte[]> bytes, String target, String source) throws IOException;
+
+    default void addDirectory(String directory) throws IOException {
+        addDirectory(directory, UNKNOWN_SOURCE);
+    }
+
+    default void addFile(Path origin, String target) throws IOException {
+        addFile(origin, target, UNKNOWN_SOURCE);
+    }
+
+    default void addFile(byte[] bytes, String target) throws IOException {
+        addFile(bytes, target, UNKNOWN_SOURCE);
+    }
+
+    default void addFileIfNotExists(Path origin, String target) throws IOException {
+        addFileIfNotExists(origin, target, UNKNOWN_SOURCE);
+    }
+
+    default void addFileIfNotExists(byte[] bytes, String target) throws IOException {
+        addFileIfNotExists(bytes, target, UNKNOWN_SOURCE);
+    }
+
+    default void addFile(List<byte[]> bytes, String target) throws IOException {
+        addFile(bytes, target, UNKNOWN_SOURCE);
+    }
+
+    @Override
+    void close();
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/Decompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/Decompiler.java
@@ -1,0 +1,37 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.nio.file.Path;
+
+interface Decompiler {
+
+    void init(Context context);
+
+    /**
+     * @return {@code true} if the decompiler was successfully download or already exists
+     */
+    boolean downloadIfNecessary();
+
+    /**
+     * @return {@code true} if the decompilation process was successful
+     */
+    boolean decompile(Path jarToDecompile);
+
+    class Context {
+        final String versionStr;
+        final Path jarLocation;
+        final Path decompiledOutputDir;
+
+        public Context(Path jarLocation, Path decompiledOutputDir) {
+            this.versionStr = null;
+            this.jarLocation = jarLocation;
+            this.decompiledOutputDir = decompiledOutputDir;
+        }
+
+        public Context(String versionStr, Path jarLocation, Path decompiledOutputDir) {
+            this.versionStr = versionStr;
+            this.jarLocation = jarLocation;
+            this.decompiledOutputDir = decompiledOutputDir;
+        }
+
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
@@ -64,18 +64,8 @@ public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
     private static final String MP_CONFIG_FILE = "META-INF/microprofile-config.properties";
 
-    private final CurateOutcomeBuildItem curateOutcome;
-    private final OutputTargetBuildItem outputTarget;
-    private final ApplicationInfoBuildItem applicationInfo;
-    private final PackageConfig packageConfig;
-    private final MainClassBuildItem mainClass;
-    private final ApplicationArchivesBuildItem applicationArchives;
     private final List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives;
-    private final TransformedClassesBuildItem transformedClasses;
-    private final List<GeneratedClassBuildItem> generatedClasses;
-    private final List<GeneratedResourceBuildItem> generatedResources;
     private final Set<ArtifactKey> parentFirstArtifactKeys;
-    private final Set<ArtifactKey> removedArtifactKeys;
 
     public FastJarBuilder(CurateOutcomeBuildItem curateOutcome,
             OutputTargetBuildItem outputTarget,
@@ -89,18 +79,10 @@ public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             List<GeneratedResourceBuildItem> generatedResources,
             Set<ArtifactKey> parentFirstArtifactKeys,
             Set<ArtifactKey> removedArtifactKeys) {
-        this.curateOutcome = curateOutcome;
-        this.outputTarget = outputTarget;
-        this.applicationInfo = applicationInfo;
-        this.packageConfig = packageConfig;
-        this.mainClass = mainClass;
-        this.applicationArchives = applicationArchives;
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
+                generatedClasses, generatedResources, removedArtifactKeys);
         this.additionalApplicationArchives = additionalApplicationArchives;
-        this.transformedClasses = transformedClasses;
-        this.generatedClasses = generatedClasses;
-        this.generatedResources = generatedResources;
         this.parentFirstArtifactKeys = parentFirstArtifactKeys;
-        this.removedArtifactKeys = removedArtifactKeys;
     }
 
     public JarBuildItem build() throws IOException {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
@@ -1,0 +1,539 @@
+package io.quarkus.deployment.pkg.jar;
+
+import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.model.MutableJarApplicationModel;
+import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
+import io.quarkus.bootstrap.runner.SerializedApplication;
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem.TransformedClass;
+import io.quarkus.deployment.pkg.JarUnsigner;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.util.FileUtil;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.sbom.ApplicationComponent;
+import io.quarkus.sbom.ApplicationManifestConfig;
+
+public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
+
+    private static final Logger LOG = Logger.getLogger(FastJarBuilder.class);
+
+    private static final String MP_CONFIG_FILE = "META-INF/microprofile-config.properties";
+
+    private final CurateOutcomeBuildItem curateOutcome;
+    private final OutputTargetBuildItem outputTarget;
+    private final ApplicationInfoBuildItem applicationInfo;
+    private final PackageConfig packageConfig;
+    private final MainClassBuildItem mainClass;
+    private final ApplicationArchivesBuildItem applicationArchives;
+    private final List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives;
+    private final TransformedClassesBuildItem transformedClasses;
+    private final List<GeneratedClassBuildItem> generatedClasses;
+    private final List<GeneratedResourceBuildItem> generatedResources;
+    private final Set<ArtifactKey> parentFirstArtifactKeys;
+    private final Set<ArtifactKey> removedArtifactKeys;
+
+    public FastJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            Set<ArtifactKey> parentFirstArtifactKeys,
+            Set<ArtifactKey> removedArtifactKeys) {
+        this.curateOutcome = curateOutcome;
+        this.outputTarget = outputTarget;
+        this.applicationInfo = applicationInfo;
+        this.packageConfig = packageConfig;
+        this.mainClass = mainClass;
+        this.applicationArchives = applicationArchives;
+        this.additionalApplicationArchives = additionalApplicationArchives;
+        this.transformedClasses = transformedClasses;
+        this.generatedClasses = generatedClasses;
+        this.generatedResources = generatedResources;
+        this.parentFirstArtifactKeys = parentFirstArtifactKeys;
+        this.removedArtifactKeys = removedArtifactKeys;
+    }
+
+    public JarBuildItem build() throws IOException {
+        boolean rebuild = outputTarget.isRebuild();
+
+        Path buildDir;
+
+        if (packageConfig.outputDirectory().isPresent()) {
+            buildDir = outputTarget.getOutputDirectory();
+        } else {
+            buildDir = outputTarget.getOutputDirectory().resolve(FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME);
+        }
+
+        final ApplicationManifestConfig.Builder manifestConfig = ApplicationManifestConfig.builder()
+                .setApplicationModel(curateOutcome.getApplicationModel())
+                .setDistributionDirectory(buildDir);
+        //unmodified 3rd party dependencies
+        Path libDir = buildDir.resolve(FastJarFormat.LIB);
+        Path mainLib = libDir.resolve(FastJarFormat.MAIN);
+        //parent first entries
+        Path baseLib = libDir.resolve(FastJarFormat.BOOT_LIB);
+        Files.createDirectories(baseLib);
+
+        Path appDir = buildDir.resolve(FastJarFormat.APP);
+        Path quarkus = buildDir.resolve(FastJarFormat.QUARKUS);
+        Path userProviders = null;
+        if (packageConfig.jar().userProvidersDirectory().isPresent()) {
+            userProviders = buildDir.resolve(packageConfig.jar().userProvidersDirectory().get());
+        }
+        if (!rebuild) {
+            IoUtils.createOrEmptyDir(buildDir);
+            Files.createDirectories(mainLib);
+            Files.createDirectories(baseLib);
+            Files.createDirectories(appDir);
+            Files.createDirectories(quarkus);
+            if (userProviders != null) {
+                Files.createDirectories(userProviders);
+                //we add this dir so that it can be copied into container images if required
+                //and will still be copied even if empty
+                Path keepFile = userProviders.resolve(".keep");
+                if (!keepFile.toFile().exists()) {
+                    // check if the file exists to avoid a FileAlreadyExistsException
+                    Files.createFile(keepFile);
+                }
+            }
+        } else {
+            IoUtils.createOrEmptyDir(quarkus);
+        }
+
+        Path decompiledOutputDir = null;
+        boolean wasDecompiledSuccessfully = true;
+        Decompiler decompiler = null;
+        PackageConfig.DecompilerConfig decompilerConfig = packageConfig.jar().decompiler();
+        if (decompilerConfig.enabled()) {
+            decompiledOutputDir = buildDir.getParent().resolve(decompilerConfig.outputDirectory());
+            FileUtil.deleteDirectory(decompiledOutputDir);
+            Files.createDirectory(decompiledOutputDir);
+            decompiler = new VineflowerDecompiler();
+            Path jarDirectory = Paths.get(decompilerConfig.jarDirectory());
+            if (!Files.exists(jarDirectory)) {
+                Files.createDirectory(jarDirectory);
+            }
+            decompiler.init(new Decompiler.Context(jarDirectory, decompiledOutputDir));
+            decompiler.downloadIfNecessary();
+        }
+
+        FastJarJars.FastJarJarsBuilder fastJarJarsBuilder = new FastJarJars.FastJarJarsBuilder();
+        List<Path> parentFirst = new ArrayList<>();
+        //we process in order of priority
+        //transformed classes first
+        if (!transformedClasses.getTransformedClassesByJar().isEmpty()) {
+            Path transformedZip = quarkus.resolve(FastJarFormat.TRANSFORMED_BYTECODE_JAR);
+            fastJarJarsBuilder.setTransformedJar(transformedZip);
+            try (FileSystem out = createNewZip(transformedZip, packageConfig)) {
+                for (Set<TransformedClass> transformedSet : transformedClasses
+                        .getTransformedClassesByJar().values()) {
+                    for (TransformedClass transformed : transformedSet) {
+                        Path target = out.getPath(transformed.getFileName());
+                        if (transformed.getData() != null) {
+                            if (target.getParent() != null) {
+                                Files.createDirectories(target.getParent());
+                            }
+                            Files.write(target, transformed.getData());
+                        }
+                    }
+                }
+            }
+            if (decompiler != null) {
+                wasDecompiledSuccessfully = decompiler.decompile(transformedZip);
+            }
+        }
+        //now generated classes and resources
+        Path generatedZip = quarkus.resolve(FastJarFormat.GENERATED_BYTECODE_JAR);
+        fastJarJarsBuilder.setGeneratedJar(generatedZip);
+        try (FileSystem out = createNewZip(generatedZip, packageConfig)) {
+            for (GeneratedClassBuildItem i : generatedClasses) {
+                String fileName = fromClassNameToResourceName(i.getName());
+                Path target = out.getPath(fileName);
+                if (target.getParent() != null) {
+                    Files.createDirectories(target.getParent());
+                }
+                Files.write(target, i.getClassData());
+            }
+
+            for (GeneratedResourceBuildItem i : generatedResources) {
+                Path target = out.getPath(i.getName());
+                if (target.getParent() != null) {
+                    Files.createDirectories(target.getParent());
+                }
+                Files.write(target, i.getData());
+            }
+        }
+        if (decompiler != null) {
+            wasDecompiledSuccessfully &= decompiler.decompile(generatedZip);
+        }
+
+        if (wasDecompiledSuccessfully && (decompiledOutputDir != null)) {
+            LOG.info("The decompiled output can be found at: " + decompiledOutputDir.toAbsolutePath().toString());
+        }
+
+        //now the application classes
+        Path runnerJar = appDir.resolve(outputTarget.getBaseName() + DOT_JAR);
+        fastJarJarsBuilder.setRunnerJar(runnerJar);
+
+        if (!rebuild) {
+            manifestConfig.addComponent(ApplicationComponent.builder()
+                    .setResolvedDependency(applicationArchives.getRootArchive().getResolvedDependency())
+                    .setPath(runnerJar));
+            Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
+            try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
+                copyFiles(applicationArchives.getRootArchive(), runnerZipFs, null, ignoredEntriesPredicate);
+            }
+        }
+        final StringBuilder classPath = new StringBuilder();
+        final Map<ArtifactKey, List<Path>> copiedArtifacts = new HashMap<>();
+        for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
+            if (!rebuild) {
+                copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, mainLib, baseLib,
+                        fastJarJarsBuilder::addDependency, true,
+                        classPath, appDep, transformedClasses, removedArtifactKeys, packageConfig, manifestConfig);
+            } else if (includeAppDependency(appDep, outputTarget.getIncludedOptionalDependencies(), removedArtifactKeys)) {
+                appDep.getResolvedPaths().forEach(fastJarJarsBuilder::addDependency);
+            }
+            if (parentFirstArtifactKeys.contains(appDep.getKey())) {
+                appDep.getResolvedPaths().forEach(parentFirst::add);
+            }
+        }
+        for (AdditionalApplicationArchiveBuildItem i : additionalApplicationArchives) {
+            for (Path path : i.getResolvedPaths()) {
+                if (!path.getParent().equals(userProviders)) {
+                    throw new RuntimeException(
+                            "Additional application archives can only be provided from the user providers directory. " + path
+                                    + " is not present in " + userProviders);
+                }
+                fastJarJarsBuilder.addDependency(path);
+            }
+        }
+
+        /*
+         * There are some files like META-INF/microprofile-config.properties that usually don't exist in application
+         * and yet are always looked up (spec compliance...) and due to the location in the jar,
+         * the RunnerClassLoader needs to look into every jar to determine whether they exist or not.
+         * In keeping true to the original design of the RunnerClassLoader which indexes the directory structure,
+         * we just add a fail-fast path for files we know don't exist.
+         *
+         * TODO: if this gets more complex, we'll probably want a build item to carry this information instead of hard
+         * coding it here
+         */
+        List<String> nonExistentResources = new ArrayList<>(1);
+        Enumeration<URL> mpConfigURLs = Thread.currentThread().getContextClassLoader().getResources(MP_CONFIG_FILE);
+        if (!mpConfigURLs.hasMoreElements()) {
+            nonExistentResources.add(MP_CONFIG_FILE);
+        }
+
+        Path appInfo = buildDir.resolve(QuarkusEntryPoint.QUARKUS_APPLICATION_DAT);
+        try (OutputStream out = Files.newOutputStream(appInfo)) {
+            FastJarJars fastJarJars = fastJarJarsBuilder.build();
+            List<Path> allJars = new ArrayList<>();
+            if (fastJarJars.transformedJar != null) {
+                allJars.add(fastJarJars.transformedJar);
+            }
+            allJars.add(fastJarJars.generatedJar);
+            allJars.add(fastJarJars.runnerJar);
+            List<Path> sortedDeps = new ArrayList<>(fastJarJars.dependencies);
+            Collections.sort(sortedDeps);
+            allJars.addAll(sortedDeps);
+            List<Path> sortedParentFirst = new ArrayList<>(parentFirst);
+            Collections.sort(sortedParentFirst);
+            List<String> sortedNonExistentResources = new ArrayList<>(nonExistentResources);
+            Collections.sort(sortedNonExistentResources);
+            SerializedApplication.write(out, mainClass.getClassName(), buildDir, allJars, sortedParentFirst,
+                    sortedNonExistentResources);
+        }
+
+        runnerJar.toFile().setReadable(true, false);
+        Path initJar = buildDir.resolve(FastJarFormat.QUARKUS_RUN_JAR);
+        manifestConfig.setMainComponent(ApplicationComponent.builder()
+                .setPath(initJar)
+                .setDependencies(List.of(curateOutcome.getApplicationModel().getAppArtifact())))
+                .setRunnerPath(initJar);
+        boolean mutableJar = packageConfig.jar().type() == MUTABLE_JAR;
+        if (mutableJar) {
+            //we output the properties in a reproducible manner, so we remove the date comment
+            //and sort them
+            //we still use Properties to get the escaping right though, so basically we write out the lines
+            //to memory, split them, discard comments, sort them, then write them to disk
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            outputTarget.getBuildSystemProperties().store(out, null);
+            List<String> lines = Arrays.stream(out.toString(StandardCharsets.UTF_8).split("\n"))
+                    .filter(s -> !s.startsWith("#")).sorted().collect(Collectors.toList());
+            Path buildSystemProps = quarkus.resolve(FastJarFormat.BUILD_SYSTEM_PROPERTIES);
+            manifestConfig.addComponent(ApplicationComponent.builder().setPath(buildSystemProps).setDevelopmentScope());
+            try (OutputStream fileOutput = Files.newOutputStream(buildSystemProps)) {
+                fileOutput.write(String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        if (!rebuild) {
+            try (FileSystem runnerZipFs = createNewZip(initJar, packageConfig)) {
+                ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
+                generateManifest(runnerZipFs, classPath.toString(), packageConfig, appArtifact,
+                        QuarkusEntryPoint.class.getName(),
+                        applicationInfo);
+            }
+
+            //now copy the deployment artifacts, if required
+            if (mutableJar) {
+                Path deploymentLib = libDir.resolve(FastJarFormat.DEPLOYMENT_LIB);
+                Files.createDirectories(deploymentLib);
+                for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getDependencies()) {
+                    copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, deploymentLib, baseLib, p -> {
+                    }, false, classPath, appDep, new TransformedClassesBuildItem(Map.of()), removedArtifactKeys, packageConfig,
+                            manifestConfig); //we don't care about transformation here, so just pass in an empty item
+                }
+                Map<ArtifactKey, List<String>> relativePaths = new HashMap<>();
+                for (Map.Entry<ArtifactKey, List<Path>> e : copiedArtifacts.entrySet()) {
+                    relativePaths.put(e.getKey(),
+                            e.getValue().stream().map(s -> buildDir.relativize(s).toString().replace('\\', '/'))
+                                    .collect(Collectors.toList()));
+                }
+
+                //now we serialize the data needed to build up the reaugmentation class path
+                //first the app model
+                MutableJarApplicationModel model = new MutableJarApplicationModel(outputTarget.getBaseName(),
+                        relativePaths,
+                        curateOutcome.getApplicationModel(),
+                        packageConfig.jar().userProvidersDirectory().orElse(null), buildDir.relativize(runnerJar).toString());
+                Path appmodelDat = deploymentLib.resolve(FastJarFormat.APPMODEL_DAT);
+                manifestConfig.addComponent(ApplicationComponent.builder().setPath(appmodelDat).setDevelopmentScope());
+                try (OutputStream out = Files.newOutputStream(appmodelDat)) {
+                    ObjectOutputStream obj = new ObjectOutputStream(out);
+                    obj.writeObject(model);
+                    obj.close();
+                }
+                //now the bootstrap CP
+                //we just include all deployment deps, even though we only really need bootstrap
+                //as we don't really have a resolved bootstrap CP
+                //once we have the app model it will all be done in QuarkusClassLoader anyway
+                Path deploymentCp = deploymentLib.resolve(FastJarFormat.DEPLOYMENT_CLASS_PATH_DAT);
+                manifestConfig.addComponent(ApplicationComponent.builder().setPath(deploymentCp).setDevelopmentScope());
+                try (OutputStream out = Files.newOutputStream(deploymentCp)) {
+                    ObjectOutputStream obj = new ObjectOutputStream(out);
+                    List<String> paths = new ArrayList<>();
+                    for (ResolvedDependency i : curateOutcome.getApplicationModel().getDependencies()) {
+                        final List<String> list = relativePaths.get(i.getKey());
+                        // some of the dependencies may have been filtered out
+                        if (list != null) {
+                            paths.addAll(list);
+                        }
+                    }
+                    obj.writeObject(paths);
+                    obj.close();
+                }
+            }
+
+            if (packageConfig.jar().includeDependencyList()) {
+                Path deplist = buildDir.resolve(FastJarFormat.QUARKUS_APP_DEPS);
+                List<String> lines = new ArrayList<>();
+                for (ResolvedDependency i : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
+                    lines.add(i.toGACTVString());
+                }
+                lines.sort(Comparator.naturalOrder());
+                Files.write(deplist, lines);
+            }
+        } else {
+            //if it is a rebuild we might have classes
+        }
+        try (Stream<Path> files = Files.walk(buildDir)) {
+            files.forEach(new Consumer<Path>() {
+                @Override
+                public void accept(Path path) {
+                    path.toFile().setReadable(true, false);
+                }
+            });
+        }
+        return new JarBuildItem(initJar, null, libDir, packageConfig.jar().type(), null, manifestConfig.build());
+    }
+
+    private static Predicate<String> getThinJarIgnoredEntriesPredicate(PackageConfig packageConfig) {
+        return packageConfig.jar().userConfiguredIgnoredEntries().map(Set::copyOf).orElse(Set.of())::contains;
+    }
+
+    private static void copyDependency(Set<ArtifactKey> parentFirstArtifacts, OutputTargetBuildItem outputTargetBuildItem,
+            Map<ArtifactKey, List<Path>> runtimeArtifacts, Path libDir, Path baseLib, Consumer<Path> targetPathConsumer,
+            boolean allowParentFirst, StringBuilder classPath, ResolvedDependency appDep,
+            TransformedClassesBuildItem transformedClasses, Set<ArtifactKey> removedDeps,
+            PackageConfig packageConfig, ApplicationManifestConfig.Builder manifestConfig)
+            throws IOException {
+
+        // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
+        // and are not part of the optional dependencies to include
+        if (!includeAppDependency(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDeps)) {
+            return;
+        }
+        if (runtimeArtifacts.containsKey(appDep.getKey())) {
+            return;
+        }
+        for (Path resolvedDep : appDep.getResolvedPaths()) {
+            final String fileName = FastJarFormat.getJarFileName(appDep, resolvedDep);
+            final Path targetPath;
+
+            if (allowParentFirst && parentFirstArtifacts.contains(appDep.getKey())) {
+                targetPath = baseLib.resolve(fileName);
+                classPath.append(" ").append(FastJarFormat.LIB).append("/").append(FastJarFormat.BOOT_LIB).append("/")
+                        .append(fileName);
+            } else {
+                targetPath = libDir.resolve(fileName);
+                targetPathConsumer.accept(targetPath);
+            }
+            runtimeArtifacts.computeIfAbsent(appDep.getKey(), (s) -> new ArrayList<>(1)).add(targetPath);
+
+            if (Files.isDirectory(resolvedDep)) {
+                // This case can happen when we are building a jar from inside the Quarkus repository
+                // and Quarkus Bootstrap's localProjectDiscovery has been set to true. In such a case
+                // the non-jar dependencies are the Quarkus dependencies picked up on the file system
+                packageClasses(resolvedDep, targetPath, packageConfig);
+            } else {
+                Set<TransformedClassesBuildItem.TransformedClass> transformedFromThisArchive = transformedClasses
+                        .getTransformedClassesByJar().get(resolvedDep);
+                Set<String> removedFromThisArchive = new HashSet<>();
+                if (transformedFromThisArchive != null) {
+                    for (TransformedClassesBuildItem.TransformedClass i : transformedFromThisArchive) {
+                        if (i.getData() == null) {
+                            removedFromThisArchive.add(i.getFileName());
+                        }
+                    }
+                }
+                var appComponent = ApplicationComponent.builder()
+                        .setPath(targetPath)
+                        .setResolvedDependency(appDep);
+                if (removedFromThisArchive.isEmpty()) {
+                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING,
+                            StandardCopyOption.COPY_ATTRIBUTES);
+                } else {
+                    // we copy jars for which we remove entries to the same directory
+                    // which seems a bit odd to me
+                    JarUnsigner.unsignJar(resolvedDep, targetPath, Predicate.not(removedFromThisArchive::contains));
+
+                    var list = new ArrayList<>(removedFromThisArchive);
+                    Collections.sort(list);
+                    var sb = new StringBuilder("Removed ").append(list.get(0));
+                    for (int i = 1; i < list.size(); ++i) {
+                        sb.append(",").append(list.get(i));
+                    }
+                    appComponent.setPedigree(sb.toString());
+                }
+                manifestConfig.addComponent(appComponent);
+            }
+        }
+    }
+
+    private static void packageClasses(Path resolvedDep, final Path targetPath, PackageConfig packageConfig)
+            throws IOException {
+        try (FileSystem runnerZipFs = createNewZip(targetPath, packageConfig)) {
+            Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                    new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                                throws IOException {
+                            final Path relativePath = resolvedDep.relativize(file);
+                            final Path targetPath = runnerZipFs.getPath(relativePath.toString());
+                            if (targetPath.getParent() != null) {
+                                Files.createDirectories(targetPath.getParent());
+                            }
+                            Files.copy(file, targetPath, StandardCopyOption.REPLACE_EXISTING); //replace only needed for testing
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+        }
+    }
+
+    private static class FastJarJars {
+        private final Path transformedJar;
+        private final Path generatedJar;
+        private final Path runnerJar;
+        private final List<Path> dependencies;
+
+        public FastJarJars(FastJarJarsBuilder builder) {
+            this.transformedJar = builder.transformedJar;
+            this.generatedJar = builder.generatedJar;
+            this.runnerJar = builder.runnerJar;
+            this.dependencies = builder.dependencies;
+        }
+
+        public static class FastJarJarsBuilder {
+            private Path transformedJar;
+            private Path generatedJar;
+            private Path runnerJar;
+            private final List<Path> dependencies = new ArrayList<>();
+
+            public FastJarJarsBuilder setTransformedJar(Path transformedJar) {
+                this.transformedJar = transformedJar;
+                return this;
+            }
+
+            public FastJarJarsBuilder setGeneratedJar(Path generatedJar) {
+                this.generatedJar = generatedJar;
+                return this;
+            }
+
+            public FastJarJarsBuilder setRunnerJar(Path runnerJar) {
+                this.runnerJar = runnerJar;
+                return this;
+            }
+
+            public FastJarJarsBuilder addDependency(Path dependency) {
+                this.dependencies.add(dependency);
+                return this;
+            }
+
+            public FastJarJars build() {
+                return new FastJarJars(this);
+            }
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarFormat.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarFormat.java
@@ -1,0 +1,48 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+public class FastJarFormat {
+
+    public static final String QUARKUS_RUN_JAR = "quarkus-run.jar";
+    public static final String DEFAULT_FAST_JAR_DIRECTORY_NAME = "quarkus-app";
+    public static final String BOOT_LIB = "boot";
+    public static final String LIB = "lib";
+    public static final String MAIN = "main";
+    public static final String APP = "app";
+    public static final String DEPLOYMENT_LIB = "deployment";
+    public static final String QUARKUS = "quarkus";
+    public static final String QUARKUS_APP_DEPS = "quarkus-app-dependencies.txt";
+    public static final String DEPLOYMENT_CLASS_PATH_DAT = "deployment-class-path.dat";
+    public static final String BUILD_SYSTEM_PROPERTIES = "build-system.properties";
+    public static final String APPMODEL_DAT = "appmodel.dat";
+
+    static final String GENERATED_BYTECODE_JAR = "generated-bytecode.jar";
+    static final String TRANSFORMED_BYTECODE_JAR = "transformed-bytecode.jar";
+
+    /**
+     * Returns a JAR file name to be used for a content of a dependency, depending on whether the resolved path
+     * is a directory or not.
+     * We don't use getFileName() for directories, since directories would often be "classes" ending up merging
+     * content from multiple dependencies in the same package
+     *
+     * @param dep dependency
+     * @param resolvedPath path of the resolved dependency
+     * @return JAR file name
+     */
+    public static String getJarFileName(ResolvedDependency dep, Path resolvedPath) {
+        boolean isDirectory = Files.isDirectory(resolvedPath);
+        if (!isDirectory) {
+            return dep.getGroupId() + "." + resolvedPath.getFileName();
+        }
+        final StringBuilder sb = new StringBuilder();
+        sb.append(dep.getGroupId()).append(".").append(dep.getArtifactId()).append("-");
+        if (!dep.getClassifier().isEmpty()) {
+            sb.append(dep.getClassifier()).append("-");
+        }
+        return sb.append(dep.getVersion()).append(".").append(dep.getType()).toString();
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/JarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/JarBuilder.java
@@ -1,0 +1,12 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.IOException;
+
+import io.quarkus.builder.item.BuildItem;
+
+public interface JarBuilder<T extends BuildItem> {
+
+    String DOT_JAR = ".jar";
+
+    T build() throws IOException;
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
@@ -1,0 +1,56 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+public class LegacyThinJarBuilder extends AbstractLegacyThinJarBuilder<JarBuildItem> {
+
+    private static final Logger LOG = Logger.getLogger(LegacyThinJarBuilder.class);
+
+    public LegacyThinJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            Set<ArtifactKey> removedArtifactKeys) {
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
+                generatedClasses, generatedResources, removedArtifactKeys);
+    }
+
+    public JarBuildItem build() throws IOException {
+        Path runnerJar = outputTarget.getOutputDirectory()
+                .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
+        Path libDir = outputTarget.getOutputDirectory().resolve(LegacyThinJarFormat.LIB);
+        Files.deleteIfExists(runnerJar);
+        IoUtils.createOrEmptyDir(libDir);
+
+        LOG.info("Building thin jar: " + runnerJar);
+
+        doBuild(runnerJar, libDir);
+
+        return new JarBuildItem(runnerJar, null, libDir, packageConfig.jar().type(),
+                suffixToClassifier(packageConfig.computedRunnerSuffix()));
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.jboss.logging.Logger;
 
@@ -34,9 +35,10 @@ public class LegacyThinJarBuilder extends AbstractLegacyThinJarBuilder<JarBuildI
             TransformedClassesBuildItem transformedClasses,
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
-            Set<ArtifactKey> removedArtifactKeys) {
+            Set<ArtifactKey> removedArtifactKeys,
+            ExecutorService executorService) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys);
+                generatedClasses, generatedResources, removedArtifactKeys, executorService);
     }
 
     public JarBuildItem build() throws IOException {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarFormat.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarFormat.java
@@ -1,0 +1,6 @@
+package io.quarkus.deployment.pkg.jar;
+
+public class LegacyThinJarFormat {
+
+    public static final String LIB = "lib";
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/NativeImageSourceJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/NativeImageSourceJarBuilder.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -44,10 +45,11 @@ public class NativeImageSourceJarBuilder extends AbstractLegacyThinJarBuilder<Na
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
             List<GeneratedNativeImageClassBuildItem> nativeImageResources,
-            Set<ArtifactKey> removedArtifactKeys) {
+            Set<ArtifactKey> removedArtifactKeys,
+            ExecutorService executorService) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
                 augmentGeneratedClasses(generatedClasses, nativeImageResources), generatedResources,
-                augmentRemovedArtifactKeys(removedArtifactKeys));
+                augmentRemovedArtifactKeys(removedArtifactKeys), executorService);
     }
 
     public NativeImageSourceJarBuildItem build() throws IOException {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/NativeImageSourceJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/NativeImageSourceJarBuilder.java
@@ -1,0 +1,136 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedNativeImageClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GACT;
+
+public class NativeImageSourceJarBuilder extends AbstractLegacyThinJarBuilder<NativeImageSourceJarBuildItem> {
+
+    private static final Logger LOG = Logger.getLogger(NativeImageSourceJarBuilder.class);
+
+    public NativeImageSourceJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            List<GeneratedNativeImageClassBuildItem> nativeImageResources,
+            Set<ArtifactKey> removedArtifactKeys) {
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
+                augmentGeneratedClasses(generatedClasses, nativeImageResources), generatedResources,
+                augmentRemovedArtifactKeys(removedArtifactKeys));
+    }
+
+    public NativeImageSourceJarBuildItem build() throws IOException {
+        Path targetDirectory = outputTarget.getOutputDirectory()
+                .resolve(outputTarget.getBaseName() + "-native-image-source-jar");
+        IoUtils.createOrEmptyDir(targetDirectory);
+
+        Path runnerJar = targetDirectory
+                .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
+        Path libDir = targetDirectory.resolve(LegacyThinJarFormat.LIB);
+        Files.createDirectories(libDir);
+
+        copyJsonConfigFiles(applicationArchives, targetDirectory);
+
+        // complain if graal-sdk is present as a dependency as nativeimage should be preferred
+        if (curateOutcome.getApplicationModel().getDependencies().stream()
+                .anyMatch(d -> d.getGroupId().equals("org.graalvm.sdk") && d.getArtifactId().equals("graal-sdk"))) {
+            LOG.warn("org.graalvm.sdk:graal-sdk is present in the classpath. "
+                    + "From Quarkus 3.8 and onwards, org.graalvm.sdk:nativeimage should be preferred. "
+                    + "Make sure you report the issue to the maintainers of the extensions that bring it.");
+        }
+
+        LOG.info("Building native image source jar: " + runnerJar);
+
+        doBuild(runnerJar, libDir);
+
+        return new NativeImageSourceJarBuildItem(runnerJar, libDir);
+    }
+
+    private static List<GeneratedClassBuildItem> augmentGeneratedClasses(List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedNativeImageClassBuildItem> nativeImageResources) {
+        List<GeneratedClassBuildItem> allGeneratedClasses = new ArrayList<>(generatedClasses);
+        allGeneratedClasses.addAll(nativeImageResources.stream()
+                .map((s) -> new GeneratedClassBuildItem(true, s.getName(), s.getClassData()))
+                .toList());
+        return allGeneratedClasses;
+    }
+
+    private static Set<ArtifactKey> augmentRemovedArtifactKeys(Set<ArtifactKey> removedArtifactKeys) {
+        final Set<ArtifactKey> allRemovedArtifactKeys = new HashSet<>(removedArtifactKeys);
+        // Remove svm and graal-sdk artifacts as they are provided by GraalVM itself
+        allRemovedArtifactKeys.add(GACT.fromString("org.graalvm.nativeimage:svm"));
+        allRemovedArtifactKeys.add(GACT.fromString("org.graalvm.sdk:graal-sdk"));
+        allRemovedArtifactKeys.add(GACT.fromString("org.graalvm.sdk:nativeimage"));
+        allRemovedArtifactKeys.add(GACT.fromString("org.graalvm.sdk:word"));
+        allRemovedArtifactKeys.add(GACT.fromString("org.graalvm.sdk:collections"));
+        return allRemovedArtifactKeys;
+    }
+
+    /**
+     * This is done in order to make application specific native image configuration files available to the native-image tool
+     * without the user needing to know any specific paths.
+     * The files that are copied don't end up in the native image unless the user specifies they are needed, all this method
+     * does is copy them to a convenient location
+     */
+    private static void copyJsonConfigFiles(ApplicationArchivesBuildItem applicationArchivesBuildItem, Path thinJarDirectory)
+            throws IOException {
+        for (Path root : applicationArchivesBuildItem.getRootArchive().getRootDirectories()) {
+            try (Stream<Path> stream = Files.find(root, 1, IsJsonFilePredicate.INSTANCE)) {
+                stream.forEach(new Consumer<Path>() {
+                    @Override
+                    public void accept(Path jsonPath) {
+                        try {
+                            Files.createDirectories(thinJarDirectory);
+                            Files.copy(jsonPath, thinJarDirectory.resolve(jsonPath.getFileName().toString()));
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(
+                                    "Unable to copy json config file from " + jsonPath + " to " + thinJarDirectory,
+                                    e);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    private static class IsJsonFilePredicate implements BiPredicate<Path, BasicFileAttributes> {
+
+        private static final BiPredicate<Path, BasicFileAttributes> INSTANCE = new IsJsonFilePredicate();
+
+        @Override
+        public boolean test(Path path, BasicFileAttributes basicFileAttributes) {
+            return basicFileAttributes.isRegularFile() && path.toString().endsWith(".json");
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -1,0 +1,387 @@
+package io.quarkus.deployment.pkg.jar;
+
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.UBER_JAR;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.UberJarIgnoredResourceBuildItem;
+import io.quarkus.deployment.pkg.builditem.UberJarMergedResourceBuildItem;
+import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+import io.quarkus.sbom.ApplicationComponent;
+import io.quarkus.sbom.ApplicationManifestConfig;
+
+public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
+
+    private static final Logger LOG = Logger.getLogger(UberJarBuilder.class);
+
+    private static final Predicate<String> UBER_JAR_IGNORED_ENTRIES_PREDICATE = new IsEntryIgnoredForUberJarPredicate();
+
+    private static final Predicate<String> UBER_JAR_CONCATENATED_ENTRIES_PREDICATE = new Predicate<>() {
+        @Override
+        public boolean test(String path) {
+            return "META-INF/io.netty.versions.properties".equals(path) ||
+                    (path.startsWith("META-INF/services/") && path.length() > 18) ||
+            // needed to initialize the CLI bootstrap Maven resolver
+                    "META-INF/sisu/javax.inject.Named".equals(path);
+        }
+    };
+
+    private final CurateOutcomeBuildItem curateOutcome;
+    private final OutputTargetBuildItem outputTarget;
+    private final ApplicationInfoBuildItem applicationInfo;
+    private final PackageConfig packageConfig;
+    private final MainClassBuildItem mainClass;
+    private final ApplicationArchivesBuildItem applicationArchives;
+    private final TransformedClassesBuildItem transformedClasses;
+    private final List<GeneratedClassBuildItem> generatedClasses;
+    private final List<GeneratedResourceBuildItem> generatedResources;
+    private final Set<ArtifactKey> removedArtifactKeys;
+    private final List<UberJarMergedResourceBuildItem> mergedResources;
+    private final List<UberJarIgnoredResourceBuildItem> ignoredResources;
+
+    public UberJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            Set<ArtifactKey> removedArtifactKeys,
+            List<UberJarMergedResourceBuildItem> mergedResources,
+            List<UberJarIgnoredResourceBuildItem> ignoredResources) {
+        this.curateOutcome = curateOutcome;
+        this.outputTarget = outputTarget;
+        this.applicationInfo = applicationInfo;
+        this.packageConfig = packageConfig;
+        this.mainClass = mainClass;
+        this.applicationArchives = applicationArchives;
+        this.transformedClasses = transformedClasses;
+        this.generatedClasses = generatedClasses;
+        this.generatedResources = generatedResources;
+        this.removedArtifactKeys = removedArtifactKeys;
+        this.mergedResources = mergedResources;
+        this.ignoredResources = ignoredResources;
+    }
+
+    @Override
+    public JarBuildItem build() throws IOException {
+
+        //we use the -runner jar name, unless we are building both types
+        final Path runnerJar = outputTarget.getOutputDirectory()
+                .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
+
+        // If the runner jar appears to exist already we create a new one with a tmp suffix.
+        // Deleting an existing runner jar may result in deleting the original (non-runner) jar (in case the runner suffix is empty)
+        // which is used as a source of content for the runner jar.
+        final Path tmpRunnerJar;
+        if (Files.exists(runnerJar)) {
+            tmpRunnerJar = outputTarget.getOutputDirectory()
+                    .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + ".tmp");
+            Files.deleteIfExists(tmpRunnerJar);
+        } else {
+            tmpRunnerJar = runnerJar;
+        }
+
+        buildUberJar0(curateOutcome,
+                outputTarget,
+                transformedClasses,
+                applicationArchives,
+                packageConfig,
+                applicationInfo,
+                generatedClasses,
+                generatedResources,
+                mergedResources,
+                ignoredResources,
+                mainClass,
+                removedArtifactKeys,
+                tmpRunnerJar);
+
+        if (tmpRunnerJar != runnerJar) {
+            Files.copy(tmpRunnerJar, runnerJar, StandardCopyOption.REPLACE_EXISTING);
+            tmpRunnerJar.toFile().deleteOnExit();
+        }
+
+        //for uberjars we move the original jar, so there is only a single jar in the output directory
+        final Path standardJar = outputTarget.getOutputDirectory()
+                .resolve(outputTarget.getOriginalBaseName() + DOT_JAR);
+        final Path originalJar = Files.exists(standardJar) ? standardJar : null;
+
+        ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
+        final String classifier = suffixToClassifier(packageConfig.computedRunnerSuffix());
+        if (classifier != null && !classifier.isEmpty()) {
+            appArtifact = ResolvedDependencyBuilder.newInstance()
+                    .setGroupId(appArtifact.getGroupId())
+                    .setArtifactId(appArtifact.getArtifactId())
+                    .setClassifier(classifier)
+                    .setType(appArtifact.getType())
+                    .setVersion(appArtifact.getVersion())
+                    .setResolvedPaths(appArtifact.getResolvedPaths())
+                    .addDependencies(appArtifact.getDependencies())
+                    .setWorkspaceModule(appArtifact.getWorkspaceModule())
+                    .setFlags(appArtifact.getFlags())
+                    .build();
+        }
+        final ApplicationManifestConfig manifestConfig = ApplicationManifestConfig.builder()
+                .setMainComponent(ApplicationComponent.builder()
+                        .setPath(runnerJar)
+                        .setResolvedDependency(appArtifact)
+                        .build())
+                .setRunnerPath(runnerJar)
+                .addComponents(curateOutcome.getApplicationModel().getDependencies())
+                .build();
+
+        return new JarBuildItem(runnerJar, originalJar, null, UBER_JAR,
+                suffixToClassifier(packageConfig.computedRunnerSuffix()), manifestConfig);
+    }
+
+    private void buildUberJar0(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            OutputTargetBuildItem outputTargetBuildItem,
+            TransformedClassesBuildItem transformedClasses,
+            ApplicationArchivesBuildItem applicationArchivesBuildItem,
+            PackageConfig packageConfig,
+            ApplicationInfoBuildItem applicationInfo,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            List<UberJarMergedResourceBuildItem> mergedResources,
+            List<UberJarIgnoredResourceBuildItem> ignoredResources,
+            MainClassBuildItem mainClassBuildItem,
+            Set<ArtifactKey> removedArtifactKeys,
+            Path runnerJar) throws IOException {
+        try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
+            LOG.info("Building uber jar: " + runnerJar);
+
+            final Map<String, String> seen = new HashMap<>();
+            final Map<String, Set<Dependency>> duplicateCatcher = new HashMap<>();
+            final Map<String, List<byte[]>> concatenatedEntries = new HashMap<>();
+            final Set<String> mergeResourcePaths = mergedResources.stream()
+                    .map(UberJarMergedResourceBuildItem::getPath)
+                    .collect(Collectors.toSet());
+
+            Set<String> ignoredEntries = new HashSet<>();
+            packageConfig.jar().userConfiguredIgnoredEntries().ifPresent(ignoredEntries::addAll);
+            ignoredResources.stream()
+                    .map(UberJarIgnoredResourceBuildItem::getPath)
+                    .forEach(ignoredEntries::add);
+            Predicate<String> allIgnoredEntriesPredicate = new Predicate<String>() {
+                @Override
+                public boolean test(String path) {
+                    return UBER_JAR_IGNORED_ENTRIES_PREDICATE.test(path)
+                            || ignoredEntries.contains(path);
+                }
+            };
+
+            ResolvedDependency appArtifact = curateOutcomeBuildItem.getApplicationModel().getAppArtifact();
+
+            // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
+            // see https://bugs.openjdk.java.net/browse/JDK-8031748
+            generateManifest(runnerZipFs, "", packageConfig, appArtifact, mainClassBuildItem.getClassName(),
+                    applicationInfo);
+
+            for (ResolvedDependency appDep : curateOutcomeBuildItem.getApplicationModel().getRuntimeDependencies()) {
+
+                // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
+                // and are not part of the optional dependencies to include
+                if (!includeAppDependency(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(),
+                        removedArtifactKeys)) {
+                    continue;
+                }
+
+                for (Path resolvedDep : appDep.getResolvedPaths()) {
+                    Set<String> existingEntries = new HashSet<>();
+                    Set<String> transformedFilesByJar = transformedClasses.getTransformedFilesByJar().get(resolvedDep);
+                    if (transformedFilesByJar != null) {
+                        existingEntries.addAll(transformedFilesByJar);
+                    }
+                    generatedResources.stream()
+                            .map(GeneratedResourceBuildItem::getName)
+                            .forEach(existingEntries::add);
+
+                    if (!Files.isDirectory(resolvedDep)) {
+                        try (FileSystem artifactFs = ZipUtils.newFileSystem(resolvedDep)) {
+                            for (final Path root : artifactFs.getRootDirectories()) {
+                                walkFileDependencyForDependency(root, runnerZipFs, seen, duplicateCatcher, concatenatedEntries,
+                                        allIgnoredEntriesPredicate, appDep, existingEntries, mergeResourcePaths);
+                            }
+                        }
+                    } else {
+                        walkFileDependencyForDependency(resolvedDep, runnerZipFs, seen, duplicateCatcher,
+                                concatenatedEntries, allIgnoredEntriesPredicate, appDep, existingEntries,
+                                mergeResourcePaths);
+                    }
+                }
+            }
+            Set<Set<Dependency>> explained = new HashSet<>();
+            for (Map.Entry<String, Set<Dependency>> entry : duplicateCatcher.entrySet()) {
+                if (entry.getValue().size() > 1) {
+                    if (explained.add(entry.getValue())) {
+                        LOG.warn("Dependencies with duplicate files detected. The dependencies " + entry.getValue()
+                                + " contain duplicate files, e.g. " + entry.getKey());
+                    }
+                }
+            }
+            copyCommonContent(runnerZipFs, concatenatedEntries, applicationArchivesBuildItem, transformedClasses,
+                    generatedClasses,
+                    generatedResources, seen, allIgnoredEntriesPredicate);
+            // now that all entries have been added, check if there's a META-INF/versions/ entry. If present,
+            // mark this jar as multi-release jar. Strictly speaking, the jar spec expects META-INF/versions/N
+            // directory where N is an integer greater than 8, but we don't do that level of checks here but that
+            // should be OK.
+            if (Files.isDirectory(runnerZipFs.getPath("META-INF", "versions"))) {
+                LOG.debug("uber jar will be marked as multi-release jar");
+                final Path manifestPath = runnerZipFs.getPath("META-INF", "MANIFEST.MF");
+                final Manifest manifest = new Manifest();
+                // read the existing one
+                try (final InputStream is = Files.newInputStream(manifestPath)) {
+                    manifest.read(is);
+                }
+                manifest.getMainAttributes().put(Attributes.Name.MULTI_RELEASE, "true");
+                try (final OutputStream os = Files.newOutputStream(manifestPath)) {
+                    manifest.write(os);
+                }
+            }
+        }
+
+        runnerJar.toFile().setReadable(true, false);
+    }
+
+    private void walkFileDependencyForDependency(Path root, FileSystem runnerZipFs, Map<String, String> seen,
+            Map<String, Set<Dependency>> duplicateCatcher, Map<String, List<byte[]>> concatenatedEntries,
+            Predicate<String> ignoredEntriesPredicate, Dependency appDep, Set<String> existingEntries,
+            Set<String> mergeResourcePaths) throws IOException {
+        final Path metaInfDir = root.resolve("META-INF");
+        Files.walkFileTree(root, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                            throws IOException {
+                        final String relativePath = toUri(root.relativize(dir));
+                        if (!relativePath.isEmpty()) {
+                            addDirectory(runnerZipFs, relativePath);
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                            throws IOException {
+                        final String relativePath = toUri(root.relativize(file));
+                        //if this has been transformed we do not copy it
+                        // if it's a signature file (under the <jar>/META-INF directory),
+                        // then we don't add it to the uber jar
+                        if (isBlockOrSF(relativePath) &&
+                                file.relativize(metaInfDir).getNameCount() == 1) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Signature file " + file.toAbsolutePath() + " from app " +
+                                        "dependency " + appDep + " will not be included in uberjar");
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                        if (!existingEntries.contains(relativePath)) {
+                            if (UBER_JAR_CONCATENATED_ENTRIES_PREDICATE.test(relativePath)
+                                    || mergeResourcePaths.contains(relativePath)) {
+                                concatenatedEntries.computeIfAbsent(relativePath, (u) -> new ArrayList<>())
+                                        .add(Files.readAllBytes(file));
+                                return FileVisitResult.CONTINUE;
+                            } else if (!ignoredEntriesPredicate.test(relativePath)) {
+                                duplicateCatcher.computeIfAbsent(relativePath, (a) -> new HashSet<>())
+                                        .add(appDep);
+                                if (!seen.containsKey(relativePath)) {
+                                    seen.put(relativePath, appDep.toString());
+                                    Files.copy(file, runnerZipFs.getPath(relativePath),
+                                            StandardCopyOption.REPLACE_EXISTING);
+                                }
+                            }
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+    }
+
+    // same as the impl in sun.security.util.SignatureFileVerifier#isBlockOrSF()
+    private static boolean isBlockOrSF(final String s) {
+        if (s == null) {
+            return false;
+        }
+        return s.endsWith(".SF")
+                || s.endsWith(".DSA")
+                || s.endsWith(".RSA")
+                || s.endsWith(".EC");
+    }
+
+    private static class IsEntryIgnoredForUberJarPredicate implements Predicate<String> {
+
+        private static final Set<String> UBER_JAR_IGNORED_ENTRIES = Set.of(
+                "META-INF/INDEX.LIST",
+                "META-INF/MANIFEST.MF",
+                "module-info.class",
+                "META-INF/LICENSE",
+                "META-INF/LICENSE.txt",
+                "META-INF/LICENSE.md",
+                "META-INF/LGPL-3.0.txt",
+                "META-INF/ASL-2.0.txt",
+                "META-INF/NOTICE",
+                "META-INF/NOTICE.txt",
+                "META-INF/NOTICE.md",
+                "META-INF/README",
+                "META-INF/README.txt",
+                "META-INF/README.md",
+                "META-INF/DEPENDENCIES",
+                "META-INF/DEPENDENCIES.txt",
+                "META-INF/beans.xml",
+                "META-INF/quarkus-config-roots.list",
+                "META-INF/quarkus-javadoc.properties",
+                "META-INF/quarkus-extension.properties",
+                "META-INF/quarkus-extension.json",
+                "META-INF/quarkus-extension.yaml",
+                "META-INF/quarkus-deployment-dependency.graph",
+                "META-INF/jandex.idx",
+                "META-INF/panache-archive.marker", // deprecated and unused, but still present in some archives
+                "META-INF/build.metadata", // present in the Red Hat Build of Quarkus
+                "LICENSE");
+
+        @Override
+        public boolean test(String path) {
+            return UBER_JAR_IGNORED_ENTRIES.contains(path)
+                    || path.endsWith("module-info.class");
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
@@ -1,0 +1,72 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jboss.logging.Logger;
+
+import io.smallrye.common.process.ProcessBuilder;
+import io.smallrye.common.process.ProcessUtil;
+
+class VineflowerDecompiler implements Decompiler {
+
+    private static final Logger LOG = Logger.getLogger(VineflowerDecompiler.class);
+    private static final String DEFAULT_VINEFLOWER_VERSION = "1.11.1";
+
+    private Context context;
+    private Path decompilerJar;
+
+    @Override
+    public void init(Context context) {
+        this.context = context;
+        this.decompilerJar = context.jarLocation.resolve(String.format("vineflower-%s.jar",
+                context.versionStr != null ? context.versionStr : DEFAULT_VINEFLOWER_VERSION));
+    }
+
+    @Override
+    public boolean downloadIfNecessary() {
+        if (Files.exists(decompilerJar)) {
+            return true;
+        }
+        String downloadURL = String.format(
+                "https://repo.maven.apache.org/maven2/org/vineflower/vineflower/%s/vineflower-%s.jar",
+                context.versionStr, context.versionStr);
+        try (BufferedInputStream in = new BufferedInputStream(new URL(downloadURL).openStream());
+                OutputStream fileOutputStream = Files.newOutputStream(decompilerJar)) {
+            in.transferTo(fileOutputStream);
+            return true;
+        } catch (IOException e) {
+            LOG.error("Unable to download Vineflower from " + downloadURL, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean decompile(Path jarToDecompile) {
+        String jarFileName = jarToDecompile.getFileName().toString();
+        int dotIndex = jarFileName.indexOf('.');
+        String outputDirectory = jarFileName.substring(0, dotIndex);
+        var pb = ProcessBuilder.newBuilder(ProcessUtil.pathOfJava())
+                .arguments(
+                        "-jar",
+                        decompilerJar.toAbsolutePath().toString(),
+                        "-rsy=0", // synthetic methods
+                        "-rbr=0", // bridge methods
+                        jarToDecompile.toAbsolutePath().toString(),
+                        context.decompiledOutputDir.resolve(outputDirectory).toAbsolutePath().toString());
+        if (LOG.isDebugEnabled()) {
+            pb.output().consumeLinesWith(8192, LOG::debug);
+        }
+        try {
+            pb.run();
+        } catch (Exception e) {
+            LOG.error("Decompilation failed", e);
+            return false;
+        }
+        return true;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.pkg.jar;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -118,15 +119,7 @@ class ZipFileSystemArchiveCreator implements ArchiveCreator {
         if (MANIFESTS.contains(target)) {
             return;
         }
-        Path targetInFsPath = zipFileSystem.getPath(target);
-        handleParentDirectories(targetInFsPath, source);
-        try (final OutputStream os = Files.newOutputStream(targetInFsPath)) {
-            for (byte[] i : bytes) {
-                os.write(i);
-                os.write('\n');
-            }
-            addedFiles.put(target, source);
-        }
+        addFile(joinWithNewlines(bytes), target, source);
     }
 
     /**
@@ -155,6 +148,18 @@ class ZipFileSystemArchiveCreator implements ArchiveCreator {
     private void handleParentDirectories(Path targetInFsPath, String source) throws IOException {
         if (targetInFsPath.getParent() != null) {
             Files.createDirectories(targetInFsPath.getParent());
+        }
+    }
+
+    private static byte[] joinWithNewlines(List<byte[]> lines) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            for (byte[] line : lines) {
+                out.write(line);
+                out.write('\n');
+            }
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("Error joining byte arrays", e);
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
@@ -1,0 +1,169 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import io.quarkus.fs.util.ZipUtils;
+
+class ZipFileSystemArchiveCreator implements ArchiveCreator {
+
+    private static final Path MANIFEST = Path.of("META-INF", "MANIFEST.MF");
+    // we probably don't need the Windows entry but let's be safe
+    private static final Set<String> MANIFESTS = Set.of("META-INF/MANIFEST.MF", "META-INF\\MANIFEST.MF");
+
+    private final FileSystem zipFileSystem;
+
+    private final Map<String, String> addedFiles = new HashMap<>();
+
+    public ZipFileSystemArchiveCreator(Path archivePath, boolean compressed) {
+        try {
+            if (compressed) {
+                zipFileSystem = ZipUtils.newZip(archivePath);
+            } else {
+                zipFileSystem = ZipUtils.newZip(archivePath, Map.of("compressionMethod", "STORED"));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to initialize ZipFileSystem: " + archivePath, e);
+        }
+    }
+
+    @Override
+    public void addManifest(Manifest manifest) throws IOException {
+        Path manifestInFsPath = zipFileSystem.getPath("META-INF", "MANIFEST.MF");
+        handleParentDirectories(manifestInFsPath, CURRENT_APPLICATION);
+        try (final OutputStream os = Files.newOutputStream(manifestInFsPath)) {
+            manifest.write(os);
+        }
+    }
+
+    @Override
+    public void addDirectory(String directory, String source) throws IOException {
+        if (addedFiles.putIfAbsent(directory, source) != null) {
+            return;
+        }
+        final Path targetInFsPath = zipFileSystem.getPath(directory);
+        try {
+            handleParentDirectories(targetInFsPath, source);
+            Files.createDirectory(targetInFsPath);
+        } catch (FileAlreadyExistsException e) {
+            if (!Files.isDirectory(targetInFsPath)) {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public void addFile(Path origin, String target, String source) throws IOException {
+        if (MANIFESTS.contains(target)) {
+            return;
+        }
+        if (addedFiles.putIfAbsent(target, source) != null) {
+            return;
+        }
+        Path targetInFsPath = zipFileSystem.getPath(target);
+        handleParentDirectories(targetInFsPath, source);
+        Files.copy(origin, targetInFsPath, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @Override
+    public void addFile(byte[] bytes, String target, String source) throws IOException {
+        if (MANIFESTS.contains(target)) {
+            return;
+        }
+        Path targetInFsPath = zipFileSystem.getPath(target);
+        handleParentDirectories(targetInFsPath, source);
+        Files.write(targetInFsPath, bytes);
+        addedFiles.put(target, source);
+    }
+
+    @Override
+    public void addFileIfNotExists(Path origin, String target, String source) throws IOException {
+        if (MANIFESTS.contains(target)) {
+            return;
+        }
+        if (addedFiles.containsKey(target)) {
+            return;
+        }
+
+        addFile(origin, target, source);
+    }
+
+    @Override
+    public void addFileIfNotExists(byte[] bytes, String target, String source) throws IOException {
+        if (MANIFESTS.contains(target)) {
+            return;
+        }
+        if (addedFiles.containsKey(target)) {
+            return;
+        }
+
+        addFile(bytes, target, source);
+    }
+
+    @Override
+    public void addFile(List<byte[]> bytes, String target, String source) throws IOException {
+        if (MANIFESTS.contains(target)) {
+            return;
+        }
+        Path targetInFsPath = zipFileSystem.getPath(target);
+        handleParentDirectories(targetInFsPath, source);
+        try (final OutputStream os = Files.newOutputStream(targetInFsPath)) {
+            for (byte[] i : bytes) {
+                os.write(i);
+                os.write('\n');
+            }
+            addedFiles.put(target, source);
+        }
+    }
+
+    /**
+     * Note: this method may only be used for Uberjars, for which we might need to amend the manifest at the end of the build.
+     */
+    public boolean isMultiVersion() {
+        return Files.isDirectory(zipFileSystem.getPath("META-INF", "versions"));
+    }
+
+    /**
+     * Note: this method may only be used for Uberjars, for which we might need to amend the manifest at the end of the build.
+     */
+    public void makeMultiVersion() throws IOException {
+        final Path manifestPath = zipFileSystem.getPath("META-INF", "MANIFEST.MF");
+        final Manifest manifest = new Manifest();
+        // read the existing one
+        try (final InputStream is = Files.newInputStream(manifestPath)) {
+            manifest.read(is);
+        }
+        manifest.getMainAttributes().put(Attributes.Name.MULTI_RELEASE, "true");
+        try (final OutputStream os = Files.newOutputStream(manifestPath)) {
+            manifest.write(os);
+        }
+    }
+
+    private void handleParentDirectories(Path targetInFsPath, String source) throws IOException {
+        if (targetInFsPath.getParent() != null) {
+            Files.createDirectories(targetInFsPath.getParent());
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            zipFileSystem.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
@@ -104,7 +105,8 @@ public class JarResultBuildStep {
             QuarkusBuildCloseablesBuildItem closeablesBuildItem,
             List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchiveBuildItems,
             MainClassBuildItem mainClassBuildItem,
-            Optional<JvmStartupOptimizerArchiveRequestedBuildItem> jvmStartupOptimizerArchiveRequested)
+            Optional<JvmStartupOptimizerArchiveRequestedBuildItem> jvmStartupOptimizerArchiveRequested,
+            ExecutorService buildExecutor)
             throws Exception {
 
         if (jvmStartupOptimizerArchiveRequested.isPresent()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -138,7 +138,8 @@ public class JarResultBuildStep {
                     transformedClasses,
                     generatedClasses,
                     generatedResources,
-                    removedArtifactKeys).build();
+                    removedArtifactKeys,
+                    buildExecutor).build();
             case FAST_JAR, MUTABLE_JAR -> new FastJarBuilder(curateOutcomeBuildItem,
                     outputTargetBuildItem,
                     applicationInfo,
@@ -150,7 +151,8 @@ public class JarResultBuildStep {
                     generatedClasses,
                     generatedResources,
                     parentFirstArtifactKeys,
-                    removedArtifactKeys).build();
+                    removedArtifactKeys,
+                    buildExecutor).build();
         };
     }
 
@@ -168,7 +170,8 @@ public class JarResultBuildStep {
             List<GeneratedNativeImageClassBuildItem> nativeImageResources,
             List<GeneratedResourceBuildItem> generatedResources,
             MainClassBuildItem mainClassBuildItem,
-            ClassLoadingConfig classLoadingConfig) throws Exception {
+            ClassLoadingConfig classLoadingConfig,
+            ExecutorService buildExecutor) throws Exception {
 
         return new NativeImageSourceJarBuilder(curateOutcomeBuildItem,
                 outputTargetBuildItem,
@@ -180,7 +183,8 @@ public class JarResultBuildStep {
                 generatedClasses,
                 generatedResources,
                 nativeImageResources,
-                getRemovedArtifactKeys(classLoadingConfig)).build();
+                getRemovedArtifactKeys(classLoadingConfig),
+                buildExecutor).build();
     }
 
     // the idea here is to just dump the class names of the generated and transformed classes into a file

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1,59 +1,22 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
 import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
 import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.UBER_JAR;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedWriter;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
-import java.io.UncheckedIOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileVisitOption;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiPredicate;
 import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.jboss.logging.Logger;
-
-import io.quarkus.bootstrap.model.MutableJarApplicationModel;
-import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
-import io.quarkus.bootstrap.runner.SerializedApplication;
-import io.quarkus.bootstrap.util.IoUtils;
-import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
@@ -65,7 +28,6 @@ import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.QuarkusBuildCloseablesBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.configuration.ClassLoadingConfig;
-import io.quarkus.deployment.pkg.JarUnsigner;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
@@ -76,20 +38,13 @@ import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.UberJarIgnoredResourceBuildItem;
 import io.quarkus.deployment.pkg.builditem.UberJarMergedResourceBuildItem;
-import io.quarkus.deployment.util.FileUtil;
-import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.deployment.pkg.jar.FastJarBuilder;
+import io.quarkus.deployment.pkg.jar.LegacyThinJarBuilder;
+import io.quarkus.deployment.pkg.jar.NativeImageSourceJarBuilder;
+import io.quarkus.deployment.pkg.jar.UberJarBuilder;
 import io.quarkus.maven.dependency.ArtifactKey;
-import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.GACT;
-import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
-import io.quarkus.paths.PathVisit;
-import io.quarkus.paths.PathVisitor;
-import io.quarkus.sbom.ApplicationComponent;
-import io.quarkus.sbom.ApplicationManifestConfig;
-import io.smallrye.common.process.ProcessBuilder;
-import io.smallrye.common.process.ProcessUtil;
 
 /**
  * This build step builds both the thin jars and uber jars.
@@ -107,55 +62,6 @@ import io.smallrye.common.process.ProcessUtil;
  * build items and transform them into {@link ArtifactResultBuildItem}.
  */
 public class JarResultBuildStep {
-
-    private static final String DOT_JAR = ".jar";
-
-    private static final Predicate<String> UBER_JAR_IGNORED_ENTRIES_PREDICATE = new IsEntryIgnoredForUberJarPredicate();
-
-    private static final Predicate<String> UBER_JAR_CONCATENATED_ENTRIES_PREDICATE = new Predicate<>() {
-        @Override
-        public boolean test(String path) {
-            return "META-INF/io.netty.versions.properties".equals(path) ||
-                    (path.startsWith("META-INF/services/") && path.length() > 18) ||
-            // needed to initialize the CLI bootstrap Maven resolver
-                    "META-INF/sisu/javax.inject.Named".equals(path);
-        }
-    };
-
-    private static final Logger log = Logger.getLogger(JarResultBuildStep.class);
-
-    private static final BiPredicate<Path, BasicFileAttributes> IS_JSON_FILE_PREDICATE = new IsJsonFilePredicate();
-
-    public static final String DEPLOYMENT_CLASS_PATH_DAT = "deployment-class-path.dat";
-
-    public static final String BUILD_SYSTEM_PROPERTIES = "build-system.properties";
-
-    public static final String DEPLOYMENT_LIB = "deployment";
-
-    public static final String APPMODEL_DAT = "appmodel.dat";
-
-    public static final String QUARKUS_RUN_JAR = "quarkus-run.jar";
-
-    public static final String QUARKUS_APP_DEPS = "quarkus-app-dependencies.txt";
-
-    public static final String BOOT_LIB = "boot";
-
-    public static final String LIB = "lib";
-
-    public static final String MAIN = "main";
-
-    public static final String GENERATED_BYTECODE_JAR = "generated-bytecode.jar";
-
-    public static final String TRANSFORMED_BYTECODE_JAR = "transformed-bytecode.jar";
-
-    public static final String APP = "app";
-
-    public static final String QUARKUS = "quarkus";
-
-    public static final String DEFAULT_FAST_JAR_DIRECTORY_NAME = "quarkus-app";
-
-    public static final String MP_CONFIG_FILE = "META-INF/microprofile-config.properties";
-    private static final String VINEFLOWER_VERSION = "1.11.1";
 
     @BuildStep
     OutputTargetBuildItem outputTarget(BuildSystemTargetBuildItem bst, PackageConfig packageConfig) {
@@ -205,21 +111,74 @@ public class JarResultBuildStep {
             handleAppCDSSupportFileGeneration(transformedClasses, generatedClasses, jvmStartupOptimizerArchiveRequested.get());
         }
 
+        Set<ArtifactKey> removedArtifactKeys = getRemovedArtifactKeys(classLoadingConfig);
+        Set<ArtifactKey> parentFirstArtifactKeys = getParentFirstArtifactKeys(curateOutcomeBuildItem, classLoadingConfig);
+
         return switch (packageConfig.jar().type()) {
-            case UBER_JAR ->
-                buildUberJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses, applicationArchivesBuildItem,
-                        packageConfig, applicationInfo, generatedClasses, generatedResources, uberJarMergedResourceBuildItems,
-                        uberJarIgnoredResourceBuildItems, mainClassBuildItem, classLoadingConfig);
-            case LEGACY_JAR -> buildLegacyThinJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
+            case UBER_JAR -> new UberJarBuilder(curateOutcomeBuildItem,
+                    outputTargetBuildItem,
+                    applicationInfo,
+                    packageConfig,
+                    mainClassBuildItem,
                     applicationArchivesBuildItem,
-                    packageConfig, applicationInfo, generatedClasses, generatedResources, mainClassBuildItem,
-                    classLoadingConfig);
-            case FAST_JAR, MUTABLE_JAR ->
-                buildThinJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses, applicationArchivesBuildItem,
-                        packageConfig, classLoadingConfig, applicationInfo, generatedClasses,
-                        generatedResources,
-                        additionalApplicationArchiveBuildItems, mainClassBuildItem);
+                    transformedClasses,
+                    generatedClasses,
+                    generatedResources,
+                    removedArtifactKeys,
+                    uberJarMergedResourceBuildItems,
+                    uberJarIgnoredResourceBuildItems).build();
+            case LEGACY_JAR -> new LegacyThinJarBuilder(curateOutcomeBuildItem,
+                    outputTargetBuildItem,
+                    applicationInfo,
+                    packageConfig,
+                    mainClassBuildItem,
+                    applicationArchivesBuildItem,
+                    transformedClasses,
+                    generatedClasses,
+                    generatedResources,
+                    removedArtifactKeys).build();
+            case FAST_JAR, MUTABLE_JAR -> new FastJarBuilder(curateOutcomeBuildItem,
+                    outputTargetBuildItem,
+                    applicationInfo,
+                    packageConfig,
+                    mainClassBuildItem,
+                    applicationArchivesBuildItem,
+                    additionalApplicationArchiveBuildItems,
+                    transformedClasses,
+                    generatedClasses,
+                    generatedResources,
+                    parentFirstArtifactKeys,
+                    removedArtifactKeys).build();
         };
+    }
+
+    /**
+     * Native images are built from a specially created jar file. This allows for changes in how the jar file is generated.
+     */
+    @BuildStep
+    public NativeImageSourceJarBuildItem buildNativeImageJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            OutputTargetBuildItem outputTargetBuildItem,
+            TransformedClassesBuildItem transformedClasses,
+            ApplicationArchivesBuildItem applicationArchivesBuildItem,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedNativeImageClassBuildItem> nativeImageResources,
+            List<GeneratedResourceBuildItem> generatedResources,
+            MainClassBuildItem mainClassBuildItem,
+            ClassLoadingConfig classLoadingConfig) throws Exception {
+
+        return new NativeImageSourceJarBuilder(curateOutcomeBuildItem,
+                outputTargetBuildItem,
+                applicationInfo,
+                packageConfig,
+                mainClassBuildItem,
+                applicationArchivesBuildItem,
+                transformedClasses,
+                generatedClasses,
+                generatedResources,
+                nativeImageResources,
+                getRemovedArtifactKeys(classLoadingConfig)).build();
     }
 
     // the idea here is to just dump the class names of the generated and transformed classes into a file
@@ -246,1212 +205,10 @@ public class JarResultBuildStep {
                 }
             }
 
-            if (classes.length() != 0) {
+            if (!classes.isEmpty()) {
                 writer.write(classes.toString());
             }
         }
-    }
-
-    private JarBuildItem buildUberJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses,
-            ApplicationArchivesBuildItem applicationArchivesBuildItem,
-            PackageConfig packageConfig,
-            ApplicationInfoBuildItem applicationInfo,
-            List<GeneratedClassBuildItem> generatedClasses,
-            List<GeneratedResourceBuildItem> generatedResources,
-            List<UberJarMergedResourceBuildItem> mergeResources,
-            List<UberJarIgnoredResourceBuildItem> ignoredResources,
-            MainClassBuildItem mainClassBuildItem,
-            ClassLoadingConfig classLoadingConfig) throws Exception {
-
-        //we use the -runner jar name, unless we are building both types
-        final Path runnerJar = outputTargetBuildItem.getOutputDirectory()
-                .resolve(outputTargetBuildItem.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
-
-        // If the runner jar appears to exist already we create a new one with a tmp suffix.
-        // Deleting an existing runner jar may result in deleting the original (non-runner) jar (in case the runner suffix is empty)
-        // which is used as a source of content for the runner jar.
-        final Path tmpRunnerJar;
-        if (Files.exists(runnerJar)) {
-            tmpRunnerJar = outputTargetBuildItem.getOutputDirectory()
-                    .resolve(outputTargetBuildItem.getBaseName() + packageConfig.computedRunnerSuffix() + ".tmp");
-            Files.deleteIfExists(tmpRunnerJar);
-        } else {
-            tmpRunnerJar = runnerJar;
-        }
-
-        buildUberJar0(curateOutcomeBuildItem,
-                outputTargetBuildItem,
-                transformedClasses,
-                applicationArchivesBuildItem,
-                packageConfig,
-                applicationInfo,
-                generatedClasses,
-                generatedResources,
-                mergeResources,
-                ignoredResources,
-                mainClassBuildItem,
-                classLoadingConfig,
-                tmpRunnerJar);
-
-        if (tmpRunnerJar != runnerJar) {
-            Files.copy(tmpRunnerJar, runnerJar, StandardCopyOption.REPLACE_EXISTING);
-            tmpRunnerJar.toFile().deleteOnExit();
-        }
-
-        //for uberjars we move the original jar, so there is only a single jar in the output directory
-        final Path standardJar = outputTargetBuildItem.getOutputDirectory()
-                .resolve(outputTargetBuildItem.getOriginalBaseName() + DOT_JAR);
-        final Path originalJar = Files.exists(standardJar) ? standardJar : null;
-
-        ResolvedDependency appArtifact = curateOutcomeBuildItem.getApplicationModel().getAppArtifact();
-        final String classifier = suffixToClassifier(packageConfig.computedRunnerSuffix());
-        if (classifier != null && !classifier.isEmpty()) {
-            appArtifact = ResolvedDependencyBuilder.newInstance()
-                    .setGroupId(appArtifact.getGroupId())
-                    .setArtifactId(appArtifact.getArtifactId())
-                    .setClassifier(classifier)
-                    .setType(appArtifact.getType())
-                    .setVersion(appArtifact.getVersion())
-                    .setResolvedPaths(appArtifact.getResolvedPaths())
-                    .addDependencies(appArtifact.getDependencies())
-                    .setWorkspaceModule(appArtifact.getWorkspaceModule())
-                    .setFlags(appArtifact.getFlags())
-                    .build();
-        }
-        final ApplicationManifestConfig manifestConfig = ApplicationManifestConfig.builder()
-                .setMainComponent(ApplicationComponent.builder()
-                        .setPath(runnerJar)
-                        .setResolvedDependency(appArtifact)
-                        .build())
-                .setRunnerPath(runnerJar)
-                .addComponents(curateOutcomeBuildItem.getApplicationModel().getDependencies())
-                .build();
-
-        return new JarBuildItem(runnerJar, originalJar, null, UBER_JAR,
-                suffixToClassifier(packageConfig.computedRunnerSuffix()), manifestConfig);
-    }
-
-    private String suffixToClassifier(String suffix) {
-        return suffix.startsWith("-") ? suffix.substring(1) : suffix;
-    }
-
-    private void buildUberJar0(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses,
-            ApplicationArchivesBuildItem applicationArchivesBuildItem,
-            PackageConfig packageConfig,
-            ApplicationInfoBuildItem applicationInfo,
-            List<GeneratedClassBuildItem> generatedClasses,
-            List<GeneratedResourceBuildItem> generatedResources,
-            List<UberJarMergedResourceBuildItem> mergedResources,
-            List<UberJarIgnoredResourceBuildItem> ignoredResources,
-            MainClassBuildItem mainClassBuildItem,
-            ClassLoadingConfig classLoadingConfig,
-            Path runnerJar) throws Exception {
-        try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
-
-            log.info("Building uber jar: " + runnerJar);
-
-            final Map<String, String> seen = new HashMap<>();
-            final Map<String, Set<Dependency>> duplicateCatcher = new HashMap<>();
-            final Map<String, List<byte[]>> concatenatedEntries = new HashMap<>();
-            final Set<String> mergeResourcePaths = mergedResources.stream()
-                    .map(UberJarMergedResourceBuildItem::getPath)
-                    .collect(Collectors.toSet());
-            final Set<ArtifactKey> removed = getRemovedArtifactKeys(classLoadingConfig);
-
-            Set<String> ignoredEntries = new HashSet<>();
-            packageConfig.jar().userConfiguredIgnoredEntries().ifPresent(ignoredEntries::addAll);
-            ignoredResources.stream()
-                    .map(UberJarIgnoredResourceBuildItem::getPath)
-                    .forEach(ignoredEntries::add);
-            Predicate<String> allIgnoredEntriesPredicate = new Predicate<String>() {
-                @Override
-                public boolean test(String path) {
-                    return UBER_JAR_IGNORED_ENTRIES_PREDICATE.test(path)
-                            || ignoredEntries.contains(path);
-                }
-            };
-
-            ResolvedDependency appArtifact = curateOutcomeBuildItem.getApplicationModel().getAppArtifact();
-
-            // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
-            // see https://bugs.openjdk.java.net/browse/JDK-8031748
-            generateManifest(runnerZipFs, "", packageConfig, appArtifact, mainClassBuildItem.getClassName(),
-                    applicationInfo);
-
-            for (ResolvedDependency appDep : curateOutcomeBuildItem.getApplicationModel().getRuntimeDependencies()) {
-
-                // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
-                // and are not part of the optional dependencies to include
-                if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removed)) {
-                    continue;
-                }
-
-                for (Path resolvedDep : appDep.getResolvedPaths()) {
-                    Set<String> existingEntries = new HashSet<>();
-                    Set<String> transformedFilesByJar = transformedClasses.getTransformedFilesByJar().get(resolvedDep);
-                    if (transformedFilesByJar != null) {
-                        existingEntries.addAll(transformedFilesByJar);
-                    }
-                    generatedResources.stream()
-                            .map(GeneratedResourceBuildItem::getName)
-                            .forEach(existingEntries::add);
-
-                    if (!Files.isDirectory(resolvedDep)) {
-                        try (FileSystem artifactFs = ZipUtils.newFileSystem(resolvedDep)) {
-                            for (final Path root : artifactFs.getRootDirectories()) {
-                                walkFileDependencyForDependency(root, runnerZipFs, seen, duplicateCatcher, concatenatedEntries,
-                                        allIgnoredEntriesPredicate, appDep, existingEntries, mergeResourcePaths);
-                            }
-                        }
-                    } else {
-                        walkFileDependencyForDependency(resolvedDep, runnerZipFs, seen, duplicateCatcher,
-                                concatenatedEntries, allIgnoredEntriesPredicate, appDep, existingEntries,
-                                mergeResourcePaths);
-                    }
-                }
-            }
-            Set<Set<Dependency>> explained = new HashSet<>();
-            for (Map.Entry<String, Set<Dependency>> entry : duplicateCatcher.entrySet()) {
-                if (entry.getValue().size() > 1) {
-                    if (explained.add(entry.getValue())) {
-                        log.warn("Dependencies with duplicate files detected. The dependencies " + entry.getValue()
-                                + " contain duplicate files, e.g. " + entry.getKey());
-                    }
-                }
-            }
-            copyCommonContent(runnerZipFs, concatenatedEntries, applicationArchivesBuildItem, transformedClasses,
-                    generatedClasses,
-                    generatedResources, seen, allIgnoredEntriesPredicate);
-            // now that all entries have been added, check if there's a META-INF/versions/ entry. If present,
-            // mark this jar as multi-release jar. Strictly speaking, the jar spec expects META-INF/versions/N
-            // directory where N is an integer greater than 8, but we don't do that level of checks here but that
-            // should be OK.
-            if (Files.isDirectory(runnerZipFs.getPath("META-INF", "versions"))) {
-                log.debug("uber jar will be marked as multi-release jar");
-                final Path manifestPath = runnerZipFs.getPath("META-INF", "MANIFEST.MF");
-                final Manifest manifest = new Manifest();
-                // read the existing one
-                try (final InputStream is = Files.newInputStream(manifestPath)) {
-                    manifest.read(is);
-                }
-                manifest.getMainAttributes().put(Attributes.Name.MULTI_RELEASE, "true");
-                try (final OutputStream os = Files.newOutputStream(manifestPath)) {
-                    manifest.write(os);
-                }
-            }
-        }
-
-        runnerJar.toFile().setReadable(true, false);
-    }
-
-    /**
-     * Indicates whether the given dependency should be included or not.
-     * <p>
-     * A dependency should be included if it is a jar file and:
-     * <p>
-     * <ul>
-     * <li>The dependency is not optional or</li>
-     * <li>The dependency is part of the optional dependencies to include or</li>
-     * <li>The optional dependencies to include are absent</li>
-     * </ul>
-     *
-     * @param appDep the dependency to test.
-     * @param optionalDependencies the optional dependencies to include into the final package.
-     * @return {@code true} if the dependency should be included, {@code false} otherwise.
-     */
-    private static boolean includeAppDep(ResolvedDependency appDep, Optional<Set<ArtifactKey>> optionalDependencies,
-            Set<ArtifactKey> removedArtifacts) {
-        if (!appDep.isJar()) {
-            return false;
-        }
-        if (appDep.isOptional()) {
-            return optionalDependencies.map(appArtifactKeys -> appArtifactKeys.contains(appDep.getKey()))
-                    .orElse(true);
-        }
-        if (removedArtifacts.contains(appDep.getKey())) {
-            return false;
-        }
-        return true;
-    }
-
-    private void walkFileDependencyForDependency(Path root, FileSystem runnerZipFs, Map<String, String> seen,
-            Map<String, Set<Dependency>> duplicateCatcher, Map<String, List<byte[]>> concatenatedEntries,
-            Predicate<String> ignoredEntriesPredicate, Dependency appDep, Set<String> existingEntries,
-            Set<String> mergeResourcePaths) throws IOException {
-        final Path metaInfDir = root.resolve("META-INF");
-        Files.walkFileTree(root, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
-                new SimpleFileVisitor<Path>() {
-                    @Override
-                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                            throws IOException {
-                        final String relativePath = toUri(root.relativize(dir));
-                        if (!relativePath.isEmpty()) {
-                            addDir(runnerZipFs, relativePath);
-                        }
-                        return FileVisitResult.CONTINUE;
-                    }
-
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                            throws IOException {
-                        final String relativePath = toUri(root.relativize(file));
-                        //if this has been transformed we do not copy it
-                        // if it's a signature file (under the <jar>/META-INF directory),
-                        // then we don't add it to the uber jar
-                        if (isBlockOrSF(relativePath) &&
-                                file.relativize(metaInfDir).getNameCount() == 1) {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Signature file " + file.toAbsolutePath() + " from app " +
-                                        "dependency " + appDep + " will not be included in uberjar");
-                            }
-                            return FileVisitResult.CONTINUE;
-                        }
-                        if (!existingEntries.contains(relativePath)) {
-                            if (UBER_JAR_CONCATENATED_ENTRIES_PREDICATE.test(relativePath)
-                                    || mergeResourcePaths.contains(relativePath)) {
-                                concatenatedEntries.computeIfAbsent(relativePath, (u) -> new ArrayList<>())
-                                        .add(Files.readAllBytes(file));
-                                return FileVisitResult.CONTINUE;
-                            } else if (!ignoredEntriesPredicate.test(relativePath)) {
-                                duplicateCatcher.computeIfAbsent(relativePath, (a) -> new HashSet<>())
-                                        .add(appDep);
-                                if (!seen.containsKey(relativePath)) {
-                                    seen.put(relativePath, appDep.toString());
-                                    Files.copy(file, runnerZipFs.getPath(relativePath),
-                                            StandardCopyOption.REPLACE_EXISTING);
-                                }
-                            }
-                        }
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
-    }
-
-    @SuppressWarnings("deprecation")
-    private JarBuildItem buildLegacyThinJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses,
-            ApplicationArchivesBuildItem applicationArchivesBuildItem,
-            PackageConfig packageConfig,
-            ApplicationInfoBuildItem applicationInfo,
-            List<GeneratedClassBuildItem> generatedClasses,
-            List<GeneratedResourceBuildItem> generatedResources,
-            MainClassBuildItem mainClassBuildItem,
-            ClassLoadingConfig classLoadingConfig) throws Exception {
-
-        Path runnerJar = outputTargetBuildItem.getOutputDirectory()
-                .resolve(outputTargetBuildItem.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
-        Path libDir = outputTargetBuildItem.getOutputDirectory().resolve("lib");
-        Files.deleteIfExists(runnerJar);
-        IoUtils.createOrEmptyDir(libDir);
-
-        try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
-
-            log.info("Building thin jar: " + runnerJar);
-
-            doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
-                    applicationArchivesBuildItem, applicationInfo,
-                    packageConfig, generatedResources, libDir, generatedClasses, runnerZipFs, mainClassBuildItem,
-                    getRemovedArtifactKeys(classLoadingConfig));
-        }
-        runnerJar.toFile().setReadable(true, false);
-
-        return new JarBuildItem(runnerJar, null, libDir, packageConfig.jar().type(),
-                suffixToClassifier(packageConfig.computedRunnerSuffix()));
-    }
-
-    @SuppressWarnings("deprecation")
-    private JarBuildItem buildThinJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses,
-            ApplicationArchivesBuildItem applicationArchivesBuildItem,
-            PackageConfig packageConfig,
-            ClassLoadingConfig classLoadingConfig,
-            ApplicationInfoBuildItem applicationInfo,
-            List<GeneratedClassBuildItem> generatedClasses,
-            List<GeneratedResourceBuildItem> generatedResources,
-            List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchiveBuildItems,
-            MainClassBuildItem mainClassBuildItem) throws Exception {
-
-        boolean rebuild = outputTargetBuildItem.isRebuild();
-
-        Path buildDir;
-
-        if (packageConfig.outputDirectory().isPresent()) {
-            buildDir = outputTargetBuildItem.getOutputDirectory();
-        } else {
-            buildDir = outputTargetBuildItem.getOutputDirectory().resolve(DEFAULT_FAST_JAR_DIRECTORY_NAME);
-        }
-
-        final ApplicationManifestConfig.Builder manifestConfig = ApplicationManifestConfig.builder()
-                .setApplicationModel(curateOutcomeBuildItem.getApplicationModel())
-                .setDistributionDirectory(buildDir);
-        //unmodified 3rd party dependencies
-        Path libDir = buildDir.resolve(LIB);
-        Path mainLib = libDir.resolve(MAIN);
-        //parent first entries
-        Path baseLib = libDir.resolve(BOOT_LIB);
-        Files.createDirectories(baseLib);
-
-        Path appDir = buildDir.resolve(APP);
-        Path quarkus = buildDir.resolve(QUARKUS);
-        Path userProviders = null;
-        if (packageConfig.jar().userProvidersDirectory().isPresent()) {
-            userProviders = buildDir.resolve(packageConfig.jar().userProvidersDirectory().get());
-        }
-        if (!rebuild) {
-            IoUtils.createOrEmptyDir(buildDir);
-            Files.createDirectories(mainLib);
-            Files.createDirectories(baseLib);
-            Files.createDirectories(appDir);
-            Files.createDirectories(quarkus);
-            if (userProviders != null) {
-                Files.createDirectories(userProviders);
-                //we add this dir so that it can be copied into container images if required
-                //and will still be copied even if empty
-                Path keepFile = userProviders.resolve(".keep");
-                if (!keepFile.toFile().exists()) {
-                    // check if the file exists to avoid a FileAlreadyExistsException
-                    Files.createFile(keepFile);
-                }
-            }
-        } else {
-            IoUtils.createOrEmptyDir(quarkus);
-        }
-
-        Path decompiledOutputDir = null;
-        boolean wasDecompiledSuccessfully = true;
-        Decompiler decompiler = null;
-        PackageConfig.DecompilerConfig decompilerConfig = packageConfig.jar().decompiler();
-        if (decompilerConfig.enabled()) {
-            decompiledOutputDir = buildDir.getParent().resolve(decompilerConfig.outputDirectory());
-            FileUtil.deleteDirectory(decompiledOutputDir);
-            Files.createDirectory(decompiledOutputDir);
-            decompiler = new Decompiler.VineflowerDecompiler();
-            Path jarDirectory = Paths.get(decompilerConfig.jarDirectory());
-            if (!Files.exists(jarDirectory)) {
-                Files.createDirectory(jarDirectory);
-            }
-            decompiler.init(new Decompiler.Context(VINEFLOWER_VERSION, jarDirectory, decompiledOutputDir));
-            decompiler.downloadIfNecessary();
-        }
-
-        FastJarJars.FastJarJarsBuilder fastJarJarsBuilder = new FastJarJars.FastJarJarsBuilder();
-        List<Path> parentFirst = new ArrayList<>();
-        //we process in order of priority
-        //transformed classes first
-        if (!transformedClasses.getTransformedClassesByJar().isEmpty()) {
-            Path transformedZip = quarkus.resolve(TRANSFORMED_BYTECODE_JAR);
-            fastJarJarsBuilder.setTransformed(transformedZip);
-            try (FileSystem out = createNewZip(transformedZip, packageConfig)) {
-                for (Set<TransformedClassesBuildItem.TransformedClass> transformedSet : transformedClasses
-                        .getTransformedClassesByJar().values()) {
-                    for (TransformedClassesBuildItem.TransformedClass transformed : transformedSet) {
-                        Path target = out.getPath(transformed.getFileName());
-                        if (transformed.getData() != null) {
-                            if (target.getParent() != null) {
-                                Files.createDirectories(target.getParent());
-                            }
-                            Files.write(target, transformed.getData());
-                        }
-                    }
-                }
-            }
-            if (decompiler != null) {
-                wasDecompiledSuccessfully = decompiler.decompile(transformedZip);
-            }
-        }
-        //now generated classes and resources
-        Path generatedZip = quarkus.resolve(GENERATED_BYTECODE_JAR);
-        fastJarJarsBuilder.setGenerated(generatedZip);
-        try (FileSystem out = createNewZip(generatedZip, packageConfig)) {
-            for (GeneratedClassBuildItem i : generatedClasses) {
-                String fileName = fromClassNameToResourceName(i.getName());
-                Path target = out.getPath(fileName);
-                if (target.getParent() != null) {
-                    Files.createDirectories(target.getParent());
-                }
-                Files.write(target, i.getClassData());
-            }
-
-            for (GeneratedResourceBuildItem i : generatedResources) {
-                Path target = out.getPath(i.getName());
-                if (target.getParent() != null) {
-                    Files.createDirectories(target.getParent());
-                }
-                Files.write(target, i.getData());
-            }
-        }
-        if (decompiler != null) {
-            wasDecompiledSuccessfully &= decompiler.decompile(generatedZip);
-        }
-
-        if (wasDecompiledSuccessfully && (decompiledOutputDir != null)) {
-            log.info("The decompiled output can be found at: " + decompiledOutputDir.toAbsolutePath().toString());
-        }
-
-        //now the application classes
-        Path runnerJar = appDir.resolve(outputTargetBuildItem.getBaseName() + DOT_JAR);
-        fastJarJarsBuilder.setRunner(runnerJar);
-
-        if (!rebuild) {
-            manifestConfig.addComponent(ApplicationComponent.builder()
-                    .setResolvedDependency(applicationArchivesBuildItem.getRootArchive().getResolvedDependency())
-                    .setPath(runnerJar));
-            Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
-            try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
-                copyFiles(applicationArchivesBuildItem.getRootArchive(), runnerZipFs, null, ignoredEntriesPredicate);
-            }
-        }
-        final Set<ArtifactKey> parentFirstKeys = getParentFirstKeys(curateOutcomeBuildItem, classLoadingConfig);
-        final StringBuilder classPath = new StringBuilder();
-        final Set<ArtifactKey> removed = getRemovedArtifactKeys(classLoadingConfig);
-        final Map<ArtifactKey, List<Path>> copiedArtifacts = new HashMap<>();
-        for (ResolvedDependency appDep : curateOutcomeBuildItem.getApplicationModel().getRuntimeDependencies()) {
-            if (!rebuild) {
-                copyDependency(parentFirstKeys, outputTargetBuildItem, copiedArtifacts, mainLib, baseLib,
-                        fastJarJarsBuilder::addDep, true,
-                        classPath, appDep, transformedClasses, removed, packageConfig, manifestConfig);
-            } else if (includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removed)) {
-                appDep.getResolvedPaths().forEach(fastJarJarsBuilder::addDep);
-            }
-            if (parentFirstKeys.contains(appDep.getKey())) {
-                appDep.getResolvedPaths().forEach(parentFirst::add);
-            }
-        }
-        for (AdditionalApplicationArchiveBuildItem i : additionalApplicationArchiveBuildItems) {
-            for (Path path : i.getResolvedPaths()) {
-                if (!path.getParent().equals(userProviders)) {
-                    throw new RuntimeException(
-                            "Additional application archives can only be provided from the user providers directory. " + path
-                                    + " is not present in " + userProviders);
-                }
-                fastJarJarsBuilder.addDep(path);
-            }
-        }
-
-        /*
-         * There are some files like META-INF/microprofile-config.properties that usually don't exist in application
-         * and yet are always looked up (spec compliance...) and due to the location in the jar,
-         * the RunnerClassLoader needs to look into every jar to determine whether they exist or not.
-         * In keeping true to the original design of the RunnerClassLoader which indexes the directory structure,
-         * we just add a fail-fast path for files we know don't exist.
-         *
-         * TODO: if this gets more complex, we'll probably want a build item to carry this information instead of hard
-         * coding it here
-         */
-        List<String> nonExistentResources = new ArrayList<>(1);
-        Enumeration<URL> mpConfigURLs = Thread.currentThread().getContextClassLoader().getResources(MP_CONFIG_FILE);
-        if (!mpConfigURLs.hasMoreElements()) {
-            nonExistentResources.add(MP_CONFIG_FILE);
-        }
-
-        Path appInfo = buildDir.resolve(QuarkusEntryPoint.QUARKUS_APPLICATION_DAT);
-        try (OutputStream out = Files.newOutputStream(appInfo)) {
-            FastJarJars fastJarJars = fastJarJarsBuilder.build();
-            List<Path> allJars = new ArrayList<>();
-            if (fastJarJars.transformed != null) {
-                allJars.add(fastJarJars.transformed);
-            }
-            allJars.add(fastJarJars.generated);
-            allJars.add(fastJarJars.runner);
-            List<Path> sortedDeps = new ArrayList<>(fastJarJars.deps);
-            Collections.sort(sortedDeps);
-            allJars.addAll(sortedDeps);
-            List<Path> sortedParentFirst = new ArrayList<>(parentFirst);
-            Collections.sort(sortedParentFirst);
-            List<String> sortedNonExistentResources = new ArrayList<>(nonExistentResources);
-            Collections.sort(sortedNonExistentResources);
-            SerializedApplication.write(out, mainClassBuildItem.getClassName(), buildDir, allJars, sortedParentFirst,
-                    sortedNonExistentResources);
-        }
-
-        runnerJar.toFile().setReadable(true, false);
-        Path initJar = buildDir.resolve(QUARKUS_RUN_JAR);
-        manifestConfig.setMainComponent(ApplicationComponent.builder()
-                .setPath(initJar)
-                .setDependencies(List.of(curateOutcomeBuildItem.getApplicationModel().getAppArtifact())))
-                .setRunnerPath(initJar);
-        boolean mutableJar = packageConfig.jar().type() == MUTABLE_JAR;
-        if (mutableJar) {
-            //we output the properties in a reproducible manner, so we remove the date comment
-            //and sort them
-            //we still use Properties to get the escaping right though, so basically we write out the lines
-            //to memory, split them, discard comments, sort them, then write them to disk
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            outputTargetBuildItem.getBuildSystemProperties().store(out, null);
-            List<String> lines = Arrays.stream(out.toString(StandardCharsets.UTF_8).split("\n"))
-                    .filter(s -> !s.startsWith("#")).sorted().collect(Collectors.toList());
-            Path buildSystemProps = quarkus.resolve(BUILD_SYSTEM_PROPERTIES);
-            manifestConfig.addComponent(ApplicationComponent.builder().setPath(buildSystemProps).setDevelopmentScope());
-            try (OutputStream fileOutput = Files.newOutputStream(buildSystemProps)) {
-                fileOutput.write(String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
-            }
-        }
-        if (!rebuild) {
-            try (FileSystem runnerZipFs = createNewZip(initJar, packageConfig)) {
-                ResolvedDependency appArtifact = curateOutcomeBuildItem.getApplicationModel().getAppArtifact();
-                generateManifest(runnerZipFs, classPath.toString(), packageConfig, appArtifact,
-                        QuarkusEntryPoint.class.getName(),
-                        applicationInfo);
-            }
-
-            //now copy the deployment artifacts, if required
-            if (mutableJar) {
-                Path deploymentLib = libDir.resolve(DEPLOYMENT_LIB);
-                Files.createDirectories(deploymentLib);
-                for (ResolvedDependency appDep : curateOutcomeBuildItem.getApplicationModel().getDependencies()) {
-                    copyDependency(parentFirstKeys, outputTargetBuildItem, copiedArtifacts, deploymentLib, baseLib, p -> {
-                    }, false, classPath, appDep, new TransformedClassesBuildItem(Map.of()), removed, packageConfig,
-                            manifestConfig); //we don't care about transformation here, so just pass in an empty item
-                }
-                Map<ArtifactKey, List<String>> relativePaths = new HashMap<>();
-                for (Map.Entry<ArtifactKey, List<Path>> e : copiedArtifacts.entrySet()) {
-                    relativePaths.put(e.getKey(),
-                            e.getValue().stream().map(s -> buildDir.relativize(s).toString().replace('\\', '/'))
-                                    .collect(Collectors.toList()));
-                }
-
-                //now we serialize the data needed to build up the reaugmentation class path
-                //first the app model
-                MutableJarApplicationModel model = new MutableJarApplicationModel(outputTargetBuildItem.getBaseName(),
-                        relativePaths,
-                        curateOutcomeBuildItem.getApplicationModel(),
-                        packageConfig.jar().userProvidersDirectory().orElse(null), buildDir.relativize(runnerJar).toString());
-                Path appmodelDat = deploymentLib.resolve(APPMODEL_DAT);
-                manifestConfig.addComponent(ApplicationComponent.builder().setPath(appmodelDat).setDevelopmentScope());
-                try (OutputStream out = Files.newOutputStream(appmodelDat)) {
-                    ObjectOutputStream obj = new ObjectOutputStream(out);
-                    obj.writeObject(model);
-                    obj.close();
-                }
-                //now the bootstrap CP
-                //we just include all deployment deps, even though we only really need bootstrap
-                //as we don't really have a resolved bootstrap CP
-                //once we have the app model it will all be done in QuarkusClassLoader anyway
-                Path deploymentCp = deploymentLib.resolve(DEPLOYMENT_CLASS_PATH_DAT);
-                manifestConfig.addComponent(ApplicationComponent.builder().setPath(deploymentCp).setDevelopmentScope());
-                try (OutputStream out = Files.newOutputStream(deploymentCp)) {
-                    ObjectOutputStream obj = new ObjectOutputStream(out);
-                    List<String> paths = new ArrayList<>();
-                    for (ResolvedDependency i : curateOutcomeBuildItem.getApplicationModel().getDependencies()) {
-                        final List<String> list = relativePaths.get(i.getKey());
-                        // some of the dependencies may have been filtered out
-                        if (list != null) {
-                            paths.addAll(list);
-                        }
-                    }
-                    obj.writeObject(paths);
-                    obj.close();
-                }
-            }
-
-            if (packageConfig.jar().includeDependencyList()) {
-                Path deplist = buildDir.resolve(QUARKUS_APP_DEPS);
-                List<String> lines = new ArrayList<>();
-                for (ResolvedDependency i : curateOutcomeBuildItem.getApplicationModel().getRuntimeDependencies()) {
-                    lines.add(i.toGACTVString());
-                }
-                lines.sort(Comparator.naturalOrder());
-                Files.write(deplist, lines);
-            }
-        } else {
-            //if it is a rebuild we might have classes
-        }
-        try (Stream<Path> files = Files.walk(buildDir)) {
-            files.forEach(new Consumer<Path>() {
-                @Override
-                public void accept(Path path) {
-                    path.toFile().setReadable(true, false);
-                }
-            });
-        }
-        return new JarBuildItem(initJar, null, libDir, packageConfig.jar().type(), null, manifestConfig.build());
-    }
-
-    /**
-     * @return a {@code Set} containing the key of the artifacts to load from the parent ClassLoader first.
-     */
-    private Set<ArtifactKey> getParentFirstKeys(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            ClassLoadingConfig classLoadingConfig) {
-        final Set<ArtifactKey> parentFirstKeys = new HashSet<>();
-        curateOutcomeBuildItem.getApplicationModel().getDependencies().forEach(d -> {
-            if (d.isFlagSet(DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST)) {
-                parentFirstKeys.add(d.getKey());
-            }
-        });
-        classLoadingConfig.parentFirstArtifacts().ifPresent(
-                parentFirstArtifacts -> {
-                    for (String artifact : parentFirstArtifacts) {
-                        parentFirstKeys.add(new GACT(artifact.split(":")));
-                    }
-                });
-        return parentFirstKeys;
-    }
-
-    private Set<ArtifactKey> getRemovedArtifactKeys(ClassLoadingConfig classLoadingConfig) {
-        if (classLoadingConfig.removedArtifacts().isEmpty()) {
-            return Set.of();
-        }
-
-        Set<ArtifactKey> removedArtifacts = new HashSet<>();
-        for (String artifact : classLoadingConfig.removedArtifacts().get()) {
-            removedArtifacts.add(GACT.fromString(artifact));
-        }
-        return Collections.unmodifiableSet(removedArtifacts);
-    }
-
-    private void copyDependency(Set<ArtifactKey> parentFirstArtifacts, OutputTargetBuildItem outputTargetBuildItem,
-            Map<ArtifactKey, List<Path>> runtimeArtifacts, Path libDir, Path baseLib, Consumer<Path> targetPathConsumer,
-            boolean allowParentFirst, StringBuilder classPath, ResolvedDependency appDep,
-            TransformedClassesBuildItem transformedClasses, Set<ArtifactKey> removedDeps,
-            PackageConfig packageConfig, ApplicationManifestConfig.Builder manifestConfig)
-            throws IOException {
-
-        // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
-        // and are not part of the optional dependencies to include
-        if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDeps)) {
-            return;
-        }
-        if (runtimeArtifacts.containsKey(appDep.getKey())) {
-            return;
-        }
-        for (Path resolvedDep : appDep.getResolvedPaths()) {
-            final String fileName = getJarFileName(appDep, resolvedDep);
-            final Path targetPath;
-
-            if (allowParentFirst && parentFirstArtifacts.contains(appDep.getKey())) {
-                targetPath = baseLib.resolve(fileName);
-                classPath.append(" ").append(LIB).append("/").append(BOOT_LIB).append("/").append(fileName);
-            } else {
-                targetPath = libDir.resolve(fileName);
-                targetPathConsumer.accept(targetPath);
-            }
-            runtimeArtifacts.computeIfAbsent(appDep.getKey(), (s) -> new ArrayList<>(1)).add(targetPath);
-
-            if (Files.isDirectory(resolvedDep)) {
-                // This case can happen when we are building a jar from inside the Quarkus repository
-                // and Quarkus Bootstrap's localProjectDiscovery has been set to true. In such a case
-                // the non-jar dependencies are the Quarkus dependencies picked up on the file system
-                packageClasses(resolvedDep, targetPath, packageConfig);
-            } else {
-                Set<TransformedClassesBuildItem.TransformedClass> transformedFromThisArchive = transformedClasses
-                        .getTransformedClassesByJar().get(resolvedDep);
-                Set<String> removedFromThisArchive = new HashSet<>();
-                if (transformedFromThisArchive != null) {
-                    for (TransformedClassesBuildItem.TransformedClass i : transformedFromThisArchive) {
-                        if (i.getData() == null) {
-                            removedFromThisArchive.add(i.getFileName());
-                        }
-                    }
-                }
-                var appComponent = ApplicationComponent.builder()
-                        .setPath(targetPath)
-                        .setResolvedDependency(appDep);
-                if (removedFromThisArchive.isEmpty()) {
-                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING,
-                            StandardCopyOption.COPY_ATTRIBUTES);
-                } else {
-                    // we copy jars for which we remove entries to the same directory
-                    // which seems a bit odd to me
-                    JarUnsigner.unsignJar(resolvedDep, targetPath, Predicate.not(removedFromThisArchive::contains));
-
-                    var list = new ArrayList<>(removedFromThisArchive);
-                    Collections.sort(list);
-                    var sb = new StringBuilder("Removed ").append(list.get(0));
-                    for (int i = 1; i < list.size(); ++i) {
-                        sb.append(",").append(list.get(i));
-                    }
-                    appComponent.setPedigree(sb.toString());
-                }
-                manifestConfig.addComponent(appComponent);
-            }
-        }
-    }
-
-    /**
-     * Returns a JAR file name to be used for a content of a dependency, depending on whether the resolved path
-     * is a directory or not.
-     * We don't use getFileName() for directories, since directories would often be "classes" ending up merging
-     * content from multiple dependencies in the same package
-     *
-     * @param dep dependency
-     * @param resolvedPath path of the resolved dependency
-     * @return JAR file name
-     */
-    public static String getJarFileName(ResolvedDependency dep, Path resolvedPath) {
-        boolean isDirectory = Files.isDirectory(resolvedPath);
-        if (!isDirectory) {
-            return dep.getGroupId() + "." + resolvedPath.getFileName();
-        }
-        final StringBuilder sb = new StringBuilder();
-        sb.append(dep.getGroupId()).append(".").append(dep.getArtifactId()).append("-");
-        if (!dep.getClassifier().isEmpty()) {
-            sb.append(dep.getClassifier()).append("-");
-        }
-        return sb.append(dep.getVersion()).append(".").append(dep.getType()).toString();
-    }
-
-    private void packageClasses(Path resolvedDep, final Path targetPath, PackageConfig packageConfig) throws IOException {
-        try (FileSystem runnerZipFs = createNewZip(targetPath, packageConfig)) {
-            Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
-                    new SimpleFileVisitor<Path>() {
-                        @Override
-                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                                throws IOException {
-                            final Path relativePath = resolvedDep.relativize(file);
-                            final Path targetPath = runnerZipFs.getPath(relativePath.toString());
-                            if (targetPath.getParent() != null) {
-                                Files.createDirectories(targetPath.getParent());
-                            }
-                            Files.copy(file, targetPath, StandardCopyOption.REPLACE_EXISTING); //replace only needed for testing
-                            return FileVisitResult.CONTINUE;
-                        }
-                    });
-        }
-    }
-
-    /**
-     * Native images are built from a specially created jar file. This allows for changes in how the jar file is generated.
-     */
-    @BuildStep
-    public NativeImageSourceJarBuildItem buildNativeImageJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses,
-            ApplicationArchivesBuildItem applicationArchivesBuildItem,
-            ApplicationInfoBuildItem applicationInfo,
-            PackageConfig packageConfig,
-            List<GeneratedClassBuildItem> generatedClasses,
-            List<GeneratedNativeImageClassBuildItem> nativeImageResources,
-            List<GeneratedResourceBuildItem> generatedResources,
-            MainClassBuildItem mainClassBuildItem,
-            ClassLoadingConfig classLoadingConfig) throws Exception {
-        Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
-                .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
-        IoUtils.createOrEmptyDir(targetDirectory);
-
-        List<GeneratedClassBuildItem> allClasses = new ArrayList<>(generatedClasses);
-        allClasses.addAll(nativeImageResources.stream()
-                .map((s) -> new GeneratedClassBuildItem(true, s.getName(), s.getClassData()))
-                .collect(Collectors.toList()));
-
-        return buildNativeImageThinJar(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
-                applicationArchivesBuildItem,
-                applicationInfo, packageConfig, allClasses, generatedResources, mainClassBuildItem, targetDirectory,
-                classLoadingConfig);
-    }
-
-    private NativeImageSourceJarBuildItem buildNativeImageThinJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses,
-            ApplicationArchivesBuildItem applicationArchivesBuildItem,
-            ApplicationInfoBuildItem applicationInfo,
-            PackageConfig packageConfig,
-            List<GeneratedClassBuildItem> allClasses,
-            List<GeneratedResourceBuildItem> generatedResources,
-            MainClassBuildItem mainClassBuildItem,
-            Path targetDirectory,
-            ClassLoadingConfig classLoadingConfig) throws Exception {
-        copyJsonConfigFiles(applicationArchivesBuildItem, targetDirectory);
-
-        Path runnerJar = targetDirectory
-                .resolve(outputTargetBuildItem.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
-        Path libDir = targetDirectory.resolve(LIB);
-        Files.createDirectories(libDir);
-
-        try (FileSystem runnerZipFs = ZipUtils.newZip(runnerJar)) {
-
-            log.info("Building native image source jar: " + runnerJar);
-
-            final Set<ArtifactKey> removedArtifacts = new HashSet<>(getRemovedArtifactKeys(classLoadingConfig));
-            // Remove svm and graal-sdk artifacts as they are provided by GraalVM itself
-            removedArtifacts.add(GACT.fromString("org.graalvm.nativeimage:svm"));
-            removedArtifacts.add(GACT.fromString("org.graalvm.sdk:graal-sdk"));
-            removedArtifacts.add(GACT.fromString("org.graalvm.sdk:nativeimage"));
-            removedArtifacts.add(GACT.fromString("org.graalvm.sdk:word"));
-            removedArtifacts.add(GACT.fromString("org.graalvm.sdk:collections"));
-
-            // complain if graal-sdk is present as a dependency as nativeimage should be preferred
-            if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream()
-                    .anyMatch(d -> d.getGroupId().equals("org.graalvm.sdk") && d.getArtifactId().equals("graal-sdk"))) {
-                log.warn("org.graalvm.sdk:graal-sdk is present in the classpath. "
-                        + "From Quarkus 3.8 and onwards, org.graalvm.sdk:nativeimage should be preferred. "
-                        + "Make sure you report the issue to the maintainers of the extensions that bring it.");
-            }
-
-            doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
-                    applicationArchivesBuildItem, applicationInfo, packageConfig, generatedResources, libDir, allClasses,
-                    runnerZipFs, mainClassBuildItem, removedArtifacts);
-        }
-        runnerJar.toFile().setReadable(true, false);
-        return new NativeImageSourceJarBuildItem(runnerJar, libDir);
-    }
-
-    /**
-     * This is done in order to make application specific native image configuration files available to the native-image tool
-     * without the user needing to know any specific paths.
-     * The files that are copied don't end up in the native image unless the user specifies they are needed, all this method
-     * does is copy them to a convenient location
-     */
-    private void copyJsonConfigFiles(ApplicationArchivesBuildItem applicationArchivesBuildItem, Path thinJarDirectory)
-            throws IOException {
-        for (Path root : applicationArchivesBuildItem.getRootArchive().getRootDirectories()) {
-            try (Stream<Path> stream = Files.find(root, 1, IS_JSON_FILE_PREDICATE)) {
-                stream.forEach(new Consumer<Path>() {
-                    @Override
-                    public void accept(Path jsonPath) {
-                        try {
-                            Files.createDirectories(thinJarDirectory);
-                            Files.copy(jsonPath, thinJarDirectory.resolve(jsonPath.getFileName().toString()));
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(
-                                    "Unable to copy json config file from " + jsonPath + " to " + thinJarDirectory,
-                                    e);
-                        }
-                    }
-                });
-            }
-        }
-    }
-
-    private void doLegacyThinJarGeneration(CurateOutcomeBuildItem curateOutcomeBuildItem,
-            OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses,
-            ApplicationArchivesBuildItem applicationArchivesBuildItem,
-            ApplicationInfoBuildItem applicationInfo,
-            PackageConfig packageConfig,
-            List<GeneratedResourceBuildItem> generatedResources,
-            Path libDir,
-            List<GeneratedClassBuildItem> allClasses,
-            FileSystem runnerZipFs,
-            MainClassBuildItem mainClassBuildItem,
-            Set<ArtifactKey> removedArtifacts)
-            throws IOException {
-        final Map<String, String> seen = new HashMap<>();
-        final StringBuilder classPath = new StringBuilder();
-        final Map<String, List<byte[]>> services = new HashMap<>();
-
-        final Collection<ResolvedDependency> appDeps = curateOutcomeBuildItem.getApplicationModel()
-                .getRuntimeDependencies();
-
-        Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
-
-        copyLibraryJars(runnerZipFs, outputTargetBuildItem, transformedClasses, libDir, classPath, appDeps, services,
-                ignoredEntriesPredicate, removedArtifacts);
-
-        ResolvedDependency appArtifact = curateOutcomeBuildItem.getApplicationModel().getAppArtifact();
-        // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
-        // see https://bugs.openjdk.java.net/browse/JDK-8031748
-        generateManifest(runnerZipFs, classPath.toString(), packageConfig, appArtifact, mainClassBuildItem.getClassName(),
-                applicationInfo);
-
-        copyCommonContent(runnerZipFs, services, applicationArchivesBuildItem, transformedClasses, allClasses,
-                generatedResources, seen, ignoredEntriesPredicate);
-    }
-
-    private void copyLibraryJars(FileSystem runnerZipFs, OutputTargetBuildItem outputTargetBuildItem,
-            TransformedClassesBuildItem transformedClasses, Path libDir,
-            StringBuilder classPath, Collection<ResolvedDependency> appDeps, Map<String, List<byte[]>> services,
-            Predicate<String> ignoredEntriesPredicate, Set<ArtifactKey> removedDependencies) throws IOException {
-        for (ResolvedDependency appDep : appDeps) {
-
-            // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
-            // and are not part of the optional dependencies to include
-            if (!includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDependencies)) {
-                continue;
-            }
-
-            for (Path resolvedDep : appDep.getResolvedPaths()) {
-                if (!Files.isDirectory(resolvedDep)) {
-                    Set<String> transformedFromThisArchive = transformedClasses.getTransformedFilesByJar().get(resolvedDep);
-                    if (transformedFromThisArchive == null || transformedFromThisArchive.isEmpty()) {
-                        final String fileName = appDep.getGroupId() + "." + resolvedDep.getFileName();
-                        final Path targetPath = libDir.resolve(fileName);
-                        // Unsign the jar before copying it
-                        JarUnsigner.unsignJar(resolvedDep, targetPath);
-                        classPath.append(" lib/").append(fileName);
-                    } else {
-                        //we have transformed classes, we need to handle them correctly
-                        final String fileName = "modified-" + appDep.getGroupId() + "."
-                                + resolvedDep.getFileName();
-                        final Path targetPath = libDir.resolve(fileName);
-                        classPath.append(" lib/").append(fileName);
-                        JarUnsigner.unsignJar(resolvedDep, targetPath, Predicate.not(transformedFromThisArchive::contains));
-                    }
-                } else {
-                    // This case can happen when we are building a jar from inside the Quarkus repository
-                    // and Quarkus Bootstrap's localProjectDiscovery has been set to true. In such a case
-                    // the non-jar dependencies are the Quarkus dependencies picked up on the file system
-                    Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
-                            new SimpleFileVisitor<Path>() {
-                                @Override
-                                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                                        throws IOException {
-                                    final Path relativePath = resolvedDep.relativize(file);
-                                    final String relativeUri = toUri(relativePath);
-                                    if (ignoredEntriesPredicate.test(relativeUri)) {
-                                        return FileVisitResult.CONTINUE;
-                                    }
-                                    if (relativeUri.startsWith("META-INF/services/") && relativeUri.length() > 18) {
-                                        services.computeIfAbsent(relativeUri, (u) -> new ArrayList<>())
-                                                .add(Files.readAllBytes(file));
-                                    } else if (file.getFileName().toString().endsWith(".class")) {
-                                        final Path targetPath = runnerZipFs.getPath(relativePath.toString());
-                                        if (targetPath.getParent() != null) {
-                                            Files.createDirectories(targetPath.getParent());
-                                        }
-                                        Files.copy(file, targetPath, StandardCopyOption.REPLACE_EXISTING); //replace only needed for testing
-                                    }
-                                    return FileVisitResult.CONTINUE;
-                                }
-                            });
-                }
-            }
-        }
-    }
-
-    private void copyCommonContent(FileSystem runnerZipFs, Map<String, List<byte[]>> concatenatedEntries,
-            ApplicationArchivesBuildItem appArchives, TransformedClassesBuildItem transformedClassesBuildItem,
-            List<GeneratedClassBuildItem> generatedClasses,
-            List<GeneratedResourceBuildItem> generatedResources, Map<String, String> seen,
-            Predicate<String> ignoredEntriesPredicate)
-            throws IOException {
-
-        //TODO: this is probably broken in gradle
-        //        if (Files.exists(augmentOutcome.getConfigDir())) {
-        //            copyFiles(augmentOutcome.getConfigDir(), runnerZipFs, services);
-        //        }
-        for (Set<TransformedClassesBuildItem.TransformedClass> transformed : transformedClassesBuildItem
-                .getTransformedClassesByJar().values()) {
-            for (TransformedClassesBuildItem.TransformedClass i : transformed) {
-                if (i.getData() != null) {
-                    Path target = runnerZipFs.getPath(i.getFileName());
-                    handleParent(runnerZipFs, i.getFileName(), seen);
-                    try (final OutputStream out = Files.newOutputStream(target)) {
-                        out.write(i.getData());
-                    }
-                    seen.put(i.getFileName(), "Current Application");
-                }
-            }
-        }
-        for (GeneratedClassBuildItem i : generatedClasses) {
-            String fileName = fromClassNameToResourceName(i.getName());
-            seen.put(fileName, "Current Application");
-            Path target = runnerZipFs.getPath(fileName);
-            handleParent(runnerZipFs, fileName, seen);
-            if (Files.exists(target)) {
-                continue;
-            }
-            try (final OutputStream os = Files.newOutputStream(target)) {
-                os.write(i.getClassData());
-            }
-        }
-
-        for (GeneratedResourceBuildItem i : generatedResources) {
-            if (ignoredEntriesPredicate.test(i.getName())) {
-                continue;
-            }
-            Path target = runnerZipFs.getPath(i.getName());
-            handleParent(runnerZipFs, i.getName(), seen);
-            if (Files.exists(target)) {
-                continue;
-            }
-            if (i.getName().startsWith("META-INF/services/")) {
-                concatenatedEntries.computeIfAbsent(i.getName(), (u) -> new ArrayList<>()).add(i.getData());
-            } else {
-                try (final OutputStream os = Files.newOutputStream(target)) {
-                    os.write(i.getData());
-                }
-            }
-        }
-
-        copyFiles(appArchives.getRootArchive(), runnerZipFs, concatenatedEntries, ignoredEntriesPredicate);
-
-        for (Map.Entry<String, List<byte[]>> entry : concatenatedEntries.entrySet()) {
-            try (final OutputStream os = Files.newOutputStream(runnerZipFs.getPath(entry.getKey()))) {
-                // TODO: Handle merging of XMLs
-                for (byte[] i : entry.getValue()) {
-                    os.write(i);
-                    os.write('\n');
-                }
-            }
-        }
-    }
-
-    private void handleParent(FileSystem runnerZipFs, String fileName, Map<String, String> seen) throws IOException {
-        for (int i = 0; i < fileName.length(); ++i) {
-            if (fileName.charAt(i) == '/') {
-                String dir = fileName.substring(0, i);
-                if (!seen.containsKey(dir)) {
-                    seen.put(dir, "Current Application");
-                    Files.createDirectories(runnerZipFs.getPath(dir));
-                }
-            }
-        }
-    }
-
-    /**
-     * Manifest generation is quite simple : we just have to push some attributes in manifest.
-     * However, it gets a little more complex if the manifest preexists.
-     * So we first try to see if a manifest exists, and otherwise create a new one.
-     *
-     * <b>BEWARE</b> this method should be invoked after file copy from target/classes and so on.
-     * Otherwise, this manifest manipulation will be useless.
-     */
-    private void generateManifest(FileSystem runnerZipFs, final String classPath, PackageConfig config,
-            ResolvedDependency appArtifact,
-            String mainClassName,
-            ApplicationInfoBuildItem applicationInfo)
-            throws IOException {
-        final Path manifestPath = runnerZipFs.getPath("META-INF", "MANIFEST.MF");
-        final Manifest manifest = new Manifest();
-        if (Files.exists(manifestPath)) {
-            try (InputStream is = Files.newInputStream(manifestPath)) {
-                manifest.read(is);
-            }
-            Files.delete(manifestPath);
-        } else {
-            Files.createDirectories(runnerZipFs.getPath("META-INF"));
-        }
-        Files.createDirectories(manifestPath.getParent());
-        Attributes attributes = manifest.getMainAttributes();
-        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
-        // JDK 24+ needs --add-opens=java.base/java.lang=ALL-UNNAMED for org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals()
-        attributes.put(new Attributes.Name("Add-Opens"), "java.base/java.lang");
-
-        for (Map.Entry<String, String> attribute : config.jar().manifest().attributes().entrySet()) {
-            attributes.putValue(attribute.getKey(), attribute.getValue());
-        }
-        if (attributes.containsKey(Attributes.Name.CLASS_PATH)) {
-            log.warn(
-                    "A CLASS_PATH entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Class-Path\". Quarkus has overwritten this existing entry.");
-        }
-        attributes.put(Attributes.Name.CLASS_PATH, classPath);
-        if (attributes.containsKey(Attributes.Name.MAIN_CLASS)) {
-            String existingMainClass = attributes.getValue(Attributes.Name.MAIN_CLASS);
-            if (!mainClassName.equals(existingMainClass)) {
-                log.warn(
-                        "A MAIN_CLASS entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Main-Class\". Quarkus has overwritten your existing entry.");
-            }
-        }
-        attributes.put(Attributes.Name.MAIN_CLASS, mainClassName);
-        if (config.jar().manifest().addImplementationEntries()
-                && !attributes.containsKey(Attributes.Name.IMPLEMENTATION_TITLE)) {
-            String name = ApplicationInfoBuildItem.UNSET_VALUE.equals(applicationInfo.getName())
-                    ? appArtifact.getArtifactId()
-                    : applicationInfo.getName();
-            attributes.put(Attributes.Name.IMPLEMENTATION_TITLE, name);
-        }
-        if (config.jar().manifest().addImplementationEntries()
-                && !attributes.containsKey(Attributes.Name.IMPLEMENTATION_VERSION)) {
-            String version = ApplicationInfoBuildItem.UNSET_VALUE.equals(applicationInfo.getVersion())
-                    ? appArtifact.getVersion()
-                    : applicationInfo.getVersion();
-            attributes.put(Attributes.Name.IMPLEMENTATION_VERSION, version);
-        }
-        for (String sectionName : config.jar().manifest().sections().keySet()) {
-            for (Map.Entry<String, String> entry : config.jar().manifest().sections().get(sectionName).entrySet()) {
-                Attributes attribs = manifest.getEntries().computeIfAbsent(sectionName, k -> new Attributes());
-                attribs.putValue(entry.getKey(), entry.getValue());
-            }
-        }
-        try (final OutputStream os = Files.newOutputStream(manifestPath)) {
-            manifest.write(os);
-        }
-    }
-
-    /**
-     * Copy files from {@code archive} to {@code fs}, filtering out service providers into the given map.
-     *
-     * @param archive the root application archive
-     * @param fs the destination filesystem
-     * @param services the services map
-     * @throws IOException if an error occurs
-     */
-    private void copyFiles(ApplicationArchive archive, FileSystem fs, Map<String, List<byte[]>> services,
-            Predicate<String> ignoredEntriesPredicate) throws IOException {
-        try {
-            archive.accept(tree -> {
-                tree.walk(new PathVisitor() {
-                    @Override
-                    public void visitPath(PathVisit visit) {
-                        final Path file = visit.getRoot().relativize(visit.getPath());
-                        final String relativePath = toUri(file);
-                        if (relativePath.isEmpty() || ignoredEntriesPredicate.test(relativePath)) {
-                            return;
-                        }
-                        try {
-                            if (Files.isDirectory(visit.getPath())) {
-                                addDir(fs, relativePath);
-                            } else {
-                                if (relativePath.startsWith("META-INF/services/") && relativePath.length() > 18
-                                        && services != null) {
-                                    final byte[] content;
-                                    try {
-                                        content = Files.readAllBytes(visit.getPath());
-                                    } catch (IOException e) {
-                                        throw new UncheckedIOException(e);
-                                    }
-                                    services.computeIfAbsent(relativePath, (u) -> new ArrayList<>()).add(content);
-                                } else if (!relativePath.equals("META-INF/INDEX.LIST")) {
-                                    //TODO: auto generate INDEX.LIST
-                                    //this may have implications for Camel though, as they change the layout
-                                    //also this is only really relevant for the thin jar layout
-                                    Path target = fs.getPath(relativePath);
-                                    if (!Files.exists(target)) {
-                                        Files.copy(visit.getPath(), target, StandardCopyOption.REPLACE_EXISTING);
-                                    }
-                                }
-                            }
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                    }
-                });
-            });
-        } catch (RuntimeException re) {
-            final Throwable cause = re.getCause();
-            if (cause instanceof IOException) {
-                throw (IOException) cause;
-            }
-            throw re;
-        }
-
-    }
-
-    private void addDir(FileSystem fs, final String relativePath)
-            throws IOException {
-        final Path targetDir = fs.getPath(relativePath);
-        try {
-            Files.createDirectory(targetDir);
-        } catch (FileAlreadyExistsException e) {
-            if (!Files.isDirectory(targetDir)) {
-                throw e;
-            }
-        }
-    }
-
-    private static String toUri(Path path) {
-        if (path.isAbsolute()) {
-            return path.toUri().getPath();
-        }
-        if (path.getNameCount() == 0) {
-            return "";
-        }
-        return toUri(new StringBuilder(), path, 0).toString();
-    }
-
-    private static StringBuilder toUri(StringBuilder b, Path path, int seg) {
-        b.append(path.getName(seg));
-        if (seg < path.getNameCount() - 1) {
-            b.append('/');
-            toUri(b, path, seg + 1);
-        }
-        return b;
     }
 
     static class JarRequired implements BooleanSupplier {
@@ -1468,201 +225,35 @@ public class JarResultBuildStep {
         }
     }
 
-    // same as the impl in sun.security.util.SignatureFileVerifier#isBlockOrSF()
-    static boolean isBlockOrSF(final String s) {
-        if (s == null) {
-            return false;
-        }
-        return s.endsWith(".SF")
-                || s.endsWith(".DSA")
-                || s.endsWith(".RSA")
-                || s.endsWith(".EC");
+    /**
+     * @return a {@code Set} containing the key of the artifacts to load from the parent ClassLoader first.
+     */
+    private static Set<ArtifactKey> getParentFirstArtifactKeys(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            ClassLoadingConfig classLoadingConfig) {
+        final Set<ArtifactKey> parentFirstKeys = new HashSet<>();
+        curateOutcomeBuildItem.getApplicationModel().getDependencies().forEach(d -> {
+            if (d.isFlagSet(DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST)) {
+                parentFirstKeys.add(d.getKey());
+            }
+        });
+        classLoadingConfig.parentFirstArtifacts().ifPresent(
+                parentFirstArtifacts -> {
+                    for (String artifact : parentFirstArtifacts) {
+                        parentFirstKeys.add(new GACT(artifact.split(":")));
+                    }
+                });
+        return parentFirstKeys;
     }
 
-    private Predicate<String> getThinJarIgnoredEntriesPredicate(PackageConfig packageConfig) {
-        return packageConfig.jar().userConfiguredIgnoredEntries().map(Set::copyOf).orElse(Set.of())::contains;
+    private static Set<ArtifactKey> getRemovedArtifactKeys(ClassLoadingConfig classLoadingConfig) {
+        if (classLoadingConfig.removedArtifacts().isEmpty()) {
+            return Set.of();
+        }
+
+        Set<ArtifactKey> removedArtifacts = new HashSet<>();
+        for (String artifact : classLoadingConfig.removedArtifacts().get()) {
+            removedArtifacts.add(GACT.fromString(artifact));
+        }
+        return Collections.unmodifiableSet(removedArtifacts);
     }
-
-    private static class IsEntryIgnoredForUberJarPredicate implements Predicate<String> {
-
-        private static final Set<String> UBER_JAR_IGNORED_ENTRIES = Set.of(
-                "META-INF/INDEX.LIST",
-                "META-INF/MANIFEST.MF",
-                "module-info.class",
-                "META-INF/LICENSE",
-                "META-INF/LICENSE.txt",
-                "META-INF/LICENSE.md",
-                "META-INF/LGPL-3.0.txt",
-                "META-INF/ASL-2.0.txt",
-                "META-INF/NOTICE",
-                "META-INF/NOTICE.txt",
-                "META-INF/NOTICE.md",
-                "META-INF/README",
-                "META-INF/README.txt",
-                "META-INF/README.md",
-                "META-INF/DEPENDENCIES",
-                "META-INF/DEPENDENCIES.txt",
-                "META-INF/beans.xml",
-                "META-INF/quarkus-config-roots.list",
-                "META-INF/quarkus-javadoc.properties",
-                "META-INF/quarkus-extension.properties",
-                "META-INF/quarkus-extension.json",
-                "META-INF/quarkus-extension.yaml",
-                "META-INF/quarkus-deployment-dependency.graph",
-                "META-INF/jandex.idx",
-                "META-INF/panache-archive.marker", // deprecated and unused, but still present in some archives
-                "META-INF/build.metadata", // present in the Red Hat Build of Quarkus
-                "LICENSE");
-
-        @Override
-        public boolean test(String path) {
-            return UBER_JAR_IGNORED_ENTRIES.contains(path)
-                    || path.endsWith("module-info.class");
-        }
-    }
-
-    static class FastJarJars {
-        private final Path transformed;
-        private final Path generated;
-        private final Path runner;
-        private final List<Path> deps;
-
-        public FastJarJars(FastJarJarsBuilder builder) {
-            this.transformed = builder.transformed;
-            this.generated = builder.generated;
-            this.runner = builder.runner;
-            this.deps = builder.deps;
-        }
-
-        public static class FastJarJarsBuilder {
-            private Path transformed;
-            private Path generated;
-            private Path runner;
-            private final List<Path> deps = new ArrayList<>();
-
-            public FastJarJarsBuilder setTransformed(Path transformed) {
-                this.transformed = transformed;
-                return this;
-            }
-
-            public FastJarJarsBuilder setGenerated(Path generated) {
-                this.generated = generated;
-                return this;
-            }
-
-            public FastJarJarsBuilder setRunner(Path runner) {
-                this.runner = runner;
-                return this;
-            }
-
-            public FastJarJarsBuilder addDep(Path dep) {
-                this.deps.add(dep);
-                return this;
-            }
-
-            public FastJarJars build() {
-                return new FastJarJars(this);
-            }
-        }
-    }
-
-    private static class IsJsonFilePredicate implements BiPredicate<Path, BasicFileAttributes> {
-
-        @Override
-        public boolean test(Path path, BasicFileAttributes basicFileAttributes) {
-            return basicFileAttributes.isRegularFile() && path.toString().endsWith(".json");
-        }
-    }
-
-    private interface Decompiler {
-
-        void init(Context context);
-
-        /**
-         * @return {@code true} if the decompiler was successfully download or already exists
-         */
-        boolean downloadIfNecessary();
-
-        /**
-         * @return {@code true} if the decompilation process was successful
-         */
-        boolean decompile(Path jarToDecompile);
-
-        class Context {
-            final String versionStr;
-            final Path jarLocation;
-            final Path decompiledOutputDir;
-
-            public Context(String versionStr, Path jarLocation, Path decompiledOutputDir) {
-                this.versionStr = versionStr;
-                this.jarLocation = jarLocation;
-                this.decompiledOutputDir = decompiledOutputDir;
-            }
-
-        }
-
-        class VineflowerDecompiler implements Decompiler {
-
-            private Context context;
-            private Path decompilerJar;
-
-            @Override
-            public void init(Context context) {
-                this.context = context;
-                this.decompilerJar = context.jarLocation.resolve(String.format("vineflower-%s.jar", context.versionStr));
-            }
-
-            @Override
-            public boolean downloadIfNecessary() {
-                if (Files.exists(decompilerJar)) {
-                    return true;
-                }
-                String downloadURL = String.format(
-                        "https://repo.maven.apache.org/maven2/org/vineflower/vineflower/%s/vineflower-%s.jar",
-                        context.versionStr, context.versionStr);
-                try (BufferedInputStream in = new BufferedInputStream(new URL(downloadURL).openStream());
-                        OutputStream fileOutputStream = Files.newOutputStream(decompilerJar)) {
-                    in.transferTo(fileOutputStream);
-                    return true;
-                } catch (IOException e) {
-                    log.error("Unable to download Vineflower from " + downloadURL, e);
-                    return false;
-                }
-            }
-
-            @Override
-            public boolean decompile(Path jarToDecompile) {
-                String jarFileName = jarToDecompile.getFileName().toString();
-                int dotIndex = jarFileName.indexOf('.');
-                String outputDirectory = jarFileName.substring(0, dotIndex);
-                var pb = ProcessBuilder.newBuilder(ProcessUtil.pathOfJava())
-                        .arguments(
-                                "-jar",
-                                decompilerJar.toAbsolutePath().toString(),
-                                "-rsy=0", // synthetic methods
-                                "-rbr=0", // bridge methods
-                                jarToDecompile.toAbsolutePath().toString(),
-                                context.decompiledOutputDir.resolve(outputDirectory).toAbsolutePath().toString());
-                if (log.isDebugEnabled()) {
-                    pb.output().consumeLinesWith(8192, log::debug);
-                }
-                try {
-                    pb.run();
-                } catch (Exception e) {
-                    log.error("Decompilation failed", e);
-                    return false;
-                }
-                return true;
-            }
-        }
-    }
-
-    private static FileSystem createNewZip(Path runnerJar, PackageConfig config) throws IOException {
-        boolean useUncompressedJar = !config.jar().compress();
-        if (useUncompressedJar) {
-            return ZipUtils.newZip(runnerJar, Map.of("compressionMethod", "STORED"));
-        }
-        return ZipUtils.newZip(runnerJar);
-    }
-
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveRequestedBu
 import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveType;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.jar.FastJarFormat;
 import io.quarkus.deployment.steps.MainClassBuildStep;
 import io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime;
 import io.quarkus.runtime.LaunchMode;
@@ -192,14 +193,14 @@ public class JvmStartupOptimizerArchiveBuildStep {
         List<String> command;
         if (containerImage != null) {
             List<String> dockerRunCommand = dockerRunCommands(outputTarget, containerImage,
-                    isFastJar ? CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME
+                    isFastJar ? CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME
                             : CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + jarResult.getPath().getFileName().toString());
             command = new ArrayList<>(dockerRunCommand.size() + 1 + javaArgs.size());
             command.addAll(dockerRunCommand);
             command.add("java");
             command.addAll(javaArgs);
             if (isFastJar) {
-                command.add(JarResultBuildStep.QUARKUS_RUN_JAR);
+                command.add(FastJarFormat.QUARKUS_RUN_JAR);
             } else {
                 command.add(jarResult.getPath().getFileName().toString());
             }
@@ -209,7 +210,7 @@ public class JvmStartupOptimizerArchiveBuildStep {
             command.addAll(javaArgs);
             if (isFastJar) {
                 command
-                        .add(jarResult.getLibraryDir().getParent().resolve(JarResultBuildStep.QUARKUS_RUN_JAR)
+                        .add(jarResult.getLibraryDir().getParent().resolve(FastJarFormat.QUARKUS_RUN_JAR)
                                 .getFileName().toString());
             } else {
                 command.add(jarResult.getPath().getFileName().toString());
@@ -254,14 +255,14 @@ public class JvmStartupOptimizerArchiveBuildStep {
         List<String> command;
         if (containerImage != null) {
             List<String> dockerRunCommand = dockerRunCommands(outputTarget, containerImage,
-                    isFastJar ? CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME
+                    isFastJar ? CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME
                             : CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + jarResult.getPath().getFileName().toString());
             command = new ArrayList<>(dockerRunCommand.size() + 1 + javaArgs.size());
             command.addAll(dockerRunCommand);
             command.add("java");
             command.addAll(javaArgs);
             if (isFastJar) {
-                command.add(JarResultBuildStep.QUARKUS_RUN_JAR);
+                command.add(FastJarFormat.QUARKUS_RUN_JAR);
             } else {
                 command.add(jarResult.getPath().getFileName().toString());
             }
@@ -271,7 +272,7 @@ public class JvmStartupOptimizerArchiveBuildStep {
             command.addAll(javaArgs);
             if (isFastJar) {
                 command
-                        .add(jarResult.getLibraryDir().getParent().resolve(JarResultBuildStep.QUARKUS_RUN_JAR)
+                        .add(jarResult.getLibraryDir().getParent().resolve(FastJarFormat.QUARKUS_RUN_JAR)
                                 .getFileName().toString());
             } else {
                 command.add(jarResult.getPath().getFileName().toString());
@@ -292,14 +293,14 @@ public class JvmStartupOptimizerArchiveBuildStep {
         List<String> command;
         if (containerImage != null) {
             List<String> dockerRunCommand = dockerRunCommands(outputTarget, containerImage,
-                    isFastJar ? CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME
+                    isFastJar ? CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME
                             : CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + jarResult.getPath().getFileName().toString());
             command = new ArrayList<>(dockerRunCommand.size() + 1 + javaArgs.size());
             command.addAll(dockerRunCommand);
             command.add("java");
             command.addAll(javaArgs);
             if (isFastJar) {
-                command.add(JarResultBuildStep.QUARKUS_RUN_JAR);
+                command.add(FastJarFormat.QUARKUS_RUN_JAR);
             } else {
                 command.add(jarResult.getPath().getFileName().toString());
             }
@@ -309,7 +310,7 @@ public class JvmStartupOptimizerArchiveBuildStep {
             command.addAll(javaArgs);
             if (isFastJar) {
                 command
-                        .add(jarResult.getLibraryDir().getParent().resolve(JarResultBuildStep.QUARKUS_RUN_JAR)
+                        .add(jarResult.getLibraryDir().getParent().resolve(FastJarFormat.QUARKUS_RUN_JAR)
                                 .getFileName().toString());
             } else {
                 command.add(jarResult.getPath().getFileName().toString());

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -50,6 +50,7 @@ import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabledBuildItem;
+import io.quarkus.deployment.pkg.jar.LegacyThinJarFormat;
 import io.quarkus.deployment.steps.LocaleProcessor;
 import io.quarkus.deployment.steps.NativeImageFeatureStep;
 import io.quarkus.maven.dependency.ResolvedDependency;
@@ -406,7 +407,7 @@ public class NativeImageBuildStep {
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
         Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
-        Path libDir = targetDirectory.resolve(JarResultBuildStep.LIB);
+        Path libDir = targetDirectory.resolve(LegacyThinJarFormat.LIB);
         File libDirFile = libDir.toFile();
         if (!libDirFile.exists()) {
             libDirFile.mkdirs();
@@ -445,7 +446,7 @@ public class NativeImageBuildStep {
     private void removeJarSourcesFromLib(OutputTargetBuildItem outputTargetBuildItem) {
         Path targetDirectory = outputTargetBuildItem.getOutputDirectory()
                 .resolve(outputTargetBuildItem.getBaseName() + "-native-image-source-jar");
-        Path libDir = targetDirectory.resolve(JarResultBuildStep.LIB);
+        Path libDir = targetDirectory.resolve(LegacyThinJarFormat.LIB);
 
         final File[] jarSources = libDir.toFile()
                 .listFiles((file, name) -> name.endsWith("-sources.jar"));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
@@ -19,7 +19,7 @@ import org.gradle.api.tasks.TaskAction;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.pkg.PackageConfig;
-import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
+import io.quarkus.deployment.pkg.jar.FastJarFormat;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.gradle.QuarkusPlugin;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -185,7 +185,7 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
                     ResolvedDependency dep = depAndTarget.getValue();
                     Path targetDir = depAndTarget.getKey();
                     dep.getResolvedPaths().forEach(p -> {
-                        String file = JarResultBuildStep.getJarFileName(dep, p);
+                        String file = FastJarFormat.getJarFileName(dep, p);
                         Path target = targetDir.resolve(file);
                         if (!Files.exists(target)) {
                             getLogger().debug("Dependency {} : copying {} to {}",

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -78,7 +78,7 @@ import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveResultBuild
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
-import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
+import io.quarkus.deployment.pkg.jar.FastJarFormat;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.fs.util.ZipUtils;
@@ -419,7 +419,7 @@ public class JibProcessor {
             Optional<JvmStartupOptimizerArchiveResultBuildItem> maybeJvmStartupOptimizerArchiveResult,
             boolean isMutableJar) {
         Path componentsPath = sourceJarBuildItem.getPath().getParent();
-        Path appLibDir = componentsPath.resolve(JarResultBuildStep.LIB).resolve(JarResultBuildStep.MAIN);
+        Path appLibDir = componentsPath.resolve(FastJarFormat.LIB).resolve(FastJarFormat.MAIN);
 
         AbsoluteUnixPath workDirInContainer = AbsoluteUnixPath.get(jibConfig.workingDirectory());
         Map<String, String> envVars = createEnvironmentVariables(jibConfig);
@@ -431,7 +431,7 @@ public class JibProcessor {
             // we want to use run-java.sh by default. However, if AppCDS are being used, run-java.sh cannot be used because it would lead to using different JVM args
             // which would mean AppCDS would not be taken into account at all
             entrypoint = List.of(RUN_JAVA_PATH);
-            envVars.put("JAVA_APP_JAR", workDirInContainer + "/" + JarResultBuildStep.QUARKUS_RUN_JAR);
+            envVars.put("JAVA_APP_JAR", workDirInContainer + "/" + FastJarFormat.QUARKUS_RUN_JAR);
             envVars.put("JAVA_APP_DIR", workDirInContainer.toString());
             envVars.put("JAVA_OPTS_APPEND",
                     String.join(" ",
@@ -443,7 +443,7 @@ public class JibProcessor {
             argsList.add("java");
             argsList.addAll(effectiveJvmArguments);
             argsList.add("-jar");
-            argsList.add(JarResultBuildStep.QUARKUS_RUN_JAR);
+            argsList.add(FastJarFormat.QUARKUS_RUN_JAR);
             entrypoint = Collections.unmodifiableList(argsList);
         }
 
@@ -513,7 +513,7 @@ public class JibProcessor {
             JibContainerBuilder jibContainerBuilder = toJibContainerBuilder(baseJvmImage, jibConfig);
             if (fastChangingLibPaths.isEmpty()) {
                 // just create a layer with the entire lib structure intact
-                addLayer(jibContainerBuilder, Collections.singletonList(componentsPath.resolve(JarResultBuildStep.LIB)),
+                addLayer(jibContainerBuilder, Collections.singletonList(componentsPath.resolve(FastJarFormat.LIB)),
                         workDirInContainer, "fast-jar-lib", isMutableJar, enforceModificationTime, modificationTime);
             } else {
                 // we need to manually create each layer
@@ -521,12 +521,12 @@ public class JibProcessor {
                 // docker doesn't have to create an entire layer with all dependencies - only change the fast ones
 
                 FileEntriesLayer.Builder bootLibsLayerBuilder = FileEntriesLayer.builder().setName("fast-jar-boot-libs");
-                Path bootLibPath = componentsPath.resolve(JarResultBuildStep.LIB).resolve(JarResultBuildStep.BOOT_LIB);
+                Path bootLibPath = componentsPath.resolve(FastJarFormat.LIB).resolve(FastJarFormat.BOOT_LIB);
                 try (Stream<Path> bootLibPaths = Files.list(bootLibPath)) {
                     bootLibPaths.forEach(lib -> {
                         try {
-                            AbsoluteUnixPath libPathInContainer = workDirInContainer.resolve(JarResultBuildStep.LIB)
-                                    .resolve(JarResultBuildStep.BOOT_LIB)
+                            AbsoluteUnixPath libPathInContainer = workDirInContainer.resolve(FastJarFormat.LIB)
+                                    .resolve(FastJarFormat.BOOT_LIB)
                                     .resolve(lib.getFileName());
                             Instant bootLibModificationTime;
                             if (maybeJvmStartupOptimizerArchiveResult.isPresent()) {
@@ -544,15 +544,15 @@ public class JibProcessor {
                 jibContainerBuilder.addFileEntriesLayer(bootLibsLayerBuilder.build());
 
                 if (isMutableJar) {
-                    Path deploymentPath = componentsPath.resolve(JarResultBuildStep.LIB)
-                            .resolve(JarResultBuildStep.DEPLOYMENT_LIB);
+                    Path deploymentPath = componentsPath.resolve(FastJarFormat.LIB)
+                            .resolve(FastJarFormat.DEPLOYMENT_LIB);
                     addLayer(jibContainerBuilder, Collections.singletonList(deploymentPath),
-                            workDirInContainer.resolve(JarResultBuildStep.LIB),
+                            workDirInContainer.resolve(FastJarFormat.LIB),
                             "fast-jar-deployment-libs", true, enforceModificationTime, modificationTime);
                 }
 
-                AbsoluteUnixPath libsMainPath = workDirInContainer.resolve(JarResultBuildStep.LIB)
-                        .resolve(JarResultBuildStep.MAIN);
+                AbsoluteUnixPath libsMainPath = workDirInContainer.resolve(FastJarFormat.LIB)
+                        .resolve(FastJarFormat.MAIN);
                 addLayer(jibContainerBuilder, nonFastChangingLibPaths, libsMainPath, "fast-jar-normal-libs",
                         isMutableJar, enforceModificationTime, modificationTime);
                 addLayer(jibContainerBuilder, new ArrayList<>(fastChangingLibPaths), libsMainPath, "fast-jar-changing-libs",
@@ -561,9 +561,9 @@ public class JibProcessor {
 
             if (maybeJvmStartupOptimizerArchiveResult.isPresent()) {
                 jibContainerBuilder.addFileEntriesLayer(FileEntriesLayer.builder().setName("app-cds").addEntry(
-                        componentsPath.resolve(JarResultBuildStep.QUARKUS_RUN_JAR),
-                        workDirInContainer.resolve(JarResultBuildStep.QUARKUS_RUN_JAR),
-                        Files.getLastModifiedTime(componentsPath.resolve(JarResultBuildStep.QUARKUS_RUN_JAR)).toInstant())
+                        componentsPath.resolve(FastJarFormat.QUARKUS_RUN_JAR),
+                        workDirInContainer.resolve(FastJarFormat.QUARKUS_RUN_JAR),
+                        Files.getLastModifiedTime(componentsPath.resolve(FastJarFormat.QUARKUS_RUN_JAR)).toInstant())
                         .build());
                 jibContainerBuilder
                         .addLayer(Collections.singletonList(maybeJvmStartupOptimizerArchiveResult.get().getArchive()),
@@ -572,17 +572,17 @@ public class JibProcessor {
                 jibContainerBuilder.addFileEntriesLayer(FileEntriesLayer.builder()
                         .setName("fast-jar-run")
                         .addEntry(
-                                componentsPath.resolve(JarResultBuildStep.QUARKUS_RUN_JAR),
-                                workDirInContainer.resolve(JarResultBuildStep.QUARKUS_RUN_JAR),
+                                componentsPath.resolve(FastJarFormat.QUARKUS_RUN_JAR),
+                                workDirInContainer.resolve(FastJarFormat.QUARKUS_RUN_JAR),
                                 isMutableJar ? REMOTE_DEV_FILE_PERMISSIONS : DEFAULT_FILE_PERMISSIONS,
                                 modificationTime,
                                 isMutableJar ? DEFAULT_BASE_IMAGE_USER : "")
                         .build());
             }
 
-            addLayer(jibContainerBuilder, Collections.singletonList(componentsPath.resolve(JarResultBuildStep.APP)),
+            addLayer(jibContainerBuilder, Collections.singletonList(componentsPath.resolve(FastJarFormat.APP)),
                     workDirInContainer, "fast-jar-quarkus-app", isMutableJar, enforceModificationTime, modificationTime);
-            addLayer(jibContainerBuilder, Collections.singletonList(componentsPath.resolve(JarResultBuildStep.QUARKUS)),
+            addLayer(jibContainerBuilder, Collections.singletonList(componentsPath.resolve(FastJarFormat.QUARKUS)),
                     workDirInContainer, "fast-jar-quarkus", isMutableJar, enforceModificationTime, modificationTime);
             if (ContainerImageJibConfig.DEFAULT_WORKING_DIR.equals(jibConfig.workingDirectory())) {
                 // this layer ensures that the working directory is writeable
@@ -607,8 +607,8 @@ public class JibProcessor {
                                         modificationTime, DEFAULT_BASE_IMAGE_USER))
                         .addEntry(
                                 new FileEntry(
-                                        componentsPath.resolve(JarResultBuildStep.QUARKUS_APP_DEPS),
-                                        workDirInContainer.resolve(JarResultBuildStep.QUARKUS_APP_DEPS),
+                                        componentsPath.resolve(FastJarFormat.QUARKUS_APP_DEPS),
+                                        workDirInContainer.resolve(FastJarFormat.QUARKUS_APP_DEPS),
                                         REMOTE_DEV_FOLDER_PERMISSIONS,
                                         modificationTime, DEFAULT_BASE_IMAGE_USER))
                         .build());

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -5,7 +5,7 @@ import static io.quarkus.container.image.openshift.deployment.OpenshiftUtils.get
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
 import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.FAST_JAR;
 import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -1,7 +1,7 @@
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME;
-import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.QUARKUS_RUN_JAR;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME;
+import static io.quarkus.deployment.pkg.jar.FastJarFormat.QUARKUS_RUN_JAR;
 import static io.quarkus.kubernetes.deployment.Constants.KUBERNETES;
 import static io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem.mergeList;
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
+import io.quarkus.deployment.pkg.jar.FastJarFormat;
 import io.quarkus.deployment.util.IoUtil;
 import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
 import io.quarkus.maven.it.verifier.RunningInvoker;
@@ -218,7 +218,7 @@ public class JarRunnerIT extends MojoTestBase {
 
         Path jar = testDir.toPath().toAbsolutePath()
                 .resolve(Paths.get("target",
-                        JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME,
+                        FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME,
                         "quarkus-run.jar"));
         Assertions.assertFalse(Files.exists(jar));
 
@@ -828,7 +828,7 @@ public class JarRunnerIT extends MojoTestBase {
 
         jar = testDir.toPath().toAbsolutePath()
                 .resolve(Paths.get("target",
-                        outputDir == null ? JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME : outputDir,
+                        outputDir == null ? FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME : outputDir,
                         "quarkus-run.jar"));
         Assertions.assertTrue(Files.exists(jar));
         File output = new File(testDir, "target/output.log");


### PR DESCRIPTION
> [!NOTE]
>
> This is part of my efforts on large monoliths but it should benefit all applications in the end.

This is a big patch, sorry, but I tried to have semantic commits, even if the first commit is quite large by itself.

My goal was to only implement parallel compression of jars using Commons Compress... but I ended up being unable to do it with `JarResultBuildStep` in its current state: the class was too big (1600+ lines) and it was too hard to actually comprehend the specificities of each format.

Thus why my first step was to rewrite this class with a proper hierarchy and each format splitted. FWIW, it's not the first time I struggled to adjust things there so my personal opinion is that this rewrite was long overdue.

Then I extracted the creation of the archive to an interface and finally implemented parallel compression using Commons Compress.

The last commit is just some final cleanup that was too entangled to actually be squashed in one of the existing commits.

For my test app with 37k Java source classes (+ all the ones we generate), it went from `6 seconds` to `1.6 seconds`, so a `3.75x` speedup.

For now I'm still using the `ZipFileSystem` approach for Uberjars. Uberjars are specific as the Manifest is potentially updated at the end to include the multi release bits and it comes with some subtleties as the Manifest has to be added first to the jar, nothing insurmountable but this work already consumes a lot of bandwith. I could be convinced to put the extra work and get rid of it at some point. Not in this PR though.
