### PR TITLE
Pass all the configuration minus Quarkus defaults to Gradle code generator task

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.gradle.tasks;
 
+import static io.smallrye.config.ConfigMappings.ConfigClass.configClass;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableMap;
@@ -140,6 +141,8 @@ public final class EffectiveConfig {
                         properties.put(propertyName, configValue.getValue());
                     }
                 }
+                configClass(PackageConfig.class).getProperties().keySet().forEach(properties::remove);
+                configClass(NativeConfig.class).getProperties().keySet().forEach(properties::remove);
                 return unmodifiableMap(properties);
             }
         });

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -110,8 +110,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
     @TaskAction
     public void generateCode() throws IOException {
         ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
-        Map<String, String> configMap = effectiveProvider()
-                .buildEffectiveConfiguration(appModel, new HashMap<>()).getOnlyQuarkusValues();
+        Map<String, String> configMap = effectiveProvider().buildEffectiveConfiguration(appModel, new HashMap<>()).getValues();
 
         File outputPath = getGeneratedOutputDirectory().get().getAsFile();
 


### PR DESCRIPTION
- Fixes #49788
- Caused by https://github.com/quarkusio/quarkus/pull/49503

When running separate Gradle tasks (without the build), `application.properties` is not available in the classpath to load configuration. In the case of the code generator tasks, all the configuration values are passed down via system properties. With #49503, we replaced this only to pass Quarkus configuration, but this is insufficient, so this PR readds the ability to pass the entire Config, except the defaults already included by Quarkus.