### PR TITLE
Migrate Kubernetes Dev Service to new architecture

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/APIServerRunningKubeContainer.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/APIServerRunningKubeContainer.java
@@ -1,0 +1,63 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Collections.singletonList;
+
+import java.util.Base64;
+
+import com.dajudge.kindcontainer.client.config.Cluster;
+import com.dajudge.kindcontainer.client.config.ClusterSpec;
+import com.dajudge.kindcontainer.client.config.Context;
+import com.dajudge.kindcontainer.client.config.ContextSpec;
+import com.dajudge.kindcontainer.client.config.KubeConfig;
+import com.dajudge.kindcontainer.client.config.User;
+import com.dajudge.kindcontainer.client.config.UserSpec;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
+import io.quarkus.devservices.common.ContainerAddress;
+
+class APIServerRunningKubeContainer extends RunningKubeContainer {
+    private static final String APISERVER = "apiserver";
+    private static final String PKI_BASEDIR = "/etc/kubernetes/pki";
+    private static final String API_SERVER_CA = PKI_BASEDIR + "/ca.crt";
+    private static final String API_SERVER_CERT = PKI_BASEDIR + "/apiserver.crt";
+    private static final String API_SERVER_KEY = PKI_BASEDIR + "/apiserver.key";
+
+    APIServerRunningKubeContainer(ContainerAddress containerAddress, InspectContainerResponse containerInfo) {
+        super(containerAddress, containerInfo);
+    }
+
+    @Override
+    protected String kubeConfigFilePath() {
+        throw new UnsupportedOperationException("Should not be called");
+    }
+
+    @Override
+    protected KubeConfig getInternalKubeConfig() {
+        final Cluster cluster = new Cluster();
+        cluster.setName(APISERVER);
+        // cluster URL will need to be set, done in super.getKubeConfig
+        cluster.setCluster(new ClusterSpec());
+        cluster.getCluster().setCertificateAuthorityData((base64(getFileContentFromContainer(API_SERVER_CA))));
+        final User user = new User();
+        user.setName(APISERVER);
+        user.setUser(new UserSpec());
+        user.getUser().setClientKeyData(base64(getFileContentFromContainer(API_SERVER_KEY)));
+        user.getUser().setClientCertificateData(base64(getFileContentFromContainer(API_SERVER_CERT)));
+        final Context context = new Context();
+        context.setName(APISERVER);
+        context.setContext(new ContextSpec());
+        context.getContext().setCluster(cluster.getName());
+        context.getContext().setUser(user.getName());
+        final KubeConfig config = new KubeConfig();
+        config.setUsers(singletonList(user));
+        config.setClusters(singletonList(cluster));
+        config.setContexts(singletonList(context));
+        config.setCurrentContext(context.getName());
+        return config;
+    }
+
+    private String base64(final String str) {
+        return Base64.getEncoder().encodeToString(str.getBytes(US_ASCII));
+    }
+}

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -3,26 +3,20 @@ package io.quarkus.kubernetes.client.deployment;
 import static com.dajudge.kindcontainer.KubernetesVersionEnum.latest;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
-import static io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor.api_only;
-import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.singletonList;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
-import org.testcontainers.DockerClientFactory;
-import org.testcontainers.containers.ContainerState;
 
 import com.dajudge.kindcontainer.ApiServerContainer;
 import com.dajudge.kindcontainer.ApiServerContainerVersion;
@@ -33,46 +27,34 @@ import com.dajudge.kindcontainer.KindContainerVersion;
 import com.dajudge.kindcontainer.KubernetesContainer;
 import com.dajudge.kindcontainer.KubernetesImageSpec;
 import com.dajudge.kindcontainer.KubernetesVersionEnum;
