### PR TITLE
Correctly restore query params when OIDC does not drop redirect params

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -909,7 +909,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                                                 configContext.oidcConfig()));
                                             }
                                             if (finalUserQuery != null) {
-                                                finalUriWithoutQuery.append(!removeRedirectParams ? "" : "?");
+                                                finalUriWithoutQuery.append(!removeRedirectParams ? "&" : "?");
                                                 finalUriWithoutQuery.append(finalUserQuery);
                                             }
                                             String finalRedirectUri = finalUriWithoutQuery.toString();

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -28,6 +28,10 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-query";
         }
 
+        if (path.contains("tenant-restore-query-keep-redirect-params")) {
+            return "tenant-restore-query-keep-redirect-params";
+        }
+
         if (path.contains("tenant-listener")) {
             return "tenant-listener";
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -310,6 +310,18 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("refresh/tenant-restore-query-keep-redirect-params")
+    public String getTenantRestoreQueryKeepRedirectParams(@QueryParam("context") String context) {
+        return getRefreshToken() + ";context=" + context;
+    }
+
+    @GET
+    @Path("refresh/tenant-restore-query-keep-redirect-params/callback")
+    public String getTenantRestoreQueryKeepRedirectParamsCallback() {
+        throw new InternalServerErrorException("This method must not be invoked");
+    }
+
+    @GET
     @Path("refresh-query")
     public String getRefreshTokenQuery(@QueryParam("a") String aValue) {
         return getRefreshToken() + ":" + aValue;

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -36,6 +36,15 @@ quarkus.oidc.tenant-listener.authentication.remove-redirect-parameters=false
 quarkus.oidc.tenant-listener.authentication.redirect-path=/web-app/refresh/tenant-listener/callback
 quarkus.oidc.tenant-listener.application-type=web-app
 
+# Tenant listener configuration for testing that the login event has been captured
+quarkus.oidc.tenant-restore-query-keep-redirect-params.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc.tenant-restore-query-keep-redirect-params.client-id=quarkus-app
+quarkus.oidc.tenant-restore-query-keep-redirect-params.credentials.secret=secret
+quarkus.oidc.tenant-restore-query-keep-redirect-params.authentication.remove-redirect-parameters=false
+quarkus.oidc.tenant-restore-query-keep-redirect-params.authentication.restore-path-after-redirect=true
+quarkus.oidc.tenant-restore-query-keep-redirect-params.authentication.redirect-path=/web-app/refresh/tenant-restore-query-keep-redirect-params/callback
+quarkus.oidc.tenant-restore-query-keep-redirect-params.application-type=web-app
+
 # Tenant which does not need to restore a request path after redirect, client_secret_post method
 quarkus.oidc.tenant-1.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-1.client-id=quarkus-app

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -1550,6 +1550,28 @@ public class CodeFlowTest {
         }
     }
 
+    @Test
+    public void testRestoreQueryKeepRedirectParams() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient
+                    .getPage(
+                            "http://localhost:8081/web-app/refresh/tenant-restore-query-keep-redirect-params?context=contextValue");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getButtonByName("login").click();
+
+            assertEquals("RT injected;context=contextValue",
+                    page.getBody().asNormalizedText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
     private void doTestAccessAndRefreshTokenInjectionWithoutIndexHtmlAndListener(WebClient webClient)
             throws IOException, InterruptedException {
         HtmlPage page = webClient.getPage("http://localhost:8081/web-app/refresh/tenant-listener");


### PR DESCRIPTION
Fixes #49225 

Quarkus OIDC can restore the origin request path and query parameters after the user logged in and was redirected back to Quarkus.

Users can also choose to keep the code flow parameters such as `code`, `state` that are included in the redirect URI, and in this case, restoring the original query sequence does not work due to a missing `&`query parameter separator.

The test structured as follows - the user logs in, is redirected back to a requested callback, but since the original request URI must be restored, the test callback method fails if it is invoked, instead the method accepting the original URI and query parameter is called.