### PR TITLE
Update Flyway configuration when creating a migration with the DevUI

### DIFF
--- a/extensions/flyway/deployment/src/main/resources/dev-ui/qwc-flyway-datasources.js
+++ b/extensions/flyway/deployment/src/main/resources/dev-ui/qwc-flyway-datasources.js
@@ -228,9 +228,13 @@ export class QwcFlywayDatasources extends QwcHotReloadElement {
     }
 
     _showResultNotification(response){
-        if(response.type === "success"){
-            notifier.showInfoMessage(response.message + " (" + response.number + ")");
-        }else{
+        if (response.type === "success") {
+            if (response.number >= 0) {
+                notifier.showInfoMessage(response.message + " (" + response.number + ")");
+            } else {
+                notifier.showInfoMessage(response.message);
+            }
+        } else {
             notifier.showWarningMessage(response.message);
         }
     }

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeCreateFromHibernateTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeCreateFromHibernateTest.java
@@ -38,7 +38,11 @@ public class FlywayDevModeCreateFromHibernateTest extends DevUIJsonRPCTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(FlywayDevModeCreateFromHibernateTest.class, Endpoint.class, Fruit.class)
                     .addAsResource(new StringAsset(
-                            "quarkus.flyway.locations=db/create"), "application.properties"));
+                            """
+                                    quarkus.flyway.locations=db/create
+                                    quarkus.flyway.migrate-at-start=true
+                                    quarkus.flyway.baseline-on-migrate=true
+                                    quarkus.flyway.clean-at-start=true"""), "application.properties"));
 
     @Test
     public void testGenerateMigrationFromHibernate() throws Exception {


### PR DESCRIPTION
The Flyway Dev UI Editor checks some configuration to enable flags if not present. These configurations have defaults, meaning that they will never update the configuration (unless the configuration is explicitly cleared out, which seems unlikely).

Now, this just checks whether the expected config is a default and updates the value if so.

Also, if `FlywayDevModeCreateFromHibernateTest` calls the updateValues of the config editor with values to update (it does now because of the changes), it fails with a cryptic exception, which I cannot figure out. Would appreciate some help:

```
com.fasterxml.jackson.core.JsonParseException: Illegal character ((CTRL-CHAR, code 3)): only regular white space (\r, \n, \t) is allowed between tokens
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 2]
```