### PR TITLE
Improve documentation to clarify servlet type support is limited to RESTEasy Classic

### DIFF
--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -446,6 +446,11 @@ In addition to the method parameters that can be annotated with the appropriate 
 `jakarta.servlet.http.HttpServletRequest` and `jakarta.servlet.http.HttpServletResponse` are also supported.
 For this to function however, users need to add the `quarkus-undertow` dependency.
 
+⚠️ Important: These types are only available when using the Classic RESTEasy stack (quarkus-resteasy / quarkus-resteasy-jackson) because they rely on the Servlet API provided by Undertow (quarkus-undertow).
+
+If your application uses the Reactive stack (quarkus-rest / quarkus-rest-jackson), then the Servlet API is not supported.
+In this case, adding the quarkus-undertow dependency will not enable servlet injection and will result in runtime errors.
+
 === Exception handler method return types
 
 The following method return types are supported:

--- a/extensions/spring-web/resteasy-classic/tests/src/test/java/io/quarkus/spring/web/resteasy/classic/test/ResponseStatusAndExceptionHandlerTest.java
+++ b/extensions/spring-web/resteasy-classic/tests/src/test/java/io/quarkus/spring/web/resteasy/classic/test/ResponseStatusAndExceptionHandlerTest.java
@@ -2,6 +2,8 @@ package io.quarkus.spring.web.resteasy.classic.test;
 
 import static io.restassured.RestAssured.when;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.http.HttpStatus;
@@ -46,6 +48,11 @@ public class ResponseStatusAndExceptionHandlerTest {
         @ExceptionHandler(RuntimeException.class)
         public ResponseEntity<Object> handleException(Exception ex) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        @ExceptionHandler(RuntimeException.class)
+        public ResponseEntity<Object> forbidden(Exception ex, HttpServletRequest request) {
+            return new ResponseEntity<>(HttpStatus.FORBIDDEN);
         }
     }
 }


### PR DESCRIPTION
Add some clarifications to the doc because Jakarta servlet types are only supported in a Resteasy classic stack.

Fixes #50228 


