### PR TITLE
Qute: param declaration - skip validation for `null` default value

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1113,6 +1113,9 @@ public class QuteProcessor {
             if (defaultValue != null) {
                 MatchResult match;
                 if (defaultValue.isLiteral()) {
+                    if (defaultValue.getLiteral() == null)
+                        // Skip validation for `null`
+                        continue;
                     match = new MatchResult(assignabilityCheck);
                     setMatchValues(match, defaultValue, generatedIdsToMatches, index);
                 } else {

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ParamDeclarationDefaultValueTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ParamDeclarationDefaultValueTest.java
@@ -19,7 +19,12 @@ public class ParamDeclarationDefaultValueTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(MyEnum.class)
                     .addAsResource(new StringAsset(
-                            "{@io.quarkus.qute.deployment.typesafe.ParamDeclarationDefaultValueTest$MyEnum myEnum=MyEnum:BAR}{myEnum}"),
+                            """
+                                    {@io.quarkus.qute.deployment.typesafe.ParamDeclarationDefaultValueTest$MyEnum myEnum=MyEnum:BAR}
+                                    {@String name=null}
+                                    {myEnum}
+                                    {#if name != null}NOK!{/}
+                                    """),
                             "templates/myEnum.html"));
 
     @Inject
@@ -27,7 +32,7 @@ public class ParamDeclarationDefaultValueTest {
 
     @Test
     public void testDefaultValue() {
-        assertEquals("BAR", myEnum.render());
+        assertEquals("BAR", myEnum.render().strip());
     }
 
     @TemplateEnum

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
@@ -37,10 +37,11 @@ final class ExpressionImpl implements Expression {
         if (literal == null) {
             throw new IllegalArgumentException("Literal must not be null");
         }
-        return new ExpressionImpl(id, null,
-                Collections.singletonList(new PartImpl(literal,
-                        value != null ? Expressions.typeInfoFrom(value.getClass().getName()) : null)),
-                value, origin);
+        String typeInfo = null;
+        if (value != null) {
+            typeInfo = Expressions.typeInfoFrom(value.getClass().getName());
+        }
+        return new ExpressionImpl(id, null, List.of(new PartImpl(literal, typeInfo)), value, origin);
     }
 
     static Integer syntheticId() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -162,6 +162,10 @@ public interface SectionHelperFactory<T extends SectionHelper> {
 
     interface BlockInfo extends ParserDelegate, WithOrigin {
 
+        default boolean isMainBlock() {
+            return MAIN_BLOCK_NAME.equals(getLabel());
+        }
+
         String getLabel();
 
         /**

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SetSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SetSectionHelper.java
@@ -139,7 +139,7 @@ public class SetSectionHelper implements SectionHelper {
 
         @Override
         public Scope initializeBlock(Scope previousScope, BlockInfo block) {
-            if (block.getLabel().equals(MAIN_BLOCK_NAME)) {
+            if (block.isMainBlock()) {
                 Scope newScope = new Scope(previousScope);
                 for (Entry<String, String> e : block.getParameters().entrySet()) {
                     String key = e.getKey();

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParamDeclarationDefaultValueTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParamDeclarationDefaultValueTest.java
@@ -19,6 +19,7 @@ public class ParamDeclarationDefaultValueTest {
         assertDefaultValue(engine.parse("{@java.lang.String val= 'foo'}\n{val.toUpperCase}"), "FOO");
         assertDefaultValue(engine.parse("{@java.lang.String val='foo and bar'}\n{val.toUpperCase}"), "FOO AND BAR");
         assertDefaultValue(engine.parse("{@java.lang.String val= 'foo and bar'}\n{val.toUpperCase}"), "FOO AND BAR");
+        assertDefaultValue(engine.parse("{@java.lang.String val=null}\n{val == null ? 'ok' : 'nok'}"), "ok");
     }
 
     @Test
@@ -56,12 +57,14 @@ public class ParamDeclarationDefaultValueTest {
         assertEquals(expectedOutput, template.render());
         Expression fooExpr = template.getExpressions().stream().filter(e -> e.isLiteral()).findFirst().orElse(null);
         assertNotNull(fooExpr);
-        assertEquals("|java.lang.String|", fooExpr.collectTypeInfo());
-        Expression valExpr = template.getExpressions().stream().filter(e -> e.toOriginalString().equals("val.toUpperCase"))
-                .findAny().orElse(null);
-        assertNotNull(valExpr);
-        assertEquals("|java.lang.String|.toUpperCase", valExpr.collectTypeInfo());
-        assertEquals(2, valExpr.getOrigin().getLine());
+        if (fooExpr.getLiteral() != null) {
+            assertEquals("|java.lang.String|", fooExpr.collectTypeInfo());
+            Expression valExpr = template.getExpressions().stream().filter(e -> e.toOriginalString().equals("val.toUpperCase"))
+                    .findAny().orElse(null);
+            assertNotNull(valExpr);
+            assertEquals("|java.lang.String|.toUpperCase", valExpr.collectTypeInfo());
+            assertEquals(2, valExpr.getOrigin().getLine());
+        }
     }
 
 }


### PR DESCRIPTION
- fixes #49922