### PR TITLE
Deprecate `quarkus.native.resources.excludes`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageResourcePatternsBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageResourcePatternsBuildItem.java
@@ -30,6 +30,7 @@ import io.quarkus.util.GlobUtil;
  */
 public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
 
+    @Deprecated(since = "3.29", forRemoval = true)
     private final List<String> excludePatterns;
 
     private final List<String> includePatterns;
@@ -39,6 +40,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
         this.excludePatterns = excludePatterns;
     }
 
+    /**
+     * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+     *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1 for
+     *             JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
+     */
+    @Deprecated(since = "3.29", forRemoval = true)
     public List<String> getExcludePatterns() {
         return excludePatterns;
     }
@@ -52,6 +59,7 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
     }
 
     public static class Builder {
+        @Deprecated(since = "3.29", forRemoval = true)
         private List<String> excludePatterns = new ArrayList<>();
         private List<String> includePatterns = new ArrayList<>();
 
@@ -72,7 +80,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param glob the glob pattern to add to the list of patterns to exclude
          * @return this {@link Builder}
+         *
+         * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+         *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1
+         *             for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder excludeGlob(String glob) {
             excludePatterns.add(GlobUtil.toRegexPattern(glob));
             return this;
@@ -87,7 +100,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param globs the glob patterns to add to the list of patterns to exclude
          * @return this {@link Builder}
+         *
+         * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+         *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1
+         *             for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder excludeGlobs(Collection<String> globs) {
             globs.stream().map(GlobUtil::toRegexPattern).forEach(excludePatterns::add);
             return this;
@@ -102,7 +120,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param globs the glob patterns to add to the list of patterns to exclude
          * @return this {@link Builder}
+         *
+         * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+         *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1
+         *             for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder excludeGlobs(String... globs) {
             Stream.of(globs).map(GlobUtil::toRegexPattern).forEach(excludePatterns::add);
             return this;
@@ -116,7 +139,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param pattern the regular expression to add to the list of patterns to exclude
          * @return this {@link Builder}
+         *
+         * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+         *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1
+         *             for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder excludePattern(String pattern) {
             excludePatterns.add(pattern);
             return this;
@@ -130,7 +158,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param patterns the regular expressions to add to the list of patterns to exclude
          * @return this {@link Builder}
+         *
+         * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+         *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1
+         *             for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder excludePatterns(Collection<String> patterns) {
             excludePatterns.addAll(patterns);
             return this;
@@ -144,7 +177,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param patterns the regular expressions to add to the list of patterns to exclude
          * @return this {@link Builder}
+         *
+         * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+         *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1
+         *             for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder excludePatterns(String... patterns) {
             Stream.of(patterns).forEach(excludePatterns::add);
             return this;
@@ -187,8 +225,8 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          * @param globs the glob patterns to add
          * @return this {@link Builder}
          */
-        public Builder includeGlobs(String... patterns) {
-            Stream.of(patterns).map(GlobUtil::toRegexPattern).forEach(includePatterns::add);
+        public Builder includeGlobs(String... globs) {
+            Stream.of(globs).map(GlobUtil::toRegexPattern).forEach(includePatterns::add);
             return this;
         }
 
@@ -199,7 +237,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param pattern the regular expression to add
          * @return this {@link Builder}
+         *
+         * @deprecated Including resources using patterns is not supported in the new reachability-metadata.json file used with
+         *             Mandrel/GraalVM 25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for
+         *             Mandrel/GraalVM 23.1 for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder includePattern(String pattern) {
             includePatterns.add(pattern);
             return this;
@@ -212,7 +255,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param patterns the regular expressions to add
          * @return this {@link Builder}
+         *
+         * @deprecated Including resources using patterns is not supported in the new reachability-metadata.json file used with
+         *             Mandrel/GraalVM 25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for
+         *             Mandrel/GraalVM 23.1 for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder includePatterns(Collection<String> patterns) {
             includePatterns.addAll(patterns);
             return this;
@@ -225,7 +273,12 @@ public final class NativeImageResourcePatternsBuildItem extends MultiBuildItem {
          *
          * @param patterns the regular expressions to add
          * @return this {@link Builder}
+         *
+         * @deprecated Including resources using patterns is not supported in the new reachability-metadata.json file used with
+         *             Mandrel/GraalVM 25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for
+         *             Mandrel/GraalVM 23.1 for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         public Builder includePatterns(String... patterns) {
             Stream.of(patterns).forEach(includePatterns::add);
             return this;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -488,7 +488,12 @@ public interface NativeConfig {
          * <p>
          * the resource {@code red.png} will be available in the native image while the resources {@code foo/green.png}
          * and {@code bar/blue.png} will not be available in the native image.
+         *
+         * @deprecated Excluding resources is not supported in the new reachability-metadata.json file used with Mandrel/GraalVM
+         *             25.0 and onwards. Quarkus plans to adopt the use of reachability-metadata.json for Mandrel/GraalVM 23.1
+         *             for JDK 21 as well (see https://github.com/quarkusio/quarkus/issues/41016)
          */
+        @Deprecated(since = "3.29", forRemoval = true)
         Optional<List<String>> excludes();
     }
 

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -39,22 +39,19 @@ Other resources should be declared explicitly.
 
 ==== Using the `quarkus.native.resources.includes` configuration property
 
-To include more resources in the native executable, the easiest way is to use the `quarkus.native.resources.includes` configuration property,
-and its counterpart to exclude resources `quarkus.native.resources.excludes`.
+To include more resources in the native executable, the easiest way is to use the `quarkus.native.resources.includes` configuration property.
+The configuration property supports glob patterns.
 
-Both configuration properties support glob patterns.
-
-For instance, having the following properties in your `application.properties`:
+For instance, having the following property in your `application.properties`:
 
 [source,properties]
 ----
 quarkus.native.resources.includes=foo/**,bar/**/*.txt
-quarkus.native.resources.excludes=foo/private/**
 ----
 
 will include:
 
-* all files in the `foo/` directory and its subdirectories except for files in `foo/private/` and its subdirectories,
+* all files in the `foo/` directory and its subdirectories,
 * all text files in the `bar/` directory and its subdirectories.
 
 ==== Using a configuration file

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -80,8 +80,8 @@ class AwtProcessor {
             BuildProducer<NativeImageResourcePatternsBuildItem> resourcePatternsBuildItemBuildProducer) {
         resourcePatternsBuildItemBuildProducer
                 .produce(NativeImageResourcePatternsBuildItem.builder()
-                        .includePattern(".*/iio-plugin.*properties$") // Texts for e.g. exceptions strings
-                        .includePattern(".*/.*pf$") // Default colour profiles
+                        .includeGlobs("**/iio-plugin*.properties", // Texts for e.g. exceptions strings
+                                "**/*.pf") // Default colour profiles
                         .build());
     }
 

--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -548,6 +548,6 @@ public class JaxbProcessor {
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     void jaxbIndex(final BuildProducer<NativeImageResourcePatternsBuildItem> resource) {
         LOG.debug("adding jaxb.index to native image resources");
-        resource.produce(NativeImageResourcePatternsBuildItem.builder().includePattern(".*/jaxb.index$").build());
+        resource.produce(NativeImageResourcePatternsBuildItem.builder().includeGlob("**/jaxb.index").build());
     }
 }

--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
@@ -72,10 +72,10 @@ public class KotlinProcessor {
                         .builder("kotlin.collections.EmptyList", "kotlin.collections.EmptyMap", "kotlin.collections.EmptySet")
                         .build());
 
-        nativeResourcePatterns.produce(builder().includePatterns(
-                "META-INF/.*.kotlin_module$",
+        nativeResourcePatterns.produce(builder().includeGlobs(
+                "META-INF/**/*.kotlin_module",
                 "META-INF/services/kotlin.reflect.*",
-                ".*.kotlin_builtins")
+                "**/*.kotlin_builtins")
                 .build());
 
         reflectiveHierarchyIgnoreWarning.produce(


### PR DESCRIPTION
The new `reachability-metadata.json` file doesn't allow the exclusion of
resources and uses globs for the inclusion of them.

See:
  * https://github.com/oracle/graal/issues/7487
  * https://github.com/oracle/graal/pull/9048
  * https://github.com/oracle/graal/pull/12255


Related to https://github.com/quarkusio/quarkus/issues/41016