### PR TITLE
Log invalid host name in the DevUi CORS filter

### DIFF
--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/LocalHostOnlyFilter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/LocalHostOnlyFilter.java
@@ -34,7 +34,6 @@ public class LocalHostOnlyFilter implements Handler<RoutingContext> {
         if (hostIsValid(event)) {
             event.next();
         } else {
-            LOG.error("Dev UI: Only localhost is allowed");
             response.setStatusCode(403);
             response.setStatusMessage("Dev UI: Only localhost is allowed - Invalid host");
             response.end();
@@ -60,6 +59,7 @@ public class LocalHostOnlyFilter implements Handler<RoutingContext> {
                     }
                 }
             }
+            LOG.errorf("Dev UI: Only localhost is allowed, unexpected host: %s", host);
             return false;
         } catch (MalformedURLException | URISyntaxException e) {
             LOG.error("Error while checking if Dev UI is localhost", e);


### PR DESCRIPTION
I found it was easier to fix the problem when the unexpected host name was logged