### PR TITLE
Catch Throwable in ApplicationLifecycleManager

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -164,8 +164,8 @@ public class ApplicationLifecycleManager {
                     stateLock.unlock();
                 }
             }
-        } catch (Exception e) {
-            Throwable rootCause = ExceptionUtil.getRootCause(e);
+        } catch (Throwable t) {
+            Throwable rootCause = ExceptionUtil.getRootCause(t);
             if (exitCodeHandler == null) {
                 Logger applicationLogger = Logger.getLogger(Application.class);
                 if (rootCause instanceof QuarkusBindException qbe) {
@@ -198,7 +198,7 @@ public class ApplicationLifecycleManager {
                         && !StringUtil.isNullOrEmpty(rootCause.getMessage())) {
                     System.err.println(rootCause.getMessage());
                 } else {
-                    applicationLogger.errorv(e, "Failed to start application");
+                    applicationLogger.errorv(t, "Failed to start application");
                     ensureConsoleLogsDrained();
                 }
             }
@@ -214,7 +214,7 @@ public class ApplicationLifecycleManager {
                     ? ((PreventFurtherStepsException) rootCause).getExitCode()
                     : 1;
             currentApplication = null;
-            (exitCodeHandler == null ? defaultExitCodeHandler : exitCodeHandler).accept(exceptionExitCode, e);
+            (exitCodeHandler == null ? defaultExitCodeHandler : exitCodeHandler).accept(exceptionExitCode, t);
             return;
         } finally {
             try {

--- a/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/FailingApp.java
+++ b/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/FailingApp.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.testsupport.commandmode;
+
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+/*
+ * Because this app co-exists in a module with a QuarkusIntegrationTest, it needs to not be on the default path.
+ * Otherwise, this application is executed by the QuarkusIntegrationTest and exits early, causing test failures elsewhere.
+ */
+@QuarkusMain(name = "failing-application")
+public class FailingApp implements QuarkusApplication {
+
+    @Override
+    public int run(String... args) throws Exception {
+        // the point of this is to verify that Quarkus can properly shut down in the face of an Error (not an Exception)
+        throw new NoSuchMethodError("dummy");
+    }
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/testsupport/commandmode/QuarkusMainTestWithTestProfileAndFailingApplicationTestCase.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/testsupport/commandmode/QuarkusMainTestWithTestProfileAndFailingApplicationTestCase.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.testsupport.commandmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
+@TestProfile(QuarkusMainTestWithTestProfileAndFailingApplicationTestCase.MyTestProfile.class)
+public class QuarkusMainTestWithTestProfileAndFailingApplicationTestCase {
+
+    @Test
+    @Launch(value = {}, exitCode = 1)
+    public void testLaunchCommand(LaunchResult result) {
+        assertThat(result.getOutput()).contains("dummy");
+    }
+
+    public static class MyTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.package.main-class", "failing-application");
+        }
+    }
+}


### PR DESCRIPTION
This is needed because we need to always perform
the proper shutdown sequence, not just for regular Exception classes.

This was originally reported by @gsmet because the tests in the Quarkus GitHub bot started hanging due to:

```posh
2025-09-03 12:10:26,081 ERROR [io.qua.run.Quarkus] (main) Error running Quarkus: java.lang.NoSuchFieldError: SNAKE_CASE
    at org.kohsuke.github.GitHubClient.<clinit>(GitHubClient.java:92)
    at org.kohsuke.github.GitHub.<init>(GitHub.java:137)
    at org.kohsuke.github.GitHubBuilder.build(GitHubBuilder.java:509)
    at org.kohsuke.github.GitHub.offline(GitHub.java:458)
    at io.quarkiverse.githubaction.runtime.GitHubEvent.getGitHub(GitHubEvent.java:109)
    at io.quarkiverse.githubaction.it.ConfigFileAction_Multiplexer.test_c0f770948b130a72cc7848c04407fb57053ad599(Unknown Source)
    at io.quarkiverse.githubaction.it.ConfigFileAction_Multiplexer_Observer_test_c0f770948b130a72cc7848c04407fb57053ad599_jVQZvWbAPsheAn8mJPnHTyuwHRU.notify(Unknown Source)
    at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:365)
    at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:347)
    at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:81)
    at io.quarkiverse.githubaction.runtime.GitHubEventHandlerImpl.handle(Unknown Source)
    at io.quarkiverse.githubaction.runtime.ActionMain.run(ActionMain.java:56)
    at io.quarkiverse.githubaction.runtime.ActionMain_ClientProxy.run(Unknown Source)
    at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:141)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:80)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:51)
    at io.quarkus.runner.GeneratedMain.main(Unknown Source)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:569)
    at io.quarkus.runner.bootstrap.StartupActionImpl.runMainClassBlocking(StartupActionImpl.java:249)
```

which in turn started happening because Jackson 2.20 removed the `SNAKE_CASE` field from `PropertyNamingStrategy`