### PR TITLE
Check for invalid characters when adding an extension

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionInstallPlan.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ExtensionInstallPlan.java
@@ -14,21 +14,25 @@ public class ExtensionInstallPlan {
             Collections.emptySet(),
             Collections.emptySet(),
             Collections.emptySet(),
+            Collections.emptySet(),
             Collections.emptySet());
 
     private final Set<ArtifactCoords> platforms;
     private final Set<ArtifactCoords> managedExtensions;
     private final Set<ArtifactCoords> independentExtensions;
     private final Collection<String> unmatchedKeywords;
+    private final Collection<String> invalidKeywords;
 
     private ExtensionInstallPlan(Set<ArtifactCoords> platforms,
             Set<ArtifactCoords> managedExtensions,
             Set<ArtifactCoords> independentExtensions,
-            Collection<String> unmatchedKeywords) {
+            Collection<String> unmatchedKeywords,
+            Collection<String> invalidKeywords) {
         this.platforms = platforms;
         this.managedExtensions = managedExtensions;
         this.independentExtensions = independentExtensions;
         this.unmatchedKeywords = unmatchedKeywords;
+        this.invalidKeywords = invalidKeywords;
     }
 
     public boolean isNotEmpty() {
@@ -77,6 +81,10 @@ public class ExtensionInstallPlan {
         return unmatchedKeywords;
     }
 
+    public Collection<String> getInvalidKeywords() {
+        return invalidKeywords;
+    }
+
     @Override
     public String toString() {
         return "InstallRequest{" +
@@ -84,6 +92,7 @@ public class ExtensionInstallPlan {
                 ", managedExtensions=" + managedExtensions +
                 ", independentExtensions=" + independentExtensions +
                 ", unmatchedKeywords=" + unmatchedKeywords +
+                ", invalidKeywords=" + invalidKeywords +
                 '}';
     }
 
@@ -97,9 +106,11 @@ public class ExtensionInstallPlan {
         private final Set<ArtifactCoords> extensionsInPlatforms = new LinkedHashSet<>();
         private final Set<ArtifactCoords> independentExtensions = new LinkedHashSet<>();
         private final Collection<String> unmatchedKeywords = new ArrayList<>();
+        private final Collection<String> invalidKeywords = new ArrayList<>();
 
         public ExtensionInstallPlan build() {
-            return new ExtensionInstallPlan(platforms, extensionsInPlatforms, independentExtensions, unmatchedKeywords);
+            return new ExtensionInstallPlan(platforms, extensionsInPlatforms, independentExtensions, unmatchedKeywords,
+                    invalidKeywords);
         }
 
         public Builder addIndependentExtension(ArtifactCoords artifactCoords) {
@@ -119,6 +130,11 @@ public class ExtensionInstallPlan {
 
         public Builder addUnmatchedKeyword(String unmatchedKeyword) {
             this.unmatchedKeywords.add(unmatchedKeyword);
+            return this;
+        }
+
+        public Builder addInvalidKeyword(String invalidKeyword) {
+            this.invalidKeywords.add(invalidKeyword);
             return this;
         }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectAddExtensionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectAddExtensionTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.devtools.project.create;
+
+import static io.quarkus.devtools.project.create.MultiplePlatformBomsTestBase.enableRegistryClient;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.registry.catalog.PlatformStreamCoords;
+
+public class MavenProjectAddExtensionTest extends MultiplePlatformBomsTestBase {
+
+    private static final String PLATFORM_KEY = "io.test.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                .baseDir(configDir())
+                .newRegistry("registry.test.io")
+                .newPlatform(PLATFORM_KEY)
+                .newStream("1.0")
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom").addExtension("ext-a").release()
+                .stream().platform()
+                .newArchivedStream("0.5")
+                .newArchivedRelease("0.5.1")
+                .quarkusVersion("0.5.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom").addExtension("ext-a").release()
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    @Override
+    protected String getMainPlatformKey() {
+        return PLATFORM_KEY;
+    }
+
+    @Test
+    public void test() throws Exception {
+        final Path projectDir = newProjectDir("existing-project");
+        createProject(projectDir, new PlatformStreamCoords(null, "0.5"), List.of("ext-a"));
+
+        // valid characters, existing dependency
+        QuarkusCommandOutcome outcome = addExtensions(projectDir, List.of("io.quarkus:quarkus-info:3.20.1"));
+        assertTrue(outcome.isSuccess());
+
+        // invalid characters (tilde in artifactId)
+        outcome = addExtensions(projectDir,
+                List.of("io.quarkiverse.businessscore:quarkus-business-score-health~:1.0.0.Alpha4"));
+        assertFalse(outcome.isSuccess());
+
+        // valid characters, questionable dependency
+        outcome = addExtensions(projectDir, List.of("group:artifact:version"));
+        assertTrue(outcome.isSuccess());
+    }
+}


### PR DESCRIPTION
* Fixes #49895
* use a pattern matcher to validate the groupId and artifactId for a fully qualified extension name (group, artifact, and version)

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>
