### PR TITLE
Dev UI Agroal: Fix jdbc url parsing for url with ; in it

### DIFF
--- a/extensions/agroal/runtime-dev/src/main/java/io/quarkus/agroal/runtime/dev/ui/DatabaseInspector.java
+++ b/extensions/agroal/runtime-dev/src/main/java/io/quarkus/agroal/runtime/dev/ui/DatabaseInspector.java
@@ -453,6 +453,9 @@ public final class DatabaseInspector {
             return true;
         }
 
+        if (ads == null)
+            return false;
+
         try {
             AgroalDataSourceConfiguration configuration = ads.getConfiguration();
             String jdbcUrl = configuration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcUrl();
@@ -464,7 +467,7 @@ public final class DatabaseInspector {
                 return true;
             }
 
-            String cleanUrl = jdbcUrl.replace("jdbc:", "");
+            String cleanUrl = jdbcUrl.replace("jdbc:", "").replaceFirst(";", "?").replace(";", "&");
             URI uri = new URI(cleanUrl);
 
             String host = uri.getHost();


### PR DESCRIPTION
Fix #50014

@wjglerum - until this is merged and you use the fixed version, please try to set `quarkus.datasource.dev-ui.allowed-db-host=*` to bypass the url check that cause this issue. Let me know if that workaround works for you.