### PR TITLE
Update smallrye-jwt-oidc-web-app test to use Keycloak Dev Service

### DIFF
--- a/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
+++ b/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
         <!-- test dependencies -->
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-keycloak-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-client-common-synced</artifactId>
             <scope>test</scope>
@@ -224,34 +229,6 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
-                                <image>
-                                    <name>${keycloak.docker.image}</name>
-                                    <alias>quarkus-test-keycloak</alias>
-                                    <run>
-                                        <ports>
-                                            <port>8180:8080</port>
-                                        </ports>
-                                        <env>
-                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
-                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
-                                        </env>
-                                        <cmd>
-                                            <arg>start-dev</arg>
-                                        </cmd>
-                                        <log>
-                                            <prefix>Keycloak:</prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <http>
-                                                <url>http://localhost:8180</url>
-                                            </http>
-                                            <time>100000</time>
-                                        </wait>
-                                    </run>
-                                </image>
                                 <image>
                                     <name>${postgres.image}</name>
                                     <alias>postgresql-db</alias>

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/main/resources/application.properties
@@ -5,10 +5,10 @@ smallrye.jwt.path.groups=realm_access/roles
 mp.jwt.token.header=Cookie
 smallrye.jwt.always-check-authorization=true
 
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.application-type=web-app
-quarkus.oidc.client-id=quarkus-app
-quarkus.oidc.credentials.secret=secret
+
+quarkus.keycloak.devservices.create-realm=false
+quarkus.keycloak.devservices.port=8180
 
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=oidc_db_token_state_manager_test_user

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -1,28 +1,27 @@
 package io.quarkus.it.keycloak;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.util.JsonSerialization;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.restassured.RestAssured;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 
-public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
+public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180");
     private static final String KEYCLOAK_REALM = "quarkus";
+
+    final KeycloakTestClient client = new KeycloakTestClient();
 
     @Override
     public Map<String, String> start() {
@@ -38,31 +37,8 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.getUsers().add(createUser("bob", "user"));
         realm.getUsers().add(createUser("john", "tester"));
 
-        try {
-            RestAssured
-                    .given()
-                    .auth().oauth2(getAdminAccessToken())
-                    .contentType("application/json")
-                    .body(JsonSerialization.writeValueAsBytes(realm))
-                    .when()
-                    .post(KEYCLOAK_SERVER_URL + "/admin/realms").then()
-                    .statusCode(201);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        client.createRealm(realm);
         return Collections.emptyMap();
-    }
-
-    private static String getAdminAccessToken() {
-        return RestAssured
-                .given()
-                .param("grant_type", "password")
-                .param("username", "admin")
-                .param("password", "admin")
-                .param("client_id", "admin-cli")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/master/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
     }
 
     private static RealmRepresentation createRealm(String name) {
@@ -126,23 +102,11 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
     @Override
     public void stop() {
 
-        RestAssured
-                .given()
-                .auth().oauth2(getAdminAccessToken())
-                .when()
-                .delete(KEYCLOAK_SERVER_URL + "/admin/realms/" + KEYCLOAK_REALM).then().statusCode(204);
+        client.deleteRealm(KEYCLOAK_REALM);
     }
 
-    public static String getAccessToken(String userName) {
-        return RestAssured
-                .given()
-                .param("grant_type", "password")
-                .param("username", userName)
-                .param("password", userName)
-                .param("client_id", "quarkus-app")
-                .param("client_secret", "secret")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        client.setIntegrationTestContext(context);
     }
 }

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
@@ -12,15 +12,18 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(KeycloakRealmResourceManager.class)
 public class SmallRyeJwtOidcWebAppTest {
 
+    final KeycloakTestClient client = new KeycloakTestClient();
+
     @Test
     public void testGetUserNameWithBearerToken() {
-        RestAssured.given().auth().oauth2(KeycloakRealmResourceManager.getAccessToken("alice"))
+        RestAssured.given().auth().oauth2(client.getAccessToken("alice"))
                 .when().get("/protected")
                 .then()
                 .statusCode(200)
@@ -37,7 +40,7 @@ public class SmallRyeJwtOidcWebAppTest {
 
     @Test
     public void testGetUserNameWithCookieToken() {
-        RestAssured.given().header("Cookie", "Bearer=" + KeycloakRealmResourceManager.getAccessToken("alice"))
+        RestAssured.given().header("Cookie", "Bearer=" + client.getAccessToken("alice"))
                 .when().get("/protected")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
`integration-tests/smallrye-jwt-oidc-webapp` is a bit flaky as currently it uses the docker plugin to handle two images, so I updated it to use DevServices for Keycloak instead of it depending on the legacy way of loading Keycloak