### PR TITLE
Register `java.nio.Bits` fields for reflection

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
@@ -83,6 +84,7 @@ class NettyProcessor {
             NettyBuildTimeConfig config,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
+            BuildProducer<ReflectiveFieldBuildItem> reflectiveFields,
             List<MinNettyAllocatorMaxOrderBuildItem> minMaxOrderBuildItems) {
 
         reflectiveMethods.produce(
@@ -96,6 +98,13 @@ class NettyProcessor {
         reflectiveMethods.produce(
                 new ReflectiveMethodBuildItem("Reflectively accessed through PlatformDependent0's static initializer",
                         "java.nio.DirectByteBuffer", "<init>", new String[] { long.class.getName(), int.class.getName() }));
+
+        reflectiveFields.produce(
+                new ReflectiveFieldBuildItem("Reflectively accessed through PlatformDependent0's static initializer",
+                        "java.nio.Bits", "UNALIGNED"));
+        reflectiveFields.produce(
+                new ReflectiveFieldBuildItem("Reflectively accessed through PlatformDependent0's static initializer",
+                        "java.nio.Bits", "MAX_MEMORY"));
 
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.netty.channel.socket.nio.NioSocketChannel")
                 .build());


### PR DESCRIPTION
Register fields of `java.nio.Bits` that are reflectively accessed through `PlatformDependent0`'s static initializer

Related to https://github.com/quarkusio/quarkus/issues/50574

Will be needed once/if https://github.com/netty/netty/pull/15752 gets merged and backported to 4.1

Update: Backport PR https://github.com/netty/netty/pull/15774