### PR TITLE
Set project.projectDir as workingDir by default in Gradle

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -129,7 +129,7 @@ public abstract class QuarkusDev extends QuarkusTask {
         objectFactory = getProject().getObjects();
 
         workingDirectory = objectFactory.property(File.class);
-        workingDirectory.convention(getProject().provider(() -> QuarkusPluginExtension.getLastFile(getCompilationOutput())));
+        workingDirectory.convention(getProject().provider(() -> getProject().getLayout().getProjectDirectory().getAsFile()));
 
         environmentVariables = objectFactory.mapProperty(String.class, String.class);
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -36,7 +36,6 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.cmd.RunCommandActionResultBuildItem;
 import io.quarkus.deployment.cmd.StartDevServicesAndRunCommandHandler;
-import io.quarkus.gradle.extension.QuarkusPluginExtension;
 import io.smallrye.common.process.ProcessBuilder;
 
 public abstract class QuarkusRun extends QuarkusBuildTask {
@@ -56,7 +55,7 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
                 .getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 
         workingDirectory = objectFactory.property(File.class);
-        workingDirectory.convention(getProject().provider(() -> QuarkusPluginExtension.getLastFile(getCompilationOutput())));
+        workingDirectory.convention(getProject().provider(() -> getProject().getLayout().getProjectDirectory().getAsFile()));
 
         jvmArgs = objectFactory.listProperty(String.class);
     }


### PR DESCRIPTION
Currently, the working directory in gradle (quarkusDev and quarkusRun) is set to `./projectDir/build/classes/java/main/` by default. This PR changes it to be `./projectDir`, similar to maven:

https://github.com/quarkusio/quarkus/blob/25ceb27cef0dd2e6232a3da2cda8a50e42970b27/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java#L1371

- Fixes #49792

