### PR TITLE
Really fix continuous testing command mode test

### DIFF
--- a/integration-tests/command-mode/src/test/java/org/acme/MainContinuousTestingTest.java
+++ b/integration-tests/command-mode/src/test/java/org/acme/MainContinuousTestingTest.java
@@ -17,7 +17,7 @@ public class MainContinuousTestingTest {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
             .withApplicationRoot(jar -> jar
-                    .addClass(Main.class)
+                    // Files from this module are added automatically, so no need to add Main.class
                     .add(new StringAsset(ContinuousTestingTestUtils.appProperties()), "application.properties"))
             .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(MainTest.class));


### PR DESCRIPTION
Yesterday I moved around a disabled test to try and sort out some test issues (#49988). It turns out my changes were enough to reproduce the defect I was looking at (https://github.com/quarkusio/quarkus/issues/49780), but not enough to actually pass when https://github.com/quarkusio/quarkus/issues/49780 is fixed. 

The actual test problem seems to be a misunderstanding about how `DevModeTest` works; instead of starting with a blank slate in the application jar, it also includes classes from the module? That seems strange, so I'm not sure if it's intentional or not. Normally it wouldn't matter to have duplicated classes from two sources, but for the `@QuarkusMain` it does. I've got the test working by not including the main class in the `DevModeTest` initialisation (and I can see from the output that the main class must be there).

Given that, it might be that https://github.com/quarkusio/quarkus/pull/49988 wasn't even necessary, and the only changed needed is the one in this PR. However, I kind of like having the top-level integration test for command-mode. WDYT, @aloubyansky?

