### PR TITLE
[3.20] Backports for 3.20.2.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.6.3.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.2.Final</jboss-marshalling.version>
         <jboss-threads.version>3.8.0.Final</jboss-threads.version>
-        <vertx.version>4.5.18</vertx.version>
+        <vertx.version>4.5.20</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
 
         <mutiny.version>2.9.2</mutiny.version>
         <smallrye-common.version>2.12.0</smallrye-common.version>
-        <vertx.version>4.5.18</vertx.version>
+        <vertx.version>4.5.20</vertx.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.18.2</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.18</vertx.version>
+        <vertx.version>4.5.20</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
/cc @jmartisk @rsvoboda @gastaldi @aloubyansky @rsvoboda @mjurc

Note that we will also have to backport it in the regular backport meetings for inclusion for 3.20.3 as this targets a specific emergency release branch.