### PR TITLE
Add test which makes sure import.redis works for redis dev services

### DIFF
--- a/integration-tests/redis-devservices/src/main/resources/import.redis
+++ b/integration-tests/redis-devservices/src/main/resources/import.redis
@@ -1,0 +1,1 @@
+SET dog 'lassie'

--- a/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisTest.java
+++ b/integration-tests/redis-devservices/src/test/java/io/quarkus/redis/devservices/it/DevServicesRedisTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.redis.devservices.it.profiles.DevServiceRedis;
 import io.quarkus.test.junit.QuarkusTest;
@@ -32,10 +33,21 @@ public class DevServicesRedisTest {
 
     @Test
     @DisplayName("given redis container must communicate with it and return value by key")
-    public void shouldReturnAllKeys() {
+    public void shouldReturnKnownKey() {
         when().get("/get/anykey").then()
                 .statusCode(200)
                 .body(is("anyvalue"));
+    }
+
+    // For some reason, the quarkus.test.native isn't being set in the failsafe path with -Pnative
+    // We'll just use a different property that is being set instead
+    @DisabledIfSystemProperty(named = "native.image.path", matches = ".*", disabledReason = "Not working; tracked by https://github.com/quarkusio/quarkus/issues/50085")
+    @Test
+    @DisplayName("given redis container must have been preloaded with contents of import.redis")
+    public void shouldReturnPreloadKeys() {
+        when().get("/get/dog").then()
+                .statusCode(200)
+                .body(is("lassie"));
     }
 
 }


### PR DESCRIPTION
I noticed we cover preloading for the test resource case, but not for the dev service case.

Annoyingly, the test was reassuring for the JVM case, and profoundly unreassuring for the native case. So I've raised #50085. (Before doing the dev service rewrite, the native test would have failed anyway, but for different profile-management reasons.) I also couldn't disable the native test using the usual mechanism, for some reason.