### PR TITLE
Arc - Validate qualifiers for array typed member that lack @Nonbinding annotation

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/stereotype/DoubleScopedStereotypeTestCase.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/stereotype/DoubleScopedStereotypeTestCase.java
@@ -2,10 +2,13 @@ package io.quarkus.arc.test.stereotype;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.enterprise.inject.Stereotype;
-import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
@@ -19,7 +22,7 @@ public class DoubleScopedStereotypeTestCase {
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(DoubleScopedStereotype.class, DoubleScopedStereotypeBean.class))
-            .setExpectedException(DeploymentException.class);
+            .setExpectedException(DefinitionException.class);
 
     @Inject
     DoubleScopedStereotypeBean bean;
@@ -32,6 +35,7 @@ public class DoubleScopedStereotypeTestCase {
     @SessionScoped
     @RequestScoped
     @Stereotype
+    @Retention(RetentionPolicy.RUNTIME)
     public @interface DoubleScopedStereotype {
     }
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -252,7 +252,7 @@ public class OidcBuildStep {
         return new QualifierRegistrarBuildItem(new QualifierRegistrar() {
             @Override
             public Map<DotName, Set<String>> getAdditionalQualifiers() {
-                return Map.of(TENANT_FEATURE_NAME, Set.of());
+                return Map.of(TENANT_FEATURE_NAME, Set.of("value"));
             }
         });
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantFeature.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantFeature.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.inject.Qualifier;
 
 /**
@@ -23,6 +24,7 @@ public @interface TenantFeature {
     /**
      * Identifies OIDC tenants to which a given feature applies.
      */
+    @Nonbinding
     String[] value();
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -180,7 +180,7 @@ public class BeanDeployment {
         qualifierNonbindingMembers = new HashMap<>();
         qualifiers = findQualifiers();
         for (QualifierRegistrar registrar : builder.qualifierRegistrars) {
-            for (Map.Entry<DotName, Set<String>> entry : registrar.getAdditionalQualifiers().entrySet()) {
+            for (Entry<DotName, Set<String>> entry : registrar.getAdditionalQualifiers().entrySet()) {
                 DotName dotName = entry.getKey();
                 ClassInfo classInfo = getClassByName(getBeanArchiveIndex(), dotName);
                 if (classInfo != null) {
@@ -188,6 +188,7 @@ public class BeanDeployment {
                     if (nonbindingMembers == null) {
                         nonbindingMembers = Collections.emptySet();
                     }
+                    validateQualifier(classInfo, nonbindingMembers);
                     qualifierNonbindingMembers.put(dotName, nonbindingMembers);
                     qualifiers.put(dotName, classInfo);
                 }
@@ -251,7 +252,7 @@ public class BeanDeployment {
     }
 
     ContextRegistrar.RegistrationContext registerCustomContexts(List<ContextRegistrar> contextRegistrars) {
-        io.quarkus.arc.processor.ContextRegistrar.RegistrationContext registrationContext = new io.quarkus.arc.processor.ContextRegistrar.RegistrationContext() {
+        ContextRegistrar.RegistrationContext registrationContext = new ContextRegistrar.RegistrationContext() {
             @Override
             public <V> V put(Key<V> key, V value) {
                 return buildContext.put(key, value);
@@ -287,7 +288,7 @@ public class BeanDeployment {
         }
     }
 
-    BeanRegistrar.RegistrationContext registerBeans(List<BeanRegistrar> beanRegistrars) {
+    RegistrationContext registerBeans(List<BeanRegistrar> beanRegistrars) {
         List<InjectionPointInfo> injectionPoints = new ArrayList<>();
         BeanDiscoveryResult beanDiscoveryResult = findBeans(
                 initBeanDefiningAnnotations(beanDefiningAnnotations.values(), stereotypes.keySet()), observers,
@@ -359,10 +360,10 @@ public class BeanDeployment {
                     TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - removalStart));
             //we need to re-initialize it, so it does not contain removed beans
             initBeanByTypeMap();
-            buildContext.putInternal(BuildExtension.Key.REMOVED_INTERCEPTORS, Collections.unmodifiableSet(removedInterceptors));
-            buildContext.putInternal(BuildExtension.Key.REMOVED_DECORATORS, Collections.unmodifiableSet(removedDecorators));
+            buildContext.putInternal(Key.REMOVED_INTERCEPTORS, Collections.unmodifiableSet(removedInterceptors));
+            buildContext.putInternal(Key.REMOVED_DECORATORS, Collections.unmodifiableSet(removedDecorators));
         }
-        buildContext.putInternal(BuildExtension.Key.REMOVED_BEANS, Collections.unmodifiableSet(removedBeans));
+        buildContext.putInternal(Key.REMOVED_BEANS, Collections.unmodifiableSet(removedBeans));
         LOGGER.debugf("Bean deployment initialized in %s ms", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
     }
 
@@ -854,9 +855,42 @@ public class BeanDeployment {
             if (isExcluded(qualifierClass)) {
                 continue;
             }
+            // check that all array typed methods are @Nonbinding
+            validateQualifier(qualifierClass, null);
             qualifiers.put(qualifierClass.name(), qualifierClass);
         }
         return qualifiers;
+    }
+
+    /**
+     * Validates the qualifier for binding members which are either array or annotation-valued and throws an exception
+     * if any is found.
+     *
+     * @param qualifierClass class info of the qualifier
+     * @param nonbindingMembers collection of members we consider {@code @Nonbinding} for synthetic qualifier, null otherwise
+     */
+    private void validateQualifier(ClassInfo qualifierClass, Set<String> nonbindingMembers) {
+        for (MethodInfo mi : qualifierClass.methods()) {
+            Type returnType = mi.returnType();
+            if ((nonbindingMembers != null && !nonbindingMembers.contains(mi.name()))
+                    || (nonbindingMembers == null && mi.annotation(DotNames.NONBINDING) == null)) {
+                String problem = null;
+                if (returnType.kind().equals(Type.Kind.ARRAY)) {
+                    problem = "array";
+                } else if (returnType.kind().equals(Type.Kind.CLASS)) {
+                    ClassInfo typeClassInfo = beanArchiveImmutableIndex.getClassByName(returnType.asClassType().name());
+                    if (typeClassInfo != null && typeClassInfo.isAnnotation()) {
+                        problem = "annotation";
+                    }
+                }
+                if (problem != null) {
+                    throw new DefinitionException("Qualifier annotation '" + qualifierClass + "' contains a member '"
+                            + mi.name()
+                            + "' with " + problem
+                            + "-valued return type. All such members have to be annotated with @jakarta.enterprise.util.Nonbinding");
+                }
+            }
+        }
     }
 
     private Map<DotName, ClassInfo> findContainerAnnotations(Map<DotName, ClassInfo> annotations) {
@@ -1376,12 +1410,12 @@ public class BeanDeployment {
             }
         }
 
-        for (Map.Entry<MethodInfo, Set<ClassInfo>> entry : syncObserverMethods.entrySet()) {
+        for (Entry<MethodInfo, Set<ClassInfo>> entry : syncObserverMethods.entrySet()) {
             registerObserverMethods(entry.getValue(), observers, injectionPoints,
                     beanClassToBean, entry.getKey(), false, observerTransformers, jtaCapabilities);
         }
 
-        for (Map.Entry<MethodInfo, Set<ClassInfo>> entry : asyncObserverMethods.entrySet()) {
+        for (Entry<MethodInfo, Set<ClassInfo>> entry : asyncObserverMethods.entrySet()) {
             registerObserverMethods(entry.getValue(), observers, injectionPoints,
                     beanClassToBean, entry.getKey(), true, observerTransformers, jtaCapabilities);
         }
@@ -1414,7 +1448,7 @@ public class BeanDeployment {
         // the whole package is indexed (otherwise we'd get a lot of warnings that
         // package-info.class couldn't be loaded during on-demand indexing)
         String packageName = beanClass.name().packagePrefix();
-        org.jboss.jandex.ClassInfo packageClass = beanArchiveImmutableIndex.getClassByName(
+        ClassInfo packageClass = beanArchiveImmutableIndex.getClassByName(
                 DotName.createSimple(packageName + ".package-info"));
         return packageClass != null && annotationStore.hasAnnotation(packageClass, DotNames.VETOED);
     }
@@ -1532,7 +1566,7 @@ public class BeanDeployment {
         }
     }
 
-    io.quarkus.arc.processor.ObserverRegistrar.RegistrationContext registerSyntheticObservers(
+    ObserverRegistrar.RegistrationContext registerSyntheticObservers(
             List<ObserverRegistrar> observerRegistrars) {
         ObserverRegistrationContextImpl context = new ObserverRegistrationContextImpl(buildContext, this);
         for (ObserverRegistrar registrar : observerRegistrars) {
@@ -1727,7 +1761,7 @@ public class BeanDeployment {
             }
         }
 
-        List<Map.Entry<String, List<BeanInfo>>> duplicateBeanIds = beans.stream()
+        List<Entry<String, List<BeanInfo>>> duplicateBeanIds = beans.stream()
                 .collect(Collectors.groupingBy(BeanInfo::getIdentifier))
                 .entrySet()
                 .stream()
@@ -1740,7 +1774,7 @@ public class BeanDeployment {
                     .append("Multiple beans with the same identifier found!\n")
                     .append("----------------------------------------------\n")
                     .append("This is an internal error. Please report a bug and attach the following listing.\n\n");
-            for (Map.Entry<String, List<BeanInfo>> entry : duplicateBeanIds) {
+            for (Entry<String, List<BeanInfo>> entry : duplicateBeanIds) {
                 error.append(entry.getKey()).append(" -> ").append(entry.getValue().size()).append(" beans:\n");
                 for (BeanInfo bean : entry.getValue()) {
                     error.append("- ").append(bean).append("\n");
@@ -1865,12 +1899,12 @@ public class BeanDeployment {
 
         @Override
         public BeanStream beans() {
-            return new BeanStream(get(BuildExtension.Key.BEANS));
+            return new BeanStream(get(Key.BEANS));
         }
 
         @Override
         public BeanStream removedBeans() {
-            return new BeanStream(get(BuildExtension.Key.REMOVED_BEANS));
+            return new BeanStream(get(Key.REMOVED_BEANS));
         }
 
     }
@@ -1913,7 +1947,7 @@ public class BeanDeployment {
     }
 
     private static class ObserverRegistrationContextImpl extends RegistrationContextImpl
-            implements io.quarkus.arc.processor.ObserverRegistrar.RegistrationContext {
+            implements ObserverRegistrar.RegistrationContext {
 
         ObserverRegistrationContextImpl(BuildContext buildContext, BeanDeployment beanDeployment) {
             super(buildContext, beanDeployment);
@@ -1931,7 +1965,7 @@ public class BeanDeployment {
 
         @Override
         public BeanStream beans() {
-            return new BeanStream(get(BuildExtension.Key.BEANS));
+            return new BeanStream(get(Key.BEANS));
         }
 
     }
@@ -1958,7 +1992,7 @@ public class BeanDeployment {
         }
 
         public BeanStream beans() {
-            return new BeanStream(get(BuildExtension.Key.BEANS));
+            return new BeanStream(get(Key.BEANS));
         }
 
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/BeanRegistrarTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/BeanRegistrarTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 import jakarta.inject.Qualifier;
@@ -275,6 +276,7 @@ public class BeanRegistrarTest {
 
         int age();
 
+        @Nonbinding
         Class<?>[] classes();
 
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/QualifierWithBindingAnnotationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/QualifierWithBindingAnnotationTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Qualifier;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class QualifierWithBindingAnnotationTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Alpha.class, MyQualifier.class, SomeAnnotation.class).shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    @MyQualifier(@SomeAnnotation("foo"))
+    static class Alpha {
+
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyQualifier {
+        SomeAnnotation value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SomeAnnotation {
+        String value();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/QualifierWithBindingArrayTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/QualifierWithBindingArrayTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Qualifier;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class QualifierWithBindingArrayTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class, MyQualifier.class).shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    @MyQualifier(first = { 1 }, second = { "foobar" })
+    static class Alpha {
+
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyQualifier {
+        int[] first();
+
+        String[] second();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/SyntheticQualifierWithBindingAnnotationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/SyntheticQualifierWithBindingAnnotationTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Qualifier;
+
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.processor.QualifierRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticQualifierWithBindingAnnotationTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ToBeQualifier.class, Alpha.class, SomeAnnotation.class)
+            .qualifierRegistrars(new QualifierRegistrar() {
+
+                @Override
+                public Map<DotName, Set<String>> getAdditionalQualifiers() {
+                    Map<DotName, Set<String>> qualifiers = new HashMap<>();
+                    qualifiers.put(DotName.createSimple(ToBeQualifier.class.getName()), Collections.emptySet());
+                    return qualifiers;
+                }
+            })
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    @ToBeQualifier(@SomeAnnotation("foo"))
+    static class Alpha {
+
+    }
+
+    // not marked as @Qualifier, instead it is added via registrar
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ToBeQualifier {
+        SomeAnnotation value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SomeAnnotation {
+        String value();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/SyntheticQualifierWithBindingArrayTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/SyntheticQualifierWithBindingArrayTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.processor.QualifierRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticQualifierWithBindingArrayTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ToBeQualifier.class, Alpha.class)
+            .qualifierRegistrars(new QualifierRegistrar() {
+
+                @Override
+                public Map<DotName, Set<String>> getAdditionalQualifiers() {
+                    Map<DotName, Set<String>> qualifiers = new HashMap<>();
+                    qualifiers.put(DotName.createSimple(ToBeQualifier.class.getName()), Collections.emptySet());
+                    return qualifiers;
+                }
+            })
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    @ToBeQualifier(first = { 1 }, second = { "foobar" })
+    static class Alpha {
+
+    }
+
+    // not marked as @Qualifier, instead it is added via registrar
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ToBeQualifier {
+        int[] first();
+
+        String[] second();
+    }
+}


### PR DESCRIPTION
Fixes #49646 

Arc now validates qualifiers, both discovered and registered synthetically, for all members that have array/annotation-valued types and are not annotated `@Nonbinding`. The error looks something like this:

> [ERROR]   Qualifier annotation 'io.quarkus.arc.test.validation.SyntheticQualifierWithBindingAnnotationTest$ToBeQualifier' contains a member 'value' with annotation-valued return type. All such members have to be annotated with @jakarta.enterprise.util.Nonbinding

