### PR TITLE
Check for --sun-misc-unsafe-memory-access=allow, log a user friendly warning when not

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CheckJVMparamsProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CheckJVMparamsProcessor.java
@@ -1,0 +1,16 @@
+package io.quarkus.deployment.steps;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
+import io.quarkus.runtime.JVMChecksRecorder;
+
+public class CheckJVMparamsProcessor {
+
+    @BuildStep(onlyIfNot = NativeBuild.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void recordJvmChecks(JVMChecksRecorder recorder) {
+        recorder.check();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/JVMChecksRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/JVMChecksRecorder.java
@@ -1,0 +1,36 @@
+package io.quarkus.runtime;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class JVMChecksRecorder {
+
+    public void check() {
+        if (!isUnsafeMemoryAccessAllowed()) {
+            Logger.getLogger("JVM").warn(
+                    "Unsafe memory access is not going to be allowed in future versions of the JVM. Since Java 24, the JVM will print a warning on boot (most likely shown above), but several Quarkus extensions still require it. "
+                            +
+                            "There is currently no need to worry: please add the `--sun-misc-unsafe-memory-access=allow` JVM argument to avoid these warnings. "
+                            +
+                            "We are working with the maintainers of those libraries to get this resolved in future versions; when this is done, we will remove the need for this argument.");
+        }
+    }
+
+    public static boolean isUnsafeMemoryAccessAllowed() {
+        if (Runtime.version().feature() < 24) {
+            //Versions before Java 24 would not complain about the use of Unsafe.
+            //Also, setting `--sun-misc-unsafe-memory-access=allow` isn't possible (not a valid argument) before Java 24.
+            return true;
+        }
+        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+        List<String> arguments = runtimeMxBean.getInputArguments();
+        return arguments.contains("--sun-misc-unsafe-memory-access=allow");
+    }
+
+}


### PR DESCRIPTION
Fixes: #49940


Netty currently requires `--sun-misc-unsafe-memory-access=allow` to be set (on JVMs > 24).

When this patch is applied and the --sun-misc-unsafe-memory-access=allow is omitted, we get:

```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::allocateMemory has been called by io.netty.util.internal.PlatformDependent0$2 (file:/home/sanne/Optane/sources/quarkus-quickstarts/getting-started/target/quarkus-app/lib/main/io.netty.netty-common-4.1.124.Final.jar)
WARNING: Please consider reporting this to the maintainers of class io.netty.util.internal.PlatformDependent0$2
WARNING: sun.misc.Unsafe::allocateMemory will be removed in a future release
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2025-09-08 14:01:01,317 WARN  [JVM] (main) Unsafe memory access is not going to be allowed in future versions of the JVM. Since Java 24, the JVM will print a warning on boot (most likely shown above), but several Quarkus extensions still require it. There is currently no need to worry: please add the `--sun-misc-unsafe-memory-access=allow` JVM argument to avoid these warnings. We are working with the maintainers of those libraries to get this resolved in future versions; when this is done, we will remove the need for this argument.
2025-09-08 14:01:01,527 INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 0.503s. Listening on: http://0.0.0.0:8080
2025-09-08 14:01:01,528 INFO  [io.quarkus] (main) Profile prod activated. 
2025-09-08 14:01:01,528 INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]


```

While when the user launches with `--sun-misc-unsafe-memory-access=allow` we get:

```
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2025-09-08 14:07:56,818 INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 0.520s. Listening on: http://0.0.0.0:8080
2025-09-08 14:07:56,824 INFO  [io.quarkus] (main) Profile prod activated. 
2025-09-08 14:07:56,824 INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]

```