### PR TITLE
Initialize org.keycloak.common.util.SecretGenerator at runtime for Keycloak admin client

### DIFF
--- a/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/deployment/KeycloakAdminClientProcessor.java
+++ b/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/deployment/KeycloakAdminClientProcessor.java
@@ -1,0 +1,13 @@
+package io.quarkus.keycloak.admin.client.common.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+
+public class KeycloakAdminClientProcessor {
+
+    @BuildStep
+    public void nativeImage(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInit) {
+        runtimeInit.produce(new RuntimeInitializedClassBuildItem("org.keycloak.common.util.SecretGenerator"));
+    }
+}


### PR DESCRIPTION
Initialize org.keycloak.common.util.SecretGenerator at runtime for Keycloak admin client


Fixes https://github.com/quarkusio/quarkus/issues/50404