### PR TITLE
Qute: fix params processing for include section

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/PropertyNotFoundDevModeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/PropertyNotFoundDevModeTest.java
@@ -27,10 +27,10 @@ public class PropertyNotFoundDevModeTest {
     @Test
     public void testExceptionIsThrown() {
         assertEquals(
-                "Rendering error in template [foo.html] line 1: Key \"foo\" not found in the template data map with keys [] in expression {foo.surname}",
+                "Rendering error in template [foo.html:1]: Key \"foo\" not found in the template data map with keys [] in expression {foo.surname}",
                 RestAssured.get("test-foo").then().statusCode(200).extract().body().asString());
         assertEquals(
-                "Rendering error in template [bar.html] line 1: Property \"name\" not found on the base object \"java.lang.String\" in expression {bar.name}",
+                "Rendering error in template [bar.html:1]: Property \"name\" not found on the base object \"java.lang.String\" in expression {bar.name}",
                 RestAssured.get("test-bar").then().statusCode(200).extract().body().asString());
     }
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/enums/TemplateEnumIgnoredTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/enums/TemplateEnumIgnoredTest.java
@@ -31,7 +31,7 @@ public class TemplateEnumIgnoredTest {
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(() -> engine.parse("{TransactionType:FOO}", null, "bar").render())
                 .withMessage(
-                        "Rendering error in template [bar] line 1: No namespace resolver found for [TransactionType] in expression {TransactionType:FOO}");
+                        "Rendering error in template [bar:1]: No namespace resolver found for [TransactionType] in expression {TransactionType:FOO}");
 
     }
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/enums/TemplateEnumInvalidTargetTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/enums/TemplateEnumInvalidTargetTest.java
@@ -27,7 +27,7 @@ public class TemplateEnumInvalidTargetTest {
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(() -> engine.parse("{Transactions:VAL}", null, "bar").render())
                 .withMessage(
-                        "Rendering error in template [bar] line 1: No namespace resolver found for [Transactions] in expression {Transactions:VAL}");
+                        "Rendering error in template [bar:1]: No namespace resolver found for [Transactions] in expression {Transactions:VAL}");
 
     }
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/include/InsertTagConflictTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/include/InsertTagConflictTest.java
@@ -31,7 +31,7 @@ public class InsertTagConflictTest {
                 }
                 assertNotNull(te);
                 assertTrue(te.getMessage().contains(
-                        "Parser error in template [base.html] line 1: {#insert} defined in the {#include} conflicts with an existing section/tag: row"),
+                        "Parser error in template [base.html:1]: {#insert} defined in the {#include} conflicts with an existing section/tag: row"),
                         te.getMessage());
             });;
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/tag/UserTagArgumentsValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/tag/UserTagArgumentsValidationTest.java
@@ -27,7 +27,8 @@ public class UserTagArgumentsValidationTest {
                 }
                 assertThat(root)
                         .isInstanceOf(TemplateException.class)
