### PR TITLE
Drop Mandrel/GraalVM 23.0 support

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -172,7 +172,6 @@ public final class GraalVM {
         // Get access to GRAAL_MAPPING without making it public
         private static final Map<String, String> GRAAL_MAPPING = io.quarkus.runtime.graal.GraalVM.Version.GRAAL_MAPPING;
 
-        public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", "17", Distribution.GRAALVM);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
         public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
         public static final Version VERSION_24_0_999 = new Version("GraalVM 24.0.999", "24.0.999", "22", Distribution.GRAALVM);
@@ -187,7 +186,7 @@ public final class GraalVM {
          * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.MINIMUM} instead.
          */
         @Deprecated
-        public static final Version MINIMUM = VERSION_23_0_0;
+        public static final Version MINIMUM = VERSION_23_1_0;
         /**
          * The current version of GraalVM supported by Quarkus.
          * This version is the one actively being tested and is expected to give the best experience.

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -823,12 +823,9 @@ public class NativeImageBuildStep {
                 // Generate a file with the list of built artifacts
                 addExperimentalVMOption(nativeImageArgs, "-H:+GenerateBuildArtifactsFile");
 
-                // only available in GraalVM 23.1.0+
-                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) >= 0) {
-                    if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_0_0) < 0) {
-                        // Enabled by default in GraalVM 24.0.0.
-                        nativeImageArgs.add("--strict-image-heap");
-                    }
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_0_0) < 0) {
+                    // Enabled by default in GraalVM 24.0.0.
+                    nativeImageArgs.add("--strict-image-heap");
                 }
 
                 /*
@@ -993,20 +990,8 @@ public class NativeImageBuildStep {
 
                 if (nativeConfig.autoServiceLoaderRegistration()) {
                     addExperimentalVMOption(nativeImageArgs, "-H:+UseServiceLoaderFeature");
-                    if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) < 0) {
-                        // When enabling, at least print what exactly is being added. Only possible in <23.1.0
-                        nativeImageArgs.add("-H:+TraceServiceLoaderFeature");
-                    }
                 } else {
                     addExperimentalVMOption(nativeImageArgs, "-H:-UseServiceLoaderFeature");
-                }
-                // This option has no effect on GraalVM 23.1+
-                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) < 0) {
-                    if (nativeConfig.fullStackTraces()) {
-                        nativeImageArgs.add("-H:+StackTrace");
-                    } else {
-                        nativeImageArgs.add("-H:-StackTrace");
-                    }
                 }
 
                 if (nativeConfig.enableDashboardDump()) {
@@ -1113,13 +1098,9 @@ public class NativeImageBuildStep {
             }
 
             private void addExperimentalVMOption(List<String> nativeImageArgs, String option) {
-                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) >= 0) {
-                    nativeImageArgs.add("-H:+UnlockExperimentalVMOptions");
-                }
+                nativeImageArgs.add("-H:+UnlockExperimentalVMOptions");
                 nativeImageArgs.add(option);
-                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) >= 0) {
-                    nativeImageArgs.add("-H:-UnlockExperimentalVMOptions");
-                }
+                nativeImageArgs.add("-H:-UnlockExperimentalVMOptions");
             }
         }
     }


### PR DESCRIPTION
Mandrel/GraalVM 23.0 is not being maintained since January 2025 and Mandrel/GraalVM 25.0 which is the latest LTS release was released recently.