### PR TITLE
Tests: support InjectMock for built-in Event

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -621,11 +621,12 @@ public class ArcProcessor {
     @Consume(ResourcesGeneratedPhaseBuildItem.class)
     @Record(STATIC_INIT)
     public ArcContainerBuildItem initializeContainer(ArcConfig config, ArcRecorder recorder,
-            ShutdownContextBuildItem shutdown, Optional<CurrentContextFactoryBuildItem> currentContextFactory)
+            ShutdownContextBuildItem shutdown, Optional<CurrentContextFactoryBuildItem> currentContextFactory,
+            LaunchModeBuildItem launchMode)
             throws Exception {
         ArcContainer container = recorder.initContainer(shutdown,
                 currentContextFactory.isPresent() ? currentContextFactory.get().getFactory() : null,
-                config.strictCompatibility());
+                config.strictCompatibility(), launchMode.isTest());
         return new ArcContainerBuildItem(container);
     }
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -45,10 +45,11 @@ public class ArcRecorder {
     public static volatile Map<String, Supplier<ActiveResult>> syntheticBeanCheckActive;
 
     public ArcContainer initContainer(ShutdownContext shutdown, RuntimeValue<CurrentContextFactory> currentContextFactory,
-            boolean strictCompatibility) throws Exception {
-        ArcInitConfig.Builder builder = ArcInitConfig.builder();
-        builder.setCurrentContextFactory(currentContextFactory != null ? currentContextFactory.getValue() : null);
-        builder.setStrictCompatibility(strictCompatibility);
+            boolean strictCompatibility, boolean testMode) throws Exception {
+        ArcInitConfig.Builder builder = ArcInitConfig.builder()
+                .setCurrentContextFactory(currentContextFactory != null ? currentContextFactory.getValue() : null)
+                .setStrictCompatibility(strictCompatibility)
+                .setTestMode(testMode);
         ArcContainer container = Arc.initialize(builder.build());
         shutdown.addShutdownTask(new Runnable() {
             @Override

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -106,7 +106,7 @@ public class InjectionPointInfo {
         return injectionPoints;
     }
 
-    static InjectionPointInfo fromSyntheticInjectionPoint(TypeAndQualifiers typeAndQualifiers) {
+    public static InjectionPointInfo fromSyntheticInjectionPoint(TypeAndQualifiers typeAndQualifiers) {
         return new InjectionPointInfo(typeAndQualifiers, InjectionPointKind.CDI, null, null, false, false);
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
@@ -35,7 +35,8 @@ public final class Arc {
                 container = INSTANCE.get();
                 if (container == null) {
                     // Set the container instance first because Arc.container() can be used within ArcContainerImpl.init()
-                    container = new ArcContainerImpl(config.getCurrentContextFactory(), config.isStrictCompatibility());
+                    container = new ArcContainerImpl(config.getCurrentContextFactory(), config.isStrictCompatibility(),
+                            config.isTestMode());
                     INSTANCE.set(container);
                     container.init();
                 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
@@ -24,10 +24,12 @@ public final class ArcInitConfig {
     private ArcInitConfig(Builder builder) {
         this.currentContextFactory = builder.currentContextFactory;
         this.strictCompatibility = builder.strictCompatibility;
+        this.testMode = builder.testMode;
     }
 
     private final boolean strictCompatibility;
     private final CurrentContextFactory currentContextFactory;
+    private final boolean testMode;
 
     public boolean isStrictCompatibility() {
         return strictCompatibility;
@@ -37,14 +39,17 @@ public final class ArcInitConfig {
         return currentContextFactory;
     }
 
+    public boolean isTestMode() {
+        return testMode;
+    }
+
     public static class Builder {
+
         private boolean strictCompatibility;
         private CurrentContextFactory currentContextFactory;
+        private boolean testMode;
 
         private Builder() {
-            // init all values with their defaults
-            this.strictCompatibility = false;
-            this.currentContextFactory = null;
         }
 
         public Builder setStrictCompatibility(boolean strictCompatibility) {
@@ -54,6 +59,11 @@ public final class ArcInitConfig {
 
         public Builder setCurrentContextFactory(CurrentContextFactory currentContextFactory) {
             this.currentContextFactory = currentContextFactory;
+            return this;
+        }
+
+        public Builder setTestMode(boolean testMode) {
+            this.testMode = testMode;
             return this;
         }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -552,11 +552,6 @@ public class ArcContainerImpl implements ArcContainer {
     }
 
     private <T> InstanceHandle<T> instanceHandle(Type type, Annotation... qualifiers) {
-        if (qualifiers == null || qualifiers.length == 0) {
-            qualifiers = new Annotation[] { Default.Literal.INSTANCE };
-        } else {
-            registeredQualifiers.verify(qualifiers);
-        }
         return beanInstanceHandle(getBean(type, qualifiers), null, InjectionPointImpl.of(type, qualifiers), null);
     }
 
@@ -596,6 +591,11 @@ public class ArcContainerImpl implements ArcContainer {
 
     @SuppressWarnings("unchecked")
     private <T> InjectableBean<T> getBean(Type requiredType, Annotation... qualifiers) {
+        if (qualifiers == null || qualifiers.length == 0) {
+            qualifiers = new Annotation[] { Default.Literal.INSTANCE };
+        } else {
+            registeredQualifiers.verify(qualifiers);
+        }
         Resolvable resolvable = new Resolvable(requiredType, qualifiers);
         Set<InjectableBean<?>> resolvedBeans = resolved.getValue(resolvable);
         if (resolvedBeans.isEmpty()) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
@@ -69,7 +69,7 @@ public class BeanManagerImpl implements BeanManager {
             InjectionPoint prev = InjectionPointProvider.setCurrent(ctx, null);
             try {
                 return ArcContainerImpl.beanInstanceHandle((InjectableBean) bean, (CreationalContextImpl) ctx,
-                        false, null, true).get();
+                        null, null, true).get();
             } finally {
                 InjectionPointProvider.setCurrent(ctx, prev);
             }
@@ -93,7 +93,7 @@ public class BeanManagerImpl implements BeanManager {
             InjectionPoint prev = InjectionPointProvider.setCurrent(ctx, ij);
             try {
                 return ArcContainerImpl.beanInstanceHandle(bean, (CreationalContextImpl) ctx,
-                        false, null, true).get();
+                        null, null, true).get();
             } finally {
                 InjectionPointProvider.setCurrent(ctx, prev);
             }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
@@ -3,7 +3,6 @@ package io.quarkus.arc.impl;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -18,14 +17,11 @@ import io.quarkus.arc.InjectableReferenceProvider;
  */
 public class CurrentInjectionPointProvider<T> implements InjectableReferenceProvider<T> {
 
-    static final InjectionPoint EMPTY = new InjectionPointImpl(Object.class, Object.class, Collections.emptySet(), null, null,
-            null, -1, false);
-
     static final Supplier<InjectionPoint> EMPTY_SUPPLIER = new Supplier<InjectionPoint>() {
 
         @Override
         public InjectionPoint get() {
-            return CurrentInjectionPointProvider.EMPTY;
+            return InjectionPointImpl.EMPTY;
         }
     };
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventBean.java
@@ -20,7 +20,7 @@ public class EventBean extends BuiltInBean<Event<?>> {
     public Event<?> get(CreationalContext<Event<?>> creationalContext) {
         // Obtain current IP to get the required type and qualifiers
         InjectionPoint ip = InjectionPointProvider.getCurrent(creationalContext);
-        return new EventImpl<>(ip.getType(), ip.getQualifiers(), ip);
+        return ArcContainerImpl.instance().getEvent(ip.getType(), ip.getQualifiers(), ip);
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventProvider.java
@@ -28,7 +28,7 @@ public class EventProvider<T> implements InjectableReferenceProvider<Event<T>> {
 
     @Override
     public Event<T> get(CreationalContext<Event<T>> creationalContext) {
-        return new EventImpl<>(eventType, eventQualifiers, injectionPoint);
+        return ArcContainerImpl.instance().getEvent(eventType, eventQualifiers, injectionPoint);
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointImpl.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -26,6 +27,18 @@ import io.quarkus.arc.InjectableBean;
 
 public class InjectionPointImpl implements InjectionPoint {
 
+    static final InjectionPoint EMPTY = new InjectionPointImpl(Object.class, Object.class, Collections.emptySet(), null, null,
+            null, -1, false);
+
+    /**
+     * @param requiredType
+     * @param qualifiers
+     * @return a new injection point with the given required type and qualifiers
+     */
+    public static InjectionPointImpl of(Type requiredType, Annotation... qualifiers) {
+        return new InjectionPointImpl(null, requiredType, Set.of(qualifiers), null, Set.of(), null, 0, false);
+    }
+
     private final Type requiredType;
     private final Set<Annotation> qualifiers;
     private final InjectableBean<?> bean;
@@ -37,7 +50,7 @@ public class InjectionPointImpl implements InjectionPoint {
             InjectableBean<?> bean, Set<Annotation> annotations, Member javaMember,
             int position, boolean isTransient) {
         this.requiredType = requiredType;
-        this.qualifiers = CollectionHelpers.toImmutableSmallSet(qualifiers);
+        this.qualifiers = qualifiers != null ? Set.copyOf(qualifiers) : null;
         this.bean = bean;
         if (javaMember instanceof Executable) {
             this.annotated = new InjectionPointImpl.AnnotatedParameterImpl<>(injectionPointType, annotations, position,

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointImpl.java
@@ -36,7 +36,8 @@ public class InjectionPointImpl implements InjectionPoint {
      * @return a new injection point with the given required type and qualifiers
      */
     public static InjectionPointImpl of(Type requiredType, Annotation... qualifiers) {
-        return new InjectionPointImpl(null, requiredType, Set.of(qualifiers), null, Set.of(), null, 0, false);
+        return new InjectionPointImpl(null, requiredType, qualifiers != null ? Set.of(qualifiers) : Set.of(), null, Set.of(),
+                null, 0, false);
     }
 
     private final Type requiredType;

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/MockableEventImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/MockableEventImpl.java
@@ -1,0 +1,101 @@
+package io.quarkus.arc.impl;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.NotificationOptions;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.util.TypeLiteral;
+
+public class MockableEventImpl<T> extends EventImpl<T> implements Mockable {
+
+    private final AtomicReference<Event<?>> mock;
+
+    MockableEventImpl(Type eventType, Set<Annotation> qualifiers, InjectionPoint injectionPoint,
+            AtomicReference<Event<?>> mock) {
+        super(eventType, qualifiers, injectionPoint);
+        this.mock = mock;
+    }
+
+    @Override
+    public void fire(T event) {
+        @SuppressWarnings("unchecked")
+        Event<T> m = (Event<T>) mock.get();
+        if (m != null) {
+            m.fire(event);
+        } else {
+            super.fire(event);
+        }
+    }
+
+    @Override
+    public <U extends T> CompletionStage<U> fireAsync(U event) {
+        @SuppressWarnings("unchecked")
+        Event<T> m = (Event<T>) mock.get();
+        if (m != null) {
+            return m.fireAsync(event);
+        } else {
+            return super.fireAsync(event);
+        }
+    }
+
+    @Override
+    public <U extends T> CompletionStage<U> fireAsync(U event, NotificationOptions options) {
+        @SuppressWarnings("unchecked")
+        Event<T> m = (Event<T>) mock.get();
+        if (m != null) {
+            return m.fireAsync(event, options);
+        } else {
+            return super.fireAsync(event, options);
+        }
+    }
+
+    @Override
+    public Event<T> select(Annotation... qualifiers) {
+        @SuppressWarnings("unchecked")
+        Event<T> m = (Event<T>) mock.get();
+        if (m != null) {
+            return m.select(qualifiers);
+        } else {
+            return super.select(qualifiers);
+        }
+    }
+
+    @Override
+    public <U extends T> Event<U> select(Class<U> subtype, Annotation... qualifiers) {
+        @SuppressWarnings("unchecked")
+        Event<T> m = (Event<T>) mock.get();
+        if (m != null) {
+            return m.select(subtype, qualifiers);
+        } else {
+            return super.select(subtype, qualifiers);
+        }
+    }
+
+    @Override
+    public <U extends T> Event<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+        @SuppressWarnings("unchecked")
+        Event<T> m = (Event<T>) mock.get();
+        if (m != null) {
+            return m.select(subtype, qualifiers);
+        } else {
+            return super.select(subtype, qualifiers);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void arc$setMock(Object instance) {
+        this.mock.set((Event<T>) instance);
+    }
+
+    @Override
+    public void arc$clearMock() {
+        this.mock.set(null);
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -96,6 +96,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         private boolean strictCompatibility = false;
         private boolean optimizeContexts = false;
         private final List<Predicate<ClassInfo>> excludeTypes;
+        private boolean testMode = false;
 
         public Builder() {
             resourceReferenceProviders = new ArrayList<>();
@@ -227,6 +228,11 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             return this;
         }
 
+        public Builder testMode(boolean testMode) {
+            this.testMode = testMode;
+            return this;
+        }
+
         public Builder optimizeContexts(boolean value) {
             this.optimizeContexts = value;
             return this;
@@ -274,6 +280,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
 
     private final boolean strictCompatibility;
     private final boolean optimizeContexts;
+    private final boolean testMode;
 
     public ArcTestContainer(Class<?>... beanClasses) {
         this.resourceReferenceProviders = Collections.emptyList();
@@ -299,6 +306,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.strictCompatibility = false;
         this.optimizeContexts = false;
         this.excludeTypes = Collections.emptyList();
+        this.testMode = false;
     }
 
     public ArcTestContainer(Builder builder) {
@@ -325,6 +333,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.strictCompatibility = builder.strictCompatibility;
         this.optimizeContexts = builder.optimizeContexts;
         this.excludeTypes = builder.excludeTypes;
+        this.testMode = builder.testMode;
     }
 
     // this is where we start Arc, we operate on a per-method basis
@@ -502,8 +511,9 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
                     .setContextClassLoader(testClassLoader);
 
             // Now we are ready to initialize Arc
-            ArcInitConfig.Builder initConfigBuilder = ArcInitConfig.builder();
-            initConfigBuilder.setStrictCompatibility(strictCompatibility);
+            ArcInitConfig.Builder initConfigBuilder = ArcInitConfig.builder()
+                    .setStrictCompatibility(strictCompatibility)
+                    .setTestMode(testMode);
             Arc.initialize(initConfigBuilder.build());
 
         } catch (Throwable e) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/mock/MockEventTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/mock/MockEventTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.arc.test.event.mock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.impl.Mockable;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class MockEventTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(EventConsumer.class)
+            .additionalClasses(Drink.class)
+            .testMode(true)
+            .build();
+
+    @Test
+    public void testEvent() {
+        Arc.container().select(EventConsumer.class).get().installMockAndFire();
+        assertEquals("foo", EventConsumer.drinkName);
+    }
+
+    public record Drink(String name) {
+    }
+
+    @Singleton
+    public static class EventConsumer {
+
+        static String drinkName;
+
+        @Inject
+        Event<Drink> event;
+
+        @SuppressWarnings("unchecked")
+        public void installMockAndFire() {
+            assertInstanceOf(Mockable.class, event);
+            if (event instanceof Mockable mockable) {
+                Event<Drink> mock = Mockito.mock(Event.class);
+                Mockito.doAnswer(invocation -> {
+                    Object arg0 = invocation.getArgument(0);
+                    if (arg0 instanceof Drink drink) {
+                        drinkName = drink.name();
+                    }
+                    return null;
+                }).when(mock).fire(new Drink("foo"));
+                mockable.arc$setMock(mock);
+            }
+            event.fire(new Drink("foo"));
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injectionpoint/InjectionPointMetadataWithDynamicLookupTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injectionpoint/InjectionPointMetadataWithDynamicLookupTest.java
@@ -32,12 +32,13 @@ public class InjectionPointMetadataWithDynamicLookupTest {
     @Test
     public void arcContainerInstance() {
         // the "current" injection point of `Arc.container().instance(...)` doesn't seem to be well defined
+        // but the injection point used does support the required type and qualifiers
         BeanWithInjectionPointMetadata bean = Arc.container().instance(BeanWithInjectionPointMetadata.class).get();
 
         // this is probably an implementation artifact, not an intentional choice
         bean.assertPresent(ip -> {
-            assertEquals(Object.class, ip.getType());
-            assertEquals(Set.of(), ip.getQualifiers());
+            assertEquals(BeanWithInjectionPointMetadata.class, ip.getType());
+            assertEquals(1, ip.getQualifiers().size()); // @Default
             assertNull(ip.getMember());
             assertNull(ip.getBean());
         });

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injectionpoint/InjectionPointMetadataWithDynamicLookupTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injectionpoint/InjectionPointMetadataWithDynamicLookupTest.java
@@ -35,10 +35,9 @@ public class InjectionPointMetadataWithDynamicLookupTest {
         // but the injection point used does support the required type and qualifiers
         BeanWithInjectionPointMetadata bean = Arc.container().instance(BeanWithInjectionPointMetadata.class).get();
 
-        // this is probably an implementation artifact, not an intentional choice
         bean.assertPresent(ip -> {
             assertEquals(BeanWithInjectionPointMetadata.class, ip.getType());
-            assertEquals(1, ip.getQualifiers().size()); // @Default
+            assertEquals(Set.of(), ip.getQualifiers());
             assertNull(ip.getMember());
             assertNull(ip.getBean());
         });

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/FooBarObserver.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/FooBarObserver.java
@@ -1,10 +1,23 @@
 package io.quarkus.it.mockbean;
 
+import java.util.ArrayList;
+
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class FooBarObserver {
+
+    @Inject
+    Event<Foo.Bar> event;
+
+    Foo.Bar fireBar() {
+        Foo.Bar bar = new Foo.Bar(new ArrayList<>());
+        event.fire(bar);
+        return bar;
+    }
 
     void onBar(@Observes Foo.Bar bar) {
         bar.getNames().add("baz");

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/FooBarObserver.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/FooBarObserver.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.mockbean;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class FooBarObserver {
+
+    void onBar(@Observes Foo.Bar bar) {
+        bar.getNames().add("baz");
+    }
+
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/MockEventTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/MockEventTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.ArrayList;
 
 import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -16,27 +17,39 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 public class MockEventTest {
 
+    @Inject
+    Event<Foo.Bar> event1;
+
     @InjectMock
-    Event<Foo.Bar> event;
+    Event<Foo.Bar> event2;
+
+    @Inject
+    FooBarObserver fooBarObserver;
 
     @Test
     public void testEvent() {
-        Foo.Bar bar1 = new Bar(new ArrayList<>());
-        event.fire(bar1);
-        assertEquals(1, bar1.getNames().size());
-        assertEquals("baz", bar1.getNames().get(0));
-        
         Mockito.doAnswer(invocation -> {
             Object arg0 = invocation.getArgument(0);
             if (arg0 instanceof Bar bar) {
                 bar.getNames().add("bazinga");
             }
             return null;
-        }).when(event).fire(Mockito.any(Bar.class));
+        }).when(event2).fire(Mockito.any(Bar.class));
+
+        // FooBarObserver is not notified because @Inject Event<Foo.Bar> also delegates to the mock
+        Foo.Bar bar1 = new Bar(new ArrayList<>());
+        event1.fire(bar1);
+        assertEquals(1, bar1.getNames().size());
+        assertEquals("bazinga", bar1.getNames().get(0));
+
         Foo.Bar bar2 = new Bar(new ArrayList<>());
-        event.fire(bar2);
-        // FooBarObserver is not notified this time
+        event2.fire(bar2);
         assertEquals(1, bar1.getNames().size());
         assertEquals("bazinga", bar2.getNames().get(0));
+
+        // Event injected in FooBarObserver also delegates to the mock
+        Foo.Bar bar3 = fooBarObserver.fireBar();
+        assertEquals(1, bar3.getNames().size());
+        assertEquals("bazinga", bar3.getNames().get(0));
     }
 }

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/MockEventTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/MockEventTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.mockbean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+
+import jakarta.enterprise.event.Event;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.it.mockbean.Foo.Bar;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class MockEventTest {
+
+    @InjectMock
+    Event<Foo.Bar> event;
+
+    @Test
+    public void testEvent() {
+        Foo.Bar bar1 = new Bar(new ArrayList<>());
+        event.fire(bar1);
+        assertEquals(1, bar1.getNames().size());
+        assertEquals("baz", bar1.getNames().get(0));
+        
+        Mockito.doAnswer(invocation -> {
+            Object arg0 = invocation.getArgument(0);
+            if (arg0 instanceof Bar bar) {
+                bar.getNames().add("bazinga");
+            }
+            return null;
+        }).when(event).fire(Mockito.any(Bar.class));
+        Foo.Bar bar2 = new Bar(new ArrayList<>());
+        event.fire(bar2);
+        // FooBarObserver is not notified this time
+        assertEquals(1, bar1.getNames().size());
+        assertEquals("bazinga", bar2.getNames().get(0));
+    }
+}

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -43,6 +43,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.AmbiguousResolutionException;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
@@ -91,14 +92,19 @@ import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import io.quarkus.arc.All;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.ArcInitConfig;
 import io.quarkus.arc.ComponentsProvider;
+import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.Unremovable;
+import io.quarkus.arc.impl.EventBean;
 import io.quarkus.arc.impl.InstanceImpl;
+import io.quarkus.arc.impl.Mockable;
 import io.quarkus.arc.processor.Annotations;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanArchives;
@@ -486,7 +492,7 @@ public class QuarkusComponentTestExtension
             return;
         }
         // Init ArC
-        Arc.initialize();
+        Arc.initialize(ArcInitConfig.builder().setTestMode(true).build());
 
         QuarkusComponentTestConfiguration configuration = store(context).get(KEY_TEST_CLASS_CONFIG,
                 QuarkusComponentTestConfiguration.class);
@@ -824,16 +830,24 @@ public class QuarkusComponentTestExtension
                         if (requiredQualifiers.isEmpty()) {
                             requiredQualifiers = Set.of(AnnotationInstance.builder(DotNames.DEFAULT).build());
                         }
-                        unsatisfiedInjectionPoints
-                                .add(new TypeAndQualifiers(Types.jandexType(field.getGenericType()), requiredQualifiers));
+                        TypeAndQualifiers typeAndQualifiers = new TypeAndQualifiers(Types.jandexType(field.getGenericType()),
+                                requiredQualifiers);
+                        if (BuiltinBean.resolve(InjectionPointInfo.fromSyntheticInjectionPoint(typeAndQualifiers)) != null) {
+                            continue;
+                        }
+                        unsatisfiedInjectionPoints.add(typeAndQualifiers);
                     }
                     for (Parameter param : findInjectMockParams(testClass)) {
                         Set<AnnotationInstance> requiredQualifiers = getQualifiers(param, qualifiers);
                         if (requiredQualifiers.isEmpty()) {
                             requiredQualifiers = Set.of(AnnotationInstance.builder(DotNames.DEFAULT).build());
                         }
-                        unsatisfiedInjectionPoints
-                                .add(new TypeAndQualifiers(Types.jandexType(param.getParameterizedType()), requiredQualifiers));
+                        TypeAndQualifiers typeAndQualifiers = new TypeAndQualifiers(
+                                Types.jandexType(param.getParameterizedType()), requiredQualifiers);
+                        if (BuiltinBean.resolve(InjectionPointInfo.fromSyntheticInjectionPoint(typeAndQualifiers)) != null) {
+                            continue;
+                        }
+                        unsatisfiedInjectionPoints.add(typeAndQualifiers);
                     }
 
                     for (TypeAndQualifiers unsatisfied : unsatisfiedInjectionPoints) {
@@ -1222,7 +1236,7 @@ public class QuarkusComponentTestExtension
             BeanManager beanManager = container.beanManager();
             java.lang.reflect.Type requiredType = field.getGenericType();
             Annotation[] qualifiers = getQualifiers(field, beanManager);
-
+            boolean isMock = field.isAnnotationPresent(InjectMock.class);
             Object injectedInstance;
 
             if (Instance.class.isAssignableFrom(QuarkusComponentTestConfiguration.getRawType(requiredType))) {
@@ -1237,31 +1251,52 @@ public class QuarkusComponentTestExtension
                 unsetAction = () -> destroyDependentHandles(unsetHandles);
             } else {
                 InstanceHandle<?> handle = container.instance(requiredType, qualifiers);
-                if (field.isAnnotationPresent(Inject.class)) {
+                InjectableBean<?> bean = handle.getBean();
+                if (isMock) {
+                    // @InjectMock expects a synthetic dummy mock
+                    if (!handle.isAvailable()) {
+                        throw new IllegalStateException(String
+                                .format("The injected field [%s] expects a mocked bean; but obtained null", field));
+                    } else if (bean.getKind() == InjectableBean.Kind.BUILTIN) {
+                        if (!(bean instanceof EventBean)) {
+                            throw new IllegalStateException(
+                                    "Only the jakarta.enterprise.event.Event built-in bean can be mocked: [%s]"
+                                            .formatted(field));
+                        }
+                    } else if (bean.getKind() != io.quarkus.arc.InjectableBean.Kind.SYNTHETIC) {
+                        throw new IllegalStateException(String
+                                .format("The injected field [%s] expects a mocked bean; but obtained: %s", field,
+                                        handle.getBean()));
+                    }
+                } else {
+                    // @Inject expects a real component
                     if (!handle.isAvailable()) {
                         throw new IllegalStateException(String
                                 .format("The injected field [%s] expects a real component; but no matching component was registered",
                                         field,
                                         handle.getBean()));
-                    }
-                    if (handle.getBean().getKind() == io.quarkus.arc.InjectableBean.Kind.SYNTHETIC) {
+                    } else if (bean.getKind() == io.quarkus.arc.InjectableBean.Kind.SYNTHETIC) {
                         throw new IllegalStateException(String
                                 .format("The injected field [%s] expects a real component; but obtained: %s", field,
                                         handle.getBean()));
                     }
-                } else {
-                    if (!handle.isAvailable()) {
-                        throw new IllegalStateException(String
-                                .format("The injected field [%s] expects a mocked bean; but obtained null", field));
-                    }
-                    if (handle.getBean().getKind() != io.quarkus.arc.InjectableBean.Kind.SYNTHETIC) {
-                        throw new IllegalStateException(String
-                                .format("The injected field [%s] expects a mocked bean; but obtained: %s", field,
-                                        handle.getBean()));
-                    }
                 }
-                injectedInstance = handle.get();
-                unsetAction = () -> destroyDependentHandles(List.of(handle));
+                if (isMock && bean instanceof EventBean) {
+                    // Event mocks require special handling
+                    Event<?> mock = Mockito.mock(Event.class);
+                    Object eventInstance = handle.get();
+                    if (eventInstance instanceof Mockable mockable) {
+                        mockable.arc$setMock(mock);
+                    } else {
+                        throw new IllegalStateException(
+                                "%s is not a Mockable Event implementation".formatted(eventInstance.getClass()));
+                    }
+                    injectedInstance = mock;
+                    unsetAction = () -> mockable.arc$clearMock();
+                } else {
+                    injectedInstance = handle.get();
+                    unsetAction = () -> destroyDependentHandles(List.of(handle));
+                }
             }
 
             if (!field.canAccess(testInstance)) {

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -588,6 +588,10 @@ public class QuarkusComponentTestExtension
                 ret.add(fieldAnnotation);
             }
         }
+        if (ret.isEmpty()) {
+            // Add @Default as if @InjectMock was a normal @Inject
+            ret.add(Default.Literal.INSTANCE);
+        }
         return ret.toArray(new Annotation[0]);
     }
 

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/MockEventTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/MockEventTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class MockEventTest {
+
+    @InjectMock
+    Event<AtomicInteger> event;
+
+    @Test
+    public void testEvent() {
+        Mockito.doAnswer(invocation -> {
+            Object arg0 = invocation.getArgument(0);
+            if (arg0 instanceof AtomicInteger integer) {
+                integer.set(integer.get() + 15);
+            }
+            return null;
+        }).when(event).fire(Mockito.any(AtomicInteger.class));
+
+        AtomicInteger payload = new AtomicInteger();
+        event.fire(payload);
+
+        // AtomicIntegerObserver is not notified
+        assertEquals(15, payload.get());
+    }
+
+    // component under test - nested static classes are added automatically
+    public static class AtomicIntegerObserver {
+
+        void onInt(@Observes AtomicInteger integer) {
+            // should not be notified
+            integer.set(integer.get() + 5);
+        }
+
+    }
+
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoMocksCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoMocksCallback.java
@@ -13,7 +13,9 @@ import org.mockito.Mockito;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.impl.EventBean;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.callback.QuarkusTestAfterConstructCallback;
 import io.quarkus.test.junit.mockito.MockitoConfig;
@@ -90,7 +92,9 @@ public class CreateMockitoMocksCallback implements QuarkusTestAfterConstructCall
                             + fieldType.getTypeName() + ". Offending field is " + field.getName() + " of test class "
                             + testInstance.getClass());
         }
-        if (!beanManager.isNormalScope(handle.getBean().getScope())) {
+        InjectableBean<?> bean = handle.getBean();
+        if (!(bean instanceof EventBean)
+                && !beanManager.isNormalScope(bean.getScope())) {
             throw new IllegalStateException(
                     "Invalid use of " + annotationType.getTypeName()
                             + " - the injected bean does not declare a CDI normal scope but: "

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoMocksCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoMocksCallback.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.mockito.Mockito;
@@ -112,6 +113,10 @@ public class CreateMockitoMocksCallback implements QuarkusTestAfterConstructCall
             if (beanManager.isQualifier(fieldAnnotation.annotationType())) {
                 qualifiers.add(fieldAnnotation);
             }
+        }
+        if (qualifiers.isEmpty()) {
+            // Add @Default as if @InjectMock was a normal @Inject
+            qualifiers.add(Default.Literal.INSTANCE);
         }
         return qualifiers.toArray(new Annotation[0]);
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/MockSupport.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/MockSupport.java
@@ -68,7 +68,13 @@ class MockSupport {
     private static <T> void mockObservers(T instance, boolean mock) throws NoSuchMethodException, SecurityException,
             ClassNotFoundException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         // io.quarkus.arc.ClientProxy.arc_bean()
-        Method getBeanMethod = instance.getClass().getDeclaredMethod("arc_bean");
+        Method getBeanMethod;
+        try {
+            getBeanMethod = instance.getClass().getDeclaredMethod("arc_bean");
+        } catch (NoSuchMethodException e) {
+            // Not a client proxy
+            return;
+        }
         Object bean = getBeanMethod.invoke(instance);
         // io.quarkus.arc.InjectableBean.getIdentifier()
         Method getIdMethod = bean.getClass().getDeclaredMethod("getIdentifier");


### PR DESCRIPTION
This has been discussed on Zulip.

The feature request comes from @melloware.

`@InjectMock Event` should work in both `@QuarkusTest` and `QuarkusComponentTest`.