### PR TITLE
Make test-fixture sources available to continuous testing

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -411,6 +411,16 @@ public abstract class QuarkusDev extends QuarkusTask {
         return false;
     }
 
+    /**
+     * Returns launch mode for the target application model.
+     *
+     * @return launch mode for the target application model
+     */
+    @Internal
+    protected LaunchMode getLaunchMode() {
+        return LaunchMode.DEVELOPMENT;
+    }
+
     private DevModeCommandLine newLauncher(final AnalyticsService analyticsService) throws Exception {
         final Project project = getProject();
         final JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
@@ -466,7 +476,7 @@ public abstract class QuarkusDev extends QuarkusTask {
 
         builder.sourceEncoding(getSourceEncoding());
 
-        final ApplicationModel appModel = extension().getApplicationModel(LaunchMode.DEVELOPMENT);
+        final ApplicationModel appModel = extension().getApplicationModel(getLaunchMode());
         builder.extensionDevModeConfig(appModel.getExtensionDevModeConfig())
                 .extensionDevModeJvmOptionFilter(extensionJvmOptions);
 
@@ -538,7 +548,8 @@ public abstract class QuarkusDev extends QuarkusTask {
         serializedModel.toFile().deleteOnExit();
         builder.jvmArgs("-D" + BootstrapConstants.SERIALIZED_APP_MODEL + "=" + serializedModel.toAbsolutePath());
 
-        final ApplicationModel testAppModel = extension().getApplicationModel(LaunchMode.TEST);
+        final ApplicationModel testAppModel = getLaunchMode().equals(LaunchMode.TEST) ? appModel
+                : extension().getApplicationModel(LaunchMode.TEST);
         final Path serializedTestModel = ToolingUtils.serializeAppModel(testAppModel, this, true);
         serializedTestModel.toFile().deleteOnExit();
         builder.jvmArgs("-D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=" + serializedTestModel.toAbsolutePath());

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTest.java
@@ -1,15 +1,14 @@
 package io.quarkus.gradle.tasks;
 
-import java.util.function.Consumer;
-
 import javax.inject.Inject;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.Internal;
 
 import io.quarkus.deployment.dev.DevModeCommandLineBuilder;
-import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.IsolatedTestModeMain;
 import io.quarkus.gradle.extension.QuarkusPluginExtension;
+import io.quarkus.runtime.LaunchMode;
 
 public abstract class QuarkusTest extends QuarkusDev {
 
@@ -21,12 +20,15 @@ public abstract class QuarkusTest extends QuarkusDev {
                 extension);
     }
 
+    @Override
     protected void modifyDevModeContext(DevModeCommandLineBuilder builder) {
-        builder.entryPointCustomizer(new Consumer<DevModeContext>() {
-            @Override
-            public void accept(DevModeContext devModeContext) {
-                devModeContext.setAlternateEntryPoint(IsolatedTestModeMain.class.getName());
-            }
-        });
+        builder.entryPointCustomizer(
+                devModeContext -> devModeContext.setAlternateEntryPoint(IsolatedTestModeMain.class.getName()));
+    }
+
+    @Override
+    @Internal
+    protected LaunchMode getLaunchMode() {
+        return LaunchMode.TEST;
     }
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -241,18 +241,36 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
     private void collectExtensionDependencies(Project project, Configuration deploymentConfiguration,
             ApplicationModelBuilder modelBuilder) {
         final ResolvedConfiguration rc = deploymentConfiguration.getResolvedConfiguration();
+        final Set<ArtifactKey> processedDeps = new HashSet<>();
         for (var dep : rc.getFirstLevelModuleDependencies()) {
-            processDeploymentDependency(project, dep, modelBuilder, false);
+            processDeploymentDependency(project, dep, modelBuilder, false, processedDeps);
         }
     }
 
     private static void processDeploymentDependency(Project project, ResolvedDependency resolvedDep,
-            ApplicationModelBuilder modelBuilder, boolean clearReloadableFlag) {
-        boolean processChildren = false;
-        for (var a : resolvedDep.getModuleArtifacts()) {
-            ResolvedDependencyBuilder dep = modelBuilder.getDependency(getKey(a));
+            ApplicationModelBuilder modelBuilder, boolean clearReloadableFlag, Set<ArtifactKey> processedDeps) {
+        final Set<ResolvedArtifact> resolvedArtifacts = resolvedDep.getModuleArtifacts();
+        boolean processChildren = resolvedArtifacts.isEmpty();
+        for (var a : resolvedArtifacts) {
+            final ArtifactKey artifactKey = getKey(a);
+            if (!processedDeps.add(artifactKey)) {
+                continue;
+            }
+            processChildren = true;
+            ResolvedDependencyBuilder dep = modelBuilder.getDependency(artifactKey);
             if (dep == null) {
-                if (a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier projectComponentIdentifier) {
+                if (isApplicationRoot(modelBuilder, artifactKey)) {
+                    // An application root artifact may be found among the dependencies in a could of cases:
+                    // test fixtures in an application project and as a deployment module in an extension project
+                    // running deployment module tests.
+                    // In case of test fixtures, the root artifact does not have to be added to the model as a dependency,
+                    // it can simply be skipped.
+                    // In case of a deployment test, it has to be added as a dependency, since otherwise, the deployment
+                    // module will appear to be missing.
+                    // This part here looks like a hack but appears to work for both cases so far.
+                    dep = modelBuilder.getApplicationArtifact();
+                } else if (a.getId()
+                        .getComponentIdentifier() instanceof ProjectComponentIdentifier projectComponentIdentifier) {
                     var includedBuild = ToolingUtils.includedBuild(project,
                             projectComponentIdentifier.getBuild().getBuildPath());
                     final Project projectDep;
@@ -297,10 +315,10 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                 }
             }
             if (dep != null) {
-                if (!dep.isDeploymentCp()) {
-                    dep.setDeploymentCp();
-                    processChildren = true;
+                if (dep.isRuntimeExtensionArtifact()) {
+                    clearReloadableFlag = true;
                 }
+                dep.setDeploymentCp();
                 if (clearReloadableFlag) {
                     dep.clearFlag(DependencyFlags.RELOADABLE);
                 }
@@ -308,9 +326,13 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         }
         if (processChildren) {
             for (var child : resolvedDep.getChildren()) {
-                processDeploymentDependency(project, child, modelBuilder, clearReloadableFlag);
+                processDeploymentDependency(project, child, modelBuilder, clearReloadableFlag, processedDeps);
             }
         }
+    }
+
+    private static boolean isApplicationRoot(ApplicationModelBuilder modelBuilder, ArtifactKey artifactKey) {
+        return modelBuilder.getApplicationArtifact().getKey().equals(artifactKey);
     }
 
     private static ResolvedDependencyBuilder addArtifactDependency(Project project, ApplicationModelBuilder modelBuilder,
@@ -350,9 +372,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
 
         final Set<File> artifactFiles = getArtifactFilesOrNull(configuration, dependencies);
         for (ResolvedDependency d : configuration.getFirstLevelModuleDependencies()) {
-            collectDependencies(d, workspaceDiscovery, project, artifactFiles, new HashSet<>(),
-                    modelBuilder,
-                    wsModule,
+            collectDependencies(d, workspaceDiscovery, project, artifactFiles, modelBuilder, wsModule,
                     (byte) (COLLECT_TOP_EXTENSION_RUNTIME_NODES | COLLECT_DIRECT_DEPS | COLLECT_RELOADABLE_MODULES));
         }
 
@@ -403,86 +423,94 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
     }
 
     private void collectDependencies(org.gradle.api.artifacts.ResolvedDependency resolvedDep, boolean workspaceDiscovery,
-            Project project, Set<File> artifactFiles, Set<ArtifactKey> processedModules, ApplicationModelBuilder modelBuilder,
+            Project project, Set<File> artifactFiles, ApplicationModelBuilder modelBuilder,
             WorkspaceModule.Mutable parentModule,
             byte flags) {
         WorkspaceModule.Mutable projectModule = null;
-        for (ResolvedArtifact a : resolvedDep.getModuleArtifacts()) {
+        final Set<ResolvedArtifact> resolvedArtifacts = resolvedDep.getModuleArtifacts();
+        boolean processChildren = resolvedArtifacts.isEmpty();
+        for (ResolvedArtifact a : resolvedArtifacts) {
             if (!isDependency(a)) {
                 continue;
             }
-            var depBuilder = modelBuilder.getDependency(getKey(a));
-            if (depBuilder != null) {
-                if (isFlagOn(flags, COLLECT_DIRECT_DEPS)) {
-                    depBuilder.setDirect(true);
-                }
+            final ArtifactKey artifactKey = getKey(a);
+            if (isApplicationRoot(modelBuilder, artifactKey)) {
                 continue;
             }
-            final ArtifactCoords depCoords = getArtifactCoords(a);
-            depBuilder = ResolvedDependencyBuilder.newInstance()
-                    .setCoords(depCoords)
-                    .setRuntimeCp();
-            if (isFlagOn(flags, COLLECT_DIRECT_DEPS)) {
-                depBuilder.setDirect(true);
-                flags = clearFlag(flags, COLLECT_DIRECT_DEPS);
-            }
-            if (parentModule != null) {
-                parentModule.addDependency(new ArtifactDependency(depCoords));
-            }
+            var depBuilder = modelBuilder.getDependency(artifactKey);
+            if (depBuilder == null) {
+                processChildren = true;
+                final ArtifactCoords depCoords = getArtifactCoords(a);
+                depBuilder = ResolvedDependencyBuilder.newInstance()
+                        .setCoords(depCoords)
+                        .setRuntimeCp();
+                if (parentModule != null) {
+                    parentModule.addDependency(new ArtifactDependency(depCoords));
+                }
 
-            PathCollection paths = null;
-            if (workspaceDiscovery && a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier compId) {
-                Project projectDep = project.getRootProject().findProject(compId.getProjectPath());
+                PathCollection paths = null;
+                if (workspaceDiscovery && a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier compId) {
+                    Project projectDep = project.getRootProject().findProject(compId.getProjectPath());
 
-                final String classifier = a.getClassifier();
-                if (classifier == null || classifier.isEmpty()) {
-                    final IncludedBuild includedBuild = ToolingUtils.includedBuild(project.getRootProject(),
-                            compId.getBuild().getBuildPath());
-                    if (includedBuild != null) {
-                        if (includedBuild instanceof IncludedBuildInternal ib) {
-                            projectDep = ToolingUtils.includedBuildProject(ib, compId.getProjectPath());
-                        }
-                        if (projectDep != null) {
-                            initProjectModuleAndBuildPaths(projectDep, a, modelBuilder, depBuilder);
+                    final String classifier = a.getClassifier();
+                    if (classifier == null || classifier.isEmpty()) {
+                        final IncludedBuild includedBuild = ToolingUtils.includedBuild(project.getRootProject(),
+                                compId.getBuild().getBuildPath());
+                        if (includedBuild != null) {
+                            if (includedBuild instanceof IncludedBuildInternal ib) {
+                                projectDep = ToolingUtils.includedBuildProject(ib, compId.getProjectPath());
+                            }
+                            if (projectDep != null) {
+                                initProjectModuleAndBuildPaths(projectDep, a, modelBuilder, depBuilder);
+                            } else {
+                                final PathList.Builder pathBuilder = PathList.builder();
+                                addSubstitutedProject(pathBuilder, includedBuild.getProjectDir());
+                                paths = pathBuilder.build();
+                            }
                         } else {
-                            final PathList.Builder pathBuilder = PathList.builder();
-                            addSubstitutedProject(pathBuilder, includedBuild.getProjectDir());
-                            paths = pathBuilder.build();
+                            initProjectModuleAndBuildPaths(projectDep, a, modelBuilder, depBuilder);
                         }
                     } else {
                         initProjectModuleAndBuildPaths(projectDep, a, modelBuilder, depBuilder);
                     }
-                } else {
-                    initProjectModuleAndBuildPaths(projectDep, a, modelBuilder, depBuilder);
+                }
+
+                depBuilder.setResolvedPaths(paths == null ? PathList.of(a.getFile().toPath()) : paths);
+                if (processQuarkusDependency(depBuilder, modelBuilder)) {
+                    flags = clearFlag(flags, COLLECT_RELOADABLE_MODULES);
+                }
+                modelBuilder.addDependency(depBuilder);
+                if (projectModule == null && depBuilder.getWorkspaceModule() != null) {
+                    projectModule = depBuilder.getWorkspaceModule().mutable();
+                }
+
+                if (artifactFiles != null) {
+                    artifactFiles.add(a.getFile());
                 }
             }
-
-            depBuilder.setResolvedPaths(paths == null ? PathList.of(a.getFile().toPath()) : paths);
-            if (processQuarkusDependency(depBuilder, modelBuilder)) {
-                if (isFlagOn(flags, COLLECT_TOP_EXTENSION_RUNTIME_NODES)) {
+            if (isFlagOn(flags, COLLECT_DIRECT_DEPS)) {
+                depBuilder.setDirect(true);
+                flags = clearFlag(flags, COLLECT_DIRECT_DEPS);
+            }
+            if (depBuilder.isRuntimeExtensionArtifact()) {
+                if (isFlagOn(flags, COLLECT_RELOADABLE_MODULES)) {
+                    flags = clearFlag(flags, COLLECT_RELOADABLE_MODULES);
+                    processChildren = true;
+                }
+                if (isFlagOn(flags, COLLECT_TOP_EXTENSION_RUNTIME_NODES)
+                        && !depBuilder.isFlagSet(DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT)) {
                     depBuilder.setFlags(DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
                     flags = clearFlag(flags, COLLECT_TOP_EXTENSION_RUNTIME_NODES);
                 }
-                flags = clearFlag(flags, COLLECT_RELOADABLE_MODULES);
             }
             if (!isFlagOn(flags, COLLECT_RELOADABLE_MODULES)) {
                 depBuilder.clearFlag(DependencyFlags.RELOADABLE);
             }
-            modelBuilder.addDependency(depBuilder);
-            if (projectModule == null && depBuilder.getWorkspaceModule() != null) {
-                projectModule = depBuilder.getWorkspaceModule().mutable();
-            }
-
-            if (artifactFiles != null) {
-                artifactFiles.add(a.getFile());
-            }
         }
 
-        processedModules.add(ArtifactKey.ga(resolvedDep.getModuleGroup(), resolvedDep.getModuleName()));
-        for (org.gradle.api.artifacts.ResolvedDependency child : resolvedDep.getChildren()) {
-            if (!processedModules.contains(ArtifactKey.ga(child.getModuleGroup(), child.getModuleName()))) {
-                collectDependencies(child, workspaceDiscovery, project, artifactFiles, processedModules,
-                        modelBuilder, projectModule, flags);
+        if (processChildren) {
+            for (org.gradle.api.artifacts.ResolvedDependency child : resolvedDep.getChildren()) {
+                collectDependencies(child, workspaceDiscovery, project, artifactFiles, modelBuilder, projectModule, flags);
             }
         }
     }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -193,6 +193,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
 
         initProjectModule(project, mainModule, sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME), ArtifactSources.MAIN);
         if (workspaceDiscovery) {
+            appArtifact.setReloadable();
             final TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
             if (!testTasks.isEmpty()) {
                 final Map<File, SourceSet> sourceSetsByClassesDir = new HashMap<>();
@@ -319,7 +320,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                     clearReloadableFlag = true;
                 }
                 dep.setDeploymentCp();
-                if (clearReloadableFlag) {
+                if (clearReloadableFlag && dep != modelBuilder.getApplicationArtifact()) {
                     dep.clearFlag(DependencyFlags.RELOADABLE);
                 }
             }
@@ -480,13 +481,13 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                     flags = clearFlag(flags, COLLECT_RELOADABLE_MODULES);
                 }
                 modelBuilder.addDependency(depBuilder);
-                if (projectModule == null && depBuilder.getWorkspaceModule() != null) {
-                    projectModule = depBuilder.getWorkspaceModule().mutable();
-                }
 
                 if (artifactFiles != null) {
                     artifactFiles.add(a.getFile());
                 }
+            }
+            if (projectModule == null && depBuilder.getWorkspaceModule() != null) {
+                projectModule = depBuilder.getWorkspaceModule().mutable();
             }
             if (isFlagOn(flags, COLLECT_DIRECT_DEPS)) {
                 depBuilder.setDirect(true);

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/application/build.gradle
@@ -18,10 +18,10 @@ dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    implementation 'io.quarkus:quarkus-resteasy'
-    implementation ('org.acme.libs:libraryB')
-    implementation ('org.acme.libs:libraryA')
-    implementation ('org.acme.extensions:example-extension')
+    implementation 'io.quarkus:quarkus-rest'
+    implementation 'org.acme.libs:libraryB'
+    implementation 'org.acme.libs:libraryA'
+    implementation 'org.acme.extensions:example-extension'
 
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryA/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryA/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    implementation ("${quarkusPlatformGroupId}:quarkus-arc:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryB/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/libraries/libraryB/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    implementation ("${quarkusPlatformGroupId}:quarkus-arc:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     implementation project(':libraryA')

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-project/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-project/application/build.gradle
@@ -18,9 +18,9 @@ dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    implementation 'io.quarkus:quarkus-resteasy'
-    implementation ('org.acme.libs:libraryB')
-    implementation ('org.acme.libs:libraryA')
+    implementation 'io.quarkus:quarkus-rest'
+    implementation 'org.acme.libs:libraryB'
+    implementation 'org.acme.libs:libraryA'
 
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryA/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryA/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    implementation ("${quarkusPlatformGroupId}:quarkus-arc:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryB/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-project/libraries/libraryB/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    implementation ("${quarkusPlatformGroupId}:quarkus-arc:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     implementation project(':libraryA')

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
@@ -4,16 +4,61 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.io.ObjectInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.util.BootstrapUtils;
+import io.quarkus.maven.dependency.ArtifactKey;
 
 public class TestFixtureMultiModuleTest extends QuarkusGradleWrapperTestBase {
 
     @Test
-    public void testTaskShouldUseTestFixtures() throws IOException, URISyntaxException, InterruptedException {
+    public void testTaskShouldUseTestFixtures() throws Exception {
         final File projectDir = getProjectDir("test-fixtures-multi-module");
         final BuildResult result = runGradleWrapper(projectDir, "clean", "test");
         assertThat(BuildResult.isSuccessful(result.getTasks().get(":application:test"))).isTrue();
+
+        final Path testModelDat = projectDir.toPath().resolve("application").resolve("build").resolve("quarkus")
+                .resolve("application-model").resolve("quarkus-app-test-model.dat");
+        assertThat(testModelDat).exists();
+        final ApplicationModel model = deserializeAppModel(testModelDat);
+        final Map<ArtifactKey, String> actualDepFlags = new HashMap<>();
+        for (var dep : model.getDependencies()) {
+            if (dep.getGroupId().equals("my-groupId")) {
+                actualDepFlags.put(dep.getKey(), BootstrapUtils.toTextFlags(dep.getFlags()));
+            }
+        }
+        assertThat(actualDepFlags).containsExactlyInAnyOrderEntriesOf(Map.of(
+                ArtifactKey.fromString("my-groupId:library-1::jar"),
+                "runtime-cp, deployment-cp, workspace-module, reloadable",
+                ArtifactKey.fromString("my-groupId:library-1:test-fixtures:jar"),
+                "runtime-cp, deployment-cp, workspace-module, reloadable",
+                ArtifactKey.fromString("my-groupId:library-2::jar"),
+                "direct, runtime-cp, deployment-cp, workspace-module, reloadable",
+                ArtifactKey.fromString("my-groupId:library-2:test-fixtures:jar"),
+                "direct, runtime-cp, deployment-cp, workspace-module, reloadable",
+                ArtifactKey.fromString("my-groupId:static-init-library::jar"),
+                "runtime-cp, deployment-cp, workspace-module, reloadable"));
+    }
+
+    /**
+     * Copied from ToolingUtils
+     *
+     * @param path application model dat file
+     * @return deserialized ApplicationModel
+     * @throws IOException in case of a failure to read the model
+     */
+    private static ApplicationModel deserializeAppModel(Path path) throws IOException {
+        try (ObjectInputStream out = new ObjectInputStream(Files.newInputStream(path))) {
+            return (ApplicationModel) out.readObject();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
This change is not a complete fix but a necessary groundwork to fix https://github.com/quarkusio/quarkus/issues/43576

In fact, these changes make it partially working. I.e. the test-fixtures sources in dependency projects are watched for changes and even recompiled. But there is still some issue elsewhere related to test re-runs.