### PR TITLE
ArC: fix interception proxy of abstract classes with interfaces

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptionProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptionProxyGenerator.java
@@ -325,7 +325,7 @@ public class InterceptionProxyGenerator extends AbstractGenerator {
                     }
                 }
 
-                ResultHandle superResult = isInterface
+                ResultHandle superResult = method.declaringClass().isInterface()
                         ? funcBytecode.invokeInterfaceMethod(methodDescriptor, targetHandle, superParamHandles)
                         : funcBytecode.invokeVirtualMethod(methodDescriptor, targetHandle, superParamHandles);
                 funcBytecode.returnValue(superResult != null ? superResult : funcBytecode.loadNull());

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithAbstractClassAndInterfaceInterceptionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithAbstractClassAndInterfaceInterceptionTest.java
@@ -1,0 +1,128 @@
+package io.quarkus.arc.test.interceptors.producer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InterceptionProxy;
+import io.quarkus.arc.NoClassInterceptors;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ProducerWithAbstractClassAndInterfaceInterceptionTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBinding1.class, MyInterceptor1.class,
+            MyBinding2.class, MyInterceptor2.class, MyProducer.class);
+
+    @Test
+    public void test() {
+        MyNonbeanBase nonbean = Arc.container().instance(MyNonbeanBase.class).get();
+        assertEquals("intercepted1: hello1_foobar", nonbean.hello1());
+        assertEquals("intercepted1: hello2_foobar", nonbean.hello2());
+        assertEquals("hello3", nonbean.hello3());
+        assertEquals("hello4_foobar", nonbean.hello4());
+        assertEquals("hello5", nonbean.hello5());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+    @InterceptorBinding
+    @interface MyBinding1 {
+    }
+
+    @MyBinding1
+    @Priority(1)
+    @Interceptor
+    static class MyInterceptor1 {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted1: " + ctx.proceed();
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+    @InterceptorBinding
+    @interface MyBinding2 {
+    }
+
+    @MyBinding2
+    @Priority(2)
+    @Interceptor
+    static class MyInterceptor2 {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted2: " + ctx.proceed();
+        }
+    }
+
+    interface MyNonbean {
+        String hello1();
+
+        @MyBinding2 // this should be ignored, because interceptor bindings are ignored on interfaces
+        String hello2();
+
+        @MyBinding2 // this should be ignored, because interceptor bindings are ignored on interfaces
+        @NoClassInterceptors
+        default String hello3() {
+            return "hello3";
+        }
+
+        @NoClassInterceptors
+        String hello4();
+
+        @NoClassInterceptors
+        default String hello5() {
+            return "hello5";
+        };
+    }
+
+    @MyBinding1
+    abstract static class MyNonbeanBase implements MyNonbean {
+    }
+
+    static class MyNonbeanImpl extends MyNonbeanBase {
+        private final String value;
+
+        MyNonbeanImpl(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String hello1() {
+            return "hello1_" + value;
+        }
+
+        @Override
+        public String hello2() {
+            return "hello2_" + value;
+        }
+
+        @Override
+        public String hello4() {
+            return "hello4_" + value;
+        }
+    }
+
+    @Dependent
+    static class MyProducer {
+        @Produces
+        MyNonbeanBase produce(InterceptionProxy<MyNonbeanBase> proxy) {
+            return proxy.create(new MyNonbeanImpl("foobar"));
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithAbstractClassWithInterfaceInterceptionAndBindingsSourceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithAbstractClassWithInterfaceInterceptionAndBindingsSourceTest.java
@@ -1,0 +1,113 @@
+package io.quarkus.arc.test.interceptors.producer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BindingsSource;
+import io.quarkus.arc.InterceptionProxy;
+import io.quarkus.arc.NoClassInterceptors;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ProducerWithAbstractClassWithInterfaceInterceptionAndBindingsSourceTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBinding1.class, MyInterceptor1.class,
+            MyBinding2.class, MyInterceptor2.class, MyProducer.class);
+
+    @Test
+    public void test() {
+        MyNonbeanBase nonbean = Arc.container().instance(MyNonbeanBase.class).get();
+        assertEquals("intercepted1: hello1", nonbean.hello1());
+        assertEquals("intercepted1: intercepted2: hello2", nonbean.hello2());
+        assertEquals("intercepted2: hello3", nonbean.hello3());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+    @InterceptorBinding
+    @interface MyBinding1 {
+    }
+
+    @MyBinding1
+    @Priority(1)
+    @Interceptor
+    static class MyInterceptor1 {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted1: " + ctx.proceed();
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+    @InterceptorBinding
+    @interface MyBinding2 {
+    }
+
+    @MyBinding2
+    @Priority(2)
+    @Interceptor
+    static class MyInterceptor2 {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted2: " + ctx.proceed();
+        }
+    }
+
+    interface MyNonbean {
+        String hello1();
+    }
+
+    abstract static class MyNonbeanBase implements MyNonbean {
+        public abstract String hello2();
+
+        public String hello3() {
+            return "hello3";
+        }
+    }
+
+    static class MyNonbeanImpl extends MyNonbeanBase {
+        @Override
+        public String hello1() {
+            return "hello1";
+        }
+
+        @Override
+        public String hello2() {
+            return "hello2";
+        }
+    }
+
+    @MyBinding1
+    static abstract class MyNonbeanBindings {
+        @MyBinding2
+        abstract String hello2();
+
+        @MyBinding2
+        @NoClassInterceptors
+        abstract String hello3();
+    }
+
+    @Dependent
+    static class MyProducer {
+        @Produces
+        MyNonbeanBase produce(@BindingsSource(MyNonbeanBindings.class) InterceptionProxy<MyNonbeanBase> proxy) {
+            return proxy.create(new MyNonbeanImpl());
+        }
+    }
+}


### PR DESCRIPTION
This fixes the following error if an interception proxy for an abstract class with interfaces is created:
```
java.lang.IncompatibleClassChangeError: Found interface io.quarkus.arc.test.interceptors.producer.ProducerWithAbsractClassAndInterfaceInterceptionTest$MyNonbean, but class was expected
	at io.quarkus.arc.test.interceptors.producer.ProducerWithAbsractClassAndInterfaceInterceptionTest$MyNonbeanBase_InterceptionSubclass$$function$$2.apply(Unknown Source)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:73)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:62)
	at io.quarkus.arc.test.interceptors.producer.ProducerWithAbsractClassAndInterfaceInterceptionTest$MyInterceptor1.intercept(ProducerWithAbsractClassAndInterfaceInterceptionTest.java:53)
	at io.quarkus.arc.test.interceptors.producer.ProducerWithAbsractClassAndInterfaceInterceptionTest_MyInterceptor1_Bean.intercept(Unknown Source)
	at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:30)
	at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:27)
	at io.quarkus.arc.test.interceptors.producer.ProducerWithAbsractClassAndInterfaceInterceptionTest$MyNonbeanBase_InterceptionSubclass.hello1(Unknown Source)
	at io.quarkus.arc.test.interceptors.producer.ProducerWithAbsractClassAndInterfaceInterceptionTest.test(ProducerWithAbsractClassAndInterfaceInterceptionTest.java:34)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```