### PR TITLE
Avoid importing BOMs managing extensions managed by BOMs with higher preferences

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -4,12 +4,18 @@ import static io.quarkus.devtools.commands.CreateProject.CreateProjectKey.*;
 import static io.quarkus.devtools.commands.handlers.CreateProjectCodestartDataConverter.toCodestartData;
 import static io.quarkus.devtools.commands.handlers.QuarkusCommandHandlers.computeExtensionsFromQuery;
 import static io.quarkus.platform.catalog.processor.ExtensionProcessor.getMinimumJavaVersion;
+import static io.quarkus.platform.tools.ToolsUtils.countOf;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,8 +33,10 @@ import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.JavaVersion;
 import io.quarkus.devtools.project.extensions.Extensions;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.platform.tools.ToolsUtils;
 import io.quarkus.registry.CatalogMergeUtility;
+import io.quarkus.registry.Constants;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.ExtensionOrigin;
@@ -42,6 +50,150 @@ import io.quarkus.registry.catalog.selection.OriginSelector;
  * of {@link QuarkusCommandInvocation}.
  */
 public class CreateProjectCommandHandler implements QuarkusCommandHandler {
+
+    private static final String MAVEN = "maven";
+    private static final String GRADLE = "gradle";
+    private static final String QUARKUS_BOM = "quarkus-bom";
+    private static final String QUARKUS_CORE = "quarkus-core";
+
+    private static class ProjectDependencyInfo {
+
+        private final ExtensionCatalog primaryCatalog;
+        private final ExtensionCatalog dataCatalog;
+        private final List<ArtifactCoords> platformBoms;
+        private final List<ArtifactCoords> extensionDeps;
+
+        ProjectDependencyInfo(ExtensionCatalog primaryCatalog, List<Extension> selectedExtensions) {
+
+            this.primaryCatalog = primaryCatalog;
+            this.dataCatalog = primaryCatalog;
+            this.platformBoms = List.of(primaryCatalog.getBom());
+
+            this.extensionDeps = new ArrayList<>(selectedExtensions.size());
+            for (Extension e : selectedExtensions) {
+                ArtifactCoords coords = e.getArtifact();
+                for (ExtensionOrigin origin : e.getOrigins()) {
+                    if (origin.isPlatform() && origin.getBom() != null && platformBoms.contains(origin.getBom())) {
+                        coords = Extensions.stripVersion(coords);
+                        break;
+                    }
+                }
+                extensionDeps.add(coords);
+            }
+
+        }
+
+        ProjectDependencyInfo(List<ExtensionCatalog> extensionOrigins, List<Extension> selectedExtensions,
+                Collection<String> extensionsQuery) {
+
+            final Map<ArtifactKey, ArtifactCoords> extensionDeps = new LinkedHashMap<>(selectedExtensions.size());
+
+            // TODO Compatibility of user-provided extension artifacts to be taken into account.
+            // If a user provided some complete artifact coordinates then we actually do not check for compatibility
+            // of those artifact (possibly extensions) with the recommended platforms and Quarkus core.
+            // It has worked like this from the beginning but it should be reviewed in the future.
+            final Map<ArtifactKey, ArtifactCoords> userProvidedCoords = collectArtifactCoords(extensionsQuery);
+
+            final ArrayDeque<Extension> extensionDeque = new ArrayDeque<>(selectedExtensions);
+
+            // necessary to set the versions from the selected origins
+            this.dataCatalog = CatalogMergeUtility.merge(extensionOrigins);
+            // collect platform BOMs to import
+            boolean sawFirstPlatform = false;
+            ExtensionCatalog primaryCatalog = null;
+            this.platformBoms = new ArrayList<>(extensionOrigins.size());
+            for (ExtensionCatalog c : extensionOrigins) {
+                if (c.isPlatform()) {
+                    if (c.getBom().getArtifactId().equals(QUARKUS_BOM) || !sawFirstPlatform) {
+                        primaryCatalog = c;
+                        sawFirstPlatform = true;
+                    }
+                    platformBoms.add(c.getBom());
+                }
+
+                final Map<ArtifactKey, ArtifactCoords> allCatalogExtensions = getCatalogExtensions(c);
+                var i = extensionDeque.iterator();
+                while (i.hasNext()) {
+                    final ArtifactKey extKey = i.next().getArtifact().getKey();
+                    ArtifactCoords addedCoords = userProvidedCoords.get(extKey);
+                    if (addedCoords != null) {
+                        extensionDeps.put(extKey, addedCoords);
+                        i.remove();
+                    } else {
+                        ArtifactCoords mappedCoords = extensionDeps.get(extKey);
+                        if (mappedCoords == null || c.isPlatform()) {
+                            addedCoords = allCatalogExtensions.get(extKey);
+                            if (addedCoords != null) {
+                                if (c.isPlatform()) {
+                                    addedCoords = Extensions.stripVersion(addedCoords);
+                                    i.remove();
+                                }
+                                extensionDeps.put(extKey, addedCoords);
+                            }
+                        }
+                    }
+                }
+            }
+
+            this.primaryCatalog = Objects.requireNonNull(primaryCatalog, "primary catalog is null");
+            this.extensionDeps = List.copyOf(extensionDeps.values());
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<ArtifactKey, ArtifactCoords> getCatalogExtensions(ExtensionCatalog catalog) {
+            if (catalog.getMetadata()
+                    .get(Constants.REGISTRY_CLIENT_ALL_CATALOG_EXTENSIONS) instanceof Map<?, ?> allCatalogExtensions) {
+                return (Map<ArtifactKey, ArtifactCoords>) allCatalogExtensions;
+            }
+            final Collection<Extension> extensions = catalog.getExtensions();
+            final Map<ArtifactKey, ArtifactCoords> result = new HashMap<>(extensions.size());
+            for (Extension e : extensions) {
+                result.put(e.getArtifact().getKey(), e.getArtifact());
+            }
+            return result;
+        }
+
+        /**
+         * Collects complete artifact coordinates from a user-provided input. If a user-provided input
+         * does not appear to contain complete artifact coordinates, the method returns an empty map.
+         *
+         * @param extensionsQuery user-provided input
+         * @return complete artifact coordinates collected from a user-provided input
+         */
+        private static Map<ArtifactKey, ArtifactCoords> collectArtifactCoords(Collection<String> extensionsQuery) {
+            Map<ArtifactKey, ArtifactCoords> result = Map.of();
+            for (String extensionExpr : extensionsQuery) {
+                if (countOf(extensionExpr, ':') > 1) {
+                    if (result.isEmpty()) {
+                        result = new HashMap<>();
+                    }
+                    final ArtifactCoords coords = ArtifactCoords.fromString(extensionExpr);
+                    result.put(coords.getKey(), coords);
+                }
+            }
+            return result;
+        }
+
+        ExtensionCatalog getPrimaryPlatformCatalog() {
+            return primaryCatalog;
+        }
+
+        List<ArtifactCoords> getBoms() {
+            return platformBoms;
+        }
+
+        List<ArtifactCoords> getDependencies() {
+            return extensionDeps;
+        }
+
+        Map<String, Object> getPlatformProjectData() {
+            return ToolsUtils.readProjectData(dataCatalog);
+        }
+
+        void setQuarkusProperties(QuarkusCommandInvocation invocation) {
+            CreateProjectCommandHandler.setQuarkusProperties(invocation, dataCatalog);
+        }
+    }
 
     @Override
     public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
@@ -69,43 +221,11 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
         checkMinimumJavaVersion(javaVersion, extensionsToAdd);
         final List<ExtensionCatalog> extensionOrigins = getExtensionOrigins(mainCatalog, extensionsToAdd);
 
-        final List<ArtifactCoords> platformBoms = new ArrayList<>(Math.max(extensionOrigins.size(), 1));
-        Map<String, Object> platformProjectData;
-        if (!extensionOrigins.isEmpty()) {
-            // necessary to set the versions from the selected origins
-            final ExtensionCatalog mergedCatalog = CatalogMergeUtility.merge(extensionOrigins);
-            platformProjectData = ToolsUtils.readProjectData(mergedCatalog);
-            setQuarkusProperties(invocation, mergedCatalog);
-            extensionsToAdd = computeRequiredExtensions(mergedCatalog, extensionsQuery, invocation.log());
-            // collect platform BOMs to import
-            boolean sawFirstPlatform = false;
-            for (ExtensionCatalog c : extensionOrigins) {
-                if (!c.isPlatform()) {
-                    continue;
-                }
-                if (c.getBom().getArtifactId().equals("quarkus-bom") || !sawFirstPlatform) {
-                    mainCatalog = c;
-                    sawFirstPlatform = true;
-                }
-                platformBoms.add(c.getBom());
-            }
-        } else {
-            platformProjectData = ToolsUtils.readProjectData(mainCatalog);
-            platformBoms.add(mainCatalog.getBom());
-            setQuarkusProperties(invocation, mainCatalog);
-        }
-
-        final List<ArtifactCoords> extensionCoords = new ArrayList<>(extensionsToAdd.size());
-        for (Extension e : extensionsToAdd) {
-            ArtifactCoords coords = e.getArtifact();
-            for (ExtensionOrigin origin : e.getOrigins()) {
-                if (origin.isPlatform() && origin.getBom() != null && platformBoms.contains(origin.getBom())) {
-                    coords = Extensions.stripVersion(coords);
-                    break;
-                }
-            }
-            extensionCoords.add(coords);
-        }
+        final ProjectDependencyInfo depInfo = extensionOrigins.isEmpty()
+                ? new ProjectDependencyInfo(mainCatalog, extensionsToAdd)
+                : new ProjectDependencyInfo(extensionOrigins, extensionsToAdd, extensionsQuery);
+        mainCatalog = depInfo.getPrimaryPlatformCatalog();
+        depInfo.setQuarkusProperties(invocation);
 
         invocation.setValue(CatalogKey.BOM_GROUP_ID, mainCatalog.getBom().getGroupId());
         invocation.setValue(CatalogKey.BOM_ARTIFACT_ID, mainCatalog.getBom().getArtifactId());
@@ -114,22 +234,22 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
 
         try {
             Map<String, Object> platformData = new HashMap<>();
-            if (mainCatalog.getMetadata().get("maven") != null) {
-                platformData.put("maven", mainCatalog.getMetadata().get("maven"));
+            if (mainCatalog.getMetadata().get(MAVEN) != null) {
+                platformData.put(MAVEN, mainCatalog.getMetadata().get(MAVEN));
             }
-            if (mainCatalog.getMetadata().get("gradle") != null) {
-                platformData.put("gradle", mainCatalog.getMetadata().get("gradle"));
+            if (mainCatalog.getMetadata().get(GRADLE) != null) {
+                platformData.put(GRADLE, mainCatalog.getMetadata().get(GRADLE));
             }
             final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
-                    .addPlatforms(platformBoms)
-                    .addExtensions(extensionCoords)
+                    .addPlatforms(depInfo.getBoms())
+                    .addExtensions(depInfo.getDependencies())
                     .buildTool(invocation.getQuarkusProject().getBuildTool())
                     .example(invocation.getValue(EXAMPLE))
                     .noCode(invocation.getValue(NO_CODE, false))
                     .addCodestarts(invocation.getValue(EXTRA_CODESTARTS, Set.of()))
                     .noBuildToolWrapper(invocation.getValue(NO_BUILDTOOL_WRAPPER, false))
                     .noDockerfiles(invocation.getValue(NO_DOCKERFILES, false))
-                    .addData(platformProjectData)
+                    .addData(depInfo.getPlatformProjectData())
                     .addData(platformData)
                     .addData(toCodestartData(invocation.getValues()))
                     .addData(invocation.getValue(DATA, Map.of()))
@@ -138,10 +258,10 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
                     .build();
 
             invocation.log().info("-----------");
-            if (!extensionsToAdd.isEmpty()) {
+            if (!depInfo.getDependencies().isEmpty()) {
                 invocation.log().info("selected extensions: \n"
-                        + extensionsToAdd.stream()
-                                .map(e -> "- " + e.getArtifact().getGroupId() + ":" + e.getArtifact().getArtifactId() + "\n")
+                        + depInfo.getDependencies().stream()
+                                .map(e -> "- " + e.getGroupId() + ":" + e.getArtifactId() + "\n")
                                 .collect(Collectors.joining()));
             }
 
@@ -196,22 +316,20 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
         final List<ExtensionOrigins> originsWithPreferences;
         if (extensionsToAdd.isEmpty()) {
             // if no extensions were requested, we select the core BOM
-            if (quarkusCore.getOrigins().size() == 1 && quarkusCore.getOrigins().get(0) instanceof ExtensionCatalog) {
+            if (quarkusCore.getOrigins().size() == 1
+                    && quarkusCore.getOrigins().get(0) instanceof ExtensionCatalog originCatalog) {
                 // in this case, there is only one origin to choose from
-                return List.of((ExtensionCatalog) quarkusCore.getOrigins().get(0));
+                return List.of(originCatalog);
             }
-            originsWithPreferences = new ArrayList<>(quarkusCore.getOrigins().size());
             extensionsToAdd = List.of(quarkusCore);
-        } else {
-            originsWithPreferences = new ArrayList<>();
-            for (Extension e : extensionsToAdd) {
-                addOriginsWithPreferences(originsWithPreferences, e);
-            }
         }
 
-        addOriginsWithPreferences(originsWithPreferences, quarkusCore);
+        originsWithPreferences = new ArrayList<>();
+        for (Extension e : extensionsToAdd) {
+            addOriginsWithPreferences(originsWithPreferences, e);
+        }
         if (!originsWithPreferences.isEmpty()) {
-            return getRecommendedOrigins(extensionsToAdd, originsWithPreferences);
+            return getRecommendedOrigins(extensionsToAdd, quarkusCore, originsWithPreferences);
         }
 
         // no origin preferences were found (origin-preference data is missing)
@@ -222,34 +340,150 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
         }
 
         // fallback to the best guess
-        final Map<String, ExtensionCatalog> catalogMap = new HashMap<>();
+        final Map<String, ExtensionCatalog> catalogMap = new LinkedHashMap<>();
         for (var e : extensionsToAdd) {
-            var origin = e.getOrigins().get(0);
-            if (origin instanceof ExtensionCatalog) {
-                catalogMap.putIfAbsent(origin.getId(), (ExtensionCatalog) origin);
+            final List<ExtensionOrigin> origins = e.getOrigins();
+            if (!origins.isEmpty()) {
+                if (origins.get(0) instanceof ExtensionCatalog originCatalog) {
+                    catalogMap.putIfAbsent(originCatalog.getId(), originCatalog);
+                }
             }
         }
         return List.copyOf(catalogMap.values());
     }
 
     private static List<ExtensionCatalog> getRecommendedOrigins(List<Extension> extensionsToAdd,
-            List<ExtensionOrigins> extOrigins) throws QuarkusCommandException {
+            Extension quarkusCore, List<ExtensionOrigins> extOrigins) throws QuarkusCommandException {
         final OriginCombination recommendedCombination = OriginSelector.of(extOrigins).calculateRecommendedCombination();
         if (recommendedCombination == null) {
-            final StringBuilder buf = new StringBuilder();
-            buf.append("Failed to determine a compatible Quarkus version for the requested extensions: ");
-            buf.append(extensionsToAdd.get(0).getArtifact().getKey().toGacString());
-            for (int i = 1; i < extensionsToAdd.size(); ++i) {
-                buf.append(", ").append(extensionsToAdd.get(i).getArtifact().getKey().toGacString());
-            }
-            throw new QuarkusCommandException(buf.toString());
+            throw new QuarkusCommandException(noCompatibleQuarkusCoreVersion(extensionsToAdd));
         }
-        return recommendedCombination.getUniqueSortedCatalogs();
+        // get the recommended catalogs in the right order according to the preferences
+        List<ExtensionCatalog> sortedCatalogs = recommendedCombination.getUniqueSortedCatalogs();
+
+        if (!containsQuarkusCore(extensionsToAdd)) {
+            sortedCatalogs = ensureQuarkusCorePresent(sortedCatalogs, quarkusCore);
+            if (sortedCatalogs.isEmpty()) {
+                throw new QuarkusCommandException(noCompatibleQuarkusCoreVersion(extensionsToAdd));
+            }
+        }
+
+        // with the introduction of offering-based filtering, some extensions may appear to be picked
+        // from a catalog with a lower preference while still having their version managed in a catalog
+        // with a higher preference.
+        // For example, an unsupported extension managed in a downstream quarkus-bom could have been picked
+        // from the upstream quarkus-bom. In this case we don't want to import both downstream and upstream
+        // quarkus-boms. The logic below is making sure there is no unnecessary BOM overlap in such cases.
+        if (sortedCatalogs.size() < 2) {
+            return sortedCatalogs;
+        }
+
+        final List<ArtifactKey> extDeps = new ArrayList<>(extensionsToAdd.size());
+        for (Extension e : extensionsToAdd) {
+            extDeps.add(e.getArtifact().getKey());
+        }
+        List<ExtensionCatalog> reducedCatalogs = null;
+        for (int i = 0; i < sortedCatalogs.size(); ++i) {
+            var catalog = sortedCatalogs.get(i);
+            if (reducedCatalogs != null) {
+                reducedCatalogs.add(catalog);
+            }
+            if (catalog.isPlatform()) {
+                var o = catalog.getMetadata().get(Constants.REGISTRY_CLIENT_ALL_CATALOG_EXTENSIONS);
+                if (o instanceof Map<?, ?> allManagedExtensionKeys) {
+                    if (extDeps.removeIf(allManagedExtensionKeys::containsKey)) {
+                        if (reducedCatalogs == null) {
+                            // if we got to the end, then we return the original catalogs
+                            if (i == sortedCatalogs.size() - 1) {
+                                break;
+                            }
+                            reducedCatalogs = new ArrayList<>(sortedCatalogs.size());
+                            for (int j = 0; j <= i; ++j) {
+                                reducedCatalogs.add(sortedCatalogs.get(j));
+                            }
+                        }
+                        if (extDeps.isEmpty()) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return reducedCatalogs == null ? sortedCatalogs : reducedCatalogs;
+    }
+
+    private static List<ExtensionCatalog> ensureQuarkusCorePresent(List<ExtensionCatalog> catalogs, Extension quarkusCore) {
+        Map<String, ExtensionCatalog> allCoreOrigins = null;
+        ExtensionCatalog matchingQuarkusCoreOrigin = null;
+        int catalogContainingCoreIndex = -1;
+        for (int i = 0; i < catalogs.size(); ++i) {
+            ExtensionCatalog catalog = catalogs.get(i);
+            if (catalog.getMetadata()
+                    .get(Constants.REGISTRY_CLIENT_ALL_CATALOG_EXTENSIONS) instanceof Map<?, ?> allCatalogExtensions) {
+                final ArtifactCoords managedQuarkusCore = (ArtifactCoords) allCatalogExtensions
+                        .get(quarkusCore.getArtifact().getKey());
+                if (managedQuarkusCore != null) {
+                    if (i == 0) {
+                        return catalogs;
+                    }
+                    catalogContainingCoreIndex = i;
+                    matchingQuarkusCoreOrigin = catalog;
+                    break;
+                }
+            }
+            if (matchingQuarkusCoreOrigin == null) {
+                if (allCoreOrigins == null) {
+                    allCoreOrigins = getOriginCatalogsByQuarkusCore(quarkusCore.getOrigins());
+                }
+                matchingQuarkusCoreOrigin = allCoreOrigins.get(catalog.getQuarkusCoreVersion());
+            }
+        }
+        if (matchingQuarkusCoreOrigin == null) {
+            return List.of();
+        }
+        if (catalogContainingCoreIndex >= 0) {
+            final List<ExtensionCatalog> result = new ArrayList<>(catalogs);
+            Collections.swap(result, 0, catalogContainingCoreIndex);
+            return result;
+        }
+        final List<ExtensionCatalog> result = new ArrayList<>(catalogs.size() + 1);
+        result.add(matchingQuarkusCoreOrigin);
+        result.addAll(catalogs);
+        return result;
+    }
+
+    private static String noCompatibleQuarkusCoreVersion(List<Extension> extensionsToAdd) {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("Failed to determine a compatible Quarkus version for the requested extensions: ");
+        buf.append(extensionsToAdd.get(0).getArtifact().getKey().toGacString());
+        for (int i = 1; i < extensionsToAdd.size(); ++i) {
+            buf.append(", ").append(extensionsToAdd.get(i).getArtifact().getKey().toGacString());
+        }
+        return buf.toString();
+    }
+
+    private static Map<String, ExtensionCatalog> getOriginCatalogsByQuarkusCore(List<ExtensionOrigin> origins) {
+        final Map<String, ExtensionCatalog> result = new HashMap<>(origins.size());
+        for (ExtensionOrigin origin : origins) {
+            if (origin instanceof ExtensionCatalog catalog) {
+                result.putIfAbsent(catalog.getQuarkusCoreVersion(), catalog);
+            }
+        }
+        return result;
+    }
+
+    private static boolean containsQuarkusCore(List<Extension> extensions) {
+        for (Extension e : extensions) {
+            if (e.getArtifact().getArtifactId().equals(QUARKUS_CORE)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Extension findQuarkusCore(ExtensionCatalog extensionCatalog) throws QuarkusCommandException {
         final Optional<Extension> quarkusCore = extensionCatalog.getExtensions().stream()
-                .filter(e -> e.getArtifact().getArtifactId().equals("quarkus-core")).findFirst();
+                .filter(e -> e.getArtifact().getArtifactId().equals(QUARKUS_CORE)).findFirst();
         if (quarkusCore.isEmpty()) {
             throw new QuarkusCommandException("Failed to locate quarkus-core in the extension catalog");
         }
@@ -259,13 +493,13 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
     private static void addOriginsWithPreferences(final List<ExtensionOrigins> extOrigins, Extension e) {
         ExtensionOrigins.Builder eoBuilder = null;
         for (ExtensionOrigin c : e.getOrigins()) {
-            if (c instanceof ExtensionCatalog) {
-                final OriginPreference op = (OriginPreference) c.getMetadata().get("origin-preference");
+            if (c instanceof ExtensionCatalog catalog) {
+                final OriginPreference op = (OriginPreference) c.getMetadata().get(Constants.REGISTRY_CLIENT_ORIGIN_PREFERENCE);
                 if (op != null) {
                     if (eoBuilder == null) {
                         eoBuilder = ExtensionOrigins.builder(e.getArtifact().getKey());
                     }
-                    eoBuilder.addOrigin((ExtensionCatalog) c, op);
+                    eoBuilder.addOrigin(catalog, op);
                 }
             }
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
@@ -319,7 +319,7 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
         }
 
         String getRegistryUserSelectedSupportKey() {
-            var supportKey = e.getMetadata().get(Constants.REGISTRY_USER_SELECTED_SUPPORT_KEY);
+            var supportKey = e.getMetadata().get(Constants.REGISTRY_CLIENT_USER_SELECTED_SUPPORT_KEY);
             if (supportKey == null) {
                 return null;
             }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
@@ -6,6 +6,7 @@ import static io.quarkus.devtools.utils.Patterns.toRegex;
 import static io.quarkus.platform.catalog.processor.ExtensionProcessor.getExtendedKeywords;
 import static io.quarkus.platform.catalog.processor.ExtensionProcessor.getShortName;
 import static io.quarkus.platform.catalog.processor.ExtensionProcessor.isUnlisted;
+import static io.quarkus.platform.tools.ToolsUtils.countOf;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -15,8 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.data.SelectionResult;
@@ -37,7 +36,7 @@ final class QuarkusCommandHandlers {
         final ArrayList<Extension> builder = new ArrayList<>();
         final Collection<Extension> extensionCatalog = catalog.getExtensions();
         for (String query : extensionsQuery) {
-            final int countColons = StringUtils.countMatches(query, ":");
+            final int countColons = countOf(query, ':');
             if (countColons > 1) {
                 ArtifactCoords artifact = ArtifactCoords.fromString(query);
                 final Extension ext = Extension.builder()

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
@@ -15,6 +15,7 @@ import io.quarkus.devtools.project.state.TopExtensionDependency;
 import io.quarkus.devtools.project.update.ExtensionMapBuilder.ExtensionUpdateInfoBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.registry.Constants;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.ExtensionOrigin;
@@ -215,7 +216,7 @@ public final class ProjectUpdateInfos {
         ExtensionOrigins.Builder eoBuilder = null;
         for (ExtensionOrigin o : e.getOrigins()) {
             if (o instanceof ExtensionCatalog c) {
-                final OriginPreference op = (OriginPreference) c.getMetadata().get("origin-preference");
+                final OriginPreference op = (OriginPreference) c.getMetadata().get(Constants.REGISTRY_CLIENT_ORIGIN_PREFERENCE);
                 if (op == null) {
                     continue;
                 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
@@ -23,6 +23,7 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.CatalogMergeUtility;
+import io.quarkus.registry.Constants;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.selection.OriginPreference;
 import io.quarkus.registry.util.PlatformArtifacts;
@@ -86,6 +87,30 @@ public class ToolsUtils {
             buf.append('.').append(parts[i++]);
         }
         return buf.toString();
+    }
+
+    /**
+     * Returns the number of occurrences of a character in a string.
+     * If the string argument is null, the method will return zero.
+     *
+     * @param str a string to search in
+     * @param ch a character look for
+     * @return number of occurrences of the character in string
+     */
+    public static int countOf(String str, int ch) {
+        if (str == null || str.isEmpty()) {
+            return 0;
+        }
+        int i = str.indexOf(ch);
+        if (i < 0) {
+            return 0;
+        }
+        int count = 0;
+        while (i >= 0) {
+            ++count;
+            i = str.indexOf(ch, i + 1);
+        }
+        return count;
     }
 
     public static ExtensionCatalog resolvePlatformDescriptorDirectly(String bomGroupId, String bomArtifactId, String bomVersion,
@@ -172,7 +197,7 @@ public class ToolsUtils {
                         final OriginPreference originPreference = new OriginPreference(registryPreference, 1, 1, ++memberIndex,
                                 1);
                         Map<String, Object> metadata = new HashMap<>(memberCatalog.getMetadata());
-                        metadata.put("origin-preference", originPreference);
+                        metadata.put(Constants.REGISTRY_CLIENT_ORIGIN_PREFERENCE, originPreference);
                         ExtensionCatalog.Mutable mutableMemberCatalog = memberCatalog.mutable();
                         mutableMemberCatalog.setMetadata(metadata);
                         catalogs.add(mutableMemberCatalog.build());

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MixingOfferingAndNonOfferingExtensionsInTheSameBomTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MixingOfferingAndNonOfferingExtensionsInTheSameBomTest.java
@@ -1,0 +1,137 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class MixingOfferingAndNonOfferingExtensionsInTheSameBomTest extends MultiplePlatformBomsTestBase {
+
+    private static final String DOWNSTREAM_PLATFORM_KEY = "io.downstream.platform";
+    private static final String UPSTREAM_PLATFORM_KEY = "io.upstream.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("downstream.registry.test")
+                .recognizedQuarkusVersions("*downstream")
+                .setOffering("offering-a")
+                // platform key
+                .newPlatform(DOWNSTREAM_PLATFORM_KEY)
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1.downstream")
+                .quarkusVersion("1.1.1.downstream")
+                .upstreamQuarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                .addExtensionWithMetadata("io.quarkus", "quarkus-rest", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .addExtension("io.quarkus", "quarkus-magic", "1.1.1.downstream")
+                .release()
+                // foo platform member
+                .newMember("acme-a-bom")
+                .addExtensionWithMetadata("io.acme", "ext-a", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .addExtension("io.acme", "ext-b", "1.1.1.downstream")
+                .release()
+                .stream().platform().registry()
+                .clientBuilder()
+                .newRegistry("upstream.registry.test")
+                // platform key
+                .newPlatform(UPSTREAM_PLATFORM_KEY)
+                // 1.1 STREAM
+                .newStream("1.1")
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember()
+                .addExtension("io.quarkus", "quarkus-rest", "1.1.1")
+                .addExtension("io.quarkus", "quarkus-magic", "1.1.1")
+                .release()
+                .newMember("acme-a-bom")
+                .addExtension("io.acme", "ext-a", "1.1.1")
+                .addExtension("io.acme", "ext-b", "1.1.1")
+                .release()
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return DOWNSTREAM_PLATFORM_KEY;
+    }
+
+    @Test
+    public void downstreamCoreBomOnlyForSupportedExtension() throws Exception {
+        final Path projectDir = newProjectDir("downstream-core-bom-only-for-supported-extension");
+        createProject(projectDir, List.of("quarkus-rest"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom()),
+                List.of(ArtifactCoords.jar("io.quarkus", "quarkus-rest", null)),
+                "1.1.1.downstream");
+    }
+
+    @Test
+    public void downstreamBomUsedForNotSupportedExtensions() throws Exception {
+        final Path projectDir = newProjectDir("downstream-bom-used-for-unsupported-extensions");
+        createProject(projectDir, List.of("quarkus-rest", "quarkus-magic"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom()),
+                List.of(ArtifactCoords.jar("io.quarkus", "quarkus-rest", null),
+                        ArtifactCoords.jar("io.quarkus", "quarkus-magic", null)),
+                "1.1.1.downstream");
+    }
+
+    @Test
+    public void upstreamCoreBomOnly() throws Exception {
+        final Path projectDir = newProjectDir("upstream-core-bom-only-project");
+        createProject(projectDir, List.of("quarkus-magic"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom()),
+                List.of(ArtifactCoords.jar("io.quarkus", "quarkus-magic", null)),
+                Map.of("quarkus.platform.group-id", UPSTREAM_PLATFORM_KEY,
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "1.1.1"));
+    }
+
+    @Test
+    public void downstreamBomsOnly() throws Exception {
+        final Path projectDir = newProjectDir("downstream-bom-only-project");
+        createProject(projectDir, List.of("ext-a", "ext-b"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null)),
+                "1.1.1.downstream");
+    }
+
+    @Test
+    public void upstreamBomsOnly() throws Exception {
+        final Path projectDir = newProjectDir("upstream-bom-only-project");
+        createProject(projectDir, List.of("ext-b"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-b", null)),
+                Map.of("quarkus.platform.group-id", UPSTREAM_PLATFORM_KEY,
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "1.1.1"));
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
@@ -191,9 +191,7 @@ public abstract class MultiplePlatformBomsTestBase {
                 .map(d -> ArtifactCoords.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(),
                         d.getVersion()))
                 .collect(Collectors.toList());
-        // TODO the order should be predictable
-        assertThat(actualBoms).containsAll(expectedBoms);
-        assertThat(expectedBoms).containsAll(actualBoms);
+        assertThat(actualBoms).containsExactlyElementsOf(expectedBoms);
         //assertThat(model.getDependencyManagement().getDependencies().size()).isEqualTo(expectedBoms.size());
 
         // TODO the order should be predictable

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PlatformWithoutQuarkusBomTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PlatformWithoutQuarkusBomTest.java
@@ -175,8 +175,8 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
 
         assertModel(projectDir,
                 List.of(mainPlatformBom(),
-                        ArtifactCoords.pom("${quarkus.platform.group-id}", "quarkus-zoo-bom", "${quarkus.platform.version}"),
-                        ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7")),
+                        ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7"),
+                        ArtifactCoords.pom("${quarkus.platform.group-id}", "quarkus-zoo-bom", "${quarkus.platform.version}")),
                 List.of(ArtifactCoords.jar("org.acme.platform", "acme-magic", null),
                         ArtifactCoords.jar("org.quarkus.platform", "quarkus-giraffe", null)),
                 "2.0.4");

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig2Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig2Test.java
@@ -93,9 +93,9 @@ public class RegistryOfferingFilteringConfig2Test extends MultiplePlatformBomsTe
 
         assertModel(projectDir,
                 List.of(mainPlatformBom(),
-                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-a-bom", "1.1.1"),
                         platformMemberBomCoords("acme-b-bom"),
                         platformMemberBomCoords("acme-c-bom"),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-a-bom", "1.1.1"),
                         ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-d-bom", "1.1.1")),
                 List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
                         ArtifactCoords.jar("io.acme", "ext-b", null),

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig3Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RegistryOfferingFilteringConfig3Test.java
@@ -93,9 +93,9 @@ public class RegistryOfferingFilteringConfig3Test extends MultiplePlatformBomsTe
 
         assertModel(projectDir,
                 List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-c-bom"),
                         ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-a-bom", "1.1.1"),
                         ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-b-bom", "1.1.1"),
-                        platformMemberBomCoords("acme-c-bom"),
                         ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-d-bom", "1.1.1")),
                 List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
                         ArtifactCoords.jar("io.acme", "ext-b", null),

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
@@ -27,8 +27,26 @@ public interface Constants {
     String OFFERING = "offering";
 
     /**
-     * An internal metadata key optionally added to extension metadata by a registry client
+     * An internal key optionally added to extension metadata by a registry client
      * to indicate a user configured offering-based support key that should be displayed by extension listing commands
      */
-    String REGISTRY_USER_SELECTED_SUPPORT_KEY = "registry-user-selected-support-key";
+    String REGISTRY_CLIENT_USER_SELECTED_SUPPORT_KEY = "registry-client:user-selected-support-key";
+
+    /**
+     * An internal key added to extension catalog metadata by a registry client
+     * to provide information about the complete list of extension artifacts included in the catalog.
+     * The value associated with this key will be a map of {@link io.quarkus.maven.dependency.ArtifactKey}
+     * to {@link io.quarkus.maven.dependency.ArtifactCoords} of extension artifacts.
+     * <p>
+     * The list of extension artifacts will contain all the extension artifacts before the offering-based
+     * filtered applied.
+     */
+    String REGISTRY_CLIENT_ALL_CATALOG_EXTENSIONS = "registry-client:offering-managed-not-supported-keys";
+
+    /**
+     * An internal key added to an extension catalog metadata by a registry client
+     * to associate a given extension catalog with a preference code that will be used by an algorithm
+     * selecting the latest recommended combination of extension and platform BOM versions.
+     */
+    String REGISTRY_CLIENT_ORIGIN_PREFERENCE = "registry-client:origin-preference";
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -520,7 +520,7 @@ public class ExtensionCatalogResolver {
     }
 
     private static void addOriginPreference(final ExtensionCatalog.Mutable ec, OriginPreference originPreference) {
-        ec.getMetadata().put("origin-preference", originPreference);
+        ec.getMetadata().put(Constants.REGISTRY_CLIENT_ORIGIN_PREFERENCE, originPreference);
     }
 
     public ExtensionCatalog resolveExtensionCatalog(String quarkusCoreVersion) throws RegistryResolutionException {


### PR DESCRIPTION
This is a fix for an issue of redundant BOM imports **when a registry client is configured with a specific offering value** and a user selected an extension included in the offering and an extension that is not included in the offering but managed in the same BOM as the extension from the offering.

The issue can be reproduced with recent CLI versions (3.27+) by configuring a registry client as
````
registries:
  - registry.quarkus.redhat.com:
      offering: redhat
  - registry.quarkus.io
````
and running a command such as
````
quarkus create -x quarkus-rest,qute-web
````
The resulting project configuration will look like
````
...
        <quarkus-plugin.version>3.20.2.SP1-redhat-00003</quarkus-plugin.version>
        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
        <quarkus.platform.version>3.20.2</quarkus.platform.version>
        <skipITs>true</skipITs>
        <surefire-plugin.version>3.5.2</surefire-plugin.version>
    </properties>

    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>com.redhat.quarkus.platform</groupId>
                <artifactId>${quarkus.platform.artifact-id}</artifactId>
                <version>3.20.2.SP1-redhat-00003</version>
                <type>pom</type>
                <scope>import</scope>
            </dependency>
            <dependency>
                <groupId>${quarkus.platform.group-id}</groupId>
                <artifactId>${quarkus.platform.artifact-id}</artifactId>
                <version>${quarkus.platform.version}</version>
                <type>pom</type>
                <scope>import</scope>
            </dependency>
        </dependencies>
    </dependencyManagement>

    <dependencies>
        <dependency>
            <groupId>io.quarkiverse.qute.web</groupId>
            <artifactId>quarkus-qute-web</artifactId>
        </dependency>
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-rest</artifactId>
        </dependency>
...
````
With this change the generated POM will look like
````
...
        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
        <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
        <quarkus.platform.version>3.20.2.SP1-redhat-00003</quarkus.platform.version>
        <skipITs>true</skipITs>
        <surefire-plugin.version>3.5.2</surefire-plugin.version>
    </properties>

    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>${quarkus.platform.group-id}</groupId>
                <artifactId>${quarkus.platform.artifact-id}</artifactId>
                <version>${quarkus.platform.version}</version>
                <type>pom</type>
                <scope>import</scope>
            </dependency>
        </dependencies>
    </dependencyManagement>

    <dependencies>
        <dependency>
            <groupId>io.quarkiverse.qute.web</groupId>
            <artifactId>quarkus-qute-web</artifactId>
        </dependency>
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-rest</artifactId>
        </dependency>
...
````
This change also introduces a check for a specific BOM import ordering in tests.

FYI @jedla97, this issue came up in our previous discussions.