### PR TITLE
 Format property added in micrometer prometheus config

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigOpenMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigOpenMetricsTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.micrometer.deployment.export;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.prometheus.client.exporter.common.TextFormat;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+class PrometheusFormatConfigOpenMetricsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.export.prometheus.format", "openmetrics")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .withEmptyApplication();
+
+    @Test
+    void testPrometheusFormatConfigOpenMetricsDefault() {
+        RestAssured.given()
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+                .header("Content-Type", TextFormat.CONTENT_TYPE_OPENMETRICS_100);
+    }
+
+    @Test
+    void testPrometheusFormatConfigOpenMetricsWithTextPlainHeader() {
+        RestAssured.given()
+                .header("Accept", TextFormat.CONTENT_TYPE_004)
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+                .header("Content-Type", TextFormat.CONTENT_TYPE_004);
+    }
+
+    @Test
+    void testPrometheusFormatConfigOpenMetricsWithOpenMetricsHeader() {
+        RestAssured.given()
+                .header("Accept", TextFormat.CONTENT_TYPE_OPENMETRICS_100)
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+                .header("Content-Type", TextFormat.CONTENT_TYPE_OPENMETRICS_100);
+    }
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigOpenMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigOpenMetricsTest.java
@@ -16,6 +16,7 @@ class PrometheusFormatConfigOpenMetricsTest {
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.format", "openmetrics")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withEmptyApplication();
 
     @Test

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigPlainTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigPlainTest.java
@@ -16,6 +16,7 @@ class PrometheusFormatConfigPlainTest {
             .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
             .overrideConfigKey("quarkus.micrometer.export.prometheus.format", "plain")
             .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withEmptyApplication();
 
     @Test

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigPlainTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusFormatConfigPlainTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.micrometer.deployment.export;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.prometheus.client.exporter.common.TextFormat;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+class PrometheusFormatConfigPlainTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.export.prometheus.format", "plain")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .withEmptyApplication();
+
+    @Test
+    void testPrometheusFormatConfigPlainDefault() {
+        RestAssured.given()
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+                .header("Content-Type", TextFormat.CONTENT_TYPE_004);
+    }
+
+    @Test
+    void testPrometheusFormatConfigPlainWithOpenMetricsHeader() {
+        RestAssured.given()
+                .header("Accept", TextFormat.CONTENT_TYPE_OPENMETRICS_100)
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+                .header("Content-Type", TextFormat.CONTENT_TYPE_OPENMETRICS_100);
+    }
+
+    @Test
+    void testPrometheusFormatConfigPlainWithTextPlainHeader() {
+        RestAssured.given()
+                .header("Accept", TextFormat.CONTENT_TYPE_004)
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+                .header("Content-Type", TextFormat.CONTENT_TYPE_004);
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusConfigGroup.java
@@ -44,4 +44,13 @@ public interface PrometheusConfigGroup extends MicrometerConfig.CapabilityEnable
      */
     @WithDefault("true")
     boolean defaultRegistry();
+
+    /**
+     * The output format for Prometheus metrics.
+     * <p>
+     * By default, metrics are exported using the OpenMetrics format (application/openmetrics-text).
+     * Set this to {@code plain} to use the legacy Prometheus text format (text/plain).
+     */
+    @WithDefault("openmetrics")
+    String format();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusConfigGroup.java
@@ -49,8 +49,8 @@ public interface PrometheusConfigGroup extends MicrometerConfig.CapabilityEnable
      * The output format for Prometheus metrics.
      * <p>
      * By default, metrics are exported using the OpenMetrics format (application/openmetrics-text).
-     * Set this to {@code plain} to use the legacy Prometheus text format (text/plain).
+     * Set this to {@code PLAIN} to use the legacy Prometheus text format (text/plain).
      */
-    @WithDefault("openmetrics")
-    String format();
+    @WithDefault("OPENMETRICS")
+    PrometheusFormat format();
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusFormat.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/PrometheusFormat.java
@@ -1,0 +1,18 @@
+package io.quarkus.micrometer.runtime.config;
+
+import io.prometheus.client.exporter.common.TextFormat;
+
+public enum PrometheusFormat {
+    OPENMETRICS(TextFormat.CONTENT_TYPE_OPENMETRICS_100),
+    PLAIN(TextFormat.CONTENT_TYPE_004);
+
+    private final String contentType;
+
+    PrometheusFormat(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
@@ -11,6 +11,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
+import io.quarkus.micrometer.runtime.config.PrometheusFormat;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
@@ -51,14 +52,11 @@ public class PrometheusHandler implements Handler<RoutingContext> {
 
     private String chooseContentType(String acceptHeader) {
         if (acceptHeader == null || "*/*".equals(acceptHeader)) {
-            String configuredFormat = ConfigProvider.getConfig()
-                    .getOptionalValue("quarkus.micrometer.export.prometheus.format", String.class)
-                    .orElse("openmetrics");
+            PrometheusFormat configuredFormat = ConfigProvider.getConfig()
+                    .getOptionalValue("quarkus.micrometer.export.prometheus.format", PrometheusFormat.class)
+                    .orElse(PrometheusFormat.OPENMETRICS);
             
-            if ("plain".equals(configuredFormat)) {
-                return TextFormat.CONTENT_TYPE_004;
-            }
-            return TextFormat.CONTENT_TYPE_OPENMETRICS_100;
+            return configuredFormat.getContentType();
         }
         if (acceptHeader.contains("text/plain") || acceptHeader.contains("text/html")) {
             return TextFormat.CONTENT_TYPE_004;

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
@@ -55,7 +55,7 @@ public class PrometheusHandler implements Handler<RoutingContext> {
             PrometheusFormat configuredFormat = ConfigProvider.getConfig()
                     .getOptionalValue("quarkus.micrometer.export.prometheus.format", PrometheusFormat.class)
                     .orElse(PrometheusFormat.OPENMETRICS);
-            
+
             return configuredFormat.getContentType();
         }
         if (acceptHeader.contains("text/plain") || acceptHeader.contains("text/html")) {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.micrometer.prometheus.PrometheusMeterRegistry;
@@ -49,7 +50,14 @@ public class PrometheusHandler implements Handler<RoutingContext> {
     }
 
     private String chooseContentType(String acceptHeader) {
-        if (acceptHeader == null) {
+        if (acceptHeader == null || "*/*".equals(acceptHeader)) {
+            String configuredFormat = ConfigProvider.getConfig()
+                    .getOptionalValue("quarkus.micrometer.export.prometheus.format", String.class)
+                    .orElse("openmetrics");
+            
+            if ("plain".equals(configuredFormat)) {
+                return TextFormat.CONTENT_TYPE_004;
+            }
             return TextFormat.CONTENT_TYPE_OPENMETRICS_100;
         }
         if (acceptHeader.contains("text/plain") || acceptHeader.contains("text/html")) {


### PR DESCRIPTION
This PR adds support for configuring the default Prometheus metrics format through the
`quarkus.micrometer.export.prometheus.format` configuration property.

## Changes

- Added `format()` configuration option to `PrometheusConfigGroup` with values `"openmetrics"` (default) and `"plain"`
- Modified `PrometheusHandler` to use the configured format when no specific Accept header is provided
- Accept headers continue to override the configured format when present
- Added comprehensive test coverage for both configuration options and Accept header interactions

## Configuration

```properties
# Use legacy Prometheus text format by default 
quarkus.micrometer.export.prometheus.format=plain
# Use OpenMetrics format by default (default behavior) 
quarkus.micrometer.export.prometheus.format=openmetrics
```

## Behavior

- When no Accept header is provided, the configured format is used
- When Accept header is provided (e.g., text/plain or application/openmetrics-text), it takes precedence over
  configuration
- This allows custom metrics exporters/sidecars that don't support custom Accept headers to work with the plain text
  format

## Issues

- Fixes #49152
