### PR TITLE
Minor update to rest-client.adoc

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1334,7 +1334,7 @@ Alternatively, you can implement the `ResteasyReactiveClientRequestFilter` inter
 public class TestClientRequestFilter implements ResteasyReactiveClientRequestFilter {
 
     @Override
-    public void filter(ResteasyReactiveClientRequestFilter requestContext) {
+    public void filter(ResteasyReactiveClientRequestContext requestContext) {
         Providers providers = requestContext.getProviders();
         // ...
     }


### PR DESCRIPTION
While following the steps outlined in the documentation for implementing a Filter of my own, I noticed this minor error in the documentation. This PR is just a small correction to the `ResteasyReactiveClientRequestFilter` code snippet - corrected the type of the parameter `requestContext` in the method `filter`.