### PR TITLE
Introduce Template#getSource()

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -13,6 +13,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Modifier;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -77,6 +78,9 @@ import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.arc.processor.QualifierRegistrar;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
@@ -91,12 +95,14 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
@@ -148,6 +154,7 @@ import io.quarkus.qute.runtime.EngineProducer;
 import io.quarkus.qute.runtime.QuteConfig;
 import io.quarkus.qute.runtime.QuteRecorder;
 import io.quarkus.qute.runtime.QuteRecorder.QuteContext;
+import io.quarkus.qute.runtime.QuteRecorder.TemplateInfo;
 import io.quarkus.qute.runtime.TemplateProducer;
 import io.quarkus.qute.runtime.debug.DebugQuteEngineObserver;
 import io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions;
@@ -653,7 +660,7 @@ public class QuteProcessor {
         for (TemplatePathBuildItem path : effectiveTemplatePaths.getTemplatePaths()) {
             if (path.isTag()) {
                 String tagPath = path.getPath();
-                String tagName = tagPath.substring(TemplatePathBuildItem.TAGS.length(), tagPath.length());
+                String tagName = tagPath.substring(EngineProducer.TAGS.length(), tagPath.length());
                 if (tagName.contains(".")) {
                     tagName = tagName.substring(0, tagName.indexOf('.'));
                 }
@@ -764,7 +771,7 @@ public class QuteProcessor {
                         }
                     }
 
-                    if (templateId.startsWith(TemplatePathBuildItem.TAGS)) {
+                    if (templateId.startsWith(EngineProducer.TAGS)) {
                         parserHelper.addParameter(UserTagSectionHelper.Factory.ARGS,
                                 UserTagSectionHelper.Arguments.class.getName());
                     }
@@ -2222,7 +2229,8 @@ public class QuteProcessor {
             BuildProducer<TemplatePathBuildItem> templatePaths,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
             QuteConfig config,
-            TemplateRootsBuildItem templateRoots)
+            TemplateRootsBuildItem templateRoots,
+            LaunchModeBuildItem launchMode)
             throws IOException {
 
         // Make sure the new templates are watched as well
@@ -2244,27 +2252,35 @@ public class QuteProcessor {
             excludePatterns.add(Pattern.compile(exclude.getRegexPattern()));
         }
 
+        final boolean tryLocateSource = launchMode.getLaunchMode().isDev()
+                && DevModeType.LOCAL == launchMode.getDevModeType().orElse(null);
         final Set<ApplicationArchive> allApplicationArchives = applicationArchives.getAllApplicationArchives();
         final Set<ArtifactKey> appArtifactKeys = new HashSet<>(allApplicationArchives.size());
         for (var archive : allApplicationArchives) {
             appArtifactKeys.add(archive.getKey());
         }
-        for (ResolvedDependency artifact : curateOutcome.getApplicationModel()
-                .getDependencies(DependencyFlags.RUNTIME_EXTENSION_ARTIFACT)) {
+        ApplicationModel applicationModel = curateOutcome.getApplicationModel();
+        for (ResolvedDependency artifact : applicationModel.getDependencies(DependencyFlags.RUNTIME_EXTENSION_ARTIFACT)) {
             // Skip extension archives that are also application archives
             if (!appArtifactKeys.contains(artifact.getKey())) {
                 scanPathTree(artifact.getContentTree(), templateRoots, watchedPaths, templatePaths, nativeImageResources,
-                        config, excludePatterns, TemplatePathBuildItem.APP_ARCHIVE_PRIORITY);
+                        config, excludePatterns, TemplatePathBuildItem.APP_ARCHIVE_PRIORITY, null, tryLocateSource);
             }
         }
         for (ApplicationArchive archive : applicationArchives.getApplicationArchives()) {
             archive.accept(
                     tree -> scanPathTree(tree, templateRoots, watchedPaths, templatePaths, nativeImageResources, config,
-                            excludePatterns, TemplatePathBuildItem.APP_ARCHIVE_PRIORITY));
+                            excludePatterns, TemplatePathBuildItem.APP_ARCHIVE_PRIORITY, null, tryLocateSource));
+        }
+        WorkspaceModule appModule;
+        if (tryLocateSource) {
+            appModule = applicationModel.getApplicationModule();
+        } else {
+            appModule = null;
         }
         applicationArchives.getRootArchive().accept(
                 tree -> scanPathTree(tree, templateRoots, watchedPaths, templatePaths, nativeImageResources, config,
-                        excludePatterns, TemplatePathBuildItem.ROOT_ARCHIVE_PRIORITY));
+                        excludePatterns, TemplatePathBuildItem.ROOT_ARCHIVE_PRIORITY, appModule, tryLocateSource));
     }
 
     private void scanPathTree(PathTree pathTree, TemplateRootsBuildItem templateRoots,
@@ -2272,27 +2288,46 @@ public class QuteProcessor {
             BuildProducer<TemplatePathBuildItem> templatePaths,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
             QuteConfig config, List<Pattern> excludePatterns,
-            int templatePriority) {
+            int templatePriority, WorkspaceModule module, boolean tryLocateSource) {
         for (String templateRoot : templateRoots) {
             if (PathTreeUtils.containsCaseSensitivePath(pathTree, templateRoot)) {
                 pathTree.walkIfContains(templateRoot, visit -> {
-                    if (Files.isRegularFile(visit.getPath())) {
-                        if (!Identifiers.isValid(visit.getPath().getFileName().toString())) {
+                    Path path = visit.getPath();
+                    if (Files.isRegularFile(path)) {
+                        if (!Identifiers.isValid(path.getFileName().toString())) {
                             LOGGER.warnf("Invalid file name detected [%s] - template is ignored", visit.getPath());
                             return;
                         }
-                        LOGGER.debugf("Found template: %s", visit.getPath());
+                        LOGGER.debugf("Found template: %s", path);
                         // remove templateRoot + /
                         final String relativePath = visit.getRelativePath();
                         String templatePath = relativePath.substring(templateRoot.length() + 1);
                         for (Pattern p : excludePatterns) {
                             if (p.matcher(templatePath).matches()) {
-                                LOGGER.debugf("Template file excluded: %s", visit.getPath());
+                                LOGGER.debugf("Template file excluded: %s", path);
                                 return;
                             }
                         }
+                        // Try to find source
+                        URI source = null;
+                        if (module != null) {
+                            for (SourceDir resources : module.getMainSources().getResourceDirs()) {
+                                Path sourcePath = resources.getDir().resolve(visit.getRelativePath());
+                                if (Files.isRegularFile(sourcePath)) {
+                                    LOGGER.debugf("Source file found for template %s: %s", templatePath, sourcePath);
+                                    source = sourcePath.toUri();
+                                }
+                            }
+                        } else if (tryLocateSource) {
+                            try {
+                                source = visit.getUrl().toURI();
+                                LOGGER.debugf("Source file found for template %s: %s", templatePath, source);
+                            } catch (Exception e) {
+                                LOGGER.warnf("Unable to locate source for %s: %s", templatePath, e.toString());
+                            }
+                        }
                         produceTemplateBuildItems(templatePaths, watchedPaths, nativeImageResources,
-                                relativePath, templatePath, visit.getPath(), config, templatePriority);
+                                relativePath, templatePath, path, config, templatePriority, source);
                     }
                 });
             }
@@ -2621,20 +2656,12 @@ public class QuteProcessor {
             EffectiveTemplatePathsBuildItem effectiveTemplatePaths, Optional<TemplateVariantsBuildItem> templateVariants,
             TemplateRootsBuildItem templateRoots, List<TemplatePathExcludeBuildItem> templatePathExcludes) {
 
-        List<String> templates = new ArrayList<>();
-        List<String> tags = new ArrayList<>();
-        Map<String, String> templateContents = new HashMap<>();
-        for (TemplatePathBuildItem templatePath : effectiveTemplatePaths.getTemplatePaths()) {
-            if (templatePath.isTag()) {
-                // tags/myTag.html -> myTag.html
-                String tagPath = templatePath.getPath();
-                tags.add(tagPath.substring(TemplatePathBuildItem.TAGS.length(), tagPath.length()));
-            } else {
-                templates.add(templatePath.getPath());
-            }
-            if (!templatePath.isFileBased()) {
-                templateContents.put(templatePath.getPath(), templatePath.getContent());
-            }
+        Map<String, TemplateInfo> templates = new HashMap<>();
+        for (TemplatePathBuildItem template : effectiveTemplatePaths.getTemplatePaths()) {
+            templates.put(template.getPath(),
+                    new TemplateInfo(template.getPath(),
+                            template.getSource() != null ? template.getSource().toString() : null,
+                            template.isFileBased() ? null : template.getContent()));
         }
         Map<String, List<String>> variants;
         if (templateVariants.isPresent()) {
@@ -2650,10 +2677,9 @@ public class QuteProcessor {
 
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(QuteContext.class)
                 .scope(BuiltinScope.SINGLETON.getInfo())
-                .supplier(recorder.createContext(templates,
-                        tags, variants,
-                        templateRoots.getPaths().stream().map(p -> p + "/").collect(Collectors.toSet()), templateContents,
-                        excludePatterns))
+                .supplier(recorder.createContext(variants,
+                        templateRoots.getPaths().stream().map(p -> p + "/").collect(Collectors.toSet()),
+                        excludePatterns, templates))
                 .done());
     }
 
@@ -3635,7 +3661,7 @@ public class QuteProcessor {
     private static void produceTemplateBuildItems(BuildProducer<TemplatePathBuildItem> templatePaths,
             BuildProducer<HotDeploymentWatchedFileBuildItem> watchedPaths,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources, String resourcePath,
-            String templatePath, Path originalPath, QuteConfig config, int templatePriority) {
+            String templatePath, Path originalPath, QuteConfig config, int templatePriority, URI source) {
         if (templatePath.isEmpty()) {
             return;
         }
@@ -3652,6 +3678,7 @@ public class QuteProcessor {
         templatePaths.produce(TemplatePathBuildItem.builder()
                 .path(templatePath)
                 .fullPath(originalPath)
+                .source(source)
                 .priority(templatePriority)
                 .content(readTemplateContent(originalPath, config.defaultCharset()))
                 .build());

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplatePathBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplatePathBuildItem.java
@@ -1,9 +1,11 @@
 package io.quarkus.qute.deployment;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Objects;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.qute.runtime.EngineProducer;
 import io.quarkus.qute.runtime.QuteConfig;
 
 /**
@@ -44,8 +46,6 @@ public final class TemplatePathBuildItem extends MultiBuildItem {
         return new Builder();
     }
 
-    static final String TAGS = "tags/";
-
     private final String path;
     private final String content;
     private final Path fullPath;
@@ -53,25 +53,16 @@ public final class TemplatePathBuildItem extends MultiBuildItem {
 
     private final int priority;
 
-    /**
-     *
-     * @param path
-     * @param fullPath
-     * @param content
-     * @deprecated Use the {@link #builder()} instead
-     */
-    @Deprecated(forRemoval = true, since = "3.13")
-    public TemplatePathBuildItem(String path, Path fullPath, String content) {
-        this(Objects.requireNonNull(path), Objects.requireNonNull(content), Objects.requireNonNull(fullPath), null,
-                BUILD_ITEM_PRIORITY);
-    }
+    private final URI source;
 
-    private TemplatePathBuildItem(String path, String content, Path fullPath, String extensionInfo, int priority) {
+    private TemplatePathBuildItem(String path, String content, Path fullPath, String extensionInfo, int priority,
+            URI source) {
         this.path = path;
         this.content = content;
         this.fullPath = fullPath;
         this.extensionInfo = extensionInfo;
         this.priority = priority;
+        this.source = source;
     }
 
     /**
@@ -93,6 +84,14 @@ public final class TemplatePathBuildItem extends MultiBuildItem {
      */
     public Path getFullPath() {
         return fullPath;
+    }
+
+    /**
+     *
+     * @return the source, or {@code null} if not available
+     */
+    public URI getSource() {
+        return source;
     }
 
     /**
@@ -125,7 +124,7 @@ public final class TemplatePathBuildItem extends MultiBuildItem {
      * @return {@code true} if it represents a user tag, {@code false} otherwise
      */
     public boolean isTag() {
-        return path.startsWith(TAGS);
+        return path.startsWith(EngineProducer.TAGS);
     }
 
     /**
@@ -153,6 +152,7 @@ public final class TemplatePathBuildItem extends MultiBuildItem {
         private String path;
         private String content;
         private Path fullPath;
+        private URI source;
         private String extensionInfo;
         private int priority = BUILD_ITEM_PRIORITY;
 
@@ -193,6 +193,17 @@ public final class TemplatePathBuildItem extends MultiBuildItem {
         }
 
         /**
+         * Set the source path of the template.
+         *
+         * @param source
+         * @return self
+         */
+        public Builder source(URI source) {
+            this.source = source;
+            return this;
+        }
+
+        /**
          * Set the extension info for templates that are not backed by a file.
          *
          * @param info
@@ -219,7 +230,7 @@ public final class TemplatePathBuildItem extends MultiBuildItem {
             if (fullPath == null && extensionInfo == null) {
                 throw new IllegalStateException("Templates that are not backed by a file must provide extension info");
             }
-            return new TemplatePathBuildItem(path, content, fullPath, extensionInfo, priority);
+            return new TemplatePathBuildItem(path, content, fullPath, extensionInfo, priority, source);
         }
 
     }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/SourceRoute.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/SourceRoute.java
@@ -1,0 +1,26 @@
+package io.quarkus.qute.deployment.devmode;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.qute.Template;
+import io.quarkus.vertx.web.Route;
+import io.vertx.ext.web.RoutingContext;
+
+public class SourceRoute {
+
+    @Inject
+    Template test;
+
+    @Route(path = "test")
+    public void test(RoutingContext ctx) {
+        URI source = test.getSource().orElse(null);
+        if (source == null) {
+            ctx.response().setStatusCode(500).end();
+        } else {
+            ctx.end(source.toString());
+        }
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TemplateSourceDevModeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TemplateSourceDevModeTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.qute.deployment.devmode;
+
+import static io.restassured.RestAssured.given;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+/**
+ * Test that Template#getSource() works correctly in the local dev mode.
+ */
+public class TemplateSourceDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(SourceRoute.class)
+                    .addAsResource(new StringAsset(
+                            "{foo}"),
+                            "templates/test.html"));
+
+    @Test
+    public void testTemplateSource() {
+        given().get("test")
+                .then()
+                .statusCode(200)
+                .body(Matchers.startsWith("file:"),
+                        Matchers.endsWith("src/main/resources/templates/test.html"));
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
@@ -3,6 +3,7 @@ package io.quarkus.qute.runtime;
 import java.lang.annotation.Annotation;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -182,6 +183,14 @@ public class TemplateProducer {
         }
 
         @Override
+        public Optional<URI> getSource() {
+            if (unambiguousTemplate != null) {
+                return unambiguousTemplate.get().getSource();
+            }
+            throw ambiguousTemplates("getSource()");
+        }
+
+        @Override
         public TemplateInstance instance() {
             TemplateInstance instance = new InjectableTemplateInstanceImpl();
             return renderedResults != null ? new ResultsCollectingTemplateInstance(instance, renderedResults) : instance;
@@ -334,6 +343,11 @@ public class TemplateProducer {
             @Override
             public SectionNode getRootNode() {
                 return InjectableTemplate.this.getRootNode();
+            }
+
+            @Override
+            public Optional<URI> getSource() {
+                return InjectableTemplate.this.getSource();
             }
 
             @Override

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.CharBuffer;
@@ -32,6 +33,7 @@ import io.quarkus.qute.SectionHelperFactory.BlockInfo;
 import io.quarkus.qute.SectionHelperFactory.MissingEndTagStrategy;
 import io.quarkus.qute.SectionHelperFactory.ParametersInfo;
 import io.quarkus.qute.SectionHelperFactory.ParserDelegate;
+import io.quarkus.qute.TemplateLocator.TemplateLocation;
 import io.quarkus.qute.TemplateNode.Origin;
 
 /**
@@ -64,7 +66,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
 
     private final EngineImpl engine;
     private final Reader reader;
-    private final Optional<Variant> variant;
+    private final TemplateLocation location;
     private final String templateId;
     private final String generatedId;
 
@@ -83,12 +85,12 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
 
     private TemplateImpl template;
 
-    public Parser(EngineImpl engine, Reader reader, String templateId, String generatedId, Optional<Variant> variant) {
+    public Parser(EngineImpl engine, String templateId, String generatedId, Reader reader, TemplateLocation location) {
         this.engine = engine;
         this.templateId = templateId;
         this.generatedId = generatedId;
-        this.variant = variant;
-        this.reader = reader;
+        this.location = location;
+        this.reader = ensureBufferedReader(reader);
 
         this.state = State.TEXT;
         this.buffer = new StringBuilder();
@@ -209,7 +211,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
                         .build();
             }
             template = new TemplateImpl(engine, root.build(this::currentTemplate), templateId, generatedId,
-                    variant);
+                    location.getVariant(), location.getSource());
 
             Set<TemplateNode> nodesToRemove = Collections.emptySet();
             if (hasLineSeparator && engine.removeStandaloneLines) {
@@ -1116,11 +1118,12 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
     }
 
     Origin origin(int lineCharacterOffset) {
-        return new OriginImpl(line, lineCharacter - lineCharacterOffset, lineCharacter, templateId, generatedId, variant);
+        return new OriginImpl(line, lineCharacter - lineCharacterOffset, lineCharacter, templateId, generatedId,
+                location.getVariant());
     }
 
     Origin syntheticOrigin() {
-        return new OriginImpl(-1, -1, -1, templateId, generatedId, variant);
+        return new OriginImpl(-1, -1, -1, templateId, generatedId, location.getVariant());
     }
 
     private List<List<TemplateNode>> readLines(SectionNode rootNode) {
@@ -1200,6 +1203,12 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
             }
         }
         return true;
+    }
+
+    private Reader ensureBufferedReader(Reader reader) {
+        return reader instanceof BufferedReader ? reader
+                : new BufferedReader(
+                        reader);
     }
 
     private static String toString(Reader in)

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/StringTemplateLocation.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/StringTemplateLocation.java
@@ -1,0 +1,34 @@
+package io.quarkus.qute;
+
+import java.io.Reader;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.quarkus.qute.Parser.StringReader;
+import io.quarkus.qute.TemplateLocator.TemplateLocation;
+
+public class StringTemplateLocation implements TemplateLocation {
+
+    private final String content;
+    private final Optional<Variant> variant;
+
+    public StringTemplateLocation(String content) {
+        this(content, Optional.empty());
+    }
+
+    public StringTemplateLocation(String content, Optional<Variant> variant) {
+        this.content = Objects.requireNonNull(content);
+        this.variant = Objects.requireNonNull(variant);
+    }
+
+    @Override
+    public Reader read() {
+        return new StringReader(content);
+    }
+
+    @Override
+    public Optional<Variant> getVariant() {
+        return variant;
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Template.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Template.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -211,6 +212,15 @@ public interface Template {
      * @return the root section node
      */
     SectionNode getRootNode();
+
+    /**
+     * Returns a URI reference to the template source in the local development mode.
+     * <p>
+     * If invoked upon a fragment instance then delegate to the defining template.
+     *
+     * @return the source
+     */
+    Optional<URI> getSource();
 
     /**
      * A fragment represents a part of the template that can be treated as a separate template.

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateLocator.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateLocator.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute;
 
 import java.io.Reader;
+import java.net.URI;
 import java.util.Optional;
 
 /**
@@ -34,6 +35,13 @@ public interface TemplateLocator extends WithPriority {
          * @return the template variant
          */
         Optional<Variant> getVariant();
+
+        /**
+         * @return the source
+         */
+        default Optional<URI> getSource() {
+            return Optional.empty();
+        }
 
     }
 

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/adapter/RegisterDebugServerAdapter.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/adapter/RegisterDebugServerAdapter.java
@@ -251,7 +251,9 @@ public class RegisterDebugServerAdapter implements EngineListener {
     }
 
     public void reset() {
-        agent.reset();
+        if (agent != null) {
+            agent.reset();
+        }
         trackedEngines.clear();
         if (!notInitializedEngines.isEmpty()) {
             notInitializedEngines.forEach(engine -> {


### PR DESCRIPTION
Currently, we only support `Template#getSource()` for the templates in the application root (`src/main/resources/templates`) in the local development mode.
 
- [x] add support for templates from dependencies?
- [x] tests (unfortunately, it's not possible to test additional dependencies in a `QuarkusDevModeTest`)
~~- [ ] docs~~

CC @ia3andy @angelozerr 