### PR TITLE
Dev UI: Small fixes to setting screen

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -397,7 +397,7 @@ To add a tab to the Dev UI settings dialog, produce a `SettingPageBuildItem`:
     @BuildStep(onlyIf = IsLocalDevelopment.class) // <1>
     void createMCPSettingsTab(BuildProducer<SettingPageBuildItem> settingPageProducer) {
 
-        SettingPageBuildItem mcpSettingTab = new SettingPageBuildItem("Dev MCP");// <2>
+        SettingPageBuildItem mcpSettingTab = new SettingPageBuildItem();// <2>
 
         mcpSettingTab.addPage(Page.webComponentPageBuilder() // <3>
                 .title("Dev MCP")// <4>
@@ -438,7 +438,7 @@ To do this, produce a `UnlistedPageBuildItem`:
     @BuildStep(onlyIf = IsLocalDevelopment.class) // <1>
     void createMCPUnlistedPages(BuildProducer<UnlistedPageBuildItem> unlistedPageProducer) {
 
-        UnlistedPageBuildItem mcpOtherPages = new UnlistedPageBuildItem("Dev MCP"); // <2>
+        UnlistedPageBuildItem mcpOtherPages = new UnlistedPageBuildItem(); // <2>
 
         mcpOtherPages.addPage(Page.webComponentPageBuilder() // <3>
                 .title("Tools") // <4>

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -775,6 +775,12 @@ public class DevUIProcessor {
                                             extension.addMenuPage(page);
                                         }
                                     }
+                                    // See if there is a headless component
+                                    String headlessJs = menuPageBuildItem.getHeadlessComponentLink();
+                                    if (headlessJs != null) {
+                                        extension.setHeadlessComponent(headlessJs);
+                                    }
+
                                     // Also make sure the static resources for that static resource is available
                                     produceResources(runtimeExt, webJarBuildProducer, devUIWebJarProducer);
                                     sectionMenuExtensions.add(extension);
@@ -793,6 +799,12 @@ public class DevUIProcessor {
                                             if (!page.isAssistantPage() || assistantIsAvailable) {
                                                 extension.addFooterPage(page);
                                             }
+                                        }
+
+                                        // See if there is a headless component
+                                        String headlessJs = footerPageBuildItem.getHeadlessComponentLink();
+                                        if (headlessJs != null) {
+                                            extension.setHeadlessComponent(headlessJs);
                                         }
                                         // Also make sure the static resources for that static resource is available
                                         produceResources(runtimeExt, webJarBuildProducer, devUIWebJarProducer);
@@ -814,6 +826,11 @@ public class DevUIProcessor {
                                                 extension.addSettingPage(page);
                                             }
                                         }
+                                        // See if there is a headless component
+                                        String headlessJs = settingPageBuildItem.getHeadlessComponentLink();
+                                        if (headlessJs != null) {
+                                            extension.setHeadlessComponent(headlessJs);
+                                        }
                                         // Also make sure the static resources for that static resource is available
                                         produceResources(runtimeExt, webJarBuildProducer, devUIWebJarProducer);
                                         settingTabExtensions.add(extension);
@@ -833,6 +850,11 @@ public class DevUIProcessor {
                                             if (!page.isAssistantPage() || assistantIsAvailable) {
                                                 extension.addUnlistedPage(page);
                                             }
+                                        }
+                                        // See if there is a headless component
+                                        String headlessJs = unlistedPageBuildItem.getHeadlessComponentLink();
+                                        if (headlessJs != null) {
+                                            extension.setHeadlessComponent(headlessJs);
                                         }
                                         // Also make sure the static resources for that static resource is available
                                         produceResources(runtimeExt, webJarBuildProducer, devUIWebJarProducer);

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
@@ -32,7 +32,7 @@ public class MCPProcessor {
     void createMCPPage(BuildProducer<SettingPageBuildItem> settingPageProducer,
             BuildProducer<UnlistedPageBuildItem> unlistedPageProducer) {
 
-        SettingPageBuildItem mcpSettingTab = new SettingPageBuildItem("Dev MCP");
+        SettingPageBuildItem mcpSettingTab = new SettingPageBuildItem(NS_MCP);
 
         mcpSettingTab.addPage(Page.webComponentPageBuilder()
                 .namespace(NS_MCP)
@@ -41,7 +41,7 @@ public class MCPProcessor {
                 .componentLink("qwc-dev-mcp-setting.js"));
         settingPageProducer.produce(mcpSettingTab);
 
-        UnlistedPageBuildItem mcpOtherPages = new UnlistedPageBuildItem("Dev MCP");
+        UnlistedPageBuildItem mcpOtherPages = new UnlistedPageBuildItem(NS_MCP);
 
         mcpOtherPages.addPage(Page.webComponentPageBuilder()
                 .namespace(NS_MCP)

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-setting.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-setting.js
@@ -44,6 +44,7 @@ export class QwcDevMCPSetting extends QwcHotReloadElement {
     `;
 
     static properties = {
+        namespace: {type: String},
         _mcpPath: {state: false},
         _configuration: {state: true},
         _connectedClients: {state: true}
@@ -141,7 +142,7 @@ export class QwcDevMCPSetting extends QwcHotReloadElement {
     }
     
     _renderUnlistedPagesLinks(){
-        let unlistedPages = this.routerController.getPagesForNamespace("devmcp");
+        let unlistedPages = this.routerController.getPagesForNamespace(this.namespace);
         return html`<div class="unlistedLinks">
                         ${unlistedPages.map((page) =>
                             html`${this._renderUnlistedPageLink(page)}`


### PR DESCRIPTION
This PR makes sure extensions can contribute to the settings screen, and you can "deep link" into a certains tab of the settings screen (this is done with an event since the settings screen is a dialog). 
This also makes sure that headless components can be added by any Page type.
This is done while moving Chappie extension config to the setting screen