### PR TITLE
Adding recommended to quarkus-opentelemetry

### DIFF
--- a/docs/src/main/asciidoc/observability.adoc
+++ b/docs/src/main/asciidoc/observability.adoc
@@ -42,8 +42,8 @@ The following table provides an overview of the observability extensions availab
 |Extension |Logging |Metrics |Tracing |Profiling |Health Check|Events
 
 |xref:opentelemetry.adoc[quarkus-opentelemetry]
-|O
-|O
+|O, R
+|O, R
 |R
 |
 |


### PR DESCRIPTION
This came up on today's Quarkus insights

logging/metrics for `quarkus-opentelemetry` should be recommended in addition to `off by default`