### PR TITLE
Dev MCP: Allow enable/disable of methods

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/DevMCPEnableByDefault.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/DevMCPEnableByDefault.java
@@ -1,0 +1,18 @@
+package io.quarkus.runtime.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Enable a JsonRPC Method for MCP by default
+ */
+@Retention(RUNTIME)
+@Target({ METHOD })
+@Documented
+public @interface DevMCPEnableByDefault {
+
+}

--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -52,7 +52,17 @@ footerPageBuildItem.addBuildTimeData(
 );
 ----
 
-The extra `description` argument is new: without it the data only appears in the Dev UI. Once supplied, the `jokes` data becomes an MCP resource.
+The extra `description` argument is new: without it the data only appears in the Dev UI. Once supplied, the `jokes` data becomes an MCP resource, however, by default this resource will be disabled. You can change the default by passing in `true` as another parameter after description, that will change this default to be enabled. Users can change this in Dev UI anyway, so this is just a sensible default.
+
+[source,java]
+----
+footerPageBuildItem.addBuildTimeData(
+    "jokes",
+    jokesBuildItem.getJokes(),
+    "Some funny jokes that the user might enjoy",
+    true
+);
+----
 
 ==== MCP Resources against a recorded value
 
@@ -75,6 +85,8 @@ BuildTimeActionBuildItem createBuildTimeActions() {
 <2> Use the builder to configure the action.
 <3> Set a human‑readable description.
 <4> Provide the runtime value returned by your recorder.
+
+By default this resource will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFuctionByDefault()` in the builder method.
 
 === MCP tools
 
@@ -99,6 +111,8 @@ public class MyExtensionRPCService {
 ----
 <1> Description of the method.
 <2> Description of each parameter.
+
+By default this tool will be disabled, and the user has to enable it in Dev UI. You can change this default by adding the `@DevMCPEnableByDefault` annotation on the method.
 
 You must register the JSON‑RPC service in the deployment module:
 
@@ -144,6 +158,8 @@ BuildTimeActionBuildItem createBuildTimeActions() {
 <2> Description of each parameter.
 
 The code in the `function` runs on the deployment classpath. The function can return a plain value, a `CompletionStage` or `CompletableFuture` for asynchronous work.
+
+By default this tool will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFuctionByDefault()` in the builder method.
 
 === JSON‑RPC usage
 

--- a/extensions/agroal/runtime-dev/src/main/java/io/quarkus/agroal/runtime/dev/ui/DatabaseInspector.java
+++ b/extensions/agroal/runtime-dev/src/main/java/io/quarkus/agroal/runtime/dev/ui/DatabaseInspector.java
@@ -40,6 +40,7 @@ import io.quarkus.arc.InjectableInstance;
 import io.quarkus.assistant.runtime.dev.Assistant;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 
 public final class DatabaseInspector {
@@ -96,6 +97,7 @@ public final class DatabaseInspector {
     }
 
     @JsonRpcDescription("Get all available datasources for the Database")
+    @DevMCPEnableByDefault
     public List<Datasource> getDataSources() {
         if (isDev) {
             List<Datasource> datasources = new ArrayList<>();
@@ -110,6 +112,7 @@ public final class DatabaseInspector {
     }
 
     @JsonRpcDescription("Get a spesific datasource for the Database by name")
+    @DevMCPEnableByDefault
     private Datasource getDatasource(@JsonRpcDescription("Datasource name") String datasource) {
         if (isDev) {
             AgroalDataSource ads = checkedDataSources.get(datasource);
@@ -126,6 +129,7 @@ public final class DatabaseInspector {
     }
 
     @JsonRpcDescription("Get all the tables for a certain datasource")
+    @DevMCPEnableByDefault
     public List<Table> getTables(@JsonRpcDescription("Datasource name") String datasource) {
         if (isDev) {
             List<Table> tableList = new ArrayList<>();
@@ -238,6 +242,7 @@ public final class DatabaseInspector {
     }
 
     @JsonRpcDescription("Execute SQL against a certain datasource")
+    @DevMCPEnableByDefault
     public DataSet executeSQL(@JsonRpcDescription("Datasource name") String datasource,
             @JsonRpcDescription("Valid SQL to execute") String sql,
             @JsonRpcDescription("Page number for pagable rusults, starting at 1") Integer pageNumber,

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/DevUIContent.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/DevUIContent.java
@@ -11,6 +11,7 @@ public class DevUIContent {
     private final byte[] template;
     private final Map<String, Object> data;
     private final Map<String, String> descriptions;
+    private final Map<String, String> mcpDefaultEnabled;
     private final Map<String, String> contentTypes;
 
     private DevUIContent(DevUIContent.Builder builder) {
@@ -18,6 +19,7 @@ public class DevUIContent {
         this.template = builder.template;
         this.data = builder.data;
         this.descriptions = builder.descriptions;
+        this.mcpDefaultEnabled = builder.mcpDefaultEnabled;
         this.contentTypes = builder.contentTypes;
     }
 
@@ -37,6 +39,10 @@ public class DevUIContent {
         return descriptions;
     }
 
+    public Map<String, String> getMcpDefaultEnables() {
+        return mcpDefaultEnabled;
+    }
+
     public Map<String, String> getContentTypes() {
         return contentTypes;
     }
@@ -51,6 +57,7 @@ public class DevUIContent {
         private Map<String, Object> data;
         private Map<String, String> descriptions;
         private Map<String, String> contentTypes;
+        private Map<String, String> mcpDefaultEnabled;
 
         private Builder() {
             this.data = new HashMap<>();
@@ -85,6 +92,11 @@ public class DevUIContent {
 
         public Builder descriptions(Map<String, String> descriptions) {
             this.descriptions = descriptions;
+            return this;
+        }
+
+        public Builder mcpDefaultEnables(Map<String, String> mcpDefaultEnabled) {
+            this.mcpDefaultEnabled = mcpDefaultEnabled;
             return this;
         }
 

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
@@ -61,31 +61,31 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
     @Deprecated
     public <T> void addAction(String methodName,
             Function<Map<String, String>, T> action) {
-        this.addAction(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), action));
+        this.addAction(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), true, action));
     }
 
     @Deprecated
     public <T> void addAssistantAction(String methodName,
             BiFunction<Object, Map<String, String>, T> action) {
-        this.addAction(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), action));
+        this.addAction(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), true, action));
     }
 
     @Deprecated
     public <T> void addAction(String methodName,
             RuntimeValue runtimeValue) {
-        this.addAction(new RecordedJsonRpcMethod(methodName, null, Usage.onlyDevUI(), runtimeValue));
+        this.addAction(new RecordedJsonRpcMethod(methodName, null, Usage.onlyDevUI(), true, runtimeValue));
     }
 
     @Deprecated
     public <T> void addSubscription(String methodName,
             Function<Map<String, String>, T> action) {
-        this.addSubscription(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), action));
+        this.addSubscription(new DeploymentJsonRpcMethod(methodName, null, Usage.onlyDevUI(), true, action));
     }
 
     @Deprecated
     public <T> void addSubscription(String methodName,
             RuntimeValue runtimeValue) {
-        this.addSubscription(new RecordedJsonRpcMethod(methodName, null, Usage.onlyDevUI(), runtimeValue));
+        this.addSubscription(new RecordedJsonRpcMethod(methodName, null, Usage.onlyDevUI(), true, runtimeValue));
     }
 
     private BuildTimeActionBuildItem addAction(DeploymentJsonRpcMethod deploymentJsonRpcMethod) {
@@ -116,6 +116,7 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
         private Function<Map<String, String>, ?> function;
         private BiFunction<Object, Map<String, String>, ?> assistantFunction;
         private RuntimeValue<?> runtimeValue;
+        private boolean mcpEnabledByDefault = false;
 
         public ActionBuilder methodName(String methodName) {
             this.methodName = methodName;
@@ -138,6 +139,11 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
 
         public ActionBuilder usage(EnumSet<Usage> usage) {
             this.usage = usage;
+            return this;
+        }
+
+        public ActionBuilder enableMcpFuctionByDefault() {
+            this.mcpEnabledByDefault = true;
             return this;
         }
 
@@ -170,13 +176,17 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
             if (function != null) {
                 return addAction(
                         new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                                mcpEnabledByDefault,
                                 function));
             } else if (runtimeValue != null) {
                 return addAction(
-                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description), runtimeValue));
+                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description),
+                                mcpEnabledByDefault,
+                                runtimeValue));
             } else if (assistantFunction != null) {
                 return addAction(
                         new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                                mcpEnabledByDefault,
                                 assistantFunction));
             } else {
                 throw new IllegalStateException("Either function, assistantFunction or runtimeValue must be provided");
@@ -189,6 +199,7 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
         private String description;
         private Map<String, AbstractJsonRpcMethod.Parameter> parameters = new LinkedHashMap<>();;
         private EnumSet<Usage> usage;
+        private boolean mcpEnabledByDefault = false;
         private Function<Map<String, String>, ?> function;
         private RuntimeValue<?> runtimeValue;
 
@@ -216,6 +227,11 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
             return this;
         }
 
