### PR TITLE
Add support for Hibernate's hibernate.hbm2ddl.extra_physical_table_types

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/ConfigPropertiesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/ConfigPropertiesTest.java
@@ -34,16 +34,8 @@ public class ConfigPropertiesTest {
             .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".datasource", "<default>")
             // Overrides to test that Quarkus configuration properties are taken into account
             .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".flush.mode", "always")
-            .overrideConfigKey("quarkus.hibernate-orm.schema-management.extra-physical-table-types",
-                    "MATERIALIZED VIEW,FOREIGN TABLE")
-            .overrideConfigKey("quarkus.hibernate-orm.\"*\".schema-management.extra-physical-table-types",
-                    "MATERIALIZED VIEW,FOREIGN TABLE")
             .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".schema-management.extra-physical-table-types",
-                    "MATERIALIZED VIEW,FOREIGN TABLE")
-            // Disable metrics to avoid requiring metrics deployment artifacts on test classpath
-            .overrideConfigKey("quarkus.smallrye-metrics.enabled", "false")
-            .overrideConfigKey("quarkus.agroal.metrics.enabled", "false")
-            .overrideConfigKey("quarkus.agroal.enabled", "false");
+                    "MATERIALIZED VIEW,FOREIGN TABLE");
 
     @Inject
     Session sessionForDefaultPU;

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/ConfigPropertiesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/ConfigPropertiesTest.java
@@ -7,6 +7,7 @@ import jakarta.transaction.Transactional;
 
 import org.hibernate.FlushMode;
 import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,17 @@ public class ConfigPropertiesTest {
             .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".packages", MyEntityForOverridesPU.class.getPackageName())
             .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".datasource", "<default>")
             // Overrides to test that Quarkus configuration properties are taken into account
-            .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".flush.mode", "always");
+            .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".flush.mode", "always")
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.extra-physical-table-types",
+                    "MATERIALIZED VIEW,FOREIGN TABLE")
+            .overrideConfigKey("quarkus.hibernate-orm.\"*\".schema-management.extra-physical-table-types",
+                    "MATERIALIZED VIEW,FOREIGN TABLE")
+            .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".schema-management.extra-physical-table-types",
+                    "MATERIALIZED VIEW,FOREIGN TABLE")
+            // Disable metrics to avoid requiring metrics deployment artifacts on test classpath
+            .overrideConfigKey("quarkus.smallrye-metrics.enabled", "false")
+            .overrideConfigKey("quarkus.agroal.metrics.enabled", "false")
+            .overrideConfigKey("quarkus.agroal.enabled", "false");
 
     @Inject
     Session sessionForDefaultPU;
@@ -46,6 +57,22 @@ public class ConfigPropertiesTest {
     public void propertiesAffectingSession() {
         assertThat(sessionForDefaultPU.getHibernateFlushMode()).isEqualTo(FlushMode.AUTO);
         assertThat(sessionForOverridesPU.getHibernateFlushMode()).isEqualTo(FlushMode.ALWAYS);
+    }
+
+    @Test
+    @Transactional
+    public void extraPhysicalTableTypes() {
+        // Access the configuration through the SessionFactory properties
+        Object extraPhysicalTableTypes = sessionForOverridesPU.getSessionFactory()
+                .getProperties()
+                .get(AvailableSettings.EXTRA_PHYSICAL_TABLE_TYPES);
+
+        assertThat(extraPhysicalTableTypes).isNotNull();
+        assertThat(extraPhysicalTableTypes).isInstanceOf(String.class);
+
+        String tableTypesStr = (String) extraPhysicalTableTypes;
+        String[] tableTypes = tableTypesStr.split(",");
+        assertThat(tableTypes).containsExactly("MATERIALIZED VIEW", "FOREIGN TABLE");
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -483,6 +483,13 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                     "When using offline mode with `quarkus.hibernate-orm.database.start-offline=true`, the schema management strategy `quarkus.hibernate-orm.schema-management.strategy` must be unset or set to `none`");
         }
 
+        // Pass extraPhysicalTableTypes configuration
+        Optional<String> extraPhysicalTableTypes = persistenceUnitConfig.schemaManagement().extraPhysicalTableTypes();
+        if (extraPhysicalTableTypes.isPresent()) {
+            String extraTableTypesStr = extraPhysicalTableTypes.get();
+            runtimeSettingsBuilder.put(AvailableSettings.EXTRA_PHYSICAL_TABLE_TYPES, extraTableTypesStr);
+        }
+
         runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION,
                 persistenceUnitConfig.database().generation().generation()
                         .orElse(generationStrategy));

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -172,6 +172,20 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
          */
         @WithDefault("false")
         boolean haltOnError();
+
+        /**
+         * Additional database object types to include in schema management operations.
+         *
+         * By default, Hibernate ORM only considers tables and sequences when performing
+         * schema management operations.
+         * This setting allows you to specify additional database object types that should be included,
+         * such as "MATERIALIZED VIEW", "VIEW", or other database-specific object types.
+         *
+         * The exact supported values depend on the underlying database and dialect.
+         *
+         * @asciidoclet
+         */
+        Optional<@WithConverter(TrimmedStringConverter.class) String> extraPhysicalTableTypes();
     }
 
     @ConfigGroup

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -383,6 +383,13 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
                     "When using offline mode with `quarkus.hibernate-orm.database.start-offline=true`, the schema management strategy `quarkus.hibernate-orm.schema-management.strategy` must be unset or set to `none`");
         }
 
+        // Pass extraPhysicalTableTypes configuration
+        Optional<String> extraPhysicalTableTypes = persistenceUnitConfig.schemaManagement().extraPhysicalTableTypes();
+        if (extraPhysicalTableTypes.isPresent()) {
+            String extraTableTypesStr = extraPhysicalTableTypes.get();
+            runtimeSettingsBuilder.put(AvailableSettings.EXTRA_PHYSICAL_TABLE_TYPES, extraTableTypesStr);
+        }
+
         // Database
         runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION,
                 persistenceUnitConfig.database().generation().generation()


### PR DESCRIPTION
This MR adds support for configuring additional database object types to be included
in schema management operations, such as materialized views or other database-specific objects.

Changes:

    Add documentation for the existing extraPhysicalTableTypes() method
    Pass the configuration to Hibernate ORM in FastBootHibernatePersistenceProvider
    Add the same implementation for Hibernate Reactive in FastBootHibernateReactivePersistenceProvider
    Define a constant for the setting if not already available in Hibernate's AvailableSettings

Example usage: quarkus.hibernate-orm.extra-physical-table-types=MATERIALIZED VIEW,VIEW

- Replaces: #49063
- Closes: #47854