### PR TITLE
Add OIDC CacheControl configuration

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -575,6 +575,7 @@ Session cookie is created after an authorizaion code flow is completed. An expir
 |quarkus.oidc.token.refresh-token-time-skew || Refresh token time skew
 |quarkus.oidc.authentication.session-age-extension |5 minutes| Session age extension
 |quarkus.oidc.authentication.session-expired-path || Session expired path
+|quarkus.oidc.authentication.cache-control || Set of Cache-Control header directives
 |====
 
 `quarkus.oidc.token.refresh-expired` can be used to enable automatic user session renewal when the user session has expired and the refresh token is available. This property is not enabled by default because with the automatic renewal, the user, after authenticating once, may not be asked to re-authenticate for a very long time. Therefore an admin level decision may be required to enable an automatic session renewal.
@@ -591,6 +592,9 @@ The `quarkus.oidc.token.refresh-token` property is automatically enabled if the 
 `quarkus.oidc.authentication.session-expired-path` can be used to present the user whose session has expired with the page explaining that the session has expired and letting user follow a link to re-authenticate. It improves the user experience, since otherwise, the authenticated user, whose session has expired, may get surprised after getting an unexpected OIDC provider's authentication challenge screen, when accessing the Quarkus application, following some delay after successfully authenticating earlier.
 
 See also the <<token-state-manager>> section for more information about managing session cookies.
+
+When a new session cookie is created, either after a successful authorization code flow completion or a token refresh, it may be necessary to control how the session cookie is managed by HTTP cache intermediaries and the browser cache.
+Currently, only a `Cache-Control` `no-store` directive that prohibits caching the session cookie anywhere in the client request chain can be configured.
 
 [[token-state-manager]]
 == Store authorization code flow tokens

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1819,6 +1819,8 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
          */
         public Optional<String> stateSecret = Optional.empty();
 
+        public Optional<Set<CacheControl>> cacheControl = Optional.empty();
+
         public Optional<Duration> getInternalIdTokenLifespan() {
             return internalIdTokenLifespan;
         }
@@ -2061,6 +2063,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             this.sessionExpiredPath = Optional.of(sessionExpiredPath);
         }
 
+        @Override
+        public Optional<Set<CacheControl>> cacheControl() {
+            return cacheControl;
+        }
+
         private void addConfigMappingValues(io.quarkus.oidc.runtime.OidcTenantConfig.Authentication mapping) {
             responseMode = mapping.responseMode().map(Enum::toString).map(ResponseMode::valueOf);
             redirectPath = mapping.redirectPath();
@@ -2094,6 +2101,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             pkceRequired = mapping.pkceRequired();
             pkceSecret = mapping.pkceSecret();
             stateSecret = mapping.stateSecret();
+            cacheControl = mapping.cacheControl();
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
@@ -9,12 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.oidc.runtime.OidcTenantConfig;
 import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.CacheControl;
 import io.quarkus.oidc.runtime.OidcTenantConfig.CertificateChain;
 import io.quarkus.oidc.runtime.OidcTenantConfig.CodeGrant;
 import io.quarkus.oidc.runtime.OidcTenantConfig.IntrospectionCredentials;
@@ -234,6 +236,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
     private IntrospectionCredentials introspectionCredentials;
     private Roles roles;
     private ResourceMetadata resourceMetadata;
+    private Optional<Set<CacheControl>> cacheControl;
     private CertificateChain certificateChain;
     private CodeGrant codeGrant;
     private TokenStateManager tokenStateManager;
@@ -858,7 +861,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
     }
 
     /**
-     * Builder for the {@link IntrospectionCredentials}.
+     * Builder for the {@link ResourceMetadata}.
      */
     public static final class ResourceMetadataBuilder {
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -12,6 +12,7 @@ import java.util.Base64.Encoder;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -39,6 +40,7 @@ import io.quarkus.oidc.common.runtime.AbstractJsonObject;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.CacheControl;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.ResponseMode;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Logout.LogoutMode;
 import io.quarkus.security.AuthenticationCompletionException;
@@ -1108,6 +1110,16 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                             OidcUtils.createSessionCookie(context, configContext.oidcConfig(), sessionName,
                                                     cookieValue, sessionMaxAge);
                                         }