+        public SubscriptionBuilder enableMcpFuctionByDefault() {
+            this.mcpEnabledByDefault = true;
+            return this;
+        }
+
         public <T> SubscriptionBuilder function(Function<Map<String, String>, T> function) {
             this.function = function;
             return this;
@@ -233,10 +249,12 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
                 parameters = null;
             if (function != null) {
                 addSubscription(new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                        mcpEnabledByDefault,
                         function));
             } else if (runtimeValue != null) {
                 addSubscription(
-                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description), runtimeValue));
+                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description), mcpEnabledByDefault,
+                                runtimeValue));
             } else {
                 throw new IllegalStateException("Either function or runtimeValue must be provided");
             }

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeData.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeData.java
@@ -7,6 +7,7 @@ public class BuildTimeData {
     private Object content;
     private String description;
     private String contentType = "application/json"; // default
+    private boolean mcpEnabledByDefault = false;
 
     public BuildTimeData() {
 
@@ -21,9 +22,16 @@ public class BuildTimeData {
         this.description = description;
     }
 
-    public BuildTimeData(Object content, String description, String contentType) {
+    public BuildTimeData(Object content, String description, boolean mcpEnabledByDefault) {
         this.content = content;
         this.description = description;
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
+    }
+
+    public BuildTimeData(Object content, String description, boolean mcpEnabledByDefault, String contentType) {
+        this.content = content;
+        this.description = description;
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
         this.contentType = contentType;
     }
 
@@ -49,5 +57,13 @@ public class BuildTimeData {
 
     public void setContentType(String contentType) {
         this.contentType = contentType;
+    }
+
+    public boolean isMcpEnabledByDefault() {
+        return mcpEnabledByDefault;
+    }
+
+    public void setMcpEnabledByDefault(boolean mcpEnabledByDefault) {
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
     }
 }

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/QuteTemplateBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/QuteTemplateBuildItem.java
@@ -33,12 +33,13 @@ public final class QuteTemplateBuildItem extends AbstractDevUIBuildItem {
     }
 
     public void add(String templatename, Map<String, Object> data) {
-        templateDatas.add(new TemplateData(templatename, templatename, data, Map.of(), Map.of())); // By default the template is used for only one file.
+        templateDatas.add(new TemplateData(templatename, templatename, data, Map.of(), Map.of(), Map.of())); // By default the template is used for only one file.
     }
 
     public void add(String templatename, String fileName, Map<String, Object> data, Map<String, String> descriptions,
+            Map<String, String> mcpDefaultEnabled,
             Map<String, String> contentTypes) {
-        templateDatas.add(new TemplateData(templatename, fileName, data, descriptions, contentTypes));
+        templateDatas.add(new TemplateData(templatename, fileName, data, descriptions, mcpDefaultEnabled, contentTypes));
     }
 
     public static class TemplateData {
@@ -46,14 +47,20 @@ public final class QuteTemplateBuildItem extends AbstractDevUIBuildItem {
         final String fileName;
         final Map<String, Object> data;
         final Map<String, String> descriptions;
+        final Map<String, String> mcpDefaultEnabled;
         final Map<String, String> contentTypes;
 
-        private TemplateData(String templateName, String fileName, Map<String, Object> data, Map<String, String> descriptions,
+        private TemplateData(String templateName,
+                String fileName,
+                Map<String, Object> data,
+                Map<String, String> descriptions,
+                Map<String, String> mcpDefaultEnabled,
                 Map<String, String> contentTypes) {
             this.templateName = templateName;
             this.fileName = fileName;
             this.data = data;
             this.descriptions = descriptions;
+            this.mcpDefaultEnabled = mcpDefaultEnabled;
             this.contentTypes = contentTypes;
         }
 
@@ -71,6 +78,10 @@ public final class QuteTemplateBuildItem extends AbstractDevUIBuildItem {
 
         public Map<String, String> getDescriptions() {
             return descriptions;
+        }
+
+        public Map<String, String> getMcpDefaultEnables() {
+            return mcpDefaultEnabled;
         }
 
         public Map<String, String> getContentTypes() {

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/AbstractJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/AbstractJsonRpcMethod.java
@@ -15,23 +15,26 @@ public abstract class AbstractJsonRpcMethod {
     private String description;
     private Map<String, Parameter> parameters;
     private EnumSet<Usage> usage;
+    private boolean mcpEnabledByDefault = false;
 
     public AbstractJsonRpcMethod() {
     }
 
     public AbstractJsonRpcMethod(String methodName, String description,
-            EnumSet<Usage> usage) {
+            EnumSet<Usage> usage, boolean mcpEnabledByDefault) {
         this.methodName = methodName;
         this.description = description;
         this.usage = usage;
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
     }
 
     public AbstractJsonRpcMethod(String methodName, String description, Map<String, Parameter> parameters,
-            EnumSet<Usage> usage) {
+            EnumSet<Usage> usage, boolean mcpEnabledByDefault) {
         this.methodName = methodName;
         this.description = description;
         this.parameters = parameters;
         this.usage = usage;
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
     }
 
     public String getMethodName() {
@@ -80,6 +83,14 @@ public abstract class AbstractJsonRpcMethod {
 
     public void setUsage(EnumSet<Usage> usage) {
         this.usage = usage;
+    }
+
+    public boolean isMcpEnabledByDefault() {
+        return mcpEnabledByDefault;
+    }
+
+    public void setMcpEnabledByDefault(boolean mcpEnabledByDefault) {
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
     }
 
     public static class Parameter {

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/DeploymentJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/DeploymentJsonRpcMethod.java
@@ -21,8 +21,9 @@ public final class DeploymentJsonRpcMethod extends AbstractJsonRpcMethod {
     public DeploymentJsonRpcMethod(String methodName,
             String description,
             EnumSet<Usage> usage,
+            boolean mcpEnabledByDefault,
             Function<Map<String, String>, ?> action) {
-        super(methodName, description, usage);
+        super(methodName, description, usage, mcpEnabledByDefault);
         this.action = action;
     }
 
@@ -30,16 +31,18 @@ public final class DeploymentJsonRpcMethod extends AbstractJsonRpcMethod {
             String description,
             Map<String, Parameter> parameters,
             EnumSet<Usage> usage,
+            boolean mcpEnabledByDefault,
             Function<Map<String, String>, ?> action) {
-        super(methodName, description, parameters, usage);
+        super(methodName, description, parameters, usage, mcpEnabledByDefault);
         this.action = action;
     }
 
     public DeploymentJsonRpcMethod(String methodName,
             String description,
             EnumSet<Usage> usage,
+            boolean mcpEnabledByDefault,
             BiFunction<Object, Map<String, String>, ?> assistantAction) {
-        super(methodName, description, usage);
+        super(methodName, description, usage, mcpEnabledByDefault);
         this.assistantAction = assistantAction;
     }
 
@@ -47,8 +50,9 @@ public final class DeploymentJsonRpcMethod extends AbstractJsonRpcMethod {
             String description,
             Map<String, Parameter> parameters,
             EnumSet<Usage> usage,
+            boolean mcpEnabledByDefault,
             BiFunction<Object, Map<String, String>, ?> assistantAction) {
-        super(methodName, description, parameters, usage);
+        super(methodName, description, parameters, usage, mcpEnabledByDefault);
         this.assistantAction = assistantAction;
     }
 

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RecordedJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RecordedJsonRpcMethod.java
@@ -18,8 +18,9 @@ public final class RecordedJsonRpcMethod extends AbstractJsonRpcMethod {
     public RecordedJsonRpcMethod(String methodName,
             String description,
             EnumSet<Usage> usage,
+            boolean mcpEnabledByDefault,
             RuntimeValue runtimeValue) {
-        super(methodName, description, usage);
+        super(methodName, description, usage, mcpEnabledByDefault);
         this.runtimeValue = runtimeValue;
     }
 

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RuntimeJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RuntimeJsonRpcMethod.java
@@ -22,10 +22,11 @@ public final class RuntimeJsonRpcMethod extends AbstractJsonRpcMethod {
             String description,
             Map<String, Parameter> parameters,
             EnumSet<Usage> usage,
+            boolean mcpEnabledByDefault,
             Class<?> bean,
             boolean blocking,
             boolean nonBlocking) {
-        super(methodName, description, parameters, usage);
+        super(methodName, description, parameters, usage, mcpEnabledByDefault);
         this.bean = bean;
         this.blocking = blocking;
         this.nonBlocking = nonBlocking;

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
@@ -62,6 +62,10 @@ public abstract class AbstractPageBuildItem extends AbstractDevUIBuildItem {
         this.buildTimeData.put(fieldName, new BuildTimeData(fieldData, description));
     }
 
+    public void addBuildTimeData(String fieldName, Object fieldData, String description, boolean mcpEnabledByDefault) {
+        this.buildTimeData.put(fieldName, new BuildTimeData(fieldData, description, mcpEnabledByDefault));
+    }
+
     public Map<String, BuildTimeData> getBuildTimeData() {
         return this.buildTimeData;
     }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeConstBuildItem.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeConstBuildItem.java
@@ -32,11 +32,11 @@ public final class BuildTimeConstBuildItem extends AbstractDevUIBuildItem {
     }
 
     public void addBuildTimeData(String fieldName, Object fieldData) {
-        this.addBuildTimeData(fieldName, fieldData, null);
+        this.addBuildTimeData(fieldName, fieldData, null, false);
     }
 
-    public void addBuildTimeData(String fieldName, Object fieldData, String description) {
-        this.buildTimeData.put(fieldName, new BuildTimeData(fieldData, description));
+    public void addBuildTimeData(String fieldName, Object fieldData, String description, boolean mcpEnabledAsDefault) {
+        this.buildTimeData.put(fieldName, new BuildTimeData(fieldData, description, mcpEnabledAsDefault));
     }
 
     public void addAllBuildTimeData(Map<String, BuildTimeData> buildTimeData) {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -356,6 +356,7 @@ public class BuildTimeContentProcessor {
 
         var mapper = DatabindCodec.mapper().writerWithDefaultPrettyPrinter();
         Map<String, String> descriptions = new HashMap<>();
+        Map<String, String> mcpDefaultEnabled = new HashMap<>();
         Map<String, String> contentTypes = new HashMap<>();
         for (BuildTimeConstBuildItem buildTimeConstBuildItem : buildTimeConstBuildItems) {
             Map<String, Object> data = new HashMap<>();
@@ -365,13 +366,18 @@ public class BuildTimeContentProcessor {
                         String ns = buildTimeConstBuildItem.getExtensionPathName(curateOutcomeBuildItem);
                         String key = pageData.getKey();
                         String value = mapper.writeValueAsString(pageData.getValue().getContent());
+                        String fullName = ns + UNDERSCORE + key;
+
                         String description = pageData.getValue().getDescription();
                         if (description != null) {
-                            descriptions.put(ns + UNDERSCORE + key, description);
+                            descriptions.put(fullName, description);
                         }
+                        boolean isEnabledByDefault = pageData.getValue().isMcpEnabledByDefault();
+
+                        mcpDefaultEnabled.put(fullName, String.valueOf(isEnabledByDefault));
                         String contentType = pageData.getValue().getContentType();
                         if (contentType != null) {
-                            contentTypes.put(ns + UNDERSCORE + key, contentType);
+                            contentTypes.put(fullName, contentType);
                         }
                         data.put(key, value);
                     } catch (JsonProcessingException ex) {
@@ -385,7 +391,7 @@ public class BuildTimeContentProcessor {
 
                 String ref = buildTimeConstBuildItem.getExtensionPathName(curateOutcomeBuildItem) + "-data";
                 String file = ref + ".js";
-                quteTemplateBuildItem.add("build-time-data.js", file, qutedata, descriptions, contentTypes);
+                quteTemplateBuildItem.add("build-time-data.js", file, qutedata, descriptions, mcpDefaultEnabled, contentTypes);
                 internalImportMapBuildItem.add(ref, contextRoot + file);
             }
         }
@@ -489,6 +495,7 @@ public class BuildTimeContentProcessor {
                 String templateName = e.getTemplateName(); // Relative to BUILD_TIME_PATH
                 Map<String, Object> data = e.getData();
                 Map<String, String> descriptions = e.getDescriptions();
+                Map<String, String> mcpDefaultEnabled = e.getMcpDefaultEnables();
                 Map<String, String> contentTypes = e.getContentTypes();
                 String resourceName = BUILD_TIME_PATH + SLASH + templateName;
                 String fileName = e.getFileName();
@@ -502,6 +509,7 @@ public class BuildTimeContentProcessor {
                                 .template(templateContent)
                                 .addData(data)
                                 .descriptions(descriptions)
+                                .mcpDefaultEnables(mcpDefaultEnabled)
                                 .contentTypes(contentTypes)
                                 .build();
                         contentPerExtension.add(content);

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -672,7 +672,7 @@ public class BuildTimeContentProcessor {
         }
 
         internalBuildTimeData.addBuildTimeData("footerTabs", footerTabs);
-        internalBuildTimeData.addBuildTimeData("loggerLevels", LEVELS, "All the available logger levels");
+        internalBuildTimeData.addBuildTimeData("loggerLevels", LEVELS, "All the available logger levels", true);
     }
 
     private void addApplicationInfoBuildTimeData(BuildTimeConstBuildItem internalBuildTimeData,

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/InternalPageBuildItem.java
@@ -46,7 +46,12 @@ public final class InternalPageBuildItem extends MultiBuildItem {
     }
 
     public void addBuildTimeData(String key, Object value, String description, String contentType) {
-        this.buildTimeData.put(key, new BuildTimeData(value, description, contentType));
+        this.buildTimeData.put(key, new BuildTimeData(value, description, false, contentType));
+    }
+
+    public void addBuildTimeData(String key, Object value, String description, boolean mcpEnabledByDefault,
+            String contentType) {
+        this.buildTimeData.put(key, new BuildTimeData(value, description, mcpEnabledByDefault, contentType));
     }
 
     public List<Page> getPages() {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
@@ -62,6 +62,7 @@ public class LogStreamProcessor {
                     RuntimeUpdatesProcessor.INSTANCE.doScan(true, true);
                     return Map.of();
                 })
+                .enableMcpFuctionByDefault()
                 .build();
 
         keyStrokeActions.actionBuilder()

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
@@ -126,6 +126,7 @@ public class ConfigurationProcessor {
                     updateConfig(name, value, profile, target);
                     return true;
                 })
+                .enableMcpFuctionByDefault()
                 .build();
 
         configActions.actionBuilder()

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -112,6 +112,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
+                .enableMcpFuctionByDefault()
                 .build();
     }
 
@@ -137,6 +138,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
+                .enableMcpFuctionByDefault()
                 .build();
     }
 
@@ -157,6 +159,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
+                .enableMcpFuctionByDefault()
                 .build();
     }
 
@@ -258,6 +261,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
+                .enableMcpFuctionByDefault()
                 .build();
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
@@ -89,6 +89,7 @@ public class DevServicesProcessor {
                 .function(ignored -> CompletableFuture.supplyAsync(() -> getServices(devServiceDescriptions, otherDevServices)))
                 .description(
                         "Get all the DevServices started by this Quarkus app, including information on container (if any) and the config that is being set automatically")
+                .enableMcpFuctionByDefault()
                 .build();
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -46,7 +46,8 @@ public class ExtensionsProcessor {
 
         extensionsPages.addBuildTimeData("extensions", response, "All the extensions added to this Quarkus application. "
                 + "Some extensions are 'active' meaning they have actions in Dev UI, and some are 'inactive', meaning they will be listed in Dev UI, but a user can not perform any actions."
-                + "For both active and inactive all sorts of information is available about the extension, like it's name, URL to the guide, GAV and much more");
+                + "For both active and inactive all sorts of information is available about the extension, like it's name, URL to the guide, GAV and much more",
+                true, null);
 
         // Page
         extensionsPages.addPage(Page.webComponentPageBuilder()
@@ -127,6 +128,7 @@ public class ExtensionsProcessor {
                         }
                     });
                 })
+                .enableMcpFuctionByDefault()
                 .build();
     }
 
@@ -197,6 +199,7 @@ public class ExtensionsProcessor {
                         }
                     });
                 })
+                .enableMcpFuctionByDefault()
                 .build();
     }
 
@@ -222,6 +225,7 @@ public class ExtensionsProcessor {
                         }
                     });
                 })
+                .enableMcpFuctionByDefault()
                 .build();
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
@@ -10,7 +10,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.devui.runtime.DevUIRecorder;
-import io.quarkus.devui.runtime.mcp.DevMcpJsonRpcService;
+import io.quarkus.devui.runtime.mcp.McpDevUIJsonRpcService;
 import io.quarkus.devui.runtime.mcp.McpResourcesService;
 import io.quarkus.devui.runtime.mcp.McpToolsService;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
@@ -84,7 +84,7 @@ public class MCPProcessor {
     void createMCPJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> bp) {
         bp.produce(List.of(new JsonRPCProvidersBuildItem(NS_RESOURCES, McpResourcesService.class),
                 new JsonRPCProvidersBuildItem(NS_TOOLS, McpToolsService.class),
-                new JsonRPCProvidersBuildItem(NS_MCP, DevMcpJsonRpcService.class)));
+                new JsonRPCProvidersBuildItem(NS_MCP, McpDevUIJsonRpcService.class)));
 
     }
 }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
@@ -175,6 +175,7 @@ public class WorkspaceProcessor {
                     .function((t) -> {
                         return workspaceBuildItem.get().getWorkspaceItems();
                     })
+                    .enableMcpFuctionByDefault()
                     .build();
 
             buildItemActions.actionBuilder()
@@ -236,6 +237,7 @@ public class WorkspaceProcessor {
                         }
                         return null;
                     })
+                    .enableMcpFuctionByDefault()
                     .build();
 
             buildItemActions.actionBuilder()
@@ -254,6 +256,7 @@ public class WorkspaceProcessor {
                         }
                         return new SavedResult(null, false, "Invalid input");
                     })
