### PR TITLE
Pulsar native compilation fix after grpc4 update

### DIFF
--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
@@ -190,7 +190,8 @@ public class SmallRyeReactiveMessagingPulsarProcessor {
                 .addRuntimeInitializedClass("org.asynchttpclient.RequestBuilder")
                 .addRuntimeInitializedClass("org.asynchttpclient.BoundRequestBuilder")
                 .addRuntimeInitializedClass("org.asynchttpclient.ntlm.NtlmEngine")
-                .addRuntimeInitializedClass("sun.awt.dnd.SunDropTargetContextPeer$EventDispatcher");
+                .addRuntimeInitializedClass("sun.awt.dnd.SunDropTargetContextPeer$EventDispatcher")
+                .addRuntimeInitializedClass("com.google.protobuf.JavaFeaturesProto");
         if (QuarkusClassLoader.isClassPresentAtRuntime("org.apache.pulsar.common.util.Backoff")) {
             nativeImageConfig
                     .addRuntimeInitializedClass("org.apache.pulsar.common.util.Backoff");


### PR DESCRIPTION
Fixes #50428

After #50326 native compilation of Pulsar-only apps fails as the protobuf schema is still accessible through class initialisation.

This fix adds the `com.google.protobuf.JavaFeaturesProto` as runtime-initialised, like the grpc extension.