### PR TITLE
Set correct OAuth2 protected metadata challenge parameter

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
@@ -184,7 +184,8 @@ public class ResourceMetadataHandler implements Handler<RoutingContext> {
 
     static String resourceMetadataAuthenticateParameter(RoutingContext context, DefaultTenantConfigResolver resolver,
             OidcTenantConfig oidcConfig) {
-        return " " + RESOURCE_METADATA_AUTHENTICATE_PARAM + "=\"" + buildResourceIdentifierUrl(context, resolver, oidcConfig)
+        return " " + RESOURCE_METADATA_AUTHENTICATE_PARAM + "=\""
+                + buildAbsoluteResourceIdentifierUrl(context, resolver, oidcConfig)
                 + "\"";
     }
 
@@ -202,6 +203,19 @@ public class ResourceMetadataHandler implements Handler<RoutingContext> {
             } else if (!OidcUtils.DEFAULT_TENANT_ID.equals(oidcConfig.tenantId().get())) {
                 configuredResource += OidcCommonUtils.prependSlash(oidcConfig.tenantId().get().toLowerCase());
             }
+            String authority = URI.create(context.request().absoluteURI()).getAuthority();
+            return buildUri(context, resolver.isEnableHttpForwardedPrefix(),
+                    oidcConfig.resourceMetadata().forceHttpsScheme(), authority, configuredResource);
+        }
+    }
+
+    static String buildAbsoluteResourceIdentifierUrl(RoutingContext context, DefaultTenantConfigResolver resolver,
+            OidcTenantConfig oidcConfig) {
+        String configuredResource = getResourceMetadataPath(oidcConfig, resolver.getRootPath());
+
+        if (configuredResource.startsWith(HTTP_SCHEME)) {
+            return configuredResource;
+        } else {
             String authority = URI.create(context.request().absoluteURI()).getAuthority();
             return buildUri(context, resolver.isEnableHttpForwardedPrefix(),
                     oidcConfig.resourceMetadata().forceHttpsScheme(), authority, configuredResource);

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/AbstractBearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/AbstractBearerTokenAuthorizationTest.java
@@ -10,6 +10,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.quarkus.test.keycloak.client.KeycloakTestClient.Tls;
 import io.restassured.RestAssured;
@@ -149,7 +150,8 @@ public abstract class AbstractBearerTokenAuthorizationTest {
         RestAssured.given().auth().oauth2("123")
                 .when().get("/api/users/me").then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("Bearer resource_metadata=\"https://localhost:8081\""));
+                .header("WWW-Authenticate", equalTo("Bearer resource_metadata=\"https://localhost:8081"
+                        + OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH + "\""));
     }
 
     //see https://github.com/quarkusio/quarkus/issues/5809
@@ -187,7 +189,8 @@ public abstract class AbstractBearerTokenAuthorizationTest {
                 .when().get("/bearer-only")
                 .then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("Bearer resource_metadata=\"https://localhost:8081\""));
+                .header("WWW-Authenticate", equalTo("Bearer resource_metadata=\"https://localhost:8081"
+                        + OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH + "\""));
     }
 
     @Test


### PR DESCRIPTION
Quarkus OIDC sets a wrong `request_metadata` WWW-Authenticate challenge parameter, missing the `.well-known/oauth-protected-resource` path, as [required by both RFC9728](https://www.rfc-editor.org/rfc/rfc9728.html#name-www-authenticate-response) and expected by the MCP clients.

