### PR TITLE
Bump to Mutiny 3.0.0 and Vert.x Mutiny Bindings 3.20.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.19.2</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.20.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.28.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
@@ -138,7 +138,7 @@
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <mutiny.version>2.9.4</mutiny.version>
+        <mutiny.version>3.0.0</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka3.version>4.0.0</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -47,7 +47,7 @@
         <version.gizmo>1.9.0</version.gizmo>
         <version.jandex>3.5.0</version.jandex>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
-        <version.mutiny>2.9.4</version.mutiny>
+        <version.mutiny>3.0.0</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.13.9</version.smallrye-common>
         <!-- test versions -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -44,7 +44,7 @@
         <version.gizmo2>2.0.0.Beta6</version.gizmo2>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.smallrye-common>2.13.9</version.smallrye-common>
-        <version.smallrye-mutiny>2.9.4</version.smallrye-mutiny>
+        <version.smallrye-mutiny>3.0.0</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -55,7 +55,7 @@
         <gizmo.version>1.9.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <mutiny.version>2.9.4</mutiny.version>
+        <mutiny.version>3.0.0</mutiny.version>
         <smallrye-common.version>2.13.9</smallrye-common.version>
         <vertx.version>4.5.21</vertx.version>
         <rest-assured.version>5.5.6</rest-assured.version>
@@ -66,7 +66,7 @@
         <yasson.version>3.0.4</yasson.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <smallrye-mutiny-vertx-core.version>3.19.2</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.20.0</smallrye-mutiny-vertx-core.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <mockito.version>5.19.0</mockito.version>
         <wiremock.version>3.13.1</wiremock.version>


### PR DESCRIPTION
This follows the release of [Mutiny 3.0.0](https://github.com/smallrye/smallrye-mutiny/releases/tag/3.0.0).

This is a major version bump according to semantic versioning due to the introduction of necessary breaking changes (again, see https://github.com/smallrye/smallrye-mutiny/releases/tag/3.0.0 with the notes on `Uni.join().all()` and the `.onFailure(type)` improvements).

Also, this is not to be backported. A `2.9.x` branch exists in Mutiny if need be.