### PR TITLE
Make cachePreparedStatements Optional<Boolean> with database-specific defaults

### DIFF
--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -23,8 +23,8 @@ public interface DataSourceReactiveRuntimeConfig {
     /**
      * Whether prepared statements should be cached on the client side.
      */
-    @WithDefault("false")
-    boolean cachePreparedStatements();
+    @ConfigDocDefault("true for PostgreSQL/MySQL/MariaDB/Db2, false otherwise")
+    Optional<Boolean> cachePreparedStatements();
 
     /**
      * The datasource URLs.

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -49,6 +49,8 @@ import io.vertx.sqlclient.impl.Utils;
 @Recorder
 public class DB2PoolRecorder {
 
+    private static final boolean SUPPORTS_CACHE_PREPARED_STATEMENTS = true;
+
     private static final Logger log = Logger.getLogger(DB2PoolRecorder.class);
     private static final TypeLiteral<Instance<DB2PoolCreator>> POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
@@ -221,7 +223,8 @@ public class DB2PoolRecorder {
             }
         }
 
-        connectOptions.setCachePreparedStatements(dataSourceReactiveRuntimeConfig.cachePreparedStatements());
+        connectOptions.setCachePreparedStatements(
+                dataSourceReactiveRuntimeConfig.cachePreparedStatements().orElse(SUPPORTS_CACHE_PREPARED_STATEMENTS));
 
         connectOptions.setSsl(dataSourceReactiveDB2Config.ssl());
 

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -50,6 +50,8 @@ import io.vertx.sqlclient.impl.Utils;
 @Recorder
 public class MySQLPoolRecorder {
 
+    private static final boolean SUPPORTS_CACHE_PREPARED_STATEMENTS = true;
+
     private static final TypeLiteral<Instance<MySQLPoolCreator>> POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
@@ -224,7 +226,9 @@ public class MySQLPoolRecorder {
                 }
             }
 
-            mysqlConnectOptions.setCachePreparedStatements(dataSourceReactiveRuntimeConfig.cachePreparedStatements());
+            mysqlConnectOptions
+                    .setCachePreparedStatements(dataSourceReactiveRuntimeConfig.cachePreparedStatements()
+                            .orElse(SUPPORTS_CACHE_PREPARED_STATEMENTS));
 
             dataSourceReactiveMySQLConfig.charset().ifPresent(mysqlConnectOptions::setCharset);
             dataSourceReactiveMySQLConfig.collation().ifPresent(mysqlConnectOptions::setCollation);

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -49,6 +49,8 @@ import io.vertx.sqlclient.impl.Utils;
 @Recorder
 public class PgPoolRecorder {
 
+    private static final boolean SUPPORTS_CACHE_PREPARED_STATEMENTS = true;
+
     private static final TypeLiteral<Instance<PgPoolCreator>> PG_POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
@@ -215,7 +217,8 @@ public class PgPoolRecorder {
                 }
             }
 
-            pgConnectOptions.setCachePreparedStatements(dataSourceReactiveRuntimeConfig.cachePreparedStatements());
+            pgConnectOptions.setCachePreparedStatements(
+                    dataSourceReactiveRuntimeConfig.cachePreparedStatements().orElse(SUPPORTS_CACHE_PREPARED_STATEMENTS));
 
             if (dataSourceReactivePostgreSQLConfig.pipeliningLimit().isPresent()) {
                 pgConnectOptions.setPipeliningLimit(dataSourceReactivePostgreSQLConfig.pipeliningLimit().getAsInt());


### PR DESCRIPTION
Make cachePreparedStatements `Optional<Boolean>` with database-specific defaults

* Changing `cachePreparedStatements` from `boolean` to `Optional<Boolean>`
* Removing `@WithDefault` annotation and adding `@ConfigDocDefault` with clear documentation
* Setting database-specific defaults: `true` for supported databases (PostgreSQL, MySQL, MariaDB, DB2, MSSQL, Oracle), `false` otherwise
* Replacing magic boolean values with named constants (`SUPPORTS_CACHE_PREPARED_STATEMENTS`)
* Fixes #50010