### PR TITLE
Pass app model location to Maven test process

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -14,6 +14,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.app.ApplicationModelSerializer;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
@@ -115,6 +116,13 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                             Path serializedTestAppModelPath = BootstrapUtils
                                     .getSerializedTestAppModelPath(Path.of(mavenProject().getBuild().getDirectory()));
                             ApplicationModelSerializer.serialize(appModel, serializedTestAppModelPath);
+
+                            //Pass the application model to the Surefire/Failsafe test process as a system property,
+                            //so it doesn't have to do a workspace search to find it. Same as we do for Gradle.
+                            Properties properties = mavenProject().getProperties();
+                            String argLine = properties.getProperty("argLine", "");
+                            properties.setProperty("argLine", argLine +
+                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=" + serializedTestAppModelPath);
                         } catch (IOException e) {
                             getLog().warn("Failed to serialize application model", e);
                         }


### PR DESCRIPTION
This aligns the behavior with the Gradle plugin and speeds up startup
because we no longer have to search for a POM file to find the workspace
location and load the app model.

It also makes Quarkus out-of-the-box compatible with Develocity test
distribution, because POMs are generally not transferred as inputs to the
distributed test workers.