### PR TITLE
ArC: fix NPE in InvokerGenerator

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InvokerGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InvokerGenerator.java
@@ -28,6 +28,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.JandexReflection;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.PrimitiveType;
+import org.jboss.jandex.PrimitiveType.Primitive;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
 import org.jboss.logging.Logger;
@@ -405,7 +406,7 @@ public class InvokerGenerator extends AbstractGenerator {
             bytecode = ifNotInstanceOf.trueBranch();
         }
         // widening conversions
-        for (ClassType possibleSourceType : WIDENING_CONVERSIONS_TO.get(targetType)) {
+        for (ClassType possibleSourceType : WIDENING_CONVERSIONS_TO.get(targetType.primitive())) {
             ResultHandle isInstance = bytecode.instanceOf(value, possibleSourceType.name().toString());
             BranchResult ifNotInstanceOf = bytecode.ifFalse(isInstance);
             BytecodeCreator unbox = ifNotInstanceOf.falseBranch();
@@ -431,18 +432,18 @@ public class InvokerGenerator extends AbstractGenerator {
         bytecode.throwException(exception);
     }
 
-    private static final Map<PrimitiveType, Set<ClassType>> WIDENING_CONVERSIONS_TO = Map.of(
-            PrimitiveType.BOOLEAN, Set.of(),
-            PrimitiveType.BYTE, Set.of(),
-            PrimitiveType.SHORT, Set.of(ClassType.BYTE_CLASS),
-            PrimitiveType.INT, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.CHARACTER_CLASS),
-            PrimitiveType.LONG, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.INTEGER_CLASS,
+    private static final Map<Primitive, Set<ClassType>> WIDENING_CONVERSIONS_TO = Map.of(
+            Primitive.BOOLEAN, Set.of(),
+            Primitive.BYTE, Set.of(),
+            Primitive.SHORT, Set.of(ClassType.BYTE_CLASS),
+            Primitive.INT, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.CHARACTER_CLASS),
+            Primitive.LONG, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.INTEGER_CLASS,
                     ClassType.CHARACTER_CLASS),
-            PrimitiveType.FLOAT, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.INTEGER_CLASS,
+            Primitive.FLOAT, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.INTEGER_CLASS,
                     ClassType.LONG_CLASS, ClassType.CHARACTER_CLASS),
-            PrimitiveType.DOUBLE, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.INTEGER_CLASS,
+            Primitive.DOUBLE, Set.of(ClassType.BYTE_CLASS, ClassType.SHORT_CLASS, ClassType.INTEGER_CLASS,
                     ClassType.LONG_CLASS, ClassType.FLOAT_CLASS, ClassType.CHARACTER_CLASS),
-            PrimitiveType.CHAR, Set.of());
+            Primitive.CHAR, Set.of());
 
     static class FinisherGenerator {
         private final MethodCreator method;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/invoker/basic/PrimitiveParamWithTypeAnnotationInvokerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/invoker/basic/PrimitiveParamWithTypeAnnotationInvokerTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arc.test.invoker.basic;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.invoke.Invoker;
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.invoker.InvokerHelper;
+import io.quarkus.arc.test.invoker.InvokerHelperRegistrar;
+
+public class PrimitiveParamWithTypeAnnotationInvokerTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyService.class, Min.class)
+            .beanRegistrars(new InvokerHelperRegistrar(MyService.class, (bean, factory, invokers) -> {
+                MethodInfo hello = bean.getImplClazz().firstMethod("hello");
+                invokers.put("hello", factory.createInvoker(bean, hello).build());
+            }))
+            .build();
+
+    @Test
+    public void test() throws Exception {
+        InvokerHelper helper = Arc.container().instance(InvokerHelper.class).get();
+
+        InstanceHandle<MyService> service = Arc.container().instance(MyService.class);
+
+        Invoker<MyService, String> hello = helper.getInvoker("hello");
+        assertEquals("hello_18", hello.invoke(service.get(), new Object[] { 18 }));
+    }
+
+    @Singleton
+    public static class MyService {
+        public String hello(@Min int age) {
+            return "hello_" + age;
+        }
+    }
+
+    @Target({ METHOD, FIELD, TYPE_USE })
+    @Retention(RUNTIME)
+    @Documented
+    public @interface Min {
+    }
+}


### PR DESCRIPTION
- when a primitive param is annotated with a type annotation

Unfortunately, the only workaround I can see is to avoid using primitives and use the wrapper types instead.

Fixes #50225.