### PR TITLE
Skip oracle integration tests on AArch64

### DIFF
--- a/integration-tests/hibernate-reactive-oracle/pom.xml
+++ b/integration-tests/hibernate-reactive-oracle/pom.xml
@@ -270,6 +270,12 @@
                         </configuration>
                     </plugin>
                     <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>true</skipITs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -278,6 +278,12 @@
                         </configuration>
                     </plugin>
                     <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>true</skipITs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -243,6 +243,12 @@
                         </configuration>
                     </plugin>
                     <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>true</skipITs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/25832 that skips unit tests on AArch64 due to segfaults when running `docker.io/gvenzl/oracle-free:23-slim-faststart` on AArch64.

Closes: https://github.com/quarkusio/quarkus/issues/49718