### PR TITLE
Improve Qute debugger port listening log

### DIFF
--- a/independent-projects/qute/debug/README.md
+++ b/independent-projects/qute/debug/README.md
@@ -7,7 +7,7 @@ It works seamlessly with:
 - [VS Code](https://code.visualstudio.com/)
 - [IntelliJ (via LSP4IJ)](https://github.com/redhat-developer/lsp4ij)
 
-You can use it with a simple **Java main class** or directly inside a **Quarkus application**.
+You can use it with a simple [Java main class](#usage-in-a-java-main-class) or directly inside a [Quarkus application](#usage-in-a-quarkus-application).
 
 ![Qute template debugging](./images/QuteDebuggerDemo.gif)
 
@@ -67,7 +67,7 @@ The [Quarkus Tools for IntelliJ](https://plugins.jetbrains.com/plugin/13234-quar
 When you start a Quarkus application in **Dev Mode**, IntelliJ automatically detects the Qute Debugger startup message:
 
 ```
-DebugServerAdapter listening on port 4971
+Qute debugger server listening on port 4971
 ```
 
 It then creates a **Remote Qute Debug** run configuration automatically, which you can launch directly:
@@ -101,10 +101,10 @@ The DAP client (e.g., your IDE) must then connect to port `12345`.
 
 ### 1. Enable Qute Debugger in `application.properties`
 
-The Qute debugger is **disabled by default**. Enable it by adding:
+The Qute debugger is **enabled by default**. Disable it by adding (if you need):
 
 ```properties
-quarkus.qute.debug.enabled=true
+quarkus.qute.debug.enabled=false
 ```
 
 ### 2. Start Quarkus with Debug Ports

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/adapter/RegisterDebugServerAdapter.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/adapter/RegisterDebugServerAdapter.java
@@ -187,21 +187,21 @@ public class RegisterDebugServerAdapter implements EngineListener {
 
         try {
             serverSocket = new ServerSocket(port);
-            log("DebugServerAdapter listening on port " + serverSocket.getLocalPort());
+            log("Qute debugger server listening on port " + serverSocket.getLocalPort());
             if (suspend) {
                 // Suspend mode: block here until a DAP client connects
-                log("Waiting for DAP client to connect (suspend mode)...");
+                log("Waiting for Qute debugger client to connect (suspend mode)...");
                 var client = serverSocket.accept();
-                log("DAP client connected (suspend mode)!");
+                log("Qute debugger client connected (suspend mode)!");
                 setupLauncher(client, true);
             } else {
                 // Non-suspend mode: accept clients asynchronously in a daemon thread loop
                 executor.execute(() -> {
                     while (serverSocket != null && !serverSocket.isClosed()) {
                         try {
-                            log("Waiting for a new DAP client...");
+                            log("Waiting for a new Qute debugger client...");
                             var client = serverSocket.accept();
-                            log("DAP client connected!");
+                            log("Qute debugger client connected");
                             setupLauncher(client, false);
                             trackedEngines.forEach(engine -> agent.track(engine));
                         } catch (IOException e) {


### PR DESCRIPTION
Improve Qute debugger port listening log

Here the new trace in console:

```
Qute debugger server listening on port 56725
Waiting for a new debugger client...
Debugger client connected
Waiting for a new debugger client...

```

@FroMage please review the PR