### PR TITLE
Fix incorrect timing computation

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -92,7 +92,9 @@ public class ExecutorRecorder {
                             intervalRemaining, interruptRemaining);
                     try {
                         if (!executor.awaitTermination(Math.min(remaining, intervalRemaining), TimeUnit.NANOSECONDS)) {
-                            long elapsed = System.nanoTime() - start;
+                            long end = System.nanoTime();
+                            long elapsed = Math.max(0, end - start);
+                            start = end;
                             intervalRemaining -= elapsed;
                             remaining -= elapsed;
                             interruptRemaining -= elapsed;


### PR DESCRIPTION
Closes #49921. Fixes #49733.

The timing computation for thread pool termination is wrong because the elapsed time is recomputed based on the original start time, rather than the time elapsed since the last check.

Clarify the code and correct the error. Replacing #49921 due to lack of response to feedback on that one.