### PR TITLE
Ignore quarkus-core in non-platform extension catalogs

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -418,7 +418,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
         int catalogContainingCoreIndex = -1;
         for (int i = 0; i < catalogs.size(); ++i) {
             ExtensionCatalog catalog = catalogs.get(i);
-            if (catalog.getMetadata()
+            if (catalog.isPlatform() && catalog.getMetadata()
                     .get(Constants.REGISTRY_CLIENT_ALL_CATALOG_EXTENSIONS) instanceof Map<?, ?> allCatalogExtensions) {
                 final ArtifactCoords managedQuarkusCore = (ArtifactCoords) allCatalogExtensions
                         .get(quarkusCore.getArtifact().getKey());

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -982,7 +982,7 @@ public class TestRegistryClientBuilder {
         }
 
         private void persist(Path nonPlatformDir) {
-            codestarts.forEach(c -> c.persist());
+            codestarts.forEach(TestCodestartBuilder::persist);
             final Path json = getNonPlatformCatalogPath(nonPlatformDir, extensions.getQuarkusCoreVersion());
             try {
                 extensions.persist(json);

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class CreateProjectWithNonPlatformExtensionTest extends MultiplePlatformBomsTestBase {
+
+    private static final String PLATFORM_KEY = "org.acme.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("registry.acme.org")
+                // platform key
+                .newPlatform(PLATFORM_KEY)
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .stream().platform().registry()
+                .newNonPlatformCatalog("1.1.1")
+                .addExtension("org.bla", "bla-magic", "5.5.5")
+                // this is just to make sure quarkus-core (by accident) included in a non-platform catalog does not mislead the tools
+                .addExtension("io.quarkus", "quarkus-core", "5.5.5")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return PLATFORM_KEY;
+    }
+
+    @Test
+    public void projectWithNonPlatformExtensionOnly() throws Exception {
+        final Path projectDir = newProjectDir("project-non-platform-ext");
+        createProject(projectDir, List.of("bla-magic"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom()),
+                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "5.5.5")),
+                "1.1.1");
+    }
+}


### PR DESCRIPTION
Fix #50528

This change makes sure that even if `quarkus-core` appears among non-platform extensions, it does not mislead the tools to use the non-platform extension catalog as the platform catalog.