### PR TITLE
Maven ITs - Reduce waiting times in multi-module tests

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -1406,14 +1406,6 @@ public class DevMojoIT extends LaunchMojoTestBase {
     }
 
     @Test
-    public void testMultiModuleDevModeWithoutJavaSrc() throws MavenInvocationException, IOException {
-        testDir = initProject("projects/multimodule", "projects/multimodule-no-java-src");
-        runAndCheck();
-
-        assertThat(running.log()).doesNotContain("The project's sources directory does not exist");
-    }
-
-    @Test
     public void testThatTheApplicationIsNotStartedWithoutBuildGoal() throws MavenInvocationException, IOException {
         testDir = initProject("projects/classic-no-build");
         run(true);

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/dependency/src/main/java/org/acme/dependency/Dummy.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/dependency/src/main/java/org/acme/dependency/Dummy.java
@@ -1,0 +1,4 @@
+package org.acme.dependency;
+
+public class Dummy {
+}


### PR DESCRIPTION
We were having a very long waiting time in multi-module tests due to the dependency module not having a class.
This was throwing an exception and then we were waiting forever before actually doing something else.

The fact that the project is empty is somehow related to the test I removed. The test was introduced in
https://github.com/quarkusio/quarkus/pull/9197 to check we didn't have a warning when there were no Java sources. Given we actually throw an exception in the multi-module project now if the classes are not around, it doesn't make a lot of sense to check for this warning anyway.
