### PR TITLE
Introduce a ModuleOpenBuildItem to let extensions control --add-opens needs for the runtime

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3642,6 +3642,11 @@
                 <artifactId>byte-buddy</artifactId>
                 <version>${bytebuddy.version}</version>
             </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${bytebuddy.version}</version>
+            </dependency>
 
             <!-- GRPC dependencies -->
             <dependency>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -143,6 +143,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- There's a single use of this, as a migration facilitator as we polish Java 25 support.
+                It's probably worth removing soon: the implication would be that the JVM flags required
+                by the various implementations of JvmModulesReconfigurer become strictly required
+                (at least one of these will be required).
+                Currently we're issues warnings when none is set - so in a few release cycles we should be
+                able to expect users will have applied them, then remove this.
+                At that time - please considering removing from the BOM as well -->
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bom-quarkus-platform-properties</artifactId>
             <type>pom</type>
@@ -232,6 +243,10 @@
                     <execution>
                         <id>default-compile</id>
                         <configuration>
+                            <!-- We can't set "-release" and also use "-add-exports" -->
+                            <release combine.self="override"></release>
+                            <source>${maven.compiler.release}</source>
+                            <target>${maven.compiler.release}</target>
                             <annotationProcessorPaths>
                                 <path>
                                     <groupId>io.quarkus</groupId>
@@ -241,6 +256,7 @@
                             </annotationProcessorPaths>
                             <compilerArgs>
                                 <arg>-AsplitOnConfigRootDescription=true</arg>
+                                <arg>--add-exports=java.base/jdk.internal.module=ALL-UNNAMED</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>

