### PR TITLE
Fix QwcExtention typo in docs

### DIFF
--- a/docs/src/main/asciidoc/assistant.adoc
+++ b/docs/src/main/asciidoc/assistant.adoc
@@ -257,7 +257,7 @@ To use this state in your page:
 import { observeState } from 'lit-element-state'; // <1>
 import { assistantState } from 'assistant-state'; // <2>
 
-export class QwcExtentionPage extends observeState(LitElement) {  // <3>
+export class QwcExtensionPage extends observeState(LitElement) {  // <3>
 ----
 <1> import observeState from the LitState library.
 <2> import the state you are interested in, in this case assistant state.

--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -728,7 +728,7 @@ To use this state in your page:
 import { observeState } from 'lit-element-state'; // <1>
 import { connectionState } from 'connection-state'; // <2>
 
-export class QwcExtentionPage extends observeState(LitElement) {  // <3>
+export class QwcExtensionPage extends observeState(LitElement) {  // <3>
 ----
 <1> import observeState from the LitState library.
 <2> import the state you are interested in, in this case connection state.
@@ -756,7 +756,7 @@ To use this state in your page:
 import { observeState } from 'lit-element-state'; // <1>
 import { themeState } from 'theme-state'; // <2>
 
-export class QwcExtentionPage extends observeState(LitElement) {  // <3>
+export class QwcExtensionPage extends observeState(LitElement) {  // <3>
 ----
 <1> import observeState from the LitState library.
 <2> import the state you are interested in, in this case theme state.
@@ -790,7 +790,7 @@ To use this state in your page:
 import { observeState } from 'lit-element-state'; // <1>
 import { assistantState } from 'assistant-state'; // <2>
 
-export class QwcExtentionPage extends observeState(LitElement) {  // <3>
+export class QwcExtensionPage extends observeState(LitElement) {  // <3>
 ----
 <1> import observeState from the LitState library.
 <2> import the state you are interested in, in this case assistant state.


### PR DESCRIPTION
Everyone would know what 'extention' means, but 'extension' is the more conventional spelling. I think this is safe to change because it's just docs examples, not an actual API. 