### PR TITLE
Revert: Dependabot - Group mvnpm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -198,10 +198,6 @@ updates:
           - "org.hibernate.reactive*"
           - "org.hibernate.search*"
           - "org.hibernate.tool*"
-      Mvnpm:
-        patterns:
-          - "org.mvnpm:*"
-          - "org.mvnpm.*:*"
     ignore:
       - dependency-name: org.eclipse.microprofile.config:microprofile-config-tck
         update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
This PR revert the Grouping of MVNPM dependabot updates. The grouping does not really work because:

- We can never merge a grouped PR as there is always updates in there that we do not want (usually updates that is out of the range of a transitive dependency)
- If there is one that needs to be updates, we need to manually open a new PR for that.
- It sends the same update everyday because we keep on closing the grouped one. 

I understand that the prs can be overwhelming when not grouped. As shown in the grouped one, there are 21 updates currently. I suggest that after this revert I will go though all 21, and at least when we close them one by one, it will not ask again for the same update. Once that is done the updates are manageable. 
