### PR TITLE
chore: make grpc-hibernate test more stable

### DIFF
--- a/integration-tests/grpc-hibernate/src/main/resources/application.properties
+++ b/integration-tests/grpc-hibernate/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
 
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 


### PR DESCRIPTION
I ported the `grpc-` prefixed integration tests to the `quarkus-grpc-zero` repo, and found out that this test was just a little(~1 failure every 20 runs) flaky:
https://github.com/quarkiverse/quarkus-grpc-zero/pull/16

Using H2 directly in-memory seems to fix the issue.
