### PR TITLE
Fix OIDC TokenRevocation filter binding and improve request logging

### DIFF
--- a/integration-tests/oidc-wiremock-logout/src/main/java/io/quarkus/it/keycloak/OidcTokenRevocationRequestFilter.java
+++ b/integration-tests/oidc-wiremock-logout/src/main/java/io/quarkus/it/keycloak/OidcTokenRevocationRequestFilter.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestFilter;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = { Type.TOKEN_REVOCATION })
+public class OidcTokenRevocationRequestFilter implements OidcRequestFilter {
+
+    @Override
+    public void filter(OidcRequestContext rc) {
+        String body = rc.requestBody().toString();
+        if (body.contains("token_type_hint=access_token")) {
+            rc.request().putHeader("token-revocation-filter", "access-token");
+        } else if (body.contains("token_type_hint=refresh_token")) {
+            rc.request().putHeader("token-revocation-filter", "refresh-token");
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #50390

Fix a typo with  token revocation request filter binding and use `TokenOperation` enum to log a correct operation name and do other checks.

Enum does not follow a typical naming pattern, I thought of having `GET` than transform to `Get` or have an enum constructor, but then thought for the internal work it was ok... 