+
+                                        Set<CacheControl> cacheControl = configContext.oidcConfig().authentication()
+                                                .cacheControl()
+                                                .orElse(Set.of());
+                                        if (!cacheControl.isEmpty()) {
+                                            // Only 'no-store' is currently supported
+                                            context.response().putHeader(HttpHeaders.CACHE_CONTROL,
+                                                    cacheControl.iterator().next().directive());
+                                        }
+
                                         fireEvent(SecurityEvent.Type.OIDC_LOGIN, securityIdentity);
                                         return null;
                                     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -657,6 +657,32 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         Optional<ResponseMode> responseMode();
 
         /**
+         * Supported cache control directives
+         */
+        enum CacheControl {
+            NO_STORE("no-store");
+
+            private String dir;
+
+            CacheControl(String dir) {
+                this.dir = dir;
+            }
+
+            String directive() {
+                return dir;
+            }
+        }
+
+        /**
+         * Set of cache-control directives that must be set when a new session cookie is created,
+         * either after a successful authorization code completion or token refresh.
+         * <p>
+         * Currently, only a `no-store` directive that prohibits caching the session cookie anywhere in the client request chain
+         * can be configured.
+         */
+        Optional<Set<CacheControl>> cacheControl();
+
+        /**
          * The relative path for calculating a `redirect_uri` query parameter.
          * It has to start from a forward slash and is appended to the request URI's host and port.
          * For example, if the current request URI is `https://localhost:8080/service`, a `redirect_uri` parameter

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
@@ -4,13 +4,16 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import io.quarkus.oidc.OidcTenantConfigBuilder;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.CacheControl;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.CookieSameSite;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.ResponseMode;
 
@@ -25,9 +28,9 @@ public final class AuthenticationConfigBuilder {
             Optional<List<String>> scopes, Optional<String> scopeSeparator, boolean nonceRequired,
             Optional<Boolean> addOpenidScope, Map<String, String> extraParams, Optional<List<String>> forwardParams,
             boolean cookieForceSecure, Optional<String> cookieSuffix, String cookiePath, Optional<String> cookiePathHeader,
-            Optional<String> cookieDomain, CookieSameSite cookieSameSite, boolean allowMultipleCodeFlows,
-            boolean failOnMissingStateParam, boolean failOnUnresolvedKid, Optional<Boolean> userInfoRequired,
-            Duration sessionAgeExtension,
+            Optional<String> cookieDomain, CookieSameSite cookieSameSite, Optional<Set<CacheControl>> cacheControl,
+            boolean allowMultipleCodeFlows, boolean failOnMissingStateParam, boolean failOnUnresolvedKid,
+            Optional<Boolean> userInfoRequired, Duration sessionAgeExtension,
             Duration stateCookieAge, boolean javaScriptAutoRedirect, Optional<Boolean> idTokenRequired,
             Optional<Duration> internalIdTokenLifespan, Optional<Boolean> pkceRequired, Optional<String> pkceSecret,
             Optional<String> stateSecret) implements Authentication {
@@ -54,6 +57,7 @@ public final class AuthenticationConfigBuilder {
     private Optional<String> cookiePathHeader;
     private Optional<String> cookieDomain;
     private CookieSameSite cookieSameSite;
+    private Set<CacheControl> cacheControl = new HashSet<>();
     private boolean allowMultipleCodeFlows;
     private boolean failOnMissingStateParam;
     private boolean failOnUnresolvedKid;
@@ -98,6 +102,9 @@ public final class AuthenticationConfigBuilder {
         this.cookiePathHeader = authentication.cookiePathHeader();
         this.cookieDomain = authentication.cookieDomain();
         this.cookieSameSite = authentication.cookieSameSite();
+        if (authentication.cacheControl().isPresent()) {
+            this.cacheControl.addAll(authentication.cacheControl().get());
+        }
         this.allowMultipleCodeFlows = authentication.allowMultipleCodeFlows();
         this.failOnMissingStateParam = authentication.failOnMissingStateParam();
         this.failOnUnresolvedKid = authentication.failOnUnresolvedKid();
@@ -239,6 +246,15 @@ public final class AuthenticationConfigBuilder {
         if (scopes != null) {
             this.scopes.addAll(Arrays.asList(scopes));
         }
+        return this;
+    }
+
+    /**
+     * @param cacheControl {@link Authentication#cacheControl()}
+     * @return this builder
+     */
+    public AuthenticationConfigBuilder cacheControl(CacheControl directive) {
+        this.cacheControl.add(directive);
         return this;
     }
 
