### PR TITLE
container-image-docker-common: swallow stderr on success

### DIFF
--- a/extensions/container-image/container-image-docker-common/deployment/src/main/java/io/quarkus/container/image/docker/common/deployment/CommonProcessor.java
+++ b/extensions/container-image/container-image-docker-common/deployment/src/main/java/io/quarkus/container/image/docker/common/deployment/CommonProcessor.java
@@ -167,6 +167,7 @@ public abstract class CommonProcessor<C extends CommonConfig> {
             ProcessBuilder.newBuilder(executableName)
                     .arguments("login", registry, "-u", containerImageConfig.username().get(), "-p",
                             containerImageConfig.password().get())
+                    .error().logOnSuccess(false).inherited()
                     .run();
         }
     }
@@ -200,7 +201,9 @@ public abstract class CommonProcessor<C extends CommonConfig> {
                 .map(additionalTag -> new String[] { "tag", image, additionalTag })
                 .forEach(tagArgs -> {
                     LOGGER.infof("Running '%s %s'", executableName, String.join(" ", tagArgs));
-                    ProcessBuilder.exec(executableName, tagArgs);
+                    ProcessBuilder.newBuilder(executableName).arguments(tagArgs)
+                            .error().logOnSuccess(false).inherited()
+                            .run();
                 });
     }
 
@@ -214,7 +217,9 @@ public abstract class CommonProcessor<C extends CommonConfig> {
     }
 
     protected void pushImage(String image, String executableName, C config) {
-        ProcessBuilder.exec(executableName, createPushArgs(image, config));
+        ProcessBuilder.newBuilder(executableName).arguments(createPushArgs(image, config))
+                .error().logOnSuccess(false).inherited()
+                .run();
         LOGGER.infof("Successfully pushed %s image %s", getProcessorImplementation(), image);
     }
 
@@ -233,6 +238,7 @@ public abstract class CommonProcessor<C extends CommonConfig> {
         ProcessBuilder.newBuilder(executableName)
                 .directory(out.getOutputDirectory())
                 .arguments(args)
+                .error().logOnSuccess(false).inherited()
                 .run();
 
         if (createAdditionalTags && !containerImageInfo.getAdditionalImageTags().isEmpty()) {


### PR DESCRIPTION
fixes: #50568
relates to: #48959

### How I tested

```
./mvnw verify --batch-mode -f integration-tests/pom.xml -fn -Dnative
-Dquarkus.native.native-image-xmx=8g
-Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-25
-Dmaven.test.failure.ignore=true -Dno-format -Dtest-containers -Dstart-containers
-Ddocker -pl awt -Dquarkus.container-image.build=true -Dquarkus.native.container-build=true 
```

### Before patch

```
[INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor] Starting (local) container image build for jar using docker
[WARNING] [io.quarkus.container.image.docker.deployment.DockerProcessor] Using executable podman within the quarkus-container-image-docker extension. Maybe you should use the quarkus-container-image-podman extension instead?
[INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor] Executing the following command to build image: 'podman build -f /home/karm/workspaceRH/quarkus/integration-tests/awt/src/main/docker/Dockerfile.native -t karm/quarkus-integration-test-awt:999-SNAPSHOT /home/karm/workspaceRH/quarkus/integration-tests/awt'
[WARNING] [io.smallrye.common.process] SRCOM05000: Command podman (pid 1699671) completed but logged errors:
    
    (microdnf:2): librhsm-WARNING **: 23:27:22.170: Found 0 entitlement certificates
    
    (microdnf:2): librhsm-WARNING **: 23:27:22.171: Found 0 entitlement certificates
    
    (microdnf:1): librhsm-WARNING **: 23:27:26.340: Found 0 entitlement certificates
    
    (microdnf:1): librhsm-WARNING **: 23:27:26.341: Found 0 entitlement certificates
[INFO] [io.quarkus.container.image.docker.deployment.DockerProcessor] Built container image karm/quarkus-integration-test-awt:999-SNAPSHOT
```

### After patch

```
[INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor] Starting (local) container image build for jar using docker
[WARNING] [io.quarkus.container.image.docker.deployment.DockerProcessor] Using executable podman within the quarkus-container-image-docker extension. Maybe you should use the quarkus-container-image-podman extension instead?
[INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor] Executing the following command to build image: 'podman build -f /home/karm/workspaceRH/quarkus/integration-tests/awt/src/main/docker/Dockerfile.native -t karm/quarkus-integration-test-awt:999-SNAPSHOT /home/karm/workspaceRH/quarkus/integration-tests/awt'
[INFO] [io.quarkus.container.image.docker.deployment.DockerProcessor] Built container image karm/quarkus-integration-test-awt:999-SNAPSHOT
```