--- a/core/deployment/src/main/java/io/quarkus/deployment/JBossThreadsProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/JBossThreadsProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 public class JBossThreadsProcessor {
@@ -11,4 +12,11 @@ public class JBossThreadsProcessor {
         // see https://github.com/jbossas/jboss-threads/pull/200
         return new RuntimeInitializedClassBuildItem("org.jboss.threads.EnhancedQueueExecutor$RuntimeFields");
     }
+
+    @BuildStep
+    ModuleOpenBuildItem allowClearThreadLocals() {
+        // Since JDK 24, JBoss Threads needs `--add-opens java.base/java.lang=org.jboss.threads` to handle org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals()
+        return new ModuleOpenBuildItem("java.base", "org.jboss.threads", "java.lang");
+    }
+
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ModuleOpenBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ModuleOpenBuildItem.java
@@ -1,0 +1,95 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Set;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * This will generate the equivalent of "--add-opens=[openedModule/package(s)]=[openingModule]" for
+ * all runners of the generated application.
+ * Some limitations apply which will depend on the launch mode of Quarkus; specifically, when
+ * generating a runnable Jar we can only open a module to ALL-UNNAMED; this is considered
+ * acceptable at the time of writing as extensions are generally placed on the classpath for
+ * both fast-jar and uber-jar packaging formats. We expect this to evolve as further packaging
+ * formats are introduced which would better leverage the module system.
+ * We specifically don't allow opening a module to "ALL-UNNAMED" explicitly to encourage using the module
+ * names that a library has or will have in the near future: for this reason, when a module name
+ * is provided which doesn't exist, we map it to the unnamed module.
+ * This should be treated as an implementation detail of the current packaging format and is most
+ * likely bound to evolve.
+ * When running integration tests, we aim to run the tests within module access rules consistent with
+ * the production packaging modes, but as we need to dynamically modify the module system's access
+ * restrictions we need to apply these rules to specific, targeted classloaders: we'll only instrument
+ * the unnamed module relating to the Quarkus app classloader. This should be effective but is based
+ * on the general understanding that libraries within Quarkus shouldn't use custom classloaders;
+ * should this assumption be violated, there's the risk of a "module opens" instruction to not be
+ * applied automatically, and users would be required to issue the matching command line flags.
+ */
+public final class ModuleOpenBuildItem extends MultiBuildItem {
+
+    /**
+     * This represents the name of what people refer to as the "unnamed module" in the JVM.
+     * We should strictly avoid extensions attempting to refer to the unnamed modules
+     * (yes technically there's multiple: each classloader comes with one)
+     * so to encourage future-proofing of code using this API.
+     */
+    private static final String ALL_UNNAMED = "ALL-UNNAMED";
+
+    private final String openedModuleName;
+    private final String openingModuleName;
+    private final Set<String> packageNames;
+
+    /**
+     * Create a new ModuleOpenBuildItem instance.
+     * We are currently imposing a strict expectation to not refer to the unnamed module
+     * as an opening module so to encourage extension maintainers to pick the right module name
+     * in preparation for more extensive modularization.
+     * If the library to which you're opening to isn't on the module path yet at this point, it
+     * should still be beneficial to refer to it by the expected module name.
+     * When a module name is specified which couldn't be identified by name, we'll fallback
+     * the opening module name to the unnamed module to allow for an easier transition.
+     *
+     * @param openedModuleName The name of the module which needs to be opened.
+     * @param openingModuleName The name of the module which is being granted access.
+     * @param packageNames The packages which are being opened. At least one must be specified.
+     */
+    public ModuleOpenBuildItem(String openedModuleName, String openingModuleName, String... packageNames) {
+        this.openedModuleName = Assert.checkNotEmptyParam("openedModuleName", openedModuleName);
+        this.openingModuleName = Assert.checkNotEmptyParam("openingModuleName", openingModuleName);
+        this.packageNames = Assert.checkNotEmptyParam("packageNames", Set.of(packageNames));
+        if (packageNames.length == 0) {
+            throw new IllegalArgumentException("At least one package name must be specified");
+        }
+        if (ALL_UNNAMED.equals(openedModuleName)) {
+            throw new IllegalArgumentException("The unnamed module cannot be opened to other modules");
+        }
+        if (ALL_UNNAMED.equals(openingModuleName)) {
+            throw new IllegalArgumentException(
+                    "The unnamed module cannot be used as an opening module identifier: please read the Javadocs for more details");
+        }
+    }
+
+    public String openedModuleName() {
+        return openedModuleName;
+    }
+
+    public String openingModuleName() {
+        return openingModuleName;
+    }
+
+    public Set<String> packageNames() {
+        return packageNames;
+    }
+
+    @Override
+    public String toString() {
+        //Used for diagnostic logging purposes
+        return "ModuleOpenBuildItem{" +
+                "openedModule='" + openedModuleName + '\'' +
+                ", openingModule='" + openingModuleName + '\'' +
+                ", packages=" + packageNames +
+                '}';
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCommandLineBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCommandLineBuilder.java
@@ -398,8 +398,13 @@ public class DevModeCommandLineBuilder {
             jvmOptionsBuilder.add("enable-preview");
         }
 
+        //Useful for AgentBasedModulesReconfigurer; should we use -agent and load it explicitly?
+        jvmOptionsBuilder.addXxOption("EnableDynamicAgentLoading", "true");
+
         setJvmOptions();
         args.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
+        args.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+        args.add("--add-exports=java.base/jdk.internal.module=ALL-UNNAMED");
 
         outputDir.mkdirs();
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/AgentBasedModulesReconfigurer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/AgentBasedModulesReconfigurer.java
@@ -1,0 +1,152 @@
+package io.quarkus.deployment.jvm;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+
+final class AgentBasedModulesReconfigurer implements JvmModulesReconfigurer {
+
+    private final Instrumentation instrumentation;
+    private static final Logger logger = JVMDeploymentLogger.logger;
+
+    /**
+     * Initializes, attempting to find or load an `Instrumentation` instance:
+     * first we check if the `ClassChangeAgent` is attached - in which case
+     * we can use it.
+     * Otherwise we'll proceed to attaching a new agent leveraging the
+     * self-attaching strategy from Byte Buddy.
+     * If an agent cannot be installed, an {@link IllegalStateException} is thrown.
+     */
+    AgentBasedModulesReconfigurer(Instrumentation instrumentation) {
+        this.instrumentation = Objects.requireNonNull(instrumentation, "Instrumentation cannot be null");
+        if (logger.isDebugEnabled()) {
+            instrumentation.addTransformer(new UnnamedModulesTracker());
+        }
+    }
+
+    private static void reportUnnamedModulesSet(Instrumentation inst) {
+        if (!logger.isDebugEnabled()) {
+            //All following work is only useful to emit a comprehensive debugging report
+            return;
+        }
+        Set<Module> unnamedModules = new HashSet<>();
+
+        // Always add the Boot Loader's unnamed module (for -Xbootclasspath/a):
+        // there isn't a ClassLoader object for Boot, but we can get it via the Layer.
+        unnamedModules.add(ClassLoader.getSystemClassLoader().getUnnamedModule());
+
+        // Iterate all loaded classes to find other ClassLoaders (expensive!)
+        Class<?>[] allClasses = inst.getAllLoadedClasses();
+
+        for (Class<?> clazz : allClasses) {
+            ClassLoader loader = clazz.getClassLoader();
+
+            // If loader is null, it's the Boot Loader (already handled)
+            if (loader != null) {
+                Module m = loader.getUnnamedModule();
+                unnamedModules.add(m);
+            }
+        }
+
+        long pid = ProcessHandle.current().pid();
+        logger.debugf("Set of unnamed modules currently defined in process with pid=%d: %s", pid, unnamedModules);
+    }
+
+    @Override
+    public void openJavaModules(List<ModuleOpenBuildItem> addOpens, ModulesClassloaderContext modulesContext) {
+        if (addOpens.isEmpty())
+            return;
+        reportUnnamedModulesSet(this.instrumentation);//Provides very useful diagnostics
+        //We now need to aggregate the list into a differently organized data structure
+        HashMap<Module, PerModuleOpenInstructions> aggregateByModule = new HashMap<>();
+        for (ModuleOpenBuildItem m : addOpens) {
+            final Module openedModule = modulesContext.findModule(m.openedModuleName());
+            PerModuleOpenInstructions perModuleOpenInstructions = aggregateByModule.computeIfAbsent(openedModule,
+                    k -> new PerModuleOpenInstructions());
+            final Module openingModule = modulesContext.findModule(m.openingModuleName());
+            for (String packageName : m.packageNames()) {
+                perModuleOpenInstructions.addOpens(packageName, openingModule);
+            }
+        }
+        //Now that we have a map of openings for each module, let's instrument each of them
+        for (Map.Entry<Module, PerModuleOpenInstructions> entry : aggregateByModule.entrySet()) {
+            addOpens(entry.getKey(), entry.getValue().modulesToOpenToByPackage);
+        }
+    }
+
+    /**
+     * Uses the MethodHandle to open a package.
+     *
+     * @param sourceModule The module to open
+     * @param openInstructions The map of packages / target modules to open to
+     */
+    private void addOpens(Module sourceModule, Map<String, Set<Module>> openInstructions) {
+        if (logger.isDebugEnabled()) {
+            openInstructions.forEach(
+                    (pkg, modules) -> logger.debugf("Opening package %s of %s to modules %s", pkg, sourceModule, modules));
+        }
+        try {
+            // We are redefining the target module, adding a new "open"
+            // rule for it.
+            //This method is additive: we don't need to read previous reads and exports
+            //to avoid losing them.
+            instrumentation.redefineModule(
+                    sourceModule, // The module to change
+                    Set.of(), // Extra reads
+                    Map.of(), // Extra exports
+                    openInstructions, // The relevant one
+                    Set.of(), // Extra uses
+                    Map.of() // Extra provides
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to redefine module " + sourceModule.getName());
+        }
+    }
+
+    // A convenience container to keep our logic above more readable
+    private static class PerModuleOpenInstructions {
+        private final Map<String, Set<Module>> modulesToOpenToByPackage = new HashMap<>();
+
+        public void addOpens(final String packageName, final Module openingModule) {
+            final Set<Module> modulesToOpenTo = modulesToOpenToByPackage.computeIfAbsent(packageName, k -> new HashSet<>());
+            modulesToOpenTo.add(openingModule);
+        }
+    }
+
+    /**
+     * This isn't going to transform any class, but we leverage the existing agent
+     * and register as a callback to provide useful diagnostics: we can detect new
+     * unnamed modules being created and log them.
+     * Obviously this has a cost, so register this only when the matching log level is enabled.
+     * N.B. we can use this approach only when having an agent: other implementations
+     * of JvmModulesReconfigurer will be more limited.
+     */
+    private static class UnnamedModulesTracker implements ClassFileTransformer {
+
+        private final Set<Module> knownUnnamedModules = new CopyOnWriteArraySet<>();
+
+        @Override
+        public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+            if (loader != null) {
+                Module m = loader.getUnnamedModule();
+                // Check if this module is one of the "known" ones from your bootstrap list
+                if (knownUnnamedModules.add(m)) {
+                    logger.debugf("New unnamed module detected: %s", m);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/DirectExportedModulesAPIModulesReconfigurer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/DirectExportedModulesAPIModulesReconfigurer.java
@@ -1,0 +1,54 @@
+package io.quarkus.deployment.jvm;
+
+import java.util.List;
+
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+
+/**
+ * A concrete implementation of {@link JvmModulesReconfigurer} designed to reconfigure
+ * JVM module restrictions using the direct API calls available in `jdk.internal.module`.
+ * Methods in this package are normally not accessible: to compile this class we need to
+ * declare the export --add-exports=java.base/jdk.internal.module=ALL-UNNAMED to javac,
+ * and this same export is also required at runtime; otherwise an 'java.lang.IllegalAccessError'
+ * will be thrown when these methods are invoked.
+ */
+final class DirectExportedModulesAPIModulesReconfigurer implements JvmModulesReconfigurer {
+
+    DirectExportedModulesAPIModulesReconfigurer() {
+        //We need to throw a RuntimeException at construction time if the openJavaModules method is going to fail,
+        //so to give the system a chance to try a different strategy when this one won't work.
+        testMethodAccessOrFail();
+    }
+
+    @Override
+    public void openJavaModules(List<ModuleOpenBuildItem> addOpens, ModulesClassloaderContext modulesContext) {
+        for (ModuleOpenBuildItem e : addOpens) {
+            final Module openedModule = modulesContext.findModule(e.openedModuleName());
+            final Module openingModule = modulesContext.findModule(e.openingModuleName());
+            for (String packageName : e.packageNames()) {
+                jdk.internal.module.Modules.addOpens(openedModule, packageName, openingModule);
+            }
+        }
+    }
+
+    /**
+     * This method will throw a RuntimeException if we're not allowed to invoke methods on the internal API:
+     * useful to validate this particular approach.
+     */
+    private static void testMethodAccessOrFail() {
+        // "null" is not a valid argument for the following method: we use it intentionally to check for being allowed to invoke it,
+        // without actually modifying any module.
+        try {
+            jdk.internal.module.Modules.addOpens(null, null, null);
+        } catch (NullPointerException e) {
+            //This suggests the method is working as intended: all good!
+            //We can return and finish the initialization of this valid instance.
+        } catch (java.lang.IllegalAccessError e) {
+            //This suggests we're not allowed to invoke it: we need to use a different strategy.
+            throw new RuntimeException(
+                    "Failed to invoke jdk.internal.module.Modules.addOpens: --add-exports=java.base/jdk.internal.module=ALL-UNNAMED is required, but wasn't set.",
+                    e);
+        }
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/FallbackModulesReconfigurer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/FallbackModulesReconfigurer.java
@@ -1,0 +1,26 @@
+package io.quarkus.deployment.jvm;
+
+import java.util.List;
+
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+
+/**
+ * A fallback implementation of {@link JvmModulesReconfigurer} that handles scenarios where
+ * we were not allowed to install an agent or get our way via reflection.
+ * <p>
+ * This implementation will not try to apply any changes to the runtime, but reports warnings
+ * for all operations which we should have performed.
+ */
+final class FallbackModulesReconfigurer implements JvmModulesReconfigurer {
+
+    @Override
+    public void openJavaModules(final List<ModuleOpenBuildItem> addOpens, ModulesClassloaderContext ignored) {
+        for (ModuleOpenBuildItem addOpen : addOpens) {
+            JVMDeploymentLogger.logger.warnf(
+                    "FallbackModulesReconfigurer: Could not apply and add-opens for module %s/%s, to module %s",
+                    addOpen.openedModuleName(), addOpen.packageNames(),
+                    addOpen.openingModuleName());
+        }
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/JVMDeploymentLogger.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/JVMDeploymentLogger.java
@@ -1,0 +1,12 @@
+package io.quarkus.deployment.jvm;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Convenience logger to be shared in this package
+ */
+final class JVMDeploymentLogger {
+
+    static final Logger logger = Logger.getLogger("io.quarkus.deployment.jvm");
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/JvmModulesReconfigurer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/JvmModulesReconfigurer.java
@@ -1,0 +1,84 @@
+package io.quarkus.deployment.jvm;
+
+import java.lang.instrument.Instrumentation;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.changeagent.ClassChangeAgent;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+import net.bytebuddy.agent.ByteBuddyAgent;
+
+/**
+ * Interface for reconfiguring JVM module restrictions on the running JVM.
+ * It's an interface as I expect us to possibly explore different strategies
+ * to accomplish this.
+ */
+public interface JvmModulesReconfigurer {
+
+    void openJavaModules(List<ModuleOpenBuildItem> addOpens, ModulesClassloaderContext referenceClassloader);
+
+    /**
+     * Creates a new instance of {@link JvmModulesReconfigurer}.
+     * Initialization of such services is fairly costly: try
+     * to avoid it, and aim to reuse the produced instance.
+     *
+     * @return a new {@link JvmModulesReconfigurer} instance
+     */
+    static JvmModulesReconfigurer create() {
+        final Logger logger = JVMDeploymentLogger.logger;
+
+        //First thing to check, is if we have our agent connected; that would make things really simple and avoid any need
+        //for warnings; this is especially important in some launch modes, specifically the ones in which it would be more
+        //difficult for the user to provide explicit configuration as we control them from Quarkus tooling e.g. 'dev-mode'.
+        //N.B. this is also our favourite implementation because it allows for better diagnostics and easier debugging.
+        Instrumentation existingInstrumentation = ClassChangeAgent.getInstrumentation();
+        //Checking this first as it's very cheap:
+        if (existingInstrumentation != null) {
+            //Intentionally not warning, we'll do a single warning below to not be overwhelming.
+            logger.debugf("Initializing AgentBasedModulesReconfigurer from existing instrumentation agent");
+            return new AgentBasedModulesReconfigurer(existingInstrumentation);
+        }
+
+        //Let's try to see if --add-opens=java.base/java.lang.invoke=ALL-UNNAMED was set, that would give us a great entry point:
+        logger.debugf("Attempting to initialize ReflectiveAccessModulesReconfigurer");
+        try {
+            return new ReflectiveAccessModulesReconfigurer();
+        } catch (RuntimeException e) {
+            //Intentionally not warning, we'll do a single warning below to not be overwhelming.
+            logger.debugf(e, "Failed to initialize ReflectiveAccessModulesReconfigurer");
+        }
+
+        //Next let's try the approach based on --add-exports being set on JVM boot:
+        logger.debugf("Attempting to initialize DirectExportedModulesAPIModulesReconfigurer");
+        try {
+            return new DirectExportedModulesAPIModulesReconfigurer();
+        } catch (RuntimeException e) {
+            //Intentionally not warning, we'll do a single warning below to not be overwhelming.
+            logger.debugf(e, "Failed to initialize DirectExportedModulesAPIModulesReconfigurer");
+        }
+
+        //ONE actionable warning:
+        //N.B. this is the only warning in this complex block, so to provide a single clear direction to the user;
+        //the "add-opens=java.base" seems to be our preference, so that's what we suggest setting.
+        logger.warn(
+                "Could not get access to jdk.internal.module API: this is required for Quarkus to adjust Java Modules configuration to match the various requirements of each extension. Please ensure this JVM is launched with --add-opens=java.base/java.lang.invoke=ALL-UNNAMED.");
+
+        //Last resort when all above failed: let's try via ByteBuddy auto-attach; this WILL trigger JVM warnings (on top of ours) but at least
+        //tests will run within the expected behavior of the module system.
+        logger.debugf(
+                "Attempting to initialize AgentBasedModulesReconfigurer by self-attaching an agent - this will most likely trigger warnings by the JVM, and might fail in future JVM versions");
+        try {
+            // ByteBuddyAgent.install() attaches its own agent to the current
+            // JVM and returns the Instrumentation instance.
+            final Instrumentation instrumentation = ByteBuddyAgent.install();
+            return new AgentBasedModulesReconfigurer(instrumentation);
+        } catch (IllegalStateException e) {
+            logger.debugf("ByteBuddy failed to auto-attach", e);
+        }
+
+        //At this point, we failed to load a functional strategy - let's at least log which modules should have been reconfigured (but won't):
+        return new FallbackModulesReconfigurer();
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/ModulesClassloaderContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/ModulesClassloaderContext.java
@@ -1,0 +1,47 @@
+package io.quarkus.deployment.jvm;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Context for looking up modules in a classloader:
+ * encapsulates code dealing with the module layers,
+ * and provides a cache for the modules found.
+ * N.B. at this time, to be lenient during evolutions,
+ * any module which can't be found by name will resolve
+ * to the unnamed module of the reference classloader
+ * being passed to the constructor; this can be observed
+ * by setting log level to DEBUG of category {@code io.quarkus.deployment.jvm}.
+ */
+final class ModulesClassloaderContext {
+
+    private final Module classloaderUnnamedModule; //The unnamed module for this reference classloader
+    private final ModuleLayer currentLayer; //The module layer for this reference classloader
+    private final ConcurrentHashMap<String, Module> moduleCache = new ConcurrentHashMap<>();
+
+    public ModulesClassloaderContext(final ClassLoader classloader) {
+        Module unnamedModule = classloader.getUnnamedModule();
+        this.classloaderUnnamedModule = unnamedModule;
+        this.currentLayer = currentLayer(unnamedModule);
+    }
+
+    public Module findModule(final String moduleName) {
+        return moduleCache.computeIfAbsent(moduleName, this::findOrFallbackModule);
+    }
+
+    private Module findOrFallbackModule(final String moduleName) {
+        return currentLayer.findModule(moduleName).orElseGet(() -> {
+            JVMDeploymentLogger.logger.debugf(
+                    "Module %s not found, falling back to unnamed module", moduleName);
+            return classloaderUnnamedModule;
+        });
+    }
+
+    private static ModuleLayer currentLayer(final Module module) {
+        ModuleLayer layer = module.getLayer();
+        if (layer == null) {
+            return ModuleLayer.boot();
+        }
+        return layer;
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/ReflectiveAccessModulesReconfigurer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/ReflectiveAccessModulesReconfigurer.java
@@ -1,0 +1,103 @@
+package io.quarkus.deployment.jvm;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+
+/**
+ * Implements the {@link JvmModulesReconfigurer} interface to reconfigure JVM module restrictions through reflective access.
+ *
+ * Restrictions:
+ * - This class relies on the JVM option: `--add-opens=java.base/java.lang.invoke=ALL-UNNAMED` to access otherwise
+ * sealed private methods and fields of the java.base module. Without this option, reflective access will fail.
+ *
+ * Design Notes:
+ * - Reflection is used to access internal JVM mechanisms, making this implementation dependent on the stability of the
+ * relevant internal API. We therefore rely on a multiple of different strategies - this being one of them.
+ * - This approach bypasses strict module system rules, enabling dynamic adjustments to module access at runtime:
+ * it's meant as a convenience during development, Quarkus does not use such techniques in production mode.
+ */
+final class ReflectiveAccessModulesReconfigurer implements JvmModulesReconfigurer {
+
+    private static final Logger logger = JVMDeploymentLogger.logger;
+    private final MethodHandle implAddOpensHandle;
+
+    ReflectiveAccessModulesReconfigurer() {
+        implAddOpensHandle = methodHandleInit();
+    }
+
+    @Override
+    public void openJavaModules(List<ModuleOpenBuildItem> addOpens, ModulesClassloaderContext modulesContext) {
+        if (addOpens.isEmpty())
+            return;
+        for (ModuleOpenBuildItem m : addOpens) {
+            final Module openedModule = modulesContext.findModule(m.openedModuleName());
+            final Module openingModule = modulesContext.findModule(m.openingModuleName());
+            for (String packageName : m.packageNames()) {
+                addOpens(openedModule, packageName, openingModule);
+            }
+        }
+    }
+
+    /**
+     * Attempts to get a handle to the private implAddOpens method of Module;
+     * this is normally sealed, so it MUST be run with: --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+     * Once we have it, we have full access to reconfigure other modules.
+     */
+    private static MethodHandle methodHandleInit() {
+        final MethodHandle handle;
+        try {
+            //Get the super-privileged MethodHandles.Lookup instance (IMPL_LOOKUP):
+            //this is necessary to access the otherwise sealed private implAddOpens method.
+            Field lookupField = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
+
+            //This setAccessible call is the part that would fail when the java.base module is not opened.
+            lookupField.setAccessible(true);
+
+            MethodHandles.Lookup privilegedLookup = (MethodHandles.Lookup) lookupField.get(null);
+
+            //Signature of the method we want to find
+            MethodType methodType = MethodType.methodType(void.class, String.class, Module.class);
+
+            //Use the privileged lookup to find the private method
+            handle = privilegedLookup.findVirtual(
+                    Module.class, // Class to find the method in
+                    "implAddOpens", // Name of the private method
+                    methodType // Signature of the method
+            );
+
+            logger.debug("Successfully acquired MethodHandle for implAddOpens.");
+            return handle;
+
+        } catch (NoSuchFieldException | IllegalAccessException | NoSuchMethodException | InaccessibleObjectException e) {
+            throw new RuntimeException("Failed to acquire handle to Module#implAddOpens. " +
+                    "This must be run with JVM parameter '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED'", e);
+        }
+    }
+
+    /**
+     * Uses the MethodHandle to open a package.
+     *
+     * @param sourceModule The module to open
+     * @param packageName The package to open
+     * @param targetModule The module to open to
+     */
+    private void addOpens(Module sourceModule, String packageName, Module targetModule) {
+        try {
+            implAddOpensHandle.invokeExact(sourceModule, packageName, targetModule);
+            logger.debugf("Successfully opened module %s/%s to %s",
+                    sourceModule.getName(), packageName, targetModule.isNamed() ? targetModule.getName() : "UNNAMED");
+        } catch (Throwable e) {
+            // MethodHandle.invokeExact throws Throwable
+            throw new RuntimeException("Failed to invoke implAddOpens", e);
+        }
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/ResolvedJVMRequirements.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/ResolvedJVMRequirements.java
@@ -1,0 +1,63 @@
+package io.quarkus.deployment.jvm;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.jar.Attributes;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+
+/**
+ * Represents requirements and restrictions on the runtime.
+ * Currently only used to track add-opens requirements; we'd like to eventually
+ * support tracking, for example, the required JVM version as we start to see
+ * some libraries having more specific restrictions.
+ * Another use could be, for example, to force enabling experimental features such
+ * as needing jdk.incubator.vector and implied version requirements.
+ */
+public final class ResolvedJVMRequirements extends SimpleBuildItem {
+
+    private static final Attributes.Name ADD_OPENS_JARATTRIBUTENAME = new Attributes.Name("Add-Opens");
+
+    private final List<ModuleOpenBuildItem> addOpens;
+
+    public ResolvedJVMRequirements(final List<ModuleOpenBuildItem> addOpens) throws BuildException {
+        this.addOpens = addOpens;
+    }
+
+    public void renderAddOpensElementToJarManifest(final Attributes attributes) {
+        //N.B. in the format of the Add-Opens attribute in the MANIFEST.MF, the "target module" to which things
+        //get opened to is implicitly the Jar itself, so it will always point to ALL-UNNAMED:
+        //we're ignoring the ModuleOpenBuildItem#openingModuleName in this context.
+        //N.B.2: if the app is a module, this Manifest attribute will apparently be ignored!
+        final Collection<String> modulesToAddOpens = new TreeSet<>(); //Choose a TreeSet as it will sort them, providing a stable order for reproducibility
+        for (ModuleOpenBuildItem moduleOpenBuildItem : addOpens) {
+            for (String packageName : moduleOpenBuildItem.packageNames()) {
+                //When there are multiple packages to be opened within the same module, the whole definition needs to be repeated; e.g.:
+                //Add-Opens: java.base/java.lang java.base/java.util
+                modulesToAddOpens.add(moduleOpenBuildItem.openedModuleName() + '/' + packageName);
+            }
+        }
+        if (!modulesToAddOpens.isEmpty()) {
+            if (attributes.getValue(ADD_OPENS_JARATTRIBUTENAME) != null) {
+                Logger.getLogger(ResolvedJVMRequirements.class)
+                        .warn(
+                                "An 'Add-Opens' entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Add-Opens\". Quarkus has overwritten this existing entry.");
+            }
+            attributes.put(ADD_OPENS_JARATTRIBUTENAME, String.join(" ", modulesToAddOpens));
+        }
+    }
+
+    public void applyJavaModuleConfigurationToRuntime(JvmModulesReconfigurer reconfigurer,
+            ClassLoader referenceClassloader) {
+        if (addOpens.isEmpty())
+            return;
+        ModulesClassloaderContext context = new ModulesClassloaderContext(referenceClassloader);
+        reconfigurer.openJavaModules(addOpens, context);
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
@@ -51,6 +52,7 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
     protected final List<GeneratedClassBuildItem> generatedClasses;
     protected final List<GeneratedResourceBuildItem> generatedResources;
     protected final Set<ArtifactKey> removedArtifactKeys;
+    protected final ResolvedJVMRequirements jvmRequirements;
 
     public AbstractJarBuilder(CurateOutcomeBuildItem curateOutcome,
             OutputTargetBuildItem outputTarget,
@@ -61,7 +63,8 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
             TransformedClassesBuildItem transformedClasses,
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
-            Set<ArtifactKey> removedArtifactKeys) {
+            Set<ArtifactKey> removedArtifactKeys,
+            ResolvedJVMRequirements jvmRequirements) {
         this.curateOutcome = curateOutcome;
         this.outputTarget = outputTarget;
         this.applicationInfo = applicationInfo;
@@ -72,7 +75,7 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
         this.generatedClasses = generatedClasses;
         this.generatedResources = generatedResources;
         this.removedArtifactKeys = removedArtifactKeys;
-
+        this.jvmRequirements = jvmRequirements;
         checkConsistency(generatedClasses);
     }
 
@@ -204,6 +207,7 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
      */
     protected static void generateManifest(ArchiveCreator archiveCreator, final String classPath, PackageConfig config,
             ResolvedDependency appArtifact,
+            ResolvedJVMRequirements jvmRequirements,
             String mainClassName,
             ApplicationInfoBuildItem applicationInfo)
             throws IOException {
@@ -211,8 +215,8 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
 
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
-        // JDK 24+ needs --add-opens=java.base/java.lang=ALL-UNNAMED for org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals()
-        attributes.put(new Attributes.Name("Add-Opens"), "java.base/java.lang");
+
+        jvmRequirements.renderAddOpensElementToJarManifest(attributes);
 
         for (Map.Entry<String, String> attribute : config.jar().manifest().attributes().entrySet()) {
             attributes.putValue(attribute.getKey(), attribute.getValue());

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -26,6 +26,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.JarUnsigner;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
@@ -49,9 +50,10 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
             Set<ArtifactKey> removedArtifactKeys,
-            ExecutorService executorService) {
+            ExecutorService executorService,
+            ResolvedJVMRequirements jvmRequirements) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys);
+                generatedClasses, generatedResources, removedArtifactKeys, jvmRequirements);
 
         this.executorService = executorService;
     }
@@ -77,7 +79,8 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
             ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
             // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
             // see https://bugs.openjdk.java.net/browse/JDK-8031748
-            generateManifest(archiveCreator, classPath.toString(), packageConfig, appArtifact, mainClass.getClassName(),
+            generateManifest(archiveCreator, classPath.toString(), packageConfig, appArtifact, jvmRequirements,
+                    mainClass.getClassName(),
                     applicationInfo);
 
             copyCommonContent(archiveCreator, services, ignoredEntriesPredicate);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
@@ -49,6 +49,7 @@ import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem.TransformedClass;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.JarUnsigner;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
@@ -83,9 +84,10 @@ public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             List<GeneratedResourceBuildItem> generatedResources,
             Set<ArtifactKey> parentFirstArtifactKeys,
             Set<ArtifactKey> removedArtifactKeys,
-            ExecutorService executorService) {
+            ExecutorService executorService,
+            ResolvedJVMRequirements jvmRequirements) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys);
+                generatedClasses, generatedResources, removedArtifactKeys, jvmRequirements);
         this.additionalApplicationArchives = additionalApplicationArchives;
         this.parentFirstArtifactKeys = parentFirstArtifactKeys;
         this.executorService = executorService;
@@ -314,6 +316,7 @@ public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                     outputTarget.getOutputDirectory(), executorService)) {
                 ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
                 generateManifest(archiveCreator, classPath.toString(), packageConfig, appArtifact,
+                        jvmRequirements,
                         QuarkusEntryPoint.class.getName(),
                         applicationInfo);
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/LegacyThinJarBuilder.java
@@ -16,6 +16,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
@@ -36,9 +37,10 @@ public class LegacyThinJarBuilder extends AbstractLegacyThinJarBuilder<JarBuildI
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
             Set<ArtifactKey> removedArtifactKeys,
-            ExecutorService executorService) {
+            ExecutorService executorService,
+            ResolvedJVMRequirements jvmRequirements) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys, executorService);
+                generatedClasses, generatedResources, removedArtifactKeys, executorService, jvmRequirements);
     }
 
     public JarBuildItem build() throws IOException {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/NativeImageSourceJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/NativeImageSourceJarBuilder.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.builditem.GeneratedNativeImageClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
@@ -46,10 +47,11 @@ public class NativeImageSourceJarBuilder extends AbstractLegacyThinJarBuilder<Na
             List<GeneratedResourceBuildItem> generatedResources,
             List<GeneratedNativeImageClassBuildItem> nativeImageResources,
             Set<ArtifactKey> removedArtifactKeys,
-            ExecutorService executorService) {
+            ExecutorService executorService,
+            ResolvedJVMRequirements jvmRequirements) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
                 augmentGeneratedClasses(generatedClasses, nativeImageResources), generatedResources,
-                augmentRemovedArtifactKeys(removedArtifactKeys), executorService);
+                augmentRemovedArtifactKeys(removedArtifactKeys), executorService, jvmRequirements);
     }
 
     public NativeImageSourceJarBuildItem build() throws IOException {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
@@ -73,9 +74,10 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             List<GeneratedResourceBuildItem> generatedResources,
             Set<ArtifactKey> removedArtifactKeys,
             List<UberJarMergedResourceBuildItem> mergedResources,
-            List<UberJarIgnoredResourceBuildItem> ignoredResources) {
+            List<UberJarIgnoredResourceBuildItem> ignoredResources,
+            ResolvedJVMRequirements jvmRequirements) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys);
+                generatedClasses, generatedResources, removedArtifactKeys, jvmRequirements);
 
         this.mergedResources = mergedResources;
         this.ignoredResources = ignoredResources;
@@ -169,7 +171,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
             // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
             // see https://bugs.openjdk.java.net/browse/JDK-8031748
-            generateManifest(archiveCreator, "", packageConfig, appArtifact, mainClass.getClassName(),
+            generateManifest(archiveCreator, "", packageConfig, appArtifact, jvmRequirements, mainClass.getClassName(),
                     applicationInfo);
 
             for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getRuntimeDependencies()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.QuarkusBuildCloseablesBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.configuration.ClassLoadingConfig;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
@@ -92,6 +93,7 @@ public class JarResultBuildStep {
     @SuppressWarnings("deprecation") // JarType#LEGACY_JAR
     @BuildStep
     public JarBuildItem buildRunnerJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            ResolvedJVMRequirements jvmRequirements,
             OutputTargetBuildItem outputTargetBuildItem,
             TransformedClassesBuildItem transformedClasses,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
@@ -128,7 +130,8 @@ public class JarResultBuildStep {
                     generatedResources,
                     removedArtifactKeys,
                     uberJarMergedResourceBuildItems,
-                    uberJarIgnoredResourceBuildItems).build();
+                    uberJarIgnoredResourceBuildItems,
+                    jvmRequirements).build();
             case LEGACY_JAR -> new LegacyThinJarBuilder(curateOutcomeBuildItem,
                     outputTargetBuildItem,
                     applicationInfo,
@@ -139,7 +142,8 @@ public class JarResultBuildStep {
                     generatedClasses,
                     generatedResources,
                     removedArtifactKeys,
-                    buildExecutor).build();
+                    buildExecutor,
+                    jvmRequirements).build();
             case FAST_JAR, MUTABLE_JAR -> new FastJarBuilder(curateOutcomeBuildItem,
                     outputTargetBuildItem,
                     applicationInfo,
@@ -152,7 +156,8 @@ public class JarResultBuildStep {
                     generatedResources,
                     parentFirstArtifactKeys,
                     removedArtifactKeys,
-                    buildExecutor).build();
+                    buildExecutor,
+                    jvmRequirements).build();
         };
     }
 
@@ -171,7 +176,8 @@ public class JarResultBuildStep {
             List<GeneratedResourceBuildItem> generatedResources,
             MainClassBuildItem mainClassBuildItem,
             ClassLoadingConfig classLoadingConfig,
-            ExecutorService buildExecutor) throws Exception {
+            ExecutorService buildExecutor,
+            ResolvedJVMRequirements jvmRequirements) throws Exception {
 
         return new NativeImageSourceJarBuilder(curateOutcomeBuildItem,
                 outputTargetBuildItem,
@@ -184,7 +190,8 @@ public class JarResultBuildStep {
                 generatedResources,
                 nativeImageResources,
                 getRemovedArtifactKeys(classLoadingConfig),
-                buildExecutor).build();
+                buildExecutor,
+                jvmRequirements).build();
     }
 
     // the idea here is to just dump the class names of the generated and transformed classes into a file

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/JvmRequirementsBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/JvmRequirementsBuildStep.java
@@ -1,0 +1,34 @@
+package io.quarkus.deployment.steps;
+
+import java.util.List;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
+
+/**
+ * Build step that resolves and aggregates JVM requirements for the Quarkus application.
+ * <p>
+ * This build step processes module open requirements (--add-opens) that are needed
+ * at runtime for the generated application.
+ * More JVM requirements in the same ballpark might be added in the future.
+ */
+public class JvmRequirementsBuildStep {
+
+    /**
+     * Resolves JVM requirements from the collected module open build items.
+     * <p>
+     * This method aggregates all {@link ModuleOpenBuildItem}s that have been produced
+     * during the build process and creates a {@link ResolvedJVMRequirements} build item
+     * containing the consolidated requirements.
+     *
+     * @param addOpens the list of modules that need to be opened.
+     * @return a resolved JVM requirements build item containing all JVM requirements.
+     */
+    @BuildStep
+    ResolvedJVMRequirements resolveJVMRequirements(final List<ModuleOpenBuildItem> addOpens) throws BuildException {
+        return new ResolvedJVMRequirements(addOpens);
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -46,6 +46,7 @@ import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.DeploymentResultBuildItem;
@@ -65,7 +66,7 @@ public class AugmentActionImpl implements AugmentAction {
     private static final Class[] NON_NORMAL_MODE_OUTPUTS = { GeneratedClassBuildItem.class,
             GeneratedResourceBuildItem.class, ApplicationClassNameBuildItem.class,
             MainClassBuildItem.class, GeneratedFileSystemResourceHandledBuildItem.class,
-            TransformedClassesBuildItem.class };
+            TransformedClassesBuildItem.class, ResolvedJVMRequirements.class };
 
     private final QuarkusBootstrap quarkusBootstrap;
     private final CuratedApplication curatedApplication;

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/FastJarManifestEntryTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/FastJarManifestEntryTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+
+import io.quarkus.bootstrap.app.AugmentResult;
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+
+/**
+ * Verifies that the fast-jar generated Jar has a META-INF/MANIFEST.MF containing the
+ * matching Add-Opens entries from the ModuleOpenBuildItem(s) defined by all available extensions.
+ */
+public class FastJarManifestEntryTest extends BootstrapFromOriginalJarTestBase {
+
+    @Override
+    protected TsArtifact composeApplication() {
+        return TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties());
+    }
+
+    @Override
+    protected void testBootstrap(QuarkusBootstrap creator) throws Exception {
+        final CuratedApplication curated = creator.bootstrap();
+        AugmentResult app = curated.createAugmentor().createProductionApplication();
+        final Path runnerJar = app.getJar().getPath();
+        assertTrue(Files.exists(runnerJar));
+        try (JarFile jar = new JarFile(runnerJar.toFile())) {
+            final Attributes mainAttrs = jar.getManifest().getMainAttributes();
+            assertEquals("java.base/java.lang", mainAttrs.getValue("Add-Opens"));
+        }
+    }
+
+    @Override
+    protected Properties buildSystemProperties() {
+        var props = new Properties();
+        props.setProperty("quarkus.package.jar.type", "fast-jar");
+        return props;
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/UberJarManifestEntryTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/UberJarManifestEntryTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.deployment.runnerjar;
+
+import java.util.Properties;
+
+/**
+ * Verifies that the uber-jar generated Jar has a META-INF/MANIFEST.MF containing the
+ * matching Add-Opens entries from the ModuleOpenBuildItem(s) defined by all available extensions.
+ */
+public class UberJarManifestEntryTest extends FastJarManifestEntryTest {
+    @Override
+    protected Properties buildSystemProperties() {
+        var props = new Properties();
+        props.setProperty("quarkus.package.jar.type", "uber-jar");
+        return props;
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
@@ -1,6 +1,7 @@
 package io.quarkus.maven.components;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -9,6 +10,9 @@ import javax.inject.Singleton;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
 
 import io.quarkus.maven.BuildAnalyticsProvider;
 import io.quarkus.maven.QuarkusBootstrapProvider;
@@ -17,13 +21,16 @@ import io.quarkus.maven.QuarkusBootstrapProvider;
 @Named("quarkus-bootstrap")
 public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant {
 
+    private final Logger logger;
     private final QuarkusBootstrapProvider bootstrapProvider;
     private final BuildAnalyticsProvider buildAnalyticsProvider;
 
     private boolean enabled;
 
     @Inject
-    public BootstrapSessionListener(QuarkusBootstrapProvider bootstrapProvider, BuildAnalyticsProvider buildAnalyticsProvider) {
+    public BootstrapSessionListener(Logger logger, QuarkusBootstrapProvider bootstrapProvider,
+            BuildAnalyticsProvider buildAnalyticsProvider) {
+        this.logger = logger;
         this.bootstrapProvider = bootstrapProvider;
         this.buildAnalyticsProvider = buildAnalyticsProvider;
     }
@@ -39,10 +46,65 @@ public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant 
     }
 
     @Override
-    public void afterProjectsRead(MavenSession session)
-            throws MavenExecutionException {
+    public void afterProjectsRead(MavenSession session) {
         // if this method is called then Maven plugin extensions are enabled
         enabled = true;
+
+        // Now let's automatically apply the required JVM flags to Surefire;
+        // bear in mind that this is just a convenience: we can't rely on Maven
+        // extensions to be enabled - but when they are, we can make it more useful.
+        injectSurefireTuning(session);
+    }
+
+    private void injectSurefireTuning(MavenSession session) {
+        logger.debug("Quarkus Maven extension: inspecting Surefire configuration");
+        for (MavenProject project : session.getProjects()) {
+            //Let's not interfere with non-Quarkus modules:
+            if (isQuarkusPluginConfigured(project)) {
+                injectSurefireArgs(project);
+            }
+        }
+    }
+
+    private void injectSurefireArgs(MavenProject project) {
+        Properties props = project.getProperties();
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "Found quarkus-maven-plugin in " + project.getArtifactId() + ": inspecting for missing Surefire arguments");
+        }
+        final String originalArgLine = props.getProperty("argLine", "");
+        String newArgLine = originalArgLine;
+        //We need these parameters set in advance; N.B. this approach won't scale efficiently.
+        newArgLine = possiblyInject(newArgLine, "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+        newArgLine = possiblyInject(newArgLine, "--add-opens=java.base/java.lang=ALL-UNNAMED");
+        newArgLine = possiblyInject(newArgLine, "--add-exports=java.base/jdk.internal.module=ALL-UNNAMED");
+        newArgLine = newArgLine.trim(); // micro cleanup
+        props.setProperty("argLine", newArgLine);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Quarkus Maven extension: injected 'argLine' for Surefire: " + newArgLine);
+        }
+    }
+
+    private String possiblyInject(final String existingArgLine, final String requiredJvmParameter) {
+        if (!existingArgLine.contains(requiredJvmParameter)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Quarkus Maven extension: injecting JVM parameter '" + requiredJvmParameter + "' into Surefire");
+            }
+            return existingArgLine + " " + requiredJvmParameter;
+        }
+        return existingArgLine;
+    }
+
+    private boolean isQuarkusPluginConfigured(MavenProject project) {
+        if (project.getBuild() == null || project.getBuild().getPlugins() == null) {
+            return false;
+        }
+        for (Plugin plugin : project.getBuild().getPlugins()) {
+            if ("quarkus-maven-plugin".equals(plugin.getArtifactId())) {
+                return true; // it's enabled on this project
+            }
+        }
+        return false;
     }
 
     public boolean isEnabled() {

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOnJava24ProcessorExtension.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOnJava24ProcessorExtension.java
@@ -1,0 +1,31 @@
+package io.quarkus.netty.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
+
+/**
+ * As Java 24 locks down access to sun.misc.Unsafe, Netty needs to adapt to this
+ * to maintain its efficiency.
+ * As this work progresses in upstream Netty to handle this better automatically,
+ * we can already apply the following recommendations by the Netty team.
+ * See also <a href="https://github.com/quarkusio/quarkus/issues/39907">#39907</a>
+ * and <a href="https://netty.io/wiki/java-24-and-sun.misc.unsafe.html">Java 24 and sun.misc.unsafe</a>
+ * </p>
+ * Unfortunately, "--sun-misc-unsafe-memory-access=allow" should also be set,
+ * but this can't be applied automatically as the Manifest format doesn't allow
+ * setting such an option.
+ */
+public class NettyOnJava24ProcessorExtension {
+
+    @BuildStep
+    public NativeImageSystemPropertyBuildItem jdk24CleanersViaSetAccessible() {
+        return new NativeImageSystemPropertyBuildItem("io.netty.tryReflectionSetAccessible", "true");
+    }
+
+    @BuildStep
+    ModuleOpenBuildItem openModules() {
+        return new ModuleOpenBuildItem("java.base", "io.netty.common", "java.nio", "jdk.internal.misc");
+    }
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -44,4 +44,15 @@ public interface StartupAction {
 
     void addRuntimeCloseTask(Closeable closeTask);
 
+    /**
+     * This particular StartupAction might need to enforce Java module configurations as
+     * required by the extensions. Such tuning often need to be applied to the running
+     * classloader: if additional classloaders are derived from the application classloader,
+     * they should be adjusted accordingly by invoking this method on them before starting
+     * the application. (This is apparently necessary in the JUnit integration).
+     *
+     * @param classLoader
+     */
+    void applyModuleConfigurationToClassloader(ClassLoader classLoader);
+
 }

--- a/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/ModulesCustomProcessor.java
+++ b/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/ModulesCustomProcessor.java
@@ -1,0 +1,12 @@
+package io.quarkus.extest.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+
+public class ModulesCustomProcessor {
+
+    @BuildStep
+    ModuleOpenBuildItem openModules() {
+        return new ModuleOpenBuildItem("java.base", "test-module-fake-name", "java.util");
+    }
+}

--- a/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/extension/ModulesOpenedTestEndpoint.java
+++ b/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/extension/ModulesOpenedTestEndpoint.java
@@ -1,0 +1,63 @@
+package io.quarkus.it.extension;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+import java.util.ArrayList;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * This test verifies that the module java.base/java.util is open:
+ * this should have been requested by {@code io.quarkus.extest.deployment.ModulesCustomProcessor},
+ * so we're verifying that the ModuleOpenBuildItem is working as expected.
+ */
+@WebServlet(name = "ModulesOpenedTestEndpoint", urlPatterns = "/core/modulesOpen")
+public class ModulesOpenedTestEndpoint extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        PrintWriter writer = resp.getWriter();
+        boolean testPassed;
+        String errorMessage = null;
+        try {
+            verifyJavaUtilsWasOpened();
+            testPassed = true;
+        } catch (Exception e) {
+            testPassed = false;
+            errorMessage = e.getMessage();
+        }
+        if (testPassed) {
+            writer.write("OK");
+        } else {
+            writer.write("Test Failed: " + errorMessage);
+        }
+    }
+
+    public void verifyJavaUtilsWasOpened() throws Exception {
+        String SOME_DATA = "anything";
+        ArrayList<String> list = new ArrayList<>();
+        list.add(SOME_DATA);
+
+        // Let's try some cheeky operation which shouldn't be allowed:
+        Field internalArray = ArrayList.class.getDeclaredField("elementData");
+
+        // .. and specifically this will fail if "--add-opens=java.base/java.util=ALL-UNNAMED", hasn't been set:
+        try {
+            internalArray.setAccessible(true);
+        } catch (InaccessibleObjectException e) {
+            throw new RuntimeException("Test Failed: Module java.base/java.util is NOT open! ", e);
+        }
+
+        // Check that we can indeed read it:
+        Object[] data = (Object[]) internalArray.get(list);
+        if (!data[0].equals(SOME_DATA)) {
+            throw new RuntimeException("Test Failed: Internal array content is not as expected!");
+        }
+    }
+
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ModulesOpenedGraalITCase.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ModulesOpenedGraalITCase.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.extension;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+//Tests in native-image
+@QuarkusIntegrationTest
+public class ModulesOpenedGraalITCase extends ModulesOpenedTestCase {
+
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ModulesOpenedTestCase.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ModulesOpenedTestCase.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.extension;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ModulesOpenedTestCase {
+    @Test
+    public void test() {
+        when().get("/core/modulesOpen").then()
+                .body(is("OK"));
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -199,6 +199,10 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
             CuratedApplication curatedApplication = startupAction.getClassLoader()
                     .getCuratedApplication();
+
+            startupAction.applyModuleConfigurationToClassloader(curatedApplication.getAugmentClassLoader());
+            startupAction.applyModuleConfigurationToClassloader(curatedApplication.getBaseRuntimeClassLoader());
+
             Path testClassLocation = getTestClassesLocation(requiredTestClass, curatedApplication);
 
             // Do we need the augmentation classloader as the TCCL?


### PR DESCRIPTION
Implementation of what's being discussed on:
 - [#dev > JVM parameters recommender](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/JVM.20parameters.20recommender/with/538027156)

Fixes #51434 

(This was a draft, updating description)

This is part of a larger plan described on https://github.com/quarkusio/quarkus/discussions/51041 but can be merged independently.

It should be followed up some further polishing to be tracked on https://github.com/orgs/quarkusio/projects/59/views/1  - but I consider this a good incremental improvement which doesn't strictly require any follow-up.

Most notably this will avoid all warnings related to module usage, and reconfigure the module system fully transparently w/o users needing to apply any changes _in most cases_. When we can't fully automate something, an actionable warning should be visible.