### PR TITLE
Upgrade to Hibernate ORM 7.2, Reactive 3.2, Search 8.2, Elasticsearch 9.2 / OpenSearch 3.3 for clients / server (dev services)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -99,7 +99,7 @@
         <narayana-lra.version>1.0.3.Final</narayana-lra.version>
         <agroal.version>2.8</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-opensource-components.version>9.1.5</elasticsearch-opensource-components.version>
+        <elasticsearch-opensource-components.version>9.2.2</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl-java.version>2.2.5.Final</wildfly.openssl-java.version>
         <wildfly.openssl-linux.version>2.2.2.SP01</wildfly.openssl-linux.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -167,7 +167,7 @@
         <mongo-client.version>5.6.2</mongo-client.version>
         <proton-j.version>0.34.1</proton-j.version>
         <javaparser.version>3.27.1</javaparser.version>
-        <hibernate-quarkus-local-cache.version>0.3.1</hibernate-quarkus-local-cache.version>
+        <hibernate-quarkus-local-cache.version>0.5.0</hibernate-quarkus-local-cache.version>
         <flapdoodle.mongo.version>4.21.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>6.2.SP1</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>3.5</quarkus-spring-data-api.version>
@@ -5462,7 +5462,7 @@
                 <version>${hibernate-reactive.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.local-cache</groupId>
                 <artifactId>quarkus-local-cache</artifactId>
                 <version>${hibernate-quarkus-local-cache.version}</version>
             </dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -191,7 +191,7 @@
         <log4j2-jboss-logmanager.version>2.0.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.25.3</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.3.1.Final</log4j-jboss-logmanager.version>
-        <avro.version>1.12.0</avro.version>
+        <avro.version>1.12.1</avro.version>
         <apicurio-registry.version>2.6.13.Final</apicurio-registry.version>
         <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <testcontainers.version>2.0.3</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -74,12 +74,12 @@
         <volume.access.modifier>:Z</volume.access.modifier>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>9.1.5</elasticsearch-server.version>
+        <elasticsearch-server.version>9.2.2</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
-        <opensearch-server.version>3.1.0</opensearch-server.version>
+        <opensearch-server.version>3.3.2</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
         <junit-pioneer.version>2.3.0</junit-pioneer.version>

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -820,7 +820,7 @@ as shown below.
 
 [source,properties]
 ----
-quarkus.hibernate-search-orm.elasticsearch.version=opensearch:3.1
+quarkus.hibernate-search-orm.elasticsearch.version=opensearch:3.3
 ----
 
 All other configuration options and APIs are exactly the same as with Elasticsearch.

--- a/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
@@ -738,7 +738,7 @@ as shown below.
 
 [source,properties]
 ----
-quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:3.1
+quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:3.3
 ----
 
 All other configuration options and APIs are exactly the same as with Elasticsearch.

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -331,6 +331,7 @@ public final class ClassNames {
             createConstant("org.hibernate.annotations.DynamicUpdate"),
             createConstant("org.hibernate.annotations.EmbeddableInstantiator"),
             createConstant("org.hibernate.annotations.EmbeddedColumnNaming"),
+            createConstant("org.hibernate.annotations.EmbeddedTable"),
             createConstant("org.hibernate.annotations.EmbeddableInstantiatorRegistration"),
             createConstant("org.hibernate.annotations.EmbeddableInstantiatorRegistrations"),
             createConstant("org.hibernate.annotations.Fetch"),
@@ -434,7 +435,7 @@ public final class ClassNames {
             createConstant("org.hibernate.annotations.View"));
 
     public static final List<DotName> ANNOTATED_WITH_INJECT_SERVICE = List.of(
-            createConstant("org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl"));
+            createConstant("org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProvider"));
 
     public static final List<DotName> JPA_LISTENER_ANNOTATIONS = List.of(
             createConstant("jakarta.persistence.PostLoad"),

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -435,7 +435,7 @@ public final class ClassNames {
             createConstant("org.hibernate.annotations.View"));
 
     public static final List<DotName> ANNOTATED_WITH_INJECT_SERVICE = List.of(
-            createConstant("org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProvider"));
+            createConstant("org.hibernate.engine.jdbc.connections.internal.DataSourceConnectionProvider"));
 
     public static final List<DotName> JPA_LISTENER_ANNOTATIONS = List.of(
             createConstant("jakarta.persistence.PostLoad"),

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
@@ -103,6 +103,8 @@ public abstract class AbstractTransactionLifecycleTest {
         ValueAndExecutionMetadata<String> calledStoredProcedure = crud.callStoredProcedure(id);
         checkPostConditions(calledStoredProcedure,
                 // Strangely, calling a stored procedure isn't considered as a statement for Hibernate ORM listeners
+                LifecycleOperation.FLUSH,
+                expectDoubleFlush() ? LifecycleOperation.FLUSH : null,
                 LifecycleOperation.TRANSACTION_COMPLETION);
         assertThat(calledStoredProcedure.value).isEqualTo(MyStoredProcedure.execute(id));
 
@@ -110,12 +112,14 @@ public abstract class AbstractTransactionLifecycleTest {
         checkPostConditions(deleted,
                 LifecycleOperation.STATEMENT, // select
                 LifecycleOperation.FLUSH, LifecycleOperation.STATEMENT, // delete
-                // No double flush here, since there's nothing in the session after the first flush.
+                expectDoubleFlush() ? LifecycleOperation.FLUSH : null,
                 LifecycleOperation.TRANSACTION_COMPLETION);
 
         retrieved = crud.retrieve(id);
         checkPostConditions(retrieved,
                 LifecycleOperation.STATEMENT, // select
+                LifecycleOperation.FLUSH,
+                expectDoubleFlush() ? LifecycleOperation.FLUSH : null,
                 LifecycleOperation.TRANSACTION_COMPLETION);
         assertThat(retrieved.value).isNull();
     }

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -91,7 +91,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.local-cache</groupId>
             <artifactId>quarkus-local-cache</artifactId>
             <exclusions>
                 <exclusion>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -373,7 +373,7 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
         }
 
         for (ProvidedService<?> providedService : rs.getProvidedServices()) {
-            if (!runtimeInitiatedServiceClasses.contains(providedService.getServiceRole())) {
+            if (!runtimeInitiatedServiceClasses.contains(providedService.serviceRole())) {
                 serviceRegistryBuilder.addService(providedService);
             }
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/StatelessSessionLazyDelegator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/StatelessSessionLazyDelegator.java
@@ -1,6 +1,8 @@
 package io.quarkus.hibernate.orm.runtime;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import jakarta.persistence.EntityGraph;
@@ -14,6 +16,8 @@ import org.hibernate.Filter;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.SessionFactory;
+import org.hibernate.SharedSessionBuilder;
+import org.hibernate.SharedStatelessSessionBuilder;
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
 import org.hibernate.graph.GraphSemantic;
@@ -461,6 +465,26 @@ class StatelessSessionLazyDelegator implements StatelessSession {
     @Override
     public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
         return delegate.get().getEntityGraphs(entityClass);
+    }
+
+    @Override
+    public SharedSessionBuilder sessionWithOptions() {
+        return delegate.get().sessionWithOptions();
+    }
+
+    @Override
+    public SharedStatelessSessionBuilder statelessWithOptions() {
+        return delegate.get().statelessWithOptions();
+    }
+
+    @Override
+    public void inTransaction(Consumer<? super Transaction> action) {
+        delegate.get().inTransaction(action);
+    }
+
+    @Override
+    public <R> R fromTransaction(Function<? super Transaction, R> action) {
+        return delegate.get().fromTransaction(action);
     }
 
     @Override

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -14,7 +14,6 @@ import static org.hibernate.cfg.AvailableSettings.TRANSACTION_COORDINATOR_STRATE
 import static org.hibernate.cfg.AvailableSettings.URL;
 import static org.hibernate.cfg.AvailableSettings.USER;
 import static org.hibernate.cfg.AvailableSettings.XML_MAPPING_ENABLED;
-import static org.hibernate.internal.CoreLogging.messageLogger;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -52,12 +51,12 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
 import org.hibernate.integrator.spi.Integrator;
-import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.jpa.boot.internal.StandardJpaScanEnvironmentImpl;
 import org.hibernate.jpa.boot.spi.JpaSettings;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
+import org.hibernate.jpa.internal.JpaLogger;
 import org.hibernate.jpa.internal.util.LogHelper;
 import org.hibernate.jpa.internal.util.PersistenceUnitTransactionTypeHelper;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
@@ -101,7 +100,7 @@ public class FastBootMetadataBuilder {
     @Deprecated
     private static final String ALLOW_ENHANCEMENT_AS_PROXY = "hibernate.bytecode.allow_enhancement_as_proxy";
 
-    private static final CoreMessageLogger LOG = messageLogger(FastBootMetadataBuilder.class);
+    private static final JpaLogger LOG = JpaLogger.JPA_LOGGER;
 
     private final PersistenceUnitDescriptor persistenceUnit;
     private final BuildTimeSettings buildTimeSettings;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusProxyFactory.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusProxyFactory.java
@@ -1,7 +1,5 @@
 package io.quarkus.hibernate.orm.runtime.customized;
 
-import static org.hibernate.internal.CoreLogging.messageLogger;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -28,7 +26,7 @@ import io.quarkus.hibernate.orm.runtime.proxies.ProxyDefinitions;
  */
 public final class QuarkusProxyFactory implements ProxyFactory {
 
-    private static final CoreMessageLogger LOG = messageLogger(QuarkusProxyFactory.class);
+    private static final CoreMessageLogger LOG = CoreMessageLogger.CORE_LOGGER;
 
     private final ProxyDefinitions proxyClassDefinitions;
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/FlatClassLoaderService.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/FlatClassLoaderService.java
@@ -12,17 +12,16 @@ import java.util.List;
 import java.util.ServiceLoader;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.boot.BootLogging;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
-import org.hibernate.internal.CoreLogging;
-import org.hibernate.internal.CoreMessageLogger;
 
 /**
  * Replaces the ClassLoaderService in Hibernate ORM with one which should work in native mode.
  */
 public class FlatClassLoaderService implements ClassLoaderService {
 
-    private static final CoreMessageLogger log = CoreLogging.messageLogger(FlatClassLoaderService.class);
+    private static final BootLogging log = BootLogging.BOOT_LOGGER;
     public static final ClassLoaderService INSTANCE = new FlatClassLoaderService();
 
     private FlatClassLoaderService() {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactory.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactory.java
@@ -1,7 +1,5 @@
 package io.quarkus.hibernate.orm.runtime.service;
 
-import static org.hibernate.internal.CoreLogging.messageLogger;
-
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -10,9 +8,10 @@ import org.hibernate.HibernateException;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.DialectLogging;
 import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfoSource;
-import org.hibernate.internal.CoreMessageLogger;
+import org.jboss.logging.Logger;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
@@ -26,7 +25,7 @@ import io.quarkus.runtime.configuration.ConfigurationException;
  * @see QuarkusStaticInitDialectFactory
  */
 public class QuarkusRuntimeInitDialectFactory implements DialectFactory {
-    private static final CoreMessageLogger LOG = messageLogger(QuarkusRuntimeInitDialectFactory.class);
+    private static final Logger LOG = DialectLogging.DIALECT_LOGGER;
     private final String persistenceUnitName;
     private final boolean isFromPersistenceXml;
     private final Dialect dialect;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
@@ -859,7 +859,7 @@ public class TransactionScopedSession implements Session {
     }
 
     @Override
-    public <T> T merge(T object, EntityGraph<?> loadGraph) {
+    public <T> T merge(T object, EntityGraph<? super T> loadGraph) {
         checkBlocking();
         try (SessionResult emr = acquireSession()) {
             return emr.session.merge(object, loadGraph);

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/SchemaValidateTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/SchemaValidateTest.java
@@ -1,10 +1,16 @@
 package io.quarkus.hibernate.reactive;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
 import jakarta.inject.Inject;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.tool.schema.spi.SchemaManagementException;
 import org.junit.jupiter.api.Assertions;
@@ -32,13 +38,15 @@ public class SchemaValidateTest {
     }
 
     private static void isSchemaValidationException(Throwable t) {
-        Throwable cause = t;
-        while (cause != null && !cause.getClass().getName().equals(SchemaManagementException.class.getName())) {
-            cause = cause.getCause();
-        }
-        String causeName = cause != null ? cause.getClass().getName() : null;
-        Assertions.assertEquals(SchemaManagementException.class.getName(), causeName);
-        Assertions.assertTrue(cause.getMessage().contains("Schema-validation: missing table [" + Hero.TABLE + "]"));
+        assertThat(t)
+                .extracting(SchemaValidateTest::getSelfAndCauses, InstanceOfAssertFactories.stream(Throwable.class))
+                .anySatisfy(e -> assertThat(e)
+                        .hasMessageContaining("Schema-validation: missing table [" + Hero.TABLE + "]")
+                        .extracting(e2 -> e2.getClass().getName()).isEqualTo(SchemaManagementException.class.getName()));
+    }
+
+    private static Stream<Throwable> getSelfAndCauses(Throwable e) {
+        return Stream.iterate(e, Objects::nonNull, Throwable::getCause);
     }
 
     @Entity(name = "Hero")

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/SchemaValidateTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/SchemaValidateTest.java
@@ -41,7 +41,7 @@ public class SchemaValidateTest {
         assertThat(t)
                 .extracting(SchemaValidateTest::getSelfAndCauses, InstanceOfAssertFactories.stream(Throwable.class))
                 .anySatisfy(e -> assertThat(e)
-                        .hasMessageContaining("Schema-validation: missing table [" + Hero.TABLE + "]")
+                        .hasMessageContaining("Schema validation: missing table [" + Hero.TABLE + "]")
                         .extracting(e2 -> e2.getClass().getName()).isEqualTo(SchemaManagementException.class.getName()));
     }
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -317,7 +317,7 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
         }
 
         for (ProvidedService<?> providedService : recordedState.getProvidedServices()) {
-            if (!runtimeInitiatedServiceClasses.contains(providedService.getServiceRole())) {
+            if (!runtimeInitiatedServiceClasses.contains(providedService.serviceRole())) {
                 serviceRegistryBuilder.addService(providedService);
             }
         }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
@@ -17,11 +17,11 @@ quarkus.hibernate-orm."namedpu".schema-management.strategy=drop-and-create
 
 # Hibernate Search is inactive for the default PU
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=9.1
+quarkus.hibernate-search-orm.elasticsearch.version=9.2
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 
 # ... but it's (implicitly) active for a named PU
-quarkus.hibernate-search-orm."namedpu".elasticsearch.version=9.1
+quarkus.hibernate-search-orm."namedpu".elasticsearch.version=9.2
 quarkus.hibernate-search-orm."namedpu".elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm."namedpu".schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -7,6 +7,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=9.1
+quarkus.hibernate-search-orm.elasticsearch.version=9.2
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -6,6 +6,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=9.1
+quarkus.hibernate-search-orm.elasticsearch.version=9.2
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=9.1
+quarkus.hibernate-search-orm.elasticsearch.version=9.2
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-orm.schema-management.strategy=none

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -2,6 +2,6 @@
 quarkus.devservices.enabled=false
 
 quarkus.hibernate-search-standalone.active=false
-quarkus.hibernate-search-standalone.elasticsearch.version=9.1
+quarkus.hibernate-search-standalone.elasticsearch.version=9.2
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -1,6 +1,6 @@
 # We already start Elasticsearch with Maven
 quarkus.devservices.enabled=false
 
-quarkus.hibernate-search-standalone.elasticsearch.version=9.1
+quarkus.hibernate-search-standalone.elasticsearch.version=9.2
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -1,4 +1,4 @@
-quarkus.hibernate-search-standalone.elasticsearch.version=9.1
+quarkus.hibernate-search-standalone.elasticsearch.version=9.2
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-standalone.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-standalone.schema-management.strategy=none

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/nested/fields/CustomerRepositoryNestedFieldsDerivedMethodsTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/nested/fields/CustomerRepositoryNestedFieldsDerivedMethodsTest.java
@@ -63,10 +63,12 @@ class CustomerRepositoryNestedFieldsDerivedMethodsTest {
 
         QueryArgumentException exception = assertThrows(QueryArgumentException.class,
                 () -> customerRepository.findAllByAddressCountry("Spain"));
-        assertThat(exception).hasMessageContaining("Argument [Spain] of type [java.lang.String] did not match parameter type");
+        assertThat(exception).hasMessageContaining(
+                "Argument to query parameter has an incompatible type (java.lang.String is not assignable to io.quarkus.spring.data.deployment.Customer$Country)");
         assertThrows(QueryArgumentException.class,
                 () -> customerRepository.findAllByAddress_Country("Spain"));
-        assertThat(exception).hasMessageContaining("Argument [Spain] of type [java.lang.String] did not match parameter type");
+        assertThat(exception).hasMessageContaining(
+                "Argument to query parameter has an incompatible type (java.lang.String is not assignable to io.quarkus.spring.data.deployment.Customer$Country)");
 
     }
 

--- a/integration-tests/hibernate-reactive-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/reactive/kotlin/PanacheFunctionalityTest.kt
+++ b/integration-tests/hibernate-reactive-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/reactive/kotlin/PanacheFunctionalityTest.kt
@@ -14,7 +14,6 @@ import io.restassured.RestAssured.`when`
 import io.restassured.http.ContentType
 import io.smallrye.mutiny.Uni
 import jakarta.json.bind.JsonbBuilder
-import jakarta.persistence.PersistenceException
 import java.util.function.Supplier
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Assertions
@@ -280,10 +279,14 @@ open class PanacheFunctionalityTest {
     @Order(300)
     @RunOnVertxContext
     @DisabledOnIntegrationTest
-    fun testPersistenceException(asserter: UniAsserter) {
+    fun testDeleteUnmanaged(asserter: UniAsserter) {
+        // This used to throw PersistenceException but that was invalid,
+        // see https://github.com/hibernate/hibernate-reactive/commit/10b0d421ae6a554528f1239ad74cde5a4400bf5d
+        // If you're wondering why we're testing this:
+        // apparently we're actually testing UniAsserter here, see https://github.com/quarkusio/quarkus/pull/18794
         asserter.assertFailedWith(
             { Panache.withSession { Person().delete() } },
-            PersistenceException::class.java,
+            IllegalArgumentException::class.java,
         )
     }
 }

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
-import jakarta.persistence.PersistenceException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -299,8 +298,12 @@ public class PanacheFunctionalityTest {
     @RunOnVertxContext
     @Test
     @Order(300)
-    public void testPersistenceException(UniAsserter asserter) {
-        asserter.assertFailedWith(() -> Panache.withTransaction(() -> new Person().delete()), PersistenceException.class);
+    public void testDeleteUnmanaged(UniAsserter asserter) {
+        // This used to throw PersistenceException but that was invalid,
+        // see https://github.com/hibernate/hibernate-reactive/commit/10b0d421ae6a554528f1239ad74cde5a4400bf5d
+        // If you're wondering why we're testing this:
+        // apparently we're actually testing UniAsserter here, see https://github.com/quarkusio/quarkus/pull/18794
+        asserter.assertFailedWith(() -> Panache.withTransaction(() -> new Person().delete()), IllegalArgumentException.class);
     }
 
     @Test

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.1"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.2"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.1");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.2");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesTest.java
@@ -30,7 +30,7 @@ public class HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesT
         public Map<String, String> getConfigOverrides() {
             Map<String, String> config = new HashMap<>();
             config.put("quarkus.elasticsearch.devservices.enabled", "true");
-            config.put("quarkus.hibernate-search-orm.elasticsearch.version", "9.1");
+            config.put("quarkus.hibernate-search-orm.elasticsearch.version", "9.2");
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.1"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.3"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.1");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:3.3");
         }
 
         @Override

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.1"));
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.2"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.1");
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.2");
         }
 
         @Override

--- a/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.1"));
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.3"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.1");
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:3.3");
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,12 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.4.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.2.0.CR3</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.2.0.CR4</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>3.2.0.CR1</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.2.0.CR2</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.2.0.CR1</hibernate-search.version>
         <hibernate-tools.version>7.2.0.CR2</hibernate-tools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,15 +71,15 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.4.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.2.0.CR4</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.2.0.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>3.2.0.CR2</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.2.0.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
-        <hibernate-search.version>8.2.0.CR1</hibernate-search.version>
-        <hibernate-tools.version>7.2.0.CR2</hibernate-tools.version>
+        <hibernate-search.version>8.2.0.Final</hibernate-search.version>
+        <hibernate-tools.version>7.2.0.Final</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.77.0</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.4.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.2.0.CR1</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.2.0.CR2</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.6</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
@@ -79,7 +79,7 @@
         <hibernate-reactive.version>3.1.11.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.1.2.Final</hibernate-search.version>
-        <hibernate-tools.version>7.2.0.CR1</hibernate-tools.version>
+        <hibernate-tools.version>7.2.0.CR2</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.77.0</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>3.2.0.CR1</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
-        <hibernate-search.version>8.1.2.Final</hibernate-search.version>
+        <hibernate-search.version>8.2.0.CR1</hibernate-search.version>
         <hibernate-tools.version>7.2.0.CR2</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.4.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.1.12.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.2.0.CR1</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.6</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
@@ -79,7 +79,7 @@
         <hibernate-reactive.version>3.1.11.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.1.2.Final</hibernate-search.version>
-        <hibernate-tools.version>7.1.12.Final</hibernate-tools.version>
+        <hibernate-tools.version>7.2.0.CR1</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.77.0</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,12 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.4.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.2.0.CR2</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.2.0.CR3</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
-        <bytebuddy.version>1.17.6</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
+        <bytebuddy.version>1.17.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>3.1.11.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.2.0.CR1</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.1.2.Final</hibernate-search.version>
         <hibernate-tools.version>7.2.0.CR2</hibernate-tools.version>

--- a/test-framework/vertx/src/main/java/io/quarkus/test/vertx/DefaultUniAsserter.java
+++ b/test-framework/vertx/src/main/java/io/quarkus/test/vertx/DefaultUniAsserter.java
@@ -180,7 +180,7 @@ public final class DefaultUniAsserter implements UnwrappableUniAsserter {
         return assertFailedWith(uni, t -> {
             if (!c.isInstance(t)) {
                 Assertions.fail(String.format("Uni failure type '%s' was not of the expected type '%s'.",
-                        t.getClass().getName(), c.getName()));
+                        t.getClass().getName(), c.getName()), t);
             }
         });
     }


### PR DESCRIPTION
Draft because:

- [x] I likely need some more changes ('m still testing on my fork)
- [x] Based on #51055 which must be merged first
- [x] We need a `.Final` release of ORM, and an upgrade to that
- [x] We need a `.Final` release of Reactive, and an upgrade to that
- [x] We need a `.Final` release of Search, and an upgrade to that
- [x] We need a migration guide entry
----

* Fixes #50505
* Does not fix any other Hibernate-related bug tracked in the Quarkus issue tracker
* See https://hibernate.org/orm/releases/7.2/
* See https://hibernate.org/search/releases/8.2/
* See https://hibernate.org/reactive/releases/3.2/

----

Migration guide entry:

`````asciidoc

== Hibernate ORM

=== Upgrade to Hibernate ORM 7.2

The Quarkus extension for Hibernate ORM was upgraded to Hibernate ORM 7.2.

Hibernate ORM 7.2 is for the most part backwards-compatible with Hibernate ORM 7.1, apart from a few changes affecting only advanced or infrequent use cases.

Refer to the https://docs.jboss.org/hibernate/orm/7.2/migration-guide/[Hibernate ORM 7.2 migration guide] for more information.

[[orm-db-versions]]
=== Minimum database versions

The minimum required version of databases did not change in Hibernate ORM 7.2.

See https://docs.hibernate.org/orm/7.2/dialect/[here] for details on the current minimum versions.

== Hibernate Reactive

=== Upgrade to Hibernate Reactive 3.2

The Quarkus extension for Hibernate Reactive was upgraded to Hibernate Reactive 3.2.

Hibernate Reactive 3.2 is backwards-compatible with Hibernate Reactive 3.1, with the exception of a few breaking changes inherited from Hibernate ORM and listed xref:#++hibernate-orm++[above].

== Hibernate Search

=== Upgrade to Hibernate Search 8.2

The Quarkus extensions for Hibernate Search were upgraded to Hibernate Search 8.2.

Hibernate Search 8.2 is backwards-compatible with Hibernate Search 8.1, apart from a few deprecations.

Refer to the the https://docs.hibernate.org/search/8.2/migration/html_single/[Hibernate Search 8.2 migration guide] for more information.

== Dev Services

Several Dev Services default images have been updated:

* Elasticsearch from 9.1 to 9.2
* OpenSearch from 3.1 to 3.3

NOTE: You can configure Quarkus explicitly to use a specific image for each Dev Service, e.g. see https://quarkus.io/guides/elasticsearch-dev-services#configuring-the-image[here for Elasticsearch/OpenSearch].
`````