### PR TITLE
Reduce allocations due to ClassLoader#defineClassSourceLocation

### DIFF
--- a/integration-tests/maven/src/test/resources-filtered/projects/classic/src/main/java/org/acme/ProtectionDomain.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic/src/main/java/org/acme/ProtectionDomain.java
@@ -6,7 +6,10 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import java.nio.charset.StandardCharsets;
@@ -46,8 +49,9 @@ public class ProtectionDomain {
 
     private String assertReadManifestFromJar() {
         final String testType = "manifest-from-jar";
+        URL location = null;
         try {
-            URL location = org.apache.commons.io.Charsets.class.getProtectionDomain().getCodeSource().getLocation();
+            location = org.apache.commons.io.Charsets.class.getProtectionDomain().getCodeSource().getLocation();
             if (location == null) {
                 return errorResult(testType, "location should not be null");
             }
@@ -66,12 +70,19 @@ public class ProtectionDomain {
             }
             return SUCCESS;
         } catch (Exception e) {
-            e.printStackTrace();
-            return errorResult(testType, "exception during resolution of resource");
+            return errorResult(testType, "Exception during resolution of resource (" + location + "): " + e + "\n" + getStackTraceAsString(e));
         }
     }
 
     private String errorResult(String testType, String message) {
         return testType + " / " + message;
+    }
+
+    private static String getStackTraceAsString(Throwable t) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            t.printStackTrace(pw);
+        }
+        return sw.toString();
     }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/java/org/acme/ProtectionDomain.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/java/org/acme/ProtectionDomain.java
@@ -6,6 +6,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URL;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
@@ -46,8 +48,9 @@ public class ProtectionDomain {
 
     private String assertReadManifestFromJar() {
         final String testType = "manifest-from-jar";
+        URL location = null;
         try {
-            URL location = org.apache.commons.io.Charsets.class.getProtectionDomain().getCodeSource().getLocation();
+            location = org.apache.commons.io.Charsets.class.getProtectionDomain().getCodeSource().getLocation();
             if (location == null) {
                 return errorResult(testType, "location should not be null");
             }
@@ -66,12 +69,19 @@ public class ProtectionDomain {
             }
             return SUCCESS;
         } catch (Exception e) {
-            e.printStackTrace();
-            return errorResult(testType, "exception during resolution of resource");
+            return errorResult(testType, "Exception during resolution of resource (" + location + "): " + e + "\n" + getStackTraceAsString(e));
         }
     }
 
     private String errorResult(String testType, String message) {
         return testType + " / " + message;
+    }
+
+    private static String getStackTraceAsString(Throwable t) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            t.printStackTrace(pw);
+        }
+        return sw.toString();
     }
 }


### PR DESCRIPTION
It will call URL#toExternalForm() for each class, which will generate again and again the same string pointing to the jar files.

By introducing a specific URLStreamHandler, we are able to avoid calling URL#toExternalForm() and use a cached version of it for each JarResource.

While not making a tremendous difference, it is an easy way to reduce our allocations at startup.

<img width="3004" height="414" alt="Screenshot From 2025-09-23 15-09-57" src="https://github.com/user-attachments/assets/fa1cfb03-9e7c-4b38-8692-d4993e796555" />
