### PR TITLE
Don't mark Hibernate ORM and Search dev services as beans

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
@@ -3,8 +3,6 @@ package io.quarkus.hibernate.orm.deployment.dev;
 import java.util.List;
 
 import io.quarkus.agroal.spi.JdbcInitialSQLGeneratorBuildItem;
-import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -56,16 +54,6 @@ public class HibernateOrmDevUIProcessor {
     @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(HibernateOrmDevJsonRpcService.class);
-    }
-
-    @BuildStep
-    AdditionalBeanBuildItem additionalBeans() {
-        return AdditionalBeanBuildItem
-                .builder()
-                .addBeanClass(HibernateOrmDevJsonRpcService.class)
-                .setUnremovable()
-                .setDefaultScope(DotNames.APPLICATION_SCOPED)
-                .build();
     }
 
     @BuildStep

--- a/extensions/hibernate-orm/runtime-dev/src/main/java/io/quarkus/hibernate/orm/dev/ui/HibernateOrmDevJsonRpcService.java
+++ b/extensions/hibernate-orm/runtime-dev/src/main/java/io/quarkus/hibernate/orm/dev/ui/HibernateOrmDevJsonRpcService.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.orm.dev.ui;
 
-import static org.hibernate.internal.util.StringHelper.isBlank;
 import static org.hibernate.query.sqm.internal.SqmUtil.isMutation;
 
 import java.net.URI;

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/dev/HibernateSearchElasticsearchDevUIProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/dev/HibernateSearchElasticsearchDevUIProcessor.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -40,16 +38,6 @@ public class HibernateSearchElasticsearchDevUIProcessor {
                 .dynamicLabelJsonRPCMethodName("getNumberOfIndexedEntityTypes"));
 
         return card;
-    }
-
-    @BuildStep
-    AdditionalBeanBuildItem additionalBeans() {
-        return AdditionalBeanBuildItem
-                .builder()
-                .addBeanClass(HibernateSearchElasticsearchDevJsonRpcService.class)
-                .setUnremovable()
-                .setDefaultScope(DotNames.APPLICATION_SCOPED)
-                .build();
     }
 
     @BuildStep


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

I don't see why we would need to mark the JSON RPC dev services as beans, they are already provided to dev-mode through `JsonRPCProvidersBuildItem`.

* Fixes #49818

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

