### PR TITLE
Remove deprecated Console configuration

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleHelper.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleHelper.java
@@ -23,7 +23,7 @@ public class ConsoleHelper {
         //if there is no color we need a basic console
         //note that we never enable input for tests
         //surefire communicates of stdin, so this can mess with it
-        boolean inputSupport = !test && !config.disableConsoleInput().orElse(consoleConfig.disableInput());
+        boolean inputSupport = !test && !consoleConfig.disableInput();
         if (!inputSupport) {
             //note that in this case we don't hold onto anything from this class loader
             //which is important for the test suite
@@ -34,7 +34,7 @@ public class ConsoleHelper {
             new TerminalConnection(new Consumer<Connection>() {
                 @Override
                 public void accept(Connection connection) {
-                    if (connection.supportsAnsi() && !config.basicConsole().orElse(consoleConfig.basic())) {
+                    if (connection.supportsAnsi() && !consoleConfig.basic()) {
                         QuarkusConsole.INSTANCE = new AeshConsole(connection);
                     } else {
                         LinkedBlockingDeque<Integer> queue = new LinkedBlockingDeque<>();

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
@@ -66,7 +66,7 @@ public class ConsoleProcessor {
             return ConsoleInstalledBuildItem.INSTANCE;
         }
         consoleInstalled = true;
-        if (config.console().orElse(consoleConfig.enabled())) {
+        if (consoleConfig.enabled()) {
             ConsoleHelper.installConsole(config, consoleConfig, launchModeBuildItem.isTest());
             ConsoleStateManager.init(QuarkusConsole.INSTANCE, launchModeBuildItem.getDevModeType().get());
             //note that this bit needs to be refactored so it is no longer tied to continuous testing

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -101,45 +101,6 @@ public interface TestConfig {
     Optional<List<String>> excludeEngines();
 
     /**
-     * Disable the testing status/prompt message at the bottom of the console
-     * and log these messages to STDOUT instead.
-     * <p>
-     * Use this option if your terminal does not support ANSI escape sequences.
-     * <p>
-     * This is deprecated, {@literal quarkus.console.basic} should be used instead.
-     */
-    @Deprecated
-    Optional<Boolean> basicConsole();
-
-    /**
-     * Disable color in the testing status and prompt messages.
-     * <p>
-     * Use this option if your terminal does not support color.
-     * <p>
-     * This is deprecated, {@literal quarkus.console.disable-color} should be used instead.
-     */
-    @Deprecated
-    Optional<Boolean> disableColor();
-
-    /**
-     * If test results and status should be displayed in the console.
-     * <p>
-     * If this is false results can still be viewed in the dev console.
-     * <p>
-     * This is deprecated, {@literal quarkus.console.enabled} should be used instead.
-     */
-    @Deprecated
-    Optional<Boolean> console();
-
-    /**
-     * Disables the ability to enter input on the console.
-     * <p>
-     * This is deprecated, {@literal quarkus.console.disable-input} should be used instead.
-     */
-    @Deprecated
-    Optional<Boolean> disableConsoleInput();
-
-    /**
      * Changes tests to use the 'flat' ClassPath used in Quarkus 1.x versions.
      * <p>
      * This means all Quarkus and test classes are loaded in the same ClassLoader,

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
@@ -314,18 +314,6 @@ public interface LogRuntimeConfig {
         Level level();
 
         /**
-         * If the console logging should be in color. If undefined, Quarkus takes
-         * best guess based on the operating system and environment.
-         * Note that this value is ignored if an extension is present that takes
-         * control of console formatting (e.g., an XML or JSON-format extension).
-         * <p>
-         * This has been deprecated and replaced with <code>quarkus.console.color</code>,
-         * as Quarkus now provides more console-based functionality than just logging.
-         */
-        @Deprecated
-        Optional<Boolean> color();
-
-        /**
          * Specify how much the colors should be darkened.
          * Note that this value is ignored if an extension is present that takes
          * control of console formatting (e.g., an XML or JSON-format extension).

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -875,9 +875,6 @@ public class LoggingSetupRecorder {
         if (consoleConfig.color().isPresent()) {
             return consoleConfig.color().get();
         }
-        if (logConfig.color().isPresent()) {
-            return logConfig.color().get();
-        }
         return QuarkusConsole.hasColorSupport();
     }
 


### PR DESCRIPTION
Removes configuration deprecated a long time ago (https://github.com/quarkusio/quarkus/pull/18286):

- `quarkus.test.basic-console`
- `quarkus.test.disable-color`
- `quarkus.test.console`
- `quarkus.test.disable-console-input`
- `quarkus.log.console.color`
