### PR TITLE
Tidy obsolete comments in dev services tests

### DIFF
--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesKafkaContinuousTestingTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesKafkaContinuousTestingTest.java
@@ -75,7 +75,6 @@ public class DevServicesKafkaContinuousTestingTest extends BaseDevServiceTest {
 
         ping500();
 
-        // We could check the container goes away, but we'd have to check slowly, because ryuk can be slow
         List<Container> kafkaContainers = getKafkaContainers();
         assertTrue(kafkaContainers.isEmpty(),
                 "Expected no containers, but got: " + prettyPrintContainerList(kafkaContainers));

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/continuoustesting/it/DevServicesRedisContinuousTestingTest.java
@@ -73,7 +73,6 @@ public class DevServicesRedisContinuousTestingTest {
 
         ping500();
 
-        // We could check the container goes away, but we'd have to check slowly, because ryuk can be slow
         List<Container> containers = getAllContainers();
         assertTrue(containers.isEmpty(), "Expected no containers, but got: " + prettyPrintContainerList(containers));
     }


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/48787 strengthened these tests, but the comment explaining why the tests are weak is still there. 