### PR TITLE
Support for a custom  OIDC resource metadata's authorization server URL

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -1295,6 +1295,7 @@ In turn, a client that requested the protected resource metadata can use its pro
 
 |quarkus.oidc.resource-metadata.enabled |false|Enable resource metadata properties
 |quarkus.oidc.resource-metadata.resource ||Resource identifier
+|quarkus.oidc.resource-metadata.authorization-server ||Authorization server URL
 |quarkus.oidc.resource-metadata.force-https-scheme |true|Force that a resource identifier URL has an HTTPS scheme
 |====
 
@@ -1307,7 +1308,9 @@ According to the https://datatracker.ietf.org/doc/rfc9728/[OAuth2 Protected Reso
 
 If it is configured as a relative path then it is added to the current request URL's host and port to build a resource identifier URL. If it is not configured at all then, unless it is a default tenant id, the tenand id is added to the current request URL's host and port to build a resource identifier URL.
 
-In such cases, the `quarkus.oidc.resource-metadata.force-https-scheme` property can be used to set a correct URL scheme, which is set to HTTPS by default.
+The resource identifier URL scheme is set to `HTTPS` by default. You can enable an `HTTP` URL scheme with `quarkus.oidc.resource-metadata.force-https-scheme=false`, it can be particularly useful in simple demos and tests.
+
+`quarkus.oidc.resource-metadata.authorization-server` allows to customize an authorization server URL that will be included in the resource metadata. The `quarkus.oidc.auth-server-url` URL is included by default, however, for some cases where an OIDC proxy interposes over the actual OIDC provider, returning the OIDC proxy's URL is required instead.
 
 See also the <<oidc-metadata-properties>> for details about the OIDC provider metadata that Quarkus OIDC uses for its work.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -2751,6 +2751,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
 
         public boolean enabled;
         public Optional<String> resource = Optional.empty();
+        public Optional<String> authorizationServer = Optional.empty();
         public boolean forceHttpsScheme = true;
 
         @Override
@@ -2764,6 +2765,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         }
 
         @Override
+        public Optional<String> authorizationServer() {
+            return authorizationServer;
+        }
+
+        @Override
         public boolean forceHttpsScheme() {
             return forceHttpsScheme;
         }
