### PR TITLE
Support HttpServerRequest and HttpServerResponse in Spring ExceptionHandlers

### DIFF
--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -469,6 +469,46 @@ The following parameter types are supported, in arbitrary order:
 
 Other parameter types mentioned in the Spring `https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/ExceptionHandler.html[ExceptionHandler javadoc]` are not supported.
 
+==== Using `HttpServerRequest` and `HttpServerResponse` in Spring Web-style exception handlers
+
+When using the Quarkus Spring Web compatibility layer on top of the reactive stack (`quarkus-rest-jackson`),
+you cannot inject servlet-based request and response types such as `jakarta.servlet.http.HttpServletRequest` or `jakarta.servlet.http.HttpServletResponse`.
+These types are only available when using the Classic RESTEasy stack (quarkus-resteasy / quarkus-resteasy-jackson), which relies on the Servlet API provided by `quarkus-undertow` dependency.
+
+To provide a Spring-friendly experience while staying reactive, Quarkus allows you to inject the following types into your `@ExceptionHandler` methods:
+
+- io.vertx.core.http.HttpServerRequest
+
+- io.vertx.core.http.HttpServerResponse
+
+These types give you direct access to the underlying Vert.x HTTP layer.
+This allows you to manipulate the response (e.g. set headers, cookies, or status codes) or enrich the returned information using details from the request.
+
+For example:
+
+[source, java]
+----
+@ExceptionHandler(IllegalArgumentException.class)
+public ResponseEntity<Object> handleException(Exception ex,
+                                                       HttpServerRequest request,
+                                                       HttpServerResponse response) {
+    // Add a custom header to the response
+    response.putHeader("X-Error-Reason", "IllegalArgument");
+
+    // Build a response body enriched with request details
+    String body = String.format("Request %s %s failed",
+            request.method().name(),
+            request.uri());
+
+    return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+}
+
+----
+
+**Warning:** This is potentially dangerous.
+Users should only do this if they understand the reactive model, and are aware that writing directly to the response can bypass normal handling of status codes, headers, and serialization.
+
+
 == Important Technical Note
 
 Please note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.

--- a/extensions/spring-web/core/deployment/src/main/java/io/quarkus/spring/web/deployment/ControllerAdviceExceptionMapperGenerator.java
+++ b/extensions/spring-web/core/deployment/src/main/java/io/quarkus/spring/web/deployment/ControllerAdviceExceptionMapperGenerator.java
@@ -32,6 +32,8 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.spring.web.runtime.common.ResponseEntityConverter;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 
 class ControllerAdviceExceptionMapperGenerator extends AbstractExceptionMapperGenerator {
 
@@ -250,6 +252,16 @@ class ControllerAdviceExceptionMapperGenerator extends AbstractExceptionMapperGe
                     parameterTypeHandles[i] = getBeanFromArc(toResponse, UriInfo.class.getName());
                 } else if (typesUtil.isAssignable(Request.class, parameterType.name())) {
                     parameterTypeHandles[i] = getBeanFromArc(toResponse, Request.class.getName());
+                } else if (typesUtil.isAssignable(HttpServerRequest.class, parameterType.name())) {
+                    parameterTypeHandles[i] = getBeanFromArc(toResponse, HttpServerRequest.class.getName());
+                } else if (typesUtil.isAssignable(HttpServerResponse.class, parameterType.name())) {
+                    ResultHandle requestHandle = getBeanFromArc(toResponse, HttpServerRequest.class.getName());
+                    ResultHandle responseHandle = toResponse.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(HttpServerRequest.class,
+                                    "response",
+                                    HttpServerResponse.class),
+                            requestHandle);
+                    parameterTypeHandles[i] = responseHandle;
                 } else {
                     throw new IllegalArgumentException(
                             "Parameter type '" + parameterType.name() + "' is not supported for method '"


### PR DESCRIPTION


<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Related to #50228 
This PR adds documentation for the new support in Quarkus Spring Web for injecting HttpServerRequest and HttpServerResponse into @ExceptionHandler methods when using the reactive stack (quarkus-rest-jackson).

This provides a Spring-friendly way for users to access the Vert.x request/response objects directly, allowing them to manipulate headers, cookies, status codes, and enrich error responses.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

