### PR TITLE
Disable log file rotation when running tests

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingConfigBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingConfigBuilder.java
@@ -1,0 +1,19 @@
+package io.quarkus.deployment.logging;
+
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+/**
+ * Set only for Dev and Test.
+ * <p>
+ * Because we set the log early in {@code io.quarkus.test.config.LoggingSetupExtension}, the log may end up in rotating
+ * files at runtime when running tests, if components log messages before Quarkus sets up the final runtime log. Turning
+ * off the rotation ensures that Quarkus log ends up in the same file (if any), set by the
+ * {@code io.quarkus.test.config.LoggingSetupExtension}.
+ */
+public class LoggingConfigBuilder implements ConfigBuilder {
+    @Override
+    public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
+        return builder.withDefaultValue("quarkus.log.file.rotation.rotate-on-boot", "false");
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -84,6 +84,7 @@ import io.quarkus.deployment.builditem.LogHandlerBuildItem;
 import io.quarkus.deployment.builditem.LogSocketFormatBuildItem;
 import io.quarkus.deployment.builditem.LogSyslogFormatBuildItem;
 import io.quarkus.deployment.builditem.NamedLogHandlersBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownListenerBuildItem;
@@ -242,6 +243,11 @@ public final class LoggingResourceProcessor {
                 .accept(new NativeImageSystemPropertyBuildItem("java.util.logging.manager", "org.jboss.logmanager.LogManager"));
         provider.accept(
                 new ServiceProviderBuildItem(LogContextInitializer.class.getName(), InitialConfigurator.class.getName()));
+    }
+
+    @BuildStep(onlyIfNot = IsProduction.class)
+    void runtimeLogConfig(BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(LoggingConfigBuilder.class));
     }
 
     @BuildStep

--- a/test-framework/junit5-config/src/main/java/io/quarkus/test/config/LoggingSetupExtension.java
+++ b/test-framework/junit5-config/src/main/java/io/quarkus/test/config/LoggingSetupExtension.java
@@ -1,8 +1,10 @@
 package io.quarkus.test.config;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.extension.Extension;
 
 import io.quarkus.runtime.logging.LoggingSetupRecorder;
+import io.smallrye.config.SmallRyeConfig;
 
 /**
  * A global JUnit extension that enables/sets up basic logging if logging has not already been set up.
@@ -11,7 +13,12 @@ import io.quarkus.runtime.logging.LoggingSetupRecorder;
  * test), but also for getting instant log output from {@code QuarkusTestResourceLifecycleManagers} etc.
  */
 public class LoggingSetupExtension implements Extension {
+    private static final String JUNIT_QUARKUS_ENABLE_BASIC_LOGGING = "junit.quarkus.enable-basic-logging";
+
     public LoggingSetupExtension() {
-        LoggingSetupRecorder.handleFailedStart();
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        if (config.getOptionalValue(JUNIT_QUARKUS_ENABLE_BASIC_LOGGING, boolean.class).orElse(true)) {
+            LoggingSetupRecorder.handleFailedStart();
+        }
     }
 }


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/22920, we added a way to initialize the log early when running tests (plus get instant logging). We did carry this behaviour with https://github.com/quarkusio/quarkus/pull/42715.

Now, this setup of logging early can cause issues if components log messages before Quarkus sets the final log. Because `quarkus.log.file.rotation.rotate-on-boot` default is set to `true`, it will rotate the log, and messages may be split between two files, causing issues when looking up messages for asserts.

This proposal is to disable the log file rotation when setting the final Quarkus log, so it will use the same file set by our test early log. The test early log would still keep `quarkus.log.file.rotation.rotate-on-boot` enabled, so the log will still rotate between test executions.

This depends on:
- https://github.com/quarkusio/quarkus/pull/49822
- https://github.com/quarkusio/quarkus/pull/49823

To unblock:
- https://github.com/quarkusio/quarkus/pull/49096