### PR TITLE
Create proxies for abstract entity classes too in Hibernate ORM

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ProxyBuildingHelper.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ProxyBuildingHelper.java
@@ -44,7 +44,6 @@ final class ProxyBuildingHelper implements AutoCloseable {
     public boolean isProxiable(ClassInfo classInfo) {
         return classInfo != null
                 && !classInfo.isInterface()
-                && !classInfo.isAbstract()
                 && !classInfo.isFinal()
                 && classInfo.hasNoArgsConstructor();
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusProxyFactory.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusProxyFactory.java
@@ -69,9 +69,6 @@ public final class QuarkusProxyFactory implements ProxyFactory {
             else if (Modifier.isFinal(persistentClass.getModifiers())) {
                 reason = "this class is final. Your application might perform better if this class was non-final.";
             }
-            if (Modifier.isAbstract(persistentClass.getModifiers())) {
-                reason = "this class is abstract. Your application might perform better if this class was non-abstract.";
-            }
             if (reason != null) {
                 // This is caught and logged as a warning by Hibernate ORM.
                 throw new HibernateException(String.format(Locale.ROOT,

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/proxy/ProxyTestEndpoint.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/proxy/ProxyTestEndpoint.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import org.hibernate.proxy.HibernateProxy;
+
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.narayana.jta.runtime.TransactionConfiguration;
 import io.quarkus.runtime.StartupEvent;
@@ -75,6 +77,18 @@ public class ProxyTestEndpoint {
         if (list.size() != 1) {
             throw new RuntimeException("Expected 1 result, got " + list.size());
         }
+        return "OK";
+    }
+
+    @GET
+    @Path("abstract")
+    @Transactional
+    public String testAbstract() {
+        var result = entityManager.getReference(AbstractEntity.class, "1");
+        expectTrue(result != null);
+        expectTrue(result instanceof HibernateProxy);
+        // Make sure we don't get fooled by some kind of "fallback" eager loading
+        expectFalse(result instanceof ConcreteEntity);
         return "OK";
     }
 

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
@@ -1,13 +1,26 @@
 package io.quarkus.it.jpa.proxy;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.LogCollectingTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
+@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+        @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
+        @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
+        // Ignore logs about schema management:
+        // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
+        // but for now we have to live with them.
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+})
 public class ProxyTest {
 
     @Test
@@ -23,6 +36,28 @@ public class ProxyTest {
     @Test
     public void testEnhancedProxies() {
         RestAssured.when().get("/jpa-test/proxy/enhanced").then().body(is("OK"));
+    }
+
+    @Test
+    public void testAbstractClassProxies() {
+        RestAssured.when().get("/jpa-test/proxy/abstract").then().body(is("OK"));
+    }
+
+    @Test
+    // When running as integration test, we cannot easily spy on logs.
+    @DisabledOnIntegrationTest
+    public void testProxyWarningsOnStartup() {
+        assertThat(LogCollectingTestResource.current().getRecords())
+                // There shouldn't be any warning or error
+                .as("Startup logs (warning or higher)")
+                .extracting(LogCollectingTestResource::format)
+                .satisfiesExactlyInAnyOrder(
+                        // Final classes cannot be proxied
+                        m -> assertThat(m).contains(
+                                "Could not create proxy factory", CompanyCustomer.class.getName(),
+                                "this class is final", "Your application might perform better if this class was non-final.")
+                // Importantly, we don't expect any other warning about proxies!
+                );
     }
 
 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/LogCollectingTestResource.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/LogCollectingTestResource.java
@@ -25,7 +25,7 @@ public class LogCollectingTestResource implements QuarkusTestResourceLifecycleMa
     public static final String EXCLUDE = "exclude";
     public static final String INCLUDE = "include";
 
-    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%m");
 
     public static String format(LogRecord record) {
         return LOG_FORMATTER.format(record);


### PR DESCRIPTION
Fixes a problem reported by @mzellho (thank you!)  [here](https://github.com/quarkusio/quarkus/commit/b2dad43b6be1b2e591e4f227f63c6842a6248676#r166453173): we abstain from creating entity proxies for abstract classes at build time, but in practice... there is no reason to not create them.

The problem seems to have been introduced by mistake [here](https://github.com/quarkusio/quarkus/commit/f1c54b687b2c5d630a3352a5ab44ad6e545a8418#diff-82ae43c0790681a1a2fbab04bdfc53398b56fc01253c3cc3f0cbcdc90a93f015L55-R60) when adding conditions to prevent the creation of proxies for final classes (which, indeed, simply cannot be proxied). It was made more visible by #49591 which revamped the warnings (and maybe added some?) and removed some fallback behavior that could generate proxies at static init.