### PR TITLE
Remove support for Hibernate ORM proxy generation at static init

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
@@ -145,11 +145,11 @@ public final class ProxyDefinitions {
             } else {
                 //TODO: this should be changed to an exception after 1.4
                 //really it should be an exception now
-                LOGGER.errorf(
+                throw new IllegalStateException(String.format(
                         "Unable to use a build time generated proxy for entity %s, as the build time proxy " +
                                 "interfaces %s are different to the runtime ones %s. This should not happen, please open an " +
                                 "issue at https://github.com/quarkusio/quarkus/issues",
-                        persistentClass.getClassName(), preProxy.getProxyInterfaces(), proxyInterfaces);
+                        persistentClass.getClassName(), preProxy.getProxyInterfaces(), proxyInterfaces));
             }
             Class<?> proxyDef = byteBuddyProxyHelper.get().buildProxy(mappedClass, toArray(proxyInterfaces));
             return proxyDef;


### PR DESCRIPTION
I had this lying around but apparently forgot to send the PR...

* Fixes #46847 
