### PR TITLE
Allow ecosystem extensions to use dev service result builder

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
@@ -250,6 +250,11 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
             return this;
         }
 
+        public OwnedServiceBuilder<T> feature(String featureName) {
+            this.name = featureName;
+            return this;
+        }
+
         public OwnedServiceBuilder<T> description(String description) {
             this.description = description;
             return this;


### PR DESCRIPTION
I was converting the Minecraft extension to use the new dev service, since it's clearly a high-priority part of our ecosystem. I realised that the `feature()` method takes a `Feature`, which is nice and typesafe ... but `Feature` is an enum, so any features outside core can't be added. (Oops.)