### PR TITLE
Fix server requests metrics tags for 404s when initialPath ends with /

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/HttpTagExplosionPreventionTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/HttpTagExplosionPreventionTest.java
@@ -63,6 +63,17 @@ public class HttpTagExplosionPreventionTest {
 
         Assertions.assertEquals(2, registry.find("http.server.requests").tag("uri", "UNKNOWN").timers().size()); // 2 different set of tags
         Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/api/failure/{message}").timers().size());
+
+        RestAssured.get("/api/not-there").then().statusCode(404);
+        Util.waitForMeters(registry.find("http.server.requests").timers(), 17);
+        Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "NOT_FOUND").timers().size());
+
+        RestAssured.get("/api/not-there/").then().statusCode(404);
+        Util.waitForMeters(registry.find("http.server.requests").timers(), 18);
+        // no other uri tags and count should be 2
+        Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "NOT_FOUND").timers().size());
+        Assertions.assertEquals(2,
+                registry.find("http.server.requests").tag("uri", "NOT_FOUND").timers().iterator().next().count());
     }
 
     @Path("/")

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpCommonTags.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpCommonTags.java
@@ -100,6 +100,8 @@ public class HttpCommonTags {
 
     private static boolean isTemplatedPath(String pathInfo, String initialPath) {
         // only include the path info if it has been matched to a template (initialPath != pathInfo) to avoid a metrics explosion with lots of entries
-        return initialPath != null && !Objects.equals(initialPath, pathInfo);
+        // /not-there/ must have the same behaviour as /not-there
+        return initialPath != null && !(Objects.equals(initialPath, pathInfo) ||
+                Objects.equals(initialPath, pathInfo + "/"));
     }
 }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/HttpCommonTagsTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/HttpCommonTagsTest.java
@@ -33,6 +33,9 @@ public class HttpCommonTagsTest {
         Assertions.assertEquals(HttpCommonTags.URI_ROOT, HttpCommonTags.uri("/", null, 404, false));
         Assertions.assertEquals(Tag.of("uri", "/known/ok"), HttpCommonTags.uri("/known/ok", null, 200, false));
         Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid", null, 404, false));
+        Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid", "/invalid", 404, false));
+        Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid/", "/invalid/", 404, false));
+        Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid", "/invalid/", 404, false));
         Assertions.assertEquals(Tag.of("uri", "/invalid/{id}"),
                 HttpCommonTags.uri("/invalid/{id}", "/invalid/111", 404, false));
         Assertions.assertEquals(Tag.of("uri", "/known/bad/request"),
@@ -49,6 +52,10 @@ public class HttpCommonTagsTest {
         Assertions.assertEquals(HttpCommonTags.URI_ROOT, HttpCommonTags.uri("/", null, 404, true));
         Assertions.assertEquals(Tag.of("uri", "/known/ok"), HttpCommonTags.uri("/known/ok", null, 200, true));
         Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid", null, 404, true));
+        Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid/", null, 404, true));
+        Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid", "/invalid", 404, true));
+        Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid/", "/invalid/", 404, true));
+        Assertions.assertEquals(HttpCommonTags.URI_NOT_FOUND, HttpCommonTags.uri("/invalid", "/invalid/", 404, true));
         Assertions.assertEquals(Tag.of("uri", "/invalid/{id}"), HttpCommonTags.uri("/invalid/{id}", "/invalid/111", 404, true));
         Assertions.assertEquals(HttpCommonTags.URI_UNKNOWN, HttpCommonTags.uri("/known/bad/request", null, 400, true));
         Assertions.assertEquals(Tag.of("uri", "/known/bad/{request}"),


### PR DESCRIPTION
Fixes #50226 
