### PR TITLE
Optimize qualifiers collection and BeanInfo#hasDefaultQualifiers()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1458,12 +1458,18 @@ public class BeanDeployment {
             List<DisposerInfo> disposers) {
         // we don't have a `BeanInfo` for the producer yet (the outcome of this method is used to build it),
         // so we need to construct its set of qualifiers manually
-        Set<AnnotationInstance> qualifiers = new HashSet<>();
-        // ignore annotations on producer method parameters -- they may be injection point qualifiers
-        for (AnnotationInstance annotation : Annotations.getAnnotations(producer.kind(), getAnnotations(producer))) {
-            qualifiers.addAll(extractQualifiers(annotation));
+        Set<AnnotationInstance> annotations = Annotations.getAnnotations(producer.kind(), getAnnotations(producer));
+        Set<AnnotationInstance> qualifiers;
+        if (!annotations.isEmpty()) {
+            qualifiers = new HashSet<>();
+            // ignore annotations on producer method parameters -- they may be injection point qualifiers
+            for (AnnotationInstance annotation : annotations) {
+                qualifiers.addAll(extractQualifiers(annotation));
+            }
+        } else {
+            qualifiers = Set.of();
         }
-        Beans.addImplicitQualifiers(qualifiers); // need to consider `@Any` (and possibly `@Default`) too
+        qualifiers = Beans.addImplicitQualifiers(qualifiers); // need to consider `@Any` (and possibly `@Default`) too
 
         List<DisposerInfo> found = new ArrayList<>();
         for (DisposerInfo disposer : disposers) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -63,6 +63,7 @@ public class BeanInfo implements InjectionTargetInfo {
     protected final Set<Type> unrestrictedTypes;
 
     protected final Set<AnnotationInstance> qualifiers;
+    private final boolean hasDefaultQualifiers;
 
     private final List<Injection> injections;
 
@@ -142,8 +143,11 @@ public class BeanInfo implements InjectionTargetInfo {
             Beans.analyzeType(type, beanDeployment);
         }
         this.unrestrictedTypes = unrestrictedTypes != null ? unrestrictedTypes : types;
-        Beans.addImplicitQualifiers(qualifiers);
-        this.qualifiers = qualifiers;
+        this.qualifiers = Beans.addImplicitQualifiers(qualifiers);
+        // we have a fast path for all beans which didn't have a qualifier and for which we added them, which is the most common case
+        this.hasDefaultQualifiers = (this.qualifiers == BuiltinQualifier.DEFAULT_QUALIFIERS) ||
+                (this.qualifiers.size() == 2 && this.qualifiers.contains(BuiltinQualifier.DEFAULT.getInstance())
+                        && this.qualifiers.contains(BuiltinQualifier.ANY.getInstance()));
         this.injections = injections;
         this.declaringBean = declaringBean;
         this.disposer = disposer;
@@ -300,8 +304,7 @@ public class BeanInfo implements InjectionTargetInfo {
     }
 
     public boolean hasDefaultQualifiers() {
-        return qualifiers.size() == 2 && qualifiers.contains(BuiltinQualifier.DEFAULT.getInstance())
-                && qualifiers.contains(BuiltinQualifier.ANY.getInstance());
+        return hasDefaultQualifiers;
     }
 
     List<Injection> getInjections() {
@@ -712,7 +715,7 @@ public class BeanInfo implements InjectionTargetInfo {
                     .beanDeployment(beanDeployment)
                     .target(targetClass)
                     .types(new HashSet<>(Set.of(ClassType.create(interceptionProxy.getTargetClass()))))
-                    .qualifiers(new HashSet<>())
+                    .qualifiers(Set.of())
                     .build();
             pseudoBean.interceptedMethods = Map.copyOf(pseudoBean.initInterceptedMethods(errors,
                     bytecodeTransformerConsumer, transformUnproxyableClasses, bindingsSourceClass));

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -735,13 +735,16 @@ public final class Beans {
         return false;
     }
 
-    static void addImplicitQualifiers(Set<AnnotationInstance> qualifiers) {
-        if (qualifiers.isEmpty()
-                || (qualifiers.size() <= 2 && qualifiers.stream()
-                        .allMatch(a -> DotNames.NAMED.equals(a.name()) || DotNames.ANY.equals(a.name())))) {
+    static Set<AnnotationInstance> addImplicitQualifiers(Set<AnnotationInstance> qualifiers) {
+        if (qualifiers.isEmpty()) {
+            return BuiltinQualifier.DEFAULT_QUALIFIERS;
+        }
+        if ((qualifiers.size() <= 2 && qualifiers.stream()
+                .allMatch(a -> DotNames.NAMED.equals(a.name()) || DotNames.ANY.equals(a.name())))) {
             qualifiers.add(BuiltinQualifier.DEFAULT.getInstance());
         }
         qualifiers.add(BuiltinQualifier.ANY.getInstance());
+        return qualifiers;
     }
 
     static List<MethodInfo> getCallbacks(ClassInfo beanClass, DotName annotation, IndexView index) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinQualifier.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinQualifier.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.processor;
 
 import java.util.Collections;
+import java.util.Set;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
@@ -17,6 +18,8 @@ enum BuiltinQualifier {
             Default.Literal.class.getName()),
     ANY(AnnotationInstance.create(DotNames.ANY, null, Collections.emptyList()),
             Any.Literal.class.getName()),;
+
+    static final Set<AnnotationInstance> DEFAULT_QUALIFIERS = Set.of(DEFAULT.getInstance(), ANY.getInstance());
 
     private final AnnotationInstance instance;
 


### PR DESCRIPTION
Handle the case with no annotations more effectively. It will avoid adding elements to the HashSet and allows for some clever optimization of BeanInfo#hasDefaultQualifiers().

(noticed while benchmarking ArC rewrite to Gizmo 2)
