### PR TITLE
Rename leftovers of GlobalDevServicesConfig

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -36,10 +36,10 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
     private final DevServicesConfig globalConfig;
     private final LaunchMode launchMode;
 
-    public DevServicesRegistryBuildItem(UUID uuid, DevServicesConfig globalDevServicesConfig, LaunchMode launchMode) {
+    public DevServicesRegistryBuildItem(UUID uuid, DevServicesConfig devServicesConfig, LaunchMode launchMode) {
         this.launchMode = launchMode;
         this.uuid = uuid;
-        this.globalConfig = globalDevServicesConfig;
+        this.globalConfig = devServicesConfig;
     }
 
     public RunningService getRunningServices(String featureName, String configName, Object identifyingConfig) {

--- a/docs/src/main/asciidoc/extension-writing-dev-service.adoc
+++ b/docs/src/main/asciidoc/extension-writing-dev-service.adoc
@@ -118,7 +118,7 @@ For example,
 
 [source,java]
 ----
-@BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+@BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
 public DevServicesResultBuildItem createContainer(MyConfig config) {}
 ----
 

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
@@ -92,7 +92,7 @@ public class DevServicesProcessor {
     @BuildStep(onlyIf = IsDevServicesSupportedByLaunchMode.class)
     @Produce(ServiceStartBuildItem.class)
     public DevServicesCustomizerBuildItem containerCustomizer(LaunchModeBuildItem launchModeBuildItem,
-            DevServicesConfig globalDevServicesConfig) {
+            DevServicesConfig devServicesConfig) {
         return new DevServicesCustomizerBuildItem((devService, startable) -> {
             LaunchMode launchMode = launchModeBuildItem.getLaunchMode();
             if (startable instanceof StartableContainer startableContainer) {
@@ -101,10 +101,10 @@ public class DevServicesProcessor {
                 if (shouldConfigureSharedServiceLabel(launchMode)) {
                     container.withLabel(Labels.QUARKUS_DEV_SERVICE, devService.getServiceName());
                 }
-                globalDevServicesConfig.timeout().ifPresent(container::withStartupTimeout);
+                devServicesConfig.timeout().ifPresent(container::withStartupTimeout);
             } else if (startable instanceof GenericContainer container) {
                 configureLabels(container, launchMode);
-                globalDevServicesConfig.timeout().ifPresent(container::withStartupTimeout);
+                devServicesConfig.timeout().ifPresent(container::withStartupTimeout);
                 if (shouldConfigureSharedServiceLabel(launchMode)) {
                     container.withLabel(Labels.QUARKUS_DEV_SERVICE, devService.getServiceName());
                 }
@@ -144,10 +144,10 @@ public class DevServicesProcessor {
     @Produce(ServiceStartBuildItem.class)
     DevServicesRegistryBuildItem devServicesRegistry(LaunchModeBuildItem launchMode,
             ApplicationInstanceIdBuildItem applicationId,
-            DevServicesConfig globalDevServicesConfig,
+            DevServicesConfig devServicesConfig,
             CuratedApplicationShutdownBuildItem shutdownBuildItem) {
         DevServicesRegistryBuildItem registryBuildItem = new DevServicesRegistryBuildItem(applicationId.getUUID(),
-                globalDevServicesConfig, launchMode.getLaunchMode());
+                devServicesConfig, launchMode.getLaunchMode());
         shutdownBuildItem.addCloseTask(registryBuildItem::closeAllRunningServices, true);
         return registryBuildItem;
     }


### PR DESCRIPTION
Renaming some leftovers of `GlobalDevServicesConfig`, which got deprecated a while ago