### PR TITLE
Fix build failure when `quarkus-rest-data-panache` is used

### DIFF
--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
@@ -16,7 +16,6 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.rest.data.panache.deployment.utils.ResourceName;
-import io.quarkus.security.Authenticated;
 
 public class ResourcePropertiesProvider {
 
@@ -27,7 +26,7 @@ public class ResourcePropertiesProvider {
             io.quarkus.rest.data.panache.MethodProperties.class.getName());
 
     private static final List<String> ANNOTATIONS_TO_COPY = List.of(RolesAllowed.class.getPackageName(),
-            Authenticated.class.getPackageName(),
+            "io.quarkus.security.Authenticated",
             // To also support `@EndpointDisabled` if used
             "io.quarkus.resteasy.reactive.server");
 


### PR DESCRIPTION
`quarkus-rest-data-panache` does not depend on security, so we do not need to reference the `@Authenticated` annotation directly

The reason we never saw this in CI is that  all tests that include `quarkus-rest-data-panache` also include the REST layer, which transitively depends on `io.quarkus.security:quarkus-security`

If one built an application without the REST layer, then they would receive the following exception: 

```posh
[ERROR] Failed to execute goal io.quarkus.platform:quarkus-maven-plugin:3.26.3:build (default) on project code-with-quarkus: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]         [error]: Build step io.quarkus.rest.data.panache.deployment.RestDataProcessor#implementResources threw an exception: java.lang.NoClassDefFoundError: io/quarkus/security/Authenticated
[ERROR]         at io.quarkus.rest.data.panache.deployment.properties.ResourcePropertiesProvider.<clinit>(ResourcePropertiesProvider.java:29)
[ERROR]         at io.quarkus.rest.data.panache.deployment.RestDataProcessor.implementResources(RestDataProcessor.java:78)
[ERROR]         at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
[ERROR]         at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:874)
[ERROR]         at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
[ERROR]         at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1622)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
[ERROR]         at java.base/java.lang.Thread.run(Thread.java:1583)
[ERROR]         at org.jboss.threads.JBossThread.run(JBossThread.java:501)
[ERROR] Caused by: java.lang.ClassNotFoundException: io.quarkus.security.Authenticated
[ERROR]         at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:42)
[ERROR]         at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:225)
[ERROR]         at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:210)
[ERROR]         at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:205)
[ERROR]         at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:577)
[ERROR]         at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:524)
[ERROR]         ... 12 more
```