### PR TITLE
 Add strict property validation for QuarkusUnitTest

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/DebugConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/DebugConfig.java
@@ -47,4 +47,10 @@ public interface DebugConfig {
      */
     @WithDefault("false")
     boolean dumpBuildMetrics();
+
+    /**
+     * If set to true, the application will fail when an unknown configuration property is detected.
+     */
+    @WithDefault("false")
+    boolean failOnMissingProperties();
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -103,6 +103,8 @@ public class JunitTestRunner {
     public static final DotName NESTED = DotName.createSimple(Nested.class.getName());
     private static final String ARCHUNIT_FIELDSOURCE_FQCN = "com.tngtech.archunit.junit.FieldSource";
     private static final String FACADE_CLASS_LOADER_NAME = "io.quarkus.test.junit.classloading.FacadeClassLoader";
+
+    // TODO Luca: unrecognised property
     private static final String TEST_DISCOVERY_PROPERTY = "quarkus.continuous-tests-discovery";
 
     private final long runId;

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -42,6 +42,7 @@ import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.objectweb.asm.Opcodes;
 
+import io.quarkus.bootstrap.BootstrapDebug;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.IsProduction;
@@ -359,9 +360,12 @@ public class ConfigGenerationBuildStep {
 
         // So it only reports during the build, because it is very likely that the property is available in runtime
         // and, it will be caught by the RuntimeConfig and log double warnings
-        if (!launchModeBuildItem.getLaunchMode().isDevOrTest()) {
-            ConfigDiagnostic.unknownProperties(configItem.getReadResult().getUnknownBuildProperties());
-        }
+
+        String configValue = BootstrapDebug.failOnMissingProperties();
+        boolean failOnMissingProperties = Boolean.parseBoolean(configValue);
+
+        ConfigDiagnostic.unknownProperties(configItem.getReadResult().getUnknownBuildProperties(),
+                failOnMissingProperties);
 
         // TODO - Test live reload with ConfigSource
         if (liveReloadBuildItem.isLiveReload()) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -85,14 +85,17 @@ public final class ConfigDiagnostic {
         }
     }
 
-    public static void unknown(String name) {
+    public static void unknown(String name, boolean failOnMissingProperties) {
+        if (failOnMissingProperties) {
+            throw new IllegalArgumentException("Build failed due to unrecognized configuration properties: " + name);
+        }
         log.warnf(
                 "Unrecognized configuration key \"%s\" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo",
                 name);
     }
 
     public static void unknown(NameIterator name) {
-        unknown(name.getName());
+        unknown(name.getName(), false);
     }
 
     /**
@@ -107,8 +110,9 @@ public final class ConfigDiagnostic {
      * format.
      *
      * @param properties the set of possible unused properties
+     * @param failOnMissingProperties whether Quarkus should log a missing property or fail if it was mispelled
      */
-    public static void unknownProperties(Set<String> properties) {
+    public static void unknownProperties(Set<String> properties, boolean failOnMissingProperties) {
         if (properties.isEmpty()) {
             return;
         }
@@ -154,7 +158,7 @@ public final class ConfigDiagnostic {
             if (!found) {
                 ConfigValue configValue = config.getConfigValue(property);
                 if (property.equals(configValue.getName())) {
-                    unknown(property);
+                    unknown(property, failOnMissingProperties);
                 }
             }
         }
@@ -162,12 +166,12 @@ public final class ConfigDiagnostic {
 
     public static void reportUnknown(Set<String> properties) {
         if (ImageMode.current() == ImageMode.NATIVE_BUILD) {
-            unknownProperties(properties);
+            unknownProperties(properties, false);
         }
     }
 
     public static void reportUnknownRuntime(Set<String> properties) {
-        unknownProperties(properties);
+        unknownProperties(properties, false);
     }
 
     /**

--- a/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionJdbcObjectStoreValidationFailureTest.java
+++ b/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionJdbcObjectStoreValidationFailureTest.java
@@ -23,6 +23,7 @@ public class TransactionJdbcObjectStoreValidationFailureTest {
             .withApplicationRoot((jar) -> jar
                     .addAsResource("jdbc-object-store-validation.properties", "application.properties"))
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))
+            .failOnUnknownProperties(false) // quarkus.datasource.test.jdbc.url
             .assertException(t -> {
                 Throwable rootCause = ExceptionUtil.getRootCause(t);
                 if (rootCause instanceof ConfigurationException) {

--- a/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionJdbcObjectStoreValidationFailureTest.java
+++ b/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionJdbcObjectStoreValidationFailureTest.java
@@ -17,6 +17,7 @@ import io.quarkus.test.QuarkusUnitTest;
 
 public class TransactionJdbcObjectStoreValidationFailureTest {
 
+    // TODO Luca quarkus.datasource.test.jdbc.url
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultSSLOptionsTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultSSLOptionsTest.java
@@ -22,6 +22,7 @@ import io.smallrye.certs.junit5.Certificates;
 })
 public class DefaultSSLOptionsTest {
 
+    // TODO Luca does this property exist?  quarkus.tls.session-timeout=20s
     private static final String configuration = """
             quarkus.tls.alpn=true
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultSSLOptionsTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultSSLOptionsTest.java
@@ -42,7 +42,8 @@ public class DefaultSSLOptionsTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
-                    .add(new StringAsset(configuration), "application.properties"));
+                    .add(new StringAsset(configuration), "application.properties"))
+            .failOnUnknownProperties(false); // quarkus.tls.session-timeout
 
     @Inject
     TlsConfigurationRegistry certificates;

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedSSLOptionsTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedSSLOptionsTest.java
@@ -23,6 +23,7 @@ import io.vertx.core.net.SSLOptions;
 })
 public class NamedSSLOptionsTest {
 
+    // TODO Luca does this property exist?  quarkus.tls.session-timeout=20s
     private static final String configuration = """
             quarkus.tls.foo.alpn=true
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedSSLOptionsTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedSSLOptionsTest.java
@@ -43,7 +43,8 @@ public class NamedSSLOptionsTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
-                    .add(new StringAsset(configuration), "application.properties"));
+                    .add(new StringAsset(configuration), "application.properties"))
+            .failOnUnknownProperties(false); // quarkus.tls.foo.session-timeout
 
     @Inject
     TlsConfigurationRegistry certificates;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapDebug.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapDebug.java
@@ -35,6 +35,12 @@ public final class BootstrapDebug {
         return System.getProperty("quarkus.debug.generated-sources-dir");
     }
 
+    public static final String FAIL_ON_MISSING_PROPERTY_KEY = "quarkus.debug.fail-on-missing-properties";
+
+    public static String failOnMissingProperties() {
+        return System.getProperty(FAIL_ON_MISSING_PROPERTY_KEY);
+    }
+
     private BootstrapDebug() {
     }
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
@@ -75,6 +75,7 @@ class BuildIT extends MojoTestBase {
                 Map.of());
         assertThat(result.getProcess().waitFor()).isZero();
 
+        // TODO Luca unrecognised property on quarkus.generate-code.skip=true
         // with the source generation disabled (this will use a new resolver initialized before bootstrapping the test)
         result = running.execute(List.of("clean", "test",
                 "-Dquarkus.analytics.disabled=true", "-Dquarkus.generate-code.skip=true"),

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/ExitCodeTestCase.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/ExitCodeTestCase.java
@@ -18,7 +18,8 @@ public class ExitCodeTestCase {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withEmptyApplication();
+            .withEmptyApplication()
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void testReturnedExitCode() throws ExecutionException, InterruptedException {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/BuildTimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/BuildTimeConfigTest.java
@@ -34,7 +34,8 @@ public class BuildTimeConfigTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .withConfigurationResource("application.properties")
-            .overrideConfigKey("test-map-config", testFile.getAbsolutePath());
+            .overrideConfigKey("test-map-config", testFile.getAbsolutePath())
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     /**
      * The checks are done before the test is started, in {@link io.quarkus.extest.deployment.MapBuildTimeConfigBuildStep}

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/ByteArrayConverterTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/ByteArrayConverterTest.java
@@ -16,7 +16,8 @@ public class ByteArrayConverterTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
-            .overrideConfigKey("someapp.bytearray", "XyZ*123");
+            .overrideConfigKey("someapp.bytearray", "XyZ*123")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @ConfigProperty(name = "someapp.bytearray")
     protected byte[] bytearray;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/ConfigBuilderTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/ConfigBuilderTest.java
@@ -17,6 +17,7 @@ import io.smallrye.config.SmallRyeConfig;
 public class ConfigBuilderTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .failOnUnknownProperties(false)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Inject

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/DeprecatedPropertiesTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/DeprecatedPropertiesTest.java
@@ -15,6 +15,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class DeprecatedPropertiesTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .failOnUnknownProperties(false) // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             .assertLogRecords(logRecords -> {
                 List<LogRecord> deprecatedProperties = logRecords.stream()

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/MapConverterTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/MapConverterTest.java
@@ -20,7 +20,8 @@ class MapConverterTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
-            .overrideConfigKey("map.value", "key1:value1,key2:value2");
+            .overrideConfigKey("map.value", "key1:value1,key2:value2")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     MapMapping mapping;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RecordedBuildProfileInRuntimeTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RecordedBuildProfileInRuntimeTest.java
@@ -21,7 +21,8 @@ public class RecordedBuildProfileInRuntimeTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
-            .withConfigurationResource("application.properties");
+            .withConfigurationResource("application.properties")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     SmallRyeConfig config;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RecorderRuntimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RecorderRuntimeConfigTest.java
@@ -21,7 +21,8 @@ import io.smallrye.config.SmallRyeConfig;
 public class RecorderRuntimeConfigTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     SmallRyeConfig config;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RenameConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RenameConfigTest.java
@@ -22,7 +22,8 @@ import io.smallrye.config.SmallRyeConfig;
 public class RenameConfigTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     RenameConfig renameConfig;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/SecretKeysConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/SecretKeysConfigTest.java
@@ -20,7 +20,8 @@ public class SecretKeysConfigTest {
                     .addClass(SecretKeysConfigInterceptorFactory.class)
                     .addAsServiceProvider("io.smallrye.config.ConfigSourceInterceptorFactory",
                             SecretKeysConfigInterceptorFactory.class.getName()))
-            .overrideConfigKey("secrets.my.secret", "secret");
+            .overrideConfigKey("secrets.my.secret", "secret")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     SmallRyeConfig config;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/StaticInitConfigMappingInvalidTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/StaticInitConfigMappingInvalidTest.java
@@ -18,7 +18,8 @@ public class StaticInitConfigMappingInvalidTest {
                     .addAsServiceProvider("io.smallrye.config.ConfigSourceFactory",
                             StaticInitConfigSourceFactory.class.getName()))
             .assertException(throwable -> {
-            });
+            })
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     StaticInitConfigMapping mapping;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/StaticInitConfigMappingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/StaticInitConfigMappingTest.java
@@ -18,7 +18,8 @@ public class StaticInitConfigMappingTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(StaticInitConfigSourceFactory.class)
                     .addAsServiceProvider("io.smallrye.config.ConfigSourceFactory",
-                            StaticInitConfigSourceFactory.class.getName()));
+                            StaticInitConfigSourceFactory.class.getName()))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     // This does not come from the static init Config, but it is registered in both static and runtime.
     // If it doesn't fail, it means that the static mapping was done correctly.

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/UnknownConfigFilesTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/UnknownConfigFilesTest.java
@@ -21,6 +21,7 @@ class UnknownConfigFilesTest {
                     .addAsResource(EmptyAsset.INSTANCE, "application-prod.properties")
                     .addAsResource(EmptyAsset.INSTANCE, "application.yaml")
                     .addAsResource(EmptyAsset.INSTANCE, "application-test.toml"))
+            .failOnUnknownProperties(false) // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             .assertLogRecords(logRecords -> {
                 List<LogRecord> unknownConfigFiles = logRecords.stream()

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/UnremoveableConfigMappingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/UnremoveableConfigMappingTest.java
@@ -15,7 +15,8 @@ public class UnremoveableConfigMappingTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClass(UnremovableMappingFromBuildItem.class));
+                    .addClass(UnremovableMappingFromBuildItem.class))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     SmallRyeConfig config;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/def/ControllerConfigurationTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/def/ControllerConfigurationTest.java
@@ -15,7 +15,8 @@ public class ControllerConfigurationTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withEmptyApplication();
+            .withEmptyApplication()
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     ControllerConfiguration controllerConfiguration;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfigMappingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfigMappingTest.java
@@ -17,7 +17,8 @@ public class ConfigMappingTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application.properties"));
+                    .addAsResource("application.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     TestMappingBuildTimeRunTime mappingBuildTimeRunTime;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
@@ -37,7 +37,8 @@ public class ConfiguredBeanTest {
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addAsServiceProvider(ConfigSource.class, DoNotRecordEnvConfigSource.class)
-                    .addAsResource("application.properties"));
+                    .addAsResource("application.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     SmallRyeConfig config;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildDefaultInRuntimeTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildDefaultInRuntimeTest.java
@@ -15,6 +15,7 @@ public class OverrideBuildDefaultInRuntimeTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withEmptyApplication()
+            .failOnUnknownProperties(false) // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
             .addBuildChainCustomizer(b -> {
                 b.addBuildStep(new BuildStep() {
                     @Override

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/PackageTestCase.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/PackageTestCase.java
@@ -20,7 +20,7 @@ public class PackageTestCase {
         public JavaArchive get() {
             return ShrinkWrap.create(JavaArchive.class).addClasses(PackageTestCase.class);
         }
-    });
+    }).failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void testVersionInPackage() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeDefaultsTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeDefaultsTest.java
@@ -21,7 +21,8 @@ public class RuntimeDefaultsTest {
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addAsServiceProvider(ConfigSource.class, EnvBuildTimeConfigSource.class)
-                    .addAsResource("application.properties"));
+                    .addAsResource("application.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Inject
     SmallRyeConfig config;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/StaticInitSourcesTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/StaticInitSourcesTest.java
@@ -19,7 +19,8 @@ public class StaticInitSourcesTest {
                     .addAsServiceProvider("io.smallrye.config.SmallRyeConfigBuilderCustomizer",
                             StaticInitSafeConfigBuilderCustomizer.class.getName(),
                             StaticInitNotSafeConfigBuilderCustomizer.class.getName())
-                    .addAsResource("application.properties"));
+                    .addAsResource("application.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     void staticInitSources() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
@@ -23,6 +23,7 @@ import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 public class UnknownConfigTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .failOnUnknownProperties(false)
             .withApplicationRoot((jar) -> jar
                     .addAsResource("application.properties"))
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
@@ -31,6 +32,7 @@ public class UnknownConfigTest {
                         logRecord -> Stream.of(Optional.ofNullable(logRecord.getParameters()).orElse(new Object[0])))
                         .map(Object::toString).collect(Collectors.toSet());
                 assertTrue(properties.contains("quarkus.unknown.prop"));
+                // TODO Luca not sure why quarkus.build.unknown.prop shouldn't be in the log
                 assertFalse(properties.contains("quarkus.build.unknown.prop"));
                 assertFalse(properties.contains("proprietary.should.not.report.unknown"));
             });

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AdditionalHandlersTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AdditionalHandlersTest.java
@@ -19,7 +19,8 @@ public class AdditionalHandlersTest {
             .withConfigurationResource("application-additional-handlers.properties")
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
-                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void additionalHandlersConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AsyncConsoleHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AsyncConsoleHandlerTest.java
@@ -22,7 +22,8 @@ public class AsyncConsoleHandlerTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName("AsyncConsoleHandlerTest.log");
+            .setLogFileName("AsyncConsoleHandlerTest.log")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void asyncConsoleHandlerConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AsyncFileHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AsyncFileHandlerTest.java
@@ -22,7 +22,8 @@ public class AsyncFileHandlerTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName("AsyncFileHandlerTest.log");
+            .setLogFileName("AsyncFileHandlerTest.log")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void asyncFileHandlerConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
@@ -22,7 +22,8 @@ public class AsyncSyslogHandlerTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName("AsyncSyslogHandlerTest.log");
+            .setLogFileName("AsyncSyslogHandlerTest.log")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void asyncSyslogHandlerConfigurationTest() throws NullPointerException {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerInvalidDueToMultipleHandlersTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerInvalidDueToMultipleHandlersTest.java
@@ -14,7 +14,8 @@ public class CategoryConfiguredHandlerInvalidDueToMultipleHandlersTest {
             .setExpectedException(RuntimeException.class)
             .withConfigurationResource("application-category-invalid-configured-handlers-output.properties")
             .withApplicationRoot((jar) -> jar
-                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void consoleOutputTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
@@ -25,7 +25,8 @@ public class CategoryConfiguredHandlerTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withConfigurationResource("application-category-configured-handlers-output.properties")
             .withApplicationRoot((jar) -> jar
-                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void consoleOutputTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/ConsoleHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/ConsoleHandlerTest.java
@@ -21,7 +21,8 @@ public class ConsoleHandlerTest {
             .withConfigurationResource("application-console-output.properties")
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
-                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void consoleOutputTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/FileHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/FileHandlerTest.java
@@ -21,7 +21,8 @@ public class FileHandlerTest {
             .withConfigurationResource("application-file-output-log.properties")
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
-                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void fileOutputTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/NoRotationLoggingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/NoRotationLoggingTest.java
@@ -22,7 +22,8 @@ public class NoRotationLoggingTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName("NoRotationLoggingTest.log");
+            .setLogFileName("NoRotationLoggingTest.log")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void sizeRotatingConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/PeriodicRotatingLoggingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/PeriodicRotatingLoggingTest.java
@@ -22,7 +22,8 @@ public class PeriodicRotatingLoggingTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName("PeriodicRotatingLoggingTest.log");
+            .setLogFileName("PeriodicRotatingLoggingTest.log")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void periodicRotatingConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingRotateOnBootTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingRotateOnBootTest.java
@@ -24,7 +24,8 @@ public class PeriodicSizeRotatingLoggingRotateOnBootTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName(FILE_NAME);
+            .setLogFileName(FILE_NAME)
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void periodicSizeRotatingConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingTest.java
@@ -22,7 +22,8 @@ public class PeriodicSizeRotatingLoggingTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName("PeriodicSizeRotatingLoggingTest.log");
+            .setLogFileName("PeriodicSizeRotatingLoggingTest.log")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void periodicSizeRotatingConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SizeRotatingLoggingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SizeRotatingLoggingTest.java
@@ -22,7 +22,8 @@ public class SizeRotatingLoggingTest {
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
                     .addAsManifestResource("application.properties", "microprofile-config.properties"))
-            .setLogFileName("SizeRotatingLoggingTest.log");
+            .setLogFileName("SizeRotatingLoggingTest.log")
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void sizeRotatingConfigurationTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SocketHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SocketHandlerTest.java
@@ -21,7 +21,8 @@ class SocketHandlerTest {
             .withConfigurationResource("application-socket-output.properties")
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
-                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     void socketOutputTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogCountingFramingTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogCountingFramingTest.java
@@ -15,7 +15,8 @@ public class SyslogCountingFramingTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withConfigurationResource("application-syslog-output.properties")
             .overrideConfigKey("quarkus.log.syslog.protocol", "UDP")
-            .withApplicationRoot((jar) -> jar.addClass(LoggingTestsHelper.class));
+            .withApplicationRoot((jar) -> jar.addClass(LoggingTestsHelper.class))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void syslogOutputTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
@@ -23,7 +23,8 @@ public class SyslogHandlerTest {
             .withConfigurationResource("application-syslog-output.properties")
             .withApplicationRoot((jar) -> jar
                     .addClass(LoggingTestsHelper.class)
-                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void syslogOutputTest() {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/naming/DisableJNDITestCase.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/naming/DisableJNDITestCase.java
@@ -20,7 +20,8 @@ import io.quarkus.test.QuarkusUnitTest;
 public class DisableJNDITestCase {
 
     @RegisterExtension
-    static QuarkusUnitTest unitTest = new QuarkusUnitTest();
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .failOnUnknownProperties(false); // quarkus.build.unknown.prop from UnknownBuildPropertyConfigSourceFactory
 
     @Test
     public void testJNDIDisabled() throws Exception {

--- a/test-framework/junit5-test/pom.xml
+++ b/test-framework/junit5-test/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-junit5-test</artifactId>
+    <name>Quarkus - Test framework - JUnit 5 - Testing</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/junit5-test/src/test/java/io/quarkus/test/StrictValidationDefaultTest.java
+++ b/test-framework/junit5-test/src/test/java/io/quarkus/test/StrictValidationDefaultTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.test;
+
+import java.util.logging.LogRecord;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class StrictValidationDefaultTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.log.levle", "INFO") // Intentional typo: "levle" instead of "level"
+            .assertException(throwable -> {
+                // We expect this test to fail due to the unknown property
+                if (throwable instanceof IllegalArgumentException &&
+                        throwable.getMessage().contains("Build failed due to unrecognized configuration properties") &&
+                        throwable.getMessage().contains("quarkus.log.levle")) {
+                    // This is the expected behavior - the strict validation caught our typo
+                    return;
+                }
+                // If we get here, the test failed for an unexpected reason
+                throw new AssertionError("Expected strict property validation failure for typo 'quarkus.log.levle', but got: "
+                        + throwable.getMessage());
+            })
+            .assertLogRecords(records -> {
+                // We don't want logs we want failures
+                Assertions.assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .doesNotContain(
+                                "Unrecognized configuration key \"%s\" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo");
+            });
+
+    @Test
+    public void shouldNotReachThis() {
+        throw new AssertionError(
+                "This test method should never execute because QuarkusUnitTest setup should fail first due to the typo");
+    }
+}

--- a/test-framework/junit5-test/src/test/java/io/quarkus/test/StrictValidationDisabledTest.java
+++ b/test-framework/junit5-test/src/test/java/io/quarkus/test/StrictValidationDisabledTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.test;
+
+import java.util.logging.LogRecord;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class StrictValidationDisabledTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.log.levle", "INFO") // Intentional typo: "levle" instead of "level"
+            .failOnUnknownProperties(false)
+            .setLogRecordPredicate(record -> "io.quarkus.config".equals(record.getLoggerName()))
+            .assertLogRecords(records -> {
+                // We want logs if failure on unknown properties is disabled
+                Assertions.assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .contains(
+                                "Unrecognized configuration key \"%s\" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo");
+            });
+
+    @Test
+    public void applicationShouldRun() {
+        // Application should start
+    }
+}

--- a/test-framework/junit5-test/src/test/java/io/quarkus/test/StrictValidationEnabledTest.java
+++ b/test-framework/junit5-test/src/test/java/io/quarkus/test/StrictValidationEnabledTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.test;
+
+import java.util.logging.LogRecord;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class StrictValidationEnabledTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.log.levle", "INFO") // Intentional typo: "levle" instead of "level"
+            .failOnUnknownProperties(true)
+            .assertException(throwable -> {
+                // We expect this test to fail due to the unknown property
+                if (throwable instanceof IllegalArgumentException &&
+                        throwable.getMessage().contains("Build failed due to unrecognized configuration properties") &&
+                        throwable.getMessage().contains("quarkus.log.levle")) {
+                    // This is the expected behavior - the strict validation caught our typo
+                    return;
+                }
+                // If we get here, the test failed for an unexpected reason
+                throw new AssertionError("Expected strict property validation failure for typo 'quarkus.log.levle', but got: "
+                        + throwable.getMessage());
+            })
+            .assertLogRecords(records -> {
+                // We don't want logs we want failures
+                Assertions.assertThat(records)
+                        .extracting(LogRecord::getMessage)
+                        .doesNotContain(
+                                "Unrecognized configuration key \"%s\" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo");
+            });
+
+    @Test
+    public void shouldNotReachThis() {
+        throw new AssertionError(
+                "This test method should never execute because QuarkusUnitTest setup should fail first due to the typo");
+    }
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -26,6 +26,7 @@
         <module>junit5-component</module>
         <module>junit5-mockito</module>
         <module>junit5-mockito-config</module>
+        <module>junit5-test</module>
         <module>vertx</module>
         <module>hibernate-reactive-panache</module>
         <module>amazon-lambda</module>


### PR DESCRIPTION
Add strict property validation for QuarkusUnitTest

 Enable automatic failure on unrecognized configuration properties in test mode by default.
 Tests now fail fast when configuration typos are detected, eliminating the need for manual
 log assertions. Users can opt-out with .failOnUnknownProperties(false) when needed.

  - Use System property `quarkus.debug.fail-on-missing-properties` for feature flag
  - Enhance `ConfigDiagnostic.unknown()` to throw `IllegalArgumentException` when strict mode enabled
  - Add `failOnUnknownProperties()` method to QuarkusUnitTest for opt-out capability
  - Maintain backward compatibility: production mode unchanged, warnings only

  See https://github.com/quarkusio/quarkus/pull/48130#discussion_r2245673606

  # Release notes

  Added property `quarkus.debug.fail-on-missing-properties` to make application fail when an unknown property is being set

