### PR TITLE
OpenAPI: Support OASFilter implementations as managed CDI beans

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ManagedBeanOASFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ManagedBeanOASFilterTest.java
@@ -1,0 +1,116 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.smallrye.openapi.OpenApiFilter;
+import io.quarkus.smallrye.openapi.OpenApiFilter.RunStage;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpServerRequest;
+
+class ManagedBeanOASFilterTest {
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyFilter1.class, MyFilter2.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.http.auth.basic=true
+                            quarkus.http.auth.permission.basic.paths=/*
+                            quarkus.http.auth.permission.basic.policy=authenticated
+                            quarkus.security.users.embedded.enabled=true
+                            quarkus.security.users.embedded.plain-text=true
+                            quarkus.security.users.embedded.users.alice=alice
+                            quarkus.security.users.embedded.users.bob=bob
+                            quarkus.smallrye-openapi.always-run-filter=true
+                            """),
+                            "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-security", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-vertx-http", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-elytron-security-properties-file", Version.getVersion())));
+
+    @RequestScoped
+    @OpenApiFilter(value = RunStage.RUN, priority = 99)
+    public static class MyFilter1 implements OASFilter {
+        @Inject
+        HttpServerRequest req;
+
+        @Inject
+        SecurityIdentity principal;
+
+        @Override
+        public void filterOpenAPI(OpenAPI openAPI) {
+            openAPI.addTag(OASFactory.createTag()
+                    .name("customized-for-" + principal.getPrincipal())
+                    .description("custom: " + req.getParam("custom")));
+        }
+    }
+
+    @ApplicationScoped
+    @OpenApiFilter(value = RunStage.RUN, priority = 98)
+    public static class MyFilter2 implements OASFilter {
+        @Inject
+        HttpServerRequest req;
+
+        @Inject
+        SecurityIdentity principal;
+
+        AtomicInteger counter = new AtomicInteger(0);
+
+        @Override
+        public void filterOpenAPI(OpenAPI openAPI) {
+            openAPI.addTag(OASFactory.createTag()
+                    .name("tag-sequence")
+                    .description(Integer.toString(counter.incrementAndGet())));
+        }
+    }
+
+    @Test
+    void testOpenApiPathAccessResource() {
+        RestAssured
+                .given()
+                .queryParam("format", "JSON")
+                .queryParam("custom", "special-value-for-alice")
+                .auth().basic("alice", "alice")
+                .when()
+                .get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("tags[0].name", is("customized-for-alice"))
+                .body("tags[0].description", is("custom: special-value-for-alice"))
+                .body("tags[1].name", is("tag-sequence"))
+                .body("tags[1].description", is("1"));
+        RestAssured
+                .given()
+                .queryParam("format", "JSON")
+                .queryParam("custom", "special-value-for-bob")
+                .auth().basic("bob", "bob")
+                .when()
+                .get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("tags[0].name", is("customized-for-bob"))
+                .body("tags[0].description", is("custom: special-value-for-bob"))
+                .body("tags[1].name", is("tag-sequence"))
+                .body("tags[1].description", is("2"));
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
@@ -2,7 +2,14 @@ package io.quarkus.smallrye.openapi.runtime;
 
 import java.util.List;
 
+import jakarta.enterprise.event.Event;
+
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.openapi.runtime.io.Format;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
@@ -19,14 +26,69 @@ public class OpenApiHandler implements Handler<RoutingContext> {
     private volatile OpenApiDocumentService openApiDocumentService;
     private static final String ALLOWED_METHODS = "GET, HEAD, OPTIONS";
     private static final String QUERY_PARAM_FORMAT = "format";
-    private final String documentName;
 
-    public OpenApiHandler(String documentName) {
+    private final String documentName;
+    private final boolean alwaysRunFilter;
+    private final Event<SecurityIdentity> securityIdentityEvent;
+    private final CurrentIdentityAssociation currentIdentityAssociation;
+    private final CurrentVertxRequest currentVertxRequest;
+    private final ManagedContext requestContext;
+
+    public OpenApiHandler(String documentName, boolean alwaysRunFilter) {
         this.documentName = documentName;
+        this.alwaysRunFilter = alwaysRunFilter;
+
+        if (alwaysRunFilter) {
+            this.securityIdentityEvent = Arc.container().beanManager().getEvent().select(SecurityIdentity.class);
+            this.currentVertxRequest = Arc.container().instance(CurrentVertxRequest.class).get();
+            this.requestContext = Arc.container().requestContext();
+            this.currentIdentityAssociation = Arc.container().instance(CurrentIdentityAssociation.class).get();
+        } else {
+            this.securityIdentityEvent = null;
+            this.currentVertxRequest = null;
+            this.requestContext = null;
+            this.currentIdentityAssociation = null;
+        }
     }
 
     @Override
-    public void handle(RoutingContext event) {
+    public void handle(RoutingContext context) {
+        boolean manageRequestContext = alwaysRunFilter && !requestContext.isActive();
+
+        try {
+            if (manageRequestContext) {
+                requestContext.activate();
+                currentVertxRequest.setCurrent(context);
+            }
+            if (alwaysRunFilter) {
+                associateSecurityIdentity(context);
+            }
+            invoke(context);
+        } finally {
+            if (manageRequestContext) {
+                // Deactivate the context, i.e. cleanup the thread locals
+                requestContext.deactivate();
+            }
+        }
+    }
+
+    private void associateSecurityIdentity(RoutingContext context) {
+        QuarkusHttpUser user = (QuarkusHttpUser) context.user();
+
+        if (currentIdentityAssociation != null) {
+            if (user != null) {
+                SecurityIdentity identity = user.getSecurityIdentity();
+                currentIdentityAssociation.setIdentity(identity);
+            } else {
+                currentIdentityAssociation.setIdentity(QuarkusHttpUser.getSecurityIdentity(context, null));
+            }
+        }
+        if (user != null) {
+            securityIdentityEvent.fire(user.getSecurityIdentity());
+        }
+    }
+
+    private void invoke(RoutingContext event) {
         HttpServerRequest req = event.request();
         HttpServerResponse resp = event.response();
 

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -38,9 +38,9 @@ public class OpenApiRecorder {
         return null;
     }
 
-    public Handler<RoutingContext> handler(String documentName) {
+    public Handler<RoutingContext> handler(String documentName, boolean alwaysRunFilter) {
         if (openApiConfig.getValue().enable().orElse(openApiConfig.getValue().enabled())) {
-            return new OpenApiHandler(documentName);
+            return new OpenApiHandler(documentName, alwaysRunFilter);
         } else {
             return new OpenApiNotFoundHandler();
         }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

For runtime OpenAPI `OASFilter` implementations, load instances from CDI when possible, falling back to the current class loading method. This adds a dependency on `quarkus-reactive-routes` to the `quarkus-smallrye-openapi` extension so that the `OpenApiHandler` (`/q/openapi`) can extend `io.quarkus.vertx.web.runtime.RouteHandler` and utilize the request scope setup that it performs.

Closes #50415

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:


See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

