### PR TITLE
Restructure tests so that continuous testing for main tests tests 'work'

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -117,7 +117,7 @@
         {
             "category": "Misc3",
             "timeout": 80,
-            "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-graphql-client-keycloak,  picocli-native",
+            "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-graphql-client-keycloak,  command-mode, picocli-native",
             "os-name": "ubuntu-latest"
         },
         {

--- a/integration-tests/command-mode/pom.xml
+++ b/integration-tests/command-mode/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-command-mode</artifactId>
+    <name>Quarkus - Integration Tests - Command Mode</name>
+    <description>Module that exercises command mode and command mode tests, including in continuous testing mode
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/command-mode/src/main/java/org/acme/Main.java
+++ b/integration-tests/command-mode/src/main/java/org/acme/Main.java
@@ -1,0 +1,25 @@
+package org.acme;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class Main implements QuarkusApplication {
+
+    @Override
+    public int run(String... args) throws Exception {
+        System.out.println("ARGS: " + Arrays.asList(args));
+
+        final Path path = Paths.get("target/done.txt");
+        if (Files.exists(path)) {
+            Files.delete(path);
+        }
+        Files.createFile(path);
+        return 10;
+    }
+}

--- a/integration-tests/command-mode/src/test/java/org/acme/MainContinuousTestingTest.java
+++ b/integration-tests/command-mode/src/test/java/org/acme/MainContinuousTestingTest.java
@@ -12,7 +12,7 @@ import io.quarkus.test.ContinuousTestingTestUtils;
 import io.quarkus.test.ContinuousTestingTestUtils.TestStatus;
 import io.quarkus.test.QuarkusDevModeTest;
 
-@Disabled("Fails due to 'More than one @QuarkusMain method found with name '': org.acme.Main and org.acme.Main'")
+@Disabled("See https://github.com/quarkusio/quarkus/issues/49780#issuecomment-3265067545")
 public class MainContinuousTestingTest {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/integration-tests/command-mode/src/test/java/org/acme/MainTest.java
+++ b/integration-tests/command-mode/src/test/java/org/acme/MainTest.java
@@ -1,0 +1,18 @@
+package org.acme;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
+public class MainTest {
+
+    @Test
+    @Launch(value = { "one" }, exitCode = 10)
+    public void testMain(LaunchResult result) {
+        Assertions.assertTrue(result.getOutput().contains("ARGS: [one]"));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -307,6 +307,7 @@
                 <module>resteasy-mutiny</module>
                 <module>virtual-http</module>
                 <module>virtual-http-resteasy</module>
+                <module>command-mode</module>
                 <module>maven</module>
                 <module>scala</module>
                 <module>kotlin</module>


### PR DESCRIPTION
I've put 'work' in quotes since the tests don't pass, they just successfully reproduce https://github.com/quarkusio/quarkus/issues/49780. 

We added continuous testing tests for command mode as part of https://github.com/quarkusio/quarkus/pull/47534, but couldn’t get them working (using a resources project in a higher level integration project). 

I decided that using a nested project to run internal-style test (using ContinuousTestingUtils and DevModeTest) was not our typical pattern, so rather than try and make it work in the current structure, I'd rearrange. The command mode support is significant enough it merits a top-level integration test. A lot of the function is covered by the picocli and picocli-native module, but those modules are more focussed on exercising variations of picocli function.

I wondered about whether to delete the tests from the maven project entirely. In the end I left them in both places. It has the disadvantage of increasing build times for duplicated tests, so I’m open to arguments that I should delete the integration-tests/maven version.

I know it’s a bit weird to do a PR which just moved around a test without enabling it, but the change was big enough I wanted to keep it separate from the fix for https://github.com/quarkusio/quarkus/issues/49780.