### PR TITLE
Add a mapping with only the default values of Auth and Cors

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/DefaultAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/DefaultAuthConfig.java
@@ -1,0 +1,41 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocIgnore;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.vertx.http.runtime.cors.CORSConfig;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
+
+/**
+ * Mapping for Quarkus Security fluent API defaults
+ */
+@ConfigMapping(prefix = "quarkus.http")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface DefaultAuthConfig {
+    @WithParentName
+    @ConfigDocIgnore
+    Defaults defaults();
+
+    default AuthRuntimeConfig auth() {
+        return defaults().auth().get("defaults");
+    }
+
+    default CORSConfig cors() {
+        return defaults().cors().get("defaults");
+    }
+
+    interface Defaults {
+        @WithUnnamedKey
+        @WithDefaults
+        Map<String, AuthRuntimeConfig> auth();
+
+        @WithUnnamedKey
+        @WithDefaults
+        Map<String, CORSConfig> cors();
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityImpl.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityImpl.java
@@ -105,7 +105,7 @@ final class HttpSecurityImpl implements HttpSecurity {
     public HttpSecurity mechanism(HttpAuthenticationMechanism mechanism) {
         Objects.requireNonNull(mechanism);
         if (mechanism.getClass() == FormAuthenticationMechanism.class) {
-            final FormAuthConfig defaults = HttpSecurityUtils.getDefaultVertxHttpConfig().auth().form();
+            final FormAuthConfig defaults = HttpSecurityUtils.getDefaultAuthConfig().auth().form();
             final FormAuthConfig actualConfig = vertxHttpConfig.auth().form();
             if (!actualConfig.equals(defaults)) {
                 throw new IllegalArgumentException("Cannot configure form-based authentication programmatically "

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityUtils.java
@@ -7,11 +7,13 @@ import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.security.auth.x500.X500Principal;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
-import io.quarkus.vertx.http.runtime.VertxHttpConfig;
-import io.smallrye.config.SmallRyeConfigBuilder;
+import io.quarkus.vertx.http.runtime.DefaultAuthConfig;
+import io.smallrye.config.SmallRyeConfig;
 import io.vertx.ext.web.RoutingContext;
 
 public final class HttpSecurityUtils {
@@ -110,12 +112,7 @@ public final class HttpSecurityUtils {
         return null;
     }
 
-    public static VertxHttpConfig getDefaultVertxHttpConfig() {
-        return new SmallRyeConfigBuilder()
-                .addDiscoveredConverters()
-                .withDefaultValue("quarkus.http.host", "8081")
-                .withMapping(VertxHttpConfig.class)
-                .build()
-                .getConfigMapping(VertxHttpConfig.class);
+    public static DefaultAuthConfig getDefaultAuthConfig() {
+        return ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getConfigMapping(DefaultAuthConfig.class);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
@@ -49,7 +49,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
         private Optional<List<String>> origins;
 
         public Builder() {
-            this(HttpSecurityUtils.getDefaultVertxHttpConfig().cors());
+            this(HttpSecurityUtils.getDefaultAuthConfig().cors());
         }
 
         public Builder(CORSConfig corsConfig) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/MTLS.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/MTLS.java
@@ -312,7 +312,7 @@ public interface MTLS {
          * @return default value as hardcoded in the {@link AuthRuntimeConfig} mapping.
          */
         private static String getDefaultCertificateAttributeValue() {
-            return HttpSecurityUtils.getDefaultVertxHttpConfig().auth().certificateRoleAttribute();
+            return HttpSecurityUtils.getDefaultAuthConfig().auth().certificateRoleAttribute();
         }
     }
 


### PR DESCRIPTION
- Fixes #49638

This exposes only the defaults of `AuthRuntimeConfig` and `CORSConfig` in a new mapping `DefaultsAuthConfig`.

This uses `@ConfigMapping` `@WithDefaults` `@WithUnnamedKey` with `Map` to populate defaults for any key. See https://smallrye.io/smallrye-config/Latest/config/mappings/#maps

The runtime configuration is available in the `Map` associated with the `null` key.  A lookup to the `Map` with any other keys, yields the config object with the defaults. It is still possible to influence these defaults by using the named key `defaults` as part of the path of `quarkus.http.auth.defaults.*` and `quarkus.http.cors.defaults.*`. This is only valid for `DefaultsAuthConfig`.