### PR TITLE
Arc - detect usage of unsupported @Specializes annotation and fail fast

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchiveBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchiveBuildItem.java
@@ -1,28 +1,100 @@
 package io.quarkus.arc.deployment;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * Marks a bean archive with given coordinates (groupId, artifactId and optionally classifier)
- * as known compatible with Quarkus. This is only useful for bean archives whose {@code beans.xml}
- * defines a bean discovery mode of {@code all}; bean archives with discovery mode of {@code none}
- * or {@code annotated} are always compatible. If a bean archive is known to be compatible with
- * Quarkus, no warning about {@code all} discovery is logged during application build.
+ * as known compatible with Quarkus. If a bean archive is known to be compatible with
+ * Quarkus, any error logging or exception throwing related to that compatibility is skipped.
+ * <p>
+ * This is useful in the following cases:
+ * <li>Bean archives whose {@code beans.xml} defines a bean discovery mode of {@code all}; bean archives with discovery mode of
+ * {@code none} or {@code annotated} are always compatible.</li>
+ * <li>Bean archives that contain the unsupported {@link jakarta.enterprise.inject.Specializes} annotation.</li>
  */
 public final class KnownCompatibleBeanArchiveBuildItem extends MultiBuildItem {
+    final Set<Reason> reasons;
     final String groupId;
     final String artifactId;
     final String classifier;
 
+    /**
+     * Deprecated, use {@link KnownCompatibleBeanArchiveBuildItem#builder(String, String)} method instead.
+     * For compatibility reasons, this method automatically registers the artifact with {@link Reason#BEANS_XML_ALL}.
+     */
+    @Deprecated
     public KnownCompatibleBeanArchiveBuildItem(String groupId, String artifactId) {
         this(groupId, artifactId, "");
     }
 
+    /**
+     * Deprecated, use {@link KnownCompatibleBeanArchiveBuildItem#builder(String, String)} method instead.
+     * For compatibility reasons, this method automatically registers the artifact with {@link Reason#BEANS_XML_ALL}.
+     */
+    @Deprecated
     public KnownCompatibleBeanArchiveBuildItem(String groupId, String artifactId, String classifier) {
-        this.groupId = Objects.requireNonNull(groupId, "groupId must be set");
-        this.artifactId = Objects.requireNonNull(artifactId, "artifactId must be set");
-        this.classifier = Objects.requireNonNull(classifier, "classifier must be set");
+        this(groupId, artifactId, classifier, Set.of(Reason.BEANS_XML_ALL));
+    }
+
+    private KnownCompatibleBeanArchiveBuildItem(String groupId, String artifactId, String classifier, Set<Reason> reasons) {
+        Objects.requireNonNull(groupId, "groupId must be set");
+        Objects.requireNonNull(artifactId, "artifactId must be set");
+        Objects.requireNonNull(classifier, "classifier must be set");
+        if (reasons.isEmpty()) {
+            throw new IllegalStateException(
+                    "KnownCompatibleBeanArchiveBuildItem.Builder needs to declare at least one compatibility reason. Artifact with following coordinates had no reason associated: "
+                            + groupId + ":" + artifactId);
+        }
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.classifier = classifier;
+        this.reasons = reasons;
+    }
+
+    public static Builder builder(String groupId, String artifactId) {
+        return new Builder(groupId, artifactId);
+    }
+
+    /**
+     * An enum listing known reasons for which an archive might be marked as compatible despite using some unsupported
+     * feature such as {@code beans.xml} discovery mode {@code all} or using {@link jakarta.enterprise.inject.Specializes}
+     * annotation on its classes.
+     */
+    public enum Reason {
+        BEANS_XML_ALL,
+        SPECIALIZES_ANNOTATION;
+    }
+
+    public static class Builder {
+
+        private final String groupId;
+        private final String artifactId;
+        private final Set<Reason> reasons;
+        private String classifier;
+
+        private Builder(String groupId, String artifactId) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.classifier = "";
+            this.reasons = new HashSet<>();
+        }
+
+        public Builder setClassifier(String classifier) {
+            this.classifier = classifier;
+            return this;
+        }
+
+        public Builder addReason(Reason reason) {
+            this.reasons.add(reason);
+            return this;
+        }
+
+        public KnownCompatibleBeanArchiveBuildItem build() {
+            return new KnownCompatibleBeanArchiveBuildItem(groupId, artifactId, classifier, reasons);
+        }
     }
 }

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/specialization/SpecializationUnsupportedTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/specialization/SpecializationUnsupportedTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.arc.test.specialization;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Specializes;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SpecializationUnsupportedTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SomeBean.class))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                assertTrue(
+                        rootCause.getMessage().contains(
+                                "Quarkus does not support CDI Full @Specializes annotation"),
+                        t.toString());
+            });
+
+    @Test
+    public void trigger() {
+        Assertions.fail();
+    }
+
+    @ApplicationScoped
+    @Specializes
+    public static class SomeBean {
+
+        @Specializes
+        @Produces
+        String someProducer() {
+            return "foo";
+        }
+    }
+
+}

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -30,6 +30,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
+import io.quarkus.arc.deployment.KnownCompatibleBeanArchiveBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
@@ -879,6 +880,15 @@ public class SmallRyeGraphQLProcessor {
             additionalIndexedClasses
                     .produce(new AdditionalIndexedClassesBuildItem("io.quarkus.panache.common.Sort$NullPrecedence"));
         }
+    }
+
+    // This build step can be removed after Quarkus updated to any version newer than 2.14.1
+    // See also https://github.com/smallrye/smallrye-graphql/pull/2299
+    @BuildStep
+    void registerKnownSpecializationAnnotation(
+            BuildProducer<KnownCompatibleBeanArchiveBuildItem> compatArchiveProducer) {
+        compatArchiveProducer.produce(KnownCompatibleBeanArchiveBuildItem.builder("io.smallrye", "smallrye-graphql-cdi")
+                .addReason(KnownCompatibleBeanArchiveBuildItem.Reason.SPECIALIZES_ANNOTATION).build());
     }
 
     // In dev mode, when you click on the logo, you should go to Dev UI

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
@@ -31,6 +31,7 @@ import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Intercepted;
 import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Specializes;
 import jakarta.enterprise.inject.Stereotype;
 import jakarta.enterprise.inject.TransientReference;
 import jakarta.enterprise.inject.Typed;
@@ -142,6 +143,7 @@ public final class DotNames {
     public static final DotName VETOED_PRODUCER = create(VetoedProducer.class);
     public static final DotName LIST = create(List.class);
     public static final DotName ALL = create(All.class);
+    public static final DotName SPECIALIZES = create(Specializes.class);
     /**
      * @see Identified
      */


### PR DESCRIPTION
Fixes #49812 

Quarkus now detects usage of this annotation and throws an exception that looks something like this:
> `jakarta.enterprise.inject.spi.DefinitionException: 
Quarkus does not support CDI Full @Specializes annotation; try using an @Alternative instead.
Annotations found: [java.lang.String someProducer(), io.quarkus.arc.test.specialization.SpecializationUnsupportedTest$SomeBean]`
