### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,12 +73,16 @@ fixes, documentation, examples... But first, read this page (including the small
 
 ## Legal
 
+
+
 All original contributions to Quarkus are licensed under the
 [ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0), version 2.0 or later, or, if another license is
 specified as governing the file or directory being modified, such other license.
 
-All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The DCO
-text is also included verbatim in the [dco.txt](dco.txt) file in the root directory of the repository.
+All contributions require agreement with the
+[Developer Certificate of Origin (DCO)](dco.txt) and must comply with
+applicable export control laws, including the U.S. Export Administration
+Regulations (EAR). The [DCO text](dco.txt) is also included verbatim in the dco.txt file in the root directory of the repository.
 
 ## Reporting an issue
 


### PR DESCRIPTION
Hello,

I’m writing to suggest a small but potentially important update to our Contributing Guide.
Recently, there was some confusion in a pull request [involving contributors from Russia](https://github.com/quarkusio/quarkus/pull/49581). I’m certain it was just a misunderstanding — no ill intent — but it highlighted a legal nuance that many of us, as developers, might not be fully aware of.

The discussion involved a reference to the Linux Foundation's rules, which in turn point to the U.S. Export Administration Regulations (EAR). While referencing EAR is perfectly reasonable, it became clear that most of us aren’t familiar with the legal specifics.

To prevent similar situations in the future, I propose adding a clear, concise note about EAR compliance to our Contributing Guide. This would help ensure all contributors are on the same page regarding export control regulations.

I’m not attached to my specific implementation — the goal is simply to make sure the mention is included. It might be a good idea to have your legal team review the wording to ensure it’s accurate.

Thanks for your time and consideration.

Best regards, Egor Lem.

P.S. Dura lex, sed lex — but a little clarity goes a long way.
