### PR TITLE
Log OIDC Client requests in debug mode

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -240,6 +240,9 @@ public class OidcClientImpl implements OidcClient {
                 body.add(entry.getKey(), entry.getValue());
             }
         }
+        if (LOG.isDebugEnabled()) {
+            LOG.debugf("Token endpoint: %s, request params: %s, headers: %s", request.uri(), body, request.headers());
+        }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Buffer buffer = OidcCommonUtils.encodeForm(body);
         Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, endpointType, request, buffer)

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -40,6 +40,12 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcClientImpl implements OidcClient {
 
+    private enum Operation {
+        Get,
+        Refresh,
+        Revoke
+    }
+
     private static final Logger LOG = Logger.getLogger(OidcClientImpl.class);
     private static final String CLIENT_ID_ATTRIBUTE = "client-id";
     private static final String DEFAULT_OIDC_CLIENT_ID = "Default";
@@ -95,7 +101,7 @@ public class OidcClientImpl implements OidcClient {
             throw new OidcClientException(
                     "Only 'refresh_token' grant is supported, please call OidcClient#refreshTokens method instead");
         }
-        return getJsonResponse(OidcEndpoint.Type.TOKEN, tokenGrantParams, additionalGrantParameters, false);
+        return getJsonResponse(OidcEndpoint.Type.TOKEN, tokenGrantParams, additionalGrantParameters, Operation.Get);
     }
 
     @Override
@@ -106,7 +112,7 @@ public class OidcClientImpl implements OidcClient {
         }
         MultiMap refreshGrantParams = copyMultiMap(commonRefreshGrantParams);
         refreshGrantParams.add(OidcConstants.REFRESH_TOKEN_VALUE, refreshToken);
-        return getJsonResponse(OidcEndpoint.Type.TOKEN, refreshGrantParams, additionalGrantParameters, true);
+        return getJsonResponse(OidcEndpoint.Type.TOKEN, refreshGrantParams, additionalGrantParameters, Operation.Refresh);
     }
 
     @Override
