### PR TITLE
Correctly handle multiple Set-Cookie headers for API Gateway v2

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -109,7 +109,7 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                             continue;
                         }
                         // Handle cookies separately to preserve commas in the header values
-                        if ("set-cookie".equals(name)) {
+                        if ("set-cookie".equalsIgnoreCase(name)) {
                             responseBuilder.setCookies(allForName);
                             continue;
                         }

--- a/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/CookiesResource.java
+++ b/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/CookiesResource.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.amazon.lambda;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+
+@Path("/cookies")
+@Produces(MediaType.APPLICATION_JSON)
+public class CookiesResource {
+
+    @GET
+    @Path("/one/{name}")
+    public Response one(@PathParam("name") String name) {
+        NewCookie cookie = buildCookie("cookie1", name);
+        return Response.ok("{\"status\":\"ok\"}").cookie(cookie).build();
+    }
+
+    @GET
+    @Path("/two/{name1}/{name2}")
+    public Response two(@PathParam("name1") String name1, @PathParam("name2") String name2) {
+        NewCookie cookie1 = buildCookie("cookie1", name1);
+        NewCookie cookie2 = buildCookie("cookie2", name2);
+        return Response.ok("{\"status\":\"ok\"}").cookie(cookie1, cookie2).build();
+    }
+
+    private static NewCookie buildCookie(String name, String value) {
+        return new NewCookie.Builder(name)
+                .value(value)
+                .path("/")
+                .maxAge(3600)
+                .secure(true)
+                .httpOnly(true)
+                .sameSite(NewCookie.SameSite.LAX)
+                .build();
+    }
+}


### PR DESCRIPTION
Multiple Set-Cookie headers were merged into a single header when running Quarkus as an AWS Lambda behind API Gateway v2. The cause was a case-sensitive check for "set-cookie" in LambdaHttpHandler, while Vert.x HeadersMultiMap normalizes names (e.g., "Set-Cookie") and is case-insensitive. As a result, cookie values were treated as regular headers and comma-joined, breaking multiple-cookie scenarios.

Change the comparison to equalsIgnoreCase and route Set-Cookie values to the API Gateway v2 cookies array, preserving each cookie as a separate entry and omitting headers.'Set-Cookie' in the Lambda response.

Also add tests and a small resource to verify behavior:
- CookiesResource to emit one or two cookies via JAX-RS.
- AmazonLambdaSimpleTestCase:
  - testSingleCookieByEvent and testMultipleCookiesByEvent assert cookies[] is populated and headers.'Set-Cookie' is absent for API Gateway v2 events.
  - testMultipleCookiesDirectHttp asserts direct HTTP responses still return multiple Set-Cookie headers.

References:
- API Gateway v2 Lambda payload: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

- Fixes: #50075