@@ -2771,6 +2777,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         private void addConfigMappingValues(io.quarkus.oidc.runtime.OidcTenantConfig.ResourceMetadata mapping) {
             enabled = mapping.enabled();
             resource = mapping.resource();
+            authorizationServer = mapping.authorizationServer();
             forceHttpsScheme = mapping.forceHttpsScheme();
         }
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
@@ -863,12 +863,13 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
     public static final class ResourceMetadataBuilder {
 
         private record ResourceMetadataImpl(boolean enabled, Optional<String> resource,
-                boolean forceHttpsScheme) implements ResourceMetadata {
+                Optional<String> authorizationServer, boolean forceHttpsScheme) implements ResourceMetadata {
         }
 
         private final OidcTenantConfigBuilder builder;
         private boolean enabled;
         private Optional<String> resource;
+        private Optional<String> authorizationServer;
         private boolean forceHttpsScheme;
 
         public ResourceMetadataBuilder() {
@@ -879,6 +880,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
             this.builder = Objects.requireNonNull(builder);
             this.enabled = builder.resourceMetadata.enabled();
             this.resource = builder.resourceMetadata.resource();
+            this.authorizationServer = builder.resourceMetadata.authorizationServer();
             this.forceHttpsScheme = builder.resourceMetadata.forceHttpsScheme();
         }
 
@@ -906,6 +908,15 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
          */
         public ResourceMetadataBuilder resource(String resource) {
             this.resource = Optional.ofNullable(resource);
+            return this;
+        }
+
+        /**
+         * @param resource {@link ResourceMetadata#authorizationServer()}
+         * @return this builder
+         */
+        public ResourceMetadataBuilder authorizationServer(String authorizationServer) {
+            this.authorizationServer = Optional.ofNullable(authorizationServer);
             return this;
         }
 
@@ -938,7 +949,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
          * @return built ResourceMetadata
          */
         public ResourceMetadata build() {
-            return new ResourceMetadataImpl(enabled, resource, forceHttpsScheme);
+            return new ResourceMetadataImpl(enabled, resource, authorizationServer, forceHttpsScheme);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -163,6 +163,12 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         Optional<String> resource();
 
         /**
+         * Authorization server URL.
+         * 'quarkus.oidc.auth-server-url' property value is reported by default.
+         */
+        Optional<String> authorizationServer();
+
+        /**
          * Force a protected resource identifier HTTPS scheme.
          * This property is ignored if {@link #resource() is an absolute URL}
          */

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
@@ -147,7 +147,8 @@ public class ResourceMetadataHandler implements Handler<RoutingContext> {
             metadata.put(OidcConstants.RESOURCE_METADATA_RESOURCE, resourceIdentifier);
 
             JsonArray authorizationServers = new JsonArray();
-            authorizationServers.add(0, oidcConfig.authServerUrl().get());
+            authorizationServers.add(0, oidcConfig.resourceMetadata().authorizationServer()
+                    .orElse(oidcConfig.authServerUrl().get()));
             metadata.put(OidcConstants.RESOURCE_METADATA_AUTHORIZATION_SERVERS, authorizationServers);
             return metadata.toString();
         }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -161,6 +161,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         CERTIFICATION_CHAIN_TRUST_STORE_FILE_TYPE,
         RESOURCE_METADATA_ENABLED,
         RESOURCE_METADATA_RESOURCE,
+        RESOURCE_METADATA_AUTHORIZATION_SERVER,
         RESOURCE_METADATA_FORCE_HTTPS_SCHEME,
         LOGOUT_PATH,
         LOGOUT_POST_LOGOUT_PATH,
@@ -617,6 +618,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             @Override
             public Optional<String> resource() {
                 invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA_RESOURCE, true);
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<String> authorizationServer() {
+                invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA_AUTHORIZATION_SERVER, true);
                 return Optional.empty();
             }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -138,6 +138,7 @@ quarkus.oidc.tenant-nonce.token-state-manager.encryption-required=false
 quarkus.oidc.tenant-nonce.token.allow-jwt-introspection=false
 quarkus.oidc.tenant-nonce.resource-metadata.enabled=true
 quarkus.oidc.tenant-nonce.resource-metadata.resource=/metadata
+quarkus.oidc.tenant-nonce.resource-metadata.authorization-server=http://localhost:8080/q/oidc
 
 quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-javascript.client-id=quarkus-app

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -150,7 +150,7 @@ public class CodeFlowTest {
             checkHealth();
 
             // Static default tenant
-            checkResourceMetadata(null, "quarkus");
+            checkResourceMetadata(null, "/realms/quarkus");
         }
     }
 
@@ -465,7 +465,7 @@ public class CodeFlowTest {
             assertEquals("Unexpected 401", ex.getMessage());
         }
         // Static `tenant-nonce` tenant with custom resource path
-        checkResourceMetadata("metadata", "quarkus");
+        checkResourceMetadata("metadata", ":8080/q/oidc");
     }
 
     private void doTestCodeFlowNonce(boolean wrongRedirect) throws Exception {
@@ -869,7 +869,7 @@ public class CodeFlowTest {
             webClient.getCookieManager().clearCookies();
 
             // Static `tenant-refresh` tenant
-            checkResourceMetadata("tenant-refresh", "logout-realm");
+            checkResourceMetadata("tenant-refresh", "/realms/logout-realm");
         }
     }
 
@@ -1762,7 +1762,7 @@ public class CodeFlowTest {
         return sessionCookie.getValue().split("\\|")[0];
     }
 
-    private static void checkResourceMetadata(String resource, String realm) {
+    private static void checkResourceMetadata(String resource, String authorizationServerSuffix) {
         Response metadataResponse = RestAssured.when()
                 .get("http://localhost:8081" + OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH
                         + (resource == null ? "" : "/" + resource));
@@ -1774,6 +1774,6 @@ public class CodeFlowTest {
 
         String authorizationServer = jsonAuthorizarionServers.getString(0);
         assertTrue(authorizationServer.startsWith("http://localhost:"));
-        assertTrue(authorizationServer.endsWith("/realms/" + realm));
+        assertTrue(authorizationServer.endsWith(authorizationServerSuffix));
     }
 }


### PR DESCRIPTION
I've been looking at using OIDC proxy with MCP inspector's new OAuth2 capability, and found out I had to be able to customize the authorization URL included in the OIDC resource metadata.

A few other changes are also needed, but I confirmed that this update helps to get everything working 