### PR TITLE
Update devservice strimzi Kafka image to 4.1.0

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -82,7 +82,7 @@ For Strimzi, you can select any image with a Kafka version which has Kraft suppo
 
 [source, properties]
 ----
-quarkus.kafka.devservices.image-name=quay.io/strimzi-test-container/test-container:0.106.0-kafka-3.7.0
+quarkus.kafka.devservices.image-name=quay.io/strimzi-test-container/test-container:0.112.0-kafka-4.1.0
 ----
 
 == Configuring Kafka topics

--- a/docs/src/main/asciidoc/kafka-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-getting-started.adoc
@@ -403,38 +403,19 @@ You can follow the instructions from the https://kafka.apache.org/quickstart[Apa
 
 [source, yaml]
 ----
-version: '3.5'
-
 services:
 
-  zookeeper:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    kafka:
+    image: quay.io/strimzi/kafka:latest-kafka-4.1.0
     command: [
       "sh", "-c",
-      "bin/zookeeper-server-start.sh config/zookeeper.properties"
+      "./bin/kafka-storage.sh format --standalone -t $$(./bin/kafka-storage.sh random-uuid) -c ./config/server.properties && ./bin/kafka-server-start.sh ./config/server.properties --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS}"
     ]
-    ports:
-      - "2181:2181"
-    environment:
-      LOG_DIR: /tmp/logs
-    networks:
-      - kafka-quickstart-network
-
-  kafka:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
-    command: [
-      "sh", "-c",
-      "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
-    ]
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
     environment:
       LOG_DIR: "/tmp/logs"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
     networks:
       - kafka-quickstart-network
 

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -319,39 +319,21 @@ Create a `docker-compose.yaml` file at the root of the project with the followin
 
 [source,yaml]
 ----
-version: '2'
-
 services:
 
-  zookeeper:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
-    command: [
-        "sh", "-c",
-        "bin/zookeeper-server-start.sh config/zookeeper.properties"
-    ]
-    ports:
-      - "2181:2181"
-    environment:
-      LOG_DIR: /tmp/logs
-
   kafka:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    image: quay.io/strimzi/kafka:latest-kafka-4.1.0
     command: [
-        "sh", "-c",
-        "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
+      "sh", "-c",
+      "./bin/kafka-storage.sh format --standalone -t $$(./bin/kafka-storage.sh random-uuid) -c ./config/server.properties && ./bin/kafka-server-start.sh ./config/server.properties"
     ]
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
     environment:
       LOG_DIR: "/tmp/logs"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:2.4.2.Final
+    image: apicurio/apicurio-registry-mem:2.6.13.Final
     ports:
       - 8081:8080
     depends_on:
@@ -545,7 +527,7 @@ If we couldn't use Dev Services and wanted to start a Kafka broker and Apicurio 
 <dependency>
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
-    <version>0.105.0</version>
+    <version>0.112.0</version>
     <scope>test</scope>
     <exclusions>
         <exclusion>
@@ -559,7 +541,7 @@ If we couldn't use Dev Services and wanted to start a Kafka broker and Apicurio 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-testImplementation("io.strimzi:strimzi-test-container:0.105.0") {
+testImplementation("io.strimzi:strimzi-test-container:0.112.0") {
     exclude group: "org.apache.logging.log4j", module: "log4j-core"
 }
 ----

--- a/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
@@ -347,39 +347,21 @@ Create a `docker-compose.yaml` file at the root of the project with the followin
 
 [source,yaml]
 ----
-version: '2'
-
 services:
 
-  zookeeper:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
-    command: [
-        "sh", "-c",
-        "bin/zookeeper-server-start.sh config/zookeeper.properties"
-    ]
-    ports:
-      - "2181:2181"
-    environment:
-      LOG_DIR: /tmp/logs
-
   kafka:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    image: quay.io/strimzi/kafka:latest-kafka-4.1.0
     command: [
-        "sh", "-c",
-        "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
+      "sh", "-c",
+      "./bin/kafka-storage.sh format --standalone -t $$(./bin/kafka-storage.sh random-uuid) -c ./config/server.properties && ./bin/kafka-server-start.sh ./config/server.properties"
     ]
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
     environment:
       LOG_DIR: "/tmp/logs"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:2.4.2.Final
+    image: apicurio/apicurio-registry-mem:2.6.13.Final
     ports:
       - 8081:8080
     depends_on:
@@ -573,7 +555,7 @@ If we couldn't use Dev Services and wanted to start a Kafka broker and Apicurio 
 <dependency>
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
-    <version>0.105.0</version>
+    <version>0.112.0</version>
     <scope>test</scope>
     <exclusions>
         <exclusion>
