### PR TITLE
Account for the null root bean when performing value validation

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPATestValidationOfNonEntitiesResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPATestValidationOfNonEntitiesResource.java
@@ -1,0 +1,50 @@
+package io.quarkus.hibernate.orm.validation;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/validation/nonentity")
+@ApplicationScoped
+public class JPATestValidationOfNonEntitiesResource {
+
+    @Inject
+    Validator validator;
+
+    @Path("/bean")
+    @GET
+    public String bean() {
+        Set<ConstraintViolation<MyNonEntity>> constraintViolations = validator.validate(new MyNonEntity());
+        if (constraintViolations.size() != 1) {
+            return "ko";
+        }
+        if (!constraintViolations.iterator().next().getPropertyPath().toString().equals("name")) {
+            return "ko";
+        }
+        return "ok";
+    }
+
+    @Path("/value")
+    @GET
+    public String value() {
+        Set<ConstraintViolation<MyNonEntity>> constraintViolations = validator.validateValue(MyNonEntity.class, "name", null);
+        if (constraintViolations.size() != 1) {
+            return "ko";
+        }
+        if (!constraintViolations.iterator().next().getPropertyPath().toString().equals("name")) {
+            return "ko";
+        }
+        return "ok";
+    }
+
+    public static class MyNonEntity {
+        @NotNull
+        public String name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPATestValidationOfNonEntitiesTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPATestValidationOfNonEntitiesTestCase.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.validation;
+
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class JPATestValidationOfNonEntitiesTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class, JPATestValidationOfNonEntitiesResource.class)
+                    .addAsResource("application.properties")
+                    .addAsResource(new StringAsset(""), "import.sql")); // define an empty import.sql file
+
+    @Test
+    public void testValueValidation() {
+        RestAssured.given().when().get("validation/nonentity/value").then()
+                .body(is("ok"));
+    }
+
+    @Test
+    public void testBeanValidation() {
+        RestAssured.given().when().get("validation/nonentity/bean").then()
+                .body(is("ok"));
+    }
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -306,6 +306,11 @@ public class HibernateValidatorRecorder {
         @Override
         public boolean isReachable(Object entity, Path.Node traversableProperty, Class<?> rootBeanType,
                 Path pathToTraversableObject, ElementType elementType) {
+            if (entity == null) {
+                // The entity can be null if we are validating values, as that's when the validation context does not have the root object,
+                //  In other cases we shouldn't even reach the traversable resolver when the validated bean/entity is null.
+                return true;
+            }
             return attributeLoadedPredicate.test(entity, traversableProperty.getName());
         }
 


### PR DESCRIPTION
When `Validator#validateValue()` is called, then the root validation context won't have the root bean (i.e. it'll be `null`), but at the same time, we've already retrieved the value since we are passing it to the validator method, hence no need to check for reachability there.

This affects only the value validation.

Since the causing change was included in the 3.24.1, we'd probably want to backport this to all still maintained versions... 

* Caused by https://github.com/quarkusio/quarkus/pull/48458
* Fixes https://github.com/quarkusio/quarkus/issues/49987

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