@@ -571,10 +587,13 @@ public final class AuthenticationConfigBuilder {
         Optional<List<String>> optionalScopes = scopes.isEmpty() ? Optional.empty() : Optional.of(List.copyOf(scopes));
         Optional<List<String>> optionalForwardParams = forwardParams.isEmpty() ? Optional.empty()
                 : Optional.of(List.copyOf(forwardParams));
+        Optional<Set<CacheControl>> optionalCacheControl = cacheControl.isEmpty() ? Optional.empty()
+                : Optional.of(Set.copyOf(cacheControl));
         return new AuthenticationImpl(responseMode, redirectPath, restorePathAfterRedirect, removeRedirectParameters, errorPath,
                 sessionExpiredPath, verifyAccessToken, forceRedirectHttpsScheme, optionalScopes, scopeSeparator, nonceRequired,
                 addOpenidScope, Map.copyOf(extraParams), optionalForwardParams, cookieForceSecure, cookieSuffix, cookiePath,
-                cookiePathHeader, cookieDomain, cookieSameSite, allowMultipleCodeFlows, failOnMissingStateParam,
+                cookiePathHeader, cookieDomain, cookieSameSite, optionalCacheControl, allowMultipleCodeFlows,
+                failOnMissingStateParam,
                 failOnUnresolvedKid,
                 userInfoRequired, sessionAgeExtension, stateCookieAge, javaScriptAutoRedirect, idTokenRequired,
                 internalIdTokenLifespan, pkceRequired, pkceSecret, stateSecret);

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -142,6 +142,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         AUTHENTICATION_COOKIE_PATH_HEADER,
         AUTHENTICATION_COOKIE_DOMAIN,
         AUTHENTICATION_COOKIE_SAME_SITE,
+        AUTHENTICATION_CACHE_CONTROL,
         AUTHENTICATION_ALLOW_MULTIPLE_CODE_FLOWS,
         AUTHENTICATION_FAIL_ON_MISSING_STATE_PARAM,
         AUTHENTICATION_FAIL_ON_UNRESOLVED_KID,
@@ -757,6 +758,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             public CookieSameSite cookieSameSite() {
                 invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_COOKIE_SAME_SITE, true);
                 return CookieSameSite.LAX;
+            }
+
+            @Override
+            public Optional<Set<CacheControl>> cacheControl() {
+                invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_CACHE_CONTROL, true);
+                return Optional.empty();
             }
 
             @Override

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -98,6 +98,10 @@ quarkus.oidc.tenant-refresh.authentication.cookie-path=/tenant-refresh
 quarkus.oidc.tenant-refresh.authentication.session-age-extension=2M
 quarkus.oidc.tenant-refresh.authentication.session-expired-path=/tenant-refresh/session-expired-page
 quarkus.oidc.tenant-refresh.token.refresh-expired=true
+# It avoids an auto-redirect that drops code flow parameters, to make it easier
+# to test that Cache-Control is set immediately when the session cookie is created
+quarkus.oidc.tenant-refresh.authentication.remove-redirect-parameters=false
+quarkus.oidc.tenant-refresh.authentication.cache-control=no-store
 quarkus.oidc.tenant-refresh.resource-metadata.enabled=true
 
 quarkus.oidc.tenant-autorefresh.auth-server-url=${quarkus.oidc.auth-server-url}


### PR DESCRIPTION
Fixes #50207.

Users should be able to easily activate `Cache-Control: no-store` when they have concerns about such cookies being cached by HTTP intermediaries, not only when a session cookie is created but also when it is refreshed.

Right now it can be done by monitoring OIDC events as just returning `Cache-Control: no-store` in the JAX-RS code won't work by default - when the user logs in, Quarkus OIDC, creates a session cookie and redirects the user to drop technical code flow parameters like `code` and `state`, so by the time the JAX-RS code is reached, the cookie was already returned. This extra redirect dropping technical parameters can be disabled but it is not recommended. 

PR allows to support a single directive at the moment, `no-store`, but I'd like to experiment with a `private` directive before opening it for review

