### PR TITLE
Bump smallrye-reactive-messaging from 4.28.0 to 4.29.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -58,7 +58,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.20.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.28.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.29.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
[Release 4.29.0](https://github.com/smallrye/smallrye-reactive-messaging/milestone/114?closed=1)

  Major Features & Improvements:

  - Kafka Transactions promoted to tech preview
  - AMQP connector refactor - channels moved from connector bean to separate classes
  - AMQP Outgoing channel attribute for lazy/eager connection
  - JMS Connection reuse - ability to reuse Connection on JMSContext
  - MQTT client ID fix - use correct ID for identifying MQTT clients

  Bug Fixes:

  - Fixed flaky JMS disconnection test
  - Fixed context duplication not inheriting locals from owner context
  - Fixed Kafka transactions tech preview rev API