### PR TITLE
ArC: fix subclass generation with not visible decorators

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorInfo.java
@@ -17,7 +17,7 @@ import io.quarkus.arc.impl.Sets;
 public class DecoratorInfo extends BeanInfo implements Comparable<DecoratorInfo> {
 
     private final InjectionPointInfo delegateInjectionPoint;
-    private final Set<Type> decoratedTypes;
+    private final Set<Type> decoratedTypes; // interfaces only
 
     DecoratorInfo(AnnotationTarget target, BeanDeployment beanDeployment, InjectionPointInfo delegateInjectionPoint,
             Set<Type> decoratedTypes, List<Injection> injections, int priority) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -637,6 +637,10 @@ public class SubclassGenerator extends AbstractGenerator {
         constructorParameterTypes.add(subclass.getClassName());
         Map<DecoratorInfo, FieldDescriptor> nextDecoratorToField = new HashMap<>();
         for (DecoratorInfo nextDecorator : decoratorParameters) {
+            // this can be always of type `Object`, because decorated types are always interfaces
+            // and their methods are always invoked via `invokeinterface` (see `SubclassGenerator`)
+            // and the JVM verifier doesn't care about the receiver type of interface method calls
+            // (see e.g. https://wiki.openjdk.org/display/HotSpot/InterfaceCalls)
             FieldCreator nextDecoratorField = delegateSubclass
                     .getFieldCreator(nextDecorator.getIdentifier(), Object.class)
                     .setModifiers(ACC_PRIVATE | ACC_FINAL);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/NonPublicDecoratorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/NonPublicDecoratorTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.arc.test.decorators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.decorators.other.Converter;
+import io.quarkus.arc.test.decorators.other.ToUpperCaseConverter;
+
+public class NonPublicDecoratorTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Converter.class, ToUpperCaseConverter.class,
+            TrimConverterDecorator.class, AdditionalConverterDecorator.class, LastConverterDecorator.class);
+
+    @Test
+    public void testDecoration() {
+        InstanceHandle<ToUpperCaseConverter> handle = Arc.container().instance(ToUpperCaseConverter.class);
+        ToUpperCaseConverter converter = handle.get();
+        assertEquals("HOLA! test", converter.convert(" holA!"));
+        assertEquals(" HOLA!", converter.convertNoDelegation(" holA!"));
+        handle.destroy();
+        assertTrue(TrimConverterDecorator.CONSTRUCTED.get());
+        assertTrue(TrimConverterDecorator.DESTROYED.get());
+    }
+
+    @Dependent
+    @Priority(1)
+    @Decorator
+    static class TrimConverterDecorator implements Converter<String> {
+
+        static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        static final AtomicBoolean DESTROYED = new AtomicBoolean();
+
+        @Inject
+        @Delegate
+        Converter<String> delegate;
+
+        @Override
+        public String convert(String value) {
+            return delegate.convert(value.trim());
+        }
+
+        @PostConstruct
+        void init() {
+            CONSTRUCTED.set(true);
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+
+    }
+
+    @Priority(2)
+    @Decorator
+    static class AdditionalConverterDecorator implements Converter<String> {
+
+        @Inject
+        @Delegate
+        ToUpperCaseConverter delegate;
+
+        @Override
+        public String convert(String value) {
+            return delegate.convert(value + " ");
+        }
+
+    }
+
+    @Priority(3)
+    @Decorator
+    static class LastConverterDecorator implements Converter<String> {
+
+        @Inject
+        @Delegate
+        Converter<String> delegate;
+
+        @Override
+        public String convert(String value) {
+            return delegate.convert(value) + "test";
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/InterceptorAndNonPublicDecoratorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/InterceptorAndNonPublicDecoratorTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.arc.test.decorators.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.decorators.interceptor.other.Converter;
+import io.quarkus.arc.test.decorators.interceptor.other.Logging;
+import io.quarkus.arc.test.decorators.interceptor.other.ToUpperCaseConverter;
+
+public class InterceptorAndNonPublicDecoratorTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Converter.class, ToUpperCaseConverter.class,
+            TrimConverterDecorator.class, LoggingInterceptor.class, Logging.class);
+
+    @Test
+    public void testInterceptionAndDecoration() {
+        LoggingInterceptor.LOG.set(null);
+        ToUpperCaseConverter converter = Arc.container().instance(ToUpperCaseConverter.class).get();
+        assertEquals("HOLA!", converter.convert(" holA!"));
+        assertEquals("HOLA!", LoggingInterceptor.LOG.get());
+        assertEquals(" HOLA!", converter.convertNoDelegation(" holA!"));
+        assertEquals(" HOLA!", LoggingInterceptor.LOG.get());
+    }
+
+    @Priority(1)
+    @Decorator
+    static class TrimConverterDecorator implements Converter<String> {
+
+        @Inject
+        @Delegate
+        Converter<String> delegate;
+
+        @Override
+        public String convert(String value) {
+            return delegate.convert(value.trim());
+        }
+
+    }
+
+    @Logging
+    @Priority(10)
+    @Interceptor
+    static class LoggingInterceptor {
+
+        static final AtomicReference<Object> LOG = new AtomicReference<Object>();
+
+        @AroundInvoke
+        Object log(InvocationContext ctx) throws Exception {
+            Object ret = ctx.proceed();
+            LOG.set(ret);
+            return ret;
+        }
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/other/Converter.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/other/Converter.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test.decorators.interceptor.other;
+
+public interface Converter<T> {
+
+    T convert(T value);
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/other/Logging.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/other/Logging.java
@@ -1,0 +1,19 @@
+package io.quarkus.arc.test.decorators.interceptor.other;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Documented
+@InterceptorBinding
+public @interface Logging {
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/other/ToUpperCaseConverter.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/other/ToUpperCaseConverter.java
@@ -1,0 +1,18 @@
+package io.quarkus.arc.test.decorators.interceptor.other;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@Logging
+@ApplicationScoped
+public class ToUpperCaseConverter implements Converter<String> {
+
+    @Override
+    public String convert(String value) {
+        return value.toUpperCase();
+    }
+
+    public String convertNoDelegation(String value) {
+        return value.toUpperCase();
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/other/Converter.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/other/Converter.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test.decorators.other;
+
+public interface Converter<T> {
+
+    T convert(T value);
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/other/ToUpperCaseConverter.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/other/ToUpperCaseConverter.java
@@ -1,0 +1,17 @@
+package io.quarkus.arc.test.decorators.other;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ToUpperCaseConverter implements Converter<String> {
+
+    @Override
+    public String convert(String value) {
+        return value.toUpperCase();
+    }
+
+    public String convertNoDelegation(String value) {
+        return value.toUpperCase();
+    }
+
+}


### PR DESCRIPTION
This fixes several visibility issues in the generated subclass if decorators are not visible from the decorated bean or an other decorator in the chain.
An example error looks like this:
```
java.lang.IllegalAccessError: failed to access class io.quarkus.arc.test.decorators.NonPublicDecoratorTest$AdditionalConverterDecorator from class io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_Subclass (io.quarkus.arc.test.decorators.NonPublicDecoratorTest$AdditionalConverterDecorator and io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_Subclass are in unnamed module of loader 'app')
	at io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_Subclass.<init>(Unknown Source)
	at io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_Bean.doCreate(Unknown Source)
	at io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_Bean.create(Unknown Source)
	at io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_Bean.create(Unknown Source)
	at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:119)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:38)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:35)
	at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:32)
	at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
	at io.quarkus.arc.impl.ComputingCacheContextInstances.computeIfAbsent(ComputingCacheContextInstances.java:19)
	at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:35)
	at io.quarkus.arc.impl.ClientProxies.getApplicationScopedDelegate(ClientProxies.java:23)
	at io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_ClientProxy.arc$delegate(Unknown Source)
	at io.quarkus.arc.test.decorators.other.ToUpperCaseConverter_ClientProxy.convert(Unknown Source)
	at io.quarkus.arc.test.decorators.NonPublicDecoratorTest.testDecoration(NonPublicDecoratorTest.java:36)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

The fix is to use the methods on the decorated types and not the decorator class.

A work around without the fix would be to make the decorator abstract (only works with a single decorator and not with a chain).