-                        .hasMessageContaining("Found incorrect expressions (1)").hasMessageContaining("{_args.sizes}");
+                        .hasMessageContaining("Found incorrect expressions (1)")
+                        .hasMessageContaining("{_args.sizes}");
             });
 
     @Test

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/IncludeSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/IncludeSectionHelper.java
@@ -154,7 +154,8 @@ public class IncludeSectionHelper implements SectionHelper {
             }
             String templateParam = context.getParameter(TEMPLATE);
             if (templateParam == null) {
-                throw context.error("Neither the template id nor the template name was specified").build();
+                throw context.error("Neither the template id nor the template name parameter was specified")
+                        .build();
             }
             if (LiteralSupport.isStringLiteralSeparator(templateParam.charAt(0))) {
                 templateParam = templateParam.substring(1, templateParam.length() - 1);
@@ -207,7 +208,10 @@ public class IncludeSectionHelper implements SectionHelper {
         }
 
         protected boolean skipBuiltInParam(String value) {
-            return value != null && !value.startsWith("_");
+            return value != null
+                    && !ISOLATED.equals(value)
+                    && !UNISOLATED.equals(value)
+                    && !IGNORE_FRAGMENTS.equals(value);
         }
 
         @Override

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionInitContextImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionInitContextImpl.java
@@ -70,7 +70,7 @@ final class SectionInitContextImpl implements SectionInitContext {
 
     @Override
     public TemplateException.Builder error(String message) {
-        return errorInitializer.error(message);
+        return errorInitializer.error(message).origin(getOrigin());
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateException.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateException.java
@@ -78,7 +78,11 @@ public class TemplateException extends RuntimeException {
     }
 
     private static String toMessage(String messageTemplate, Map<String, Object> arguments, Origin origin) {
-        if ((arguments == null || arguments.isEmpty()) && origin == null) {
+        if (messageTemplate == null || messageTemplate.isBlank()) {
+            return null;
+        }
+        if ((arguments == null || arguments.isEmpty())
+                && origin == null) {
             return messageTemplate;
         }
         try {
@@ -119,7 +123,7 @@ public class TemplateException extends RuntimeException {
 
         /**
          * If set then the origin key can be used in the message template. For example <code>Some error {origin}</code> will be
-         * rendered as <code>Somer error template [foo.html] line 1</code>.
+         * rendered as <code>Somer error template [foo.html:1]</code>.
          *
          * @param origin
          * @return self

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
@@ -171,7 +171,7 @@ public interface TemplateNode {
         default void appendTo(StringBuilder builder) {
             // It only makes sense to append the info for a template with an explicit id
             if (hasNonGeneratedTemplateId()) {
-                builder.append(" template [").append(getTemplateId()).append("] ").append("line ").append(getLine());
+                builder.append(" template [").append(getTemplateId()).append(":").append(getLine()).append("]");
             }
         }
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/FragmentTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/FragmentTest.java
@@ -53,7 +53,7 @@ public class FragmentTest {
         TemplateException expected = assertThrows(TemplateException.class,
                 () -> engine.parse("{#fragment id=another}{foo}{/}{#fragment another}{foo}{/}", null, "bum.html"));
         assertEquals(FragmentSectionHelper.Code.NON_UNIQUE_FRAGMENT_ID, expected.getCode());
-        assertEquals("Parser error in template [bum.html] line 1: found a non-unique fragment identifier: [another]",
+        assertEquals("Parser error in template [bum.html:1]: found a non-unique fragment identifier: [another]",
                 expected.getMessage());
     }
 
@@ -120,7 +120,7 @@ public class FragmentTest {
                 () -> engine.parse("{#fragment id='another and foo'}{/}", null, "bum.html"));
         assertEquals(FragmentSectionHelper.Code.INVALID_FRAGMENT_ID, expected.getCode());
         assertEquals(
-                "Parser error in template [bum.html] line 1: found an invalid fragment identifier [another and foo] - an identifier can only consist of alphanumeric characters and underscores",
+                "Parser error in template [bum.html:1]: found an invalid fragment identifier [another and foo] - an identifier can only consist of alphanumeric characters and underscores",
                 expected.getMessage());
     }
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
@@ -174,7 +174,7 @@ public class IncludeTest {
                 .isThrownBy(() -> engine.parse("{#include super}{#header}super header{/header}{/include}", null, "foo.html")
                         .render())
                 .withMessage(
-                        "Rendering error in template [foo.html] line 1: included template [super] not found")
+                        "Rendering error in template [foo.html:1]: included template [super] not found")
                 .hasFieldOrProperty("origin")
                 .hasFieldOrProperty("code");
     }
@@ -213,14 +213,14 @@ public class IncludeTest {
                 () -> engine.parse("{#include foo$foo_and_bar /}", null, "bum.html").render());
         assertEquals(IncludeSectionHelper.Code.FRAGMENT_NOT_FOUND, expected.getCode());
         assertEquals(
-                "Rendering error in template [bum.html] line 1: fragment [foo_and_bar] not found in the included template [foo]",
+                "Rendering error in template [bum.html:1]: fragment [foo_and_bar] not found in the included template [foo]",
                 expected.getMessage());
 
         expected = assertThrows(TemplateException.class,
                 () -> engine.parse("{#include foo$foo-and_bar /}", null, "bum.html").render());
         assertEquals(IncludeSectionHelper.Code.INVALID_FRAGMENT_ID, expected.getCode());
         assertEquals(
-                "Rendering error in template [bum.html] line 1: invalid fragment identifier [foo-and_bar]",
+                "Rendering error in template [bum.html:1]: invalid fragment identifier [foo-and_bar]",
                 expected.getMessage());
     }
 
@@ -365,9 +365,27 @@ public class IncludeTest {
                         .data("foo", "nonexistent")
                         .render())
                 .withMessage(
-                        "Rendering error in template [foo.html] line 1: included template [nonexistent] not found")
+                        "Rendering error in template [foo.html:1]: included template [nonexistent] not found")
                 .hasFieldOrProperty("origin")
                 .hasFieldOrProperty("code");
+    }
+
+    @Test
+    public void testNoTemplate() {
+        Engine engine = Engine.builder().addDefaults().build();
+        assertThatExceptionOfType(TemplateException.class)
+                .isThrownBy(() -> engine.parse("{#include /}", null, "foo.html")
+                        .render())
+                .withMessage(
+                        "Parser error in template [foo.html:1]: Neither the template id nor the template name parameter was specified");
+    }
+
+    @Test
+    public void testTemplateNameWithUnderscorePrefix() {
+        Engine engine = Engine.builder().addDefaults().build();
+        engine.putTemplate("_root", engine.parse("<html><body>{#insert foo /}</body></html>"));
+        assertEquals("<html><body>Something</body></html>",
+                engine.parse("{#include _root}{#foo}Something{/include}").render());
     }
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/NamespaceResolversTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/NamespaceResolversTest.java
@@ -66,7 +66,7 @@ public class NamespaceResolversTest {
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(() -> Engine.builder().addDefaults().build().parse("{charlie:name}", null, "alpha.html").render())
                 .withMessage(
-                        "Rendering error in template [alpha.html] line 1: No namespace resolver found for [charlie] in expression {charlie:name}")
+                        "Rendering error in template [alpha.html:1]: No namespace resolver found for [charlie] in expression {charlie:name}")
                 .hasFieldOrProperty("code");
     }
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/NodeResolveTraceLoggingTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/NodeResolveTraceLoggingTest.java
@@ -28,8 +28,8 @@ public class NodeResolveTraceLoggingTest {
         assertEquals("Hello world!", engine.parse("Hello {name}!", null, "hello").data("name", "world").render());
         List<LogRecord> records = handler.records;
         assertEquals(2, records.size());
-        assertEquals("Resolve {name} started: template [hello] line 1", records.get(0).getMessage());
-        assertEquals("Resolve {name} completed: template [hello] line 1", records.get(1).getMessage());
+        assertEquals("Resolve {name} started: template [hello:1]", records.get(0).getMessage());
+        assertEquals("Resolve {name} completed: template [hello:1]", records.get(1).getMessage());
         records.clear();
 
         try {
@@ -38,13 +38,13 @@ public class NodeResolveTraceLoggingTest {
         } catch (TemplateException expected) {
         }
         assertEquals(1, records.size());
-        assertEquals("Resolve {foo} started: template [foo] line 1", records.get(0).getMessage());
+        assertEquals("Resolve {foo} started: template [foo:1]", records.get(0).getMessage());
         records.clear();
 
         assertEquals("Hello world!", engine.parse("Hello {#if true}world{/if}!", null, "helloIf").render());
         assertEquals(2, records.size());
-        assertEquals("Resolve {#if} started: template [helloIf] line 1", records.get(0).getMessage());
-        assertEquals("Resolve {#if} completed: template [helloIf] line 1", records.get(1).getMessage());
+        assertEquals("Resolve {#if} started: template [helloIf:1]", records.get(0).getMessage());
+        assertEquals("Resolve {#if} completed: template [helloIf:1]", records.get(1).getMessage());
         records.clear();
 
         try {
@@ -53,7 +53,7 @@ public class NodeResolveTraceLoggingTest {
         } catch (TemplateException expected) {
         }
         assertEquals(1, records.size());
-        assertEquals("Resolve {#if} started: template [fooIf] line 1", records.get(0).getMessage());
+        assertEquals("Resolve {#if} started: template [fooIf:1]", records.get(0).getMessage());
         records.clear();
 
         try {
@@ -62,8 +62,8 @@ public class NodeResolveTraceLoggingTest {
         } catch (TemplateException expected) {
         }
         assertEquals(2, records.size());
-        assertEquals("Resolve {#if} started: template [fooIf] line 1", records.get(0).getMessage());
-        assertEquals("Resolve {foo} started: template [fooIf] line 1", records.get(1).getMessage());
+        assertEquals("Resolve {#if} started: template [fooIf:1]", records.get(0).getMessage());
+        assertEquals("Resolve {foo} started: template [fooIf:1]", records.get(1).getMessage());
         records.clear();
 
         setLevel(root, previousLevel);

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -201,7 +201,7 @@ public class ParserTest {
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(() -> engine.getTemplate("foo.html"))
                 .withMessage(
-                        "Parser error in template [foo.html] line 1: mandatory section parameters not declared for {#if}: [condition]")
+                        "Parser error in template [foo.html:1]: mandatory section parameters not declared for {#if}: [condition]")
                 .hasFieldOrProperty("origin");
     }
 
@@ -500,7 +500,7 @@ public class ParserTest {
         TemplateException e = assertThrows(TemplateException.class,
                 () -> Engine.builder().addDefaults().build().parse("{foo[bar]}", null, "baz"));
         assertNotNull(e.getOrigin());
-        assertEquals("Non-literal value [bar] used in bracket notation in expression {foo[bar]} in template [baz] line 1",
+        assertEquals("Non-literal value [bar] used in bracket notation in expression {foo[bar]} in template [baz:1]",
                 e.getMessage());
     }
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/StrictRenderingTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/StrictRenderingTest.java
@@ -18,7 +18,7 @@ public class StrictRenderingTest {
             fail();
         } catch (TemplateException expected) {
             assertEquals(
-                    "Rendering error in template [hero1] line 1: Property \"nams\" not found on the base object \"io.quarkus.qute.StrictRenderingTest$Hero\" in expression {hero.nams}",
+                    "Rendering error in template [hero1:1]: Property \"nams\" not found on the base object \"io.quarkus.qute.StrictRenderingTest$Hero\" in expression {hero.nams}",
                     expected.getMessage());
         }
         try {
@@ -26,7 +26,7 @@ public class StrictRenderingTest {
             fail();
         } catch (TemplateException expected) {
             assertEquals(
-                    "Rendering error in template [hero2] line 1: Property \"nams\" not found on the base object \"io.quarkus.qute.StrictRenderingTest$Hero\" in expression {hero.nams}",
+                    "Rendering error in template [hero2:1]: Property \"nams\" not found on the base object \"io.quarkus.qute.StrictRenderingTest$Hero\" in expression {hero.nams}",
                     expected.getMessage());
         }
         assertEquals(


### PR DESCRIPTION
- fix a problem when a section param starts with an underscore
- this is a follow-up to https://github.com/quarkusio/quarkus/pull/48433