### PR TITLE
Move com.google.protobuf.JavaFeaturesProto native runtime initialization config from quarkus-grpc to quarkus-grpc-common

### DIFF
--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
@@ -90,6 +90,7 @@ public class GrpcCommonProcessor {
                 .addRuntimeInitializedClass("io.grpc.netty.NettyServerBuilder")
                 .addRuntimeInitializedClass("io.grpc.netty.NettyChannelBuilder")
                 .addRuntimeInitializedClass("io.grpc.internal.RetriableStream")
+                .addRuntimeInitializedClass("com.google.protobuf.JavaFeaturesProto")
                 .addRuntimeInitializedClass("com.google.protobuf.UnsafeUtil");
         return builder.build();
     }

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcCommonProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcCommonProcessor.java
@@ -3,7 +3,6 @@ package io.quarkus.grpc.deployment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 /**
  * A processor used for both client and server
@@ -20,10 +19,5 @@ public class GrpcCommonProcessor {
     @BuildStep
     void indexGrpcStub(BuildProducer<IndexDependencyBuildItem> index) {
         index.produce(new IndexDependencyBuildItem("io.quarkus", "quarkus-grpc-stubs"));
-    }
-
-    @BuildStep
-    void runtimeInitialize(BuildProducer<RuntimeInitializedClassBuildItem> producer) {
-        producer.produce(new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto"));
     }
 }


### PR DESCRIPTION
So that extensions depending only on `quarkus-grpc-common` don't have to add their own runtime initialized class config for `com.google.protobuf.JavaFeaturesProto` (required since https://github.com/quarkusio/quarkus/pull/50326). 