### PR TITLE
Pass on container build arguments to Maven projects as arguments

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeAgentIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeAgentIT.java
@@ -27,7 +27,8 @@ public class NativeAgentIT extends MojoTestBase {
         assertThat(runJvmITsWithAgent.getProcess().waitFor()).isZero();
 
         MavenProcessInvocationResult runNativeITs = running
-                .execute(List.of("verify", "-Dnative", "-Dquarkus.native.agent-configuration-apply"), Map.of());
+                .execute(TestUtils.nativeArguments("verify", "-Dnative", "-Dquarkus.native.agent-configuration-apply"),
+                        Map.of());
         assertThat(runNativeITs.getProcess().waitFor()).isZero();
     }
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeImageIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/NativeImageIT.java
@@ -38,8 +38,9 @@ public class NativeImageIT extends MojoTestBase {
         final RunningInvoker running = new RunningInvoker(testDir, false);
 
         // trigger mvn package -Dnative -Dquarkus.ssl.native=true
-        final String[] mvnArgs = new String[] { "package", "-DskipTests", "-Dnative", "-Dquarkus.ssl.native=true" };
-        final MavenProcessInvocationResult result = running.execute(Arrays.asList(mvnArgs), Collections.emptyMap());
+        final List<String> mvnArgs = TestUtils.nativeArguments("package", "-DskipTests", "-Dnative",
+                "-Dquarkus.ssl.native=true");
+        final MavenProcessInvocationResult result = running.execute(mvnArgs, Collections.emptyMap());
         await().atMost(10, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         final String processLog = running.log();
         try {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/TestUtils.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/TestUtils.java
@@ -1,5 +1,9 @@
 package io.quarkus.maven.it;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import io.smallrye.common.os.OS;
 
 final class TestUtils {
@@ -11,5 +15,25 @@ final class TestUtils {
 
     static long getDefaultTimeout() {
         return DEFAULT_TIMEOUT;
+    }
+
+    static List<String> nativeArguments(String... initialArguments) {
+        final List<String> result = new ArrayList<>(Arrays.asList(initialArguments));
+        appendArgumentIfSet("quarkus.native.container-build", result);
+        appendArgumentIfSet("quarkus.native.builder-image", result);
+        appendArgumentIfSet("quarkus.native.container-runtime", result);
+        appendArgumentIfSet("quarkus.native.container-runtime-options", result);
+        return result;
+    }
+
+    private static void appendArgumentIfSet(String property, List<String> result) {
+        final String value = System.getProperty(property);
+        if (value != null) {
+            if (value.isEmpty()) {
+                result.add("-D" + property);
+            } else {
+                result.add(String.format("-D%s=%s", property, value));
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #50499.

It passes container build and builder image properties set via the command line onto the native Maven builds.