### PR TITLE
Add codegen source dirs to compile tasks instead of to the main source

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -21,6 +21,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <compiler-plugin.version>${version.compiler.plugin}</compiler-plugin.version>
         <kotlin.version>2.2.10</kotlin.version>
+        <ksp-gradle-plugin.version>2.2.10-2.0.2</ksp-gradle-plugin.version> <!-- Kotlin Symbol Processing plugin used in a test -->
         <dokka.version>2.0.0</dokka.version>
         <scala.version>2.13.12</scala.version>
         <scala-maven-plugin.version>4.9.5</scala-maven-plugin.version>

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class CachingTest {
     private static final Map<String, TaskOutcome> ALL_SUCCESS = Map.of(
             ":quarkusGenerateCode", TaskOutcome.SUCCESS,
-            ":quarkusGenerateCodeDev", TaskOutcome.SUCCESS,
             ":quarkusGenerateCodeTests", TaskOutcome.SUCCESS,
             ":quarkusAppPartsBuild", TaskOutcome.SUCCESS,
             ":quarkusDependenciesBuild", TaskOutcome.SUCCESS,
@@ -56,7 +55,6 @@ public class CachingTest {
             ":build", TaskOutcome.UP_TO_DATE);
     public static final Map<String, TaskOutcome> FROM_CACHE = Map.of(
             ":quarkusGenerateCode", TaskOutcome.FROM_CACHE,
-            ":quarkusGenerateCodeDev", TaskOutcome.SUCCESS,
             ":quarkusGenerateCodeTests", TaskOutcome.FROM_CACHE,
             ":quarkusAppPartsBuild", TaskOutcome.FROM_CACHE,
             ":quarkusDependenciesBuild", TaskOutcome.SUCCESS,
@@ -211,7 +209,7 @@ public class CachingTest {
                 .describedAs("output: %s", result.getOutput())
                 .containsEntry(":compileJava", TaskOutcome.FROM_CACHE)
                 .containsEntry(":quarkusGenerateCode", TaskOutcome.FROM_CACHE)
-                .containsEntry(":quarkusGenerateCodeDev", TaskOutcome.UP_TO_DATE)
+                .doesNotContainKey(":quarkusGenerateCodeDev")
                 .containsEntry(":quarkusAppPartsBuild", isFastOrLegacyJar ? TaskOutcome.FROM_CACHE : TaskOutcome.UP_TO_DATE)
                 .containsEntry(":quarkusDependenciesBuild", isFastOrLegacyJar ? TaskOutcome.SUCCESS : TaskOutcome.UP_TO_DATE)
                 .containsEntry(":quarkusBuild", simulateCI || isFastJar ? TaskOutcome.SUCCESS : TaskOutcome.FROM_CACHE);

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EagerResolutionTaskTest.java
@@ -46,7 +46,7 @@ public class EagerResolutionTaskTest {
         String addingQuarkusExtension = """
                 quarkus {
                   cachingRelevantProperties.add("FOO_ENV_VAR")
-                  quarkusBuildProperties.put("quarkus.package.type", "fast-jar")
+                  quarkusBuildProperties.put("quarkus.package.jar.type", "fast-jar")
                   quarkusBuildProperties.putAll(
                     provider {
                       tasks

--- a/integration-tests/gradle/src/main/resources/kotlin-ksp/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/kotlin-ksp/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.allopen")
+    id("io.quarkus")
+    id("com.google.devtools.ksp")
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
+
+dependencies {
+    implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+    implementation("io.quarkus:quarkus-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("io.quarkus:quarkus-rest")
+    testImplementation("io.quarkus:quarkus-junit5")
+    testImplementation("io.rest-assured:rest-assured")
+}
+
+group = "org.acme"
+version = "1.0.0-SNAPSHOT"
+
+tasks.withType<Test> {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}
+allOpen {
+    annotation("jakarta.ws.rs.Path")
+    annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("io.quarkus.test.junit.QuarkusTest")
+}
+
+kotlin {
+    compilerOptions {
+        javaParameters = true
+    }
+}
+
+java {
+    // test that the sources JAR works with the KSP plugin
+    withSourcesJar()
+}

--- a/integration-tests/gradle/src/main/resources/kotlin-ksp/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/kotlin-ksp/gradle.properties
@@ -1,0 +1,5 @@
+quarkusPluginId=io.quarkus
+quarkusPlatformGroupId=io.quarkus
+quarkusPlatformArtifactId=quarkus-bom
+kotlinVersion=${kotlin.version}
+kspVersion=${ksp-gradle-plugin.version}

--- a/integration-tests/gradle/src/main/resources/kotlin-ksp/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/kotlin-ksp/settings.gradle.kts
@@ -1,0 +1,23 @@
+pluginManagement {
+    val quarkusPluginVersion: String by settings
+    val quarkusPluginId: String by settings
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+                includeGroup("org.hibernate.orm")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id(quarkusPluginId) version quarkusPluginVersion
+        kotlin("jvm") version kotlinVersion
+        kotlin("plugin.allopen") version kotlinVersion
+        id("com.google.devtools.ksp") version kspVersion
+    }
+}
+rootProject.name="code-with-quarkus"

--- a/integration-tests/gradle/src/main/resources/kotlin-ksp/src/main/kotlin/org/acme/GreetingResource.kt
+++ b/integration-tests/gradle/src/main/resources/kotlin-ksp/src/main/kotlin/org/acme/GreetingResource.kt
@@ -1,0 +1,14 @@
+package org.acme
+
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+
+@Path("/hello")
+class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    fun hello() = "Hello from Quarkus REST"
+}

--- a/integration-tests/gradle/src/main/resources/kotlin-ksp/src/test/kotlin/org/acme/GreetingResourceTest.kt
+++ b/integration-tests/gradle/src/main/resources/kotlin-ksp/src/test/kotlin/org/acme/GreetingResourceTest.kt
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class GreetingResourceTest {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(`is`("Hello from Quarkus REST"))
+    }
+
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/KspPluginWithSourcesJarTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/KspPluginWithSourcesJarTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests compatibility of the KSP plugin with sourcesJar task.
+ * Previously, the Quarkus plugin added the codegen sources to the main sources and that created a cyclic task dependencies.
+ */
+public class KspPluginWithSourcesJarTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testKspWithSourcesJar() throws Exception {
+        final File projectDir = getProjectDir("kotlin-ksp");
+        runGradleWrapper(projectDir, "clean", "build");
+    }
+}


### PR DESCRIPTION
Fixes #29698

The main change is in that code gen source directories are not added to the main source sets. They are added as sources to compile to the compile tasks instead. The unfortunate detail is that for `compileKotlin` tasks we end up using reflection to do that.