### PR TITLE
ArC - Generate BeanGenerator.ProviderType values only once

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -2481,9 +2481,13 @@ public class BeanGenerator extends AbstractGenerator {
     static final class ProviderType {
 
         private final Type type;
+        private final String className;
+        private final String descriptorName;
 
         public ProviderType(Type type) {
             this.type = type;
+            this.className = type.name().toString();
+            this.descriptorName = DescriptorUtils.typeToString(type);
         }
 
         DotName name() {
@@ -2495,7 +2499,7 @@ public class BeanGenerator extends AbstractGenerator {
          * @return the class name, e.g. {@code org.acme.Foo}
          */
         String className() {
-            return type.name().toString();
+            return className;
         }
 
         /**
@@ -2503,7 +2507,7 @@ public class BeanGenerator extends AbstractGenerator {
          * @return the name used in JVM descriptors, e.g. {@code Lorg/acme/Foo;}
          */
         String descriptorName() {
-            return DescriptorUtils.typeToString(type);
+            return descriptorName;
         }
 
     }


### PR DESCRIPTION
They are used quite a lot and they are generating extra work we can very easily avoid.

It doesn't make a HUGE difference but given it's basically free...

Before (2 differents methods called quite a lot):

<img width="2196" height="1238" alt="Screenshot From 2025-08-20 13-18-15" src="https://github.com/user-attachments/assets/f22afce5-bd43-4496-a787-426153cd5cd3" />

<img width="2196" height="1238" alt="Screenshot From 2025-08-20 13-00-15" src="https://github.com/user-attachments/assets/32ccaa8b-a3f5-4ab0-955b-22be3bee870a" />

---

After - both initialized in init:

<img width="2196" height="1238" alt="Screenshot From 2025-08-20 13-21-43" src="https://github.com/user-attachments/assets/9aa4e5b4-5c35-4fa3-b807-99e568aed329" />


