### PR TITLE
Pass all the configuration minus PackageConfig and NativeConfig defaults to Gradle tasks

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -272,7 +272,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
         ApplicationModel appModel = resolveAppModelForBuild();
         Map<String, String> quarkusProperties = effectiveProvider()
                 .buildEffectiveConfiguration(appModel, getAdditionalForcedProperties().get().getProperties())
-                .getOnlyQuarkusValues();
+                .getQuarkusValues();
 
         if (nativeEnabled()) {
             if (nativeSourcesOnly()) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -103,7 +103,7 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
     public void runQuarkus() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getOnlyQuarkusValues());
+        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getQuarkusValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)


### PR DESCRIPTION
A better fix than the one in https://github.com/quarkusio/quarkus/pull/49503.

This now only excludes the default configuration from the `PackageConfig` and `NativeConfig`, and keeps other defaults that may have been set.

- Fixes #50495 