### PR TITLE
Deprecate SmallRye Metrics

### DIFF
--- a/extensions/agroal/deployment/pom.xml
+++ b/extensions/agroal/deployment/pom.xml
@@ -112,6 +112,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <runOrder>alphabetical</runOrder>
+                    <systemPropertyVariables>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -134,6 +134,11 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-test</id>

--- a/extensions/quartz/deployment/pom.xml
+++ b/extensions/quartz/deployment/pom.xml
@@ -71,6 +71,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/smallrye-graphql/deployment/pom.xml
+++ b/extensions/smallrye-graphql/deployment/pom.xml
@@ -121,6 +121,9 @@
                         true, some as false, so we need to create a separate JVM per test to run the initializer each time separately.
                         This is reported as https://github.com/smallrye/smallrye-graphql/issues/2039 -->
                     <reuseForks>false</reuseForks>
+                    <systemPropertyVariables>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/smallrye-metrics/deployment/pom.xml
+++ b/extensions/smallrye-metrics/deployment/pom.xml
@@ -97,6 +97,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsConfig.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsConfig.java
@@ -19,6 +19,13 @@ public interface SmallRyeMetricsConfig {
     String path();
 
     /**
+     * If the extension should be enabled even if deprecated and scheduled for removal.
+     */
+    @WithName("deprecated.enabled")
+    @WithDefault("false")
+    boolean deprecatedEnabled();
+
+    /**
      * Whether metrics published by Quarkus extensions should be enabled.
      */
     @WithName("extensions.enabled")

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -53,6 +53,7 @@ import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.InterceptorInfo;
+import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -97,7 +98,19 @@ public class SmallRyeMetricsProcessor {
     }
 
     @BuildStep
-    MetricsCapabilityBuildItem metricsCapabilityBuildItem(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
+    MetricsCapabilityBuildItem metricsCapabilityBuildItem(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem)
+            throws BuildException {
+        if (!metrics.deprecatedEnabled()) {
+            throw new BuildException("""
+                    The Quarkus SmallRye Metrics is deprecated and will be removed in the near future. Please \
+                    check our announcement at https://quarkus.io/blog/quarkus-observability-roadmap-2023/. Our \
+                    recommendation is to migrate to Quarkus Micrometer Metrics \
+                    https://quarkus.io/guides/telemetry-micrometer. If you wish to keep using Quarkus SmallRye \
+                    Metrics, please reenable it with the configuration \
+                    "quarkus.smallrye-metrics.deprecated.enabled=true".
+                    """);
+        }
+
         if (metrics.extensionsEnabled()) {
             return new MetricsCapabilityBuildItem(MetricsFactory.MP_METRICS::equals,
                     nonApplicationRootPathBuildItem.resolvePath(metrics.path()));

--- a/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.smallrye-metrics.deprecated.enabled=true
+
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.jdbc.max-size=8

--- a/integration-tests/hibernate-orm-panache/src/main/resources/ddlgeneration.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/ddlgeneration.properties
@@ -1,3 +1,5 @@
+quarkus.smallrye-metrics.deprecated.enabled=true
+
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.jdbc.max-size=8

--- a/integration-tests/hibernate-orm-panache/src/main/resources/nopaging.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/nopaging.properties
@@ -1,3 +1,5 @@
+quarkus.smallrye-metrics.deprecated.enabled=true
+
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.jdbc.max-size=8

--- a/integration-tests/smallrye-metrics/src/main/resources/application.properties
+++ b/integration-tests/smallrye-metrics/src/main/resources/application.properties
@@ -1,1 +1,2 @@
+quarkus.smallrye-metrics.deprecated.enabled=true
 quarkus.log.metrics.enabled=true

--- a/tcks/microprofile-fault-tolerance/pom.xml
+++ b/tcks/microprofile-fault-tolerance/pom.xml
@@ -27,6 +27,7 @@
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <smallrye.faulttolerance.mp-compatibility>true</smallrye.faulttolerance.mp-compatibility>
                         <quarkus.otel.metrics.enabled>true</quarkus.otel.metrics.enabled>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->

--- a/tcks/microprofile-metrics/api/pom.xml
+++ b/tcks/microprofile-metrics/api/pom.xml
@@ -21,6 +21,7 @@
                     <systemPropertyVariables>
                         <!-- Disable quarkus optimization -->
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->

--- a/tcks/microprofile-metrics/optional/pom.xml
+++ b/tcks/microprofile-metrics/optional/pom.xml
@@ -25,6 +25,7 @@
                         <!-- Change metrics endpoint to be /metrics -->
                         <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
                         <context.root/>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->

--- a/tcks/microprofile-metrics/rest/pom.xml
+++ b/tcks/microprofile-metrics/rest/pom.xml
@@ -23,6 +23,7 @@
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <!-- Change metrics endpoint to be /metrics -->
                         <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
+                        <quarkus.smallrye-metrics.deprecated.enabled>true</quarkus.smallrye-metrics.deprecated.enabled>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->


### PR DESCRIPTION
- Quarkus SmallRye Metrics has been announced as deprecated since 2023: https://quarkus.io/blog/quarkus-observability-roadmap-2023/. 
- Also, on the guide page: https://quarkus.io/guides/smallrye-metrics. 
- MicroProfile Metrics was also removed from MicroProfile 7.0: https://download.eclipse.org/microprofile/microprofile-7.0/microprofile-spec-7.0.html#microprofile7.0

This PR fails the build when using Quarkus SmallRye Metrics for increased awareness of our intention to remove the extension (after the next LTS). The extension can be reenabled by setting `quarkus.smallrye-metrics.deprecated.enabled=true`.

- Relates to https://github.com/quarkusio/quarkus/pull/49735
- Requires https://github.com/quarkusio/quarkus-quickstarts/pull/1565
