### PR TITLE
Fix handling of overlapping paths in resteasy-reactive server

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.reactive.server.mapping;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -34,24 +35,28 @@ class PathMatcher<T> implements Dumpable {
      * @param path The relative path to match
      * @return The match match. This will never be null, however if none matched its value field will be
      */
-    PathMatch<T> match(String path) {
+    List<PathMatch<T>> match(String path) {
         int length = path.length();
         final int[] lengths = this.lengths;
+        ArrayList<PathMatch<T>> matches = new ArrayList<>(1);
         for (int i = 0; i < lengths.length; ++i) {
             int pathLength = lengths[i];
             if (pathLength == length) {
                 SubstringMap.SubstringMatch<T> next = paths.get(path, length);
                 if (next != null) {
-                    return new PathMatch<>(path, "", next.getValue());
+                    matches.add(new PathMatch<>(path, "", next.getValue()));
                 }
             } else if (pathLength < length) {
                 SubstringMap.SubstringMatch<T> next = paths.get(path, pathLength);
                 if (next != null) {
-                    return new PathMatch<>(next.getKey(), path.substring(pathLength), next.getValue());
+                    matches.add(new PathMatch<>(next.getKey(), path.substring(pathLength), next.getValue()));
                 }
             }
         }
-        return defaultMatch(path);
+        if (matches.isEmpty()) {
+            matches.add(defaultMatch(path));
+        }
+        return matches;
     }
 
     PathMatch<T> defaultMatch(String path) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/PathParamOverlapTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/PathParamOverlapTest.java
@@ -53,6 +53,36 @@ public class PathParamOverlapTest {
         get("/hello/other/test/wrong")
                 .then()
                 .statusCode(404);
+
+        get("/hello/foo")
+                .then()
+                .statusCode(404);
+
+        get("/hello/foo/value")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Foo value"));
+
+        get("/hello/foo/bar")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Foo bar"));
+
+        get("/hello/foo/bar/value")
+                .then()
+                .statusCode(200)
+                .body(equalTo("FooBar value"));
+
+        get("/hello/foo/bah_value")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Foo bah_value"));
+
+        get("/hello/foo/bar_value")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Foo bar_value"));
+
     }
 
     @Path("/hello")
@@ -70,5 +100,19 @@ public class PathParamOverlapTest {
         public String second(@RestPath String id) {
             return "Hello " + id;
         }
+
+        @GET
+        @Path("/foo/{param}")
+        public String foo(@RestPath String param) {
+            return "Foo " + param;
+        }
+
+        @GET
+        @Path("/foo/bar/{param}")
+        public String fooBar(@RestPath String param) {
+            return "FooBar " + param;
+        }
+
     }
+
 }


### PR DESCRIPTION
This improves the path matching logic in resteasy-reactive server. It fixes the case when there are overlapping path templates registered, such as:

* /path/foo/{param}
* /path/foo/bar/{param}

and the incoming request has path `/path/foo/bar_something`. The expectation is that this path should be matched by the first template. The current behavior however is that server returns 404.

* Fixes #50330