### PR TITLE
Do not show 0.0.0.0 in a url

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -54,6 +54,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.NetUtil;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
@@ -1013,8 +1014,7 @@ public class VertxHttpRecorder {
         int socketCount = 0;
 
         if (!httpDisabled && httpServerOptions != null) {
-            serverListeningMessage.append(String.format(
-                    "http://%s:%s", getDeveloperFriendlyHostName(httpServerOptions), actualHttpPort));
+            appendListeningMessage(serverListeningMessage, "http", httpServerOptions.getHost(), actualHttpPort);
             socketCount++;
         }
 
@@ -1022,8 +1022,7 @@ public class VertxHttpRecorder {
             if (socketCount > 0) {
                 serverListeningMessage.append(" and ");
             }
-            serverListeningMessage
-                    .append(String.format("https://%s:%s", getDeveloperFriendlyHostName(sslConfig), actualHttpsPort));
+            appendListeningMessage(serverListeningMessage, "https", httpServerOptions.getHost(), actualHttpsPort);
             socketCount++;
         }
 
@@ -1031,33 +1030,35 @@ public class VertxHttpRecorder {
             if (socketCount > 0) {
                 serverListeningMessage.append(" and ");
             }
-            serverListeningMessage.append(String.format("unix:%s", getDeveloperFriendlyHostName(domainSocketOptions)));
+            serverListeningMessage.append(String.format("unix:%s", domainSocketOptions.getHost()));
         }
         if (managementConfig != null) {
-            serverListeningMessage.append(
-                    String.format(". Management interface listening on http%s://%s:%s.", managementConfig.isSsl() ? "s" : "",
-                            getDeveloperFriendlyHostName(managementConfig), actualManagementPort));
+            serverListeningMessage.append(". Management interface listening on ");
+            appendListeningMessage(serverListeningMessage, managementConfig.isSsl() ? "https" : "http",
+                    managementConfig.getHost(), actualManagementPort);
         }
 
         Timing.setHttpServer(serverListeningMessage.toString(), auxiliaryApplication);
     }
 
-    /**
-     * To improve developer experience in WSL dev/test mode, the server listening message should print "localhost" when
-     * the host is set to "0.0.0.0". Otherwise, display the actual host.
-     * Do not use this during the actual configuration, use options.getHost() there directly instead.
-     */
-    private static String getDeveloperFriendlyHostName(HttpServerOptions options) {
-        return (LaunchMode.current().isDevOrTest() && "0.0.0.0".equals(options.getHost()) && isWSL()) ? "localhost"
-                : options.getHost();
+    static void appendListeningMessage(StringBuilder builder, String protocol, String host, int port) {
+        boolean ipv6 = NetUtil.isValidIpV6Address(host);
+        if ((ipv6 && isAnyBindAddress(NetUtil.createByteArrayFromIpAddressString(host))) || "0.0.0.0".equals(host)) {
+            builder.append("all addresses including ");
+            host = "localhost"; // don't show the any bind address in a url
+            ipv6 = false;
+        }
+        builder.append(String.format("%s://%s:%s", protocol,
+                (ipv6 && !host.startsWith("[")) ? ("[" + host + "]") : host, port));
     }
 
-    /**
-     * @return {@code true} if the application is running in a WSL (Windows Subsystem for Linux) environment
-     */
-    private static boolean isWSL() {
-        var sysEnv = System.getenv();
-        return sysEnv.containsKey("IS_WSL") || sysEnv.containsKey("WSL_DISTRO_NAME");
+    private static boolean isAnyBindAddress(byte[] bytes) {
+        for (byte b : bytes) {
+            if (b != 0x00) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static HttpServerOptions createHttpServerOptions(

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/VertxHttpRecorderTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/VertxHttpRecorderTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.vertx.http.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+class VertxHttpRecorderTest {
+
+    @Test
+    void testListeningOnIpv6Any() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        VertxHttpRecorder.appendListeningMessage(builder, "https", "::", 123);
+        assertEquals("all addresses including https://localhost:123", builder.toString());
+    }
+
+    @Test
+    void testListeningOnIpv4Any() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        VertxHttpRecorder.appendListeningMessage(builder, "http", "0.0.0.0", 123);
+        assertEquals("all addresses including http://localhost:123", builder.toString());
+    }
+
+    @Test
+    void testListeningOnHost() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        VertxHttpRecorder.appendListeningMessage(builder, "http", "localhost4", 8080);
+        assertEquals("http://localhost4:8080", builder.toString());
+    }
+
+}


### PR DESCRIPTION
* Fixes #50231

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

The bind address 0.0.0.0 for all addresses should not be shown in the logs in a url.

Previously one might see:

Listening on: https://0.0.0.0:8444

An initial proprosal with this pr would show:

Listening on: all addresses on port 8444 for https (e.g. https://127.0.0.1:8444)

This was refined to be less verbose:

Listening on: all addresses including https://localhost:8444 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

