### PR TITLE
Set up config correctly for isolated @QuarkusMainTests

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -98,7 +98,7 @@ public class JunitTestRunner {
     public static final DotName TESTABLE = DotName.createSimple(Testable.class.getName());
     public static final DotName NESTED = DotName.createSimple(Nested.class.getName());
     private static final String ARCHUNIT_FIELDSOURCE_FQCN = "com.tngtech.archunit.junit.FieldSource";
-    public static final String FACADE_CLASS_LOADER_NAME = "io.quarkus.test.junit.classloading.FacadeClassLoader";
+    private static final String FACADE_CLASS_LOADER_NAME = "io.quarkus.test.junit.classloading.FacadeClassLoader";
 
     private final long runId;
     private final DevModeContext.ModuleInfo moduleInfo;

--- a/integration-tests/command-mode/src/test/java/org/acme/MainContinuousTestingTest.java
+++ b/integration-tests/command-mode/src/test/java/org/acme/MainContinuousTestingTest.java
@@ -4,7 +4,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -12,12 +11,11 @@ import io.quarkus.test.ContinuousTestingTestUtils;
 import io.quarkus.test.ContinuousTestingTestUtils.TestStatus;
 import io.quarkus.test.QuarkusDevModeTest;
 
-@Disabled("See https://github.com/quarkusio/quarkus/issues/49780#issuecomment-3265067545")
 public class MainContinuousTestingTest {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
             .withApplicationRoot(jar -> jar
-                    .addClass(Main.class)
+                    // Files from this module are added automatically, so no need to add Main.class
                     .add(new StringAsset(ContinuousTestingTestUtils.appProperties()), "application.properties"))
             .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(MainTest.class));

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -139,8 +139,8 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
             return ConditionEvaluationResult.enabled("Quarkus Test Profile tags only affect classes");
         }
 
-        // At this point, the TCCL is usually the FacadeClassLoader, but sometimes it's a deployment classloader (for multimodule tests), or the runtime classloader (for nested tests)
-        // Getting back to the FacadeClassLoader is non-trivial. We can't use the singleton on the class, because we will be accessing it from different classloaders.
+        // At this point, the TCCL is sometimes a deployment classloader (for multimodule tests), or the runtime classloader (for nested tests), and sometimes a FacadeClassLoader in continuous cases
+        // Getting back to a FacadeClassLoader is non-trivial. We can't use the singleton on the class, because we will be accessing it from different classloaders.
         // We can't have a hook back from the runtime classloader to the facade classloader, because
         // when evaluating execution conditions for native tests, the test will have been loaded with the system classloader, not the runtime classloader.
         // The one classloader we can reliably get to when evaluating test execution is the system classloader, so hook our config on that.

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
@@ -31,13 +31,15 @@ public class CustomLauncherInterceptor implements LauncherDiscoveryListener, Lau
          * However, the Eclipse runner calls this twice, and the second invocation happens after discovery,
          * which means there is no one to unset the TCCL. That breaks integration tests, so we
          * need to add an ugly guard to not adjust the TCCL the second time round in that scenario.
+         *
+         * There is a similar issue with continuous testing, causing us to go into tests with the FacadeClassLoader set.
+         * That's not the right CL, so in those cases skip setting it.
+         *
          * We do not do any classloading dance for prod mode tests.
          */
-        boolean isEclipse = System.getProperty("sun.java.command") != null
-                && System.getProperty("sun.java.command").contains("JUnit5TestLoader");
-        boolean shouldSkipSettingTCCL = isEclipse && discoveryStarted;
+        boolean shouldSetTCCL = !discoveryStarted;
 
-        if (!isProductionModeTests() && !shouldSkipSettingTCCL) {
+        if (!isProductionModeTests() && shouldSetTCCL) {
             actuallyIntercept();
         }
 


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/49780#issuecomment-3265067545

The fact that `@QuarkusMainTest`s pass when combined with `@QuarkusTest`s but fail otherwise gave the clue to the fix. The FacadeClassLoader initialises config on classloaders it creates, but if there's no `@QuarkusTest`, it won't create one. 

In normal testing mode, the parent classloader of the FCL is the app classloader, and that gets the test config initialised on it in some other path. (I can't remember exactly where). But in continuous testing mode, the parent classloader of the FCL is a QuarkusClassLoader, for performance reasons (that classloader has already done a lot of the work of classpath resolution and loading the classes). So a natural fix is to add the test config onto that QuarkusClassLoader. 

This isn't quite enough of a fix, because during test execution, in continuous testing mode, the TCCL is the FCL. If the TCCL is the FCL, that stops the config on the QuarkusClassLoader being found. The TCCL really shouldn't be the FCL, but it happens because the launcher session gets started twice in continuous testing mode. We detect that condition for Eclipse, so I've generalised the guard.

In a follow-up PR, I'd like to:

- Experiment with just detecting gradle and only setting the TCCL on launcher session opening in the gradle case
- Experiment with removing the TCCL-setting logic in `AbstractJVMTestExtension`, since I think I might have fixed all the cases where the TCCL comes in wrong
- Split FacadeClassLoader into two so that the continuous-testing specialisations can be in their own class. There's enough of them now that it would simplify the code. 