### PR TITLE
Expand error messages when quarkus cli fail hard on bad settings.xml

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
@@ -237,7 +237,18 @@ public class QuarkusProjectHelper {
                         .setWorkspaceDiscovery(false)
                         .build();
             } catch (BootstrapMavenException e) {
-                throw new IllegalStateException("Failed to initialize the Maven artifact resolver", e);
+                StringBuilder messages = new StringBuilder("Failed to initialize the Maven artifact resolver");
+                Throwable current = e;
+                while (null != current) {
+                    if (null != current.getMessage() && !current.getMessage().isBlank()) {
+                        messages
+                                .append("\n")
+                                .append(current.getMessage());
+                    }
+
+                    current = current.getCause();
+                }
+                throw new IllegalStateException(messages.toString().trim(), e);
             }
         }
         return artifactResolver;


### PR DESCRIPTION
* recurse the exception stack when we can't create the artifact resolver, and append together all of the error messages
* the useful error message isn't in the `BootstrapMavenException`, it's in the cause for that exception

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>

- Fixes #29817
