### PR TITLE
Disable by default DAP traces with Qute debugger tests.

### DIFF
--- a/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/DAPClient.java
+++ b/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/DAPClient.java
@@ -60,9 +60,8 @@ public class DAPClient implements IDebugProtocolClient, Debugger {
     private boolean enabled;
 
     public CompletableFuture<Void> connectToServer(int port) {
-
-        TracingMessageConsumer tracing = new TracingMessageConsumer();
-        ServerTrace serverTrace = ServerTrace.verbose;
+        ServerTrace serverTrace = ServerTrace.getDefaultValue();
+        TracingMessageConsumer tracing = serverTrace != ServerTrace.off ? new TracingMessageConsumer() : null;
         UnaryOperator<MessageConsumer> wrapper = consumer -> {
             MessageConsumer result = consumer;
             if (tracing != null) {

--- a/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/ServerTrace.java
+++ b/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/ServerTrace.java
@@ -22,6 +22,7 @@ public enum ServerTrace {
     verbose; // show message with detail
 
     public static ServerTrace getDefaultValue() {
+        // Return verbose here to enable DAP trace output in the console.
         return off;
     }
 


### PR DESCRIPTION
Disable by default DAP traces with Qute debugger tests.

//cc @mkouba 