### PR TITLE
Use annotationProcessorPathsUseDepMgmt in Jakarta Data docs

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1772,6 +1772,10 @@ you must configure it accordingly in your build tool:
 <plugin>
     <artifactId>maven-compiler-plugin</artifactId>
     <configuration>
+        <!-- This setting is required for the annotation processor dependencies to be managed by Quarkus.
+             More information is available in Maven compiler plugin documentation:
+             https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPathsUseDepMgmt -->
+        <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
         <annotationProcessorPaths>
             <path>
                 <groupId>org.hibernate.orm</groupId>


### PR DESCRIPTION
* Adding Maven compile plugin configuration ensuring that the dependencies of annotation processor are managed by Quarkus to Jakarta Data docs.