### PR TITLE
Remove outdated Renarde references in OIDC and web guides

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -25,7 +25,7 @@ The configuration of such providers can become complex, very technical and diffi
 
 `quarkus.oidc.provider` configuration property has been introduced to refer to well-known OpenID Connect and OAuth2 providers. This property can be used to refer to a provider such as `github` with only a minimum number of customizations required, typically, an account specific `client id`, `client secret` and some properties have to be set to complete the configuration.
 
-This property can be used in `application.properties`, in xref:security-openid-connect-multitenancy.adoc[multi-tenant] set-ups if more than one provider has to be configured (for example, see https://docs.quarkiverse.io/quarkus-renarde/dev/security.html#_using_oidc_for_login[Quarkus Renarde security documentation]), in custom xref:security-openid-connect-multitenancy.adoc#tenant-config-resolver[TenantConfigResolvers] if the tenant configurations are created dynamically.
+This property can be used in `application.properties` and in custom xref:security-openid-connect-multitenancy.adoc#tenant-config-resolver[TenantConfigResolvers] if the tenant configurations are created dynamically.
 
 == Well Known Providers
 

--- a/docs/src/main/asciidoc/web.adoc
+++ b/docs/src/main/asciidoc/web.adoc
@@ -83,9 +83,9 @@ Here is a simple example of a Qute template:
 
 === Model-View-Controller (MVC)
 
-The MVC approach is also made very easy with Quarkus thanks to https://docs.quarkiverse.io/quarkus-renarde/dev/index.html[the Renarde extension], a Rails-like framework using Qute.
+The MVC approach is also made very easy with Quarkus thanks to Qute.
 
-Associated with the https://docs.quarkiverse.io/quarkus-web-bundler/dev/[Web Bundler extension], the road is open to build modern web applications for all your needs. Here is what a simple Renarde controller looks like:
+Associated with the https://docs.quarkiverse.io/quarkus-web-bundler/dev/[Web Bundler extension], the road is open to build modern web applications for all your needs.
 
 .src/main/java/rest/Todos.java
 [source,java]
@@ -155,7 +155,7 @@ public class Todos extends Controller {
 }
 ----
 
-NOTE: Check out https://www.youtube.com/watch?v=JNmHNSmK180[Quarkus Insights Episode #178]. First part is a hands-on demonstration of creating a CMS with Renarde. You can also give it a try using https://github.com/quarkusio/quarkus-web-lab[the web-lab repo]).
+NOTE: Check out https://www.youtube.com/watch?v=JNmHN5mK180[Quarkus Insights Episode #178]. You can also give it a try using https://github.com/quarkusio/quarkus-web-lab[the web-lab repo].
 
 == Single Page Applications
 


### PR DESCRIPTION
### Summary
Removed outdated references to Renarde in OIDC providers and web guides.

### Why
These references are no longer relevant and caused confusion for readers.

### Verification
Built docs locally; checked that links and sections render correctly.
