### PR TITLE
Fix Amazon Lambda handler discovery fallback

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -114,8 +114,6 @@ public final class AmazonLambdaProcessor {
             final DotName name = info.name();
             final String lambda = name.toString();
             builder.addBeanClass(lambda);
-            reflectiveClassBuildItemBuildProducer
-                    .produce(ReflectiveClassBuildItem.builder(lambda).methods().build());
 
             String cdiName = null;
             AnnotationInstance named = info.declaredAnnotation(NAMED);
@@ -150,9 +148,18 @@ public final class AmazonLambdaProcessor {
                         }
                     }
                 }
-                current = combinedIndexBuildItem.getIndex().getClassByName(current.superName());
+                if (!done) {
+                    current = combinedIndexBuildItem.getIndex().getClassByName(current.superName());
+                }
             }
-            ret.add(new AmazonLambdaBuildItem(lambda, cdiName, streamHandler));
+            if (done) {
+                String handlerClass = current.name().toString();
+                ret.add(new AmazonLambdaBuildItem(handlerClass, cdiName, streamHandler));
+                reflectiveClassBuildItemBuildProducer.produce(ReflectiveClassBuildItem.builder(handlerClass).methods()
+                        .reason(getClass().getName()
+                                + ": reflectively accessed in io.quarkus.amazon.lambda.runtime.AmazonLambdaRecorder.discoverHandlerMethod")
+                        .build());
+            }
         }
         additionalBeanBuildItemBuildProducer.produce(builder.build());
         reflectiveClassBuildItemBuildProducer

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -159,6 +159,9 @@ public final class AmazonLambdaProcessor {
                         .reason(getClass().getName()
                                 + ": reflectively accessed in io.quarkus.amazon.lambda.runtime.AmazonLambdaRecorder.discoverHandlerMethod")
                         .build());
+            } else {
+                // Fall back to the root implementor if a matching `handleRequest` is not found in the class hierarchy
+                ret.add(new AmazonLambdaBuildItem(lambda, cdiName, streamHandler));
             }
         }
         additionalBeanBuildItemBuildProducer.produce(builder.build());

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -88,7 +88,7 @@ public class AmazonLambdaRecorder {
     }
 
     private static Method discoverHandlerMethod(Class<? extends RequestHandler<?, ?>> handlerClass) {
-        final Method[] methods = handlerClass.getMethods();
+        final Method[] methods = handlerClass.getDeclaredMethods();
         Method method = null;
         for (int i = 0; i < methods.length && method == null; i++) {
             if (methods[i].getName().equals("handleRequest")) {


### PR DESCRIPTION
- Reverts https://github.com/quarkusio/quarkus/pull/49416
- Adds fallback to use root implementer when no matching `handleRequest` method is found in the class hierarchy.

Fixes #49413

cc @gsmet