### PR TITLE
RestClient processor with NullPointerException during scope definition

### DIFF
--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/ClientWithWrongScopeTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/ClientWithWrongScopeTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.restclient.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClientWithWrongScopeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyClient.class))
+            .withConfigurationResource("client-with-wrong-scope.properties")
+            .assertException(t -> assertThat(t).hasMessageContaining("Not possible to define the scope"));
+
+    @RestClient
+    MyClient client;
+
+    @Test
+    public void testValidationFailed() {
+        // This method should not be invoked
+        fail();
+    }
+
+    @Path("/client")
+    @RegisterRestClient(configKey = "my-client")
+    public interface MyClient {
+
+        @GET
+        @Path("/")
+        String get();
+    }
+}

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/resources/client-with-wrong-scope.properties
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/resources/client-with-wrong-scope.properties
@@ -1,0 +1,2 @@
+my-client/mp-rest/url=http://localhost:${quarkus.http.test-port:8081}
+my-client/mp-rest/scope=wrong-scope

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientWithWrongScopeTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientWithWrongScopeTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClientWithWrongScopeTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyClient.class))
+            .withConfigurationResource("wrong-scope-test-application.properties")
+            .assertException(t -> assertThat(t).hasMessageContaining("Not possible to define the scope"));
+
+    @Test
+    public void testValidationFailed() {
+        // This method should not be invoked
+        fail();
+    }
+
+    @Path("/client")
+    @RegisterRestClient(configKey = "my-client")
+    public interface MyClient {
+
+        @GET
+        @Path("/")
+        String get();
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/wrong-scope-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/wrong-scope-test-application.properties
@@ -1,0 +1,2 @@
+my-client/mp-rest/url=http://localhost:${quarkus.http.test-port:8081}
+my-client/mp-rest/scope=wrong-scope


### PR DESCRIPTION
Before Quarkus 3.28, when we defined a wrong scope, Quarkus added a warning log to indicate that it wasn't possible to use the defined scope for the RestClient and initialize the Client with the default scope. With the current version, it is returning a NullPointerException, and no warning is thrown.

This change fixes the issue and adds a warning about it during the build.

