### PR TITLE
Test that Hibernate Validator does not attempt to fetch lazy associations with Hibernate Reactive

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/MyLazyChildEntity.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/MyLazyChildEntity.java
@@ -1,0 +1,64 @@
+package io.quarkus.hibernate.reactive.validation;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+
+@Table(name = "my_lazy_entity_child_table")
+@Entity
+public class MyLazyChildEntity {
+    public interface SomeGroup {
+    }
+
+    public static final String ENTITY_NAME_TOO_LONG = "entity name too long";
+    private long id;
+
+    // Use a non-default validation group so that validation won't trigger an exception on persist:
+    @Size(max = 5, message = ENTITY_NAME_TOO_LONG, groups = { SomeGroup.class })
+    private String name;
+
+    private MyLazyEntity parent;
+
+    public MyLazyChildEntity() {
+    }
+
+    public MyLazyChildEntity(String name) {
+        this.name = name;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @ManyToOne
+    public MyLazyEntity getParent() {
+        return parent;
+    }
+
+    public void setParent(MyLazyEntity parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public String toString() {
+        return "MyLazyChildEntity:" + name;
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/MyLazyEntity.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/MyLazyEntity.java
@@ -1,0 +1,61 @@
+package io.quarkus.hibernate.reactive.validation;
+
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+
+@Table(name = "my_lazy_entity_table")
+@Entity
+public class MyLazyEntity {
+    private long id;
+
+    private String name;
+
+    private Set<@Valid MyLazyChildEntity> children;
+
+    public MyLazyEntity() {
+    }
+
+    public MyLazyEntity(String name) {
+        this.name = name;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    public Set<MyLazyChildEntity> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Set<MyLazyChildEntity> children) {
+        this.children = children;
+    }
+
+    @Override
+    public String toString() {
+        return "MyLazyEntity:" + name;
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/ReactiveTestValidationTraversableResolverResource.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/ReactiveTestValidationTraversableResolverResource.java
@@ -1,0 +1,57 @@
+package io.quarkus.hibernate.reactive.validation;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/validation")
+@ApplicationScoped
+public class ReactiveTestValidationTraversableResolverResource {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Inject
+    Validator validator;
+
+    @POST
+    public Uni<Long> save() {
+        return sessionFactory.withTransaction(s -> {
+            MyLazyEntity entity = new MyLazyEntity();
+            entity.setName("name");
+            MyLazyChildEntity childEntity = new MyLazyChildEntity();
+            childEntity.setParent(entity);
+            childEntity.setName("123456789012345"); // should fail validation for the `SomeGroup` validation group.
+            entity.setChildren(Set.of(childEntity));
+            return s.persist(entity).map(v -> entity.getId());
+        });
+    }
+
+    @GET
+    @Path("/{id}")
+    public Uni<String> testPass(@PathParam("id") Long id) {
+        return sessionFactory.withTransaction(s -> s.find(MyLazyEntity.class, id)
+                // since the Validator shouldn't fetch a lazy association, there should be no failures here:
+                .map(e -> validator.validate(e, MyLazyChildEntity.SomeGroup.class).isEmpty() ? "OK" : "KO"));
+    }
+
+    @GET
+    @Path("/fail/{id}")
+    public Uni<String> testFail(@PathParam("id") Long id) {
+        return sessionFactory.withTransaction(s -> s.find(MyLazyEntity.class, id)
+                .chain(e -> Mutiny.fetch(e.getChildren()).map(c -> e))
+                // Validating for a SomeGroup validation group should trigger a single constraint failure on a child object
+                .map(e -> validator.validate(e, MyLazyChildEntity.SomeGroup.class).size() == 1 ? "OK" : "KO"));
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/ReactiveValidationTraversableResolverTestCase.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/validation/ReactiveValidationTraversableResolverTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.hibernate.reactive.validation;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ReactiveValidationTraversableResolverTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyLazyEntity.class, MyLazyChildEntity.class,
+                            ReactiveTestValidationTraversableResolverResource.class)
+                    .addAsResource("application.properties")
+                    .addAsResource(new StringAsset(""), "import.sql")); // define an empty import.sql file
+
+    @Test
+    public void testPass() {
+        Long id = Long.parseLong(RestAssured.post("/validation")
+                .body()
+                .asString());
+        RestAssured.get("/validation/{id}", id)
+                .then()
+                .statusCode(200)
+                .body(containsString("OK"));
+    }
+
+    @Test
+    public void testFail() {
+        Long id = Long.parseLong(RestAssured.post("/validation")
+                .body()
+                .asString());
+        RestAssured.get("/validation/fail/{id}", id)
+                .then()
+                .statusCode(200)
+                .body(containsString("OK"));
+    }
+
+}


### PR DESCRIPTION
All seems to be fine with the HR case: the Quarkus-custom traversable resolver is set (same one as for ORM), and HV does not attempt to fetch any lazy associations when performing validation. 🤞🏻 🙂 

* Fixes #49865

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

