### PR TITLE
Move Hibernate ORM/Reactive configuration reference to the bottom of the guides

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -312,20 +312,6 @@ quarkus.hibernate-orm.persistence-xml.ignore=true
 ----
 ====
 
-[TIP]
-====
-Want to start a PostgreSQL server on the side with Docker?
-
-[source,bash]
-----
-docker run --rm=true --name postgres-quarkus-hibernate -e POSTGRES_USER=hibernate \
-           -e POSTGRES_PASSWORD=hibernate -e POSTGRES_DB=hibernate_db \
-           -p 5432:5432 postgres:14.1
-----
-
-This will start a non-durable empty database: ideal for a quick experiment!
-====
-
 [[multiple-persistence-units]]
 === Multiple persistence units
 

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -100,7 +100,7 @@ They will often map to Hibernate ORM configuration properties but could have dif
 
 Also, Quarkus will set many Hibernate ORM configuration settings automatically, and will often use more modern defaults.
 
-For a list of the items that you can set in `{config-file}`, see <<hibernate-configuration-properties,Hibernate ORM configuration properties>>.
+For a list of the items that you can set in `{config-file}`, see <<configuration-reference>>.
 
 An `EntityManagerFactory` will be created based on the Quarkus `datasource` configuration as long as the Hibernate ORM extension is listed among your project dependencies.
 
@@ -295,9 +295,7 @@ There are no required properties, as long as a default datasource is configured.
 When no property is set, Quarkus can typically infer everything it needs to set up Hibernate ORM
 and will have it use the default datasource.
 
-The configuration properties listed here allow you to override such defaults, and customize and tune various aspects.
-
-include::{generated-dir}/config/quarkus-hibernate-orm.adoc[opts=optional, leveloffset=+2]
+The configuration properties listed in <<configuration-reference>> allow you to override such defaults, and customize and tune various aspects.
 
 [NOTE]
 ====
@@ -961,7 +959,7 @@ quarkus.hibernate-orm."offline".dialect.mariadb.bytes-per-character=1
 quarkus.hibernate-orm."offline".dialect.mariadb.no-backslash-escapes=true
 ----
 
-Refer to the <<hibernate-configuration-properties,Hibernate ORM configuration properties>> section for more details on the available properties.
+Refer to the <<configuration-reference>> section for more details on the available properties.
 
 
 [[caching]]
@@ -1949,3 +1947,8 @@ to learn more about the `dataStore` attribute.
 Please refer to the corresponding https://hibernate.org/repositories/[Hibernate Data Repositories]
 and https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0[Jakarta Data]
 guides to learn what else they have to offer.
+
+[[configuration-reference]]
+== Configuration Reference for Hibernate ORM
+
+include::{generated-dir}/config/quarkus-hibernate-orm.adoc[opts=optional, leveloffset=+2]

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -196,20 +196,6 @@ The configuration properties listed here allow you to override such defaults, an
 Hibernate Reactive uses the same properties you would use for Hibernate ORM: see <<configuration-reference>>. You will notice that some properties
 contain `jdbc` in the name but there is no JDBC in Hibernate Reactive, these are simply legacy property names.
 
-[TIP]
-====
-Want to start a PostgreSQL server on the side with Docker?
-
-[source,bash]
-----
-docker run --rm --name postgres-quarkus-hibernate -e POSTGRES_USER=quarkus_test \
-           -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test \
-           -p 5432:5432 postgres:14.1
-----
-
-This will start a non-durable empty database: ideal for a quick experiment!
-====
-
 [[orm-and-reactive-extension-simultaneously]]
 === Hibernate ORM and Reactive extensions simultaneously
 

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -116,7 +116,7 @@ Blocking (non-reactive) and reactive configuration xref:orm-and-reactive-extensi
 
 WARNING: Configuring Hibernate Reactive using the standard `persistence.xml` configuration file is not supported.
 
-See section <<hr-configuration-properties,Hibernate Reactive configuration properties>> for the list of properties you can set in `{config-file}`.
+See section <<configuration-reference>> for the list of properties you can set in `{config-file}`.
 
 A `Mutiny.SessionFactory` will be created based on the Quarkus `datasource` configuration as long as the Hibernate Reactive extension is listed among your project dependencies.
 
@@ -193,10 +193,8 @@ and will have it use the default datasource.
 
 The configuration properties listed here allow you to override such defaults, and customize and tune various aspects.
 
-Hibernate Reactive uses the same properties you would use for Hibernate ORM. You will notice that some properties
+Hibernate Reactive uses the same properties you would use for Hibernate ORM: see <<configuration-reference>>. You will notice that some properties
 contain `jdbc` in the name but there is no JDBC in Hibernate Reactive, these are simply legacy property names.
-
-include::{generated-dir}/config/quarkus-hibernate-orm.adoc[opts=optional, leveloffset=+2]
 
 [TIP]
 ====
@@ -446,3 +444,8 @@ by providing active record style entities (and repositories) and focuses on maki
 To find out more on how the <<quarkus-hibernate-orm_quarkus-hibernate-orm-validation-mode,`quarkus.hibernate-orm.validation.mode` configuration property>>.
 influence your Hibernate Reactive application see the xref:hibernate-orm.adoc#validator_integration[corresponding Hibernate ORM guide],
 as these modes work the same in both cases.
+
+[[configuration-reference]]
+== Configuration Reference for Hibernate Reactive
+
+include::{generated-dir}/config/quarkus-hibernate-orm.adoc[opts=optional, leveloffset=+2]

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -193,8 +193,7 @@ and will have it use the default datasource.
 
 The configuration properties listed here allow you to override such defaults, and customize and tune various aspects.
 
-Hibernate Reactive uses the same properties you would use for Hibernate ORM: see <<configuration-reference>>. You will notice that some properties
-contain `jdbc` in the name but there is no JDBC in Hibernate Reactive, these are simply legacy property names.
+Hibernate Reactive uses the same properties you would use for Hibernate ORM: see <<configuration-reference>>.
 
 [[orm-and-reactive-extension-simultaneously]]
 === Hibernate ORM and Reactive extensions simultaneously
@@ -433,5 +432,13 @@ as these modes work the same in both cases.
 
 [[configuration-reference]]
 == Configuration Reference for Hibernate Reactive
+
+[TIP]
+====
+You will notice that some properties
+contain "jdbc" in their name: this is because Hibernate ORM refers to its "data access" layer as "JDBC" for historical reasons. Hibernate Reactive uses Vert.x Reactive SQL clients for its data access layer rather than JDBC.
+
+Regardless of their name, these properties still make sense for Hibernate Reactive.
+====
 
 include::{generated-dir}/config/quarkus-hibernate-orm.adoc[opts=optional, leveloffset=+2]


### PR DESCRIPTION
Because:

1. It's super long, it makes no sense to have it in the middle of the
   guide.
2. Other guides follow this approach as well, so we'd better be
   consistent.


Also: Remove obsolete and out-of-place hints about starting PostgreSQL from Hibernate ORM guides. People should get such information from the datasource guide, which will tell them to just use dev services anyway.