### PR TITLE
Fix TLS config resolution for GraphQL clients

### DIFF
--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientClientAuthenticationBadKeystoreTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientClientAuthenticationBadKeystoreTest.java
@@ -34,6 +34,8 @@ public class TypesafeGraphQLClientClientAuthenticationBadKeystoreTest {
                 quarkus.tls.my-tls-client.key-store.p12.password=wrong-password
                 quarkus.smallrye-graphql-client.my-client.url=https://127.0.0.1:%d/
                 quarkus.tls.my-tls-client.trust-all=true
+                quarkus.tls.key-store.p12.path=target/certs/graphql-client-keystore.p12
+                quarkus.tls.key-store.p12.password=password
             """.formatted(PORT);
 
     @RegisterExtension

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientServerAuthenticationBadKeystoreOnServerTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientServerAuthenticationBadKeystoreOnServerTest.java
@@ -20,7 +20,7 @@ import io.vertx.core.http.HttpServer;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "graphql", password = "password", formats = { Format.PKCS12 }, client = true),
-        @Certificate(name = "wrong-graphql", password = "wrong-password", formats = { Format.PKCS12 })
+        @Certificate(name = "wrong-graphql", password = "wrong-password", formats = { Format.PKCS12 }, client = true)
 })
 public class TypesafeGraphQLClientServerAuthenticationBadKeystoreOnServerTest {
 
@@ -32,6 +32,8 @@ public class TypesafeGraphQLClientServerAuthenticationBadKeystoreOnServerTest {
                 quarkus.smallrye-graphql-client.my-client.tls-configuration-name=my-tls-client
                 quarkus.tls.my-tls-client.trust-store.p12.path=target/certs/graphql-client-truststore.p12
                 quarkus.tls.my-tls-client.trust-store.p12.password=password
+                quarkus.tls.trust-store.p12.path=target/certs/wrong-graphql-client-truststore.p12
+                quarkus.tls.trust-store.p12.password=wrong-password
                 quarkus.smallrye-graphql-client.my-client.url=https://127.0.0.1:%d/
             """.formatted(PORT);
 


### PR DESCRIPTION
Fixes #49623

This makes the TLS configuration resolution a bit more reasonable and predictable. 

The main fix is that when a GraphQL client declares a specific TLS configuration, it will be used (currently it uses the default one instead of the named one if the default one has some trust options defined, which is clearly a bug).

As a side fix, when the deprecated properties  (`quarkus.smallrye-graphql-client.CLIENT-NAME.key-store` and `quarkus.smallrye-graphql-client.CLIENT-NAME.trust-store`) are defined, they will now always take precedence over TLS configuration (logging a warning if an explicit TLS config is supplied too). Before this PR, they would or would not take precedence depending on whether the default TLS configuration had trust options defined or not, which is very weird.

I'm planning to remove the deprecated properties soon anyway, but I wanted to split it into steps so that this step can be backported to 3.20.