### PR TITLE
Add support for Authorization to be sent inside of the client init for WebSockets for GraphQL

### DIFF
--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientWebSocketAuthenticationClientInitTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientWebSocketAuthenticationClientInitTest.java
@@ -1,0 +1,193 @@
+package io.quarkus.smallrye.graphql.client.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.json.JsonValue;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.graphql.api.Subscription;
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.UnexpectedCloseException;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClientBuilder;
+import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Due to the complexity of establishing a WebSocket, WebSocket/Subscription testing of the GraphQL server is done here,
+ * as the client framework comes in very useful for establishing the connection to the server.
+ * <br>
+ * This test ensures that websockets that are established with Authorization inside the connection_init payload are
+ * authenticated and authorized in the same way that if included in the header.
+ * The only difference being that the endpoint cannot be secured with HTTP permissions, as the connection_init payload
+ * is only sent after the websocket is opened.
+ */
+public class DynamicGraphQLClientWebSocketAuthenticationClientInitTest {
+
+    static String url = "http://" + System.getProperty("quarkus.http.host", "localhost") + ":" +
+            System.getProperty("quarkus.http.test-port", "8081") + "/graphql";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SecuredApi.class, Foo.class)
+                    .addAsResource("application-secured.properties", "application.properties")
+                    .addAsResource("users.properties")
+                    .addAsResource("roles.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.smallrye-graphql.authorization-client-init-payload-name", "Authorization");
+
+    private static Stream<Arguments> websocketArguments() {
+        return Stream.of(WebsocketSubprotocol.values())
+                .map(Enum::name)
+                .map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("websocketArguments")
+    public void testAuthenticatedUserForQueryWebSocketOverInitParams(String subprotocolName) throws Exception {
+        DynamicGraphQLClientBuilder clientBuilder = DynamicGraphQLClientBuilder.newBuilder()
+                .url(url)
+                .initPayload(Map.of("Authorization", "Basic ZGF2aWQ6cXdlcnR5MTIz"))
+                .executeSingleOperationsOverWebsocket(true)
+                .subprotocols(WebsocketSubprotocol.valueOf(subprotocolName));
+        try (DynamicGraphQLClient client = clientBuilder.build()) {
+            // Test that repeated queries yields the same result
+            for (int i = 0; i < 3; i++) {
+                Response response = client.executeSync("{ foo { message} }");
+                assertTrue(response.hasData());
+                assertEquals("foo", response.getData().getJsonObject("foo").getString("message"));
+            }
+
+            // Unauthorized query
+            Response response = client.executeSync("{ bar { message} }");
+            assertTrue(response.hasData());
+            assertEquals(JsonValue.ValueType.NULL, response.getData().get("bar").getValueType());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("websocketArguments")
+    public void testUnauthenticatedUserForQueryWebSocketOverInitParams(String subprotocolName) throws Exception {
+        // Validate that our unit test code actually has a correctly secured endpoint
+        DynamicGraphQLClientBuilder clientBuilder = DynamicGraphQLClientBuilder.newBuilder()
+                .url(url)
+                .executeSingleOperationsOverWebsocket(true)
+                .subprotocols(WebsocketSubprotocol.valueOf(subprotocolName));
+        try (DynamicGraphQLClient client = clientBuilder.build()) {
+            Response response = client.executeSync("{ foo { message} }");
+            assertTrue(response.hasData());
+            assertEquals(JsonValue.ValueType.NULL, response.getData().get("foo").getValueType());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("websocketArguments")
+    @Disabled("Reliant on next version of SmallRye GraphQL to prevent it hanging")
+    public void testIncorrectCredentialsForQueryWebSocketOverInitParams(String subprotocolName) {
+        UnexpectedCloseException exception = assertThrows(UnexpectedCloseException.class, () -> {
+            // Validate that our unit test code actually has a correctly secured endpoint
+            DynamicGraphQLClientBuilder clientBuilder = DynamicGraphQLClientBuilder.newBuilder()
+                    .url(url)
+                    .executeSingleOperationsOverWebsocket(true)
+                    .initPayload(Map.of("Authorization", "Basic ZnJlZDpXUk9OR19QQVNTV09SRA=="))
+                    .subprotocols(WebsocketSubprotocol.valueOf(subprotocolName));
+            try (DynamicGraphQLClient client = clientBuilder.build()) {
+                client.executeSync("{ foo { message} }");
+            }
+        });
+        assertEquals((short) 4403, exception.getCloseStatusCode());
+        assertTrue(exception.getMessage().contains("Forbidden"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("websocketArguments")
+    @Disabled("Reliant on next version of SmallRye GraphQL to prevent it hanging")
+    public void testAuthenticatedUserForQueryWebSocketOverHeadersAndInitParams(String subprotocolName) {
+        UnexpectedCloseException exception = assertThrows(UnexpectedCloseException.class, () -> {
+            DynamicGraphQLClientBuilder clientBuilder = DynamicGraphQLClientBuilder.newBuilder()
+                    .url(url)
+                    // Header takes precedence over init payload
+                    .header("Authorization", "Basic ZnJlZDpmb28=")
+                    // This should be ignored as the header is set
+                    .initPayload(Map.of("Authorization", "Basic ZGF2aWQ6cXdlcnR5MTIz"))
+                    .executeSingleOperationsOverWebsocket(true)
+                    .subprotocols(WebsocketSubprotocol.valueOf(subprotocolName));
+            try (DynamicGraphQLClient client = clientBuilder.build()) {
+                // Executing the query should fail because the server will error as we've defined two methods of auth
+                client.executeSync("{ foo { message} }");
+            }
+        });
+        assertEquals((short) 4400, exception.getCloseStatusCode());
+        assertTrue(exception.getMessage().contains("Authorization specified in multiple locations"));
+    }
+
+    public static class Foo {
+
+        private String message;
+
+        public Foo(String foo) {
+            this.message = foo;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+    }
+
+    @GraphQLApi
+    public static class SecuredApi {
+
+        @Query
+        @RolesAllowed("fooRole")
+        @NonBlocking
+        public Foo foo() {
+            return new Foo("foo");
+        }
+
+        @Query
+        @RolesAllowed("barRole")
+        public Foo bar() {
+            return new Foo("bar");
+        }
+
+        @Subscription
+        @RolesAllowed("fooRole")
+        public Multi<Foo> fooSub() {
+            return Multi.createFrom().emitter(emitter -> {
+                emitter.emit(new Foo("foo"));
+                emitter.complete();
+            });
+        }
+
+        @Subscription
+        @RolesAllowed("barRole")
+        public Multi<Foo> barSub() {
+            return Multi.createFrom().emitter(emitter -> {
+                emitter.emit(new Foo("bar"));
+                emitter.complete();
+            });
+        }
+    }
+}

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientWebSocketAuthenticationHttpPermissionsTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientWebSocketAuthenticationHttpPermissionsTest.java
@@ -6,7 +6,6 @@ import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -41,7 +40,6 @@ public class DynamicGraphQLClientWebSocketAuthenticationHttpPermissionsTest {
                     .addAsResource("roles.properties")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 
-    @Disabled("TODO: enable after upgrade to smallrye-graphql 1.6.1, with 1.6.0 a websocket upgrade failure causes a hang here")
     @Test
     public void testUnauthenticatedForQueryWebSocket() throws Exception {
         DynamicGraphQLClientBuilder clientBuilder = DynamicGraphQLClientBuilder.newBuilder()

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientWebSocketAuthenticationTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/DynamicGraphQLClientWebSocketAuthenticationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.annotation.security.RolesAllowed;
@@ -125,6 +126,19 @@ public class DynamicGraphQLClientWebSocketAuthenticationTest {
             }, throwable -> Assertions.fail(throwable));
 
             await().untilTrue(returned);
+        }
+    }
+
+    @Test
+    public void testAuthenticatedUserButDefinedWithClientInitForQueryWebSocket() throws Exception {
+        DynamicGraphQLClientBuilder clientBuilder = DynamicGraphQLClientBuilder.newBuilder()
+                .url(url)
+                // Because quarkus.smallrye-graphql.authorization-client-init-payload-name is undefined, this will be ignored.
+                .initPayload(Map.of("Authorization", "Basic ZGF2aWQ6cXdlcnR5MTIz"))
+                .executeSingleOperationsOverWebsocket(true);
+        try (DynamicGraphQLClient client = clientBuilder.build()) {
+            Response response = client.executeSync("{ foo { message} }");
+            assertEquals(JsonValue.ValueType.NULL, response.getData().get("foo").getValueType());
         }
     }
 

--- a/extensions/smallrye-graphql-client/deployment/src/test/resources/roles.properties
+++ b/extensions/smallrye-graphql-client/deployment/src/test/resources/roles.properties
@@ -1,1 +1,2 @@
 david=fooRole
+fred=barRole

--- a/extensions/smallrye-graphql-client/deployment/src/test/resources/users.properties
+++ b/extensions/smallrye-graphql-client/deployment/src/test/resources/users.properties
@@ -1,1 +1,2 @@
 david=qwerty123
+fred=foo

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeAuthGraphQLTransportWSSubprotocolHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeAuthGraphQLTransportWSSubprotocolHandler.java
@@ -1,0 +1,61 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.json.JsonObject;
+
+import io.quarkus.smallrye.graphql.runtime.exception.SmallRyeAuthSecurityIdentityAlreadyAssignedException;
+import io.smallrye.graphql.websocket.GraphQLWebSocketSession;
+import io.smallrye.graphql.websocket.graphqltransportws.GraphQLTransportWSSubprotocolHandler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * An extension over GraphQLTransportWSSubprotocolHandler which supports defining an Authorization header in the client init
+ * message.
+ * This key of the Authorization header is defined by the `authorizationClientInitPayloadName` property.
+ */
+public class SmallRyeAuthGraphQLTransportWSSubprotocolHandler extends GraphQLTransportWSSubprotocolHandler {
+
+    private final SmallRyeAuthGraphQLWSHandler authHander;
+
+    public SmallRyeAuthGraphQLTransportWSSubprotocolHandler(GraphQLWebSocketSession session,
+            Map<String, Object> context,
+            RoutingContext ctx,
+            SmallRyeGraphQLAbstractHandler handler,
+            Optional<String> authorizationClientInitPayloadName) {
+        super(session, context);
+
+        this.authHander = new SmallRyeAuthGraphQLWSHandler(session, ctx, handler, authorizationClientInitPayloadName);
+    }
+
+    @Override
+    protected void onMessage(JsonObject message) {
+        if (message != null && message.getString("type").equals("connection_init")) {
+            Map<String, Object> payload = (Map<String, Object>) message.get("payload");
+
+            this.authHander.handlePayload(payload, () -> {
+                // Identity has been updated. Now pass the successful connection_init back to the SmallRye GraphQL library to take over
+                super.onMessage(message);
+            }, failure -> {
+                // Failure handling Authorization. This method triggers a 4401 (Unauthorized).
+                if (!session.isClosed()) {
+                    if (failure instanceof SmallRyeAuthSecurityIdentityAlreadyAssignedException) {
+                        session.close((short) 4400, "Authorization specified in multiple locations");
+                    } else {
+                        session.close((short) 4403, "Forbidden");
+                    }
+                }
+            });
+        } else {
+            super.onMessage(message);
+        }
+    }
+
+    @Override
+    public void onClose() {
+        super.onClose();
+
+        this.authHander.cancelAuthExpiry();
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeAuthGraphQLWSHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeAuthGraphQLWSHandler.java
@@ -1,0 +1,189 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import jakarta.json.JsonString;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.smallrye.graphql.runtime.exception.SmallRyeAuthSecurityIdentityAlreadyAssignedException;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.smallrye.graphql.websocket.GraphQLWebSocketSession;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.UniSubscriber;
+import io.smallrye.mutiny.subscription.UniSubscription;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A class which is capable of performing authentication against connection_init payloads for all GraphQL WebSocket
+ * subprotocols.
+ * Is also responsible for handling the closing of WebSockets when authentication expires.
+ */
+public class SmallRyeAuthGraphQLWSHandler {
+
+    private final GraphQLWebSocketSession session;
+    private final RoutingContext ctx;
+    private final SmallRyeGraphQLAbstractHandler handler;
+    private final Optional<String> authorizationClientInitPayloadName;
+    private final AtomicReference<Cancellable> authExpiry = new AtomicReference<>();
+
+    public SmallRyeAuthGraphQLWSHandler(GraphQLWebSocketSession session,
+            RoutingContext ctx,
+            SmallRyeGraphQLAbstractHandler handler,
+            Optional<String> authorizationClientInitPayloadName) {
+        this.session = session;
+        this.ctx = ctx;
+        this.handler = handler;
+        this.authorizationClientInitPayloadName = authorizationClientInitPayloadName;
+
+        updateIdentityExpiry(ctx);
+    }
+
+    /**
+     * Takes the payload sent from connection_init, and if quarkus.smallrye-graphql.authorization-client-init-payload-name is
+     * defined,
+     * then will take the value from the payload that matches the configured value. The value is treated as an Authorization
+     * header.
+     *
+     * @param payload The connection_init payload
+     * @param successCallback Will back called once the authentication has completed (or is skipped if not required)
+     * @param failureHandler Any errors which occur during authentication will be passed to this handler
+     */
+    void handlePayload(Map<String, Object> payload, Runnable successCallback, Consumer<Throwable> failureHandler) {
+        if (authorizationClientInitPayloadName.isPresent() && payload != null &&
+                payload.get(authorizationClientInitPayloadName.get()) instanceof JsonString authorizationJson) {
+            String authorization = authorizationJson.getString();
+
+            HttpAuthenticator authenticator = ctx.get(HttpAuthenticator.class.getName());
+            // Get the existing identity of the RoutingContext
+            QuarkusHttpUser.getSecurityIdentity(ctx, authenticator.getIdentityProviderManager()).subscribe()
+                    .withSubscriber(new UniSubscriber<SecurityIdentity>() {
+                        @Override
+                        public void onSubscribe(UniSubscription subscription) {
+
+                        }
+
+                        @Override
+                        public void onItem(SecurityIdentity previousIdentity) {
+                            if (!previousIdentity.isAnonymous()) {
+                                // Fail if this WebSocket already has an identity assigned to it
+                                onFailure(new SmallRyeAuthSecurityIdentityAlreadyAssignedException(payload));
+
+                                return;
+                            } else if (ctx.user() == null) {
+                                // Ensure that the identity which we have now got is actually set against the RoutingContext.
+                                QuarkusHttpUser.setIdentity(previousIdentity, ctx);
+                            }
+
+                            // Treat the Authorization sent in the client init in the same was that it would be if sent in the request header
+                            ctx.request().headers().add("Authorization", authorization);
+
+                            Uni<SecurityIdentity> potentialUser = authenticator.attemptAuthentication(ctx);
+                            potentialUser
+                                    .subscribe().withSubscriber(new UniSubscriber<SecurityIdentity>() {
+                                        @Override
+                                        public void onSubscribe(UniSubscription subscription) {
+
+                                        }
+
+                                        @Override
+                                        public void onItem(SecurityIdentity identity) {
+                                            // If identity is null, we've set the anonymous identity above, so we can ignore it
+                                            if (!session.isClosed() && identity != null) {
+                                                QuarkusHttpUser.setIdentity(identity, ctx);
+                                                handler.withIdentity(ctx);
+
+                                                updateIdentityExpiry(ctx);
+
+                                                successCallback.run();
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onFailure(Throwable failure) {
+                                            BiConsumer<RoutingContext, Throwable> handler = ctx
+                                                    .get(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
+                                            if (handler != null) {
+                                                handler.accept(ctx, failure);
+                                            }
+                                            failureHandler.accept(failure);
+                                        }
+                                    });
+                        }
+
+                        @Override
+                        public void onFailure(Throwable failure) {
+                            BiConsumer<RoutingContext, Throwable> handler = ctx
+                                    .get(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
+                            if (handler != null) {
+                                handler.accept(ctx, failure);
+                            }
+                            failureHandler.accept(failure);
+                        }
+                    });
+        } else {
+            successCallback.run();
+        }
+    }
+
+    private void updateIdentityExpiry(RoutingContext ctx) {
+        Cancellable replacing = authExpiry.getAndSet(createAuthExpiryTask(ctx, session));
+        if (replacing != null) {
+            // Should never replace an expiring identity.
+            // As above, we only permit updating the identity if the session starts with an anonymous identity.
+            replacing.cancel();
+        }
+    }
+
+    public void cancelAuthExpiry() {
+        Cancellable expire = authExpiry.get();
+        if (expire != null) {
+            expire.cancel();
+        }
+    }
+
+    public static Cancellable createAuthExpiryTask(RoutingContext ctx, GraphQLWebSocketSession webSocketSession) {
+        AtomicLong atomicTaskId = new AtomicLong(-1);
+
+        Cancellable sub = QuarkusHttpUser.getSecurityIdentity(ctx, null)
+                .subscribe()
+                .with(securityIdentity -> {
+                    QuarkusHttpUser user = (QuarkusHttpUser) ctx.user();
+                    if (user != null) {
+                        //close the connection when the identity expires
+                        Long expire = user.getSecurityIdentity().getAttribute("quarkus.identity.expire-time");
+                        if (expire != null) {
+                            long taskId = ctx.vertx().setTimer((expire * 1000) - System.currentTimeMillis(),
+                                    event -> {
+                                        if (!webSocketSession.isClosed()) {
+                                            webSocketSession.close((short) 1008, "Authentication expired");
+                                        }
+                                    });
+                            long previousValue = atomicTaskId.getAndSet(taskId);
+                            if (previousValue == -2) {
+                                // If -2 it's been cancelled.
+                                ctx.vertx().cancelTimer(taskId);
+                            }
+                        }
+                    }
+                });
+
+        return () -> {
+            // If we're still loading the deferred identity, cancel
+            sub.cancel();
+
+            // Set to -2 to indicate it's been cancelled.
+            long taskId = atomicTaskId.getAndSet(-2);
+
+            if (taskId >= 0) {
+                ctx.vertx().cancelTimer(taskId);
+            }
+        };
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeAuthGraphQLWSSubprotocolHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeAuthGraphQLWSSubprotocolHandler.java
@@ -1,0 +1,60 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.json.JsonObject;
+
+import io.quarkus.smallrye.graphql.runtime.exception.SmallRyeAuthSecurityIdentityAlreadyAssignedException;
+import io.smallrye.graphql.websocket.GraphQLWebSocketSession;
+import io.smallrye.graphql.websocket.graphqlws.GraphQLWSSubprotocolHandler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * An extension over GraphQLWSSubprotocolHandler which supports defining an Authorization header in the client init message.
+ * This key of the Authorization header is defined by the `authorizationClientInitPayloadName` property.
+ */
+public class SmallRyeAuthGraphQLWSSubprotocolHandler extends GraphQLWSSubprotocolHandler {
+
+    private final SmallRyeAuthGraphQLWSHandler authHander;
+
+    public SmallRyeAuthGraphQLWSSubprotocolHandler(GraphQLWebSocketSession session,
+            Map<String, Object> context,
+            RoutingContext ctx,
+            SmallRyeGraphQLAbstractHandler handler,
+            Optional<String> authorizationClientInitPayloadName) {
+        super(session, context);
+
+        this.authHander = new SmallRyeAuthGraphQLWSHandler(session, ctx, handler, authorizationClientInitPayloadName);
+    }
+
+    @Override
+    protected void onMessage(JsonObject message) {
+        if (message != null && message.getString("type").equals("connection_init")) {
+            Map<String, Object> payload = (Map<String, Object>) message.get("payload");
+
+            this.authHander.handlePayload(payload, () -> {
+                // Identity has been updated. Now pass the successful connection_init back to the SmallRye GraphQL library to take over
+                super.onMessage(message);
+            }, failure -> {
+                // Failure handling Authorization. This method triggers a 4401 (Unauthorized).
+                if (!session.isClosed()) {
+                    if (failure instanceof SmallRyeAuthSecurityIdentityAlreadyAssignedException) {
+                        session.close((short) 4400, "Authorization specified in multiple locations");
+                    } else {
+                        session.close((short) 4403, "Forbidden");
+                    }
+                }
+            });
+        } else {
+            super.onMessage(message);
+        }
+    }
+
+    @Override
+    public void onClose() {
+        super.onClose();
+
+        this.authHander.cancelAuthExpiry();
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
@@ -83,6 +83,11 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
     }
 
     private void handleWithIdentity(final RoutingContext ctx) {
+        withIdentity(ctx);
+        doHandle(ctx);
+    }
+
+    void withIdentity(RoutingContext ctx) {
         if (currentIdentityAssociation != null) {
             QuarkusHttpUser existing = (QuarkusHttpUser) ctx.user();
             if (existing != null) {
@@ -93,7 +98,6 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
             }
         }
         currentVertxRequest.setCurrent(ctx);
-        doHandle(ctx);
     }
 
     protected abstract void doHandle(final RoutingContext ctx);

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
@@ -192,4 +192,18 @@ public interface SmallRyeGraphQLConfig {
      * These are taken from the `graphql-java-extended-scalars` library.
      */
     Optional<List<ExtraScalar>> extraScalars();
+
+    /**
+     * The name of the key inside the client init payload which contains Authorization information.
+     * The associated value of this is treated in the same way as sent over as a Authorization header.
+     * Using headers is the preferred way, however in some languages, such as JavaScript, it is not possible to send
+     * headers over websockets.
+     * <br>
+     * If sending headers are not an option, another viable option is
+     * <a href=https://quarkus.io/guides/websockets-next-reference#bearer-token-authentication>Bearer Token Authentication</a>
+     * which might be preferable over this in some cases as it's able to inject headers before the WebSocket is opened.
+     * <br>
+     * Default is undefined, which means the client init payload will not be checked for Authorization information.
+     */
+    Optional<String> authorizationClientInitPayloadName();
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -89,7 +89,8 @@ public class SmallRyeGraphQLRecorder {
     public Handler<RoutingContext> graphqlOverWebsocketHandler(BeanContainer beanContainer, RuntimeValue<Boolean> initialized,
             boolean runBlocking) {
         return new SmallRyeGraphQLOverWebSocketHandler(getCurrentIdentityAssociation(),
-                Arc.container().instance(CurrentVertxRequest.class).get(), runBlocking);
+                Arc.container().instance(CurrentVertxRequest.class).get(), runBlocking,
+                graphQLConfig.authorizationClientInitPayloadName());
     }
 
     public Handler<RoutingContext> schemaHandler(RuntimeValue<Boolean> initialized, boolean schemaAvailable) {

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/exception/SmallRyeAuthSecurityIdentityAlreadyAssignedException.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/exception/SmallRyeAuthSecurityIdentityAlreadyAssignedException.java
@@ -1,0 +1,22 @@
+package io.quarkus.smallrye.graphql.runtime.exception;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An exception which is thrown when a security identity is already defined, but the connection init payload tries to
+ * change the connections identity. This is not allowed.
+ */
+public class SmallRyeAuthSecurityIdentityAlreadyAssignedException extends Exception {
+
+    private final Map<String, Object> connectionInitPayload;
+
+    public SmallRyeAuthSecurityIdentityAlreadyAssignedException(Map<String, Object> connectionInitPayload) {
+        super("Security identity already assigned to this WebSocket.");
+        this.connectionInitPayload = Collections.unmodifiableMap(connectionInitPayload);
+    }
+
+    public Map<String, Object> getConnectionInitPayload() {
+        return connectionInitPayload;
+    }
+}

--- a/integration-tests/smallrye-graphql-client-keycloak/src/main/resources/application.properties
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/main/resources/application.properties
@@ -2,3 +2,4 @@ quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.smallrye-graphql.log-payload=queryAndVariables
 quarkus.keycloak.devservices.enabled=false
+quarkus.smallrye-graphql.authorization-client-init-payload-name=Authorization

--- a/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryDeferredTest.java
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryDeferredTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.smallrye.graphql.keycloak;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Same as GraphQLAuthExpiryTest but uses deferred client authorization.
+ */
+@QuarkusTest
+@TestProfile(GraphQLAuthExpiryDeferredTest.class)
+public class GraphQLAuthExpiryDeferredTest extends GraphQLAuthExpiryTest implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.http.auth.proactive", "false");
+    }
+}

--- a/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryTest.java
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryTest.java
@@ -3,12 +3,16 @@ package io.quarkus.it.smallrye.graphql.keycloak;
 import static io.restassured.RestAssured.when;
 
 import java.net.URL;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
 
 /**
  * See `GraphQLClientTester` for the actual testing code that uses GraphQL clients.
@@ -20,11 +24,20 @@ public class GraphQLAuthExpiryTest {
     @TestHTTPResource
     URL url;
 
-    @Test
-    public void testDynamicClientWebSocketAuthenticationExpiry() {
+    private static Stream<Arguments> clientOptions() {
+        Boolean[] clientInitValues = new Boolean[] { true, false };
+        WebsocketSubprotocol[] subprotocolsValues = WebsocketSubprotocol.values();
+
+        return Stream.of(clientInitValues).flatMap(
+                clientInit -> Stream.of(subprotocolsValues).map(subprotocol -> Arguments.of(clientInit, subprotocol.name())));
+    }
+
+    @ParameterizedTest
+    @MethodSource("clientOptions")
+    public void testDynamicClientWebSocketAuthenticationExpiry(boolean clientInit, String subprotocol) {
         String token = KeycloakRealmResourceManager.getAccessToken();
         when()
-                .get("/dynamic-subscription-auth-expiry/" + token + "/" + url.toString())
+                .get("/dynamic-subscription-auth-expiry/" + clientInit + "/" + subprotocol + "/" + token + "/" + url.toString())
                 .then()
                 .log().everything()
                 .statusCode(204);


### PR DESCRIPTION
This addresses this issue: https://github.com/smallrye/smallrye-graphql/issues/2255
Some languages don't support headers over WebSockets, and require additional information such as Authorization to be sent over WebSocket instead.

This change allows Authorization to be specified on client init instead of headers (Defining in headers is still possible). I couldn't seem to find any standardized way in the GraphQL spec for defining authorization in the connection init. I have no experience with Apollo, but [their docs](https://the-guild.dev/graphql/apollo-angular/docs/data/subscriptions#authentication-over-websocket) seem to hint at using "authToken" instead of "Authorization". Maybe I should switch to using this instead?

One issue that arises with this change is that because the authentication occurs after the WebSocket is established, the endpoint cannot be secured with HTTP rules. This feels like this isn't a major issue, I could list this in the documentation if needed.

I'm not totally happy with the code as I feel like I hacked around a few things to get this in. Rather than spending another day or two working on this, I was looking for a bit of feedback first. (QuarkusGraphQLWSSubprotocolHandler and QuarkusGraphQLTransportWSSubprotocolHandler are basically a copy, which is a bit of a mess)


On a slightly unrelated note, I saw a test in DynamicGraphQLClientWebSocketAuthenticationHttpPermissionsTest was marked as @Disabled. It had a comment to enable it after 1.6.1, which we're way past. It seems to run fine, so I guess it's okay to enable. Let me know if there are any issues with me re-enabling this. I felt the more tests running, the better.