### PR TITLE
Bump to Vert.x 4.5.21 and Netty 4.1.127.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -112,7 +112,7 @@
         <wildfly-elytron.version>2.6.5.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.3.Final</jboss-marshalling.version>
         <jboss-threads.version>3.9.1</jboss-threads.version>
-        <vertx.version>4.5.20</vertx.version>
+        <vertx.version>4.5.21</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -134,7 +134,7 @@
         <infinispan.version>15.0.19.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.2.2</caffeine.version>
-        <netty.version>4.1.124.Final</netty.version>
+        <netty.version>4.1.126.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -134,7 +134,7 @@
         <infinispan.version>15.0.19.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.2.2</caffeine.version>
-        <netty.version>4.1.126.Final</netty.version>
+        <netty.version>4.1.127.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtilTest.java
@@ -113,6 +113,11 @@ class VertxUtilTest {
             }
 
             @Override
+            public @Nullable HostAndPort authority(boolean b) {
+                return null;
+            }
+
+            @Override
             public @Nullable String host() {
                 return "";
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -198,6 +198,14 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     }
 
     @Override
+    public HostAndPort authority(boolean real) {
+        if (real) {
+            return delegate.authority();
+        }
+        return this.authority();
+    }
+
+    @Override
     public boolean isValidAuthority() {
         return forwardedParser.authority() != null;
     }

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,7 +57,7 @@
 
         <mutiny.version>2.9.4</mutiny.version>
         <smallrye-common.version>2.13.8</smallrye-common.version>
-        <vertx.version>4.5.20</vertx.version>
+        <vertx.version>4.5.21</vertx.version>
         <rest-assured.version>5.5.6</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.20.0</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.20</vertx.version>
+        <vertx.version>4.5.21</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This fixes Netty CVEs: CVE-2025-58057 and CVE-2025-58056


