### PR TITLE
Do not use System Properties to set `quarkus.log.file.path`

### DIFF
--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/VertxMDCDevModeTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/VertxMDCDevModeTest.java
@@ -30,10 +30,11 @@ public class VertxMDCDevModeTest {
             .withApplicationRoot(
                     (jar) -> jar.addClasses(JavaArchive.class, VerticleDeployer.class, InMemoryLogHandler.class,
                             InMemoryLogHandlerProducer.class)
-                            .add(new StringAsset("quarkus.log.file.enabled=true\n" +
-                                    "quarkus.log.console.format=%d{HH:mm:ss} %-5p requestId=%X{requestId} [%c{2.}] (%t) %s%e%n\n"),
-                                    "application.properties"))
-            .setLogFileName("quarkus-mdc.log");
+                            .add(new StringAsset(
+                                    "quarkus.log.file.enabled=true\n" +
+                                            "quarkus.log.file.path=target/quarkus-mdc.log\n" +
+                                            "quarkus.log.console.format=%d{HH:mm:ss} %-5p requestId=%X{requestId} [%c{2.}] (%t) %s%e%n\n"),
+                                    "application.properties"));
 
     @Test
     void mdcDevMode() {

--- a/integration-tests/awt/src/test/resources/application.properties
+++ b/integration-tests/awt/src/test/resources/application.properties
@@ -1,5 +1,4 @@
 quarkus.log.file.enabled=true
-quarkus.log.file.path=quarkus.log
 quarkus.log.file.level=DEBUG
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 quarkus.native.resources.includes=MyFreeMono.ttf,MyFreeSerif.ttf,DejaVuSansMonoX.ttf

--- a/integration-tests/jaxb/src/test/resources/application.properties
+++ b/integration-tests/jaxb/src/test/resources/application.properties
@@ -1,4 +1,3 @@
 quarkus.log.file.enabled=true
-quarkus.log.file.path=quarkus.log
 quarkus.log.file.level=TRACE
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n

--- a/integration-tests/no-awt/src/test/resources/application.properties
+++ b/integration-tests/no-awt/src/test/resources/application.properties
@@ -1,4 +1,3 @@
 quarkus.log.file.enabled=true
-quarkus.log.file.path=quarkus.log
 quarkus.log.file.level=DEBUG
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n

--- a/integration-tests/vertx/src/test/resources/application.properties
+++ b/integration-tests/vertx/src/test/resources/application.properties
@@ -1,3 +1,2 @@
 vertx.event-loops.size=2
 quarkus.log.file.enabled=true
-quarkus.log.file.path=quarkus.log

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -7,6 +7,7 @@ import static io.quarkus.test.common.LauncherUtil.waitForStartedFunction;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -16,9 +17,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
+import io.smallrye.config.SmallRyeConfig;
 
 public class DefaultJarLauncher implements JarArtifactLauncher {
+    private static final Logger log = Logger.getLogger(DefaultJarLauncher.class);
 
     private static final String JAVA_HOME_SYS = "java.home";
     private static final String JAVA_HOME_ENV = "JAVA_HOME";
@@ -63,13 +70,15 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     public void start() throws IOException {
         start(new String[0], true);
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
-        var logFile = PropertyTestUtil.getLogFilePath();
+        LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
+                .getConfigMapping(LogRuntimeConfig.class);
         if (startedFunction != null) {
             IntegrationTestStartedNotifier.Result result = waitForStartedFunction(startedFunction, quarkusProcess,
-                    waitTimeSeconds, logFile);
+                    waitTimeSeconds, logRuntimeConfig.file().path().toPath());
             isSsl = result.isSsl();
         } else {
-            ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logFile, waitTimeSeconds);
+            ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(),
+                    waitTimeSeconds);
             updateConfigForPort(result.getPort());
             isSsl = result.isSsl();
         }
@@ -94,7 +103,8 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     }
 
     public void start(String[] programArgs, boolean handleIo) throws IOException {
-
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
         System.setProperty("test.url", TestHTTPResourceManager.getUri());
 
         List<String> args = new ArrayList<>();
@@ -109,8 +119,8 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
             // in the main module, since those tests hit the application itself
             args.add("-Dtest.url=" + TestHTTPResourceManager.getUri());
         }
