### PR TITLE
Fix initial download of decompiler when version not provided

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
@@ -22,9 +22,9 @@ class VineflowerDecompiler implements Decompiler {
 
     @Override
     public void init(Context context) {
-        this.context = context;
-        this.decompilerJar = context.jarLocation.resolve(String.format("vineflower-%s.jar",
-                context.versionStr != null ? context.versionStr : DEFAULT_VINEFLOWER_VERSION));
+        this.context = context.versionStr != null ? context
+                : new Context(DEFAULT_VINEFLOWER_VERSION, context.jarLocation, context.decompiledOutputDir);
+        this.decompilerJar = this.context.jarLocation.resolve(String.format("vineflower-%s.jar", this.context.versionStr));
     }
 
     @Override


### PR DESCRIPTION
Got this when packaging;

```[ERROR] [io.quarkus.deployment.pkg.jar.VineflowerDecompiler] Unable to download Vineflower from https://repo.maven.apache.org/maven2/org/vineflower/vineflower/null/vineflower-null.jar
java.io.FileNotFoundException: https://repo.maven.apache.org/maven2/org/vineflower/vineflower/null/vineflower-null.jar
```