### PR TITLE
Do not remove unused Mappings with Validator annotations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -26,6 +26,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.util.ReflectUtil;
 import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.ConfigMappingInterface;
 import io.smallrye.config.ConfigMappingInterface.LeafProperty;
@@ -36,12 +37,14 @@ import io.smallrye.config.ConfigMappingMetadata;
 import io.smallrye.config.ConfigMappings.ConfigClass;
 
 public class ConfigMappingUtils {
-
     public static final DotName CONFIG_MAPPING_NAME = DotName.createSimple(ConfigMapping.class.getName());
+    public static final DotName CONFIG_ROOT_NAME = DotName.createSimple(ConfigRoot.class.getName());
 
     private ConfigMappingUtils() {
+        throw new UnsupportedOperationException();
     }
 
+    // Used for application Mappings and MP ConfigProperties
     public static void processConfigClasses(
             CombinedIndexBuildItem combinedIndex,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
@@ -56,6 +59,11 @@ public class ConfigMappingUtils {
             AnnotationValue annotationPrefix = instance.value("prefix");
 
             if (!target.kind().equals(CLASS)) {
+                continue;
+            }
+
+            // Skip roots
+            if (target.hasAnnotation(CONFIG_ROOT_NAME)) {
                 continue;
             }
 
@@ -102,7 +110,7 @@ public class ConfigMappingUtils {
             BuildProducer<ConfigClassBuildItem> configClasses,
             BuildProducer<AdditionalConstrainedClassBuildItem> additionalConstrainedClasses) {
 
-        Class<?> configClass = configClassWithPrefix.getKlass();
+        Class<?> configClass = configClassWithPrefix.getType();
         String prefix = configClassWithPrefix.getPrefix();
 
         List<ConfigMappingMetadata> configMappingsMetadata = ConfigMappingLoader.getConfigMappingsMetadata(configClass);

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/UnremovedConfigMappingTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/UnremovedConfigMappingTest.java
@@ -35,7 +35,8 @@ public class UnremovedConfigMappingTest {
         mapping = CDI.current().select(UnremovedConfigMapping.class).get();
         assertEquals("1234", mapping.prop());
 
-        UnremovedConfigProperties properties = CDI.current().select(UnremovedConfigProperties.class).get();
+        UnremovedConfigProperties properties = CDI.current()
+                .select(UnremovedConfigProperties.class, ConfigProperties.Literal.of("mapping")).get();
         assertEquals("1234", properties.prop);
     }
 

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -249,6 +249,7 @@ class HibernateValidatorProcessor {
             CombinedIndexBuildItem combinedIndex,
             List<ConfigClassBuildItem> configClasses,
             BeanValidationAnnotationsBuildItem beanValidationAnnotations,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             BuildProducer<GeneratedResourceBuildItem> generatedResource,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -327,11 +328,13 @@ class HibernateValidatorProcessor {
                 continue;
             }
 
-            embeddingMap.get(constrainedConfigMapping).values().stream()
-                    .map(c -> c.getConfigComponentInterfaces())
-                    .flatMap(Collection::stream)
-                    .map(DotName::createSimple)
-                    .forEach(configComponentsInterfacesToRegisterForReflection::add);
+            for (ConfigClassBuildItem configClass : embeddingMap.get(constrainedConfigMapping).values()) {
+                unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(configClass.getConfigClass()));
+                configClass.getConfigComponentInterfaces()
+                        .stream()
+                        .map(DotName::createSimple)
+                        .forEach(configComponentsInterfacesToRegisterForReflection::add);
+            }
         }
         reflectiveClass.produce(ReflectiveClassBuildItem
                 .builder(configComponentsInterfacesToRegisterForReflection.stream().map(DotName::toString)

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/config/ConfigMappingInvalidTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/config/ConfigMappingInvalidTest.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.arc.Unremovable;
 import io.quarkus.runtime.configuration.DurationConverter;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.config.ConfigMapping;
@@ -73,7 +72,6 @@ public class ConfigMappingInvalidTest {
         fail();
     }
 
-    @Unremovable
     @ConfigMapping(prefix = "validator.server")
     public interface Server {
         @Max(3)
@@ -87,13 +85,11 @@ public class ConfigMappingInvalidTest {
         Integer number();
     }
 
-    @Unremovable
     @ConfigMapping(prefix = "validator.hierarchy")
     public interface Child extends Parent {
 
     }
 
-    @Unremovable
     @ConfigMapping(prefix = "validator.repeatable")
     public interface Repeatable {
         @Size(max = 10)
@@ -101,7 +97,6 @@ public class ConfigMappingInvalidTest {
         String name();
     }
 
-    @Unremovable
     @ConfigMapping(prefix = "cloud")
     @Prod
     public interface Cloud {


### PR DESCRIPTION
Application `@ConfigMappings` are not included in the application if they are unused like other CDI Beans. This PR will keep the mappings in the application (and force validation), if they contain Bean Validator annotations.

See https://github.com/quarkusio/quarkus/discussions/44705#discussioncomment-14191142