### PR TITLE
ArC: fix construction of interception proxies

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -190,9 +190,7 @@ public class SubclassGenerator extends AbstractGenerator {
         Map<MethodDescriptor, MethodDescriptor> forwardingMethods = new HashMap<>();
         List<MethodInfo> interceptedOrDecoratedMethods = bean.getInterceptedOrDecoratedMethods();
         for (MethodInfo method : interceptedOrDecoratedMethods) {
-            forwardingMethods.put(MethodDescriptor.of(method), createForwardingMethod(subclass, providerTypeName, method,
-                    (bytecode, virtualMethod, params) -> bytecode.invokeSpecialMethod(virtualMethod, bytecode.getThis(),
-                            params)));
+            forwardingMethods.put(MethodDescriptor.of(method), createForwardingMethod(subclass, providerTypeName, method));
         }
 
         // If a decorator is associated:
@@ -864,13 +862,7 @@ public class SubclassGenerator extends AbstractGenerator {
         return false;
     }
 
-    @FunctionalInterface
-    interface ForwardInvokeGenerator {
-        ResultHandle generate(BytecodeCreator bytecode, MethodDescriptor virtualMethod, ResultHandle[] params);
-    }
-
-    static MethodDescriptor createForwardingMethod(ClassCreator subclass, String providerTypeName, MethodInfo method,
-            ForwardInvokeGenerator forwardInvokeGenerator) {
+    static MethodDescriptor createForwardingMethod(ClassCreator subclass, String providerTypeName, MethodInfo method) {
         MethodDescriptor methodDescriptor = MethodDescriptor.of(method);
         String forwardMethodName = method.name() + "$$superforward";
         MethodDescriptor forwardDescriptor = MethodDescriptor.ofMethod(subclass.getClassName(), forwardMethodName,
@@ -884,7 +876,7 @@ public class SubclassGenerator extends AbstractGenerator {
         }
         MethodDescriptor virtualMethod = MethodDescriptor.ofMethod(providerTypeName, methodDescriptor.getName(),
                 methodDescriptor.getReturnType(), methodDescriptor.getParameterTypes());
-        forward.returnValue(forwardInvokeGenerator.generate(forward, virtualMethod, params));
+        forward.returnValue(forward.invokeSpecialMethod(virtualMethod, forward.getThis(), params));
         return forwardDescriptor;
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithInterceptionAndVirtualCallInCtorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithInterceptionAndVirtualCallInCtorTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.arc.test.interceptors.producer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InterceptionProxy;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ProducerWithInterceptionAndVirtualCallInCtorTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBinding.class, MyInterceptor.class, MyProducer.class);
+
+    @Test
+    public void test() {
+        MyNonbean nonbean = Arc.container().instance(MyNonbean.class).get();
+        assertEquals("intercepted: hello", nonbean.hello());
+        assertEquals("intercepted: MyNonbean", nonbean.getThisClass_intercepted());
+        assertEquals("MyNonbean", nonbean.getThisClass_notIntercepted());
+
+        assertEquals(List.of(
+                "MyNonbean",
+                "ProducerWithInterceptionAndVirtualCallInCtorTest$MyNonbean_InterceptionSubclass"),
+                MyNonbean.constructedInstances_intercepted);
+        assertEquals(MyNonbean.constructedInstances_intercepted, MyNonbean.constructedInstances_notIntercepted);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+    @InterceptorBinding
+    @interface MyBinding {
+    }
+
+    @MyBinding
+    @Priority(1)
+    @Interceptor
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted: " + ctx.proceed();
+        }
+    }
+
+    static class MyNonbean {
+        static final List<String> constructedInstances_intercepted = new ArrayList<>();
+        static final List<String> constructedInstances_notIntercepted = new ArrayList<>();
+
+        MyNonbean() {
+            constructedInstances_intercepted.add(getThisClass_intercepted());
+            constructedInstances_notIntercepted.add(getThisClass_notIntercepted());
+        }
+
+        @MyBinding
+        String getThisClass_intercepted() {
+            return this.getClass().getSimpleName();
+        }
+
+        String getThisClass_notIntercepted() {
+            return this.getClass().getSimpleName();
+        }
+
+        @MyBinding
+        String hello() {
+            return "hello";
+        }
+    }
+
+    @Dependent
+    static class MyProducer {
+        @Produces
+        MyNonbean produce(InterceptionProxy<MyNonbean> proxy) {
+            return proxy.create(new MyNonbean());
+        }
+    }
+}


### PR DESCRIPTION
During execution of the constructor of an intercepted non-contextual instance (which is a superclass of an interception proxy, `*_InterceptionSubclass`), virtual method calls were supposed to be forwarded to the delegate. This isn't correct, because the `delegate` is only set at after the superclass constructor finishes; therefore, all such attempts used to fail with `NullPointerException`.

This commit fixes that by adopting the same strategy we use for client proxies and classic interception subclasses (for contextual instances): virtual calls in the constructor are invoked on `this` (or, in fact, on `super`) and forwarding is not attempted. Note that this has to be checked both for intercepted and non-intercepted methods.

Follows up on #49853