### PR TITLE
Get the traceId into the access logs

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/VertxMDCDataAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/VertxMDCDataAttribute.java
@@ -10,6 +10,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class VertxMDCDataAttribute implements ExchangeAttribute {
 
+    public static final String ORIGINAL_OTEL_TRACE_ID_KEY = "originalOtelTraceId";
     private final String dataKey;
 
     public VertxMDCDataAttribute(String dataKey) {
@@ -19,7 +20,12 @@ public class VertxMDCDataAttribute implements ExchangeAttribute {
     @Override
     public String readAttribute(RoutingContext exchange) {
         VertxMDC mdc = VertxMDC.INSTANCE;
-        return mdc.get(dataKey);
+        String value = mdc.get(dataKey);
+        if (value == null && "traceId".equals(dataKey)) {
+            // get from cache
+            value = exchange.get(ORIGINAL_OTEL_TRACE_ID_KEY);
+        }
+        return value;
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/43570

The problem is created at the end of the request, when the OTel related data is removed from the VertxMDC context here:
https://github.com/quarkusio/quarkus/blob/c65d7acb073e3b16466fcb077da5a393fcaf6a52/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java#L110

Before the `RequestDoneHandler` is executed in the access log. 

This is just a dirty way to do it. I don't think we should touch the lifecycle, therefore, caching the value for later seems sensible enough.
We could also consider to store that data in the `QuarkusRequestWrapper`.

