### PR TITLE
Cache: introduce the CachedResults qualifier

### DIFF
--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -490,6 +490,40 @@ public class CachedService {
 <3> This key generator is not a CDI bean.
 <4> The `@CacheKey` annotation will be ignored when the `foo` cache data is invalidated, but `param1` will be the cache key when the `bar` cache data is invalidated.
 
+=== @CachedResults
+
+WARNING: This API is experimental and may change in the future.
+
+The `@io.quarkus.cache.CachedResults` qualifier may be applied to injection points to instruct the container to inject a _generated wrapper bean_ that
+delegates all method invocations to the original bean but the return values of selected business methods are cached. 
+By default, all non-void non-static business methods are included. 
+However, it is possible to exclude methods whose names match one of the regular expressions defined by `@CachedResults#exclude()`.
+The injected class must be either an interface or declare a no-args constructor.
+
+[source,java]
+----
+package org.example.cache;
+
+import org.example.PingService;
+
+import io.quarkus.cache.CachedResults;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MyBean {
+
+    @Inject
+    @CachedResults
+    PingService service; <1>
+   
+    int ping() {
+        return service.ping(); <2>
+    }
+}
+----
+<1> A _generated wrapper bean_ is injected instead of the original bean that implements the `PingService`.
+<2> The return value of the `service.ping()` invocation will be cached. The cache will be named like `org.example.PingService#ping()`.
+
 [[programmatic-api]]
 == Caching using the programmatic API
 

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CachedResultsProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CachedResultsProcessor.java
@@ -1,0 +1,255 @@
+package io.quarkus.cache.deployment;
+
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.addAnnotation;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
+import static org.jboss.jandex.gizmo2.Jandex2Gizmo.methodDescOf;
+
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmo2Adaptor;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.CachedResults;
+import io.quarkus.cache.deployment.spi.AdditionalCacheNameBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.gizmo2.ClassOutput;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+import io.quarkus.runtime.util.HashUtil;
+
+public class CachedResultsProcessor {
+
+    private static final DotName CACHED_RESULTS = DotName.createSimple(CachedResults.class);
+    private static final DotName INJECT = DotName.createSimple(Inject.class);
+
+    @BuildStep
+    AdditionalBeanBuildItem registerQualifier() {
+        return new AdditionalBeanBuildItem(CachedResults.class);
+    }
+
+    @BuildStep
+    void analyzeInjectionPoints(CombinedIndexBuildItem index,
+            BuildProducer<CachedResultsInjectConfigBuildItem> cachedResultsInjectConfigs) {
+        // Impl. note: we need to consume the CombinedIndexBuildItem because a bean class is generated in subsequent steps
+        Set<CachedResultsInjectConfig> injectConfigs = new HashSet<>();
+
+        for (AnnotationInstance annotation : index.getIndex().getAnnotations(CACHED_RESULTS)) {
+            String cacheName = CachedResults.DEFAULT;
+            DotName keyGenerator = null;
+            Long lockTimeout = null;
+            Type type;
+            List<String> excludes = List.of();
+
+            AnnotationValue cacheNameValue = annotation.value("cacheName");
+            if (cacheNameValue != null)
+                cacheName = cacheNameValue.asString();
+
+            AnnotationValue lockTimeoutValue = annotation.value("lockTimeout");
+            if (lockTimeoutValue != null)
+                lockTimeout = lockTimeoutValue.asLong();
+
+            AnnotationValue keyGeneratorValue = annotation.value("keyGenerator");
+            if (keyGeneratorValue != null)
+                keyGenerator = keyGeneratorValue.asClass().name();
+
+            AnnotationValue excludeValue = annotation.value("exclude");
+            if (excludeValue != null)
+                excludes = excludeValue.asArrayList().stream().map(AnnotationValue::asString).toList();
+
+            if (annotation.target().kind() == Kind.FIELD) {
+                type = annotation.target().asField().type();
+            } else if (annotation.target().kind() == Kind.METHOD_PARAMETER) {
+                type = annotation.target().asMethodParameter().type();
+            } else {
+                throw new IllegalStateException("Unsupported target:" + annotation.target());
+            }
+
+            if (type.kind() != Type.Kind.CLASS) {
+                throw new IllegalStateException("Invalid type: " + type);
+            }
+            ClassInfo injectedClazz = index.getComputingIndex().getClassByName(type.name());
+            if (injectedClazz == null) {
+                throw new IllegalStateException("Injected class not found in index: " + type.name());
+            }
+            if (!injectedClazz.isInterface()
+                    && !injectedClazz.hasNoArgsConstructor()) {
+                throw new IllegalStateException(
+                        "@CachedResults class must be an interface or declare a no-args constructor: " + injectedClazz);
+            }
+
+            injectConfigs.add(new CachedResultsInjectConfig(cacheName, lockTimeout, keyGenerator, injectedClazz,
+                    annotation.target().declaredAnnotations(), excludes));
+        }
+
+        injectConfigs.stream().map(CachedResultsInjectConfigBuildItem::new).forEach(cachedResultsInjectConfigs::produce);
+    }
+
+    @BuildStep
+    void generateWrapperBeans(CombinedIndexBuildItem index,
+            List<CachedResultsInjectConfigBuildItem> cachedResultsInjectConfigs,
+            BuildProducer<GeneratedBeanBuildItem> generatedBeans,
+            BuildProducer<AdditionalCacheNameBuildItem> cacheNames) {
+        ClassOutput classOutput = new GeneratedBeanGizmo2Adaptor(generatedBeans);
+        Gizmo gizmo = Gizmo.create(classOutput);
+
+        for (CachedResultsInjectConfigBuildItem cachedResultInjectConfig : cachedResultsInjectConfigs) {
+            CachedResultsInjectConfig config = cachedResultInjectConfig.getConfig();
+            CompiledExcludes excludes = config.compileExcludes();
+            DotName clazzName = config.injectedClazz().name();
+            String name = clazzName.toString() + "_CachedResults_" + HashUtil.sha1(config.cacheName());
+            gizmo.class_(name, cc -> {
+                if (config.injectedClazz().isInterface()) {
+                    cc.implements_(classDescOf(clazzName));
+                } else {
+                    cc.extends_(classDescOf(clazzName));
+                }
+                cc.addAnnotation(Dependent.class);
+                cc.addAnnotation(CachedResults.class, ac -> {
+                    ac.add("cacheName", config.cacheName());
+                    if (!config.cacheName().equals(CachedResults.DEFAULT)) {
+                        cacheNames.produce(new AdditionalCacheNameBuildItem(config.cacheName()));
+                    }
+                });
+                cc.defaultConstructor();
+
+                FieldDesc delegateField = cc.field("cachedResults_delegate", fc -> {
+                    fc.packagePrivate();
+                    fc.setType(classDescOf(config.injectedClazz()));
+                    boolean hasInject = false;
+                    for (AnnotationInstance a : config.annotations()) {
+                        // copy all but @CachedResults
+                        if (a.name().equals(CACHED_RESULTS)) {
+                            continue;
+                        }
+                        if (a.name().equals(INJECT)) {
+                            hasInject = true;
+                        }
+                        addAnnotation(fc, a, index.getIndex());
+                    }
+                    if (!hasInject) {
+                        // Make sure cachedResults_delegate is an injection point
+                        fc.addAnnotation(Inject.class);
+                    }
+                });
+
+                for (MethodInfo method : config.injectedClazz().methods()) {
+                    if (method.isConstructor()
+                            || method.isStaticInitializer()
+                            || method.isSynthetic()
+                            || method.isBridge()
+                            || Modifier.isStatic(method.flags())) {
+                        continue;
+                    }
+
+                    MethodDesc methodDesc = methodDescOf(method);
+                    cc.method(methodDesc, mc -> {
+                        mc.returning(methodDesc.returnType());
+
+                        ParamVar[] params = new ParamVar[methodDesc.parameterCount()];
+                        for (int i = 0; i < methodDesc.parameterCount(); i++) {
+                            params[i] = mc.parameter("arg" + i, i);
+                        }
+
+                        if (method.returnType().kind() != Type.Kind.VOID
+                                && !excludes.matches(method)) {
+                            String cacheName;
+                            if (config.cacheName().equals(CachedResults.DEFAULT)) {
+                                // com.example.Foo#bar(int)
+                                cacheName = method.declaringClass().name().toString()
+                                        + "#"
+                                        + method.name()
+                                        + "("
+                                        + method.parameterTypes().stream().map(Type::name).map(Object::toString)
+                                                .collect(Collectors.joining(","))
+                                        + ")";
+                                cacheNames.produce(new AdditionalCacheNameBuildItem(cacheName));
+                            } else {
+                                cacheName = config.cacheName();
+                            }
+                            // Add @CachedResult
+                            mc.addAnnotation(CacheResult.class, ac -> {
+                                ac.add("cacheName", cacheName);
+                                if (config.lockTimeout() != null)
+                                    ac.add("lockTimeout", config.lockTimeout());
+                                if (config.keyGenerator() != null)
+                                    ac.add("keyGenerator", classDescOf(config.keyGenerator()));
+
+                            });
+                        }
+
+                        mc.body(bc -> {
+                            Expr ret;
+                            if (config.injectedClazz().isInterface()) {
+                                ret = bc.invokeInterface(methodDesc, cc.this_().field(delegateField), params);
+                            } else {
+                                ret = bc.invokeVirtual(methodDesc, cc.this_().field(delegateField), params);
+                            }
+                            bc.return_(ret);
+                        });
+                    });
+                }
+            });
+        }
+    }
+
+    static final class CachedResultsInjectConfigBuildItem extends MultiBuildItem {
+
+        private final CachedResultsInjectConfig config;
+
+        CachedResultsInjectConfigBuildItem(CachedResultsInjectConfig config) {
+            this.config = config;
+        }
+
+        public CachedResultsInjectConfig getConfig() {
+            return config;
+        }
+
+    }
+
+    record CachedResultsInjectConfig(String cacheName, Long lockTimeout, DotName keyGenerator, ClassInfo injectedClazz,
+            Collection<AnnotationInstance> annotations, List<String> excludes) {
+
+        CompiledExcludes compileExcludes() {
+            return new CompiledExcludes(excludes.stream().map(Pattern::compile).toList());
+        }
+
+    }
+
+    record CompiledExcludes(List<Pattern> patterns) {
+
+        boolean matches(MethodInfo method) {
+            for (Pattern p : patterns) {
+                if (p.matcher(method.name()).matches()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    }
+
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CachedResultsInjectFailureTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CachedResultsInjectFailureTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CachedResults;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CachedResultsInjectFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(
+                    jar -> jar.addClasses(MujBean.class))
+            .setExpectedException(IllegalStateException.class);
+
+    @Inject
+    @CachedResults
+    MujBean mujBean;
+
+    @Test
+    public void testFailure() {
+        fail();
+    }
+
+    @Dependent
+    public static class MujBean {
+
+        public MujBean(BeanManager beanManager) {
+        }
+
+    }
+
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CachedResultsTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CachedResultsTest.java
@@ -1,0 +1,173 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheKeyGenerator;
+import io.quarkus.cache.CacheManager;
+import io.quarkus.cache.CachedResults;
+import io.quarkus.cache.CaffeineCache;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CachedResultsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(
+                    jar -> jar.addClasses(EmbeddingModel.class, EmbeddingModelImpl.class, AnotherModel.class));
+
+    @Inject
+    @CachedResults(cacheName = "foo")
+    EmbeddingModel model1;
+
+    @Inject
+    @CachedResults(cacheName = "foo")
+    EmbeddingModel model2;
+
+    @Inject
+    @CachedResults(cacheName = "baz", exclude = "bar")
+    EmbeddingModel model3;
+
+    @Inject
+    @CachedResults
+    EmbeddingModel model4;
+
+    @Inject
+    @CachedResults
+    EmbeddingModel model5;
+
+    @Inject
+    @CachedResults(cacheName = "model6", keyGenerator = CustomKeyGenerator.class)
+    EmbeddingModel model6;
+
+    @CachedResults
+    AnotherModel anotherModel1;
+
+    @Inject
+    CacheManager cacheManager;
+
+    @Test
+    public void testCached() {
+        int ret1 = model1.foo(1);
+        assertEquals(ret1, model1.foo(1));
+        // model2 shares the same cache
+        assertEquals(ret1, model2.foo(1));
+        // model3 has a different cache
+        assertNotEquals(ret1, model3.foo(1));
+
+        int ret2 = model1.foo(2);
+        assertNotEquals(ret2, ret1);
+        assertEquals(ret2, model1.foo(2));
+
+        String ret3 = model1.bar();
+        assertEquals(ret3, model1.bar());
+        assertEquals(ret3, model1.bar());
+
+        // model4 and model5 use a derived cache name
+        int ret4 = model4.foo(10);
+        assertEquals(ret4, model4.foo(10));
+        assertEquals(ret4, model5.foo(10));
+        assertNotEquals(ret1, model3.foo(10));
+        assertTrue(
+                cacheManager.getCache("io.quarkus.cache.test.runtime.CachedResultsTest$EmbeddingModel#foo(int)").isPresent(),
+                cacheManager.getCacheNames().toString());
+
+        // bar is ignored for model3
+        String ret5 = model3.bar();
+        assertNotEquals(ret5, model3.bar());
+
+        // update() should never be cached
+        model1.update();
+        assertTrue(EmbeddingModelImpl.lastUpdate.get() > 0);
+
+        // cache key is the method name
+        assertEquals(model6.foo(12), model6.foo(21));
+        assertEquals(model6.bar(), model6.bar());
+        Optional<Cache> model6Cache = cacheManager.getCache("model6");
+        assertTrue(model6Cache.isPresent());
+        Set<Object> keys = model6Cache.get().as(CaffeineCache.class).keySet();
+        assertTrue(keys.contains("foo"));
+        assertTrue(keys.contains("bar"));
+
+        // injected class has a no-args constructor
+        assertEquals(anotherModel1.foo(111), anotherModel1.foo(111));
+        assertEquals(anotherModel1.bar(), anotherModel1.bar());
+    }
+
+    interface EmbeddingModel {
+
+        void update();
+
+        int foo(int val);
+
+        String bar();
+
+    }
+
+    @Dependent
+    static class AnotherModel {
+
+        static final AtomicLong lastUpdate = new AtomicLong();
+
+        int foo(int val) {
+            return new Random().nextInt();
+        }
+
+        String bar() {
+            return UUID.randomUUID().toString();
+        }
+
+        void update() {
+            lastUpdate.set(System.currentTimeMillis());
+        }
+
+    }
+
+    @Singleton
+    static class EmbeddingModelImpl implements EmbeddingModel {
+
+        static final AtomicLong lastUpdate = new AtomicLong();
+
+        @Override
+        public int foo(int val) {
+            return new Random().nextInt();
+        }
+
+        @Override
+        public String bar() {
+            return UUID.randomUUID().toString();
+        }
+
+        @Override
+        public void update() {
+            lastUpdate.set(System.currentTimeMillis());
+        }
+
+    }
+
+    public static class CustomKeyGenerator implements CacheKeyGenerator {
+
+        @Override
+        public Object generate(Method method, Object... methodParams) {
+            return method.getName();
+        }
+
+    }
+
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CachedResults.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CachedResults.java
@@ -1,0 +1,72 @@
+package io.quarkus.cache;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Qualifier;
+
+import io.quarkus.cache.runtime.UndefinedCacheKeyGenerator;
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * This qualifier may be applied to injection points to instruct the container to inject a generated wrapper bean that
+ * delegates all method invocations to the original bean but the return values of selected business methods are cached.
+ * <p>
+ * By default, all non-void non-static business methods are included. However, it is possible to exclude methods
+ * whose names match one of the regular expressions defined by {@link #exclude()}.
+ * <p>
+ * The injected class must be either an interface or declare a no-args constructor.
+ *
+ * @see CacheResult
+ */
+@Experimental("This API is experimental and may change in the future")
+@Qualifier
+@Retention(RUNTIME)
+@Target({ TYPE, FIELD, PARAMETER })
+public @interface CachedResults {
+
+    /**
+     * Constant value for {@link #cacheName()} indicating that the name should be derived for each relevant business method.
+     * <p>
+     * The name consist of the binary name of the declaring class, the method name, and binary names of all parameters.
+     */
+    String DEFAULT = "<<default>>";
+
+    /**
+     * The cache name.
+     * <p>
+     * By default, the cache name is derived for each business method.
+     *
+     * @see CacheResult#cacheName()
+     */
+    String cacheName() default DEFAULT;
+
+    /**
+     * The timeout is used for all business methods.
+     *
+     * @see CacheResult#lockTimeout()
+     */
+    @Nonbinding
+    long lockTimeout() default 0;
+
+    /**
+     * The generator is used for all business methods.
+     *
+     * @see CacheResult#keyGenerator()
+     */
+    @Nonbinding
+    Class<? extends CacheKeyGenerator> keyGenerator() default UndefinedCacheKeyGenerator.class;
+
+    /**
+     * The regular expressions that are used to match the method names that should be excluded, i.e. the results should not be
+     * cached.
+     */
+    @Nonbinding
+    String[] exclude() default {};
+}


### PR DESCRIPTION
- instructs the container to inject a generated wrapper bean that delegates all method invocations to the original bean but the return values of selected business methods are cached
- related to #49768