-        Path logFile = PropertyTestUtil.getLogFilePath();
-        args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath().toString());
+        File logPath = logRuntimeConfig.file().path();
+        args.add("-Dquarkus.log.file.path=" + logPath.getAbsolutePath());
         args.add("-Dquarkus.log.file.enabled=true");
         args.add("-Dquarkus.log.category.\"io.quarkus\".level=INFO");
         if (testProfile != null) {
@@ -125,8 +135,14 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
 
         System.out.println("Executing \"" + String.join(" ", args) + "\"");
 
-        Files.deleteIfExists(logFile);
-        Files.createDirectories(logFile.getParent());
+        try {
+            Files.deleteIfExists(logPath.toPath());
+            if (logPath.getParent() != null) {
+                Files.createDirectories(logPath.toPath().getParent());
+            }
+        } catch (FileSystemException e) {
+            log.warnf("Log file %s deletion failed, could happen on Windows, we can carry on.", logPath);
+        }
 
         if (handleIo) {
             quarkusProcess = LauncherUtil.launchProcessAndDrainIO(args, env);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -9,8 +9,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,9 +22,15 @@ import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
+import io.smallrye.config.SmallRyeConfig;
 
 public class DefaultNativeImageLauncher implements NativeImageLauncher {
+    private static final Logger log = Logger.getLogger(DefaultNativeImageLauncher.class);
 
     private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
 
@@ -96,24 +102,27 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
 
     public void start() throws IOException {
         start(new String[0], true);
-
-        Path logFile = PropertyTestUtil.getLogFilePath();
         Supplier<Boolean> startedSupplier = createStartedSupplier(); // keep the legacy SPI handling
+        LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
+                .getConfigMapping(LogRuntimeConfig.class);
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
         if (startedSupplier != null) {
             waitForStartedSupplier(startedSupplier, quarkusProcess, waitTimeSeconds);
         } else if (startedFunction != null) {
             IntegrationTestStartedNotifier.Result result = waitForStartedFunction(startedFunction, quarkusProcess,
-                    waitTimeSeconds, logFile);
+                    waitTimeSeconds, logRuntimeConfig.file().path().toPath());
             isSsl = result.isSsl();
         } else {
-            ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logFile, waitTimeSeconds);
+            ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(),
+                    waitTimeSeconds);
             updateConfigForPort(result.getPort());
             isSsl = result.isSsl();
         }
     }
 
     public void start(String[] programArgs, boolean handleIo) throws IOException {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
         System.setProperty("test.url", TestHTTPResourceManager.getUri());
 
         if (nativeImagePath == null) {
@@ -131,8 +140,8 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
             // in the main module, since those tests hit the application itself
             args.add("-Dtest.url=" + TestHTTPResourceManager.getUri());
         }
-        Path logFile = PropertyTestUtil.getLogFilePath();
-        args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath());
+        File logPath = logRuntimeConfig.file().path();
+        args.add("-Dquarkus.log.file.path=" + logPath.getAbsolutePath());
         args.add("-Dquarkus.log.file.enabled=true");
         args.add("-Dquarkus.log.category.\"io.quarkus\".level=INFO");
         if (testProfile != null) {
@@ -144,8 +153,15 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
         args.addAll(Arrays.asList(programArgs));
         System.out.println("Executing \"" + String.join(" ", args) + "\"");
 
-        Files.deleteIfExists(logFile);
-        Files.createDirectories(logFile.getParent());
+        try {
+            Files.deleteIfExists(logPath.toPath());
+            if (logPath.getParent() != null) {
+                Files.createDirectories(logPath.toPath().getParent());
+            }
+        } catch (FileSystemException e) {
+            log.warnf("Log file %s deletion failed, could happen on Windows, we can carry on.", logPath);
+        }
+
         if (handleIo) {
             quarkusProcess = LauncherUtil.launchProcessAndDrainIO(args, env);
         } else {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
+@Deprecated(forRemoval = true)
 public class PropertyTestUtil {
 
     private static final String LOG_FILE_PATH_PROPERTY = "quarkus.log.file.path";

--- a/test-framework/junit5-config/src/main/java/io/quarkus/test/config/TestConfigCustomizer.java
+++ b/test-framework/junit5-config/src/main/java/io/quarkus/test/config/TestConfigCustomizer.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.config;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import io.quarkus.runtime.logging.LogRuntimeConfig.FileConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+public class TestConfigCustomizer implements SmallRyeConfigBuilderCustomizer {
+    @Override
+    public void configBuilder(SmallRyeConfigBuilder builder) {
+        builder.withDefaultValue("quarkus.log.file.path", String.join(File.separator, getLogFileLocationParts()));
+    }
+
+    private static List<String> getLogFileLocationParts() {
+        // TODO - This can probably be smarter. We can probably keep target as a default and have another source in Gradle to override with the Gradle directory layout
+        if (Files.isDirectory(Paths.get("build"))) {
+            return Arrays.asList("build", FileConfig.DEFAULT_LOG_FILE_NAME);
+        }
+        return Arrays.asList("target", FileConfig.DEFAULT_LOG_FILE_NAME);
+    }
+}

--- a/test-framework/junit5-config/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/test-framework/junit5-config/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,0 +1,1 @@
+io.quarkus.test.config.TestConfigCustomizer

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -110,7 +110,6 @@ public class QuarkusDevModeTest
     private Supplier<JavaArchive> archiveProducer;
     private Supplier<JavaArchive> testArchiveProducer;
     private List<String> codeGenSources = Collections.emptyList();
-    private String logFileName;
     private InMemoryLogHandler inMemoryLogHandler = new InMemoryLogHandler((r) -> false);
 
     private Path deploymentSourceParentPath;
@@ -201,8 +200,9 @@ public class QuarkusDevModeTest
         return this;
     }
 
+    @Deprecated(forRemoval = true)
     public QuarkusDevModeTest setLogFileName(String logFileName) {
-        this.logFileName = logFileName;
+        PropertyTestUtil.setLogFileProperty(logFileName);
         return this;
     }
 
@@ -250,12 +250,6 @@ public class QuarkusDevModeTest
             throw new RuntimeException("QuarkusDevModeTest does not have archive producer set");
         }
         ExclusivityChecker.checkTestType(extensionContext, QuarkusDevModeTest.class);
-
-        if (logFileName != null) {
-            PropertyTestUtil.setLogFileProperty(logFileName);
-        } else {
-            PropertyTestUtil.setLogFileProperty();
-        }
         ExtensionContext.Store store = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
         if (store.get(TestResourceManager.class.getName()) == null) {
             TestResourceManager testResourceManager = new TestResourceManager(extensionContext.getRequiredTestClass());

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -105,7 +105,6 @@ public class QuarkusUnitTest
     private List<Consumer<BuildChainBuilder>> buildChainCustomizers = new ArrayList<>();
     private Runnable afterUndeployListener;
 
-    private String logFileName;
     private InMemoryLogHandler inMemoryLogHandler = new InMemoryLogHandler((r) -> false);
     private Consumer<List<LogRecord>> assertLogRecords;
 
@@ -264,8 +263,9 @@ public class QuarkusUnitTest
         return this;
     }
 
+    @Deprecated(forRemoval = true)
     public QuarkusUnitTest setLogFileName(String logFileName) {
-        this.logFileName = logFileName;
+        PropertyTestUtil.setLogFileProperty(logFileName);
         return this;
     }
 
@@ -588,11 +588,6 @@ public class QuarkusUnitTest
         };
         timeoutTimer = new Timer("Test thread dump timer");
         timeoutTimer.schedule(timeoutTask, 1000 * 60 * 5);
