### PR TITLE
Reduce our dependency to exotic common-io versions in tests

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/AddExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/AddExtensionMojoTest.java
@@ -141,7 +141,8 @@ class AddExtensionMojoTest {
     void testAddMultipleDependency() throws MojoExecutionException, IOException, XmlPullParserException {
         Set<String> deps = new HashSet<>();
         deps.add(DEP_GAV);
-        deps.add("commons-io:commons-io:2.6");
+        // use an obscure jar that is lightweight and comes with no dependencies
+        deps.add("io.smallrye:jandex-test-data:3.4.0");
         mojo.extensions = deps;
         mojo.execute();
 
@@ -154,7 +155,8 @@ class AddExtensionMojoTest {
     void testThatBothParameterCannotBeSet() {
         mojo.extension = DEP_GAV;
         Set<String> deps = new HashSet<>();
-        deps.add("commons-io:commons-io:2.6");
+        // use an obscure jar that is lightweight and comes with no dependencies
+        deps.add("io.smallrye:jandex-test-data:3.4.0");
         mojo.extensions = deps;
 
         assertThrows(MojoExecutionException.class, () -> mojo.execute());

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -368,7 +368,8 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
         properties.put("projectGroupId", "org.acme");
         properties.put("projectArtifactId", "acme");
         properties.put("className", "org.acme.MyResource");
-        properties.put("extensions", "rest,commons-io:commons-io:2.5");
+        // use an obscure jar that is lightweight and comes with no dependencies
+        properties.put("extensions", "rest,io.smallrye:jandex-test-data:3.4.0");
         InvocationResult result = setup(properties);
 
         assertThat(result.getExitCode()).isZero();
@@ -379,7 +380,7 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
         assertThat(new File(testDir, "pom.xml")).isFile();
         assertThat(new File(testDir, "src/main/java/org/acme/MyResource.java")).isFile();
         assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
-                .contains("commons-io");
+                .contains("jandex-test-data");
 
         Model model = loadPom(testDir);
         assertThat(model.getDependencyManagement().getDependencies().stream()
@@ -394,8 +395,8 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
                         && d.getVersion() == null))
                 .isTrue();
 
-        assertThat(model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("commons-io")
-                && d.getVersion().equalsIgnoreCase("2.5"))).isTrue();
+        assertThat(model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("jandex-test-data")
+                && d.getVersion().equalsIgnoreCase("3.4.0"))).isTrue();
     }
 
     @Test
@@ -406,7 +407,7 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
 
         Properties properties = new Properties();
         properties.put("projectArtifactId", "acme,fail");
-        properties.put("extensions", "rest,commons-io:commons-io:2.5");
+        properties.put("extensions", "rest");
         InvocationResult result = setup(properties);
 
         assertThat(result.getExitCode()).isNotZero();
@@ -420,7 +421,7 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
 
         Properties properties = new Properties();
         properties.put("projectGroupId", "acme,fail");
-        properties.put("extensions", "rest,commons-io:commons-io:2.5");
+        properties.put("extensions", "rest");
         InvocationResult result = setup(properties);
 
         assertThat(result.getExitCode()).isNotZero();

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-inst/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-inst/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-remote-dev/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-remote-dev/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
@@ -16,7 +16,6 @@
     <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
     <commons.collections.version>4.4</commons.collections.version>
-    <commons.io.version>1.3.2</commons.io.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -55,7 +54,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>\${commons.io.version}</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
@@ -49,7 +49,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.13.0</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This is problematic as soon as we are depending on commons-io in our build.
We were fortunate enough for it to not have been a problem until now, even if I'm pretty sure Maven makes use of it (but probably only very common methods).
This is a problem now that we use commons-compress to build the jars.

Extracted from https://github.com/quarkusio/quarkus/pull/49585, that will be one less thing to review in this large PR.