### PR TITLE
Remove GraphQL client's legacy keystore/truststore configuration

### DIFF
--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/GraphQLClientConfigurationTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/GraphQLClientConfigurationTest.java
@@ -23,12 +23,6 @@ public class GraphQLClientConfigurationTest {
                     .addAsResource(
                             new StringAsset(
                                     "quarkus.smallrye-graphql-client.client1.url=https://localhost:8080\n" +
-                                            "quarkus.smallrye-graphql-client.client1.key-store=classpath:my.keystore\n" +
-                                            "quarkus.smallrye-graphql-client.client1.key-store-password=secret\n" +
-                                            "quarkus.smallrye-graphql-client.client1.key-store-type=PKCS12\n" +
-                                            "quarkus.smallrye-graphql-client.client1.trust-store=classpath:my.truststore\n" +
-                                            "quarkus.smallrye-graphql-client.client1.trust-store-password=secret2\n" +
-                                            "quarkus.smallrye-graphql-client.client1.trust-store-type=JKS\n" +
                                             "quarkus.smallrye-graphql-client.client1.proxy-host=myproxy\n" +
                                             "quarkus.smallrye-graphql-client.client1.proxy-port=1234\n" +
                                             "quarkus.smallrye-graphql-client.client1.proxy-username=dave\n" +
@@ -36,17 +30,6 @@ public class GraphQLClientConfigurationTest {
                                             "quarkus.smallrye-graphql-client.client1.max-redirects=6\n"),
                             "application.properties")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
-
-    @Test
-    public void checkSslConfiguration() {
-        GraphQLClientConfiguration config = GraphQLClientsConfiguration.getInstance().getClient("client1");
-        assertEquals("classpath:my.keystore", config.getKeyStore());
-        assertEquals("secret", config.getKeyStorePassword());
-        assertEquals("PKCS12", config.getKeyStoreType());
-        assertEquals("classpath:my.truststore", config.getTrustStore());
-        assertEquals("secret2", config.getTrustStorePassword());
-        assertEquals("JKS", config.getTrustStoreType());
-    }
 
     @Test
     public void checkProxyConfiguration() {

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
@@ -49,67 +49,6 @@ public interface GraphQLClientConfig {
     OptionalInt websocketInitializationTimeout();
 
     /**
-     * The trust store location. Can point to either a classpath resource or a file.
-     *
-     * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
-     *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
-     */
-    @Deprecated(forRemoval = true, since = "3.16.0")
-    Optional<String> trustStore();
-
-    /**
-     * The trust store password.
-     *
-     * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
-     *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
-     */
-    @Deprecated(forRemoval = true, since = "3.16.0")
-    Optional<String> trustStorePassword();
-
-    /**
-     * The type of the trust store. Defaults to "JKS".
-     *
-     * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
-     *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
-     */
-    @Deprecated(forRemoval = true, since = "3.16.0")
-    Optional<String> trustStoreType();
-
-    /**
-     * The key store location. Can point to either a classpath resource or a file.
-     *
-     * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
-     *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
-     */
-    @Deprecated(forRemoval = true, since = "3.16.0")
-    Optional<String> keyStore();
-
-    /**
-     * The key store password.
-     *
-     * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
-     *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
-     */
-    @Deprecated(forRemoval = true, since = "3.16.0")
-    Optional<String> keyStorePassword();
-
-    /**
-     * The type of the key store. Defaults to "JKS".
-     *
-     * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
-     *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
-     *
-     */
-    @Deprecated(forRemoval = true, since = "3.16.0")
-    Optional<String> keyStoreType();
-
-    /**
      * Hostname of the proxy to use.
      */
     Optional<String> proxyHost();

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
@@ -129,33 +129,15 @@ public class SmallRyeGraphQLClientRecorder {
         quarkusConfig.url().ifPresent(transformed::setUrl);
         transformed.setWebsocketSubprotocols(quarkusConfig.subprotocols().orElse(new ArrayList<>()));
 
-        // these properties are deprecated, but if they're present, they should override the TLS registry config
-        // (smallrye-graphql gives them precedence)
-        quarkusConfig.keyStore().ifPresent(transformed::setKeyStore);
-        quarkusConfig.keyStoreType().ifPresent(transformed::setKeyStoreType);
-        quarkusConfig.keyStorePassword().ifPresent(transformed::setKeyStorePassword);
-        quarkusConfig.trustStore().ifPresent(transformed::setTrustStore);
-        quarkusConfig.trustStoreType().ifPresent(transformed::setTrustStoreType);
-        quarkusConfig.trustStorePassword().ifPresent(transformed::setTrustStorePassword);
-
-        // only apply TLS registry settings if quarkus.smallrye-graphql-client.CLIENT.key-store|trust-store were not specified
-        if (quarkusConfig.keyStore().isEmpty() && quarkusConfig.trustStore().isEmpty()) {
-            resolveTlsConfigurationForRegistry(quarkusConfig)
-                    .ifPresent(tlsConfiguration -> {
-                        transformed.setTlsKeyStoreOptions(tlsConfiguration.getKeyStoreOptions());
-                        transformed.setTlsTrustStoreOptions(tlsConfiguration.getTrustStoreOptions());
-                        transformed.setSslOptions(tlsConfiguration.getSSLOptions());
-                        tlsConfiguration.getHostnameVerificationAlgorithm()
-                                .ifPresent(transformed::setHostnameVerificationAlgorithm);
-                        transformed.setUsesSni(Boolean.valueOf(tlsConfiguration.usesSni()));
-                    });
-        } else {
-            quarkusConfig.tlsConfigurationName().ifPresent(name -> {
-                logger.warn("TLS configuration " + name
-                        + " was requested but specific keystore/truststore settings were applied too, " +
-                        " ignoring the TLS configuration");
-            });
-        }
+        resolveTlsConfigurationForRegistry(quarkusConfig)
+                .ifPresent(tlsConfiguration -> {
+                    transformed.setTlsKeyStoreOptions(tlsConfiguration.getKeyStoreOptions());
+                    transformed.setTlsTrustStoreOptions(tlsConfiguration.getTrustStoreOptions());
+                    transformed.setSslOptions(tlsConfiguration.getSSLOptions());
+                    tlsConfiguration.getHostnameVerificationAlgorithm()
+                            .ifPresent(transformed::setHostnameVerificationAlgorithm);
+                    transformed.setUsesSni(Boolean.valueOf(tlsConfiguration.usesSni()));
+                });
 
         quarkusConfig.proxyHost().ifPresent(transformed::setProxyHost);
         quarkusConfig.proxyPort().ifPresent(transformed::setProxyPort);


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/45407

This has been deprecated since 3.16. People should use the TLS registry instead.