### PR TITLE
Correctly handle Agroal Dev UI settings in hot-reload scenarios

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
@@ -29,10 +29,7 @@ class AgroalDevUIProcessor {
                 cardPageBuildItem.addPage(Page.webComponentPageBuilder()
                         .icon("font-awesome-solid:database")
                         .title("Database view")
-                        .componentLink("qwc-agroal-datasource.js")
-                        .metadata("allowSql", String.valueOf(config.devui().allowSql()))
-                        .metadata("appendSql", config.devui().appendToDefaultSelect().orElse(""))
-                        .metadata("allowedHost", config.devui().allowedDBHost().orElse(null)));
+                        .componentLink("qwc-agroal-datasource.js"));
             }
         }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
@@ -46,8 +46,7 @@ public class HibernateOrmDevUIProcessor {
         card.addPage(Page.webComponentPageBuilder()
                 .title("HQL Console")
                 .componentLink("hibernate-orm-hql-console.js")
-                .icon("font-awesome-solid:play")
-                .metadata("allowHql", String.valueOf(config.devui().allowHql())));
+                .icon("font-awesome-solid:play"));
         return card;
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
@@ -286,14 +286,11 @@ export class HibernateOrmHqlConsoleComponent extends observeState(QwcHotReloadEl
         const configPromise = this.configJsonRpc.getAllValues();
         const infoPromise = this.jsonRpc.getInfo();
         Promise.all([configPromise, infoPromise]).then(responses => {
-            const configResponse = responses[0];
-            const infoResponse = responses[1];
-            if (configResponse && configResponse.result) {
-                const allowHqlConfig = configResponse.result['quarkus.hibernate-orm.dev-ui.allow-hql'];
-                this._allowHql = allowHqlConfig && allowHqlConfig === 'true';
-            }
-            if (infoResponse && infoResponse.result) {
-                this._persistenceUnits = infoResponse.result.persistenceUnits;
+            const configValues = responses[0].result;
+            this._allowHql = configValues['quarkus.hibernate-orm.dev-ui.allow-hql'] === 'true';
+            const infoResponse = responses[1].result;
+            if (infoResponse) {
+                this._persistenceUnits = infoResponse.persistenceUnits;
                 this._selectPersistenceUnit(this._persistenceUnits[0]);
             }
         }).catch(error => {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Very similar solution to what was done here https://github.com/quarkusio/quarkus/pull/50371 for the Hibernate ORM extension.

I also took the liberty of handling a `todo` by adding the english-to-sql setting to local storage, @phillip-kruger let me know if that's ok.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

