### PR TITLE
Add continuous testing getResults MCP variant to use with MCP tools

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/DevUIDatabindCodec.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/DevUIDatabindCodec.java
@@ -8,6 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.junit.platform.engine.UniqueId;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -21,6 +24,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
+import io.quarkus.deployment.dev.testing.TestResult;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonTypeAdapter;
 import io.quarkus.vertx.runtime.jackson.ByteArrayDeserializer;
@@ -134,6 +138,7 @@ public class DevUIDatabindCodec implements JsonMapper {
             mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
+            mapper.addMixIn(TestResult.class, TestResultMixIn.class);
             SimpleModule module = new SimpleModule("vertx-module-common");
             module.addSerializer(Instant.class, new InstantSerializer());
             module.addDeserializer(Instant.class, new InstantDeserializer());
@@ -178,4 +183,8 @@ public class DevUIDatabindCodec implements JsonMapper {
         }
     }
 
+    private interface TestResultMixIn {
+        @JsonIgnore
+        UniqueId getUniqueId();
+    }
 }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/TrimmedTestRunResult.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/TrimmedTestRunResult.java
@@ -1,0 +1,113 @@
+package io.quarkus.devui.deployment.menu;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.deployment.dev.testing.TestClassResult;
+import io.quarkus.deployment.dev.testing.TestRunResults;
+
+public class TrimmedTestRunResult {
+
+    /**
+     * The run id
+     */
+    private final long id;
+
+    /**
+     * If this ran all tests, or just the modified ones
+     */
+    private final boolean full;
+
+    private final long started;
+    private final long completed;
+
+    private final Map<String, TestClassResult> currentFailing = new HashMap<>();
+    private final Map<String, TestClassResult> historicFailing = new HashMap<>();
+    private final Map<String, TestClassResult> currentPassing = new HashMap<>();
+    private final Map<String, TestClassResult> historicPassing = new HashMap<>();
+
+    private final long passedCount;
+    private final long failedCount;
+    private final long skippedCount;
+    private final long currentPassedCount;
+    private final long currentFailedCount;
+    private final long currentSkippedCount;
+
+    public TrimmedTestRunResult(TestRunResults testRunResults) {
+        this.id = testRunResults.getId();
+        this.full = testRunResults.isFull();
+        this.started = testRunResults.getStartedTime();
+        this.completed = testRunResults.getCompletedTime();
+        this.currentFailing.putAll(testRunResults.getCurrentFailing());
+        this.historicFailing.putAll(testRunResults.getHistoricFailing());
+        this.currentPassing.putAll(testRunResults.getCurrentPassing());
+        this.historicPassing.putAll(testRunResults.getHistoricPassing());
+        this.passedCount = testRunResults.getPassedCount();
+        this.failedCount = testRunResults.getFailedCount();
+        this.skippedCount = testRunResults.getSkippedCount();
+        this.currentPassedCount = testRunResults.getCurrentPassedCount();
+        this.currentFailedCount = testRunResults.getCurrentFailedCount();
+        this.currentSkippedCount = testRunResults.getCurrentSkippedCount();
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public boolean isFull() {
+        return full;
+    }
+
+    public Map<String, TestClassResult> getCurrentFailing() {
+        return currentFailing;
+    }
+
+    public Map<String, TestClassResult> getHistoricFailing() {
+        return historicFailing;
+    }
+
+    public Map<String, TestClassResult> getCurrentPassing() {
+        return currentPassing;
+    }
+
+    public Map<String, TestClassResult> getHistoricPassing() {
+        return historicPassing;
+    }
+
+    public long getStartedTime() {
+        return started;
+    }
+
+    public long getCompletedTime() {
+        return completed;
+    }
+
+    public long getTotalTime() {
+        return completed - started;
+    }
+
+    public long getPassedCount() {
+        return passedCount;
+    }
+
+    public long getFailedCount() {
+        return failedCount;
+    }
+
+    public long getSkippedCount() {
+        return skippedCount;
+    }
+
+    public long getCurrentPassedCount() {
+        return currentPassedCount;
+    }
+
+    public long getCurrentFailedCount() {
+        return currentFailedCount;
+    }
+
+    public long getCurrentSkippedCount() {
+        return currentSkippedCount;
+    }
+
+}


### PR DESCRIPTION
Trims the test results returned by the JsonRPC call to use with MCP tools.
Removes the UniqueId from the JSON representation.