### PR TITLE
Update Smallrye Config to 3.14.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0.1</microprofile-lra.version>
         <microprofile-openapi.version>4.1</microprofile-openapi.version>
         <smallrye-common.version>2.13.9</smallrye-common.version>
-        <smallrye-config.version>3.14.0</smallrye-config.version>
+        <smallrye-config.version>3.14.1</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.2.0</smallrye-open-api.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 plugin-publish = "2.0.0"
 
 kotlin = "2.2.20"
-smallrye-config = "3.14.0"
+smallrye-config = "3.14.1"
 
 junit5 = "5.13.4"
 assertj = "3.27.6"


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.14.1</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1415">#1415</a> Release 3.14.1</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1414">#1414</a> fix: typos</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1413">#1413</a> Keep all the @ConfigMapping path and names operations to resolve the final property name in ConfigMappingContext</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1412">#1412</a> Return a pre-registered Converter if one exists when calling `getImplicitConverter`</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1411">#1411</a> Improve ConfigMapping generation error</li>
    </ul>
</blockquote>
<br>

Quarkus:

- Fixes #50206