### PR TITLE
Fix DEV UI workspace directory worktree and item selection on Windows

### DIFF
--- a/bom/dev-ui/pom.xml
+++ b/bom/dev-ui/pom.xml
@@ -37,7 +37,7 @@
         <codeblock.version>1.1.1</codeblock.version>
         <qomponent.version>1.0.4</qomponent.version>
         <ldrs.version>1.1.7</ldrs.version>
-        <directory-tree.version>1.0.3</directory-tree.version>
+        <directory-tree.version>1.0.4</directory-tree.version>
         <hpcc-js-wasm.version>2.15.3</hpcc-js-wasm.version>
         <yargs.version>17.7.2</yargs.version>
         <cliui.version>8.0.1</cliui.version>

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/workspace/WorkspaceBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/workspace/WorkspaceBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkus.devui.spi.workspace;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -10,20 +11,20 @@ import io.quarkus.builder.item.SimpleBuildItem;
  * This hold all files in the user's project root
  */
 public final class WorkspaceBuildItem extends SimpleBuildItem {
-    private final List<WorkspaceItem> workspaceItems;
+    private final WorkspaceItems workspaceItems;
     private final Path rootPath;
 
     public WorkspaceBuildItem(Path rootPath, List<WorkspaceItem> workspaceItems) {
         this.rootPath = rootPath;
-        this.workspaceItems = workspaceItems;
+        this.workspaceItems = new WorkspaceItems(workspaceItems, File.separator);
     }
 
-    public List<WorkspaceItem> getWorkspaceItems() {
+    public WorkspaceItems getWorkspaceItems() {
         return workspaceItems;
     }
 
     public List<Path> getPaths() {
-        return workspaceItems.stream()
+        return workspaceItems.items.stream()
                 .map(WorkspaceBuildItem.WorkspaceItem::path)
                 .collect(Collectors.toList());
     }
@@ -32,7 +33,10 @@ public final class WorkspaceBuildItem extends SimpleBuildItem {
         return this.rootPath;
     }
 
-    public static record WorkspaceItem(String name, Path path) {
+    public record WorkspaceItems(List<WorkspaceItem> items, String fileSeparator) {
+    }
+
+    public record WorkspaceItem(String name, Path path) {
 
     }
 }

--- a/extensions/devui/resources/src/main/resources/dev-ui/qui/qui-ide-link.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qui/qui-ide-link.js
@@ -67,12 +67,12 @@ export class QuiIdeLink extends observeState(LitElement) {
     }
 
     _checkIfStringStartsWith(str, substrs) {
-        return substrs.some(substr => {
+        return substrs?.some(substr => {
             if(substr && substr.trim !== ""){
                 return str.startsWith(substr);
             }
             return false;
-        });
+        }) ?? false;
     }
 
     render() {


### PR DESCRIPTION
- closes https://github.com/quarkusio/quarkus/issues/50427
- fixes hardcoded path in our `qwc-workspace.js` component
- works around hardcoded paths in https://github.com/qomponent/qui-directory-tree/blob/main/qui-directory-tree.js (I fully expect this part to be reverted later)
- on Windows, it seems there is a different default order of files and directories, which resulted in a fact that on my Windows, files were first and directories also in a different order; that is bit clumsy if you just open DEV UI and see other file like a log or docker ignore, so I rewrote this to always select `.java` file first. when I tested it, the `GreetingResource` in a code start is selected first, which is better user experience
- `qui-ide-link` results in an error, I suppose it is related to the fact that I don't have installed IDE on Windows, but that could happen to users as well when they just play with Quarkus? so I fixed the error