### PR TITLE
Note about Gradle configuration to use deployed snapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -840,6 +840,13 @@ repositories {
 }
 ```
 
+**Note**  Use the following definition in `repositories` section when using daily snapshot builds instead of local builds:
+```gradle
+    maven {
+        url 'https://central.sonatype.com/repository/maven-snapshots/'
+    }
+```
+
 ### MicroProfile TCK's
 
 Quarkus has a TCK module in `tcks` where all the MicroProfile TCK's are set up for you to run if you wish. These include


### PR DESCRIPTION
Note about Gradle configuration to use deployed snapshots

Possible after https://github.com/quarkusio/quarkus/pull/49675 change


Executed check: I triggered https://github.com/quarkusio/quarkus/actions/runs/17204321909 and verified that my gradle app builds in dev mode and all the bits get downloaded from sonatype snapshots as I nuked `~/.gradle`  and `~/.m2/repository`

I added following entry into repositories definition in `build.gradle` and `settings.gradle`
```gradle
    maven {
        url 'https://central.sonatype.com/repository/maven-snapshots/'
    }
```
