### PR TITLE
Update OidcConfigMetadata to return supported properties such as subject and response types

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
@@ -15,9 +15,13 @@ public class OidcConfigurationMetadata {
     public static final String JWKS_ENDPOINT = "jwks_uri";
     public static final String USERINFO_ENDPOINT = "userinfo_endpoint";
     public static final String END_SESSION_ENDPOINT = "end_session_endpoint";
-    private static final String REGISTRATION_ENDPOINT = "registration_endpoint";
-    private static final String REVOCATION_ENDPOINT = "revocation_endpoint";
+    public static final String REGISTRATION_ENDPOINT = "registration_endpoint";
+    public static final String REVOCATION_ENDPOINT = "revocation_endpoint";
     public static final String SCOPES_SUPPORTED = "scopes_supported";
+    public static final String RESPONSE_TYPES_SUPPORTED = "response_types_supported";
+    public static final String SUBJECT_TYPES_SUPPORTED = "subject_types_supported";
+    public static final String ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED = "id_token_signing_alg_values_supported";
+    public static final String CODE_CHALLENGE_METHODS_SUPPORTED = "code_challenge_methods_supported";
 
     private final String discoveryUri;
     private final String tokenUri;
@@ -123,6 +127,22 @@ public class OidcConfigurationMetadata {
 
     public List<String> getSupportedScopes() {
         return getStringList(SCOPES_SUPPORTED);
+    }
+
+    public List<String> getSupportedResponseTypes() {
+        return getStringList(RESPONSE_TYPES_SUPPORTED);
+    }
+
+    public List<String> getSupportedSubjectTypes() {
+        return getStringList(SUBJECT_TYPES_SUPPORTED);
+    }
+
+    public List<String> getSupportedIdTokenSigningAlgorithms() {
+        return getStringList(ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED);
+    }
+
+    public List<String> getSupportedCodeChallengeMethods() {
+        return getStringList(CODE_CHALLENGE_METHODS_SUPPORTED);
     }
 
     public String getIssuer() {

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -104,6 +104,30 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("configMetadataResponseTypes")
+    public String configMetadataResponseTypes() {
+        return configMetadata.getSupportedResponseTypes().stream().collect(Collectors.joining(","));
+    }
+
+    @GET
+    @Path("configMetadataSubjectTypes")
+    public String configMetadataSubjectTypes() {
+        return configMetadata.getSupportedSubjectTypes().stream().collect(Collectors.joining(","));
+    }
+
+    @GET
+    @Path("configMetadataIdTokenSigningAlgorithms")
+    public String configMetadataIdTokenSigningAlgorithms() {
+        return configMetadata.getSupportedIdTokenSigningAlgorithms().stream().collect(Collectors.joining(","));
+    }
+
+    @GET
+    @Path("configMetadataCodeChallengeMethods")
+    public String configMetadataCodeChallengeMethods() {
+        return configMetadata.getSupportedCodeChallengeMethods().stream().collect(Collectors.joining(","));
+    }
+
+    @GET
     public String getName() {
         if (!idTokenCredential.getToken().equals(idToken.getRawToken())) {
             throw new OIDCException("ID token values are not equal");

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -97,16 +97,7 @@ public class CodeFlowTest {
             assertEquals("Welcome to Test App", page.getTitleText(),
                     "A second request should not redirect and just re-authenticate the user");
 
-            page = webClient.getPage("http://localhost:8081/web-app/configMetadataIssuer");
-
-            assertEquals(
-                    client.getAuthServerUrl(),
-                    page.asNormalizedText());
-
-            page = webClient.getPage("http://localhost:8081/web-app/configMetadataScopes");
-
-            assertTrue(page.asNormalizedText().contains("openid"));
-            assertTrue(page.asNormalizedText().contains("profile"));
+            verifyConfigurationMetadata(webClient);
 
             Cookie sessionCookie = getSessionCookie(webClient, null);
             assertNotNull(sessionCookie);
@@ -152,6 +143,47 @@ public class CodeFlowTest {
             // Static default tenant
             checkResourceMetadata(null, "/realms/quarkus");
         }
+    }
+
+    private void verifyConfigurationMetadata(WebClient webClient) throws IOException {
+        // Issuer
+        HtmlPage page = webClient.getPage("http://localhost:8081/web-app/configMetadataIssuer");
+
+        assertEquals(
+                client.getAuthServerUrl(),
+                page.asNormalizedText());
+
+        // Scopes
+        page = webClient.getPage("http://localhost:8081/web-app/configMetadataScopes");
+
+        assertTrue(page.asNormalizedText().contains("openid"));
+        assertTrue(page.asNormalizedText().contains("profile"));
+
+        // Response types
+        page = webClient.getPage("http://localhost:8081/web-app/configMetadataResponseTypes");
+
+        assertTrue(page.asNormalizedText().contains("code"));
+        assertTrue(page.asNormalizedText().contains("token"));
+
+        // Subject types
+        page = webClient.getPage("http://localhost:8081/web-app/configMetadataSubjectTypes");
+
+        assertTrue(page.asNormalizedText().contains("public"));
+        assertTrue(page.asNormalizedText().contains("pairwise"));
+
+        // ID token signing algorithms
+        page = webClient.getPage("http://localhost:8081/web-app/configMetadataIdTokenSigningAlgorithms");
+
+        assertTrue(page.asNormalizedText().contains("RS256"));
+        assertTrue(page.asNormalizedText().contains("ES256"));
+        assertTrue(page.asNormalizedText().contains("PS256"));
+
+        // PKCE code challenge methods
+        page = webClient.getPage("http://localhost:8081/web-app/configMetadataCodeChallengeMethods");
+
+        assertTrue(page.asNormalizedText().contains("S256"));
+        assertTrue(page.asNormalizedText().contains("plain"));
+
     }
 
     private static void checkHealth() {


### PR DESCRIPTION
This is another minor PR to expose some more available discovered OIDC properties. There are a lot of them, but the 4 supported properties added with this PR are the ones required by MCP Inspector, and we may add more.

In the short term, these properties will only be used by OIDC proxy to form a correct well known metadata response to MCP inspector.

But going forward, we'll be able to use these properties to tighten some of the Quarkus OIDC. For example, if the provider does not support PKCE S256 code challenge but the user configured it (default value) then we can fail early etc 