### PR TITLE
NPE when invalid expression is evaluated with Qute debugger

### DIFF
--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/RemoteStackFrame.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/RemoteStackFrame.java
@@ -176,7 +176,15 @@ public class RemoteStackFrame extends StackFrame {
      * </p>
      */
     private CompletableFuture<Object> evaluateExpressionInRenderThread(String expression) {
-        return remoteThread.evaluateInRenderThread(() -> event.getContext().evaluate(expression).toCompletableFuture());
+        return remoteThread.evaluateInRenderThread(() -> {
+            try {
+                return event.getContext().evaluate(expression).toCompletableFuture();
+            } catch (Exception e) {
+                // ex : with expression 'http:', the getContext().evaluate(expression) throws a TemplateException
+                // with the message "Parser error: empty expression found {http:}"
+                return CompletableFuture.failedFuture(e);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
When an invalid expression like `http:` is evaluated there is an NPE:

```
2025-10-19 12:01:35,575 SEVERE [org.ecl.lsp.jso.RemoteEndpoint] (dap-daemon-thread) Internal error: Cannot invoke "java.util.concurrent.CompletableFuture.handle(java.util.function.BiFunction)" because the return value of "io.quarkus.qute.debug.agent.RemoteStackFrame.evaluate(String)" is null: java.lang.NullPointerException: Cannot invoke "java.util.concurrent.CompletableFuture.handle(java.util.function.BiFunction)" because the return value of "io.quarkus.qute.debug.agent.RemoteStackFrame.evaluate(String)" is null
	at io.quarkus.qute.debug.agent.evaluations.EvaluationSupport.evaluate(EvaluationSupport.java:60)
	at io.quarkus.qute.debug.agent.DebuggeeAgent.evaluate(DebuggeeAgent.java:441)
	at io.quarkus.qute.debug.adapter.DebugServerAdapter.evaluate(DebugServerAdapter.java:316)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)

```

And you see `Internal error` in the evaluation result:

<img width="766" height="120" alt="image" src="https://github.com/user-attachments/assets/a3736b07-9615-4a0c-a5c4-64d1a5438b4f" />

This PR fixes this NPE and allow to show the real error:

<img width="691" height="113" alt="image" src="https://github.com/user-attachments/assets/dc6c4e1b-12a1-41f1-af74-b50fc90b1ceb" />
