### PR TITLE
Fix deprecated javax Hibernate properties

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -503,12 +503,12 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                 persistenceUnitConfig.scripts().generation().generation());
 
         if (persistenceUnitConfig.scripts().generation().createTarget().isPresent()) {
-            runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_SCRIPTS_CREATE_TARGET,
+            runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_SCRIPTS_CREATE_TARGET,
                     persistenceUnitConfig.scripts().generation().createTarget().get());
         }
 
         if (persistenceUnitConfig.scripts().generation().dropTarget().isPresent()) {
-            runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_SCRIPTS_DROP_TARGET,
+            runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_SCRIPTS_DROP_TARGET,
                     persistenceUnitConfig.scripts().generation().dropTarget().get());
         }
 


### PR DESCRIPTION
Fixes two Hibernate property constants that were still referring to the javax variant, leading to deprecation warnings.