### PR TITLE
Add support for Hibernate's hibernate.hbm2ddl.extra_physical_table_types

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -564,6 +564,19 @@ public final class LoggingResourceProcessor {
         }
     }
 
+    @BuildStep
+    @Produce(ServiceStartBuildItem.class)
+    void closeBuildTimeLogging(List<DevServicesResultBuildItem> devServices) {
+        if (devServices.isEmpty()) {
+            ((QuarkusClassLoader) Thread.currentThread().getContextClassLoader()).addCloseTask(new Runnable() {
+                @Override
+                public void run() {
+                    InitialConfigurator.DELAYED_HANDLER.buildTimeComplete();
+                }
+            });
+        }
+    }
+
     private static boolean allRootMinLevelOrHigher(
             int rootMinLogLevel,
             Map<String, CategoryBuildTimeConfig> categories,


### PR DESCRIPTION
This MR adds support for configuring additional database object types to be included
in schema management operations, such as materialized views or other database-specific objects.

Changes:

    Add documentation for the existing extraPhysicalTableTypes() method
    Pass the configuration to Hibernate ORM in FastBootHibernatePersistenceProvider
    Add the same implementation for Hibernate Reactive in FastBootHibernateReactivePersistenceProvider
    Define a constant for the setting if not already available in Hibernate's AvailableSettings

Example usage: quarkus.hibernate-orm.extra-physical-table-types=MATERIALIZED VIEW,VIEW