### PR TITLE
Fix step authentication with Keycloak when protocol mapper has 'acr' user attribute configured as single valued string

### DIFF
--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -425,7 +425,11 @@ public class OidcResource {
         }
 
         if (acr != null && !acr.isEmpty()) {
-            builder.claim("acr", Arrays.asList(acr.split(",")));
+            if (acr.endsWith("_string")) {
+                builder.claim("acr", acr);
+            } else {
+                builder.claim("acr", Arrays.asList(acr.split(",")));
+            }
         }
 
         if (authTime != null && !authTime.isEmpty()) {

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenStepUpAuthenticationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenStepUpAuthenticationTest.java
@@ -232,6 +232,15 @@ public class BearerTokenStepUpAuthenticationTest {
                 .body(is("max-age-and-acr-required"));
     }
 
+    @Test
+    public void testSingleAcrStringValueRequired() {
+        // wrong single acr -> fail
+        stepUpMethodLevelRequest(Set.of("3_string"), "no-rbac-annotation-string").statusCode(401);
+        // correct acr -> pass
+        stepUpMethodLevelRequest(Set.of("1_string"), "no-rbac-annotation-string").statusCode(200)
+                .body(is("no-rbac-annotation"));
+    }
+
     private static ValidatableResponse stepUpMethodLevelRequest(Set<String> acrValues, String path) {
         return stepUpMethodLevelRequest(acrValues, path, null);
     }
@@ -347,6 +356,13 @@ public class BearerTokenStepUpAuthenticationTest {
         @AuthenticationContext("1")
         @Path("no-rbac-annotation")
         public String noRbacAnnotationMethodLevel() {
+            return "no-rbac-annotation";
+        }
+
+        @GET
+        @AuthenticationContext("1_string")
+        @Path("no-rbac-annotation-string")
+        public String noRbacAnnotationMethodLevelString() {
             return "no-rbac-annotation";
         }
 


### PR DESCRIPTION
- closes https://github.com/quarkusio/quarkus/issues/50364
- in https://datatracker.ietf.org/doc/rfc9470/ `6.2.  OAuth 2.0 Token Introspection` section defines the `acr` claim as a single string value, so this needs to be supported