### PR TITLE
Simplify inference of the SupportedDbKind and avoid NoClassDefFoundError on `CommunityDatabase`

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -1056,7 +1056,6 @@ public final class HibernateOrmProcessor {
                 explicitDbMinVersion,
                 dialectConfig,
                 dbKindMetadataBuildItems,
-                persistenceUnitConfig.dialect().storageEngine(),
                 systemProperties,
                 puPropertiesCollector,
                 storageEngineCollector);

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -392,7 +392,6 @@ public final class HibernateReactiveProcessor {
                 explicitDbMinVersion,
                 dialectConfig,
                 dbKindDialectBuildItems,
-                persistenceUnitConfig.dialect().storageEngine(),
                 systemProperties,
                 descriptor.getProperties()::setProperty,
                 storageEngineCollector);


### PR DESCRIPTION
Second commit is the one that matters.

We used to try to derive it from the dbKind string, falling back to
attempting to interpret the Hibernate ORM "DB Product Name".

But the "DB Product Name" can only be set in situation where *we have a
dbKind string already*, so the fallback is pointless.

Since the fallback also has problems (use of `CommunityDatabase` which is
not necessarily in the classpath), we might as well remove it.

* Fixes #50141