-        if (logFileName != null) {
-            PropertyTestUtil.setLogFileProperty(logFileName);
-        } else {
-            PropertyTestUtil.setLogFileProperty();
-        }
         ExtensionContext.Store store = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
 
         ExclusivityChecker.checkTestType(extensionContext, QuarkusUnitTest.class);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -44,10 +44,10 @@ import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.runtime.logging.JBossVersion;
+import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DevServicesContext;
-import io.quarkus.test.common.PropertyTestUtil;
 import io.quarkus.test.common.RestAssuredURLManager;
 import io.quarkus.test.common.RunCommandLauncher;
 import io.quarkus.test.common.TestConfigUtil;
@@ -168,11 +168,12 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                 setState(extensionContext, state);
             } catch (Throwable e) {
                 try {
-                    Path appLogPath = PropertyTestUtil.getLogFilePath();
-                    File appLogFile = appLogPath.toFile();
+                    LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
+                            .getConfigMapping(LogRuntimeConfig.class);
+                    File appLogFile = logRuntimeConfig.file().path();
                     if (appLogFile.exists() && (appLogFile.length() > 0)) {
                         System.err.println("Failed to launch the application. The application logs can be found at: "
-                                + appLogPath.toAbsolutePath());
+                                + appLogFile.getAbsolutePath());
                     }
                 } catch (IllegalStateException ignored) {
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -69,7 +69,6 @@ import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.TestMethodInvoker;
 import io.quarkus.test.common.GroovyClassValue;
-import io.quarkus.test.common.PropertyTestUtil;
 import io.quarkus.test.common.RestAssuredURLManager;
 import io.quarkus.test.common.RestorableSystemProperties;
 import io.quarkus.test.common.TestClassIndexer;
@@ -637,7 +636,6 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     }
                 }
             }
-            PropertyTestUtil.setLogFileProperty();
             try {
                 state = doJavaStart(extensionContext, selectedProfile);
                 setState(extensionContext, state);


### PR DESCRIPTION
Changed to use a specific `ConfigSource` during test that sets the expected `quarkus.log.file.path` (usually, to set the folder path to the build output folder).

There is a slight breaking change. Before, when setting `quarkus.log.file.path` explicitly (even without a profile), the test code would change that under the covers to add either `target` or `build`.  I think we shouldn't be adding a parent folder to whatever the user defined as the `quarkus.log.file.path`. As a default, for testing, `quarkus.log.file.path` is either `target/quarkus.log` or `build/quarkus.log`. If the user overrides it, we don't change it.