### PR TITLE
Enable Qute debugger by default

### DIFF
--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/debug/DebugQuteEngineObserver.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/debug/DebugQuteEngineObserver.java
@@ -14,7 +14,8 @@ import io.smallrye.common.annotation.Experimental;
  * Observes the creation of Qute engines and attaches the Qute debugger in development mode.
  *
  * <p>
- * When a new {@link io.quarkus.qute.EngineBuilder} is observed and the application is running in
+ * When a new {@link io.quarkus.qute.EngineBuilder} is observed and the application is started with "-DquteDebugPort"
+ * and running in
  * {@link io.quarkus.runtime.LaunchMode#DEVELOPMENT development mode} with
  * {@code quarkus.qute.debug.enabled=true}, this observer:
  * <ul>
@@ -38,7 +39,11 @@ public class DebugQuteEngineObserver {
      * @param config the Qute configuration
      */
     void configureEngine(@Observes EngineBuilder builder, QuteConfig config) {
-        if (LaunchMode.current() == LaunchMode.DEVELOPMENT && config.debug().enabled()) {
+        if (LaunchMode.current() == LaunchMode.DEVELOPMENT && config.debug().enabled() && registrar.getPort() != null) {
+            // - in dev mode only
+            // - quarkus.qute.debug.enabled=true
+            // - Quarkus application is started with -DquteDebugPort
+            // --> enable the Qute debugger.
             builder.enableTracing(true);
             builder.addEngineListener(registrar);
         }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/debug/QuteDebugConfig.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/debug/QuteDebugConfig.java
@@ -23,7 +23,7 @@ public interface QuteDebugConfig {
      * </p>
      *
      * <p>
-     * <strong>Default value:</strong> {@code false}
+     * <strong>Default value:</strong> {@code true}
      * </p>
      *
      * <p>
@@ -31,11 +31,11 @@ public interface QuteDebugConfig {
      * </p>
      *
      * <pre>
-     * quarkus.qute.debug.enabled = true
+     * quarkus.qute.debug.enabled = false
      * </pre>
      *
      * @return {@code true} if Qute debug mode is active, {@code false} otherwise.
      */
-    @WithDefault("false")
+    @WithDefault("true")
     boolean enabled();
 }


### PR DESCRIPTION
This PR enables by default Qute debugger.  The Qute debugger is enabled when:

 * in dev mode only
 * quarkus.qute.debug.enabled=true (set now as true by default)
 * Quarkus application is started with -DquteDebugPort

//cc @mkouba @FroMage 