-import com.dajudge.kindcontainer.client.KubeConfigUtils;
-import com.dajudge.kindcontainer.client.config.Cluster;
-import com.dajudge.kindcontainer.client.config.ClusterSpec;
-import com.dajudge.kindcontainer.client.config.Context;
-import com.dajudge.kindcontainer.client.config.ContextSpec;
-import com.dajudge.kindcontainer.client.config.KubeConfig;
-import com.dajudge.kindcontainer.client.config.User;
-import com.dajudge.kindcontainer.client.config.UserSpec;
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.InspectContainerResponse;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.client.*;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsDevServicesSupportedByLaunchMode;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Produce;
-import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
-import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
-import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
-import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
-import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
-import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
-import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor;
@@ -83,90 +65,165 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class,
         NoQuarkusTestKubernetesClient.class })
 public class DevServicesKubernetesProcessor {
-    private static final String KUBERNETES_CLIENT_DEVSERVICES_OVERRIDE_KUBECONFIG = "quarkus.kubernetes-client.devservices.override-kubeconfig";
-    private static final Logger log = Logger.getLogger(DevServicesKubernetesProcessor.class);
-    private static final String KUBERNETES_CLIENT_MASTER_URL = "quarkus.kubernetes-client.api-server-url";
-    private static final String DEFAULT_MASTER_URL_ENDING_WITH_SLASH = Config.DEFAULT_MASTER_URL + "/";
-
     static final String DEV_SERVICE_LABEL = "quarkus-dev-service-kubernetes";
     static final int KUBERNETES_PORT = 6443;
+    private static final String KUBERNETES_CLIENT_DEVSERVICES_OVERRIDE_KUBECONFIG = "quarkus.kubernetes-client.devservices.override-kubeconfig";
+    private static final Logger log = Logger.getLogger(DevServicesKubernetesProcessor.class);
+    static final String KUBERNETES_CLIENT_MASTER_URL = "quarkus.kubernetes-client.api-server-url";
+    private static final String DEFAULT_MASTER_URL_ENDING_WITH_SLASH = Config.DEFAULT_MASTER_URL + "/";
     private static final ContainerLocator KubernetesContainerLocator = locateContainerWithLabels(KUBERNETES_PORT,
             DEV_SERVICE_LABEL);
-    static volatile RunningDevService devService;
-    static volatile KubernetesDevServiceCfg cfg;
-    static volatile boolean first = true;
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     @BuildStep
     public DevServicesResultBuildItem setupKubernetesDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
-            DevServicesComposeProjectBuildItem composeProjectBuildItem,
-            LaunchModeBuildItem launchMode,
+            DevServicesComposeProjectBuildItem compose,
+            LaunchModeBuildItem launchModeBI,
             KubernetesClientBuildConfig kubernetesClientBuildTimeConfig,
-            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
-            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
-            CuratedApplicationShutdownBuildItem closeBuildItem,
-            LoggingSetupBuildItem loggingSetupBuildItem,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetwork,
             DevServicesConfig devServicesConfig,
             BuildProducer<KubernetesDevServiceInfoBuildItem> devServicesKube,
             Optional<KubernetesDevServiceRequestBuildItem> devServiceKubeRequest) {
-
-        KubernetesDevServiceCfg configuration = getConfiguration(kubernetesClientBuildTimeConfig);
-
-        if (devService != null) {
-            boolean shouldShutdownTheCluster = !configuration.equals(cfg);
-            if (!shouldShutdownTheCluster) {
-                return devService.toBuildItem();
-            }
-            shutdownCluster();
-            cfg = null;
-        }
-
-        StartupLogCompressor compressor = new StartupLogCompressor(
-                (launchMode.isTest() ? "(test) " : "") + "Kubernetes Dev Services Starting:",
-                consoleInstalledBuildItem, loggingSetupBuildItem);
-        try {
-            devService = startKubernetes(dockerStatusBuildItem, composeProjectBuildItem, configuration, launchMode,
-                    !devServicesSharedNetworkBuildItem.isEmpty(),
-                    devServicesConfig.timeout(),
-                    devServicesKube,
-                    devServiceKubeRequest);
-            if (devService == null) {
-                compressor.closeAndDumpCaptured();
-            } else {
-                compressor.close();
-            }
-        } catch (Throwable t) {
-            compressor.closeAndDumpCaptured();
-            throw new RuntimeException(t);
-        }
-
-        if (devService == null) {
+        // If the dev service is disabled, we return null to indicate that no dev service was started.
+        final var kubeDevServiceConfig = kubernetesClientBuildTimeConfig.devservices();
+        if (devServiceDisabled(dockerStatusBuildItem, kubeDevServiceConfig, devServiceKubeRequest)) {
             return null;
         }
 
-        // Configure the watch dog
-        if (first) {
-            first = false;
-            Runnable closeTask = () -> {
-                if (devService != null) {
-                    shutdownCluster();
-                }
-                first = true;
-                devService = null;
-                cfg = null;
-            };
-            closeBuildItem.addCloseTask(closeTask, true);
-        }
-        cfg = configuration;
+        final var launchMode = launchModeBI.getLaunchMode();
+        final var useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                devServicesSharedNetwork);
+        final var serviceName = kubeDevServiceConfig.serviceName();
+        return KubernetesContainerLocator
+                .locateContainer(serviceName, kubeDevServiceConfig.shared(), launchMode)
+                .or(() -> ComposeLocator.locateContainer(compose,
+                        List.of("kube-apiserver", "k3s", "kindest/node"),
+                        KUBERNETES_PORT, launchMode, useSharedNetwork))
+                .map(containerAddress -> {
+                    final var container = RunningKubeContainer.create(containerAddress);
 
-        if (devService.isOwner()) {
-            log.info(
-                    "Dev Services for Kubernetes started. Other Quarkus applications in dev mode will find the "
-                            + "cluster automatically.");
+                    devServicesKube.produce(new KubernetesDevServiceInfoBuildItem(
+                            new KubernetesDevServiceInfoBuildItem.ConfigurationSupplier() {
+                                @Override
+                                public String getKubeConfig() {
+                                    return container.getKubeConfigAsString();
+                                }
+
+                                @Override
+                                public String getContainerId() {
+                                    return containerAddress.getId();
+                                }
+                            }));
+
+                    return DevServicesResultBuildItem.discovered()
+                            .feature(Feature.KUBERNETES_CLIENT)
+                            .containerId(containerAddress.getId())
+                            .config(container.getKubernetesClientConfig())
+                            .build();
+                })
+                .orElseGet(() -> {
+                    final var container = createContainer(kubeDevServiceConfig,
+                            devServiceKubeRequest,
+                            useSharedNetwork,
+                            devServicesConfig.timeout());
+                    final var kubeContainer = container.getContainer();
+                    final var result = DevServicesResultBuildItem.owned()
+                            .feature(Feature.KUBERNETES_CLIENT)
+                            .serviceName(serviceName)
+                            .serviceConfig(kubeDevServiceConfig)
+                            .startable(() -> container)
+                            .configProvider(
+                                    StartableKubernetesContainer.getKubernetesClientConfigFromRunningContainerKubeConfig())
+                            .postStartHook(unused -> log.info(
+                                    "Dev Services for Kubernetes started. Other Quarkus applications in dev mode will find the cluster automatically."))
+                            .build();
+
+                    devServicesKube.produce(new KubernetesDevServiceInfoBuildItem(
+                            new KubernetesDevServiceInfoBuildItem.ConfigurationSupplier() {
+                                @Override
+                                public String getKubeConfig() {
+                                    return kubeContainer.getKubeconfig();
+                                }
+
+                                @Override
+                                public String getContainerId() {
+                                    return kubeContainer.getContainerId();
+                                }
+                            }));
+
+                    return result;
+                });
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private boolean devServiceDisabled(DockerStatusBuildItem dockerStatusBuildItem,
+            KubernetesDevServicesBuildTimeConfig config,
+            Optional<KubernetesDevServiceRequestBuildItem> devServiceKubeRequest) {
+        if (!config.enabled()) {
+            // explicitly disabled
+            log.debug("Not starting Dev Services for Kubernetes, as it has been disabled in the config.");
+            return true;
         }
 
-        return devService.toBuildItem();
+        // Check if kubernetes-client.api-server-url is set
+        if (ConfigUtils.isPropertyNonEmpty(KUBERNETES_CLIENT_MASTER_URL)) {
+            log.debug("Not starting Dev Services for Kubernetes as the client has been explicitly configured via "
+                    + KUBERNETES_CLIENT_MASTER_URL);
+            return true;
+        }
+
+        // If we have an explicit request coming from extensions, start even if there's a non-explicitly overridden kube config
+        final boolean shouldStart = config.overrideKubeconfig() || devServiceKubeRequest.isPresent();
+        if (!shouldStart) {
+            var autoConfigMasterUrl = Config.autoConfigure(null).getMasterUrl();
+            if (!DEFAULT_MASTER_URL_ENDING_WITH_SLASH.equals(autoConfigMasterUrl)) {
+                log.debug(
+                        "Not starting Dev Services for Kubernetes as a kube config file has been found. Set "
+                                + KUBERNETES_CLIENT_DEVSERVICES_OVERRIDE_KUBECONFIG
+                                + " to true to disregard the config and start Dev Services for Kubernetes.");
+                return true;
+            }
+        }
+
+        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
+            log.warn(
+                    "A running container runtime is required for Dev Services to work. Please check if your container runtime is running.");
+            return true;
+        }
+
+        return false;
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private StartableKubernetesContainer createContainer(KubernetesDevServicesBuildTimeConfig config,
+            Optional<KubernetesDevServiceRequestBuildItem> devServiceKubeRequest,
+            boolean useSharedNetwork,
+            Optional<Duration> timeout) {
+        Flavor clusterType = devServiceKubeRequest
+                .map(kdsr -> Flavor.valueOf(kdsr.getFlavor()))
+                .orElse(config.flavor());
+
+        KubernetesContainer<?> container = switch (clusterType) {
+            case api_only -> createContainer(ApiServerContainer::new, ApiServerContainerVersion.class, config, clusterType);
+
+            case k3s -> createContainer(K3sContainer::new, K3sContainerVersion.class, config, clusterType);
+
+            case kind -> createContainer(KindContainer::new, KindContainerVersion.class, config, clusterType);
+        };
+
+        if (useSharedNetwork) {
+            ConfigureUtil.configureSharedNetwork(container, "quarkus-kubernetes-client");
+        }
+        final String serviceName = config.serviceName();
+        if (serviceName != null) {
+            container.withLabel(DEV_SERVICE_LABEL, serviceName);
+            container.withLabel(QUARKUS_DEV_SERVICE, serviceName);
+        }
+        timeout.ifPresent(container::withStartupTimeout);
+
+        container.withEnv(config.containerEnv());
+        return new StartableKubernetesContainer(container);
     }
 
     /**
@@ -184,8 +241,8 @@ public class DevServicesKubernetesProcessor {
             KubernetesDevServiceInfoBuildItem kubernetesDevServiceInfoBuildItem,
             KubernetesClientBuildConfig kubernetesClientBuildTimeConfig) {
         if (kubernetesDevServiceInfoBuildItem == null) {
-            // Gracefully return in case the Kubernetes dev service could not be found
-            log.error("Cannot apply manifests because the Kubernetes dev service is not running");
+            // Gracefully return in case the Kubernetes dev service could not be spun up.
+            log.warn("Cannot apply manifests because the Kubernetes dev service is not running");
             return;
         }
 
@@ -270,129 +327,17 @@ public class DevServicesKubernetesProcessor {
         }
     }
 
-    private void shutdownCluster() {
-        if (devService != null && devService.isOwner()) {
-            try {
-                devService.close();
-            } catch (Throwable e) {
-                log.error("Failed to stop the Kubernetes cluster", e);
-            } finally {
-                devService = null;
-            }
-        }
-    }
-
-    @SuppressWarnings({ "unchecked", "OptionalUsedAsFieldOrParameterType" })
-    private RunningDevService startKubernetes(DockerStatusBuildItem dockerStatusBuildItem,
-            DevServicesComposeProjectBuildItem composeProjectBuildItem,
-            KubernetesDevServiceCfg config,
-            LaunchModeBuildItem launchMode, boolean useSharedNetwork, Optional<Duration> timeout,
-            BuildProducer<KubernetesDevServiceInfoBuildItem> devServicesKube,
-            Optional<KubernetesDevServiceRequestBuildItem> devServiceKubeRequest) {
-        if (!config.devServicesEnabled) {
-            // explicitly disabled
-            log.debug("Not starting Dev Services for Kubernetes, as it has been disabled in the config.");
-            return null;
-        }
-
-        // Check if kubernetes-client.api-server-url is set
-        if (ConfigUtils.isPropertyNonEmpty(KUBERNETES_CLIENT_MASTER_URL)) {
-            log.debug("Not starting Dev Services for Kubernetes as the client has been explicitly configured via "
-                    + KUBERNETES_CLIENT_MASTER_URL);
-            return null;
-        }
-
-        // If we have an explicit request coming from extensions, start even if there's a non-explicitly overridden kube config
-        final boolean shouldStart = config.overrideKubeconfig || devServiceKubeRequest.isPresent();
-        if (!shouldStart) {
-            var autoConfigMasterUrl = Config.autoConfigure(null).getMasterUrl();
-            if (!DEFAULT_MASTER_URL_ENDING_WITH_SLASH.equals(autoConfigMasterUrl)) {
-                log.debug(
-                        "Not starting Dev Services for Kubernetes as a kube config file has been found. Set "
-                                + KUBERNETES_CLIENT_DEVSERVICES_OVERRIDE_KUBECONFIG
-                                + " to true to disregard the config and start Dev Services for Kubernetes.");
-                return null;
-            }
-        }
-
-        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
-            log.warn(
-                    "A running container runtime is required for Dev Services to work. Please check if your container runtime is running.");
-            return null;
-        }
-
-        final Optional<ContainerAddress> maybeContainerAddress = KubernetesContainerLocator.locateContainer(config.serviceName,
-                config.shared,
-                launchMode.getLaunchMode())
-                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
-                        List.of("kube-apiserver", "k3s", "kindest/node"),
-                        KUBERNETES_PORT, launchMode.getLaunchMode(), useSharedNetwork));
-
-        final Supplier<RunningDevService> defaultKubernetesClusterSupplier = () -> {
-            Flavor clusterType = config.flavor
-                    .or(() -> devServiceKubeRequest
-                            .map(KubernetesDevServiceRequestBuildItem::getFlavor)
-                            .map(Flavor::valueOf))
-                    .orElse(api_only);
-
-            @SuppressWarnings("rawtypes")
-            KubernetesContainer container = switch (clusterType) {
-                case api_only -> createContainer(ApiServerContainer::new, ApiServerContainerVersion.class, config, clusterType);
-
-                case k3s -> createContainer(K3sContainer::new, K3sContainerVersion.class, config, clusterType);
-
-                case kind -> createContainer(KindContainer::new, KindContainerVersion.class, config, clusterType);
-            };
-
-            if (useSharedNetwork) {
-                ConfigureUtil.configureSharedNetwork(container, "quarkus-kubernetes-client");
-            }
-            if (config.serviceName != null) {
-                container.withLabel(DEV_SERVICE_LABEL, config.serviceName);
-                container.withLabel(QUARKUS_DEV_SERVICE, config.serviceName);
-            }
-            timeout.ifPresent(container::withStartupTimeout);
-
-            container.withEnv(config.containerEnv);
-
-            container.start();
-
-            KubeConfig kubeConfig = KubeConfigUtils.parseKubeConfig(container.getKubeconfig());
-
-            devServicesKube
-                    .produce(new KubernetesDevServiceInfoBuildItem(container.getKubeconfig(), container.getContainerId()));
-
-            return new RunningDevService(Feature.KUBERNETES_CLIENT.getName(), container.getContainerId(),
-                    new ContainerShutdownCloseable(container, Feature.KUBERNETES_CLIENT.getName()),
-                    getKubernetesClientConfigFromKubeConfig(kubeConfig));
-        };
-
-        maybeContainerAddress.ifPresent(containerAddress -> {
-            devServicesKube
-                    .produce(new KubernetesDevServiceInfoBuildItem(
-                            KubeConfigUtils.serializeKubeConfig(getKubeconfigFromRunningContainer(containerAddress)),
-                            containerAddress.getId()));
-        });
-
-        return maybeContainerAddress
-                .map(containerAddress -> new RunningDevService(Feature.KUBERNETES_CLIENT.getName(),
-                        containerAddress.getId(),
-                        null,
-                        resolveConfigurationFromRunningContainer(containerAddress)))
-                .orElseGet(defaultKubernetesClusterSupplier);
-    }
-
     @SuppressWarnings("rawtypes")
     private <T extends KubernetesVersionEnum<T>, C extends KubernetesContainer> C createContainer(
             Function<KubernetesImageSpec<T>, C> constructor,
             Class<T> versionClass,
-            KubernetesDevServiceCfg config,
+            KubernetesDevServicesBuildTimeConfig config,
             Flavor flavor) {
-        T version = config.apiVersion
+        T version = config.apiVersion()
                 .map(v -> findOrElseThrow(flavor, v, versionClass))
                 .orElseGet(() -> latest(versionClass));
 
-        KubernetesImageSpec<T> imageSpec = version.withImage(config.imageName);
+        KubernetesImageSpec<T> imageSpec = version.withImage(config.imageName().orElse(null));
         return constructor.apply(imageSpec);
     }
 
@@ -410,195 +355,4 @@ public class DevServicesKubernetesProcessor {
                                         .collect(Collectors.joining(", ")))));
     }
 
-    private Map<String, String> getKubernetesClientConfigFromKubeConfig(KubeConfig kubeConfig) {
-
-        ClusterSpec cluster = kubeConfig.getClusters().get(0).getCluster();
-        UserSpec user = kubeConfig.getUsers().get(0).getUser();
-        return Map.of(
-                KUBERNETES_CLIENT_MASTER_URL, cluster.getServer(),
-                "quarkus.kubernetes-client.ca-cert-data",
-                cluster.getCertificateAuthorityData(),
-                "quarkus.kubernetes-client.client-cert-data",
-                user.getClientCertificateData(),
-                "quarkus.kubernetes-client.client-key-data", user.getClientKeyData(),
-                "quarkus.kubernetes-client.client-key-algo", Config.getKeyAlgorithm(null, user.getClientKeyData()),
-                "quarkus.kubernetes-client.namespace", "default");
-    }
-
-    private Map<String, String> resolveConfigurationFromRunningContainer(ContainerAddress containerAddress) {
-        var dockerClient = DockerClientFactory.lazyClient();
-        var container = new RunningContainer(dockerClient, containerAddress);
-
-        return container.getKubeconfig();
-    }
-
-    private KubeConfig getKubeconfigFromRunningContainer(ContainerAddress containerAddress) {
-        var dockerClient = DockerClientFactory.lazyClient();
-        var container = new RunningContainer(dockerClient, containerAddress);
-
-        return container.getKubeconfigFromContainer();
-    }
-
-    private KubernetesDevServiceCfg getConfiguration(KubernetesClientBuildConfig cfg) {
-        KubernetesDevServicesBuildTimeConfig devServicesConfig = cfg.devservices();
-        return new KubernetesDevServiceCfg(devServicesConfig);
-    }
-
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static final class KubernetesDevServiceCfg {
-
-        public boolean devServicesEnabled;
-        public String imageName;
-        public Optional<Flavor> flavor;
-        public Optional<String> apiVersion;
-        public boolean overrideKubeconfig;
-        public boolean shared;
-        public String serviceName;
-        public Map<String, String> containerEnv;
-        public Optional<List<String>> manifests;
-
-        public KubernetesDevServiceCfg(KubernetesDevServicesBuildTimeConfig config) {
-            this.devServicesEnabled = config.enabled();
-            this.imageName = config.imageName()
-                    .orElse(null);
-            this.serviceName = config.serviceName();
-            this.apiVersion = config.apiVersion();
-            this.overrideKubeconfig = config.overrideKubeconfig();
-            this.flavor = config.flavor();
-            this.shared = config.shared();
-            this.containerEnv = config.containerEnv();
-            this.manifests = config.manifests();
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(devServicesEnabled, imageName, flavor, apiVersion, overrideKubeconfig, shared, serviceName,
-                    containerEnv);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (!(obj instanceof KubernetesDevServiceCfg other))
-                return false;
-            return devServicesEnabled == other.devServicesEnabled && flavor == other.flavor
-                    && Objects.equals(apiVersion, other.apiVersion) && overrideKubeconfig == other.overrideKubeconfig
-                    && shared == other.shared && Objects.equals(serviceName, other.serviceName)
-                    && Objects.equals(containerEnv, other.containerEnv);
-        }
-    }
-
-    private class RunningContainer implements ContainerState {
-        private static final String KIND_KUBECONFIG = "/etc/kubernetes/admin.conf";
-        private static final String K3S_KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
-        private static final String APISERVER = "apiserver";
-        private static final String PKI_BASEDIR = "/etc/kubernetes/pki";
-        private static final String API_SERVER_CA = PKI_BASEDIR + "/ca.crt";
-        private static final String API_SERVER_CERT = PKI_BASEDIR + "/apiserver.crt";
-        private static final String API_SERVER_KEY = PKI_BASEDIR + "/apiserver.key";
-
-        private final DockerClient dockerClient;
-
-        private final InspectContainerResponse containerInfo;
-
-        private final ContainerAddress containerAddress;
-
-        public RunningContainer(DockerClient dockerClient, ContainerAddress containerAddress) {
-            this.dockerClient = dockerClient;
-            this.containerAddress = containerAddress;
-            this.containerInfo = dockerClient.inspectContainerCmd(getContainerId()).exec();
-        }
-
-        private KubeConfig getKubeconfigFromContainer() {
-            var image = getContainerInfo().getConfig().getImage();
-            if (image.contains("rancher/k3s")) {
-                return KubeConfigUtils
-                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + containerAddress.getUrl(),
-                                getFileContentFromContainer(K3S_KUBECONFIG)));
-            } else if (image.contains("kindest/node")) {
-                return KubeConfigUtils
-                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + containerAddress.getUrl(),
-                                getFileContentFromContainer(KIND_KUBECONFIG)));
-            } else if (image.contains("k8s.gcr.io/kube-apiserver") ||
-                    image.contains("registry.k8s.io/kube-apiserver")) {
-                return getKubeconfigFromApiContainer(containerAddress.getUrl());
-            }
-
-            // this can happen only if the user manually start
-            // a DEV_SERVICE_LABEL labeled container with an invalid image name
-            throw new RuntimeException("The container with the label '" + DEV_SERVICE_LABEL
-                    + "' is not compatible with Dev Services for Kubernetes. Stop it or disable Dev Services for Kubernetes.");
-        }
-
-        public Map<String, String> getKubeconfig() {
-            return getKubernetesClientConfigFromKubeConfig(getKubeconfigFromContainer());
-        }
-
-        protected KubeConfig getKubeconfigFromApiContainer(final String url) {
-            final Cluster cluster = new Cluster();
-            cluster.setName(APISERVER);
-            cluster.setCluster(new ClusterSpec());
-            cluster.getCluster().setServer(url);
-            cluster.getCluster().setCertificateAuthorityData((base64(getFileContentFromContainer(API_SERVER_CA))));
-            final User user = new User();
-            user.setName(APISERVER);
-            user.setUser(new UserSpec());
-            user.getUser().setClientKeyData(base64(getFileContentFromContainer(API_SERVER_KEY)));
-            user.getUser().setClientCertificateData(base64(getFileContentFromContainer(API_SERVER_CERT)));
-            final Context context = new Context();
-            context.setName(APISERVER);
-            context.setContext(new ContextSpec());
-            context.getContext().setCluster(cluster.getName());
-            context.getContext().setUser(user.getName());
-            final KubeConfig config = new KubeConfig();
-            config.setUsers(singletonList(user));
-            config.setClusters(singletonList(cluster));
-            config.setContexts(singletonList(context));
-            config.setCurrentContext(context.getName());
-            return config;
-        }
-
-        private String base64(final String str) {
-            return Base64.getEncoder().encodeToString(str.getBytes(US_ASCII));
-        }
-
-        @Override
-        public List<Integer> getExposedPorts() {
-            return List.of(containerAddress.getPort());
-        }
-
-        @Override
-        public DockerClient getDockerClient() {
-            return this.dockerClient;
-        }
-
-        @Override
-        public InspectContainerResponse getContainerInfo() {
-            return containerInfo;
-        }
-
-        @Override
-        public String getContainerId() {
-            return this.containerAddress.getId();
-        }
-
-        public String getFileContentFromContainer(String containerPath) {
-            return copyFileFromContainer(containerPath, this::readString);
-        }
-
-        String readString(final InputStream is) throws IOException {
-            return new String(readBytes(is), UTF_8);
-        }
-
-        private byte[] readBytes(final InputStream is) throws IOException {
-            final byte[] buffer = new byte[1024];
-            final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            int read;
-            while ((read = is.read(buffer)) > 0) {
-                bos.write(buffer, 0, read);
-            }
-            return bos.toByteArray();
-        }
-    }
 }

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/K3SRunningKubeContainer.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/K3SRunningKubeContainer.java
@@ -1,0 +1,18 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
+import io.quarkus.devservices.common.ContainerAddress;
+
+class K3SRunningKubeContainer extends RunningKubeContainer {
+    private static final String K3S_KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
+
+    K3SRunningKubeContainer(ContainerAddress containerAddress, InspectContainerResponse containerInfo) {
+        super(containerAddress, containerInfo);
+    }
+
+    @Override
+    protected String kubeConfigFilePath() {
+        return K3S_KUBECONFIG;
+    }
+}

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KindRunningKubeContainer.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KindRunningKubeContainer.java
@@ -1,0 +1,18 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
+import io.quarkus.devservices.common.ContainerAddress;
+
+class KindRunningKubeContainer extends RunningKubeContainer {
+    private static final String KIND_KUBECONFIG = "/etc/kubernetes/admin.conf";
+
+    KindRunningKubeContainer(ContainerAddress containerAddress, InspectContainerResponse containerInfo) {
+        super(containerAddress, containerInfo);
+    }
+
+    @Override
+    protected String kubeConfigFilePath() {
+        return KIND_KUBECONFIG;
+    }
+}

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/RunningKubeContainer.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/RunningKubeContainer.java
@@ -1,6 +1,6 @@
 package io.quarkus.kubernetes.client.deployment;
 
-import static io.quarkus.kubernetes.client.deployment.DevServicesKubernetesProcessor.KUBERNETES_CLIENT_MASTER_URL;
+import static io.quarkus.kubernetes.client.deployment.DevServicesKubernetesProcessor.KUBERNETES_CLIENT_API_SERVER_URL;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayOutputStream;
@@ -68,7 +68,7 @@ abstract class RunningKubeContainer implements ContainerState {
                 .getClusters().get(0).getCluster();
         UserSpec user = kubeConfig.getUsers().get(0).getUser();
         return Map.of(
-                KUBERNETES_CLIENT_MASTER_URL, cluster.getServer(),
+                KUBERNETES_CLIENT_API_SERVER_URL, cluster.getServer(),
                 "quarkus.kubernetes-client.ca-cert-data",
                 cluster.getCertificateAuthorityData(),
                 "quarkus.kubernetes-client.client-cert-data",

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/RunningKubeContainer.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/RunningKubeContainer.java
@@ -1,0 +1,140 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import static io.quarkus.kubernetes.client.deployment.DevServicesKubernetesProcessor.KUBERNETES_CLIENT_MASTER_URL;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.ContainerState;
+
+import com.dajudge.kindcontainer.client.KubeConfigUtils;
+import com.dajudge.kindcontainer.client.config.ClusterSpec;
+import com.dajudge.kindcontainer.client.config.KubeConfig;
+import com.dajudge.kindcontainer.client.config.UserSpec;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
+import io.fabric8.kubernetes.client.Config;
+import io.quarkus.devservices.common.ContainerAddress;
+
+abstract class RunningKubeContainer implements ContainerState {
+    private final ContainerAddress containerAddress;
+    private final InspectContainerResponse containerInfo;
+    private KubeConfig kubeConfig;
+
+    RunningKubeContainer(ContainerAddress containerAddress, InspectContainerResponse containerInfo) {
+        this.containerAddress = containerAddress;
+        this.containerInfo = containerInfo;
+    }
+
+    static RunningKubeContainer create(ContainerAddress containerAddress) {
+        try (final var docker = DockerClientFactory.lazyClient()) {
+            final var containerInfo = docker.inspectContainerCmd(containerAddress.getId()).exec();
+            var image = containerInfo.getConfig().getImage();
+            assert image != null;
+            if (image.contains("rancher/k3s")) {
+                return new K3SRunningKubeContainer(containerAddress, containerInfo);
+            } else if (image.contains("kindest/node")) {
+                return new KindRunningKubeContainer(containerAddress, containerInfo);
+            } else if (image.contains("k8s.gcr.io/kube-apiserver") ||
+                    image.contains("registry.k8s.io/kube-apiserver")) {
+                return new APIServerRunningKubeContainer(containerAddress, containerInfo);
+            }
+
+            throw new RuntimeException("Unable to proceed with Kubernetes Dev Services with container with image '" + image
+                    + "'. Make sure to use a compatible test container flavor.");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static KubeConfig getExternalKubeConfig(KubeConfig internalKubeConfig, String optionalServerURLToReplace) {
+        return Optional.ofNullable(optionalServerURLToReplace)
+                .map(serverURL -> {
+                    ClusterSpec cluster = internalKubeConfig.getClusters().get(0).getCluster();
+                    cluster.setServer(serverURL);
+                    return internalKubeConfig;
+                }).orElse(internalKubeConfig);
+    }
+
+    static Map<String, String> getKubernetesClientConfigFromKubeConfig(KubeConfig kubeConfig,
+            String optionalServerURLToReplace) {
+        ClusterSpec cluster = getExternalKubeConfig(kubeConfig, optionalServerURLToReplace)
+                .getClusters().get(0).getCluster();
+        UserSpec user = kubeConfig.getUsers().get(0).getUser();
+        return Map.of(
+                KUBERNETES_CLIENT_MASTER_URL, cluster.getServer(),
+                "quarkus.kubernetes-client.ca-cert-data",
+                cluster.getCertificateAuthorityData(),
+                "quarkus.kubernetes-client.client-cert-data",
+                user.getClientCertificateData(),
+                "quarkus.kubernetes-client.client-key-data", user.getClientKeyData(),
+                "quarkus.kubernetes-client.client-key-algo", Config.getKeyAlgorithm(null, user.getClientKeyData()),
+                "quarkus.kubernetes-client.namespace", "default");
+    }
+
+    KubeConfig getKubeConfig() {
+        if (kubeConfig == null) {
+            kubeConfig = getInternalKubeConfig();
+            kubeConfig = getExternalKubeConfig(kubeConfig, serverURLToReplace());
+        }
+        return kubeConfig;
+    }
+
+    String getKubeConfigAsString() {
+        final var kubeConfig = getKubeConfig();
+        return KubeConfigUtils.serializeKubeConfig(kubeConfig);
+    }
+
+    Map<String, String> getKubernetesClientConfig() {
+        return getKubernetesClientConfigFromKubeConfig(getKubeConfig(), null);
+    }
+
+    protected KubeConfig getInternalKubeConfig() {
+        return KubeConfigUtils.parseKubeConfig(getFileContentFromContainer(kubeConfigFilePath()));
+    }
+
+    protected abstract String kubeConfigFilePath();
+
+    protected String serverURLToReplace() {
+        return containerAddress.getUrl();
+    }
+
+    @Override
+    public String getContainerId() {
+        return containerAddress.getId();
+    }
+
+    @Override
+    public List<Integer> getExposedPorts() {
+        return List.of(containerAddress.getPort());
+    }
+
+    @Override
+    public InspectContainerResponse getContainerInfo() {
+        return containerInfo;
+    }
+
+    public String getFileContentFromContainer(String containerPath) {
+        return copyFileFromContainer(containerPath, this::readString);
+    }
+
+    String readString(final InputStream is) throws IOException {
+        return new String(readBytes(is), UTF_8);
+    }
+
+    private byte[] readBytes(final InputStream is) throws IOException {
+        final byte[] buffer = new byte[1024];
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        int read;
+        while ((read = is.read(buffer)) > 0) {
+            bos.write(buffer, 0, read);
+        }
+        return bos.toByteArray();
+    }
+}

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/StartableKubernetesContainer.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/StartableKubernetesContainer.java
@@ -1,0 +1,83 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import static io.quarkus.kubernetes.client.deployment.DevServicesKubernetesProcessor.KUBERNETES_CLIENT_MASTER_URL;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.testcontainers.DockerClientFactory;
+
+import com.dajudge.kindcontainer.KubernetesContainer;
+import com.dajudge.kindcontainer.client.KubeConfigUtils;
+
+import io.quarkus.deployment.builditem.Startable;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.ContainerUtil;
+
+public class StartableKubernetesContainer implements Startable {
+    private final KubernetesContainer<?> container;
+    private Map<String, String> quarkusClientConfiguration;
+
+    public StartableKubernetesContainer(KubernetesContainer<?> container) {
+        this.container = container;
+    }
+
+    @Override
+    public void start() {
+        container.start();
+    }
+
+    @Override
+    public String getConnectionInfo() {
+        return container.getKubeconfig();
+    }
+
+    @Override
+    public String getContainerId() {
+        return container.getContainerId();
+    }
+
+    @Override
+    public void close() {
+        container.stop();
+    }
+
+    public KubernetesContainer<?> getContainer() {
+        return container;
+    }
+
+    public String getServerURL() {
+        RunningContainer runningContainer = ContainerUtil.toRunningContainer(container.getContainerInfo());
+        final var defaultPort = DevServicesKubernetesProcessor.KUBERNETES_PORT;
+        final var port = runningContainer.getPortMapping(defaultPort).orElseThrow(
+                () -> new IllegalStateException("No public port found for " + defaultPort));
+        final var address = new ContainerAddress(runningContainer, DockerClientFactory.instance().dockerHostIpAddress(), port);
+        return address.getUrl();
+    }
+
+    String getKubeClientConfigFor(String key) {
+        if (quarkusClientConfiguration == null) {
+            final var kubeConfig = KubeConfigUtils.parseKubeConfig(getConnectionInfo());
+            quarkusClientConfiguration = RunningKubeContainer.getKubernetesClientConfigFromKubeConfig(kubeConfig,
+                    getServerURL());
+        }
+        return quarkusClientConfiguration.get(key);
+    }
+
+    private static Function<StartableKubernetesContainer, String> mapperFor(String key) {
+        return (StartableKubernetesContainer container) -> container.getKubeClientConfigFor(key);
+    }
+
+    static Map<String, Function<StartableKubernetesContainer, String>> getKubernetesClientConfigFromRunningContainerKubeConfig() {
+        return Map.of(
+                KUBERNETES_CLIENT_MASTER_URL, mapperFor(KUBERNETES_CLIENT_MASTER_URL),
+                "quarkus.kubernetes-client.ca-cert-data",
+                mapperFor("quarkus.kubernetes-client.ca-cert-data"),
+                "quarkus.kubernetes-client.client-cert-data",
+                mapperFor("quarkus.kubernetes-client.client-cert-data"),
+                "quarkus.kubernetes-client.client-key-data", mapperFor("quarkus.kubernetes-client.client-key-data"),
+                "quarkus.kubernetes-client.client-key-algo", mapperFor("quarkus.kubernetes-client.client-key-algo"),
+                "quarkus.kubernetes-client.namespace", mapperFor("quarkus.kubernetes-client.namespace"));
+    }
+}

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/StartableKubernetesContainer.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/StartableKubernetesContainer.java
@@ -1,6 +1,6 @@
 package io.quarkus.kubernetes.client.deployment;
 
-import static io.quarkus.kubernetes.client.deployment.DevServicesKubernetesProcessor.KUBERNETES_CLIENT_MASTER_URL;
+import static io.quarkus.kubernetes.client.deployment.DevServicesKubernetesProcessor.KUBERNETES_CLIENT_API_SERVER_URL;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -71,7 +71,7 @@ public class StartableKubernetesContainer implements Startable {
 
     static Map<String, Function<StartableKubernetesContainer, String>> getKubernetesClientConfigFromRunningContainerKubeConfig() {
         return Map.of(
-                KUBERNETES_CLIENT_MASTER_URL, mapperFor(KUBERNETES_CLIENT_MASTER_URL),
+                KUBERNETES_CLIENT_API_SERVER_URL, mapperFor(KUBERNETES_CLIENT_API_SERVER_URL),
                 "quarkus.kubernetes-client.ca-cert-data",
                 mapperFor("quarkus.kubernetes-client.ca-cert-data"),
                 "quarkus.kubernetes-client.client-cert-data",

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClusterFixtures.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClusterFixtures.java
@@ -1,0 +1,44 @@
+package io.quarkus.kubernetes.client.runtime.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.logging.Logger;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.readiness.Readiness;
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class KubernetesClusterFixtures {
+    private static final Logger log = Logger.getLogger(KubernetesClusterFixtures.class.getName());
+
+    public void apply(List<HasMetadata> resources) {
+        try (final var clientHandle = Arc.container().instance(KubernetesClient.class)) {
+            final var client = clientHandle.get();
+            List<HasMetadata> resourcesWithReadiness = new ArrayList<>();
+            resources.forEach(resource -> {
+                log.infof("Applying %s %s to the cluster",
+                        resource.getClass().getSimpleName(),
+                        resource.getMetadata().getName());
+                client.resource(resource).create();
+
+                if (Readiness.getInstance().isReadinessApplicable(resource)) {
+                    resourcesWithReadiness.add(resource);
+                }
+            });
+
+            resourcesWithReadiness.forEach(resource -> {
+                log.infof("Waiting for %s %s to be ready...",
+                        resource.getClass().getSimpleName(),
+                        resource.getMetadata().getName());
+                client.resource(resource).waitUntilReady(60, TimeUnit.SECONDS);
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesDevServicesBuildTimeConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesDevServicesBuildTimeConfig.java
@@ -37,11 +37,12 @@ public interface KubernetesDevServicesBuildTimeConfig {
     Optional<String> imageName();
 
     /**
-     * The flavor to use (kind, k3s or api-only).
+     * The {@link Flavor} to use .
      * <p>
-     * If not set, Dev Services for Kubernetes will set it to: api-only.
+     * If not set, Dev Services for Kubernetes will set it to: {@link Flavor#api_only}.
      */
-    Optional<Flavor> flavor();
+    @WithDefault("api_only")
+    Flavor flavor();
 
     /**
      * By default, if a kubeconfig is found, Dev Services for Kubernetes will not start.
@@ -52,7 +53,7 @@ public interface KubernetesDevServicesBuildTimeConfig {
 
     /**
      * A list of manifest file paths that should be applied to the Kubernetes cluster Dev Service on startup.
-     *
+     * <p>
      * If not set, no manifests are applied.
      */
     Optional<List<String>> manifests();

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -30,6 +30,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-devservices</artifactId>
+      </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>

--- a/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesDevServiceInfoBuildItem.java
+++ b/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesDevServiceInfoBuildItem.java
@@ -3,29 +3,37 @@ package io.quarkus.kubernetes.client.spi;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 /**
- * BuildItem packaging the information of the kind test container created
+ * BuildItem recording information of the started Kubernetes test container
  */
 public final class KubernetesDevServiceInfoBuildItem extends SimpleBuildItem {
-    private final String kubeConfig;
-    private final String containerId;
+    private String kubeConfig;
+    private final ConfigurationSupplier configurationSupplier;
 
-    public KubernetesDevServiceInfoBuildItem(String kubeConfig, String containerId) {
-        this.kubeConfig = kubeConfig;
-        this.containerId = containerId;
+    public KubernetesDevServiceInfoBuildItem(ConfigurationSupplier configurationSupplier) {
+        this.configurationSupplier = configurationSupplier;
     }
 
     /**
      * @return the KubeConfig as YAML string
      */
     public String getKubeConfig() {
+        if (kubeConfig == null) {
+            kubeConfig = configurationSupplier.getKubeConfig();
+        }
         return kubeConfig;
     }
 
     /**
-     * @return the containerId of the running kind test container
+     * @return the containerId of the running test container
      */
+    @SuppressWarnings("unused")
     public String getContainerId() {
-        return containerId;
+        return configurationSupplier.getContainerId();
     }
 
+    public interface ConfigurationSupplier {
+        String getKubeConfig();
+
+        String getContainerId();
+    }
 }


### PR DESCRIPTION
This PR migrates the Kubernetes Dev Service to the new architecture and should fix #49381 and #49405

Resolves [#47603](https://github.com/quarkusio/quarkus/issues/47603).

The goal is for a kube container with the same configuration to be found if running and an associated build item properly produced for the existing service so that the information from the running service can be leveraged.

/cc @LarsSven @holly-cummins @ozangunalp 
