### PR TITLE
Add findByIds API to Panache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -223,6 +223,9 @@ List<Person> allPersons = Person.listAll();
 // finding a specific person by ID
 person = Person.findById(personId);
 
+// finding specific persons by their IDs
+List<Person> personsById = Person.findByIds(List.of(personId1, personId2));
+
 // finding a specific person by ID via an Optional
 Optional<Person> optional = Person.findByIdOptional(personId);
 person = optional.orElseThrow(() -> new NotFoundException());
@@ -440,6 +443,9 @@ List<Person> allPersons = personRepository.listAll();
 
 // finding a specific person by ID
 person = personRepository.findById(personId);
+
+// finding specific persons by their IDs
+List<Person> personsById = personRepository.findByIds(List.of(personId1, personId2);
 
 // finding a specific person by ID via an Optional
 Optional<Person> optional = personRepository.findByIdOptional(personId);

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -205,6 +205,11 @@ List<Person> allPersons = Person.listAll();
 ObjectId personId = new ObjectId(idAsString);
 person = Person.findById(personId);
 
+// finding a specific persons by their ID
+ObjectId personId1 = new ObjectId(id1AsString);
+ObjectId personId2 = new ObjectId(id2AsString);
+List<Person> person = Person.findByIds(List.of(personId1, personId2);
+
 // finding a specific person by ID via an Optional
 Optional<Person> optional = Person.findByIdOptional(personId);
 person = optional.orElseThrow(() -> new NotFoundException());
@@ -372,6 +377,11 @@ List<Person> allPersons = personRepository.listAll();
 // here we build a new ObjectId, but you can also retrieve it from the existing entity after being persisted
 ObjectId personId = new ObjectId(idAsString);
 person = personRepository.findById(personId);
+
+// finding a specific persons by their ID
+ObjectId personId1 = new ObjectId(id1AsString);
+ObjectId personId2 = new ObjectId(id2AsString);
+List<Person> person = personRepository.findByIds(List.of(personId1, personId2);
 
 // finding a specific person by ID via an Optional
 Optional<Person> optional = personRepository.findByIdOptional(personId);
@@ -863,7 +873,7 @@ data class Person (
 
 [IMPORTANT]
 ====
-Unlike the @BsonCreator approach, `val` cannot be used here. Properties must be defined as `var`, otherwise, the system creates an object with 
+Unlike the @BsonCreator approach, `val` cannot be used here. Properties must be defined as `var`, otherwise, the system creates an object with
 `null` values for every property.
 ====
 
@@ -934,6 +944,11 @@ Uni<List<ReactivePerson>> allPersons = ReactivePerson.listAll();
 // here we build a new ObjectId, but you can also retrieve it from the existing entity after being persisted
 ObjectId personId = new ObjectId(idAsString);
 Uni<ReactivePerson> personById = ReactivePerson.findById(personId);
+
+// finding a specific persons by their ID
+ObjectId personId1 = new ObjectId(id1AsString);
+ObjectId personId2 = new ObjectId(id2AsString);
+Uni<List<Person>> person = ReactivePerson.findByIds(List.of(personId1, personId2);
 
 // finding a specific person by ID via an Optional
 Uni<Optional<ReactivePerson>> optional = ReactivePerson.findByIdOptional(personId);

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -2,11 +2,8 @@ package io.quarkus.hibernate.orm.panache.common.runtime;
 
 import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
@@ -193,6 +190,10 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     public Optional<?> findByIdOptional(Class<?> entityClass, Object id, LockModeType lockModeType) {
         return Optional.ofNullable(findById(entityClass, id, lockModeType));
+    }
+
+    public List<?> findByIds(Class<?> entityClass, List<?> ids) {
+        return getSession(entityClass).findMultiple(entityClass, ids);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String query, Object... params) {

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/test/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/TestAnalogs.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/test/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/TestAnalogs.kt
@@ -36,7 +36,7 @@ class TestAnalogs {
         compare(
             map(JavaPanacheRepository::class),
             map(PanacheRepository::class),
-            listOf("findByIdOptional"),
+            listOf("findByIdOptional", "findByIds"),
         )
     }
 
@@ -61,7 +61,9 @@ class TestAnalogs {
                 }
             }
         }
-        javaMethods.removeIf { it.name.endsWith("Optional") || it in implemented }
+        javaMethods.removeIf {
+            it.name.endsWith("Optional") || it.name == "findByIds" || it in implemented
+        }
 
         //        methods("javaMethods", javaMethods)
         //        methods("kotlinMethods", kotlinMethods)
@@ -101,7 +103,10 @@ class TestAnalogs {
         }
 
         javaMethods.removeIf {
-            it.name.endsWith("Optional") || it.name in allowList || it in implemented
+            it.name.endsWith("Optional") ||
+                it.name == "findByIds" ||
+                it.name in allowList ||
+                it in implemented
         }
 
         //        methods("javaMethods", javaMethods)

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -163,6 +163,18 @@ public abstract class PanacheEntityBase {
     }
 
     /**
+     * Find entities of this type by their IDs.
+     *
+     * @param ids the IDs of the entities to find.
+     * @return a list containing the entities found, with null elements representing missing entities, with the list ordered by
+     *         the positions of their ids in the given list of identifiers.
+     */
+    @GenerateBridge
+    public static <T extends PanacheEntityBase> List<T> findByIds(List<?> ids) {
+        throw implementationInjectionMissing();
+    }
+
+    /**
      * Find entities using a query, with optional indexed parameters.
      *
      * @param query a {@link io.quarkus.hibernate.orm.panache query string}

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
@@ -162,6 +162,18 @@ public interface PanacheRepositoryBase<Entity, Id> {
     }
 
     /**
+     * Find entities of this type by their IDs.
+     *
+     * @param ids the IDs of the entities to find.
+     * @return a list containing the entities found, with null elements representing missing entities, with the list ordered by
+     *         the positions of their ids in the given list of identifiers.
+     */
+    @GenerateBridge
+    default <T extends PanacheEntityBase> List<T> findByIds(List<?> ids) {
+        throw INSTANCE.implementationInjectionMissing();
+    }
+
+    /**
      * Find entities using a query, with optional indexed parameters.
      *
      * @param query a {@link io.quarkus.hibernate.orm.panache query string}

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/test/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/TestAnalogs.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/test/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/TestAnalogs.kt
@@ -66,7 +66,9 @@ class TestAnalogs {
                 }
             }
         }
-        javaMethods.removeIf { it.name == "findByIdOptional" || it in implemented }
+        javaMethods.removeIf {
+            it.name == "findByIdOptional" || it.name == "findByIds" || it in implemented
+        }
 
         methods("javaMethods", javaMethods)
         methods("kotlinMethods", kotlinMethods)

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
@@ -1,10 +1,8 @@
 package io.quarkus.mongodb.panache.common.runtime;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import static com.mongodb.client.model.Filters.in;
+
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -423,6 +421,13 @@ public abstract class MongoOperations<QueryType, UpdateType> {
 
     public Optional findByIdOptional(Class<?> entityClass, Object id) {
         return Optional.ofNullable(findById(entityClass, id));
+    }
+
+    public <Entity, ID> List<Entity> findByIds(Class<?> entityClass, List<ID> ids) {
+        MongoCollection collection = mongoCollection(entityClass);
+        ClientSession session = getSession(entityClass);
+        return session == null ? (List<Entity>) collection.find(in(ID, ids)).into(new ArrayList<>())
+                : (List<Entity>) collection.find(session, in(ID, ids)).into(new ArrayList<>());
     }
 
     public QueryType find(Class<?> entityClass, String query, Object... params) {

--- a/extensions/panache/mongodb-panache-kotlin/runtime/src/test/kotlin/io/quarkus/mongodb/panache/kotlin/TestAnalogs.kt
+++ b/extensions/panache/mongodb-panache-kotlin/runtime/src/test/kotlin/io/quarkus/mongodb/panache/kotlin/TestAnalogs.kt
@@ -54,12 +54,12 @@ class TestAnalogs {
         compare(
             map(JavaPanacheMongoRepositoryBase::class),
             map(PanacheMongoRepositoryBase::class),
-            listOf("findByIdOptional"),
+            listOf("findByIdOptional", "findByIds"),
         )
         compare(
             map(ReactiveJavaPanacheMongoRepositoryBase::class),
             map(ReactivePanacheMongoRepositoryBase::class),
-            listOf("findByIdOptional"),
+            listOf("findByIdOptional", "findByIds"),
         )
     }
 
@@ -119,7 +119,9 @@ class TestAnalogs {
                 }
             }
         }
-        javaMethods.removeIf { it.name == "findByIdOptional" || it in implemented }
+        javaMethods.removeIf {
+            it.name == "findByIdOptional" || it.name == "findByIds" || it in implemented
+        }
 
         methods("javaMethods", javaMethods)
         methods("kotlinMethods", kotlinMethods)

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
@@ -95,6 +95,17 @@ public abstract class PanacheMongoEntityBase {
     }
 
     /**
+     * Find entities of this type by their IDs.
+     *
+     * @param ids the IDs of the entities to find.
+     * @return a list containing the entities found.
+     */
+    @GenerateBridge
+    public static <T extends PanacheMongoEntityBase> List<T> findByIds(List<?> ids) {
+        throw INSTANCE.implementationInjectionMissing();
+    }
+
+    /**
      * Find entities using a query, with optional indexed parameters.
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
@@ -103,6 +103,17 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
     }
 
     /**
+     * Find entities of this type by their IDs.
+     *
+     * @param ids the IDs of the entities to find.
+     * @return a list containing the entities found.
+     */
+    @GenerateBridge
+    default List<Entity> findByIds(List<Id> ids) {
+        throw INSTANCE.implementationInjectionMissing();
+    }
+
+    /**
      * Find entities using a query, with optional indexed parameters.
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoEntityBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoEntityBase.java
@@ -98,6 +98,17 @@ public abstract class ReactivePanacheMongoEntityBase {
     }
 
     /**
+     * Find entities of this type by their IDs.
+     *
+     * @param ids the IDs of the entities to find.
+     * @return a list containing the entities found.
+     */
+    @GenerateBridge
+    public static <T extends ReactivePanacheMongoEntityBase> Uni<List<T>> findByIds(List<?> ids) {
+        throw INSTANCE.implementationInjectionMissing();
+    }
+
+    /**
      * Find entities using a query, with optional indexed parameters.
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoRepositoryBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoRepositoryBase.java
@@ -104,6 +104,17 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
     }
 
     /**
+     * Find entities of this type by their IDs.
+     *
+     * @param ids the IDs of the entities to find.
+     * @return a list containing the entities found.
+     */
+    @GenerateBridge
+    default Uni<List<Entity>> findByIds(List<?> ids) {
+        throw INSTANCE.implementationInjectionMissing();
+    }
+
+    /**
      * Find entities using a query, with optional indexed parameters.
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
@@ -748,27 +748,12 @@ public class StockMethodsAdder {
                     ResultHandle entityClass = findAllById.readInstanceField(entityClassFieldDescriptor,
                             findAllById.getThis());
 
-                    ResultHandle list;
-                    AnnotationTarget idAnnotationTarget = getIdAnnotationTarget(entityDotName, index);
-                    FieldInfo idField = getIdField(idAnnotationTarget);
-                    if ((idField != null) &&
-                            (DotNames.LONG.equals(idField.type().name()) || DotNames.INTEGER.equals(idField.type().name())
-                                    || DotNames.STRING.equals(idField.type().name()))) {
-                        MethodDescriptor method = ofMethod(RepositorySupport.class, "findByIds",
-                                List.class, AbstractJpaOperations.class, Class.class, String.class,
-                                Iterable.class);
-                        list = findAllById.invokeStaticMethod(method,
-                                findAllById.readStaticField(operationsField),
-                                entityClass,
-                                findAllById.load(idField.name()), findAllById.getMethodParam(0));
-                    } else {
-                        list = findAllById.invokeStaticMethod(
-                                MethodDescriptor.ofMethod(RepositorySupport.class, "findByIds",
-                                        List.class, AbstractJpaOperations.class, Class.class, Iterable.class),
-                                findAllById.readStaticField(operationsField),
-                                entityClass,
-                                findAllById.getMethodParam(0));
-                    }
+                    ResultHandle list = findAllById.invokeStaticMethod(
+                            MethodDescriptor.ofMethod(RepositorySupport.class, "findByIds",
+                                    List.class, AbstractJpaOperations.class, Class.class, Iterable.class),
+                            findAllById.readStaticField(operationsField),
+                            entityClass,
+                            findAllById.getMethodParam(0));
 
                     findAllById.returnValue(list);
                 }

--- a/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
+++ b/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
@@ -17,20 +17,15 @@ public final class RepositorySupport {
     public static List<?> findByIds(AbstractJpaOperations<PanacheQuery<?>> operations, Class<?> entityClass,
             Iterable<?> ids) {
         Objects.requireNonNull(ids);
-        List<Object> result = new ArrayList<>();
-        for (Object id : ids) {
-            Object byId = operations.findById(entityClass, id);
-            if (byId != null) {
-                result.add(byId);
-            }
-        }
-        return result;
-    }
 
-    public static List<?> findByIds(AbstractJpaOperations<PanacheQuery<?>> operations, Class<?> entityClass,
-            String idField, Iterable<Long> ids) {
-        Objects.requireNonNull(ids);
-        return operations.find(entityClass, String.format("%s in ?1", idField), ids).list();
+        List<Object> result = new ArrayList<>();
+        ids.forEach(result::add);
+
+        // Hibernate's findMultiple also returns null elements for non-found ids. we filter out null values here to stay consistent with the previous behavior.
+        return operations.findByIds(entityClass, new ArrayList<>(result))
+                .stream()
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     public static void deleteAll(AbstractJpaOperations<PanacheQuery<?>> operations, Iterable<?> entities) {

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
@@ -273,7 +273,17 @@ public class TestEndpoint {
         Assertions.assertEquals(person, byId);
         Assertions.assertEquals("Person<" + person.id + ">", byId.toString());
 
+        Person person2 = makeSavedPerson();
+        List<Person> byIds = Person.findByIds(List.of(person.id, Long.MAX_VALUE, person2.id));
+        Assertions.assertEquals(3, byIds.size());
+        Assertions.assertEquals(person, byIds.get(0));
+        Assertions.assertNull(byIds.get(1));
+        Assertions.assertEquals(person2, byIds.get(2));
+        Assertions.assertEquals("Person<" + person.id + ">", byIds.get(0).toString());
+        Assertions.assertEquals("Person<" + person2.id + ">", byIds.get(2).toString());
+
         person.delete();
+        person2.delete();
         Assertions.assertEquals(0, Person.count());
 
         person = makeSavedPerson();
@@ -346,7 +356,7 @@ public class TestEndpoint {
         person1.name = "testFLush1";
         person1.uniqueName = "unique";
         person1.persist();
-        Person person2 = new Person();
+        person2 = new Person();
         person2.name = "testFLush2";
         person2.uniqueName = "unique";
         try {
@@ -820,7 +830,17 @@ public class TestEndpoint {
         byId = personDao.findByIdOptional(person.id, LockModeType.PESSIMISTIC_READ).get();
         Assertions.assertEquals(person, byId);
 
+        Person person2 = makeSavedPersonDao();
+        List<Person> byIds = personDao.findByIds(List.of(person.id, Long.MAX_VALUE, person2.id));
+        Assertions.assertEquals(3, byIds.size());
+        Assertions.assertEquals(person, byIds.get(0));
+        Assertions.assertNull(byIds.get(1));
+        Assertions.assertEquals(person2, byIds.get(2));
+        Assertions.assertEquals("Person<" + person.id + ">", byIds.get(0).toString());
+        Assertions.assertEquals("Person<" + person2.id + ">", byIds.get(2).toString());
+
         personDao.delete(person);
+        personDao.delete(person2);
         Assertions.assertEquals(0, personDao.count());
 
         person = makeSavedPersonDao();
@@ -891,7 +911,7 @@ public class TestEndpoint {
         person1.name = "testFlush1";
         person1.uniqueName = "unique";
         personDao.persist(person1);
-        Person person2 = new Person();
+        person2 = new Person();
         person2.name = "testFlush2";
         person2.uniqueName = "unique";
         try {

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheMockingTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheMockingTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.panache.defaultpu;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.inject.Inject;
@@ -188,6 +189,16 @@ public class PanacheMockingTest {
         // bridge call
         Assertions.assertEquals(Optional.empty(),
                 ((PanacheRepositoryBase) realPersonRepository).findByIdOptional(0l, LockModeType.NONE));
+
+        // normal method call
+        Assertions.assertEquals(Collections.emptyList(), realPersonRepository.findByIds(List.of(0l)));
+        // bridge call
+        Assertions.assertEquals(Collections.emptyList(), ((PanacheRepositoryBase) realPersonRepository).findByIds(List.of(0l)));
+        // normal method call
+        Assertions.assertEquals(Collections.emptyList(), realPersonRepository.findByIds(List.of(0l)));
+        // bridge call
+        Assertions.assertEquals(Collections.emptyList(),
+                ((PanacheRepositoryBase) realPersonRepository).findByIds(List.of(0l)));
 
         // normal method call
         Assertions.assertEquals(false, realPersonRepository.deleteById(0l));

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
@@ -82,6 +82,12 @@ public class BookEntityResource {
         return BookEntity.<BookEntity> findByIdOptional(new ObjectId(id)).orElseThrow(() -> new NotFoundException());
     }
 
+    @POST
+    @Path("/ids")
+    public List<BookEntity> findByIdsBooks(List<String> ids) {
+        return BookEntity.findByIds(ids.stream().map(ObjectId::new).toList());
+    }
+
     @GET
     @Path("/search/{author}")
     public List<BookShortView> getBooksByAuthor(@PathParam("author") String author) {

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
@@ -77,6 +77,12 @@ public class BookRepositoryResource {
         return bookRepository.findByIdOptional(new ObjectId(id)).orElseThrow(() -> new NotFoundException());
     }
 
+    @POST
+    @Path("/ids")
+    public List<Book> findByIdsBooks(List<String> ids) {
+        return bookRepository.findByIds(ids.stream().map(ObjectId::new).toList());
+    }
+
     @GET
     @Path("/search/{author}")
     public List<BookShortView> getBooksByAuthor(@PathParam("author") String author) {

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/resources/PersonEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/resources/PersonEntityResource.java
@@ -83,6 +83,12 @@ public class PersonEntityResource {
         return PersonEntity.findById(Long.parseLong(id));
     }
 
+    @POST
+    @Path("/ids")
+    public List<PersonEntity> getPerson(List<String> ids) {
+        return PersonEntity.findByIds(ids.stream().map(Long::valueOf).toList());
+    }
+
     @GET
     @Path("/count")
     public long countAll() {

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheMockingTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheMockingTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.mongodb.panache;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.inject.Inject;
@@ -127,6 +128,12 @@ public class MongodbPanacheMockingTest {
         Assertions.assertEquals(Optional.empty(), realPersonRepository.findByIdOptional(0L));
         // bridge call
         Assertions.assertEquals(Optional.empty(), ((PanacheMongoRepositoryBase) realPersonRepository).findByIdOptional(0L));
+
+        // normal method call
+        Assertions.assertEquals(Collections.emptyList(), realPersonRepository.findByIds(List.of(0L)));
+        // bridge call
+        Assertions.assertEquals(Collections.emptyList(),
+                ((PanacheMongoRepositoryBase) realPersonRepository).findByIds(List.of(0L)));
 
         // normal method call
         Assertions.assertEquals(false, realPersonRepository.deleteById(0L));

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.it.mongodb.panache;
 
-import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
@@ -182,6 +182,22 @@ class MongodbPanacheResourceTest {
         //test findByIdOptional
         book = get(endpoint + "/optional/" + book.getId().toString()).as(BookDTO.class);
         Assertions.assertNotNull(book);
+
+        //test findByIds
+        String idBook1 = book.getId();
+        String idBook2 = get(endpoint + "/search?author=Charles Baudelaire&title=Les fleurs du mal").as(BookDTO.class).getId();
+
+        list = RestAssured
+                .given()
+                .header("Content-Type", "application/json")
+                .body(List.of(idBook1, idBook2))
+                .post(endpoint + "/ids")
+                .as(LIST_OF_BOOK_TYPE_REF);
+        Assertions.assertEquals(2, list.size());
+        Assertions.assertNotNull(list.get(0).getTitle());
+        Assertions.assertEquals("Notre-Dame de Paris 2", list.get(0).getTitle());
+        Assertions.assertNotNull(list.get(1).getTitle());
+        Assertions.assertEquals("Les fleurs du mal", list.get(1).getTitle());
 
         // update categories list using HQL
         response = RestAssured


### PR DESCRIPTION
[Hibernate 7](https://in.relation.to/2025/05/20/hibernate-orm-seven/) introduced a new API to [find multiple Entities by their IDs](https://docs.jboss.org/hibernate/orm/7.1/javadocs/org/hibernate/Session.html#findMultiple(jakarta.persistence.EntityGraph,java.util.List,jakarta.persistence.FindOption...)), which is not yet available in [Hibernate ORM with Panache](https://quarkus.io/guides/hibernate-orm-panache). To allow making use of it, this PR introduces a new API called `findByIds` (returns `List<Entity>`).

It also adds a similar `findByIds` API for [MongoDB with Panache](https://quarkus.io/guides/mongodb-panache), albeit only performing a `collection.find(Filters.in("_id", ids))`, to avoid falling short.