### PR TITLE
CredentialsProvider API should be asynchronous

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalVaultCredentialsProviderPassword.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalVaultCredentialsProviderPassword.java
@@ -18,7 +18,7 @@ public class AgroalVaultCredentialsProviderPassword extends SimplePassword {
     @Override
     public Properties asProperties() {
         Properties properties = new Properties();
-        Map<String, String> credentials = credentialsProvider.getCredentials(getWord());
+        Map<String, String> credentials = credentialsProvider.getCredentialsAsync(getWord()).await().indefinitely();
         credentials.forEach((key, value) -> properties.setProperty(key, value));
         return properties;
     }

--- a/extensions/credentials/runtime/src/main/java/io/quarkus/credentials/CredentialsProvider.java
+++ b/extensions/credentials/runtime/src/main/java/io/quarkus/credentials/CredentialsProvider.java
@@ -2,8 +2,16 @@ package io.quarkus.credentials;
 
 import java.util.Map;
 
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
 /**
  * Provides an indirection between credentials consumers such as Agroal and implementers such as Vault.
+ * <p>
+ * Quarkus extensions <strong>MUST</strong> invoke the asynchronous variant. that is {@link #getCredentialsAsync(String)}.
+ * <p>
+ * The default implementation of asynchronous variant invokes the synchronous {@link #getCredentials(String)} on a worker
+ * thread.
  */
 public interface CredentialsProvider {
 
@@ -12,11 +20,23 @@ public interface CredentialsProvider {
     String EXPIRATION_TIMESTAMP_PROPERTY_NAME = "expires-at";
 
     /**
-     * Returns the credentials for a given credentials provider
+     * Returns the credentials for a given credentials provider.
      *
      * @param credentialsProviderName the name of the credentials provider, which can be used to retrieve custom configuration
      * @return the credentials
      */
-    Map<String, String> getCredentials(String credentialsProviderName);
+    default Map<String, String> getCredentials(String credentialsProviderName) {
+        throw new UnsupportedOperationException("Either `getCredentials` or `getCredentialsAsync` must be implemented`");
+    }
 
+    /**
+     * Returns the credentials for a given credentials provider.
+     *
+     * @param credentialsProviderName the name of the credentials provider, which can be used to retrieve custom configuration
+     * @return a {@link Uni} completed with the credentials, or failed
+     */
+    default Uni<Map<String, String>> getCredentialsAsync(String credentialsProviderName) {
+        return Uni.createFrom().item(() -> getCredentials(credentialsProviderName))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor());
+    }
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -527,7 +527,7 @@ public class MongoClients {
             String beanName = config.credentialsProviderName().orElse(null);
             CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
             String name = config.credentialsProvider().get();
-            Map<String, String> credentials = credentialsProvider.getCredentials(name);
+            Map<String, String> credentials = credentialsProvider.getCredentialsAsync(name).await().indefinitely();
             String user = credentials.get(USER_PROPERTY_NAME);
             String password = credentials.get(PASSWORD_PROPERTY_NAME);
             return new UsernamePassword(user, password.toCharArray());

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -393,6 +393,7 @@ public class OidcCommonUtils {
                     String providerName = provider.name().orElse(null);
                     String keyringName = provider.keyringName().orElse(null);
                     CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(providerName);
+                    // getCredentials invocation may block the event loop
                     return credentialsProvider.getCredentials(keyringName).get(provider.key().get());
                 }
                 return null;

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ConnectOptionsSupplier.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ConnectOptionsSupplier.java
@@ -4,63 +4,45 @@ import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.IntUnaryOperator;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import io.quarkus.credentials.CredentialsProvider;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.UniHelper;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 public class ConnectOptionsSupplier<CO extends SqlConnectOptions> implements Supplier<Future<CO>> {
 
-    private final Vertx vertx;
     private final CredentialsProvider credentialsProvider;
     private final String credentialsProviderName;
     private final List<CO> connectOptionsList;
     private final UnaryOperator<CO> connectOptionsCopy;
-    private final Callable<CO> blockingCodeHandler;
+    private final AtomicInteger idx = new AtomicInteger();
 
-    public ConnectOptionsSupplier(Vertx vertx, CredentialsProvider credentialsProvider, String credentialsProviderName,
+    public ConnectOptionsSupplier(CredentialsProvider credentialsProvider, String credentialsProviderName,
             List<CO> connectOptionsList, UnaryOperator<CO> connectOptionsCopy) {
-        this.vertx = vertx;
         this.credentialsProvider = credentialsProvider;
         this.credentialsProviderName = credentialsProviderName;
         this.connectOptionsList = connectOptionsList;
         this.connectOptionsCopy = connectOptionsCopy;
-        this.blockingCodeHandler = new BlockingCodeHandler();
     }
 
     @Override
     public Future<CO> get() {
-        return vertx.executeBlocking(blockingCodeHandler, false);
-    }
-
-    private class BlockingCodeHandler implements Callable<CO>, IntUnaryOperator {
-
-        final AtomicInteger idx = new AtomicInteger();
-
-        @Override
-        public CO call() {
-            Map<String, String> credentials = credentialsProvider.getCredentials(credentialsProviderName);
-            String user = credentials.get(USER_PROPERTY_NAME);
-            String password = credentials.get(PASSWORD_PROPERTY_NAME);
-
-            int nextIdx = idx.getAndUpdate(this);
-
-            CO connectOptions = connectOptionsCopy.apply(connectOptionsList.get(nextIdx));
-            connectOptions.setUser(user).setPassword(password);
-
-            return connectOptions;
-        }
-
-        @Override
-        public int applyAsInt(int previousIdx) {
-            return previousIdx == connectOptionsList.size() - 1 ? 0 : previousIdx + 1;
-        }
+        int nextIdx = idx.getAndUpdate(previousIdx -> previousIdx == connectOptionsList.size() - 1 ? 0 : previousIdx + 1);
+        CO connectOptions = connectOptionsCopy.apply(connectOptionsList.get(nextIdx));
+        return Uni.combine()
+                .all()
+                .unis(credentialsProvider.getCredentialsAsync(credentialsProviderName), Uni.createFrom().item(connectOptions))
+                .with((credentials, co) -> {
+                    co.setUser(credentials.get(USER_PROPERTY_NAME));
+                    co.setPassword(credentials.get(PASSWORD_PROPERTY_NAME));
+                    return co;
+                })
+                .convert()
+                .with(UniHelper::toFuture);
     }
 }

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -126,19 +126,19 @@ public class DB2PoolRecorder {
         PoolOptions poolOptions = toPoolOptions(eventLoopCount, dataSourceReactiveRuntimeConfig);
         DB2ConnectOptions db2ConnectOptions = toConnectOptions(dataSourceName, dataSourceRuntimeConfig,
                 dataSourceReactiveRuntimeConfig, dataSourceReactiveDB2Config);
-        Supplier<Future<DB2ConnectOptions>> databasesSupplier = toDatabasesSupplier(vertx, List.of(db2ConnectOptions),
+        Supplier<Future<DB2ConnectOptions>> databasesSupplier = toDatabasesSupplier(List.of(db2ConnectOptions),
                 dataSourceRuntimeConfig);
         return createPool(vertx, poolOptions, db2ConnectOptions, dataSourceName, databasesSupplier, context);
     }
 
-    private Supplier<Future<DB2ConnectOptions>> toDatabasesSupplier(Vertx vertx, List<DB2ConnectOptions> db2ConnectOptionsList,
+    private Supplier<Future<DB2ConnectOptions>> toDatabasesSupplier(List<DB2ConnectOptions> db2ConnectOptionsList,
             DataSourceRuntimeConfig dataSourceRuntimeConfig) {
         Supplier<Future<DB2ConnectOptions>> supplier;
         if (dataSourceRuntimeConfig.credentialsProvider().isPresent()) {
             String beanName = dataSourceRuntimeConfig.credentialsProviderName().orElse(null);
             CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
             String name = dataSourceRuntimeConfig.credentialsProvider().get();
-            supplier = new ConnectOptionsSupplier<>(vertx, credentialsProvider, name, db2ConnectOptionsList,
+            supplier = new ConnectOptionsSupplier<>(credentialsProvider, name, db2ConnectOptionsList,
                     DB2ConnectOptions::new);
         } else {
             supplier = Utils.roundRobinSupplier(db2ConnectOptionsList);
@@ -212,7 +212,7 @@ public class DB2PoolRecorder {
             String beanName = dataSourceRuntimeConfig.credentialsProviderName().orElse(null);
             CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
             String name = dataSourceRuntimeConfig.credentialsProvider().get();
-            Map<String, String> credentials = credentialsProvider.getCredentials(name);
+            Map<String, String> credentials = credentialsProvider.getCredentialsAsync(name).await().indefinitely();
             String user = credentials.get(USER_PROPERTY_NAME);
             String password = credentials.get(PASSWORD_PROPERTY_NAME);
             if (user != null) {

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/CredentialsProviderLink.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/CredentialsProviderLink.java
@@ -50,7 +50,8 @@ public class CredentialsProviderLink implements com.rabbitmq.client.impl.Credent
 
     @Override
     public void refresh() {
-        Map<String, String> credentials = credentialsProvider.getCredentials(credentialsProviderName);
+        Map<String, String> credentials = credentialsProvider.getCredentialsAsync(credentialsProviderName).await()
+                .indefinitely();
         username = credentials.get(USER_PROPERTY_NAME);
         password = credentials.get(PASSWORD_PROPERTY_NAME);
         expiresAt = Instant.parse(credentials.getOrDefault(EXPIRATION_TIMESTAMP_PROPERTY_NAME, getDefaultExpiresAt()));

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/keystores/CredentialProviders.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/keystores/CredentialProviders.java
@@ -21,7 +21,7 @@ public class CredentialProviders {
         }
         if (config.name().isPresent()) {
             CredentialsProvider provider = lookup(config.beanName().orElse(null));
-            Map<String, String> credentials = provider.getCredentials(config.name().get());
+            Map<String, String> credentials = provider.getCredentialsAsync(config.name().get()).await().indefinitely();
             return Optional.ofNullable(credentials.get(config.passwordKey()));
         }
         return Optional.empty();
@@ -34,7 +34,7 @@ public class CredentialProviders {
         }
         if (config.name().isPresent()) {
             CredentialsProvider provider = lookup(config.beanName().orElse(null));
-            Map<String, String> credentials = provider.getCredentials(config.name().get());
+            Map<String, String> credentials = provider.getCredentialsAsync(config.name().get()).await().indefinitely();
             return Optional.ofNullable(credentials.get(config.aliasPasswordKey()));
         }
         return Optional.empty();
@@ -47,7 +47,7 @@ public class CredentialProviders {
         }
         if (config.name().isPresent()) {
             CredentialsProvider provider = lookup(config.beanName().orElse(null));
-            Map<String, String> credentials = provider.getCredentials(config.name().get());
+            Map<String, String> credentials = provider.getCredentialsAsync(config.name().get()).await().indefinitely();
             return Optional.ofNullable(credentials.get(config.passwordKey()));
         }
         return Optional.empty();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -136,7 +136,7 @@ public class HttpServerOptionsUtils {
             String beanName = sslConfig.certificate().credentialsProviderName().orElse(null);
             CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
             String name = sslConfig.certificate().credentialsProvider().get();
-            credentials = credentialsProvider.getCredentials(name);
+            credentials = credentialsProvider.getCredentialsAsync(name).await().indefinitely();
         }
 
         final Optional<String> keyStorePassword = getCredential(sslConfig.certificate().keyStorePassword(), credentials,


### PR DESCRIPTION
The synchronous method is deprecated and is invoked by the asynchronous variant.

Extensions must be updated to invoke the asynchronous variant.

- Closes: #32021