### PR TITLE
issue-50138-hibernate-orm-named-qualifier

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
@@ -374,10 +374,9 @@ public class HibernateOrmCdiProcessor {
         if (defaultPuName || puRef.forceAllQualifiers) {
             configurator.addQualifier(Default.class);
         }
-        if (!defaultPuName || puRef.forceAllQualifiers) {
-            configurator.addQualifier().annotation(DotNames.NAMED).addValue("value", puRef.persistenceUnitName).done();
-            configurator.addQualifier().annotation(PersistenceUnit.class).addValue("value", puRef.persistenceUnitName).done();
-        }
+
+        configurator.addQualifier().annotation(DotNames.NAMED).addValue("value", puRef.persistenceUnitName).done();
+        configurator.addQualifier().annotation(PersistenceUnit.class).addValue("value", puRef.persistenceUnitName).done();
 
         return configurator;
     }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiEntityManagerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiEntityManagerTest.java
@@ -56,6 +56,24 @@ public class MultiplePersistenceUnitsCdiEntityManagerTest {
     @Named("inventory")
     SessionFactory inventoryFactory;
 
+    @Inject
+    @PersistenceUnit("<default>")
+    EntityManager defaultEntityManagerWithQualifier;
+
+    @Inject
+    @PersistenceUnit("<default>")
+    SessionFactory defaultSessionFactoryWithQualifier;
+
+    @Inject
+    @Named("<default>")
+    @PersistenceUnit("<default>")
+    EntityManager defaultEntityManagerWithBothQualifiers;
+
+    @Inject
+    @Named("<default>")
+    @PersistenceUnit("<default>")
+    SessionFactory defaultSessionFactoryWithBothQualifiers;
+
     @Test
     @Transactional
     public void defaultEntityManagerInTransaction() {
@@ -170,20 +188,18 @@ public class MultiplePersistenceUnitsCdiEntityManagerTest {
     }
 
     @Test
-    public void injectedEntityManagersAndSessionFactoriesAreProperlyQualified() {
-        Assertions.assertNotNull(usersEntityManager,
-                "@PersistenceUnit(\"users\") EntityManager should be injected and non-null");
-        Assertions.assertNotNull(inventoryEntityManager,
-                "@PersistenceUnit(\"inventory\") EntityManager should be injected and non-null");
-
-        Assertions.assertNotNull(usersFactory, "@Named(\"users\") SessionFactory should be injected and non-null");
-        Assertions.assertNotNull(inventoryFactory, "@Named(\"inventory\") SessionFactory should be injected and non-null");
+    public void defaultQualifiedEntityManagerAndSessionFactoryAreInjected() {
+        Assertions.assertNotNull(defaultEntityManagerWithQualifier,
+                "@PersistenceUnit(\"<default>\") EntityManager should be injected and non-null");
+        Assertions.assertNotNull(defaultSessionFactoryWithQualifier,
+                "@PersistenceUnit(\"<default>\") SessionFactory should be injected and non-null");
     }
 
     @Test
-    public void injectedDefaultEntityManagerAndSessionFactoryAreNonNull() {
-
-        Assertions.assertNotNull(defaultEntityManager, "Default EntityManager should be injected and non-null");
-        Assertions.assertNotNull(defaultSessionFactory, "Default SessionFactory should be injected and non-null");
+    public void defaultEntityManagerAndSessionFactoryWithBothQualifiersAreInjected() {
+        Assertions.assertNotNull(defaultEntityManagerWithBothQualifiers,
+                "EntityManager should be injectable with both @Named and @PersistenceUnit qualifiers for <default>");
+        Assertions.assertNotNull(defaultSessionFactoryWithBothQualifiers,
+                "SessionFactory should be injectable with both @Named and @PersistenceUnit qualifiers for <default>");
     }
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiEntityManagerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsCdiEntityManagerTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.TransactionRequiredException;
 import jakarta.transaction.Transactional;
 
 import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -166,5 +167,23 @@ public class MultiplePersistenceUnitsCdiEntityManagerTest {
         User user = new User("gsmet");
         assertThatThrownBy(() -> inventoryEntityManager.persist(user)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unknown entity type");
+    }
+
+    @Test
+    public void injectedEntityManagersAndSessionFactoriesAreProperlyQualified() {
+        Assertions.assertNotNull(usersEntityManager,
+                "@PersistenceUnit(\"users\") EntityManager should be injected and non-null");
+        Assertions.assertNotNull(inventoryEntityManager,
+                "@PersistenceUnit(\"inventory\") EntityManager should be injected and non-null");
+
+        Assertions.assertNotNull(usersFactory, "@Named(\"users\") SessionFactory should be injected and non-null");
+        Assertions.assertNotNull(inventoryFactory, "@Named(\"inventory\") SessionFactory should be injected and non-null");
+    }
+
+    @Test
+    public void injectedDefaultEntityManagerAndSessionFactoryAreNonNull() {
+
+        Assertions.assertNotNull(defaultEntityManager, "Default EntityManager should be injected and non-null");
+        Assertions.assertNotNull(defaultSessionFactory, "Default SessionFactory should be injected and non-null");
     }
 }


### PR DESCRIPTION
Consistently apply @ Named and @PersistenceUnit qualifiers to Hibernate ORM beans

Fixes #50138

Previously, the @ Named and @PersistenceUnit qualifiers were added conditionally to Hibernate ORM beans. This change ensures that both qualifiers are always applied for every persistence unit, aligning the behavior with Hibernate Search and improving consistency and CDI injection reliability across the codebase.

Tests are updated to confirm that beans are correctly qualified and injected for each persistence unit.

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

