### PR TITLE
Add build timestamp to extension metadata

### DIFF
--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -367,7 +368,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         addCapabilities(extObject);
         addSource(extObject);
         addExtensionDependencies(extObject);
-
+        addBuildTimestamp(extObject);
         completeCodestartArtifact(mapper, extObject);
 
         final DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
@@ -380,6 +381,11 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             throw new MojoExecutionException(
                     "Failed to persist " + output.resolve(BootstrapConstants.QUARKUS_EXTENSION_FILE_NAME), e);
         }
+    }
+
+    private void addBuildTimestamp(ObjectNode extObject) {
+        ObjectNode metadata = getMetadataNode(extObject);
+        metadata.put("build-timestamp", Instant.now().toString());
     }
 
     private void recordDevModeConfig(Properties props) {


### PR DESCRIPTION
- Add support for including build timestamps in extension metadata.
- Integrate timestamp generation into the extension descriptor workflow.
- Build timestamp in the platform descriptor is performed in https://github.com/quarkusio/quarkus-platform-bom-generator/pull/385
