### PR TITLE
Correct setting kafka graceful-shutdown property for dev and test profiles

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -42,6 +42,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.AdditionalJpaModelBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames;
+import io.quarkus.smallrye.reactivemessaging.deployment.items.ChannelDirection;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ConnectorManagedChannelBuildItem;
 import io.quarkus.smallrye.reactivemessaging.kafka.DatabindProcessingStateCodec;
 import io.quarkus.smallrye.reactivemessaging.kafka.HibernateOrmStateStore;
@@ -201,24 +202,24 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
         if (launchMode.getLaunchMode().isDevOrTest()) {
             if (!buildTimeConfig.enableGracefulShutdownInDevAndTestMode()) {
-                List<AnnotationInstance> incomings = discoveryState.findRepeatableAnnotationsOnMethods(DotNames.INCOMING);
-                List<AnnotationInstance> outgoings = discoveryState.findRepeatableAnnotationsOnMethods(DotNames.OUTGOING);
-                List<AnnotationInstance> channels = discoveryState.findAnnotationsOnInjectionPoints(DotNames.CHANNEL);
-                List<AnnotationInstance> annotations = new ArrayList<>();
-                annotations.addAll(incomings);
-                annotations.addAll(outgoings);
-                annotations.addAll(channels);
-                for (AnnotationInstance annotation : annotations) {
-                    String channelName = annotation.value().asString();
-                    if (!discoveryState.isKafkaConnector(channelsManagedByConnectors, true, channelName)) {
-                        continue;
-                    }
-                    String key = getChannelPropertyKey(channelName, "graceful-shutdown", true);
-                    discoveryState.ifNotYetConfigured(key, () -> {
-                        defaultConfigProducer.produce(new RunTimeConfigurationDefaultBuildItem(key, "false"));
-                    });
-                }
+                disableGracefulShutdown(channelsManagedByConnectors, defaultConfigProducer, discoveryState);
             }
+        }
+    }
+
+    void disableGracefulShutdown(List<ConnectorManagedChannelBuildItem> channelsManagedByConnectors,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> defaultConfigProducer,
+            DefaultSerdeDiscoveryState discoveryState) {
+        for (ConnectorManagedChannelBuildItem managed : channelsManagedByConnectors) {
+            String channelName = managed.getName();
+            boolean incoming = managed.getDirection() == ChannelDirection.INCOMING;
+            if (!discoveryState.isKafkaConnector(channelsManagedByConnectors, incoming, channelName)) {
+                continue;
+            }
+            String key = getChannelPropertyKey(channelName, incoming ? "graceful-shutdown" : "close-timeout", incoming);
+            discoveryState.ifNotYetConfigured(key, () -> {
+                defaultConfigProducer.produce(new RunTimeConfigurationDefaultBuildItem(key, incoming ? "false" : "0"));
+            });
         }
     }
 


### PR DESCRIPTION
* Fixes #48641

Fix for a minor bug that only exists in development or testing mode.
In some cases that are extremely difficult to reproduce, a situation occurs where channels are not formed correctly. For example, channel-in, channel-out are recognized as belonging to 1 specific input channel.
The problem is that 1 common list of `Incoming`, `Outgoing` and `Channel` annotations was formed, and the graceful-shutdown setting was set for them as for incoming channels.
According to the [documentation](https://smallrye.io/smallrye-reactive-messaging/4.25.0/kafka/receiving-kafka-records/#configuration-reference) only incoming channels have such a setting, but not for outgoing ones.
Therefore, you can remove the setting of the property for outgoing channels.