### PR TITLE
Manage more prometheus artifacts to help enforcing dependecy convergence throughout Quarkiverse

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -565,7 +565,27 @@
             </dependency>
             <dependency>
                 <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_caffeine</artifactId>
+                <version>${prometheus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
                 <artifactId>simpleclient_common</artifactId>
+                <version>${prometheus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_tracer_common</artifactId>
+                <version>${prometheus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_tracer_otel</artifactId>
+                <version>${prometheus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_tracer_otel_agent</artifactId>
                 <version>${prometheus.version}</version>
             </dependency>
 


### PR DESCRIPTION
Before @gastaldi asks, there is indeed a prometheus BOM https://repo1.maven.org/maven2/io/prometheus/simpleclient_bom/0.16.0/simpleclient_bom-0.16.0.pom but is managing a bit more than we really need for Camel Quarkus. So keeping Quarkus BOM small seems to make sense in this situation.