### PR TITLE
Disable HTTP/2 clear text when `quarkus.http.http2` is `false`

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -368,7 +368,8 @@ public class HttpServerOptionsUtils {
                         (int) httpConfig.limits().rstFloodWindowDuration().get().toSeconds());
                 httpServerOptions.setHttp2RstFloodWindowDurationTimeUnit(TimeUnit.SECONDS);
             }
-
+        } else {
+            httpServerOptions.setHttp2ClearTextEnabled(false);
         }
 
         httpServerOptions.setUseProxyProtocol(httpConfig.proxy().useProxyProtocol());


### PR DESCRIPTION
Disable HTTP/2 clear text when `quarkus.http.http2` is `false`. Currently, H2C remains enabled even when HTTP/2 with TLS is disabled using this property.

Fixes #49592