### PR TITLE
Trim out a bit more superfluous website content for preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -110,8 +110,11 @@ jobs:
         run: |
           find assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +100 -exec rm -rf _site/{} \;
           find newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +100 -exec rm -rf _site/{} \;
+          rm -rf _site/assets/stickers
           rm -rf _site/assets/images/worldtour/2023
+          rm -rf _site/assets/images/worldtour/2024
           rm -rf _site/assets/images/desktopwallpapers
+          rm -rf _site/assets/images/stickers
 
       - name: Publishing to surge for preview
         id: deploy

--- a/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="security-oidc-auth0-tutorial"]
-= Protect Quarkus web application by using an Auth0 OpenID Connect provider
+= Protect a Quarkus web application by using an Auth0 OpenID Connect provider
 include::_attributes.adoc[]
 :diataxis-type: tutorial
 :categories: security,web


### PR DESCRIPTION
Fixes #35660 (maybe). 

Both quarkusio and quarkus previews are failing with application too large at the moment. My attempts to fix quarkusio (https://github.com/quarkusio/quarkusio.github.io/pull/2393 and https://github.com/quarkusio/quarkusio.github.io/pull/2394) haven't worked, but trying them here in case something is different on this side. :) 

Can't be tested properly until post-merge, sadly.