### PR TITLE
Make sure preferred platform BOMs passed to ExtensionCatalogResolver are actually prioritized

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -26,7 +26,6 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.CodestartResourceLoadersBuilder;
-import io.quarkus.devtools.project.JavaVersion;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.project.buildfile.MavenProjectBuildFile;
@@ -59,13 +58,13 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
     protected List<RemoteRepository> repos;
 
     @Parameter(property = "bomGroupId", required = false)
-    private String bomGroupId;
+    String bomGroupId;
 
     @Parameter(property = "bomArtifactId", required = false)
-    private String bomArtifactId;
+    String bomArtifactId;
 
     @Parameter(property = "bomVersion", required = false)
-    private String bomVersion;
+    String bomVersion;
 
     @Component
     QuarkusWorkspaceProvider workspaceProvider;
@@ -91,7 +90,7 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
         }
 
         final QuarkusProject quarkusProject;
-        if (BuildTool.MAVEN.equals(buildTool) && project.getFile() != null) {
+        if (BuildTool.MAVEN.equals(buildTool) && project.getFile() != null && bomVersion == null) {
             try {
                 quarkusProject = MavenProjectBuildFile.getProject(projectArtifact(), project.getOriginalModel(), baseDir(),
                         project.getModel().getProperties(), artifactResolver(), getExtensionCatalogResolver(),
@@ -108,7 +107,8 @@ public abstract class QuarkusProjectMojoBase extends AbstractMojo {
                     .catalog(extensionCatalog)
                     .build();
             quarkusProject = QuarkusProject.of(baseDir(), extensionCatalog,
-                    codestartsResourceLoader, log, buildTool, JavaVersion.NA);
+                    codestartsResourceLoader, log, buildTool,
+                    MavenProjectBuildFile.resolveJavaVersion(project.getModel().getProperties()));
         }
 
         doExecute(quarkusProject, getMessageWriter());

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -128,7 +128,7 @@ public class MavenProjectBuildFile extends BuildFile {
                 codestartResourceLoaders, log, extensionManager, javaVersion);
     }
 
-    private static JavaVersion resolveJavaVersion(Properties projectProps) {
+    public static JavaVersion resolveJavaVersion(Properties projectProps) {
         if (projectProps.containsKey("maven.compiler.release")) {
             return new JavaVersion(projectProps.getProperty("maven.compiler.release"));
         }

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
@@ -3,10 +3,15 @@ package io.quarkus.devtools.testing.registry.client;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.util.repository.ChainedLocalRepositoryManager;
 
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.devtools.messagewriter.MessageWriter;
@@ -29,7 +34,7 @@ public class TestRegistryClient implements RegistryClient {
     private final boolean enableMavenResolver;
 
     public TestRegistryClient(RegistryClientEnvironment env, RegistryConfig clientConfig) {
-        this.resolver = env.resolver();
+        this.resolver = configureMavenResolver(env.resolver(), clientConfig);
         this.log = env.log();
         final Path configYaml = RegistriesConfigLocator.locateConfigYaml();
         if (configYaml == null) {
@@ -71,9 +76,33 @@ public class TestRegistryClient implements RegistryClient {
                 }
             }
         }
-        final Object o = clientConfig.getExtra().get("enable-maven-resolver");
-        enableMavenResolver = o == null ? false : Boolean.parseBoolean(o.toString());
+        enableMavenResolver = Boolean.parseBoolean(String.valueOf(clientConfig.getExtra().get("enable-maven-resolver")));
         this.config = registryConfig;
+    }
+
+    private static MavenArtifactResolver configureMavenResolver(MavenArtifactResolver originalResolver,
+            RegistryConfig registryConfig) {
+        Object testLocalMavenRepo = registryConfig.getExtra().get("test-local-maven-repo");
+        if (testLocalMavenRepo == null) {
+            return originalResolver;
+        }
+        try {
+            var session = new DefaultRepositorySystemSession(originalResolver.getSession());
+            session.setLocalRepositoryManager(new ChainedLocalRepositoryManager(
+                    originalResolver.getSystem().newLocalRepositoryManager(originalResolver.getSession(),
+                            new LocalRepository(testLocalMavenRepo.toString())),
+                    List.of(originalResolver.getSystem().newLocalRepositoryManager(originalResolver.getSession(),
+                            new LocalRepository(originalResolver.getMavenContext().getLocalRepo()))),
+                    false));
+            return new MavenArtifactResolver(new BootstrapMavenContext(BootstrapMavenContext.config()
+                    .setWorkspaceDiscovery(false)
+                    .setRepositorySystemSession(session)
+                    .setRemoteRepositoryManager(originalResolver.getRemoteRepositoryManager())
+                    .setRemoteRepositories(originalResolver.getRepositories())
+                    .setRepositorySystem(originalResolver.getSystem())));
+        } catch (BootstrapMavenException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -113,6 +113,48 @@ public class TestRegistryClientBuilder {
         return codestartBuilder;
     }
 
+    public TestRegistryClientBuilder installExternalPlatform(ExtensionCatalog platformCatalog) {
+        // install the BOM artifact
+        final ArtifactCoords bomCoords = platformCatalog.getBom();
+        final Model bomModel = initModel(bomCoords);
+        final List<Dependency> managedDeps = bomModel.getDependencyManagement().getDependencies();
+        for (Extension ext : platformCatalog.getExtensions()) {
+            final ArtifactCoords extCoords = ext.getArtifact();
+            final Dependency runtime = new Dependency();
+            runtime.setGroupId(extCoords.getGroupId());
+            runtime.setArtifactId(extCoords.getArtifactId());
+            runtime.setVersion(extCoords.getVersion());
+            managedDeps.add(runtime);
+            final Dependency deployment = new Dependency();
+            deployment.setGroupId(extCoords.getGroupId());
+            deployment.setArtifactId(extCoords.getArtifactId() + "-deployment");
+            deployment.setVersion(extCoords.getVersion());
+            managedDeps.add(deployment);
+        }
+        final Path bomFile = getTmpPath(bomCoords);
+        try {
+            ModelUtils.persistModel(bomFile, bomModel);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to persist BOM at " + bomFile, e);
+        }
+        install(bomCoords, bomFile);
+
+        // install the JSON descriptor
+        final ArtifactCoords jsonCoords = PlatformArtifacts.ensureCatalogArtifact(bomCoords);
+        final Path jsonFile = getTmpPath(jsonCoords);
+        try {
+            platformCatalog.persist(jsonFile);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to persist extension catalog " + jsonFile, e);
+        }
+        install(jsonCoords, jsonFile);
+
+        // install the extensions
+        installExtensionArtifacts(platformCatalog.getExtensions());
+
+        return this;
+    }
+
     private void installExtensionArtifacts(Collection<Extension> extensions) {
         for (Extension e : extensions) {
             Path jarPath = getTmpPath(e.getArtifact());
@@ -234,7 +276,7 @@ public class TestRegistryClientBuilder {
     }
 
     private void configureRegistry(TestRegistryBuilder registry) {
-        registry.configure(getRegistryDir(baseDir, registry.config.getId()));
+        registry.configure(getRegistryDir(baseDir, registry.config.getId()), getResolver());
         config.addRegistry(registry.config);
     }
 
@@ -283,6 +325,17 @@ public class TestRegistryClientBuilder {
          */
         public TestRegistryBuilder external() {
             this.external = true;
+            return this;
+        }
+
+        /**
+         * Enables Maven resolver for platform descriptors that couldn't be resolved by the configured platforms
+         * for this registry.
+         *
+         * @return this instance
+         */
+        public TestRegistryBuilder enableMavenResolver() {
+            this.enableMavenResolver = true;
             return this;
         }
 
@@ -357,7 +410,7 @@ public class TestRegistryClientBuilder {
             memberCatalogs.add(member);
         }
 
-        private void configure(Path registryDir) {
+        private void configure(Path registryDir, MavenArtifactResolver resolver) {
             if (Files.exists(registryDir)) {
                 if (!Files.isDirectory(registryDir)) {
                     throw new IllegalStateException(registryDir + " exists and is not a directory");
@@ -375,6 +428,11 @@ public class TestRegistryClientBuilder {
                         TestRegistryClient.class.getProtectionDomain().getCodeSource().getLocation().toExternalForm());
                 if (enableMavenResolver) {
                     config.setExtra("enable-maven-resolver", true);
+                    try {
+                        config.setExtra("test-local-maven-repo", resolver.getMavenContext().getLocalRepo());
+                    } catch (BootstrapMavenException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
 
@@ -638,11 +696,7 @@ public class TestRegistryClientBuilder {
             final TestPlatformCatalogMemberBuilder quarkusBom = newMember("quarkus-bom");
             quarkusBom.addExtension("io.quarkus", "quarkus-core", release.getQuarkusCoreVersion());
             Map<String, Object> metadata = quarkusBom.getProjectProperties();
-            metadata.put("maven-plugin-groupId", quarkusBom.extensions.getBom().getGroupId());
-            metadata.put("maven-plugin-artifactId", "quarkus-maven-plugin");
-            metadata.put("maven-plugin-version", quarkusBom.extensions.getBom().getVersion());
-            metadata.put("compiler-plugin-version", "3.8.1");
-            metadata.put("surefire-plugin-version", "3.0.0");
+            setMainPlatformProjectProperties(metadata, quarkusBom.extensions.getBom());
             return quarkusBom;
         }
 
@@ -677,6 +731,26 @@ public class TestRegistryClientBuilder {
             }
             metadata.put("members", members);
         }
+    }
+
+    /**
+     * Initializes basic project metadata for dev tools
+     *
+     * @param catalog platform catalog
+     */
+    public static void initMainPlatformMetadata(ExtensionCatalog catalog) {
+        Map<String, Object> metadata = catalog.getMetadata();
+        Map map = (Map) metadata.computeIfAbsent("project", k -> new HashMap<String, Object>());
+        map = (Map) map.computeIfAbsent("properties", k -> new HashMap<String, Object>());
+        setMainPlatformProjectProperties(map, catalog.getBom());
+    }
+
+    public static void setMainPlatformProjectProperties(Map<String, Object> metadata, ArtifactCoords bomCoords) {
+        metadata.put("maven-plugin-groupId", bomCoords.getGroupId());
+        metadata.put("maven-plugin-artifactId", "quarkus-maven-plugin");
+        metadata.put("maven-plugin-version", bomCoords.getVersion());
+        metadata.put("compiler-plugin-version", "3.8.1");
+        metadata.put("surefire-plugin-version", "3.0.0");
     }
 
     public static class TestPlatformCatalogMemberBuilder {
@@ -772,7 +846,7 @@ public class TestRegistryClientBuilder {
             final Extension.Mutable e = Extension.builder()
                     .setArtifact(coords)
                     .setName(artifactId)
-                    .setOrigins(Collections.singletonList(extensions));
+                    .setOrigins(List.of(extensions));
             if (metadata != null) {
                 e.getMetadata().putAll(metadata);
             }
@@ -1011,7 +1085,7 @@ public class TestRegistryClientBuilder {
         pom.setGroupId(coords.getGroupId());
         pom.setArtifactId(coords.getArtifactId());
         pom.setVersion(coords.getVersion());
-        pom.setPackaging("pom");
+        pom.setPackaging(ArtifactCoords.TYPE_POM);
         pom.setDependencyManagement(new DependencyManagement());
 
         final Dependency d = new Dependency();

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientFactory.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientFactory.java
@@ -15,8 +15,8 @@ public class TestRegistryClientFactory implements RegistryClientFactory {
         if (instance != null) {
             return instance;
         }
-        if (Thread.currentThread().getContextClassLoader() instanceof QuarkusClassLoader) {
-            ((QuarkusClassLoader) Thread.currentThread().getContextClassLoader()).addCloseTask(() -> instance = null);
+        if (Thread.currentThread().getContextClassLoader() instanceof QuarkusClassLoader qcl) {
+            qcl.addCloseTask(() -> instance = null);
         }
         return instance = new TestRegistryClientFactory(env);
     }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionCatalogFromProvidedPlatformsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionCatalogFromProvidedPlatformsTest.java
@@ -5,12 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
-import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +17,7 @@ import io.quarkus.bootstrap.resolver.maven.workspace.ModelUtils;
 import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
 public class ExtensionCatalogFromProvidedPlatformsTest extends MultiplePlatformBomsTestBase {
@@ -60,7 +60,7 @@ public class ExtensionCatalogFromProvidedPlatformsTest extends MultiplePlatformB
 
         enableRegistryClient();
 
-        // install 1.0.0 version which is not recommended by the registry any more
+        // install 1.0.0 version which is not recommended by the registry anymore
         installNotRecommendedVersion("1.0.1", "1.0.0", "acme-foo-bom");
         installNotRecommendedVersion("1.0.1", "1.0.0", "acme-baz-bom");
         installNotRecommendedVersion("1.0.1", "1.0.0", "quarkus-bom");
@@ -104,13 +104,12 @@ public class ExtensionCatalogFromProvidedPlatformsTest extends MultiplePlatformB
     @Test
     public void test() throws Exception {
         final ExtensionCatalog catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog(
-                Collections.singletonList(ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-baz-bom::pom:1.0.0")));
-        assertThat(Arrays.asList(new ArtifactCoords[] {
+                List.of(ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-baz-bom::pom:1.0.0")));
+        assertThat(List.of(
                 ArtifactCoords.fromString("io.quarkus:quarkus-core:1.1.2"),
                 ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-foo:1.0.0"),
                 ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-baz:1.0.0"),
-                ArtifactCoords.fromString("org.acme:acme-quarkus-other:5.5.5")
-        })).isEqualTo(
-                catalog.getExtensions().stream().map(e -> e.getArtifact()).collect(Collectors.toList()));
+                ArtifactCoords.fromString("org.acme:acme-quarkus-other:5.5.5"))).isEqualTo(
+                        catalog.getExtensions().stream().map(Extension::getArtifact).collect(Collectors.toList()));
     }
 }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.maven.model.Model;
@@ -27,6 +28,7 @@ import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.platform.tools.ToolsConstants;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.PlatformStreamCoords;
 import io.quarkus.registry.config.RegistriesConfigLocator;
@@ -118,6 +120,17 @@ public abstract class MultiplePlatformBomsTestBase {
                 .execute();
     }
 
+    protected QuarkusCommandOutcome createProject(Path projectDir, List<ArtifactCoords> preferredBoms, List<String> extensions)
+            throws Exception {
+        return new CreateProject(
+                getQuarkusProject(projectDir, preferredBoms))
+                .groupId("org.acme")
+                .artifactId("acme-app")
+                .version("0.0.1-SNAPSHOT")
+                .extensions(new HashSet<>(extensions))
+                .execute();
+    }
+
     protected List<ArtifactCoords> toPlatformExtensionCoords(String... artifactIds) {
         return toPlatformExtensionCoords(Arrays.asList(artifactIds));
     }
@@ -149,10 +162,30 @@ public abstract class MultiplePlatformBomsTestBase {
 
     protected void assertModel(final Path projectDir, final List<ArtifactCoords> expectedBoms,
             final List<ArtifactCoords> expectedExtensions, String platformVersion) throws IOException {
+        assertModel(projectDir, expectedBoms, expectedExtensions, Map.of(PLATFORM_VERSION_POM_PROP, platformVersion));
+    }
+
+    protected void assertModel(final Path projectDir, final List<ArtifactCoords> expectedBoms,
+            final List<ArtifactCoords> expectedExtensions,
+            Map<String, String> expectedProperties) throws IOException {
         final Model model = ModelUtils.readModel(projectDir.resolve("pom.xml"));
-        assertThat(model.getProperties().getProperty(PLATFORM_GROUP_ID_POM_PROP)).isEqualTo(getMainPlatformKey());
-        assertThat(model.getProperties().getProperty(PLATFORM_ARTIFACT_ID_POM_PROP)).isEqualTo("quarkus-bom");
-        assertThat(model.getProperties().getProperty(PLATFORM_VERSION_POM_PROP)).isEqualTo(platformVersion);
+
+        var expectedPlatformGroupId = expectedProperties == null ? null : expectedProperties.get(PLATFORM_GROUP_ID_POM_PROP);
+        if (expectedPlatformGroupId == null) {
+            expectedPlatformGroupId = getMainPlatformKey();
+        }
+        assertThat(model.getProperties().getProperty(PLATFORM_GROUP_ID_POM_PROP)).isEqualTo(expectedPlatformGroupId);
+
+        var expectedPlatformArtifactId = expectedProperties == null ? null
+                : expectedProperties.get(PLATFORM_ARTIFACT_ID_POM_PROP);
+        if (expectedPlatformArtifactId == null) {
+            expectedPlatformArtifactId = ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID;
+        }
+        assertThat(model.getProperties().getProperty(PLATFORM_ARTIFACT_ID_POM_PROP)).isEqualTo(expectedPlatformArtifactId);
+
+        var expectedPlatformVersion = expectedProperties == null ? null : expectedProperties.get(PLATFORM_VERSION_POM_PROP);
+        assertThat(expectedPlatformVersion).isNotNull();
+        assertThat(model.getProperties().getProperty(PLATFORM_VERSION_POM_PROP)).isEqualTo(expectedPlatformVersion);
 
         final List<ArtifactCoords> actualBoms = model.getDependencyManagement().getDependencies().stream()
                 .map(d -> ArtifactCoords.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(),
@@ -167,6 +200,8 @@ public abstract class MultiplePlatformBomsTestBase {
         assertThat(model.getDependencies().stream()
                 .map(d -> ArtifactCoords.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion()))
                 .collect(Collectors.toSet())).containsAll(expectedExtensions);
+
+        assertThat(model.getProperties()).containsAllEntriesOf(expectedProperties);
     }
 
     ArtifactCoords platformExtensionCoords(String artifactId) {
@@ -189,6 +224,12 @@ public abstract class MultiplePlatformBomsTestBase {
             throws RegistryResolutionException {
         return QuarkusProjectHelper.getProject(projectDir,
                 QuarkusProjectHelper.getCatalogResolver().resolveExtensionCatalog(stream), BuildTool.MAVEN);
+    }
+
+    protected QuarkusProject getQuarkusProject(Path projectDir, List<ArtifactCoords> preferredBoms)
+            throws RegistryResolutionException {
+        return QuarkusProjectHelper.getProject(projectDir,
+                QuarkusProjectHelper.getCatalogResolver().resolveExtensionCatalog(preferredBoms), BuildTool.MAVEN);
     }
 
     static Path newProjectDir(String name) {

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PreferredPlatformKeysNotProvidedByRegistryTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PreferredPlatformKeysNotProvidedByRegistryTest.java
@@ -1,0 +1,138 @@
+package io.quarkus.devtools.project.create;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.util.PlatformArtifacts;
+
+/**
+ * This test mimics the scenario of registry.quarkus.io recommending io.quarkus.platform
+ * while there is the io.quarkus one, that is not known to registry.quarkus.io but is still resolvable
+ * by the Maven registry client configured to pull data from registry.quarkus.io.
+ *
+ * It's a weird setup, but it's been working like this from the beginning. We may want to re-work this
+ * to something more reasonable.
+ *
+ * The test makes sure that the preferred target platform, provided by a user as input (such the io.quarkus one),
+ * is prioritized over what the configured registry recommends.
+ */
+public class PreferredPlatformKeysNotProvidedByRegistryTest extends MultiplePlatformBomsTestBase {
+
+    private static final String MAIN_PLATFORM_KEY = "org.acme.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+
+        final String quarkusCoreVersion = "1.1.2";
+        final ArtifactCoords ioQuarkusBomCoords = ArtifactCoords.pom("io.quarkus", "quarkus-bom", quarkusCoreVersion);
+        var ioQuarkusPlatform = ExtensionCatalog.builder()
+                .setBom(ioQuarkusBomCoords)
+                .setId(PlatformArtifacts.ensureCatalogArtifact(ioQuarkusBomCoords).toString())
+                .setQuarkusCoreVersion(quarkusCoreVersion)
+                .setPlatform(true);
+        TestRegistryClientBuilder.initMainPlatformMetadata(ioQuarkusPlatform);
+        ioQuarkusPlatform.addExtension(Extension.builder()
+                .setName("Quarkus Core")
+                .setGroupId("io.quarkus")
+                .setArtifactId("quarkus-core")
+                .setVersion(quarkusCoreVersion)
+                .setOrigins(List.of(ioQuarkusPlatform)));
+        ioQuarkusPlatform.addExtension(Extension.builder()
+                .setName("Acme Magic")
+                .setGroupId("io.quarkus")
+                .setArtifactId("acme-magic")
+                .setVersion(quarkusCoreVersion)
+                .setOrigins(List.of(ioQuarkusPlatform)));
+        ioQuarkusPlatform.addExtension(Extension.builder()
+                .setName("Acme Foo")
+                .setGroupId("io.quarkus")
+                .setArtifactId("acme-foo")
+                .setVersion(quarkusCoreVersion)
+                .setOrigins(List.of(ioQuarkusPlatform)));
+
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("registry.acme.org")
+                // platform key
+                .newPlatform(MAIN_PLATFORM_KEY)
+                // 1.0 STREAM
+                .newStream("1.0")
+                // 1.0.1 release
+                .newRelease("1.0.1")
+                .quarkusVersion(quarkusCoreVersion)
+                .addCoreMember().release()
+                .newMember("acme-foo-bom").addExtension("io.quarkus", "acme-foo", quarkusCoreVersion).release()
+                .registry()
+                .newNonPlatformCatalog(quarkusCoreVersion)
+                .addExtension("org.acme", "acme-quarkus-other", "5.5.5")
+                .registry()
+                .enableMavenResolver()
+                .clientBuilder()
+                // external io.quarkus
+                .installExternalPlatform(ioQuarkusPlatform)
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return MAIN_PLATFORM_KEY;
+    }
+
+    @Test
+    public void testRegistryRecommendation() throws Exception {
+        final ExtensionCatalog catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog();
+        assertThat(List.of(
+                ArtifactCoords.jar("io.quarkus", "quarkus-core", "1.1.2"),
+                ArtifactCoords.jar("io.quarkus", "acme-foo", "1.1.2"),
+                ArtifactCoords.jar("org.acme", "acme-quarkus-other", "5.5.5")))
+                .containsExactlyInAnyOrderElementsOf(
+                        catalog.getExtensions().stream().map(Extension::getArtifact).collect(Collectors.toList()));
+
+        final Path projectDir = newProjectDir("preferred-platform-keys-registry-recommendation");
+        createProject(projectDir, List.of("acme-foo"));
+        assertModel(projectDir,
+                List.of(mainPlatformBom(), platformMemberBomCoords("acme-foo-bom")),
+                List.of(ArtifactCoords.jar("io.quarkus", "acme-foo", null)),
+                Map.of("quarkus.platform.group-id", MAIN_PLATFORM_KEY,
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "1.0.1"));
+    }
+
+    @Test
+    public void testIoQuarkusBom() throws Exception {
+        final List<ArtifactCoords> preferredBoms = List.of(ArtifactCoords.pom("io.quarkus", "quarkus-bom", "1.1.2"));
+        final ExtensionCatalog catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog(
+                preferredBoms);
+        assertThat(List.of(
+                ArtifactCoords.jar("io.quarkus", "quarkus-core", "1.1.2"),
+                ArtifactCoords.jar("io.quarkus", "acme-magic", "1.1.2"),
+                ArtifactCoords.jar("io.quarkus", "acme-foo", "1.1.2"),
+                ArtifactCoords.jar("org.acme", "acme-quarkus-other", "5.5.5")))
+                .containsExactlyInAnyOrderElementsOf(
+                        catalog.getExtensions().stream().map(Extension::getArtifact).collect(Collectors.toList()));
+
+        final Path projectDir = newProjectDir("preferred-platform-keys-io-quarkus");
+        createProject(projectDir, preferredBoms, List.of("acme-foo"));
+        assertModel(projectDir,
+                List.of(mainPlatformBom()),
+                List.of(ArtifactCoords.jar("io.quarkus", "acme-foo", null)),
+                Map.of("quarkus.platform.group-id", "io.quarkus",
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "1.1.2"));
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/PlatformPreferenceIndex.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/PlatformPreferenceIndex.java
@@ -1,0 +1,38 @@
+package io.quarkus.registry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maintains an index of platform release preferences for multiple registries.
+ * <p>
+ * This class maps a registry index (typically representing a specific registry)
+ * to a list of {@link PlatformReleasePreferenceIndex} instances, each corresponding
+ * to a particular platform key. It provides efficient retrieval and creation of
+ * platform release preference indices for use in managing platform preferences
+ * across different registries.
+ * </p>
+ * <p>
+ * Intended for internal use within the registry client to support platform preference
+ * resolution logic.
+ * </p>
+ */
+class PlatformPreferenceIndex {
+
+    private final Map<Integer, List<PlatformReleasePreferenceIndex>> releaseIndices = new HashMap<>();
+
+    PlatformReleasePreferenceIndex getReleaseIndex(int registryIndex, String platformKey) {
+        var list = releaseIndices.computeIfAbsent(registryIndex, k -> new ArrayList<>(1));
+        for (int i = 0; i < list.size(); ++i) {
+            final PlatformReleasePreferenceIndex candidate = list.get(i);
+            if (candidate.getPlatformKey().equals(platformKey)) {
+                return candidate;
+            }
+        }
+        final PlatformReleasePreferenceIndex result = new PlatformReleasePreferenceIndex(platformKey, list.size());
+        list.add(result);
+        return result;
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/PlatformReleasePreferenceIndex.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/PlatformReleasePreferenceIndex.java
@@ -1,0 +1,63 @@
+package io.quarkus.registry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Maintains an index of platform releases and their preference order for a specific platform key.
+ * <p>
+ * This class is used to track the order in which platform releases (by version) are preferred for a given platform,
+ * as well as the overall preference index of the platform itself.
+ */
+class PlatformReleasePreferenceIndex {
+
+    private final String platformKey;
+    private final int platformIndex;
+    private final List<String> releaseVersions = new ArrayList<>(1);
+
+    /**
+     * Constructs a new PlatformReleasePreferenceIndex for the given platform key and index.
+     *
+     * @param platformKey the unique key identifying the platform (must not be null)
+     * @param platformIndex the preference index of the platform
+     */
+    public PlatformReleasePreferenceIndex(String platformKey, int platformIndex) {
+        this.platformKey = Objects.requireNonNull(platformKey, "Platform key is null");
+        this.platformIndex = platformIndex;
+    }
+
+    /**
+     * Returns the unique key identifying the platform.
+     *
+     * @return the platform key
+     */
+    String getPlatformKey() {
+        return platformKey;
+    }
+
+    /**
+     * Returns the preference index of the platform.
+     *
+     * @return the platform index
+     */
+    int getPlatformIndex() {
+        return platformIndex;
+    }
+
+    /**
+     * Returns the preference index of the given release version for this platform.
+     * If the version is not already present, it is added to the end of the list.
+     *
+     * @param version the release version to look up or add
+     * @return the index of the release version in the preference list
+     */
+    int getReleaseIndex(String version) {
+        int i = releaseVersions.indexOf(version);
+        if (i < 0) {
+            i = releaseVersions.size();
+            releaseVersions.add(version);
+        }
+        return i;
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -52,7 +52,6 @@ class RegistryExtensionResolver {
 
     private final RegistryConfig config;
     private final RegistryClient extensionResolver;
-    private final int index;
 
     private final Pattern recognizedQuarkusVersions;
     private final Collection<String> recognizedGroupIds;
@@ -61,11 +60,9 @@ class RegistryExtensionResolver {
      */
     private final String offeringSupportKey;
 
-    RegistryExtensionResolver(RegistryClient extensionResolver,
-            MessageWriter log, int index) throws RegistryResolutionException {
+    RegistryExtensionResolver(RegistryClient extensionResolver, MessageWriter log) throws RegistryResolutionException {
         this.extensionResolver = Objects.requireNonNull(extensionResolver, "Registry extension resolver is null");
         this.config = extensionResolver.resolveRegistryConfig();
-        this.index = index;
 
         final String versionExpr = config.getQuarkusVersions() == null ? null
                 : config.getQuarkusVersions().getRecognizedVersionsExpression();
@@ -84,10 +81,6 @@ class RegistryExtensionResolver {
 
     String getId() {
         return config.getId();
-    }
-
-    int getIndex() {
-        return index;
     }
 
     int checkQuarkusVersion(String quarkusVersion) {


### PR DESCRIPTION
It seems like we haven't hit this issue or it didn't manifest itself because we haven't tested a wider range of use-cases involving user preferred platform BOMs.

The use-case I found to be problematic in the current impl was updating a project from a (current) release recommended by the registry to `io.quarkus:quarkus-bom:999-SNAPSHOT`.

First, there didn't seem to be a way to point the `io.quarkus:quarkus-bom:999-SNAPSHOT` as the desired target.
Second, even after enabling that input, the implementation of `ExtensionCatalogResolver` had to be fixed to actually prioritize that input over what the registry provides.

The effects of this change can be tested locally by
1. building the 999-SNAPSHOT branch from this PR;
2. `quarkus create app`
3. `cd code-with-quarkus`
4. `mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:update -DnoRewrite -DbomGroupId=io.quarkus -DbomVersion=999-SNAPSHOT`

With this change the output will contain
```
[INFO] Suggested Quarkus platform BOM updates:
[INFO]  -       [io.quarkus.platform:quarkus-bom:pom:3.25.4]
[INFO]  +       [io.quarkus:quarkus-bom:pom:999-SNAPSHOT]
```
instead of the "project being up-to-date" message.

The use of `-DbomXXX` parameters seems questionable and could be improved. These parameters did exist in the base mojo the `UpdateMojo` extends, so it was a matter of simply using them.

FYI @gastaldi @gsmet 