### PR TITLE
Change the max connections defaults for the Hibernate Search's Elasticsearch client

### DIFF
--- a/extensions/hibernate-search-backend-elasticsearch-common/runtime/src/main/java/io/quarkus/hibernate/search/backend/elasticsearch/common/runtime/HibernateSearchBackendElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-backend-elasticsearch-common/runtime/src/main/java/io/quarkus/hibernate/search/backend/elasticsearch/common/runtime/HibernateSearchBackendElasticsearchRuntimeConfig.java
@@ -68,13 +68,13 @@ public interface HibernateSearchBackendElasticsearchRuntimeConfig {
     /**
      * The maximum number of connections to all the Elasticsearch servers.
      */
-    @WithDefault("20")
+    @WithDefault("40")
     int maxConnections();
 
     /**
      * The maximum number of connections per Elasticsearch server.
      */
-    @WithDefault("10")
+    @WithDefault("20")
     int maxConnectionsPerRoute();
 
     /**


### PR DESCRIPTION
To match the defaults we set in Hibernate Search itself.

We have bumped the defaults in Search 8.0: https://hibernate.atlassian.net/browse/HSEARCH-5045
However, it appears that we never applied them to Quarkus. So this PR is to address that.

cc: @yrodiere 

and a migration note could be:

```adoc
== Hibernate Search

[[hibernate-search-client-defaults]]
=== Hibernate Search Elasticsearch client's defaults

Quarkus changes the defaults for the following Elasticsearch client configuration properties:

* `quarkus.hibernate-search-[orm|standalone].elasticsearch.max-connections` will be `40` by default, instead of `20`
* `quarkus.hibernate-search-[orm|standalone].elasticsearch.max-connections-per-route` will be `20` by default, instead of `10`

This is done to match the change in Hibernate Search itself that aims to prevent a potential consumption of
all connections by the indexing queues, leaving no available connections for search requests.

To keep the previous default Elasticsearch configuration, set the following configuration properties
(pick either `orm` or `standalone` variant depending on the Hibernate Search extension used):

[source,properties]
----
quarkus.hibernate-search-[orm|standalone].elasticsearch.max-connections=20
quarkus.hibernate-search-[orm|standalone].elasticsearch.max-connections-per-route=10
----
```

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

