### PR TITLE
Fix native-image version parsing for GraalVM 25.1-dev

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -201,6 +201,45 @@ public class GraalVMTest {
     }
 
     @Test
+    public void testGraalVM25_0CommunityVersion() {
+        final Version version = Version.of(Stream.of(("native-image 25 2025-09-16\n"
+                + "GraalVM Runtime Environment GraalVM CE 25+37.1 (build 25+37-jvmci-b01)\n"
+                + "Substrate VM GraalVM CE 25+37.1 (build 25+37, serial gc)").split("\\n")));
+        assertThat(version.toString().contains(GRAALVM.name()));
+        assertThat(version.getVersionAsString()).isEqualTo("25.0.0");
+        assertThat(version.javaVersion.toString()).isEqualTo("25+37-jvmci-b01");
+        assertThat(version.javaVersion.feature()).isEqualTo(25);
+        assertThat(version.javaVersion.interim()).isEqualTo(0);
+        assertThat(version.javaVersion.update()).isEqualTo(0);
+    }
+
+    @Test
+    public void testGraalVM25_0_1CommunityVersion() {
+        final Version version = Version.of(Stream.of(("native-image 25.0.1 2025-10-21\n"
+                + "GraalVM Runtime Environment GraalVM CE 25.0.1+99.1 (build 25.0.1+99-jvmci-b01)\n"
+                + "Substrate VM GraalVM CE 25.0.1+99.1 (build 25.0.1+99, serial gc)").split("\\n")));
+        assertThat(version.toString().contains(GRAALVM.name()));
+        assertThat(version.getVersionAsString()).isEqualTo("25.0.1");
+        assertThat(version.javaVersion.toString()).isEqualTo("25.0.1+99-jvmci-b01");
+        assertThat(version.javaVersion.feature()).isEqualTo(25);
+        assertThat(version.javaVersion.interim()).isEqualTo(0);
+        assertThat(version.javaVersion.update()).isEqualTo(1);
+    }
+
+    @Test
+    public void testGraalVM25_1CommunityVersionParser() {
+        final Version version = Version.of(Stream.of(("native-image 25 2025-09-16\n"
+                + "GraalVM Runtime Environment GraalVM CE 25.1.0-dev+37.1 (build 25+37-jvmci-b06)\n"
+                + "Substrate VM GraalVM CE 25.1.0-dev+37.1 (build 25+37, serial gc)").split("\\n")));
+        assertThat(version.toString().contains(GRAALVM.name()));
+        assertThat(version.getVersionAsString()).isEqualTo("25.1.0-dev");
+        assertThat(version.javaVersion.toString()).isEqualTo("25+37-jvmci-b06");
+        assertThat(version.javaVersion.feature()).isEqualTo(25);
+        assertThat(version.javaVersion.interim()).isEqualTo(0);
+        assertThat(version.javaVersion.update()).isEqualTo(0);
+    }
+
+    @Test
     public void testGraalVMVersionsOlderThan() {
         assertOlderThan("native-image 21 2023-09-19\n" +
                 "GraalVM Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -53,7 +53,7 @@ public final class GraalVM {
                     String tokens[] = version.split("\\.", 3);
                     String jdkFeature = tokens[0];
                     String jdkVers = jdkFeature;
-                    if (tokens.length == 3) {
+                    if (tokens.length == 3 && !graalVMFutureVers(tokens)) {
                         String interim = tokens[1];
                         String update = tokens[2].split("\\+")[0];
                         jdkVers = String.format("%s.%s.%s", jdkFeature, interim, update);
@@ -71,6 +71,17 @@ public final class GraalVM {
             log.warnf("Failed to parse GraalVM version from: %s. Defaulting to currently supported version %s ", value,
                     Version.CURRENT);
             return Version.CURRENT;
+        }
+
+        // Anything beyond 25.0 is a future GraalVM version not suitable for Runtime.Version.parse()
+        private static boolean graalVMFutureVers(String[] tokens) {
+            try {
+                int feature = Integer.valueOf(tokens[0]);
+                int interim = Integer.valueOf(tokens[1]);
+                return feature > 25 || (feature == 25 && interim > 0);
+            } catch (NumberFormatException e) {
+                return false;
+            }
         }
 
     }


### PR DESCRIPTION
We test graalvm `master` branch builds with Quarkus native integration tests (for our Mandrel CI). Currently `graal/master` is at version `25.1.0-dev` which fails version parsing in Quarkus. Since we'd like to continue testing graal master for now I propose we support this specific in-development version in quarkus `main`.

- Closes #50526 