### PR TITLE
Include Hibernate Validator in 3.20 dependabot upgrade group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -269,6 +269,7 @@ updates:
           - "org.hibernate.orm*"
           - "org.hibernate.reactive*"
           - "org.hibernate.search*"
+          - "org.hibernate.validator*"
     ignore:
       # Major/minor upgrades require more work and synchronization, we do them manually.
       # Only use dependabot for micros (patch versions).


### PR DESCRIPTION
Since it's for an LTS branch and it would be better to keep the updates together to not have conflicts if multiple dependabot PRs are opened

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

