### PR TITLE
Changes that allows Mcp usage from Chappie

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -682,6 +682,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devui-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-devui-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
@@ -61,7 +61,7 @@ public class MCPProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     @io.quarkus.deployment.annotations.Record(ExecutionTime.STATIC_INIT)
-    void registerDevUiHandlers(
+    void registerStreamableHTTPHandlers(
             BuildProducer<RouteBuildItem> routeProducer,
             DevUIRecorder recorder,
             LaunchModeBuildItem launchModeBuildItem,

--- a/extensions/devui/pom.xml
+++ b/extensions/devui/pom.xml
@@ -19,5 +19,6 @@
         <module>deployment</module>
         <module>test-spi</module>
         <module>deployment-spi</module>
+        <module>runtime-spi</module>
     </modules>
 </project>

--- a/extensions/devui/runtime-spi/pom.xml
+++ b/extensions/devui/runtime-spi/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-devui-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-devui-spi</artifactId>
+    <name>Quarkus - Dev UI - Runtime SPI</name>
+    <description>Quarkus Dev UI SPI</description>
+    
+</project>

--- a/extensions/devui/runtime-spi/src/main/java/io/quarkus/devui/runtime/spi/McpEvent.java
+++ b/extensions/devui/runtime-spi/src/main/java/io/quarkus/devui/runtime/spi/McpEvent.java
@@ -1,0 +1,4 @@
+package io.quarkus.devui.runtime.spi;
+
+public record McpEvent(boolean enabled) {
+}

--- a/extensions/devui/runtime-spi/src/main/java/io/quarkus/devui/runtime/spi/McpServerConfiguration.java
+++ b/extensions/devui/runtime-spi/src/main/java/io/quarkus/devui/runtime/spi/McpServerConfiguration.java
@@ -1,4 +1,4 @@
-package io.quarkus.devui.runtime.mcp;
+package io.quarkus.devui.runtime.spi;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/extensions/devui/runtime/pom.xml
+++ b/extensions/devui/runtime/pom.xml
@@ -22,6 +22,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-assistant-dev</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devui-spi</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
@@ -12,6 +12,7 @@ import io.quarkus.devui.runtime.jsonrpc.JsonRpcCodec;
 import io.quarkus.devui.runtime.jsonrpc.JsonRpcRequest;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.runtime.mcp.model.InitializeResponse;
+import io.quarkus.devui.runtime.spi.McpServerConfiguration;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;


### PR DESCRIPTION
This PR allows other extensions (in this case Chappie) to get the Dev MCP Server settings. This is needed to enable Dev MCP support in the Chappie Chat.