### PR TITLE
Add refresh parameter to create and add extension Maven plugin goals

### DIFF
--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/registry/RegistryClientMixin.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/registry/RegistryClientMixin.java
@@ -24,7 +24,7 @@ import picocli.CommandLine;
 public class RegistryClientMixin {
     static final boolean VALIDATE = !Boolean.parseBoolean(System.getenv("REGISTRY_CLIENT_TEST"));
 
-    /** @see io.quarkus.cli.registry.ToggleRegistryClientMixin#setRegistryClient */
+    /** @see io.quarkus.cli.common.registry.ToggleRegistryClientMixin#setRegistryClient */
     public final String getRegistryClientProperty() {
         return "-DquarkusRegistryClient=" + enabled();
     }


### PR DESCRIPTION
This adds an equivalent to `quarkus create --refresh` to the Maven plugin. It would look like
```
mvn io.quarkus.platform:quarkus-maven-plugin:<VERSION>:create -Drefresh
```