### PR TITLE
ArC: fix construction of interception proxies, part 2

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -184,12 +184,13 @@ public class ClientProxyGenerator extends AbstractGenerator {
 
             if (!superClass.equals(Object.class.getName())) {
                 // Skip delegation if proxy is not constructed yet
-                // This check is unnecessary for producers that return an interface
+                // This is not necessary for producers of interfaces, because interfaces cannot have constructors
+                // Similarly, this is not necessary for producers of `Object`, because its constructor does nothing
                 // if(!this.bean == null) return super.foo()
                 BytecodeCreator notConstructed = forward
                         .ifNull(forward.readInstanceField(beanField.getFieldDescriptor(), forward.getThis())).trueBranch();
-                if (Modifier.isAbstract(method.flags())) {
-                    notConstructed.throwException(IllegalStateException.class, "Cannot delegate to an abstract method");
+                if (method.isAbstract()) {
+                    notConstructed.throwException(IllegalStateException.class, "Cannot invoke abstract method");
                 } else {
                     MethodDescriptor superDescriptor = MethodDescriptor.ofMethod(superClass, method.name(),
                             method.returnType().name().toString(),


### PR DESCRIPTION
During execution of the constructor of an intercepted non-contextual instance (which is a superclass of an interception proxy, `*_InterceptionSubclass`), virtual method calls were supposed to be delegated to `super` by using `invokespecial`.

This wasn't done properly and this commit moves the logic even closer to client proxies. If the target method is `abstract`, we just throw an exception; any kind of invocation would fail anyway. Instead of emitting `invokespecial` directly for the method in question, we create a new method descriptor with the same method name, parameter types and return type, but with the owner type set to the intercepted non-contextual class. This is where method search should start anyway.

If the intercepted type is an interface (or, not very likely, `java.lang.Object`), we don't have to avoid delegation, because interfaces cannot have constructors (and the `java.lang.Object` constructor does nothing).

Follows up on #49931