### PR TITLE
Use newly introduced Jandex MethodSignatureKey

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -41,6 +41,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodSignatureKey;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.jboss.logging.Logger.Level;
@@ -1211,14 +1212,14 @@ public class BeanDeployment {
 
             // inherited methods
             ClassInfo aClass = beanClass;
-            Set<Methods.MethodKey> methods = new HashSet<>();
+            Set<MethodSignatureKey> methods = new HashSet<>();
             while (aClass != null) {
                 for (MethodInfo method : aClass.methods()) {
-                    Methods.MethodKey methodDescriptor = new Methods.MethodKey(method);
-                    if (method.isSynthetic() || Methods.isOverriden(methodDescriptor, methods)) {
+                    MethodSignatureKey methodKey = method.signatureKey();
+                    if (method.isSynthetic() || Methods.isOverridden(methodKey, methods)) {
                         continue;
                     }
-                    methods.add(methodDescriptor);
+                    methods.add(methodKey);
                     Collection<AnnotationInstance> methodAnnotations = annotationStore.getAnnotations(method);
                     if (methodAnnotations.isEmpty()) {
                         continue;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -21,6 +22,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodSignatureKey;
 import org.jboss.jandex.Type;
 
 import io.quarkus.arc.ClientProxy;
@@ -28,7 +30,6 @@ import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.impl.Mockable;
 import io.quarkus.arc.processor.BeanGenerator.ProviderType;
-import io.quarkus.arc.processor.Methods.MethodKey;
 import io.quarkus.arc.processor.ResourceOutput.Resource;
 import io.quarkus.arc.processor.ResourceOutput.Resource.SpecialType;
 import io.quarkus.gizmo.BytecodeCreator;
@@ -344,22 +345,22 @@ public class ClientProxyGenerator extends AbstractGenerator {
 
     Collection<MethodInfo> getDelegatingMethods(BeanInfo bean, Consumer<BytecodeTransformer> bytecodeTransformerConsumer,
             boolean transformUnproxyableClasses) {
-        Map<Methods.MethodKey, MethodInfo> methods = new HashMap<>();
+        Map<MethodSignatureKey, MethodInfo> methods = new HashMap<>();
         IndexView index = bean.getDeployment().getBeanArchiveIndex();
 
         if (bean.isClassBean()) {
-            Map<String, Set<MethodKey>> methodsFromWhichToRemoveFinal = new HashMap<>();
+            Map<String, Set<MethodDescriptor>> methodsFromWhichToRemoveFinal = new HashMap<>();
             ClassInfo classInfo = bean.getTarget().get().asClass();
             addDelegatesAndTransformIfNecessary(bytecodeTransformerConsumer, transformUnproxyableClasses, methods, index,
                     methodsFromWhichToRemoveFinal, classInfo);
         } else if (bean.isProducerMethod()) {
-            Map<String, Set<MethodKey>> methodsFromWhichToRemoveFinal = new HashMap<>();
+            Map<String, Set<MethodDescriptor>> methodsFromWhichToRemoveFinal = new HashMap<>();
             MethodInfo producerMethod = bean.getTarget().get().asMethod();
             ClassInfo returnTypeClass = getClassByName(index, producerMethod.returnType());
             addDelegatesAndTransformIfNecessary(bytecodeTransformerConsumer, transformUnproxyableClasses, methods, index,
                     methodsFromWhichToRemoveFinal, returnTypeClass);
         } else if (bean.isProducerField()) {
-            Map<String, Set<MethodKey>> methodsFromWhichToRemoveFinal = new HashMap<>();
+            Map<String, Set<MethodDescriptor>> methodsFromWhichToRemoveFinal = new HashMap<>();
             FieldInfo producerField = bean.getTarget().get().asField();
             ClassInfo fieldClass = getClassByName(index, producerField.type());
             addDelegatesAndTransformIfNecessary(bytecodeTransformerConsumer, transformUnproxyableClasses, methods, index,
@@ -374,15 +375,14 @@ public class ClientProxyGenerator extends AbstractGenerator {
 
     private void addDelegatesAndTransformIfNecessary(Consumer<BytecodeTransformer> bytecodeTransformerConsumer,
             boolean transformUnproxyableClasses,
-            Map<Methods.MethodKey, MethodInfo> methods, IndexView index,
-            Map<String, Set<MethodKey>> methodsFromWhichToRemoveFinal,
+            Map<MethodSignatureKey, MethodInfo> methods, IndexView index,
+            Map<String, Set<MethodDescriptor>> methodsFromWhichToRemoveFinal,
             ClassInfo fieldClass) {
         Methods.addDelegatingMethods(index, fieldClass, methods, methodsFromWhichToRemoveFinal,
                 transformUnproxyableClasses);
         if (!methodsFromWhichToRemoveFinal.isEmpty()) {
-            for (Map.Entry<String, Set<MethodKey>> entry : methodsFromWhichToRemoveFinal.entrySet()) {
-                String className = entry.getKey();
-                bytecodeTransformerConsumer.accept(new BytecodeTransformer(className,
+            for (Entry<String, Set<MethodDescriptor>> entry : methodsFromWhichToRemoveFinal.entrySet()) {
+                bytecodeTransformerConsumer.accept(new BytecodeTransformer(entry.getKey(),
                         new Methods.RemoveFinalFromMethod(entry.getValue())));
             }
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptionProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptionProxyGenerator.java
@@ -21,6 +21,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodSignatureKey;
 import org.jboss.jandex.Type;
 import org.objectweb.asm.Opcodes;
 
@@ -387,14 +388,14 @@ public class InterceptionProxyGenerator extends AbstractGenerator {
             Consumer<BytecodeTransformer> bytecodeTransformerConsumer, boolean transformUnproxyableClasses) {
         ClassInfo pseudoBeanClass = pseudoBean.getImplClazz();
 
-        Map<Methods.MethodKey, MethodInfo> methods = new HashMap<>();
-        Map<String, Set<Methods.MethodKey>> methodsFromWhichToRemoveFinal = new HashMap<>();
+        Map<MethodSignatureKey, MethodInfo> methods = new HashMap<>();
+        Map<String, Set<MethodDescriptor>> methodsFromWhichToRemoveFinal = new HashMap<>();
 
         Methods.addDelegatingMethods(beanArchiveIndex, pseudoBeanClass, methods, methodsFromWhichToRemoveFinal,
                 transformUnproxyableClasses);
 
         if (!methodsFromWhichToRemoveFinal.isEmpty()) {
-            for (Map.Entry<String, Set<Methods.MethodKey>> entry : methodsFromWhichToRemoveFinal.entrySet()) {
+            for (Map.Entry<String, Set<MethodDescriptor>> entry : methodsFromWhichToRemoveFinal.entrySet()) {
                 String className = entry.getKey();
                 bytecodeTransformerConsumer.accept(new BytecodeTransformer(className,
                         new Methods.RemoveFinalFromMethod(entry.getValue())));
@@ -403,7 +404,7 @@ public class InterceptionProxyGenerator extends AbstractGenerator {
 
         for (MethodInfo interceptedMethod : pseudoBean.getInterceptedMethods().keySet()) {
             // these methods are intercepted, so they don't need to (and in fact _must not_) forward directly
-            methods.remove(new Methods.MethodKey(interceptedMethod));
+            methods.remove(interceptedMethod.signatureKey());
         }
 
         return methods.values();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InvokerGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InvokerGenerator.java
@@ -5,9 +5,10 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -27,6 +28,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.JandexReflection;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodSignatureKey;
 import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
@@ -734,7 +736,7 @@ public class InvokerGenerator extends AbstractGenerator {
         }
 
         boolean originalClass = true;
-        Set<Methods.MethodKey> seenMethods = new HashSet<>();
+        Map<MethodSignatureKey, MethodInfo> seenMethods = new HashMap<>();
         while (!worklist.isEmpty()) {
             ClassInfo current = worklist.removeFirst();
 
@@ -743,13 +745,13 @@ public class InvokerGenerator extends AbstractGenerator {
                     continue;
                 }
 
-                Methods.MethodKey key = new Methods.MethodKey(method);
+                MethodSignatureKey key = method.signatureKey();
 
                 if (Modifier.isStatic(method.flags()) && originalClass) {
-                    seenMethods.add(key);
+                    seenMethods.put(key, method);
                 } else {
-                    if (!Methods.isOverriden(key, seenMethods)) {
-                        seenMethods.add(key);
+                    if (!Methods.isOverridden(key, seenMethods.keySet())) {
+                        seenMethods.put(key, method);
                     }
                 }
             }
@@ -763,8 +765,8 @@ public class InvokerGenerator extends AbstractGenerator {
 
         List<CandidateMethod> matching = new ArrayList<>();
         List<CandidateMethod> notMatching = new ArrayList<>();
-        for (Methods.MethodKey seenMethod : seenMethods) {
-            CandidateMethod candidate = new CandidateMethod(seenMethod.method, assignability);
+        for (Entry<MethodSignatureKey, MethodInfo> seenMethod : seenMethods.entrySet()) {
+            CandidateMethod candidate = new CandidateMethod(seenMethod.getValue(), assignability);
             if (candidate.matches(transformer, expectedType)) {
                 matching.add(candidate);
             } else {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -33,6 +33,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodSignatureKey;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.jboss.jandex.TypeVariable;
@@ -47,7 +48,6 @@ import io.quarkus.arc.processor.BeanInfo.DecorationInfo;
 import io.quarkus.arc.processor.BeanInfo.DecoratorMethod;
 import io.quarkus.arc.processor.BeanInfo.InterceptionInfo;
 import io.quarkus.arc.processor.BeanProcessor.PrivateMembersCollector;
-import io.quarkus.arc.processor.Methods.MethodKey;
 import io.quarkus.arc.processor.ResourceOutput.Resource;
 import io.quarkus.arc.processor.ResourceOutput.Resource.SpecialType;
 import io.quarkus.gizmo.AssignableResultHandle;
@@ -687,7 +687,7 @@ public class SubclassGenerator extends AbstractGenerator {
         // Identify the set of methods that should be delegated
         // Note that the delegate subclass must override ALL methods from the delegate type
         // This is not enough if the delegate type is parameterized
-        Set<MethodKey> methods = new HashSet<>();
+        Map<MethodSignatureKey, MethodInfo> methods = new HashMap<>();
         Methods.addDelegateTypeMethods(index, delegateTypeClass, methods);
 
         // The delegate type can declare type parameters
@@ -706,8 +706,8 @@ public class SubclassGenerator extends AbstractGenerator {
             }
         }
 
-        for (MethodKey m : methods) {
-            MethodInfo method = m.method;
+        for (Entry<MethodSignatureKey, MethodInfo> methodEntry : methods.entrySet()) {
+            MethodInfo method = methodEntry.getValue();
             MethodDescriptor methodDescriptor = MethodDescriptor.of(method);
             MethodCreator forward = delegateSubclass.getMethodCreator(methodDescriptor);
             // Exceptions
@@ -776,7 +776,7 @@ public class SubclassGenerator extends AbstractGenerator {
             } else {
                 // This method is not decorated or no next decorator was found in the chain
                 MethodDescriptor forwardingMethod = null;
-                MethodInfo decoratedMethod = bean.getDecoratedMethod(m.method, decorator);
+                MethodInfo decoratedMethod = bean.getDecoratedMethod(methodEntry.getValue(), decorator);
                 MethodDescriptor decoratedMethodDescriptor = decoratedMethod != null ? MethodDescriptor.of(decoratedMethod)
                         : null;
                 for (Entry<MethodDescriptor, MethodDescriptor> entry : forwardingMethods.entrySet()) {

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/MethodUtilsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/MethodUtilsTest.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodSignatureKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,76 +30,76 @@ public class MethodUtilsTest {
                 Top.class, Middle.class, Middle2.class, Bottom.class);
     }
 
-    private Set<Methods.MethodKey> gatherMethodsFromClasses(Class<?>... classes) {
+    private Set<MethodSignatureKey> gatherMethodsFromClasses(Class<?>... classes) {
         return Arrays.stream(classes)
                 .map(index::getClassByName)
                 .map(ClassInfo::methods)
                 .flatMap(List::stream)
-                .map(Methods.MethodKey::new)
+                .map(MethodInfo::signatureKey)
                 .collect(Collectors.toSet());
     }
 
     @Test
     public void shouldFindDirectOverriding() {
-        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class);
+        Set<MethodSignatureKey> methods = gatherMethodsFromClasses(SomeClass.class);
 
         MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("fromSuperClass");
 
-        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isTrue();
+        assertThat(Methods.isOverridden(parentMethod.signatureKey(), methods)).isTrue();
     }
 
     @Test
     public void shouldFindGenericOverriding() {
-        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<MethodSignatureKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
         MethodInfo genericMethod = index.getClassByName(SuperSuperClass.class).firstMethod("generic");
 
-        assertThat(Methods.isOverriden(new Methods.MethodKey(genericMethod), methods)).isTrue();
+        assertThat(Methods.isOverridden(genericMethod.signatureKey(), methods)).isTrue();
     }
 
     @Test
     public void shouldNotFindNonOverridenFromSuperClass() {
-        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class);
+        Set<MethodSignatureKey> methods = gatherMethodsFromClasses(SomeClass.class);
 
         MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("notOverridenFromSuperClass");
 
-        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
+        assertThat(Methods.isOverridden(parentMethod.signatureKey(), methods)).isFalse();
     }
 
     @Test
     public void shouldNotFindNonGenericNonOverridenFromSuperSuperClass() {
-        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<MethodSignatureKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
         MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverridenNonGeneric");
 
-        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
+        assertThat(Methods.isOverridden(parentMethod.signatureKey(), methods)).isFalse();
     }
 
     @Test
     public void shouldNotFindGenericNonOverridenFromSuperSuperClass() {
-        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<MethodSignatureKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
         MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverridenGeneric");
 
-        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
+        assertThat(Methods.isOverridden(parentMethod.signatureKey(), methods)).isFalse();
     }
 
     @Test
     public void shouldNotFindAlmostMatchingGeneric() {
-        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<MethodSignatureKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
         MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("almostMatchingGeneric");
 
-        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
+        assertThat(Methods.isOverridden(parentMethod.signatureKey(), methods)).isFalse();
     }
 
     @Test
     public void shouldFindOverridenInTheMiddleOfHierarchy() {
-        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class, SuperSuperClass.class);
+        Set<MethodSignatureKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class, SuperSuperClass.class);
 
         MethodInfo parentMethod = index.getClassByName(TheRoot.class).firstMethod("generic");
 
-        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isTrue();
+        assertThat(Methods.isOverridden(parentMethod.signatureKey(), methods)).isTrue();
     }
 
     public static class SomeClass extends SuperClass<Boolean> {


### PR DESCRIPTION
The Jandex one requires less allocations, mostly because it has access to Jandex internals and can use internal representations.

Created as draft as we will need a new Jandex release with either https://github.com/smallrye/jandex/pull/563 or https://github.com/smallrye/jandex/pull/566 in.
