### PR TITLE
Tighten up contract of AnnotationStore#hasAnyAnnotation()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
@@ -1,7 +1,6 @@
 package io.quarkus.arc.processor;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -71,12 +70,8 @@ public final class AnnotationStore {
      * @return {@code true} if the specified target contains any of the specified annotations, {@code false} otherwise
      * @see #getAnnotations(AnnotationTarget)
      */
-    public boolean hasAnyAnnotation(AnnotationTarget target, Iterable<DotName> names) {
-        Set<DotName> set = new HashSet<>();
-        for (DotName name : names) {
-            set.add(name);
-        }
-        return delegate.hasAnyAnnotation(target.asDeclaration(), set);
+    public boolean hasAnyAnnotation(AnnotationTarget target, Set<DotName> names) {
+        return delegate.hasAnyAnnotation(target.asDeclaration(), names);
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1041,7 +1041,7 @@ public class BeanDeployment {
         NO_BEAN_CONSTRUCTOR
     }
 
-    private BeanDiscoveryResult findBeans(Collection<DotName> beanDefiningAnnotations, List<ObserverInfo> observers,
+    private BeanDiscoveryResult findBeans(Set<DotName> beanDefiningAnnotations, List<ObserverInfo> observers,
             List<InjectionPointInfo> injectionPoints, boolean jtaCapabilities) {
 
         Set<ClassInfo> beanClasses = new HashSet<>();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -440,7 +440,7 @@ final class Methods {
      */
     static class SubclassSkipPredicate implements Predicate<MethodInfo> {
 
-        private static final List<DotName> INTERCEPTOR_ANNOTATIONS = List.of(DotNames.AROUND_INVOKE, DotNames.POST_CONSTRUCT,
+        private static final Set<DotName> INTERCEPTOR_ANNOTATIONS = Set.of(DotNames.AROUND_INVOKE, DotNames.POST_CONSTRUCT,
                 DotNames.PRE_DESTROY);
 
         private final BiFunction<Type, Type, Boolean> assignableFromFun;


### PR DESCRIPTION
We were using an Iterable and then creating a Set always, which we can easily avoid.

@mkouba if you thought you would see the end of my silly patches, you were mistaken :).
