### PR TITLE
Config - Avoid producing duplicate GeneratedClassBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -6,6 +6,7 @@ import static org.jboss.jandex.AnnotationTarget.Kind.CLASS;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public class ConfigMappingUtils {
     public static void processConfigClasses(
             ConfigurationBuildItem configItem,
             CombinedIndexBuildItem combinedIndex,
-            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            Map<String, GeneratedClassBuildItem> generatedConfigClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
             BuildProducer<ConfigClassBuildItem> configClasses,
@@ -74,7 +75,7 @@ public class ConfigMappingUtils {
                 continue;
             }
             Kind configClassKind = getConfigClassType(instance);
-            processConfigClass(configClass, configClassKind, combinedIndex, generatedClasses, reflectiveClasses,
+            processConfigClass(configClass, configClassKind, combinedIndex, generatedConfigClasses, reflectiveClasses,
                     reflectiveMethods, configClasses, additionalConstrainedClasses);
         }
     }
@@ -82,25 +83,25 @@ public class ConfigMappingUtils {
     public static void processConfigMapping(
             ConfigurationBuildItem configItem,
             CombinedIndexBuildItem combinedIndex,
-            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            Map<String, GeneratedClassBuildItem> generatedConfigClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
             BuildProducer<ConfigClassBuildItem> configClasses,
             BuildProducer<AdditionalConstrainedClassBuildItem> additionalConstrainedClasses) {
-        processConfigClasses(configItem, combinedIndex, generatedClasses, reflectiveClasses, reflectiveMethods, configClasses,
-                additionalConstrainedClasses, CONFIG_MAPPING_NAME);
+        processConfigClasses(configItem, combinedIndex, generatedConfigClasses, reflectiveClasses, reflectiveMethods,
+                configClasses, additionalConstrainedClasses, CONFIG_MAPPING_NAME);
     }
 
     public static void processExtensionConfigMapping(
             ConfigClass configClass,
             CombinedIndexBuildItem combinedIndex,
-            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            Map<String, GeneratedClassBuildItem> generatedConfigClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
             BuildProducer<ConfigClassBuildItem> configClasses,
             BuildProducer<AdditionalConstrainedClassBuildItem> additionalConstrainedClasses) {
 
-        processConfigClass(configClass, Kind.MAPPING, combinedIndex, generatedClasses, reflectiveClasses,
+        processConfigClass(configClass, Kind.MAPPING, combinedIndex, generatedConfigClasses, reflectiveClasses,
                 reflectiveMethods, configClasses, additionalConstrainedClasses);
     }
 
@@ -108,7 +109,7 @@ public class ConfigMappingUtils {
             ConfigClass configClassWithPrefix,
             Kind configClassKind,
             CombinedIndexBuildItem combinedIndex,
-            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            Map<String, GeneratedClassBuildItem> generatedConfigClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
             BuildProducer<ConfigClassBuildItem> configClasses,
@@ -125,9 +126,9 @@ public class ConfigMappingUtils {
             generatedClassesNames.add(mappingMetadata.getClassName());
             // This is the generated implementation of the mapping by SmallRye Config.
             byte[] classBytes = mappingMetadata.getClassBytes();
-            generatedClasses.produce(new GeneratedClassBuildItem(isApplicationClass(configClass.getName()),
-                    mappingMetadata.getClassName(),
-                    classBytes));
+            generatedConfigClasses.put(mappingMetadata.getClassName(),
+                    new GeneratedClassBuildItem(isApplicationClass(configClass.getName()), mappingMetadata.getClassName(),
+                            classBytes));
             additionalConstrainedClasses.produce(AdditionalConstrainedClassBuildItem.of(mappingMetadata.getClassName(),
                     classBytes));
             reflectiveClasses.produce(ReflectiveClassBuildItem.builder(mappingMetadata.getClassName())

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -204,19 +204,26 @@ public class ConfigGenerationBuildStep {
             BuildProducer<ConfigClassBuildItem> configClasses,
             BuildProducer<AdditionalConstrainedClassBuildItem> additionalConstrainedClasses) {
 
-        processConfigMapping(configItem, combinedIndex, generatedClasses, reflectiveClasses, reflectiveMethods, configClasses,
-                additionalConstrainedClasses);
+        Map<String, GeneratedClassBuildItem> generatedConfigClasses = new HashMap<>();
+
+        processConfigMapping(configItem, combinedIndex, generatedConfigClasses, reflectiveClasses, reflectiveMethods,
+                configClasses, additionalConstrainedClasses);
 
         List<ConfigClass> buildTimeRunTimeMappings = configItem.getReadResult().getBuildTimeRunTimeMappings();
         for (ConfigClass buildTimeRunTimeMapping : buildTimeRunTimeMappings) {
-            processExtensionConfigMapping(buildTimeRunTimeMapping, combinedIndex, generatedClasses, reflectiveClasses,
+            processExtensionConfigMapping(buildTimeRunTimeMapping, combinedIndex, generatedConfigClasses, reflectiveClasses,
                     reflectiveMethods, configClasses, additionalConstrainedClasses);
         }
 
         List<ConfigClass> runTimeMappings = configItem.getReadResult().getRunTimeMappings();
         for (ConfigClass runTimeMapping : runTimeMappings) {
-            processExtensionConfigMapping(runTimeMapping, combinedIndex, generatedClasses, reflectiveClasses, reflectiveMethods,
+            processExtensionConfigMapping(runTimeMapping, combinedIndex, generatedConfigClasses, reflectiveClasses,
+                    reflectiveMethods,
                     configClasses, additionalConstrainedClasses);
+        }
+
+        for (GeneratedClassBuildItem generatedConfigClass : generatedConfigClasses.values()) {
+            generatedClasses.produce(generatedConfigClass);
         }
     }
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -270,8 +270,13 @@ public class ConfigBuildStep {
             BuildProducer<ConfigClassBuildItem> configClasses,
             BuildProducer<AdditionalConstrainedClassBuildItem> additionalConstrainedClasses) {
 
-        processConfigClasses(configItem, combinedIndex, generatedClasses, reflectiveClasses, reflectiveMethods, configClasses,
-                additionalConstrainedClasses, MP_CONFIG_PROPERTIES_NAME);
+        Map<String, GeneratedClassBuildItem> generatedConfigClasses = new HashMap<>();
+        processConfigClasses(configItem, combinedIndex, generatedConfigClasses, reflectiveClasses, reflectiveMethods,
+                configClasses, additionalConstrainedClasses, MP_CONFIG_PROPERTIES_NAME);
+
+        for (GeneratedClassBuildItem generatedConfigClass : generatedConfigClasses.values()) {
+            generatedClasses.produce(generatedConfigClass);
+        }
     }
 
     @BuildStep

--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
@@ -5,8 +5,9 @@ import static io.quarkus.deployment.Feature.SPRING_DATA_REST;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.ws.rs.Priorities;
 
@@ -24,7 +25,6 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
-import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -82,36 +82,36 @@ class SpringDataRestProcessor {
     }
 
     @BuildStep
-    void registerRepositories(CombinedIndexBuildItem indexBuildItem, Capabilities capabilities,
+    void registerRepositories(
+            CombinedIndexBuildItem indexBuildItem,
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
             BuildProducer<ResourcePropertiesBuildItem> resourcePropertiesProducer,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer) {
         IndexView index = indexBuildItem.getIndex();
         EntityClassHelper entityClassHelper = new EntityClassHelper(index);
-        List<ClassInfo> repositoriesToImplement = getRepositoriesToImplement(index, CRUD_REPOSITORY_INTERFACE,
+        Set<ClassInfo> repositoriesToImplement = getRepositoriesToImplement(index, CRUD_REPOSITORY_INTERFACE,
                 LIST_CRUD_REPOSITORY_INTERFACE,
                 PAGING_AND_SORTING_REPOSITORY_INTERFACE, LIST_PAGING_AND_SORTING_REPOSITORY_INTERFACE,
                 JPA_REPOSITORY_INTERFACE);
 
-        implementResources(capabilities, implementationsProducer, restDataResourceProducer, resourcePropertiesProducer,
+        implementResources(implementationsProducer, restDataResourceProducer, resourcePropertiesProducer,
                 unremovableBeansProducer, new RepositoryMethodsImplementor(index, entityClassHelper),
-                index,
-                repositoriesToImplement);
+                index, repositoriesToImplement);
     }
 
     /**
      * Implement the {@link io.quarkus.rest.data.panache.RestDataResource} interface for each given Spring Data
      * repository and register its metadata and properties to be later picked up by the `rest-data-panache` extension.
      */
-    private void implementResources(Capabilities capabilities,
+    private void implementResources(
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
             BuildProducer<ResourcePropertiesBuildItem> resourcePropertiesProducer,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer,
             ResourceMethodsImplementor methodsImplementor,
             IndexView index,
-            List<ClassInfo> repositoriesToImplement) {
+            Set<ClassInfo> repositoriesToImplement) {
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
         ResourceImplementor resourceImplementor = new ResourceImplementor(methodsImplementor);
         EntityClassHelper entityClassHelper = new EntityClassHelper(index);
@@ -141,8 +141,8 @@ class SpringDataRestProcessor {
         }
     }
 
-    private List<ClassInfo> getRepositoriesToImplement(IndexView indexView, DotName... repositoryInterfaces) {
-        List<ClassInfo> result = new LinkedList<>();
+    private Set<ClassInfo> getRepositoriesToImplement(IndexView indexView, DotName... repositoryInterfaces) {
+        Set<ClassInfo> result = new LinkedHashSet<>();
         for (DotName repositoryInterface : repositoryInterfaces) {
             for (ClassInfo classInfo : indexView.getKnownDirectImplementors(repositoryInterface)) {
                 if (!hasImplementors(indexView, classInfo) && !EXCLUDED_INTERFACES.contains(classInfo.name())) {


### PR DESCRIPTION
Also guard against it in the Jar generation to make sure we don't end up with duplicate entries.

Fixes #50265