@@ -122,7 +128,7 @@ public class OidcClientImpl implements OidcClient {
             tokenRevokeParams.set(OidcConstants.REVOCATION_TOKEN, accessToken);
             return postRequest(requestProps, OidcEndpoint.Type.TOKEN_REVOCATION, client.postAbs(tokenRevokeUri),
                     tokenRevokeParams,
-                    additionalParameters, false)
+                    additionalParameters, Operation.Revoke)
                     .transform(resp -> toRevokeResponse(requestProps, resp));
         } else {
             LOG.debugf("%s OidcClient can not revoke the access token because the revocation endpoint URL is not set");
@@ -155,18 +161,18 @@ public class OidcClientImpl implements OidcClient {
     private Uni<Tokens> getJsonResponse(
             OidcEndpoint.Type endpointType, MultiMap formBody,
             Map<String, String> additionalGrantParameters,
-            boolean refresh) {
+            Operation op) {
         //Uni needs to be lazy by default, we don't send the request unless
         //something has subscribed to it. This is important for the CAS state
         //management in TokensHelper
-        String currentGrantType = refresh ? OidcConstants.REFRESH_TOKEN_GRANT : grantType;
+        String currentGrantType = isRefresh(op) ? OidcConstants.REFRESH_TOKEN_GRANT : grantType;
         final OidcRequestContextProperties requestProps = getRequestProps(currentGrantType);
         return Uni.createFrom().deferred(new Supplier<Uni<? extends Tokens>>() {
             @Override
             public Uni<Tokens> get() {
                 return postRequest(requestProps, endpointType, client.postAbs(tokenRequestUri), formBody,
-                        additionalGrantParameters, refresh)
-                        .transform(resp -> emitGrantTokens(requestProps, resp, refresh));
+                        additionalGrantParameters, op)
+                        .transform(resp -> emitGrantTokens(requestProps, resp, op));
             }
         });
     }
@@ -176,7 +182,7 @@ public class OidcClientImpl implements OidcClient {
             OidcEndpoint.Type endpointType, HttpRequest<Buffer> request,
             MultiMap formBody,
             Map<String, String> additionalGrantParameters,
-            boolean refresh) {
+            Operation op) {
         MultiMap body = formBody;
         request.putHeader(HttpHeaders.CONTENT_TYPE.toString(),
                 HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
@@ -199,14 +205,14 @@ public class OidcClientImpl implements OidcClient {
             if (clientAssertion == null) {
                 String errorMessage = String.format(
                         "%s OidcClient can not complete the %s grant request because a JWT bearer client_assertion is missing",
-                        oidcConfig.id().get(), (refresh ? OidcConstants.REFRESH_TOKEN_GRANT : grantType));
+                        oidcConfig.id().get(), (isRefresh(op) ? OidcConstants.REFRESH_TOKEN_GRANT : grantType));
                 LOG.error(errorMessage);
                 throw new OidcClientException(errorMessage);
             }
             body.set(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
         } else if (clientJwtKey != null) {
             // if it is a refresh then a map has already been copied
-            body = !refresh ? copyMultiMap(body) : body;
+            body = !isRefresh(op) ? copyMultiMap(body) : body;
             String jwt = OidcCommonUtils.signJwtWithKey(oidcConfig, tokenRequestUri, clientJwtKey);
 
             if (OidcCommonUtils.isClientSecretPostJwtAuthRequired(oidcConfig.credentials())) {
@@ -227,11 +233,11 @@ public class OidcClientImpl implements OidcClient {
                 body.add(OidcConstants.CLIENT_ASSERTION, jwt);
             }
         } else if (OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials())) {
-            body = !refresh ? copyMultiMap(body) : body;
+            body = !isRefresh(op) ? copyMultiMap(body) : body;
             body.set(OidcConstants.CLIENT_ID, oidcConfig.clientId().get());
             body.set(OidcConstants.CLIENT_SECRET, OidcCommonUtils.clientSecret(oidcConfig.credentials()));
         } else {
-            body = !refresh ? copyMultiMap(body) : body;
+            body = !isRefresh(op) ? copyMultiMap(body) : body;
             body = copyMultiMap(body).set(OidcConstants.CLIENT_ID, oidcConfig.clientId().get());
         }
         if (!additionalGrantParameters.isEmpty()) {
@@ -241,7 +247,8 @@ public class OidcClientImpl implements OidcClient {
             }
         }
         if (LOG.isDebugEnabled()) {
-            LOG.debugf("Token endpoint: %s, request params: %s, headers: %s", request.uri(), body, request.headers());
+            LOG.debugf("%s token: url : %s, headers: %s, request params: %s", op.name(), request.uri(), request.headers(),
+                    body);
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Buffer buffer = OidcCommonUtils.encodeForm(body);
@@ -258,10 +265,10 @@ public class OidcClientImpl implements OidcClient {
         return response.onItem();
     }
 
-    private Tokens emitGrantTokens(OidcRequestContextProperties requestProps, HttpResponse<Buffer> resp, boolean refresh) {
+    private Tokens emitGrantTokens(OidcRequestContextProperties requestProps, HttpResponse<Buffer> resp, Operation op) {
         Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, OidcEndpoint.Type.TOKEN);
         if (resp.statusCode() == 200) {
-            LOG.debugf("%s OidcClient has %s the tokens", oidcConfig.id().get(), (refresh ? "refreshed" : "acquired"));
+            LOG.debugf("%s OidcClient has %s the tokens", oidcConfig.id().get(), (isRefresh(op) ? "refreshed" : "acquired"));
             JsonObject json = buffer.toJsonObject();
             // access token
             final String accessToken = json.getString(oidcConfig.grant().accessTokenProperty());
@@ -277,7 +284,7 @@ public class OidcClientImpl implements OidcClient {
         } else {
             String errorMessage = buffer.toString();
             LOG.debugf("%s OidcClient has failed to complete the %s grant request:  status: %d, error message: %s",
-                    oidcConfig.id().get(), (refresh ? OidcConstants.REFRESH_TOKEN_GRANT : grantType), resp.statusCode(),
+                    oidcConfig.id().get(), (isRefresh(op) ? OidcConstants.REFRESH_TOKEN_GRANT : grantType), resp.statusCode(),
                     errorMessage);
             throw new OidcClientException(errorMessage);
         }
@@ -371,5 +378,9 @@ public class OidcClientImpl implements OidcClient {
 
     OidcClientConfig getConfig() {
         return oidcConfig;
+    }
+
+    static boolean isRefresh(Operation op) {
+        return op == Operation.Refresh;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -338,9 +338,11 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                 request.putHeader(headerEntry.getKey(), headerEntry.getValue());
             }
         }
-
-        LOG.debugf("%s token: %s params: %s headers: %s", (introspect ? "Introspect" : "Get"), metadata.getTokenUri(), formBody,
-                request.headers());
+        if (LOG.isDebugEnabled()) {
+            LOG.debugf("%s token: %s params: %s headers: %s", (introspect ? "Introspect" : "Get"), metadata.getTokenUri(),
+                    formBody,
+                    request.headers());
+        }
         // Retry up to three times with a one-second delay between the retries if the connection is closed.
 
         OidcEndpoint.Type endpoint = introspect ? OidcEndpoint.Type.INTROSPECTION : OidcEndpoint.Type.TOKEN;

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -41,7 +41,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .aResponse()
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
-                                "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+                                "{\"access_token\":\"access_token_1\", \"expires_in\":6, \"refresh_token\":\"refresh_token_1\"}")));
         server.stubFor(WireMock.post("/tokens-exchange")
                 .withRequestBody(containing("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange"))
                 .withRequestBody(containing("subject_token=token_to_be_exchanged"))
@@ -122,7 +122,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .aResponse()
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
-                                "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_2\", \"refresh_expires_in\":1}")));
+                                "{\"access_token\":\"access_token_2\", \"expires_in\":6, \"refresh_token\":\"refresh_token_2\", \"refresh_expires_in\":1}")));
 
         server.stubFor(WireMock.post("/tokens-without-expires-in")
                 .withRequestBody(matching("grant_type=client_credentials&client_id=quarkus-app&client_secret=secret"))

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -112,7 +112,7 @@ public class OidcClientTest {
     @Test
     public void testEchoAndRefreshTokens() {
         // access_token_1 and refresh_token_1 are acquired using a password grant request.
-        // access_token_1 expires in 4 seconds, refresh_token_1 has no lifespan limit as no `refresh_expires_in` property is returned.
+        // access_token_1 expires in 6 seconds, refresh_token_1 has no lifespan limit as no `refresh_expires_in` property is returned.
         // "Default OidcClient has acquired the tokens" record is added to the log
         RestAssured.when().get("/frontend/echoToken")
                 .then()
@@ -120,7 +120,7 @@ public class OidcClientTest {
                 .body(equalTo("access_token_1"));
 
         // Wait until the access_token_1 has expired
-        waitUntillAccessTokenHasExpired(5000);
+        waitUntillAccessTokenHasExpired(7000);
 
         // access_token_1 has expired, refresh_token_1 is assumed to be valid and used to acquire access_token_2 and refresh_token_2.
         // access_token_2 expires in 4 seconds, but refresh_token_2 - in 1 sec - it will expire by the time access_token_2 has expired
@@ -131,7 +131,7 @@ public class OidcClientTest {
                 .body(equalTo("access_token_2"));
 
         // Wait until the access_token_2 has expired
-        waitUntillAccessTokenHasExpired(5000);
+        waitUntillAccessTokenHasExpired(7000);
 
         // Both access_token_2 and refresh_token_2 have now expired therefore a password grant request is repeated,
         // as opposed to using a refresh token grant.


### PR DESCRIPTION
`quarkus-oidc-client` extension logs responses but not requests in the debug mode, and while a custom `OidcRequestFilter` can be used to log requests, it should not be necessary.

This PR adds support for logging `quarkus-oidc-client` OIDC client requests, very similarly to how `quarkus-oidc` does it.