### PR TITLE
PathTreeVisit - Use a very simple implementation to relativize Path

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeVisit.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeVisit.java
@@ -89,7 +89,7 @@ class PathTreeVisit implements PathVisit {
     @Override
     public String getRelativePath(String separator) {
         if (relativePath == null) {
-            return PathTreeUtils.asString(baseDir.relativize(current), separator);
+            return PathTreeUtils.asString(relativize(baseDir, current), separator);
         }
         if (!current.getFileSystem().getSeparator().equals(separator)) {
             return relativePath.replace(current.getFileSystem().getSeparator(), separator);
@@ -127,5 +127,18 @@ class PathTreeVisit implements PathVisit {
             current = baseDir.resolve(mrEntry.getValue());
             visitor.visitPath(this);
         }
+    }
+
+    /**
+     * In this particular setup, we are sure the current path is inside the baseDir.
+     * We also don't expect any {@code ..} or {@code .} in the path.
+     * Thus why we are using a simplified approach as UnixPath#relativize() is actually quite slow
+     * when you have a lot of elements in the classpath.
+     */
+    private static Path relativize(Path baseDir, Path current) {
+        if (baseDir.equals(current)) {
+            return current.getFileSystem().getPath("");
+        }
+        return current.subpath(baseDir.getNameCount(), current.getNameCount());
     }
 }


### PR DESCRIPTION
When in PathTreeVisit, we are in a very controlled environement, and we shouldn't have bad surprises with Paths.
I stumbled upon the fact that relativizing the Paths was actually quite costly in allocations, especially for UnixPath.
This PR introduces an extremely simple implementation that should be good enough in the controlled environment that is PathTreeVisit.

I checked that all the relative Paths generated in my sample app were equals to the old ones.

Before:

<img width="3332" height="1041" alt="Screenshot From 2025-09-19 14-58-47" src="https://github.com/user-attachments/assets/dc0203d8-ab8a-4103-bbd2-9c7cbc3bba49" />

After:

<img width="3332" height="1041" alt="Screenshot From 2025-09-19 14-58-40" src="https://github.com/user-attachments/assets/7aa78ef9-53d8-4436-8e08-cfbd2e36f136" />