@@ -587,7 +569,7 @@ If we couldn't use Dev Services and wanted to start a Kafka broker and Apicurio 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-testImplementation("io.strimzi:strimzi-test-container:0.105.0") {
+testImplementation("io.strimzi:strimzi-test-container:0.112.0") {
     exclude group: "org.apache.logging.log4j", module: "log4j-core"
 }
 ----

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -491,41 +491,24 @@ This is done in order to demonstrate scaling the `aggregator` aggregation to mul
 The `Dockerfile` created by Quarkus by default needs one adjustment for the `aggregator` application in order to run the Kafka Streams pipeline.
 To do so, edit the file `aggregator/src/main/docker/Dockerfile.jvm` and replace the line `FROM fabric8/java-alpine-openjdk8-jre` with `FROM fabric8/java-centos-openjdk8-jdk`.
 
-Next create a Docker Compose file (`docker-compose.yaml`) for spinning up the two applications as well as Apache Kafka and ZooKeeper like so:
+Next create a Docker Compose file (`docker-compose.yaml`) for spinning up the two applications as well as Apache Kafka like so:
 
 [source, yaml]
 ----
-version: '3.5'
-
 services:
-  zookeeper:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
-    command: [
-      "sh", "-c",
-      "bin/zookeeper-server-start.sh config/zookeeper.properties"
-    ]
-    ports:
-      - "2181:2181"
-    environment:
-      LOG_DIR: /tmp/logs
-    networks:
-      - kafkastreams-network
   kafka:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    image: quay.io/strimzi/kafka:latest-kafka-4.1.0
     command: [
       "sh", "-c",
-      "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT} --override num.partitions=$${KAFKA_NUM_PARTITIONS}"
+      "./bin/kafka-storage.sh format --standalone -t $$(./bin/kafka-storage.sh random-uuid) -c ./config/server.properties && ./bin/kafka-server-start.sh ./config/server.properties --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override num.partitions=$${KAFKA_NUM_PARTITIONS} --override group.min.session.timeout.ms=$${KAFKA_GROUP_MIN_SESSION_TIMEOUT_MS}"
     ]
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
     environment:
       LOG_DIR: "/tmp/logs"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
       KAFKA_NUM_PARTITIONS: 3
+      KAFKA_GROUP_MIN_SESSION_TIMEOUT_MS: 100
     networks:
       - kafkastreams-network
 
@@ -566,7 +549,7 @@ This image provides several useful tools such as _kafkacat_ and _httpie_:
 
 [source,bash,subs=attributes+]
 ----
-docker run --tty --rm -i --network ks debezium/tooling:1.1
+docker run --tty --rm -i --network ks debezium/tooling:latest
 ----
 
 Within the tooling container, run _kafkacat_ to examine the results of the streaming pipeline:

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -2475,7 +2475,7 @@ The configuration of the created Kafka broker can be customized using `@Resource
 [source,java]
 ----
 @QuarkusTestResource(value = KafkaCompanionResource.class, initArgs = {
-        @ResourceArg(name = "strimzi.kafka.image", value = "quay.io/strimzi-test-container/test-container:0.106.0-kafka-3.7.0"), // Image name
+        @ResourceArg(name = "strimzi.kafka.image", value = "quay.io/strimzi-test-container/test-container:0.112.0-kafka-4.1.0"), // Image name
         @ResourceArg(name = "kafka.port", value = "9092"), // Fixed port for kafka, by default it will be exposed on a random port
         @ResourceArg(name = "kraft", value = "true"), // Enable Kraft mode
         @ResourceArg(name = "num.partitions", value = "3"), // Other custom broker configurations

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -45,7 +45,7 @@ public interface KafkaDevServicesBuildTimeConfig {
 
     enum Provider {
         REDPANDA("docker.io/redpandadata/redpanda:v24.1.2"),
-        STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.7.0"),
+        STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-4.1.0"),
         KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
 
         private final String defaultImageName;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

The https://github.com/quarkusio/quarkus/pull/50032 updated the strimzi testcontainer to 0.112.0 and make few modification to only start the Kafka container with KRaft. This caused that the container not start, when running the devmode with Strimzi Kafka  (`quarkus dev -Dquarkus.kafka.devservices.provider=strimzi`).

This PR update `test-container:latest-kafka-3.7.0 -> test-container:latest-kafka-4.1.0`.

Also update the docs + quickstarts to move from old version of Kafka to 4.1.0 and use KRaft (Quickstart PR https://github.com/quarkusio/quarkus-quickstarts/pull/1568)

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

