### PR TITLE
Fix OpenTelemetry context resolution when HTTP Vert.x proactive authentication is enabled

### DIFF
--- a/integration-tests/opentelemetry-reactive/src/main/java/io/quarkus/it/opentelemetry/reactive/BaggageResource.java
+++ b/integration-tests/opentelemetry-reactive/src/main/java/io/quarkus/it/opentelemetry/reactive/BaggageResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.opentelemetry.reactive;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+
+@ApplicationScoped
+@Path("baggage")
+public class BaggageResource {
+
+    @Path("build")
+    @WithSpan
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        try (Scope ignored = Baggage.current().toBuilder().put("key", "baggage-value").build().makeCurrent()) {
+            String value = Baggage.current().getEntryValue("key");
+            if (!"baggage-value".equals(value)) {
+                throw new RuntimeException("Baggage is missing the first value!");
+            }
+            return value;
+        }
+    }
+}

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryContextPropagationTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryContextPropagationTest.java
@@ -1,0 +1,135 @@
+package io.quarkus.it.opentelemetry.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+
+@TestProfile(OpenTelemetryContextPropagationTest.OtelContextPropagationTestProfile.class)
+@QuarkusTest
+public class OpenTelemetryContextPropagationTest {
+
+    /**
+     * This message is logged by
+     * {@link io.quarkus.opentelemetry.runtime.QuarkusContextStorage#attach(Context, io.opentelemetry.context.Context)}
+     * when the context to attach is not the expected OpenTelemetry context.
+     */
+    private static final String UNEXPECTED_OTEL_CONTEXT = "Context in storage not the expected context";
+
+    @TestHTTPResource("baggage")
+    URI baggageUri;
+
+    /**
+     * This method tests and verifies <a href="https://github.com/quarkusio/quarkus/issues/49468">issue #49468</a>.
+     * If the issue wasn't fixed, presence of the Vert.x HTTP authentication handler will cause
+     * the {@link io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider}
+     * to set the incorrect OpenTelemetry context while Quarkus REST resource method is executed.
+     */
+    @Test
+    public void testContextPropagationInConcurrentRequests() throws InterruptedException {
+        // if this test turns out too heavy for our CI resources, we can lower the number of requests;
+        // whether the original issue was reproduced highly depends on number of requests and the executor machine
+        // for example on my laptop, the missing baggage value could only be always reproduced with the 100_000 requests
+        // however the 'Context in storage not the expected context' is much easier to reproduce and 10_000 requests
+        // is enough on my laptop most of the time; if this test becomes flaky, consider re-test it with increased
+        // number of requests it should make failures more frequent; nevertheless, if this test is re-run many times,
+        // it reproduces the "missing baggage value" issue as well, just less often
+        int numOfRequests = 10_000;
+        AtomicReference<Throwable> throwableReference = new AtomicReference<>();
+        CountDownLatch messageLatch = new CountDownLatch(numOfRequests);
+
+        Vertx vertx = Vertx.vertx();
+        HttpClient httpClient = vertx.createHttpClient();
+        RequestOptions options = new RequestOptions()
+                .setHost(baggageUri.getHost())
+                .setSsl(false)
+                .setMethod(HttpMethod.GET)
+                .setURI("/baggage/build")
+                .setPort(baggageUri.getPort());
+        try {
+            for (int i = 0; i < numOfRequests; i++) {
+                httpClient
+                        .request(options)
+                        .map(HttpClientRequest::send)
+                        .onComplete(ar -> {
+                            if (ar.succeeded()) {
+                                ar.result().onComplete(ar1 -> {
+                                    if (ar1.succeeded()) {
+                                        if (ar1.result().statusCode() == 200) {
+                                            messageLatch.countDown();
+                                        } else {
+                                            throwableReference.set(new RuntimeException(
+                                                    "Unexpected response status code " + ar1.result().statusCode()
+                                                            + " from server: " + ar1.result().statusMessage()));
+                                        }
+                                    } else {
+                                        throwableReference.set(ar1.cause());
+                                    }
+                                });
+                            } else {
+                                throwableReference.set(ar.cause());
+                            }
+                        });
+            }
+
+            assertTrue(messageLatch.await(30, TimeUnit.SECONDS),
+                    () -> "Latch timed out, encountered failure was: " + throwableReference.get());
+            assertThat(throwableReference.get()).isNull();
+            verifyLogs();
+        } finally {
+            Future.join(httpClient.close(), vertx.close());
+        }
+    }
+
+    private static void verifyLogs() {
+        Path quarkusLogFile = Paths.get(".", "target").resolve("quarkus.log");
+        assertTrue(quarkusLogFile.toFile().exists(), "Log file " + quarkusLogFile + " does not exist");
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new ByteArrayInputStream(Files.readAllBytes(quarkusLogFile)), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(UNEXPECTED_OTEL_CONTEXT)) {
+                    Assertions.fail("Log should not contain message: " + line);
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class OtelContextPropagationTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.log.file.enabled", "true");
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does

- fixes https://github.com/quarkusio/quarkus/issues/49468
- tiny refactoring: I mentioned that anonymous identity is not memoized and when we use deferred identity elsewhere in a code, this code every time calls identity manager, resolves the anonymous identity providers and apply augmentors. Now, the resolved anonymous identity is used instead of calling the identity manager multiple times.

### Tests (or a reproducer?)

You can use the reproducer attached to the linked issue to test this PR, because it only happens with certain level of concurrency and takes time. What I used is this:

```
git clone git@github.com:michalvavrik/eager-security-slow-context-activation-reproducer.git
cd eager-security-slow-context-activation-reproducer
mvn clean install
java -jar target/quarkus-app/quarkus-run.jar  2>&1 | tee log
# other window
seq 1 100000 | xargs -n1 -P1000 -I{} curl -v http://localhost:8080/reproducer
# look for "Baggage is missing first value" log message
```

### Explanation of the change

In https://github.com/quarkusio/quarkus/issues/49468, OpenTelemetry contextual data are lost because previous context is incorrectly determined. There is a race, caused by the fact that https://github.com/quarkusio/quarkus/blob/2ce3255df44644a66ffad4b5786d69282bcedbd0/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java#L32 invoked by `io.smallrye.context.impl.SlowActiveContextState.close(SlowActiveContextState.java:41)` is called when other code is using the same duplicated context (you can see in in the text file `key-diff` that I put into my reproducer). **I think it happens in the moment when threads are switched to the worker thread, but it is very hard to debug, I am not sure where in Quarkus REST it happens.** However this PR fixes principle, and not one scenario:

1. https://github.com/quarkusio/quarkus/blob/2ce3255df44644a66ffad4b5786d69282bcedbd0/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java#L406 is called from a subscriber `onItem` wrapper by SR Context Mutiny interceptor
2. other route handlers run until synchronous code ends and there is a context switch
3. Uni subscriber callbacks like onItem, OnFailure (onCompletion for publisher etc.) are wrapped by Mutiny interceptor https://github.com/smallrye/smallrye-mutiny/blob/main/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationInterceptor.java
4. SR Context propagation provides https://github.com/smallrye/smallrye-context-propagation/blob/main/core/src/main/java/io/smallrye/context/SmallRyeThreadContext.java
5. SR Ctx propagation is transitive dep of `quarkus-mutiny` which is transitive dep of `quarkus-vertx`
6. Otel defines its own `ThreadContextProvider` called https://github.com/quarkusio/quarkus/blob/main/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/propagation/OpenTelemetryMpContextPropagationProvider.java
7. Then `OpenTelemetryMpContextPropagationProvider` `endContext` can be called while Quarkus REST endpoint blocking method is executed and it is all about timing, when it happens, it switches to "prior" OTel context stored on the Vert.x duplicated context is used concurrently

My conclusion is that the fact that the same Vert.x duplicated context can be used concurrently is a bug, but we can easily avoid that as far as Vert.x HTTP Security goes by scheduling `routingContext.next()` once the thread local is not used. But I'd like to find more efficient way to avoid the "last" callback which needs to happen without SR Ctx propagation, something like switching context for one subscriber.

### Test added in this PR to reproduce the issue

Without the fix, the test fails on my laptop most of the time (only way how to make it always fail would be to raise concurrency and number of requests, which however would stretch CI). However if the added fix, following command succeeds:

```
for i in {1..100}; do
  echo "--- Run $i of 100 ---"
  mvn clean verify -Dtest=OpenTelemetryContextPropagationTest
  if [ $? -ne 0 ]; then
    echo "Command failed on run $i. Stopping loop."
    break
  fi
done
```

Which should verify the fix added in this PR.