### PR TITLE
OIDC extensions: retrieve credentials from credentials provider asynchronously

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
@@ -37,6 +37,16 @@ public class OidcClientCredentialsTestCase {
     }
 
     @Test
+    public void testClientSecretBasicAuthSchemeRefresh() {
+        doTestGetTokenClient("named-1");
+    }
+
+    @Test
+    public void testClientSecretPostMethodRefresh() {
+        doTestGetTokenClient("named-2");
+    }
+
+    @Test
     public void testGetTokensOnDemand() {
         String[] tokens = RestAssured.when().get("/clients/tokenOnDemand").body().asString().split(" ");
         assertTokensNotNull(tokens);

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/SecretProvider.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/SecretProvider.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc.client;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
@@ -12,10 +13,23 @@ import io.quarkus.credentials.CredentialsProvider;
 @Named("vault-secret-provider")
 public class SecretProvider implements CredentialsProvider {
 
+    private final AtomicInteger namedClient1Counter = new AtomicInteger();
+    private final AtomicInteger namedClient2Counter = new AtomicInteger();
+
     @Override
     public Map<String, String> getCredentials(String credentialsProviderName) {
         Map<String, String> creds = new HashMap<>();
-        creds.put("secret-from-vault", "secret");
+
+        if ("named-1-client-secret".equals(credentialsProviderName)) {
+            boolean setCorrect = namedClient1Counter.incrementAndGet() == 2;
+            creds.put("secret-from-vault", setCorrect ? "secret" : "wrong-secret");
+        } else if ("named-2-client-secret".equals(credentialsProviderName)) {
+            boolean setCorrect = namedClient2Counter.incrementAndGet() == 2;
+            creds.put("secret-from-vault", setCorrect ? "secret" : "wrong-secret");
+        } else {
+            creds.put("secret-from-vault", "secret");
+        }
+
         return creds;
     }
 

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
@@ -10,3 +10,16 @@ quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.credentials.client-secret.provider.name=vault-secret-provider
 quarkus.oidc-client.credentials.client-secret.provider.keyring-name=oidc
 quarkus.oidc-client.credentials.client-secret.provider.key=secret-from-vault
+
+quarkus.oidc-client.named-1.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.named-1.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.named-1.credentials.client-secret.provider.name=${quarkus.oidc-client.credentials.client-secret.provider.name}
+quarkus.oidc-client.named-1.credentials.client-secret.provider.keyring-name=named-1-client-secret
+quarkus.oidc-client.named-1.credentials.client-secret.provider.key=${quarkus.oidc-client.credentials.client-secret.provider.key}
+
+quarkus.oidc-client.named-2.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.named-2.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.named-2.credentials.client-secret.provider.name=${quarkus.oidc-client.credentials.client-secret.provider.name}
+quarkus.oidc-client.named-2.credentials.client-secret.provider.keyring-name=named-2-client-secret
+quarkus.oidc-client.named-2.credentials.client-secret.provider.key=${quarkus.oidc-client.credentials.client-secret.provider.key}
+quarkus.oidc-client.named-2.credentials.client-secret.method=post

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -130,10 +130,10 @@ public class OidcClientRecorder {
             }
         }
         return tokenUrisUni.onItemOrFailure()
-                .transform(new BiFunction<OidcConfigurationMetadata, Throwable, OidcClient>() {
+                .transformToUni(new BiFunction<OidcConfigurationMetadata, Throwable, Uni<? extends OidcClient>>() {
 
                     @Override
-                    public OidcClient apply(OidcConfigurationMetadata metadata, Throwable t) {
+                    public Uni<OidcClient> apply(OidcConfigurationMetadata metadata, Throwable t) {
                         if (t != null) {
                             throw toOidcClientException(getEndpointUrl(oidcConfig), t);
                         }
@@ -189,7 +189,7 @@ public class OidcClientRecorder {
                         MultiMap commonRefreshGrantParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
                         setGrantClientParams(oidcConfig, commonRefreshGrantParams, OidcConstants.REFRESH_TOKEN_GRANT);
 
-                        return new OidcClientImpl(client, metadata.tokenRequestUri, metadata.tokenRevokeUri, grantType,
+                        return OidcClientImpl.of(client, metadata.tokenRequestUri, metadata.tokenRevokeUri, grantType,
                                 tokenGrantParams, commonRefreshGrantParams, oidcConfig, oidcRequestFilters,
                                 oidcResponseFilters, vertx);
                     }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowCredentialsProviderRefreshTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowCredentialsProviderRefreshTest.java
@@ -1,0 +1,134 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.credentials.CredentialsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+import io.smallrye.mutiny.Uni;
+
+@QuarkusTestResource(value = KeycloakTestResourceLifecycleManager.class)
+public class CodeFlowCredentialsProviderRefreshTest {
+
+    private static final String DEFAULT_TENANT = "default";
+    private static final String NAMED_TENANT = "named";
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ProtectedResource.class,
+                            ClientSecretProviderProducer.class)
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            # Disable Dev Services, we use a test resource manager
+                                            quarkus.keycloak.devservices.enabled=false
+
+                                            quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+                                            quarkus.oidc.client-id=quarkus-web-app
+                                            quarkus.oidc.credentials.client-secret.provider.name=client-secret-provider
+                                            quarkus.oidc.credentials.client-secret.provider.keyring-name=oidc-default-tenant
+                                            quarkus.oidc.credentials.client-secret.provider.key=first-wrong-then-right
+                                            quarkus.oidc.application-type=web-app
+                                            quarkus.oidc.logout.path=/protected/logout
+                                            quarkus.oidc.authentication.pkce-required=true
+
+                                            quarkus.oidc.named.auth-server-url=${quarkus.oidc.auth-server-url}
+                                            quarkus.oidc.named.client-id=${quarkus.oidc.client-id}
+                                            quarkus.oidc.named.credentials.client-secret.provider.name=${quarkus.oidc.credentials.client-secret.provider.name}
+                                            quarkus.oidc.named.credentials.client-secret.provider.keyring-name=oidc-named-tenant
+                                            quarkus.oidc.named.credentials.client-secret.provider.key=${quarkus.oidc.credentials.client-secret.provider.key}
+                                            quarkus.oidc.named.application-type=${quarkus.oidc.application-type}
+                                            quarkus.oidc.named.logout.path=${quarkus.oidc.logout.path}
+                                            quarkus.oidc.named.authentication.pkce-required=${quarkus.oidc.authentication.pkce-required}
+                                            quarkus.oidc.named.credentials.client-secret.method=post
+
+                                            quarkus.log.category."org.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+                                            quarkus.log.category."org.htmlunit.css".level=FATAL
+                                            quarkus.log.file.enabled=true
+                                            """),
+                            "application.properties"));
+
+    @Test
+    void testFailureHandlerForClientSecretBasicAuthScheme() throws IOException {
+        testCredentialsRefreshedOn401(DEFAULT_TENANT);
+    }
+
+    @Test
+    void testFailureHandlerForClientSecretPostAuth() throws IOException {
+        testCredentialsRefreshedOn401(NAMED_TENANT);
+    }
+
+    private static void testCredentialsRefreshedOn401(String tenant) throws IOException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/protected/tenant/" + tenant);
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getButtonByName("login").click();
+
+            assertEquals(tenant + ":alice", page.getBody().asNormalizedText());
+        }
+    }
+
+    private static WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+
+    public static class ClientSecretProviderProducer {
+
+        @ApplicationScoped
+        @Named("client-secret-provider")
+        @Produces
+        CredentialsProvider createCredentialsProvider() {
+            return new CredentialsProvider() {
+
+                private final AtomicInteger defaultTenantCounter = new AtomicInteger();
+                private final AtomicInteger namedTenantCounter = new AtomicInteger();
+
+                @Override
+                public Uni<Map<String, String>> getCredentialsAsync(String credentialsProviderName) {
+                    final Map<String, String> result;
+
+                    if ("oidc-default-tenant".equals(credentialsProviderName)) {
+                        boolean setCorrect = defaultTenantCounter.incrementAndGet() == 2;
+                        String secret = setCorrect ? "secret" : "wrong-secret";
+                        result = Map.of("first-wrong-then-right", secret);
+                    } else if ("oidc-named-tenant".equals(credentialsProviderName)) {
+                        boolean setCorrect = namedTenantCounter.incrementAndGet() == 2;
+                        String secret = setCorrect ? "secret" : "wrong-secret";
+                        result = Map.of("first-wrong-then-right", secret);
+                    } else {
+                        result = Map.of();
+                    }
+
+                    return Uni.createFrom().item(result);
+                }
+            };
+        }
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -1031,7 +1031,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         builder.audience(context.oidcConfig().clientId().get());
 
         JwtSignatureBuilder sigBuilder = builder.jws().header(INTERNAL_IDTOKEN_HEADER, true);
-        String clientOrJwtSecret = OidcCommonUtils.getClientOrJwtSecret(context.oidcConfig().credentials());
+        String clientOrJwtSecret = context.getOidcProviderClient().getClientOrJwtSecret();
         if (clientOrJwtSecret != null) {
             LOG.debug("Signing internal ID token with a configured client secret");
             return sigBuilder.sign(KeyUtils.createSecretKeyFromSecret(clientOrJwtSecret));

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -669,7 +669,7 @@ public class OidcProvider implements Closeable {
         }
 
         private Key initKey(Key generatedInternalSignatureKey) {
-            String clientSecret = OidcCommonUtils.getClientOrJwtSecret(oidcConfig.credentials());
+            String clientSecret = client.getClientSecret();
             if (clientSecret != null) {
                 LOG.debug("Verifying internal ID token with a configured client secret");
                 return KeyUtils.createSecretKeyFromSecret(clientSecret);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -54,13 +54,13 @@ public sealed interface TenantConfigContext permits TenantConfigContextImpl, Laz
         return Uni.createFrom().item(this);
     }
 
-    static TenantConfigContext createReady(OidcProvider provider, OidcTenantConfig config) {
-        return new TenantConfigContextImpl(provider, config);
+    static Uni<TenantConfigContext> createReady(OidcProvider provider, OidcTenantConfig config) {
+        return TenantConfigContextImpl.createReady(provider, config);
     }
 
     static TenantConfigContext createNotReady(OidcProvider provider, OidcTenantConfig config,
             Supplier<Uni<TenantConfigContext>> staticTenantCreator) {
-        var notReadyContext = new TenantConfigContextImpl(provider, config, false);
+        var notReadyContext = new TenantConfigContextImpl(provider, config, false, null);
         return new LazyTenantConfigContext(notReadyContext, staticTenantCreator);
     }
 }


### PR DESCRIPTION
- closes https://github.com/quarkusio/quarkus/issues/50056
- significant refactoring was required as credentials may not be resolved once on startup, we must accept that some credentials are resolved later like during request or when dynamic tenant is created during the request
- change is required as documentation says we must use asynchronous method https://github.com/quarkusio/quarkus/blob/cb7338252704063bba9312703ffc951a74803b52/extensions/credentials/runtime/src/main/java/io/quarkus/credentials/CredentialsProvider.java#L11