### PR TITLE
Make the `KubernetesClient` ApplicationScoped rather than Singleton

### DIFF
--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
@@ -1,6 +1,7 @@
 package io.quarkus.kubernetes.client.runtime;
 
 import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
@@ -16,7 +17,7 @@ public class KubernetesClientProducer {
     private KubernetesClient client;
 
     @DefaultBean
-    @Singleton
+    @ApplicationScoped
     @Produces
     public KubernetesClient kubernetesClient(KubernetesSerialization kubernetesSerialization, Config config) {
         client = new KubernetesClientBuilder()


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->
Switch the `KubernetesClient` from `Singleton` to `ApplicationScoped` so that it becomes possible to mock the Kubernetes client in tests.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
- Closes: #50201 
