### PR TITLE
WebSockets Next: Expose localAddress and remoteAddress in HandshakeRequest

### DIFF
--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
@@ -91,6 +91,8 @@ public class BasicConnectorTest {
                 })
                 .onClose((c, s) -> closedLatch.countDown())
                 .connectAndAwait();
+        assertTrue(connection1.handshakeRequest().localAddress().matches("127\\.0\\.0\\.1:\\d+"));
+        assertEquals("127.0.0.1:8081", connection1.handshakeRequest().remoteAddress());
         assertEquals("Lu", connection1.pathParam("name"));
         assertTrue(connection1.userData().get(TypedKey.forBoolean("boolean")));
         assertEquals(Integer.MAX_VALUE, connection1.userData().get(TypedKey.forInt("int")));
@@ -131,6 +133,8 @@ public class BasicConnectorTest {
                 })
                 .connectAndAwait();
         assertNotNull(connection2);
+        assertTrue(connection2.handshakeRequest().localAddress().matches("127\\.0\\.0\\.1:\\d+"));
+        assertEquals("127.0.0.1:8081", connection2.handshakeRequest().remoteAddress());
         assertTrue(conn2Latch.await(5, TimeUnit.SECONDS));
     }
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/handshake/HandshakeRequestTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/handshake/HandshakeRequestTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.websockets.next.test.handshake;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 
@@ -48,6 +49,8 @@ public class HandshakeRequestTest {
         assertEquals(baseUri.getPort(), reply.getInteger("port"));
         assertEquals("/head", reply.getString("path"));
         assertEquals(query, reply.getString("query"));
+        assertEquals("127.0.0.1:8081", reply.getString("localAddress"));
+        assertTrue(reply.getString("remoteAddress").matches("127\\.0\\.0\\.1:\\d+"));
     }
 
     @WebSocket(path = "/head")
@@ -67,7 +70,9 @@ public class HandshakeRequestTest {
                     .put("host", connection.handshakeRequest().host())
                     .put("port", connection.handshakeRequest().port())
                     .put("path", connection.handshakeRequest().path())
-                    .put("query", connection.handshakeRequest().query());
+                    .put("query", connection.handshakeRequest().query())
+                    .put("localAddress", connection.handshakeRequest().localAddress().toString())
+                    .put("remoteAddress", connection.handshakeRequest().remoteAddress().toString());
         }
 
     }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/HandshakeRequest.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/HandshakeRequest.java
@@ -43,33 +43,43 @@ public interface HandshakeRequest {
 
     /**
      *
-     * @return the scheme
+     * @return the scheme component of the server endpoint URL
      */
     String scheme();
 
     /**
      *
-     * @return the host
+     * @return the host component of the server endpoint URL
      */
     String host();
 
     /**
      *
-     * @return the port
+     * @return the port number of the server endpoint URL
      */
     int port();
 
     /**
      *
-     * @return the path
+     * @return the path component of the server endpoint URL
      */
     String path();
 
     /**
-     *
-     * @return the query string
+     * @return the query string of the server endpoint URL
      */
     String query();
+
+    /**
+     *
+     * @return the local IP address and port for this connection, or {@code null} if not available
+     */
+    String localAddress();
+
+    /**
+     * @return the remote IP address and port for this connection, or {@code null} if not available
+     */
+    String remoteAddress();
 
     /**
      * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.1">Sec-WebSocket-Key</a>.

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
@@ -22,6 +22,7 @@ import io.vertx.core.buffer.impl.BufferImpl;
 import io.vertx.core.http.WebSocketBase;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.SocketAddress;
 
 public abstract class WebSocketConnectionBase implements Connection {
 
@@ -190,6 +191,25 @@ public abstract class WebSocketConnectionBase implements Connection {
     @Override
     public UserData userData() {
         return userData;
+    }
+
+    protected static class HandshakeRequestBase {
+
+        protected String formatSocketAddress(SocketAddress socketAddress) {
+            if (socketAddress == null) {
+                return null;
+            }
+            if (socketAddress.isInetSocket() && socketAddress.hostAddress() != null) {
+                return socketAddress.hostAddress() + ":" + socketAddress.port();
+            }
+            if (socketAddress.isInetSocket() && socketAddress.hostName() != null) {
+                return socketAddress.hostName() + ":" + socketAddress.port();
+            }
+            if (socketAddress.isDomainSocket()) {
+                return socketAddress.path();
+            }
+            return null;
+        }
     }
 
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
@@ -97,7 +97,7 @@ class WebSocketConnectionImpl extends WebSocketConnectionBase implements WebSock
         return Objects.equals(identifier, other.identifier);
     }
 
-    private static class HandshakeRequestImpl implements HandshakeRequest {
+    private static class HandshakeRequestImpl extends HandshakeRequestBase implements HandshakeRequest {
 
         private final ServerWebSocket webSocket;
 
@@ -147,6 +147,16 @@ class WebSocketConnectionImpl extends WebSocketConnectionBase implements WebSock
         @Override
         public String query() {
             return webSocket.query();
+        }
+
+        @Override
+        public String localAddress() {
+            return formatSocketAddress(webSocket.localAddress());
+        }
+
+        @Override
+        public String remoteAddress() {
+            return formatSocketAddress(webSocket.remoteAddress());
         }
 
         static Map<String, List<String>> initHeaders(RoutingContext ctx) {


### PR DESCRIPTION
`WebSocketConnection` provides access to `HandshakeRequest`, which exposes useful information about the incoming HTTP request. This change adds `localAddress` and `remoteAddress` to the this interface.

* Fixes #49840 
