### PR TITLE
[3.15] Bump to Vert.x 4.5.21 and Netty 4.1.127.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -137,7 +137,7 @@
         <infinispan.version>15.0.19.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.126.Final</netty.version>
+        <netty.version>4.1.127.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -115,7 +115,7 @@
         <wildfly-elytron.version>2.5.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.1.Final</jboss-marshalling.version>
         <jboss-threads.version>3.6.1.Final</jboss-threads.version>
-        <vertx.version>4.5.20</vertx.version>
+        <vertx.version>4.5.21</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -137,7 +137,7 @@
         <infinispan.version>15.0.19.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.124.Final</netty.version>
+        <netty.version>4.1.126.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
 
         <mutiny.version>2.9.4</mutiny.version>
         <smallrye-common.version>2.6.1</smallrye-common.version>
-        <vertx.version>4.5.20</vertx.version>
+        <vertx.version>4.5.21</vertx.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>


### PR DESCRIPTION
This fixes Netty CVEs: CVE-2025-58057 and CVE-2025-58056

