### PR TITLE
Fix the GraphQL RunOnVirtualThreadIT in native

### DIFF
--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/main/java/io/quarkus/virtual/graphql/RunOnVirtualThreadObjectTestThreadResource.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/main/java/io/quarkus/virtual/graphql/RunOnVirtualThreadObjectTestThreadResource.java
@@ -1,0 +1,57 @@
+package io.quarkus.virtual.graphql;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+@GraphQLApi
+public class RunOnVirtualThreadObjectTestThreadResource {
+
+    // Return type Object with @RunOnVirtualThread
+    @Query
+    @RunOnVirtualThread
+    public TestThread annotatedRunOnVirtualThreadObject() {
+        sleep();
+        return getTestThread();
+    }
+
+    // Return type Object with @RunOnVirtualThread
+    @Mutation
+    @RunOnVirtualThread
+    public TestThread annotatedRunOnVirtualThreadMutationObject(String test) {
+        sleep();
+        return getTestThread();
+    }
+
+    @Query
+    @RunOnVirtualThread
+    public TestThread pinThread() {
+        // Synchronize on an object to cause thread pinning
+        Object lock = new Object();
+        synchronized (lock) {
+            sleep();
+        }
+        return getTestThread();
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private TestThread getTestThread() {
+        Thread t = Thread.currentThread();
+        long id = t.getId();
+        String name = t.getName();
+        int priority = t.getPriority();
+        String state = t.getState().name();
+        String group = t.getThreadGroup().getName();
+        return new TestThread(id, name, priority, state, group);
+    }
+}

--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/main/java/io/quarkus/virtual/graphql/TestThread.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/main/java/io/quarkus/virtual/graphql/TestThread.java
@@ -1,0 +1,73 @@
+package io.quarkus.virtual.graphql;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Holds info about a thread
+ */
+public class TestThread {
+
+    private long id;
+    private String name;
+    private int priority;
+    private String state;
+    private String group;
+
+    public TestThread() {
+        super();
+    }
+
+    public TestThread(long id, String name, int priority, String state, String group) {
+        this.id = id;
+        this.name = name;
+        this.priority = priority;
+        this.state = state;
+        this.group = group;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public String getVertxContextClassName() {
+        Context vc = Vertx.currentContext();
+        return vc.getClass().getName();
+    }
+}

--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/AbstractGraphQLTest.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/AbstractGraphQLTest.java
@@ -16,8 +16,6 @@ import org.hamcrest.CoreMatchers;
 
 import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
 
 /**
  * Some shared methods
@@ -112,72 +110,4 @@ public abstract class AbstractGraphQLTest {
         PROPERTIES.put("smallrye.graphql.events.enabled", "true");
     }
 
-    /**
-     * Hold info about a thread
-     */
-    public static class TestThread {
-
-        private long id;
-        private String name;
-        private int priority;
-        private String state;
-        private String group;
-
-        public TestThread() {
-            super();
-        }
-
-        public TestThread(long id, String name, int priority, String state, String group) {
-            this.id = id;
-            this.name = name;
-            this.priority = priority;
-            this.state = state;
-            this.group = group;
-        }
-
-        public long getId() {
-            return id;
-        }
-
-        public void setId(long id) {
-            this.id = id;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public int getPriority() {
-            return priority;
-        }
-
-        public void setPriority(int priority) {
-            this.priority = priority;
-        }
-
-        public String getState() {
-            return state;
-        }
-
-        public void setState(String state) {
-            this.state = state;
-        }
-
-        public String getGroup() {
-            return group;
-        }
-
-        public void setGroup(String group) {
-            this.group = group;
-        }
-
-        public String getVertxContextClassName() {
-            Context vc = Vertx.currentContext();
-            return vc.getClass().getName();
-        }
-    }
 }

--- a/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/RunOnVirtualThreadTest.java
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/src/test/java/io/quarkus/virtual/graphql/RunOnVirtualThreadTest.java
@@ -1,8 +1,5 @@
 package io.quarkus.virtual.graphql;
 
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Mutation;
-import org.eclipse.microprofile.graphql.Query;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -11,7 +8,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit5.virtual.ShouldNotPin;
 import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
 import io.restassured.RestAssured;
-import io.smallrye.common.annotation.RunOnVirtualThread;
 
 @QuarkusTest
 @VirtualThreadUnit
@@ -103,53 +99,4 @@ class RunOnVirtualThreadTest extends AbstractGraphQLTest {
                         Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
     }
 
-    @GraphQLApi
-    public static class RunOnVirtualThreadObjectTestThreadResource {
-
-        // Return type Object with @RunOnVirtualThread
-        @Query
-        @RunOnVirtualThread
-        public TestThread annotatedRunOnVirtualThreadObject() {
-            sleep();
-            return getTestThread();
-        }
-
-        // Return type Object with @RunOnVirtualThread
-        @Mutation
-        @RunOnVirtualThread
-        public TestThread annotatedRunOnVirtualThreadMutationObject(String test) {
-            sleep();
-            return getTestThread();
-        }
-
-        @Query
-        @RunOnVirtualThread
-        public TestThread pinThread() {
-            // Synchronize on an object to cause thread pinning
-            Object lock = new Object();
-            synchronized (lock) {
-                sleep();
-            }
-            return getTestThread();
-        }
-
-        private void sleep() {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
-        }
-
-        private TestThread getTestThread() {
-            Thread t = Thread.currentThread();
-            long id = t.getId();
-            String name = t.getName();
-            int priority = t.getPriority();
-            String state = t.getState().name();
-            String group = t.getThreadGroup().getName();
-            return new TestThread(id, name, priority, state, group);
-        }
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/50524

The tested GraphQL endpoint is included in the test directly, not in the app, so it is not baked into the native image. This PR moves the GraphQL endpoint from the test itself into the tested app.