+                    .enableMcpFuctionByDefault()
                     .build();
 
             buildTimeActionProducer.produce(buildItemActions);

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIBuildTimeStaticService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIBuildTimeStaticService.java
@@ -9,15 +9,20 @@ import java.util.Map;
 public class DevUIBuildTimeStaticService {
     private final Map<String, String> urlAndPath = new HashMap<>();
     private final Map<String, String> descriptions = new HashMap<>();
+    private final Map<String, String> mcpDefaultEnabled = new HashMap<>();
     private final Map<String, String> contentTypes = new HashMap<>();
 
     private String basePath; // Like /q/dev-ui
 
-    public void addData(String basePath, Map<String, String> urlAndPath, Map<String, String> descriptions,
+    public void addData(String basePath,
+            Map<String, String> urlAndPath,
+            Map<String, String> descriptions,
+            Map<String, String> mcpDefaultEnabled,
             Map<String, String> contentTypes) {
         this.basePath = basePath;
         this.urlAndPath.putAll(urlAndPath);
         this.descriptions.putAll(descriptions);
+        this.mcpDefaultEnabled.putAll(mcpDefaultEnabled);
         this.contentTypes.putAll(contentTypes);
     }
 
@@ -27,6 +32,10 @@ public class DevUIBuildTimeStaticService {
 
     public Map<String, String> getDescriptions() {
         return descriptions;
+    }
+
+    public Map<String, String> getMcpDefaultEnabled() {
+        return mcpDefaultEnabled;
     }
 
     public Map<String, String> getContentTypes() {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
@@ -100,9 +100,10 @@ public class DevUIRecorder {
             String basePath,
             Map<String, String> urlAndPath,
             Map<String, String> descriptions,
+            Map<String, String> mcpDefaultEnabled,
             Map<String, String> contentTypes) {
         DevUIBuildTimeStaticService buildTimeStaticService = beanContainer.beanInstance(DevUIBuildTimeStaticService.class);
-        buildTimeStaticService.addData(basePath, urlAndPath, descriptions, contentTypes);
+        buildTimeStaticService.addData(basePath, urlAndPath, descriptions, mcpDefaultEnabled, contentTypes);
 
         return new DevUIBuildTimeStaticHandler();
     }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigJsonRPCService.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.quarkus.vertx.http.runtime.devmode.ConfigDescription;
 import io.vertx.core.json.JsonArray;
@@ -24,6 +25,7 @@ public class ConfigJsonRPCService {
     }
 
     @JsonRpcDescription("Get all configurations and their values for the Quarkus application")
+    @DevMCPEnableByDefault
     public JsonObject getAllValues() {
         JsonObject values = new JsonObject();
         for (ConfigDescription configDescription : configDescriptionBean.getAllConfig()) {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
@@ -20,6 +20,7 @@ public final class JsonRpcMethod {
     private Map<String, Parameter> parameters;
 
     private List<Usage> usage;
+    private boolean mcpEnabledByDefault = false;
 
     private RuntimeValue runtimeValue;
 
@@ -66,6 +67,14 @@ public final class JsonRpcMethod {
 
     public void setUsage(List<Usage> usage) {
         this.usage = usage;
+    }
+
+    public boolean isMcpEnabledByDefault() {
+        return mcpEnabledByDefault;
+    }
+
+    public void setMcpEnabledByDefault(boolean mcpEnabledByDefault) {
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
     }
 
     public Method getJavaMethod() {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamJsonRPCService.java
@@ -10,6 +10,7 @@ import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.Logger;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
@@ -42,6 +43,7 @@ public class LogStreamJsonRPCService {
 
     @NonBlocking
     @JsonRpcDescription("Get all the available loggers in this Quarkus application")
+    @DevMCPEnableByDefault
     public List<JsonObject> getLoggers() {
         LogContext logContext = LogContext.getLogContext();
         List<JsonObject> values = new ArrayList<>();
@@ -58,6 +60,7 @@ public class LogStreamJsonRPCService {
 
     @NonBlocking
     @JsonRpcDescription("Get a specific logger in this Quarkus application")
+    @DevMCPEnableByDefault
     public JsonObject getLogger(@JsonRpcDescription("The name of the logger") String loggerName) {
         LogContext logContext = LogContext.getLogContext();
         if (loggerName != null && !loggerName.isEmpty()) {
@@ -72,6 +75,7 @@ public class LogStreamJsonRPCService {
 
     @NonBlocking
     @JsonRpcDescription("Update a specific logger's log level in this Quarkus application")
+    @DevMCPEnableByDefault
     public JsonObject updateLogLevel(@JsonRpcDescription("The name of the logger") String loggerName,
             @JsonRpcDescription("The new level of the logger") String levelValue) {
         LogContext logContext = LogContext.getLogContext();

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/Filter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/Filter.java
@@ -1,0 +1,6 @@
+package io.quarkus.devui.runtime.mcp;
+
+public enum Filter {
+    enabled,
+    disabled
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpDevUIJsonRpcService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpDevUIJsonRpcService.java
@@ -21,7 +21,7 @@ import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
  * Normal Dev UI Json RPC Service for the Dev MPC Screen
  */
 @ApplicationScoped
-public class DevMcpJsonRpcService {
+public class McpDevUIJsonRpcService {
 
     private final BroadcastProcessor<McpClientInfo> connectedClientStream = BroadcastProcessor.create();
 
@@ -68,6 +68,26 @@ public class DevMcpJsonRpcService {
         return this.mcpServerConfiguration;
     }
 
+    public McpServerConfiguration enableMethod(String name) {
+        this.mcpServerConfiguration.enableMethod(name);
+        storeConfiguration(this.mcpServerConfiguration.toProperties());
+        return this.mcpServerConfiguration;
+    }
+
+    public McpServerConfiguration disableMethod(String name) {
+        this.mcpServerConfiguration.disableMethod(name);
+        storeConfiguration(this.mcpServerConfiguration.toProperties());
+        return this.mcpServerConfiguration;
+    }
+
+    public boolean isExplicitlyEnabled(String methodName) {
+        return this.mcpServerConfiguration.isExplicitlyEnabled(methodName);
+    }
+
+    public boolean isExplicitlyDisabled(String methodName) {
+        return this.mcpServerConfiguration.isExplicitlyDisabled(methodName);
+    }
+
     private Properties loadConfiguration() {
         Properties existingProps = new Properties();
 
@@ -94,5 +114,4 @@ public class DevMcpJsonRpcService {
 
     private final Path configDir = Paths.get(System.getProperty("user.home"), ".quarkus");
     private final Path configFile = configDir.resolve("dev-mcp.properties");
-
 }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
@@ -123,7 +123,7 @@ public class McpHttpHandler implements Handler<RoutingContext> {
     private void routeToMCPInitialize(JsonRpcRequest jsonRpcRequest, JsonRpcCodec codec, McpResponseWriter writer) {
         if (jsonRpcRequest.hasParam(CLIENT_INFO)) {
             Map map = jsonRpcRequest.getParam(CLIENT_INFO, Map.class);
-            DevMcpJsonRpcService devMcpJsonRpcService = CDI.current().select(DevMcpJsonRpcService.class).get();
+            McpDevUIJsonRpcService devMcpJsonRpcService = CDI.current().select(McpDevUIJsonRpcService.class).get();
             devMcpJsonRpcService.addClientInfo(McpClientInfo.fromMap(map));
         }
         String input = jsonMapper.toString(jsonRpcRequest, true);

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpServerConfiguration.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpServerConfiguration.java
@@ -1,10 +1,14 @@
 package io.quarkus.devui.runtime.mcp;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 public class McpServerConfiguration {
 
     private boolean enabled = false;
+
+    private Map userEnabledment = new HashMap();
 
     public McpServerConfiguration() {
 
@@ -13,10 +17,11 @@ public class McpServerConfiguration {
     public McpServerConfiguration(Properties p) {
         if (p != null) {
             if (p.containsKey(ENABLED)) {
-                this.enabled = Boolean.valueOf(p.getProperty(ENABLED, "false"));
+                this.enabled = Boolean.parseBoolean(p.getProperty(ENABLED, "false"));
+                p.remove(ENABLED);
             }
+            userEnabledment = p;
         }
-        // TODO: Here we can add future configuration, like disable methods
     }
 
     public McpServerConfiguration(boolean enabled) {
@@ -39,11 +44,37 @@ public class McpServerConfiguration {
         this.setEnable(false);
     }
 
+    public void enableMethod(String name) {
+        if (isExplicitlyDisabled(name)) {
+            this.userEnabledment.remove(name); // Revert to default
+        } else {
+            this.userEnabledment.put(name, "true");
+        }
+    }
+
+    public void disableMethod(String name) {
+        if (isExplicitlyEnabled(name)) {
+            this.userEnabledment.remove(name); // Revert to default
+        } else {
+            this.userEnabledment.put(name, "false");
+        }
+    }
+
+    public boolean isExplicitlyDisabled(String name) {
+        return (this.userEnabledment.containsKey(name) && this.userEnabledment.get(name).equals("false"));
+    }
+
+    public boolean isExplicitlyEnabled(String name) {
+        return (this.userEnabledment.containsKey(name) && this.userEnabledment.get(name).equals("true"));
+    }
+
     public Properties toProperties() {
         Properties p = new Properties();
         p.setProperty(ENABLED, String.valueOf(this.enabled));
+        p.putAll(userEnabledment);
         return p;
     }
 
     private static final String ENABLED = "enabled";
+
 }

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -306,7 +306,9 @@ public class InfoProcessor {
                 .description(
                         "Information about the environment where this Quarkus application is running. "
                                 + "Things like Operating System, Java version Git information and application details is available")
-                .runtime(finalBuildInfo).build());
+                .runtime(finalBuildInfo)
+                .enableMcpFuctionByDefault()
+                .build());
 
         return RouteBuildItem.newManagementRoute(buildTimeConfig.path())
                 .withRoutePathConfigKey("quarkus.info.path")

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/KafkaJsonRPCService.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/KafkaJsonRPCService.java
@@ -17,6 +17,7 @@ import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaAclInfo;
 import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaInfo;
 import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaMessagePage;
 import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaTopic;
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
@@ -38,11 +39,13 @@ public class KafkaJsonRPCService {
     }
 
     @JsonRpcDescription("Get all the current Kafka topics")
+    @DevMCPEnableByDefault
     public List<KafkaTopic> getTopics() throws InterruptedException, ExecutionException {
         return kafkaUiUtils.getTopics();
     }
 
     @JsonRpcDescription("Create a new Kafka topic")
+    @DevMCPEnableByDefault
     public List<KafkaTopic> createTopic(@JsonRpcDescription("The Kafka topic name") final String topicName,
             @JsonRpcDescription("The number of partitions, example 1") final int partitions,
             @JsonRpcDescription("The number of replications, example 1") final int replications,
@@ -60,6 +63,7 @@ public class KafkaJsonRPCService {
     }
 
     @JsonRpcDescription("Delete an existing Kafka topic")
+    @DevMCPEnableByDefault
     public List<KafkaTopic> deleteTopic(@JsonRpcDescription("The Kafka topic name") final String topicName)
             throws InterruptedException, ExecutionException {
         boolean deleted = kafkaAdminClient.deleteTopic(topicName);
@@ -71,6 +75,7 @@ public class KafkaJsonRPCService {
     }
 
     @JsonRpcDescription("Get all the current messages for a certain Kafka topics")
+    @DevMCPEnableByDefault
     public KafkaMessagePage topicMessages(@JsonRpcDescription("The Kafka topic name") final String topicName)
             throws ExecutionException, InterruptedException {
         List<Integer> partitions = getPartitions(topicName);
@@ -81,6 +86,7 @@ public class KafkaJsonRPCService {
     }
 
     @JsonRpcDescription("Create a new message on a specific Kafka topic")
+    @DevMCPEnableByDefault
     public KafkaMessagePage createMessage(@JsonRpcDescription("The Kafka topic name") String topicName,
             @JsonRpcDescription("The partition number, example 1") Integer partition,
             @JsonRpcDescription("The message key") String key,
@@ -106,6 +112,7 @@ public class KafkaJsonRPCService {
     }
 
     @JsonRpcDescription("Get all know information on the Kafka instance")
+    @DevMCPEnableByDefault
     public KafkaInfo getInfo() throws ExecutionException, InterruptedException {
         return kafkaUiUtils.getKafkaInfo();
     }

--- a/extensions/scheduler/runtime-dev/src/main/java/io/quarkus/scheduler/runtime/dev/ui/SchedulerJsonRPCService.java
+++ b/extensions/scheduler/runtime-dev/src/main/java/io/quarkus/scheduler/runtime/dev/ui/SchedulerJsonRPCService.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.inject.Instance;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.Scheduled;
@@ -90,6 +91,7 @@ public class SchedulerJsonRPCService {
 
     @NonBlocking
     @JsonRpcDescription("Get information on the scheduler in the system")
+    @DevMCPEnableByDefault
     public JsonObject getData() {
         SchedulerContext c = context.get();
         Scheduler s = scheduler.get();
@@ -157,6 +159,7 @@ public class SchedulerJsonRPCService {
 
     @NonBlocking
     @JsonRpcDescription("Pause a specific job in the scheduler")
+    @DevMCPEnableByDefault
     public JsonObject pauseJob(@JsonRpcDescription("The job identification") String identity) {
         Scheduler s = scheduler.get();
         if (s.isPaused(identity)) {
@@ -169,6 +172,7 @@ public class SchedulerJsonRPCService {
 
     @NonBlocking
     @JsonRpcDescription("Resume a specific job in the scheduler")
+    @DevMCPEnableByDefault
     public JsonObject resumeJob(@JsonRpcDescription("The job identification") String identity) {
         Scheduler s = scheduler.get();
         if (!s.isPaused(identity)) {
@@ -181,6 +185,7 @@ public class SchedulerJsonRPCService {
 
     @NonBlocking
     @JsonRpcDescription("Execute a specific job in the scheduler")
+    @DevMCPEnableByDefault
     public JsonObject executeJob(@JsonRpcDescription("The method description") String methodDescription) {
         SchedulerContext c = context.get();
         for (ScheduledMethod metadata : c.getScheduledMethods()) {

--- a/extensions/smallrye-graphql/runtime-dev/src/main/java/io/quarkus/smallrye/graphql/runtime/dev/GraphQLJsonRpcService.java
+++ b/extensions/smallrye-graphql/runtime-dev/src/main/java/io/quarkus/smallrye/graphql/runtime/dev/GraphQLJsonRpcService.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 
 import graphql.schema.GraphQLSchema;
 import io.quarkus.assistant.runtime.dev.Assistant;
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.smallrye.graphql.execution.SchemaPrinter;
 
@@ -26,6 +27,7 @@ public class GraphQLJsonRpcService {
     }
 
     @JsonRpcDescription("Get the running application's GraphQL Schema Document")
+    @DevMCPEnableByDefault
     public String getGraphQLSchema() {
         return schemaPrinter.print(graphQLSchema);
     }

--- a/extensions/smallrye-health/runtime-dev/src/main/java/io/quarkus/smallrye/health/runtime/dev/ui/HealthJsonRPCService.java
+++ b/extensions/smallrye-health/runtime-dev/src/main/java/io/quarkus/smallrye/health/runtime/dev/ui/HealthJsonRPCService.java
@@ -10,6 +10,7 @@ import jakarta.inject.Inject;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
@@ -81,6 +82,7 @@ public class HealthJsonRPCService {
     }
 
     @JsonRpcDescription("Get the current Health of the running Quarkus application")
+    @DevMCPEnableByDefault
     public Uni<SmallRyeHealth> getHealth() {
         return smallRyeHealthReporter.getHealthAsync();
     }

--- a/extensions/smallrye-openapi/runtime-dev/src/main/java/io/quarkus/smallrye/openapi/runtime/dev/OpenApiJsonRpcService.java
+++ b/extensions/smallrye-openapi/runtime-dev/src/main/java/io/quarkus/smallrye/openapi/runtime/dev/OpenApiJsonRpcService.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage;
 import jakarta.inject.Inject;
 
 import io.quarkus.assistant.runtime.dev.Assistant;
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService;
 import io.smallrye.openapi.runtime.io.Format;
@@ -21,6 +22,7 @@ public class OpenApiJsonRpcService {
     OpenApiDocumentService openApiDocumentService;
 
     @JsonRpcDescription("Get the running application's OpenAPI Schema Document in json format")
+    @DevMCPEnableByDefault
     public String getOpenAPISchema() {
         return new String(openApiDocumentService.getDocument(Format.JSON));
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.TemplateHtmlBuilder;
+import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.smallrye.common.annotation.NonBlocking;
@@ -138,6 +139,7 @@ public class ResourceNotFoundData {
 
     @NonBlocking
     @JsonRpcDescription("Information on endpoints exposed by this application in Dev Mode. This includes Quarkus endpoints and application endpoints")
+    @DevMCPEnableByDefault
     public JsonObject getAllEndpoints() {
         List<RouteDescription> combinedRoutes = getCombinedRoutes();
         JsonObject infoMap = new JsonObject();


### PR DESCRIPTION
This PR adds further functionality to Dev MCP allowing extension developers to set a default enable/disable flag and for end users to toggle between these.

<img width="1596" height="768" alt="image" src="https://github.com/user-attachments/assets/5b4375b8-b913-48a7-bf10-d70f334bfba2" />


It also includes some updates to the extensions already supporting Dev MCP adding the flag to some of them where is make sense .

It also updates the documentation for Dev MCP to reflect this.


Fix #49903

// cc @myfear