### PR TITLE
Remove outdated note about REST Client logging

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1861,8 +1861,6 @@ To enable logging, add the `quarkus.rest-client.logging.scope` property to your 
 
 As HTTP messages can have large bodies, we limit the amount of body characters logged. The default limit is `100`, you can change it by specifying `quarkus.rest-client.logging.body-limit`.
 
-NOTE: REST Client is logging the traffic with level DEBUG and does not alter logger properties. You may need to adjust your logger configuration to use this feature.
-
 These configuration properties work globally for all clients injected by CDI.
 If you want configure logging for a specific declarative client, you should do it by specifying named "client" properties, also known as `quarkus.rest-client."client".logging.*` properties.
 


### PR DESCRIPTION
The change in behavior was made in https://github.com/quarkusio/quarkus/pull/48745

Originally reported in: https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/REST.20client.20is.20logging.20at.20INFO.20level.20instead.20of.20DEBUG/with/539006976