### PR TITLE
Fix NPE when no library versions exist in the DevUI

### DIFF
--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
@@ -3,7 +3,8 @@ package io.quarkus.devui.spi.page;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,10 +15,10 @@ import java.util.Optional;
 public final class CardPageBuildItem extends AbstractPageBuildItem {
 
     private Optional<Card> optionalCard = Optional.empty();
-    private List<LibraryLink> libraryVersions = null;
+    private List<LibraryLink> libraryVersions;
 
-    private String darkLogo = null;
-    private String lightLogo = null;
+    private String darkLogo;
+    private String lightLogo;
 
     public CardPageBuildItem() {
         super();
@@ -43,12 +44,12 @@ public final class CardPageBuildItem extends AbstractPageBuildItem {
 
     public void addLibraryVersion(String groupId, String artifactId, String name, URL url) {
         if (libraryVersions == null)
-            libraryVersions = new LinkedList<>();
+            libraryVersions = new ArrayList<>();
         libraryVersions.add(new LibraryLink(groupId, artifactId, name, url));
     }
 
     public List<LibraryLink> getLibraryVersions() {
-        return this.libraryVersions;
+        return this.libraryVersions == null ? Collections.emptyList() : this.libraryVersions;
     }
 
     public boolean hasLibraryVersions() {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -988,7 +988,7 @@ public class DevUIProcessor {
                         (existing, replacement) -> existing // keep the first one
                 ));
 
-        if (cardPageBuildItem != null) {
+        if (cardPageBuildItem != null && cardPageBuildItem.hasLibraryVersions()) {
             for (LibraryLink lib : cardPageBuildItem.getLibraryVersions()) {
                 String key = lib.getGroupId() + ":" + lib.getArtifactId();
                 String version = versionMap.get(key);


### PR DESCRIPTION
- Follow-up from https://github.com/quarkusio/quarkus/pull/48319
-  Fixes the following exception:
```java
 java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because the return value of "io.quarkus.devui.spi.page.CardPageBuildItem.getLibraryVersions()" is null
	at io.quarkus.devui.deployment.DevUIProcessor.addLibraryLinks(DevUIProcessor.java:967)
```
