### PR TITLE
[3.26] WIP: Revert the --add-opens=java.base/java.lang=ALL-UNNAMED fix for Q 3.26

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -445,11 +445,8 @@
                         </systemPropertyVariables>
                         <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
-                        <!-- the add-opens java.naming/com.sun.naming.internal is here to allow to clear
-                             the propertiesCache in com.sun.naming.internal.ResourceManager -->
-                        <!-- the add-opens java.base/java.lang=ALL-UNNAMED is here for
-                             org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals() -->
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        <!-- the add-opens is here to allow to clear the propertiesCache in com.sun.naming.internal.ResourceManager -->
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1320,8 +1320,6 @@ public class JarResultBuildStep {
         Files.createDirectories(manifestPath.getParent());
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
-        // JDK 24+ needs --add-opens=java.base/java.lang=ALL-UNNAMED for org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals()
-        attributes.put(new Attributes.Name("Add-Opens"), "java.base/java.lang");
 
         for (Map.Entry<String, String> attribute : config.jar().manifest().attributes().entrySet()) {
             attributes.putValue(attribute.getKey(), attribute.getValue());


### PR DESCRIPTION
**Please do not merge**

Proposal to revert https://github.com/quarkusio/quarkus/commit/82b8a53bbc4c4a36af21ce181871c50cba365904 as that breaks the groovy extension on JDK 21-based native builders. See https://github.com/quarkiverse/quarkus-groovy/issues/256. The idea is that the Q 3.26 release only supports JDK-21-based native builders which don't need the `--add-opens` trick.