### PR TITLE
Copy the Gradle wrapper instead of running the exec goal

### DIFF
--- a/independent-projects/tools/base-codestarts/pom.xml
+++ b/independent-projects/tools/base-codestarts/pom.xml
@@ -28,90 +28,16 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>init-gradle-project</id>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <executable>${gradle-wrapper.path}/${gradle.executable}</executable>
-                            <environmentVariables>
-                                <!-- Force a higher value than the default 64m, used by
-                                 gradlew script, to make sure the no-daemon option is honoured
-                                -->
-                                <JAVA_OPTS>-Xmx512m</JAVA_OPTS>
-                            </environmentVariables>
-                            <arguments>
-                                <argument>init</argument>
-                                <argument>--type</argument>
-                                <argument>basic</argument>
-                                <argument>--no-daemon</argument>
-                                <argument>--overwrite</argument>
-                            </arguments>
-                            <workingDirectory>${project.build.directory}/gradle-wrapper</workingDirectory>
-                            <addOutputToClasspath>true</addOutputToClasspath>
-                        </configuration>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>install-gradle-wrapper</id>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <executable>${gradle-wrapper.path}/${gradle.executable}</executable>
-                            <environmentVariables>
-                                <!-- Force a higher value than the default 64m, used by
-                                 gradlew script, to make sure the no-daemon option is honoured
-                                -->
-                                <JAVA_OPTS>-Xmx512m</JAVA_OPTS>
-                            </environmentVariables>
-                            <arguments>
-                                <argument>wrapper</argument>
-                                <argument>--gradle-version</argument>
-                                <argument>${gradle-wrapper.version}</argument>
-                                <argument>--no-daemon</argument>
-                            </arguments>
-                            <workingDirectory>${project.build.directory}/gradle-wrapper</workingDirectory>
-                            <addOutputToClasspath>true</addOutputToClasspath>
-                        </configuration>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-gradle-wrapper</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <propertiesEncoding>UTF-8</propertiesEncoding>
-                            <outputDirectory>${project.build.outputDirectory}/codestarts/quarkus/tooling/gradle-wrapper/base/</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.build.directory}/gradle-wrapper/</directory>
-                                    <includes>
-                                        <include>gradle/wrapper/**</include>
-                                        <include>gradlew</include>
-                                        <include>gradlew.bat</include>
-                                    </includes>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <configuration>
+                        <propertiesEncoding>UTF-8</propertiesEncoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>
@@ -125,6 +51,139 @@
             <properties>
                 <gradle.executable>gradlew.bat</gradle.executable>
             </properties>
+        </profile>
+        <profile>
+            <!-- This profile can be used to re-generate the Gradle wrapper included in the codestarts -->
+            <id>install-gradle-wrapper</id>
+            <activation>
+                <property>
+                    <name>installGradleWrapper</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>init-gradle-project</id>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <executable>${gradle-wrapper.path}/${gradle.executable}</executable>
+                                    <environmentVariables>
+                                        <!-- Force a higher value than the default 64m, used by
+                                         gradlew script, to make sure the no-daemon option is honoured
+                                        -->
+                                        <JAVA_OPTS>-Xmx512m</JAVA_OPTS>
+                                    </environmentVariables>
+                                    <arguments>
+                                        <argument>init</argument>
+                                        <argument>--type</argument>
+                                        <argument>basic</argument>
+                                        <argument>--no-daemon</argument>
+                                        <argument>--overwrite</argument>
+                                    </arguments>
+                                    <workingDirectory>${project.build.directory}/gradle-wrapper</workingDirectory>
+                                    <addOutputToClasspath>true</addOutputToClasspath>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>install-gradle-wrapper</id>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <executable>${gradle-wrapper.path}/${gradle.executable}</executable>
+                                    <environmentVariables>
+                                        <!-- Force a higher value than the default 64m, used by
+                                         gradlew script, to make sure the no-daemon option is honoured
+                                        -->
+                                        <JAVA_OPTS>-Xmx512m</JAVA_OPTS>
+                                    </environmentVariables>
+                                    <arguments>
+                                        <argument>wrapper</argument>
+                                        <argument>--gradle-version</argument>
+                                        <argument>${gradle-wrapper.version}</argument>
+                                        <argument>--no-daemon</argument>
+                                    </arguments>
+                                    <workingDirectory>${project.build.directory}/gradle-wrapper</workingDirectory>
+                                    <addOutputToClasspath>true</addOutputToClasspath>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-gradle-wrapper</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}/codestarts/quarkus/tooling/gradle-wrapper/base/</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.build.directory}/gradle-wrapper/</directory>
+                                            <includes>
+                                                <include>gradle/wrapper/**</include>
+                                                <include>gradlew</include>
+                                                <include>gradlew.bat</include>
+                                            </includes>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- This profile simply copies the Gradle wrapper from the Gradle plugin module -->
+            <id>copy-gradle-wrapper</id>
+            <activation>
+                <property>
+                    <name>!installGradleWrapper</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-gradle-wrapper</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}/codestarts/quarkus/tooling/gradle-wrapper/base/</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${gradle-wrapper.path}</directory>
+                                            <includes>
+                                                <include>gradle/wrapper/**</include>
+                                                <include>gradlew</include>
+                                                <include>gradlew.bat</include>
+                                            </includes>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
This change introduces an option to simply copy the Gradle wrapper from the Gradle plugin module instead of regenerating it.