### PR TITLE
Cleanup/simplification in core module 

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/Json.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Json.java
@@ -4,9 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -230,8 +228,7 @@ public final class Json {
         public void appendTo(Appendable appendable) throws IOException {
             appendable.append(ARRAY_START);
             int idx = 0;
-            for (ListIterator<Object> iterator = values.listIterator(); iterator.hasNext();) {
-                Object value = iterator.next();
+            for (Object value : values) {
                 if (isIgnored(value)) {
                     continue;
                 }
@@ -346,8 +343,7 @@ public final class Json {
         public void appendTo(Appendable appendable) throws IOException {
             appendable.append(OBJECT_START);
             int idx = 0;
-            for (Iterator<Entry<String, Object>> iterator = properties.entrySet().iterator(); iterator.hasNext();) {
-                Entry<String, Object> entry = iterator.next();
+            for (Entry<String, Object> entry : properties.entrySet()) {
                 if (isIgnored(entry.getValue())) {
                     continue;
                 }

--- a/core/builder/src/main/java/io/quarkus/builder/Json.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Json.java
@@ -364,8 +364,7 @@ public final class Json {
 
         @Override
         void add(JsonValue element) {
-            if (element instanceof JsonMember) {
-                final JsonMember member = (JsonMember) element;
+            if (element instanceof JsonMember member) {
                 final String attribute = member.attribute().value();
                 final JsonValue value = member.value();
                 if (value instanceof JsonString) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/ConstructorPropertiesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ConstructorPropertiesProcessor.java
@@ -29,8 +29,7 @@ public class ConstructorPropertiesProcessor {
 
     private void registerInstance(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, AnnotationInstance instance) {
         AnnotationTarget annotationTarget = instance.target();
-        if (annotationTarget instanceof MethodInfo) {
-            MethodInfo methodInfo = (MethodInfo) annotationTarget;
+        if (annotationTarget instanceof MethodInfo methodInfo) {
             String classname = methodInfo.declaringClass().toString();
             reflectiveClass.produce(asReflectiveClassBuildItem(classname));
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -621,8 +621,7 @@ public final class ExtensionLoader {
                                 for (var type : ctor.getGenericParameterTypes()) {
                                     Class<?> theType;
                                     boolean isRuntimeValue = false;
-                                    if (type instanceof ParameterizedType) {
-                                        ParameterizedType pt = (ParameterizedType) type;
+                                    if (type instanceof ParameterizedType pt) {
                                         if (pt.getRawType().equals(RuntimeValue.class)) {
                                             theType = (Class<?>) pt.getActualTypeArguments()[0];
                                             isRuntimeValue = true;
@@ -853,8 +852,7 @@ public final class ExtensionLoader {
                                                         return runTimeProxies.get(s);
                                                     }
                                                     // TODO - Remove once we disallow the injection of runtime objects in build steps
-                                                    if (s instanceof ParameterizedType) {
-                                                        ParameterizedType p = (ParameterizedType) s;
+                                                    if (s instanceof ParameterizedType p) {
                                                         if (p.getRawType() == RuntimeValue.class) {
                                                             Object object = runTimeProxies.get(p.getActualTypeArguments()[0]);
                                                             if (object == null) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/tracker/ConfigTrackingValueTransformer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/tracker/ConfigTrackingValueTransformer.java
@@ -125,8 +125,8 @@ public class ConfigTrackingValueTransformer {
     public static String sha512(byte[] value) {
         final byte[] digest = getSHA512().digest(value);
         final StringBuilder sb = new StringBuilder(40);
-        for (int i = 0; i < digest.length; ++i) {
-            sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+        for (byte b : digest) {
+            sb.append(Integer.toHexString((b & 0xFF) | 0x100).substring(1, 3));
         }
         return sb.toString();
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
@@ -85,8 +85,7 @@ public class TestClassUsages implements Serializable {
                     } else {
                         return FilterResult.excluded("Has no tests");
                     }
-                } else if (source instanceof MethodSource) {
-                    MethodSource ms = (MethodSource) source;
+                } else if (source instanceof MethodSource ms) {
                     ClassAndMethod cm = new ClassAndMethod(ms.getClassName(), testDescriptor.getUniqueId());
                     if (!classNames.containsKey(cm)) {
                         return FilterResult.included("No test information");

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigDescriptionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigDescriptionBuildStep.java
@@ -57,8 +57,7 @@ public class ConfigDescriptionBuildStep {
                 Method method = property.getMethod();
 
                 String defaultValue = null;
-                if (property instanceof PrimitiveProperty) {
-                    PrimitiveProperty primitiveProperty = (PrimitiveProperty) property;
+                if (property instanceof PrimitiveProperty primitiveProperty) {
                     if (primitiveProperty.hasDefaultValue()) {
                         defaultValue = primitiveProperty.getDefaultValue();
                     } else if (primitiveProperty.getPrimitiveType() == boolean.class) {
@@ -66,8 +65,7 @@ public class ConfigDescriptionBuildStep {
                     } else if (primitiveProperty.getPrimitiveType() != char.class) {
                         defaultValue = "0";
                     }
-                } else if (property instanceof LeafProperty) {
-                    LeafProperty leafProperty = (LeafProperty) property;
+                } else if (property instanceof LeafProperty leafProperty) {
                     if (leafProperty.hasDefaultValue()) {
                         defaultValue = leafProperty.getDefaultValue();
                     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -160,7 +160,7 @@ public class ReflectiveHierarchyStep {
                     type.asArrayType().constituent(),
                     processedReflectiveHierarchies,
                     unindexedClasses, reflectiveClass, visits));
-        } else if (type instanceof ParameterizedType) {
+        } else if (type instanceof ParameterizedType parameterizedType) {
             if (!reflectiveHierarchyBuildItem.getIgnoreTypePredicate().test(type.name())) {
                 addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, newSource,
                         type.name(),
@@ -168,7 +168,6 @@ public class ReflectiveHierarchyStep {
                         processedReflectiveHierarchies,
                         unindexedClasses, reflectiveClass, visits);
             }
-            final ParameterizedType parameterizedType = (ParameterizedType) type;
             for (Type typeArgument : parameterizedType.arguments()) {
                 visits.addLast(
                         () -> addReflectiveHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem,

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -230,7 +230,7 @@ public class AugmentActionImpl implements AugmentAction {
                         }
                         File sourceFile = new File(debugPath, i.getName() + ".zig");
                         sourceFile.getParentFile().mkdirs();
-                        Files.write(sourceFile.toPath(), i.getSource().getBytes(StandardCharsets.UTF_8),
+                        Files.writeString(sourceFile.toPath(), i.getSource(),
                                 StandardOpenOption.CREATE);
                         log.infof("Wrote source: %s", sourceFile.getAbsolutePath());
                     } else {

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -3,7 +3,6 @@ package io.quarkus.runner.bootstrap;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -8,7 +8,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -486,8 +485,7 @@ public class StartupActionImpl implements StartupAction {
                             }
                             File sourceFile = new File(debugPath, i.internalName() + ".zig");
                             sourceFile.getParentFile().mkdirs();
-                            Files.write(sourceFile.toPath(), i.getSource().getBytes(StandardCharsets.UTF_8),
-                                    StandardOpenOption.CREATE);
+                            Files.writeString(sourceFile.toPath(), i.getSource(), StandardOpenOption.CREATE);
                             log.infof("Wrote source %s", sourceFile.getAbsolutePath());
                         } else {
                             log.infof("Source not available: %s", i.binaryName());

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/BannerProcessorTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/BannerProcessorTest.java
@@ -4,7 +4,6 @@ import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToR
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,7 +42,7 @@ public class BannerProcessorTest {
             try (final FileSystem fs = ZipUtils.newFileSystem(zipPath)) {
                 Path classFile = fs.getPath(fromClassNameToResourceName(MyBannerProcessor.class.getName()));
                 Files.createDirectories(classFile.getParent());
-                Files.write(classFile, "".getBytes(StandardCharsets.UTF_8));
+                Files.writeString(classFile, "");
             }
 
             try (FileSystem fs = ZipUtils.newFileSystem(zipPath)) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/JobDetails.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/JobDetails.java
@@ -71,9 +71,8 @@ public class JobDetails {
     public boolean equals(Object o) {
         if (this == o)
             return true;
-        if (!(o instanceof JobDetails))
+        if (!(o instanceof JobDetails that))
             return false;
-        JobDetails that = (JobDetails) o;
         return Objects.equals(className, that.className)
                 && Objects.equals(staticFieldName, that.staticFieldName)
                 && Objects.equals(methodName, that.methodName)

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/JobParameter.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/JobParameter.java
@@ -66,9 +66,8 @@ public class JobParameter {
     public boolean equals(Object o) {
         if (this == o)
             return true;
-        if (!(o instanceof JobParameter))
+        if (!(o instanceof JobParameter that))
             return false;
-        JobParameter that = (JobParameter) o;
         return Objects.equals(className, that.className)
                 && Objects.equals(actualClassName, that.actualClassName)
                 && Objects.equals(object, that.object);

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
@@ -105,8 +105,7 @@ public final class JavadocToAsciidocTransformer {
         Map<Integer, String> inlineTagsReplacements = new TreeMap<>();
 
         for (JavadocDescriptionElement javadocDescriptionElement : parsedJavadoc.getDescription().getElements()) {
-            if (javadocDescriptionElement instanceof JavadocInlineTag) {
-                JavadocInlineTag inlineTag = (JavadocInlineTag) javadocDescriptionElement;
+            if (javadocDescriptionElement instanceof JavadocInlineTag inlineTag) {
                 String content = inlineTag.getContent().trim();
                 switch (inlineTag.getType()) {
                     case CODE:

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
@@ -44,8 +44,7 @@ public class JavadocToMarkdownTransformer {
         StringBuilder sb = new StringBuilder();
 
         for (JavadocDescriptionElement javadocDescriptionElement : javadocDescription.getElements()) {
-            if (javadocDescriptionElement instanceof JavadocInlineTag) {
-                JavadocInlineTag inlineTag = (JavadocInlineTag) javadocDescriptionElement;
+            if (javadocDescriptionElement instanceof JavadocInlineTag inlineTag) {
                 String content = inlineTag.getContent().trim();
                 switch (inlineTag.getType()) {
                     case CODE:

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
@@ -243,8 +243,7 @@ public class ConfigResolver {
     }
 
     public static String getType(TypeMirror typeMirror) {
-        if (typeMirror instanceof DeclaredType) {
-            DeclaredType declaredType = (DeclaredType) typeMirror;
+        if (typeMirror instanceof DeclaredType declaredType) {
             TypeElement typeElement = (TypeElement) declaredType.asElement();
             return typeElement.getQualifiedName().toString();
         }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/AccessorGenerator.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/AccessorGenerator.java
@@ -60,8 +60,7 @@ public final class AccessorGenerator {
         final JSourceFile sourceFile = sources.createSourceFile(packageElement.getQualifiedName()
                 .toString(), className);
         JType clazzType = JTypes.typeOf(clazz.asType());
-        if (clazz.asType() instanceof DeclaredType) {
-            DeclaredType declaredType = ((DeclaredType) clazz.asType());
+        if (clazz.asType() instanceof DeclaredType declaredType) {
             TypeMirror enclosingType = declaredType.getEnclosingType();
             if (enclosingType != null && enclosingType.getKind() == TypeKind.DECLARED
                     && clazz.getModifiers()
@@ -91,8 +90,7 @@ public final class AccessorGenerator {
                 // 1) the field is public
                 // 2) the enclosing class is public
                 // 3) the class type of the field is public
-                if (fieldType instanceof DeclaredType) {
-                    final DeclaredType declaredType = (DeclaredType) fieldType;
+                if (fieldType instanceof DeclaredType declaredType) {
                     final TypeElement typeElement = (TypeElement) declaredType.asElement();
                     if (typeElement.getModifiers()
                             .contains(Modifier.PUBLIC)) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -272,8 +272,7 @@ public class ApplicationLifecycleManager {
      */
     private static void longLivedPostBootCleanup() {
         final ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        if (cl instanceof RunnerClassLoader) {
-            RunnerClassLoader rcl = (RunnerClassLoader) cl;
+        if (cl instanceof RunnerClassLoader rcl) {
             rcl.resetInternalCaches();
         }
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/DecorateStackUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/DecorateStackUtil.java
@@ -22,8 +22,7 @@ public class DecorateStackUtil {
     public static String getDecoratedString(final Throwable throwable, Path srcMainJava, List<String> knowClasses) {
         if (knowClasses != null && !knowClasses.isEmpty() && throwable != null) {
             StackTraceElement[] stackTrace = throwable.getStackTrace();
-            for (int i = 0; i < stackTrace.length; ++i) {
-                StackTraceElement elem = stackTrace[i];
+            for (StackTraceElement elem : stackTrace) {
                 if (knowClasses.contains(elem.getClassName())) {
                     String decoratedString = DecorateStackUtil.getDecoratedString(srcMainJava, elem);
                     if (decoratedString != null) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilter.java
@@ -31,8 +31,7 @@ public class LogCleanupFilter implements Filter {
         //we also use this filter to add a warning about errors generated after shutdown
         if (record.getLevel().intValue() >= org.jboss.logmanager.Level.ERROR.intValue() && shutdownNotifier.shutdown) {
             if (!record.getMessage().endsWith(SHUTDOWN_MESSAGE)) {
-                if (record instanceof ExtLogRecord) {
-                    ExtLogRecord elr = (ExtLogRecord) record;
+                if (record instanceof ExtLogRecord elr) {
                     elr.setMessage(record.getMessage() + SHUTDOWN_MESSAGE, elr.getFormatStyle());
                 } else {
                     record.setMessage(record.getMessage() + SHUTDOWN_MESSAGE);

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
@@ -31,8 +31,7 @@ public class GenericArrayTypeImpl implements GenericArrayType {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof GenericArrayType) {
-            GenericArrayType that = (GenericArrayType) obj;
+        if (obj instanceof GenericArrayType that) {
             if (genericComponentType == null) {
                 return that.getGenericComponentType() == null;
             } else {

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/HashUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/HashUtil.java
@@ -15,8 +15,8 @@ public final class HashUtil {
     }
 
     private static void toHex(byte[] digest, StringBuilder sb) {
-        for (int i = 0; i < digest.length; ++i) {
-            sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100), 1, 3);
+        for (byte b : digest) {
+            sb.append(Integer.toHexString((b & 0xFF) | 0x100), 1, 3);
         }
     }
 


### PR DESCRIPTION
Cleanup/simplification in core module 

3 commits covering:
* For loops simplification
* Files.writeString instead of Files.write
* Pattern variable usage with instanceOf
   * BytecodeRecorderImpl has also several cases of instanceOf usage, but I didn't touch it not to impact possible backports into LTS branches