### PR TITLE
QuarkusComponentTest: introduce QuarkusComponentTestCallbacks, integrate seamlessly with quarkus-panache-mock

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -863,7 +863,7 @@ public class JunitTestRunner {
                             ClassLoader excl = (ClassLoader) getClassLoader.invoke(ecl, componentTestClass, cl);
                             utClasses.add(excl.loadClass(componentTestClass));
                         } catch (Exception e) {
-                            log.debug(e);
+                            log.debug(e.getMessage(), e);
                             log.warnf("Failed to load component test class %s, it will not be executed this run.",
                                     componentTestClass);
                         }

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -1164,6 +1164,7 @@ public class PersonRepository implements PanacheRepositoryBase<Person,Integer> {
 
 == Mocking
 
+[[mocking_active_record]]
 === Using the active record pattern
 
 If you are using the active record pattern you cannot use Mockito directly as it does not support mocking static methods,

--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -18,7 +18,7 @@ Therefore, Quarkus provides `QuarkusComponentTestExtension` - a JUnit extension 
 Unlike `@QuarkusTest` this extension does not start a full Quarkus application but merely the CDI container and the configuration service.
 You can find more details in the <<lifecycle>> section.
 
-TIP: This extension is available in the `quarkus-junit5-component` dependency.
+TIP: This JUnit extension is available in the `quarkus-junit5-component` dependency.
 
 == Basic example
 
@@ -302,6 +302,101 @@ CDI beans are also automatically registered for all injected https://smallrye.io
 By default, only the config properties from `application.properties` and properties set by the `@TestConfigProperty` annotation or with the `QuarkusComponentTestExtensionBuilder#configProperty(String, String)` method are included in the test config.
 System properties and ENV variables are _not_ included in the test config by default.
 However, you can use `@QuarkusComponentTest#useSystemConfigSources()` or `QuarkusComponentTestExtensionBuilder#useSystemConfigSources()` to configure this behavior.
+
+== Panache entities using the active record pattern
+
+If you are using the active record pattern you cannot easily leverage `Mockito#mockStatic()` to mock static methods declared on `PanacheEntityBase`.
+In a normal Quarkus app, these static methods are automatically overridden in subclasses.
+However, `QuarkusComponentTest` does not start a full Quarkus application.
+Nevertheless, you can use the `quarkus-panache-mock` module which integrates seamlessly with `QuarkusComponentTest`.
+
+Add this dependency to your `pom.xml`:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-panache-mock</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+Given this simple entity:
+
+[source,java]
+----
+@Entity
+public class Person extends PanacheEntity {
+
+   public String name;
+   
+   public Person(String name) {
+      this.name = name;
+   }
+
+   public static List<Person> findOrdered() {
+      return find("ORDER BY name").list();
+   }
+}
+----
+
+That is used in a simple bean:
+
+[source,java]
+----
+public class PersonService {
+
+   public List<Person> getPersons(boolen sorted) {
+      if (sorted) {
+         return Person.findOrdered();
+      }
+      return Person.listAll();
+   }
+}
+----
+
+You can write your component test like:
+
+.Nested test
+[source, java]
+----
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.panache.mock.MockPanacheEntities;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusComponentTest <1>
+@MockPanacheEntities(Person.class) <2>
+public class PersonServiceTest {
+
+    @Inject
+    PersonService personService; <3>
+    
+    @Test
+    public void testGetPersons() { 
+        Mockito.when(Person.listAll()).thenReturn(List.of(new Person("Tom")));
+        List<Person> list = personService.getPersons(false);
+        assertEquals(1, list.size());
+        assertEquals("Tom", list.get(0).name);
+        
+        Mockito.when(Person.findOrdered()).thenReturn(List.of(new Person("Tom")));
+        list = personService.getPersons(true);
+        assertEquals(1, list.size());
+        assertEquals("Tom", list.get(0).name);
+    }
+
+}
+----
+<1> The `QuarkusComponentTest` annotation registers the JUnit extension.
+<2> `@MockPanacheEntities` installs mocks for the given entity classes. 
+<3> The test injects the component under the test - `PersonService`.
+
+TIP: See also xref:hibernate-orm-panache.adoc#mocking_active_record[Simplified Hibernate ORM with Panache - Using the active record pattern] for more information.
+
+NOTE: Currently, only the integration with Hibernate ORM is supported. Other variants of the Panache API, such as MongoDB and Hibernate Reactive, are not supported yet.
 
 == Mocking CDI Interceptors
 

--- a/extensions/panache/panache-mock/pom.xml
+++ b/extensions/panache/panache-mock/pom.xml
@@ -31,8 +31,18 @@
             <artifactId>quarkus-junit5-mockito</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-component</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/MockPanacheEntities.java
+++ b/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/MockPanacheEntities.java
@@ -1,0 +1,24 @@
+package io.quarkus.panache.mock;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Install mocks for the given entity classes.
+ * <p>
+ * This annotation only works together with {@code QuarkusComponentTest}.
+ *
+ * @see PanacheMock#mock(Class...)
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface MockPanacheEntities {
+
+    /**
+     * The entity classes.
+     */
+    Class<?>[] value() default {};
+}

--- a/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/impl/PanacheQuarkusComponentTestCallbacks.java
+++ b/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/impl/PanacheQuarkusComponentTestCallbacks.java
@@ -1,0 +1,189 @@
+package io.quarkus.panache.mock.impl;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.arc.processor.BytecodeTransformer;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
+import io.quarkus.gizmo.ClassTransformer;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
+import io.quarkus.panache.common.deployment.PanacheConstants;
+import io.quarkus.panache.mock.MockPanacheEntities;
+import io.quarkus.panache.mock.PanacheMock;
+import io.quarkus.test.component.QuarkusComponentTestCallbacks;
+
+public class PanacheQuarkusComponentTestCallbacks implements QuarkusComponentTestCallbacks {
+
+    private static final DotName PANACHE_ENTITY = DotName.createSimple("io.quarkus.hibernate.orm.panache.PanacheEntity");
+    private static final DotName PANACHE_ENTITY_BASE = DotName
+            .createSimple("io.quarkus.hibernate.orm.panache.PanacheEntityBase");
+
+    @Override
+    public void beforeBuild(BeforeBuildContext buildContext) {
+        Class<?> testClass = buildContext.getTestClass();
+        MockPanacheEntities panacheMocks = testClass.getAnnotation(MockPanacheEntities.class);
+        if (panacheMocks == null || panacheMocks.value().length == 0) {
+            return;
+        }
+        List<ClassInfo> mockedEntities = new ArrayList<>();
+        for (Class<?> mockClass : panacheMocks.value()) {
+            ClassInfo maybeMockedEntity = buildContext.getComputingBeanArchiveIndex().getClassByName(mockClass);
+            DotName superName = maybeMockedEntity.superName();
+            if (maybeMockedEntity.isAbstract()
+                    || superName == null
+                    || (!superName.equals(PANACHE_ENTITY)
+                            && !superName.equals(PANACHE_ENTITY_BASE))) {
+                continue;
+            }
+            mockedEntities.add(maybeMockedEntity);
+        }
+
+        Map<DotName, List<MethodInfo>> entityUserMethods = new HashMap<>();
+        for (ClassInfo entity : mockedEntities) {
+            for (MethodInfo method : entity.methods()) {
+                if (!method.isSynthetic()
+                        && Modifier.isStatic(method.flags())
+                        && Modifier.isPublic(method.flags())) {
+                    List<MethodInfo> userMethods = entityUserMethods.get(entity.name());
+                    if (userMethods == null) {
+                        userMethods = new ArrayList<>();
+                        entityUserMethods.put(entity.name(), userMethods);
+                    }
+                    userMethods.add(method);
+                }
+            }
+        }
+
+        Map<DotName, List<MethodInfo>> entityGeneratedMethods = new HashMap<>();
+        ClassInfo panacheEntityBaseClassInfo = buildContext.getComputingBeanArchiveIndex()
+                .getClassByName(DotName.createSimple("io.quarkus.hibernate.orm.panache.PanacheEntityBase"));
+        for (ClassInfo entity : mockedEntities) {
+            for (MethodInfo method : panacheEntityBaseClassInfo.methods()) {
+                if (!userMethodExists(entityUserMethods.get(entity.name()), method)) {
+                    AnnotationInstance bridge = method.annotation(PanacheConstants.DOTNAME_GENERATE_BRIDGE);
+                    if (bridge != null) {
+                        // TODO bridge.value("targetReturnTypeErased") and bridge.value("callSuperMethod")
+                        List<MethodInfo> generated = entityGeneratedMethods.get(entity.name());
+                        if (generated == null) {
+                            generated = new ArrayList<>();
+                            entityGeneratedMethods.put(entity.name(), generated);
+                        }
+                        generated.add(method);
+                    }
+                }
+            }
+        }
+
+        for (ClassInfo entity : mockedEntities) {
+            String entityClassName = entity.name().toString();
+            ClassTransformer transformer = new ClassTransformer(entity.name().toString());
+            List<MethodInfo> userMethods = entityUserMethods.get(entity.name());
+            if (userMethods != null) {
+                for (MethodInfo userMethod : userMethods) {
+                    transformer.removeMethod(MethodDescriptor.of(userMethod));
+                    addMethod(entityClassName, transformer, userMethod);
+                }
+            }
+            List<MethodInfo> generatedMethods = entityGeneratedMethods.get(entity.name());
+            if (generatedMethods != null) {
+                for (MethodInfo generatedMethod : generatedMethods) {
+                    addMethod(entityClassName, transformer, generatedMethod);
+                }
+            }
+            buildContext.addBytecodeTransformer(
+                    new BytecodeTransformer(entityClassName, new BiFunction<String, ClassVisitor, ClassVisitor>() {
+                        @Override
+                        public ClassVisitor apply(String className, ClassVisitor originalVisitor) {
+                            return transformer.applyTo(originalVisitor);
+                        }
+                    }));
+        }
+    }
+
+    private void addMethod(String entityClass, ClassTransformer transformer, MethodInfo method) {
+        MethodCreator transform = transformer.addMethod(MethodDescriptor.of(method));
+        transform.setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+        // if (!PanacheMock.IsMockEnabled)
+        //   throw new RuntimeException("Panache mock not enabled");
+        // if (!PanacheMock.isMocked(TestClass.class))
+        //   throw new RuntimeException("FooEntity not mocked");
+        // try {
+        //    return (int)PanacheMock.mockMethod(TestClass.class, "foo", new Class<?>[] {int.class}, new Object[] {arg});
+        // } catch (PanacheMock.InvokeRealMethodException e) {
+        //    throw new RuntimeException("Unstubbed method called", e);
+        // }
+        ResultHandle isMockEnabled = transform
+                .readStaticField(FieldDescriptor.of(PanacheMock.class, "IsMockEnabled", boolean.class));
+        BytecodeCreator mockNotEnabled = transform.ifTrue(isMockEnabled).falseBranch();
+        mockNotEnabled.throwException(RuntimeException.class, "Panache mock not enabled");
+        ResultHandle isMocked = transform.invokeStaticMethod(
+                MethodDescriptor.ofMethod(PanacheMock.class, "isMocked", boolean.class, Class.class),
+                transform.loadClass(entityClass));
+        BytecodeCreator notMocked = transform.ifTrue(isMocked).falseBranch();
+        notMocked.throwException(RuntimeException.class, entityClass + " not mocked");
+        ResultHandle entityClazz = transform.loadClass(entityClass);
+        ResultHandle methodName = transform.load(method.name());
+        ResultHandle paramTypes = transform.newArray(Class.class, method.parametersCount());
+        for (int i = 0; i < method.parametersCount(); i++) {
+            transform.writeArrayValue(paramTypes, i, transform.loadClass(method.parameterType(i).name().toString()));
+        }
+        ResultHandle args = transform.newArray(Object.class, method.parametersCount());
+        for (int i = 0; i < method.parametersCount(); i++) {
+            transform.writeArrayValue(args, i, transform.getMethodParam(i));
+        }
+        TryBlock tryInvoke = transform.tryBlock();
+        ResultHandle ret = tryInvoke.invokeStaticMethod(MethodDescriptor.ofMethod(PanacheMock.class, "mockMethod",
+                Object.class, Class.class, String.class, Class[].class, Object[].class), entityClazz, methodName,
+                paramTypes,
+                args);
+        tryInvoke.returnValue(ret);
+        CatchBlockCreator catched = tryInvoke.addCatch(PanacheMock.InvokeRealMethodException.class);
+        catched.throwException(RuntimeException.class,
+                "Unstubbed method called: " + method.toString(), catched.getCaughtException());
+    }
+
+    @Override
+    public void afterStart(AfterStartContext afterStartContext) {
+        Class<?> testClass = afterStartContext.getTestClass();
+        MockPanacheEntities panacheMocks = testClass.getAnnotation(MockPanacheEntities.class);
+        if (panacheMocks == null || panacheMocks.value().length == 0) {
+            return;
+        }
+        PanacheMock.mock(panacheMocks.value());
+    }
+
+    @Override
+    public void afterStop(AfterStopContext afterStopContext) {
+        PanacheMock.reset();
+    }
+
+    private boolean userMethodExists(List<MethodInfo> userMethods, MethodInfo method) {
+        if (userMethods == null || userMethods.isEmpty()) {
+            return false;
+        }
+        String descriptor = method.descriptor();
+        for (MethodInfo userMethod : userMethods) {
+            if (userMethod.descriptor().equals(descriptor)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/extensions/panache/panache-mock/src/main/resources/META-INF/services/io.quarkus.test.component.QuarkusComponentTestCallbacks
+++ b/extensions/panache/panache-mock/src/main/resources/META-INF/services/io.quarkus.test.component.QuarkusComponentTestCallbacks
@@ -1,0 +1,1 @@
+io.quarkus.panache.mock.impl.PanacheQuarkusComponentTestCallbacks

--- a/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/EntityComponentTest.java
+++ b/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/EntityComponentTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.panache.mock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+@MockPanacheEntities(Person.class)
+public class EntityComponentTest {
+
+    @Inject
+    MyComponent myComponent;
+
+    @Test
+    public void testMock() {
+        Mockito.when(Person.count()).thenReturn(23L);
+        Mockito.when(Person.count("from foo")).thenReturn(13L);
+        Mockito.when(Person.findOrdered()).thenReturn(List.of(new Person()));
+        assertEquals(23, Person.count());
+        assertEquals(13, Person.count("from foo"));
+        assertEquals(23, myComponent.ping());
+        // user method
+        List<Person> list = Person.findOrdered();
+        assertEquals(1, list.size());
+        assertNull(list.get(0).name);
+        // default values
+        assertEquals(0, Person.deleteAll());
+        assertNull(Person.findById("1"));
+    }
+
+}

--- a/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/MyComponent.java
+++ b/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/MyComponent.java
@@ -1,0 +1,12 @@
+package io.quarkus.panache.mock;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MyComponent {
+
+    public long ping() {
+        return Person.count();
+    }
+
+}

--- a/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/Person.java
+++ b/extensions/panache/panache-mock/src/test/java/io/quarkus/panache/mock/Person.java
@@ -1,0 +1,17 @@
+package io.quarkus.panache.mock;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Person extends PanacheEntity {
+
+    public String name;
+
+    public static List<Person> findOrdered() {
+        return find("ORDER BY name").list();
+    }
+}

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentFacadeClassLoaderProvider.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentFacadeClassLoaderProvider.java
@@ -72,7 +72,7 @@ public class QuarkusComponentFacadeClassLoaderProvider implements FacadeClassLoa
                 return new QuarkusComponentTestClassLoader(parent, name,
                         ComponentContainer.build(inspectionClass, configuration, buildShouldFail, tracedClasses));
             } catch (Exception e) {
-                LOG.errorf("Unable to build container for %s", name);
+                throw new IllegalStateException("Unable to build container for %s".formatted(name), e);
             }
         }
         return null;

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestCallbacks.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestCallbacks.java
@@ -1,0 +1,139 @@
+package io.quarkus.test.component;
+
+import java.util.Set;
+
+import org.jboss.jandex.AnnotationTransformation;
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.processor.BytecodeTransformer;
+
+/**
+ * This service provider can be used to contribute additional logic to {@link QuarkusComponentTestExtension}.
+ * <p>
+ * The implementations should be stateless. Callbacks are invoked in this order:
+ * <ol>
+ * <li>{@link #beforeIndex(BeforeIndexContext)}</li>
+ * <li>{@link #beforeBuild(BeforeBuildContext)}</li>
+ * <li>{@link #beforeStart(BeforeStartContext)}</li>
+ * <li>{@link #afterStart(AfterStartContext)}</li>
+ * <li>{@link #afterStop(AfterStopContext)}</li>
+ * </ol>
+ *
+ * There are no other guarantees regarding instantiation, lifecycle and thread-safety.
+ */
+public interface QuarkusComponentTestCallbacks {
+
+    /**
+     * Called before the bean archive index is built.
+     * <p>
+     * The bean archive index is built before the container is built.
+     *
+     * @param beforeIndexContext
+     */
+    default void beforeIndex(BeforeIndexContext beforeIndexContext) {
+        // No-op
+    }
+
+    /**
+     * Called before the container is built.
+     * <p>
+     * The container is built before the test class is loaded.
+     *
+     * @param beforeBuildContext
+     */
+    default void beforeBuild(BeforeBuildContext beforeBuildContext) {
+        // No-op
+    }
+
+    /**
+     * Called before the container is started.
+     * <p>
+     * If {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_METHOD} is used (default) then the container is started during
+     * the {@code before each} test phase. If {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_CLASS} is used
+     * then the container is started during the {@code before all} test phase.
+     *
+     * @param beforeStartContext
+     */
+    default void beforeStart(BeforeStartContext beforeStartContext) {
+        // No-op
+    }
+
+    /**
+     * Called after the container is started.
+     * <p>
+     * If {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_METHOD} is used (default) then the container is started during
+     * the {@code before each} test phase. If {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_CLASS} is used
+     * then the container is started during the {@code before all} test phase.
+     *
+     * @param afterStartContext
+     */
+    default void afterStart(AfterStartContext afterStartContext) {
+        // No-op
+    }
+
+    /**
+     * Called after the container is stopped.
+     * <p>
+     * If {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_METHOD} is used (default) then the container is stopped during
+     * the {@code after each} test phase. If {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_CLASS} is used then the
+     * container is during the {@code after all} test phase.
+     *
+     * @param afterStopContext
+     */
+    default void afterStop(AfterStopContext afterStopContext) {
+        // No-op
+    }
+
+    interface BeforeIndexContext extends ComponentTestContext {
+
+        /**
+         * @return the immutable set of original component classes
+         */
+        Set<Class<?>> getComponentClasses();
+
+        void addComponentClass(Class<?> componentClass);
+
+    }
+
+    interface BeforeBuildContext extends ComponentTestContext {
+
+        IndexView getImmutableBeanArchiveIndex();
+
+        IndexView getComputingBeanArchiveIndex();
+
+        void addAnnotationTransformation(AnnotationTransformation transformation);
+
+        void addBeanRegistrar(BeanRegistrar beanRegistrar);
+
+        void addBytecodeTransformer(BytecodeTransformer bytecodeTransformer);
+
+    }
+
+    interface BeforeStartContext extends ComponentTestContext {
+
+        /**
+         * Set the value of a configuration property.
+         * <p>
+         * Overrides values set by other means, including {@link io.quarkus.test.component.TestConfigProperty}.
+         *
+         * @param key
+         * @param value
+         */
+        void setConfigProperty(String key, String value);
+
+    }
+
+    interface AfterStartContext extends ComponentTestContext {
+    }
+
+    interface AfterStopContext extends ComponentTestContext {
+    }
+
+    interface ComponentTestContext {
+
+        Class<?> getTestClass();
+
+    }
+
+}

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
@@ -164,7 +164,7 @@ public class QuarkusComponentTestExtensionBuilder {
         return new MockBeanConfiguratorImpl<>(this, beanClass);
     }
 
-    QuarkusComponentTestExtensionBuilder buildShouldFail() {
+    public QuarkusComponentTestExtensionBuilder buildShouldFail() {
         this.buildShouldFail = true;
         return this;
     }
@@ -185,7 +185,7 @@ public class QuarkusComponentTestExtensionBuilder {
         return new QuarkusComponentTestExtension(new QuarkusComponentTestConfiguration(Map.copyOf(configProperties),
                 Set.copyOf(componentClasses), List.copyOf(mockConfigurators), useDefaultConfigProperties,
                 addNestedClassesAsComponents, configSourceOrdinal,
-                List.copyOf(annotationsTransformers), converters, configBuilderCustomizer, useSystemConfigSources),
+                List.copyOf(annotationsTransformers), converters, configBuilderCustomizer, useSystemConfigSources, null),
                 buildShouldFail);
     }
 

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/callbacks/MyTestCallbacks.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/callbacks/MyTestCallbacks.java
@@ -1,0 +1,57 @@
+package io.quarkus.test.component.callbacks;
+
+import org.jboss.jandex.AnnotationTransformation;
+import org.jboss.jandex.DotName;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.component.QuarkusComponentTestCallbacks;
+import io.quarkus.test.component.beans.MyOtherComponent;
+
+public class MyTestCallbacks implements QuarkusComponentTestCallbacks {
+
+    static volatile boolean afterStart = false;
+    static volatile boolean afterStop = false;
+
+    @Override
+    public void beforeIndex(BeforeIndexContext beforeIndexContext) {
+        if (isProcessed(beforeIndexContext)) {
+            beforeIndexContext.addComponentClass(MyOtherComponent.class);
+        }
+    }
+
+    @Override
+    public void beforeBuild(BeforeBuildContext buildContext) {
+        if (isProcessed(buildContext)) {
+            buildContext.addAnnotationTransformation(AnnotationTransformation
+                    .forClasses()
+                    .whenClass(DotName.createSimple(MyOtherComponent.class))
+                    .transform(t -> t.add(Unremovable.class)));
+        }
+    }
+
+    @Override
+    public void beforeStart(BeforeStartContext beforeStartContext) {
+        if (isProcessed(beforeStartContext)) {
+            beforeStartContext.setConfigProperty("foo", "RAB");
+        }
+    }
+
+    @Override
+    public void afterStart(AfterStartContext afterStartContext) {
+        if (isProcessed(afterStartContext)) {
+            afterStart = true;
+        }
+    }
+
+    @Override
+    public void afterStop(AfterStopContext afterStopContext) {
+        if (isProcessed(afterStopContext)) {
+            afterStop = true;
+        }
+    }
+
+    boolean isProcessed(ComponentTestContext testContext) {
+        return testContext.getTestClass().getSimpleName().equals("QuarkusComponentTestCallbacksTest");
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/callbacks/QuarkusComponentTestCallbacksTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/callbacks/QuarkusComponentTestCallbacksTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.test.component.callbacks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.Mockito;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+import io.quarkus.test.component.beans.Charlie;
+import io.quarkus.test.component.beans.MyComponent;
+import io.quarkus.test.component.beans.MyOtherComponent;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@QuarkusComponentTest
+public class QuarkusComponentTestCallbacksTest {
+
+    @Inject
+    MyComponent myComponent;
+
+    @InjectMock
+    Charlie charlie;
+
+    @Order(1)
+    @TestConfigProperty(key = "foo", value = "BAR") // overriden by listener
+    @Test
+    public void testPing() {
+        // Note that we cannot test the build functionality of MyTestCallbacks directly (e.g. static fields)
+        // because a different CL is used for build
+        Mockito.when(charlie.ping()).thenReturn("foo");
+        assertEquals("foo and RAB", myComponent.ping());
+        // MyOtherComponent added by listener as component class
+        // @Unremovable added to MyOtherComponent by listener
+        assertEquals("foo", Arc.container().instance(MyOtherComponent.class).get().ping());
+        // This should be ok because afterStart is executed on an instance loaded by the QuarkusComponentTestClassLoader
+        assertTrue(MyTestCallbacks.afterStart);
+        assertFalse(MyTestCallbacks.afterStop);
+    }
+
+    @Order(2)
+    @Test
+    public void testPong() {
+        assertTrue(MyTestCallbacks.afterStop);
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerClassLifecycleTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerClassLifecycleTest.java
@@ -8,10 +8,12 @@ import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
@@ -19,6 +21,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.component.QuarkusComponentTestExtension;
 import io.quarkus.test.component.beans.Charlie;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class PerClassLifecycleTest {
 

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerMethodLifecycleTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerMethodLifecycleTest.java
@@ -8,10 +8,12 @@ import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
@@ -19,6 +21,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.component.QuarkusComponentTestExtension;
 import io.quarkus.test.component.beans.Charlie;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(Lifecycle.PER_METHOD)
 public class PerMethodLifecycleTest {
 

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionDependentTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionDependentTest.java
@@ -7,11 +7,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.Dependent;
 
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.component.QuarkusComponentTest;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @QuarkusComponentTest
 public class ParameterInjectionDependentTest {
 

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionPerMethodLifecycleTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionPerMethodLifecycleTest.java
@@ -7,13 +7,16 @@ import java.util.UUID;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Singleton;
 
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.component.QuarkusComponentTest;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(Lifecycle.PER_METHOD)
 @QuarkusComponentTest
 public class ParameterInjectionPerMethodLifecycleTest {

--- a/test-framework/junit5-component/src/test/resources/META-INF/services/io.quarkus.test.component.QuarkusComponentTestCallbacks
+++ b/test-framework/junit5-component/src/test/resources/META-INF/services/io.quarkus.test.component.QuarkusComponentTestCallbacks
@@ -1,0 +1,1 @@
+io.quarkus.test.component.callbacks.MyTestCallbacks


### PR DESCRIPTION
This is a follow-up to #50164.

We introduce the `QuarkusComponentTestCallbacks` service provider that can be used to contribute additional logic to `QuarkusComponentTestExtension` (I choose the name "callbacks" to keep consistency with [quarkus-junit5](https://github.com/quarkusio/quarkus/tree/main/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback)).

In the second commit we add a few bytecode transformations in order to support `quarkus-panache-mock` functionality in a QuarkusComponentTest.