### PR TITLE
Fix mouse move on active cards

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -233,7 +233,7 @@ export class QwcExtensions extends observeState(LitElement) {
             let logoUrl = this._getLogoUrl(extension);
             return html`
                 <qwc-extension 
-                    class="active"
+                    clazz="active"
                     name="${extension.name}" 
                     description="${extension.description}"
                     guide="${extension.guide}"
@@ -290,7 +290,7 @@ export class QwcExtensions extends observeState(LitElement) {
                 let logoUrl = this._getLogoUrl(extension);
 
                 return html`<qwc-extension
-                    class="inactive"
+                    clazz="inactive"
                     name="${extension.name}" 
                     description="${extension.description}" 
                     guide="${extension.guide}"


### PR DESCRIPTION
This regression was introduced in #50006 and makes the move move not work on the cards. (The move move shows the docs links and some more clickable actions)