### PR TITLE
Allow extensions to contribute to welcome message

### DIFF
--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/welcome/DynamicWelcomeBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/welcome/DynamicWelcomeBuildItem.java
@@ -1,0 +1,20 @@
+package io.quarkus.devui.spi.welcome;
+
+import io.quarkus.devui.spi.AbstractDevUIBuildItem;
+
+/**
+ * Adds dynamic data to the welcome page
+ */
+public final class DynamicWelcomeBuildItem extends AbstractDevUIBuildItem {
+
+    private final String html;
+
+    public DynamicWelcomeBuildItem(String html) {
+        super();
+        this.html = html;
+    }
+
+    public String getHTML() {
+        return this.html;
+    }
+}

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/welcome/WelcomeData.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/welcome/WelcomeData.java
@@ -10,6 +10,7 @@ public class WelcomeData {
     public String resourcesDir;
     public String sourceDir;
     public List<SelectedExtension> selectedExtensions = new ArrayList<>();
+    public String dynamicContent;
 
     public void addSelectedExtension(String name, String description, URL guide) {
         selectedExtensions.add(new SelectedExtension(name, description, guide));

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-welcome.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-welcome.js
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { devuiState } from 'devui-state';
 import 'qwc/qwc-endpoints.js';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 /**
  * This component shows the welcome screen
@@ -65,11 +66,12 @@ export class QwcWelcome extends LitElement {
         }
     
         .content {
-            height:100%;
+            min-height:100%;
             width:100%;
             background: var(--lumo-base-color);
             display: flex;
             justify-content: space-around;
+            padding-bottom: 20px;
         }
     
         .left-column {
@@ -174,12 +176,7 @@ export class QwcWelcome extends LitElement {
                                 <h1>You just made a Quarkus application.</h1>
                                 <p>This page is served by the Quarkus Dev UI (only in dev mode ) until you provide your own Web UI</p>
                                 <a href="extensions" class="cta-button">Visit the Dev UI</a>
-                                <div class="locations">
-                                    <span>Learn how you can <a href="https://quarkus.io/guides/http-reference" target="_blank">add your own static web content</a></span>
-                                    <span>App configuration: <code>${devuiState.welcomeData.configFile}</code></span>
-                                    <span>Static assets: <code>${devuiState.welcomeData.resourcesDir}/META-INF/resources/</code></span>
-                                    <span>Code: <code>${devuiState.welcomeData.sourceDir}</code></span>
-                                </div>
+                                ${this._renderDynamicWelcomeData()}
                                 <qwc-endpoints filter="Resource Endpoints"></qwc-endpoints>
                             </div>
                             <div class="right-column">
@@ -198,6 +195,29 @@ export class QwcWelcome extends LitElement {
     
     _reload(){
         window.location.href = '/';
+    }
+    
+    _renderDynamicWelcomeData(){
+        if(devuiState.welcomeData.dynamicContent){
+                return html`
+                <div class="locations">
+                    ${unsafeHTML(devuiState.welcomeData.dynamicContent)}
+                    ${this._renderFileLocations()}
+                </div>`;
+        }else {
+            return html`
+                <div class="locations">
+                    <span>Learn how you can <a href="https://quarkus.io/guides/web" target="_blank">add your own static web content</a></span>
+                    <span>Static assets: <code>${devuiState.welcomeData.resourcesDir}/META-INF/resources/</code></span>
+                    ${this._renderFileLocations()}
+                </div>
+            `;
+        }
+    }
+    
+    _renderFileLocations(){
+        return html`<span>App configuration: <code>${devuiState.welcomeData.configFile}</code></span>
+                    <span>Code: <code>${devuiState.welcomeData.sourceDir}</code></span>`;
     }
     
     _renderSelectedExtensions(){

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevUIProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevUIProcessor.java
@@ -9,6 +9,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
+import io.quarkus.devui.spi.welcome.DynamicWelcomeBuildItem;
 import io.quarkus.webdependency.locator.deployment.ImportMapBuildItem;
 
 public class WebDependencyLocatorDevUIProcessor {
@@ -52,5 +53,16 @@ public class WebDependencyLocatorDevUIProcessor {
 
         cardPageProducer.produce(cardPageBuildItem);
     }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public DynamicWelcomeBuildItem createDynamicWelcomeData() {
+        return new DynamicWelcomeBuildItem(DYNAMIC_WELCOME);
+    }
+
+    private static final String DYNAMIC_WELCOME = """
+                <span>Learn how you can <a href="https://quarkus.io/guides/web-dependency-locator" target="_blank">add your own web content</a></span>
+                <span>Static assets: <code>${devuiState.welcomeData.resourcesDir}/META-INF/resources/</code> OR </span>
+                <span>Dynamic assets: <code>${devuiState.welcomeData.resourcesDir}/web</code></span>
+            """;
 
 }


### PR DESCRIPTION
Fix #49770

This allows Extensions to contribute to the welcome screen. So Quinoa can now do something like this example from Web Dependency Locator :

```
@BuildStep(onlyIf = IsDevelopment.class)
    public DynamicWelcomeBuildItem createDynamicWelcomeData() {
        return new DynamicWelcomeBuildItem(DYNAMIC_WELCOME);
    }

    private static final String DYNAMIC_WELCOME = """
                <span>Learn how you can <a href="https://quarkus.io/guides/web-dependency-locator" target="_blank">add your own web content</a></span>
                <span>Static assets: <code>${devuiState.welcomeData.resourcesDir}/META-INF/resources/</code> OR </span>
                <span>Dynamic assets: <code>${devuiState.welcomeData.resourcesDir}/web</code></span>
            """;
```

<img width="990" height="442" alt="image" src="https://github.com/user-attachments/assets/6597990b-8e86-46a2-9db0-1eb13e5b8f06" />
