### PR TITLE
Java code cleanup in extensions/vertx-http

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/RouteDescriptionBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/RouteDescriptionBuildItem.java
@@ -1,8 +1,5 @@
 package io.quarkus.vertx.http.deployment.devmode;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.vertx.http.runtime.devmode.RouteDescription;
 import io.quarkus.vertx.http.runtime.devmode.RouteMethodDescription;
@@ -29,7 +26,7 @@ public final class RouteDescriptionBuildItem extends MultiBuildItem {
     }
 
     private String getMediaType(String[] all) {
-        return all.length == 0 ? null : Arrays.stream(all).collect(Collectors.joining(", "));
+        return all.length == 0 ? null : String.join(", ", all);
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/fakedns/DnsMessageEncoder.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/fakedns/DnsMessageEncoder.java
@@ -3,7 +3,6 @@ package io.quarkus.vertx.http.proxy.fakedns;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -116,10 +115,7 @@ public class DnsMessageEncoder {
 
         QuestionRecordEncoder encoder = new QuestionRecordEncoder();
 
-        Iterator<QuestionRecord> it = questions.iterator();
-
-        while (it.hasNext()) {
-            QuestionRecord question = it.next();
+        for (QuestionRecord question : questions) {
             encoder.put(byteBuffer, question);
         }
     }
@@ -129,11 +125,7 @@ public class DnsMessageEncoder {
             return;
         }
 
-        Iterator<ResourceRecord> it = records.iterator();
-
-        while (it.hasNext()) {
-            ResourceRecord record = it.next();
-
+        for (ResourceRecord record : records) {
             try {
                 put(byteBuffer, record);
             } catch (IOException ioe) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompression.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompression.java
@@ -18,7 +18,7 @@ public enum HttpCompression {
     OFF,
     /**
      * Compression will be enabled if the response has the {@code Content-Type} header set and the value is listed in
-     * {@link VertxHttpConfig#compressMediaTypes}.
+     * {@link VertxHttpBuildTimeConfig#compressMediaTypes}.
      */
     UNDEFINED
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusHttpHeaders.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusHttpHeaders.java
@@ -8,6 +8,7 @@ import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 
 import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -314,9 +315,7 @@ public final class QuarkusHttpHeaders extends HttpHeaders implements MultiMap {
 
     @Override
     public QuarkusHttpHeaders clear() {
-        for (int i = 0; i < entries.length; i++) {
-            entries[i] = null;
-        }
+        Arrays.fill(entries, null);
         head.before = head.after = head;
         return this;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/CompositeExchangeAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/CompositeExchangeAttribute.java
@@ -19,8 +19,8 @@ public class CompositeExchangeAttribute implements ExchangeAttribute {
     @Override
     public String readAttribute(RoutingContext exchange) {
         final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < attributes.length; ++i) {
-            final String val = attributes[i].readAttribute(exchange);
+        for (ExchangeAttribute attribute : attributes) {
+            final String val = attribute.readAttribute(exchange);
             if (val != null) {
                 sb.append(val);
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/QuotingExchangeAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/QuotingExchangeAttribute.java
@@ -36,7 +36,7 @@ public class QuotingExchangeAttribute implements ExchangeAttribute {
                 buffer.append(svalue.substring(i));
                 i = svalue.length();
             } else {
-                buffer.append(svalue.substring(i, j + 1));
+                buffer.append(svalue, i, j + 1);
                 buffer.append('"');
                 i = j + 2;
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
@@ -46,7 +46,7 @@ public class ConfigDescriptionsManager implements Supplier<ConfigDescriptionsMan
     }
 
     public ConfigDescriptionsManager(final List<ConfigDescription> configDescriptions, Set<String> devServicesProperties) {
-        this.configDescriptions = Collections.unmodifiableList(new ArrayList<>(configDescriptions));
+        this.configDescriptions = List.copyOf(configDescriptions);
         this.devServicesProperties = devServicesProperties;
         currentCl = Thread.currentThread().getContextClassLoader();
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
@@ -3,10 +3,8 @@ package io.quarkus.vertx.http.runtime.devmode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -199,8 +197,7 @@ public final class Json {
             StringBuilder builder = new StringBuilder();
             builder.append(ARRAY_START);
             int idx = 0;
-            for (ListIterator<Object> iterator = values.listIterator(); iterator.hasNext();) {
-                Object value = iterator.next();
+            for (Object value : values) {
                 if (isIgnored(value)) {
                     continue;
                 }
@@ -284,8 +281,7 @@ public final class Json {
             StringBuilder builder = new StringBuilder();
             builder.append(OBJECT_START);
             int idx = 0;
-            for (Iterator<Entry<String, Object>> iterator = properties.entrySet().iterator(); iterator.hasNext();) {
-                Entry<String, Object> entry = iterator.next();
+            for (Entry<String, Object> entry : properties.entrySet()) {
                 if (isIgnored(entry.getValue())) {
                     continue;
                 }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckPartConverterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckPartConverterTest.java
@@ -100,7 +100,7 @@ public class TrustedProxyCheckPartConverterTest {
         var part = CONVERTER.convert("quarkus.io:8085");
         Assertions.assertNull(part.proxyCheck);
         Assertions.assertNotNull(part.hostName);
-        Assertions.assertEquals(part.port, 8085);
+        Assertions.assertEquals(8085, part.port);
     }
 
 }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
@@ -38,12 +38,11 @@ public class CORSFilterTest {
     @Test
     public void isOriginAllowedByRegexTest() {
         Assertions.assertFalse(isOriginAllowedByRegex(Collections.emptyList(), "http://locahost:8080"));
-        Assertions.assertEquals(
-                parseAllowedOriginsRegex(Optional.of(Collections.singletonList("http://localhost:8080"))).size(),
-                0);
+        Assertions.assertEquals(0,
+                parseAllowedOriginsRegex(Optional.of(Collections.singletonList("http://localhost:8080"))).size());
         List<Pattern> regexList = parseAllowedOriginsRegex(
                 Optional.of(Collections.singletonList("/https://([a-z0-9\\-_]+)\\.app\\.mydomain\\.com/")));
-        Assertions.assertEquals(regexList.size(), 1);
+        Assertions.assertEquals(1, regexList.size());
         Assertions.assertTrue(isOriginAllowedByRegex(regexList, "https://abc-123.app.mydomain.com"));
         Assertions.assertFalse(isOriginAllowedByRegex(regexList, "https://abc-123app.mydomain.com"));
     }


### PR DESCRIPTION
* Fix JavaDoc pointer to compressMediaTypes
* Fix order of assertEquals arguments
* Use enhanced for loop
* Use less verbose API like String.join Arrays.fill List.copyOf

Follow-up of the TD work on QUARKUS-6472 and QUARKUS-6473, cc @michalvavrik 