### PR TITLE
Refactor RemoteThread to improve section frame handling (#for, #each, #if)

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -45,6 +45,10 @@ public class LoopSectionHelper implements SectionHelper {
         this.engine = context.getEngine();
     }
 
+    public String getMetadataPrefix() {
+        return metadataPrefix;
+    }
+
     @Override
     public CompletionStage<ResultNode> resolve(SectionResolutionContext context) {
         return context.resolutionContext().evaluate(iterable).thenCompose(it -> {

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/DebuggeeAgent.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/DebuggeeAgent.java
@@ -1,6 +1,6 @@
 package io.quarkus.qute.debug.agent;
 
-import static io.quarkus.qute.debug.agent.RemoteStackFrame.EMPTY_STACK_FRAMES;
+import static io.quarkus.qute.debug.agent.frames.RemoteStackFrame.EMPTY_STACK_FRAMES;
 import static io.quarkus.qute.debug.agent.scopes.RemoteScope.EMPTY_SCOPES;
 
 import java.net.URI;
@@ -37,6 +37,7 @@ import io.quarkus.qute.debug.agent.breakpoints.BreakpointsRegistry;
 import io.quarkus.qute.debug.agent.breakpoints.RemoteBreakpoint;
 import io.quarkus.qute.debug.agent.completions.CompletionSupport;
 import io.quarkus.qute.debug.agent.evaluations.EvaluationSupport;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.source.SourceReferenceRegistry;
 import io.quarkus.qute.debug.agent.source.SourceTemplateRegistry;
 import io.quarkus.qute.debug.agent.variables.VariablesRegistry;
@@ -177,7 +178,7 @@ public class DebuggeeAgent implements Debugger {
      *
      * @param event the resolve event representing the current node.
      */
-    public void onTemplateNode(ResolveEvent event) {
+    public void onBeforeResolve(ResolveEvent event) {
         if (!isEnabled()) {
             return;
         }
@@ -188,7 +189,15 @@ public class DebuggeeAgent implements Debugger {
         output(args);
 
         RemoteThread debuggee = getOrCreateDebuggeeThread();
-        debuggee.onTemplateNode(event);
+        debuggee.onBeforeResolve(event);
+    }
+
+    public void onAfterResolve(ResolveEvent event) {
+        if (!isEnabled()) {
+            return;
+        }
+        RemoteThread debuggee = getOrCreateDebuggeeThread();
+        debuggee.onAfterResolve(event);
     }
 
     /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/DebuggerEvalContext.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/DebuggerEvalContext.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage;
 import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.ResolutionContext;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 
 /**
  * Implementation of {@link EvalContext} used by the Qute debugger.

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/DebuggerTraceListener.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/DebuggerTraceListener.java
@@ -39,7 +39,12 @@ public class DebuggerTraceListener implements TraceListener {
      */
     @Override
     public void onBeforeResolve(ResolveEvent event) {
-        agent.onTemplateNode(event);
+        agent.onBeforeResolve(event);
+    }
+
+    @Override
+    public void onAfterResolve(ResolveEvent event) {
+        agent.onAfterResolve(event);
     }
 
     /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/breakpoints/RemoteBreakpoint.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/breakpoints/RemoteBreakpoint.java
@@ -6,7 +6,7 @@ import org.eclipse.lsp4j.debug.Breakpoint;
 import org.eclipse.lsp4j.debug.Source;
 
 import io.quarkus.qute.TemplateNode;
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 
 /**
  * Represents a remote breakpoint set by the client through the Debug Adapter Protocol (DAP).

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/completions/CompletionContext.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/completions/CompletionContext.java
@@ -11,7 +11,7 @@ import org.eclipse.lsp4j.debug.CompletionItem;
 import org.eclipse.lsp4j.debug.CompletionItemType;
 import org.eclipse.lsp4j.debug.CompletionsResponse;
 
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.resolvers.ValueResolverContext;
 
 /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/completions/CompletionSupport.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/completions/CompletionSupport.java
@@ -8,7 +8,7 @@ import org.eclipse.lsp4j.debug.CompletionsArguments;
 import org.eclipse.lsp4j.debug.CompletionsResponse;
 
 import io.quarkus.qute.debug.agent.DebuggeeAgent;
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.resolvers.ValueResolverRegistry;
 
 /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/evaluations/EvaluationSupport.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/evaluations/EvaluationSupport.java
@@ -9,7 +9,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 
 import io.quarkus.qute.debug.agent.DebuggeeAgent;
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.variables.VariablesHelper;
 
 /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/frames/RemoteStackFrame.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/frames/RemoteStackFrame.java
@@ -1,4 +1,4 @@
-package io.quarkus.qute.debug.agent;
+package io.quarkus.qute.debug.agent.frames;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -13,6 +13,8 @@ import io.quarkus.qute.Engine;
 import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.TemplateNode;
 import io.quarkus.qute.TextNode;
+import io.quarkus.qute.debug.agent.DebuggerEvalContext;
+import io.quarkus.qute.debug.agent.RemoteThread;
 import io.quarkus.qute.debug.agent.evaluations.ConditionalExpressionHelper;
 import io.quarkus.qute.debug.agent.scopes.GlobalsScope;
 import io.quarkus.qute.debug.agent.scopes.LocalsScope;
@@ -263,7 +265,7 @@ public class RemoteStackFrame extends StackFrame {
     }
 
     /** @return the current {@link ResolveEvent} associated with this frame */
-    ResolveEvent getEvent() {
+    public ResolveEvent getEvent() {
         return event;
     }
 

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/frames/SectionFrameGroup.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/frames/SectionFrameGroup.java
@@ -1,0 +1,111 @@
+package io.quarkus.qute.debug.agent.frames;
+
+import java.util.LinkedList;
+
+import io.quarkus.qute.LoopSectionHelper;
+import io.quarkus.qute.Mapper;
+import io.quarkus.qute.SectionHelper;
+
+/**
+ * Represents a group of {@link RemoteStackFrame}s belonging to a Qute section
+ * (e.g. {@code #for}, {@code #if}, {@code #each}).
+ * <p>
+ * Each group tracks frames created within a single section instance and manages
+ * their lifecycle during template rendering:
+ * <ul>
+ * <li>When the section ends — all frames are removed.</li>
+ * <li>When a {@code #for} or {@code #each} loop advances to another iteration —
+ * the frames of the previous iteration are replaced.</li>
+ * </ul>
+ * </p>
+ */
+public class SectionFrameGroup {
+
+    private static final String ITERATION_ELEMENT_CLASS_NAME = "IterationElement"; // LoopSectionHelper$IterationElement
+
+    private final LinkedList<RemoteStackFrame> frames = new LinkedList<>();
+    private final String metadataIndex;
+    private int index;
+
+    public SectionFrameGroup(SectionHelper sectionHelper) {
+        this.metadataIndex = sectionHelper instanceof LoopSectionHelper loopSectionHelper
+                ? loopSectionHelper.getMetadataPrefix() + "index"
+                : null;
+    }
+
+    /**
+     * Returns the current iteration index (for {@code #for}/{@code #each}
+     * sections).
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * Sets a new iteration index and clears existing frames. This is typically
+     * called when a {@code #for} or {@code #each} section moves to the next
+     * iteration.
+     */
+    private void setIndex(int newIndex) {
+        this.index = newIndex;
+        this.frames.clear();
+    }
+
+    /**
+     * Adds a frame to this section group.
+     */
+    public void addFrame(RemoteStackFrame frame) {
+        frames.addFirst(frame);
+    }
+
+    /**
+     * Removes all frames of this section from the given thread frame list.
+     * <p>
+     * Used both when:
+     * <ul>
+     * <li>The section ends (e.g. {@code #endfor}, {@code #endif}).</li>
+     * <li>A {@code #for} or {@code #each} section advances to another
+     * iteration.</li>
+     * </ul>
+     * </p>
+     */
+    public void detachFrames(LinkedList<RemoteStackFrame> threadFrames) {
+        threadFrames.removeAll(frames);
+    }
+
+    /**
+     * Checks if the current iteration index has changed, and detaches the frames
+     * from the given thread frame list if needed.
+     *
+     * This is used for loop sections (#for, #each) in Qute. When the loop advances
+     * to a new iteration, the frames associated with the previous iteration must be
+     * removed from the thread's active stack.
+     *
+     * @param data the loop iteration element (expected class:
+     *        LoopSectionHelper$IterationElement)
+     * @param threadFrames the list of frames in the RemoteThread
+     */
+    public void detachFramesIfIndexChanged(Object data, LinkedList<RemoteStackFrame> threadFrames) {
+        if (metadataIndex != null && data instanceof Mapper mapper
+                && ITERATION_ELEMENT_CLASS_NAME.equals(data.getClass().getSimpleName())) {
+            // It is an LoopSectionHelper$IterationElement
+            try {
+                // Get the current index of LoopSectionHelper$IterationElement
+                var result = mapper.getAsync(metadataIndex).toCompletableFuture().getNow(null);
+                if (result instanceof Integer currentIndex) {
+                    // LoopSectionHelper$IterationElement#index has been collected
+                    if (currentIndex != this.index) {
+                        // index changed, remove frames from the current iteration
+                        detachFrames(threadFrames);
+                        // initialize with the new index
+                        setIndex(currentIndex);
+                    }
+                }
+            } catch (Exception e) {
+                // ignore error
+            }
+
+        }
+    }
+
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/resolvers/ValueResolverContext.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/resolvers/ValueResolverContext.java
@@ -3,7 +3,7 @@ package io.quarkus.qute.debug.agent.resolvers;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 
 /**
  * Context used by the debugger to collect properties and methods of an object

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/GlobalsScope.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/GlobalsScope.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import org.eclipse.lsp4j.debug.Variable;
 
 import io.quarkus.qute.ResolutionContext;
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.variables.VariablesRegistry;
 
 /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/LocalsScope.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/LocalsScope.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import org.eclipse.lsp4j.debug.Variable;
 
 import io.quarkus.qute.ResolutionContext;
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.variables.VariablesRegistry;
 
 /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/NamespaceResolversScope.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/NamespaceResolversScope.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import org.eclipse.lsp4j.debug.Variable;
 
 import io.quarkus.qute.Engine;
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.variables.VariablesHelper;
 import io.quarkus.qute.debug.agent.variables.VariablesRegistry;
 

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/RemoteScope.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/scopes/RemoteScope.java
@@ -10,7 +10,7 @@ import org.eclipse.lsp4j.debug.Variable;
 
 import io.quarkus.qute.Mapper;
 import io.quarkus.qute.ResolutionContext;
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.variables.VariablesProvider;
 import io.quarkus.qute.debug.agent.variables.VariablesRegistry;
 

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/variables/RemoteVariable.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/variables/RemoteVariable.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 
 import org.eclipse.lsp4j.debug.Variable;
 
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.resolvers.ValueResolverRegistry;
 
 /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/variables/VariableContext.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/variables/VariableContext.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import org.eclipse.lsp4j.debug.Variable;
 
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.resolvers.ValueResolverContext;
 
 /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/variables/VariablesHelper.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/variables/VariablesHelper.java
@@ -6,7 +6,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.lsp4j.debug.Variable;
 
-import io.quarkus.qute.debug.agent.RemoteStackFrame;
+import io.quarkus.qute.debug.agent.frames.RemoteStackFrame;
 import io.quarkus.qute.debug.agent.resolvers.ReflectionValueResolverCollector;
 
 /**

--- a/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/RenderTemplateInThread.java
+++ b/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/RenderTemplateInThread.java
@@ -21,7 +21,6 @@ public class RenderTemplateInThread {
 
     public void render() throws InterruptedException {
         Thread httpRequest = new Thread(() -> {
-
             var instance = template.instance(); //
             configure.accept(instance);
             instance.consume(renderResult::append);

--- a/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/DAPClient.java
+++ b/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/DAPClient.java
@@ -18,7 +18,6 @@ import org.eclipse.lsp4j.debug.CompletionsArguments;
 import org.eclipse.lsp4j.debug.CompletionsResponse;
 import org.eclipse.lsp4j.debug.ConfigurationDoneArguments;
 import org.eclipse.lsp4j.debug.ContinueArguments;
-import org.eclipse.lsp4j.debug.ContinueResponse;
 import org.eclipse.lsp4j.debug.EvaluateArguments;
 import org.eclipse.lsp4j.debug.EvaluateArgumentsContext;
 import org.eclipse.lsp4j.debug.EvaluateResponse;
@@ -148,13 +147,13 @@ public class DAPClient implements IDebugProtocolClient, Debugger {
         initialized.complete(null);
     }
 
-    public CompletableFuture<ContinueResponse> continue_(int threadId) {
+    public void continue_(int threadId) {
         if (debugProtocolServer == null) {
-            return CompletableFuture.completedFuture(null);
+            return;
         }
         ContinueArguments args = new ContinueArguments();
         args.setThreadId(threadId);
-        return debugProtocolServer.continue_(args);
+        getResult(debugProtocolServer.continue_(args));
     }
 
     public void next(int threadId) {
@@ -163,7 +162,7 @@ public class DAPClient implements IDebugProtocolClient, Debugger {
         }
         NextArguments args = new NextArguments();
         args.setThreadId(threadId);
-        debugProtocolServer.next(args);
+        getResult(debugProtocolServer.next(args));
     }
 
     public void stepOut(int threadId) {
@@ -181,7 +180,7 @@ public class DAPClient implements IDebugProtocolClient, Debugger {
         }
         StepInArguments args = new StepInArguments();
         args.setThreadId(threadId);
-        debugProtocolServer.stepIn(args);
+        getResult(debugProtocolServer.stepIn(args));
     }
 
     @Override
@@ -350,7 +349,7 @@ public class DAPClient implements IDebugProtocolClient, Debugger {
 
     private <T> T getResult(CompletableFuture<T> future) {
         try {
-            return future.get(3000, TimeUnit.DAYS);
+            return future.get(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             java.lang.Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/frames/NestedLoopIfBreakpointTest.java
+++ b/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/frames/NestedLoopIfBreakpointTest.java
@@ -1,0 +1,212 @@
+package io.quarkus.qute.debug.frames;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.lsp4j.debug.StackFrame;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.ReflectionValueResolver;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.debug.adapter.RegisterDebugServerAdapter;
+import io.quarkus.qute.debug.client.DAPClient;
+import io.quarkus.qute.debug.client.DebuggerUtils;
+
+/**
+ * Test class validating Qute debugger behavior for nested sections (#for / #if).
+ * <p>
+ * This test ensures that:
+ * <ul>
+ * <li>Stack frames are correctly grouped and ordered for nested Qute sections (e.g. nested {@code #for} and {@code #if}).</li>
+ * <li>Each iteration of a loop updates the section frame stack as expected.</li>
+ * <li>Conditional sections such as {@code #if} produce consistent frame entries during evaluation.</li>
+ * <li>The {@link io.quarkus.qute.debug.client.DAPClient} correctly steps through template nodes using {@code next()}.</li>
+ * </ul>
+ * <p>
+ * The tested template structure:
+ *
+ * <pre>
+ * &lt;html&gt;
+ *   {#for user in users}
+ *     {user.name}
+ *     {#for task in user.tasks}
+ *       {task}
+ *       {#if task_done}
+ *         Done
+ *       {/if}
+ *     {/for}
+ *   {/for}
+ * &lt;/html&gt;
+ * </pre>
+ * <p>
+ * For each step in the rendering process, the test sets a breakpoint and uses {@link DAPClient#next(int)}
+ * to verify that the reported stack frames correspond to the correct Qute AST nodes (HTML, section, or expression).
+ * <p>
+ * The test demonstrates that the debugger maintains proper frame grouping
+ * even with nested {@code #for} and {@code #if} constructs.
+ *
+ * @see io.quarkus.qute.debug.adapter.RegisterDebugServerAdapter
+ * @see io.quarkus.qute.debug.client.DAPClient
+ * @see io.quarkus.qute.debug.RenderTemplateInThread
+ * @see io.quarkus.qute.debug.agent.SectionFrameStack
+ */
+
+public class NestedLoopIfBreakpointTest {
+
+    private static final String TEMPLATE_ID = "nested.qute";
+
+    @Test
+    public void testNestedLoopsAndIfFrames() throws Exception {
+        int port = DebuggerUtils.findAvailableSocketPort();
+
+        Engine engine = Engine.builder()
+                .enableTracing(true)
+                .addEngineListener(new RegisterDebugServerAdapter(port, false))
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver())
+                .build();
+
+        Template template = engine.parse("<html>\n" +
+                "    {#for user in users}\n" +
+                "        {user.name}\n" +
+                "        {#for task in user.tasks}\n" +
+                "            {task}\n" +
+                "            {#if user.task_done}\n" +
+                "                Done\n" +
+                "            {/if}\n" +
+                "        {/for}\n" +
+                "    {/for}\n" +
+                "</html>", null, TEMPLATE_ID);
+
+        DAPClient client = new DAPClient();
+        client.connectToServer(port).get(10, TimeUnit.SECONDS);
+
+        // Set breakpoint at the start of the template
+        client.setBreakpoint("src/main/resources/templates/" + TEMPLATE_ID, 1);
+
+        final StringBuilder renderResult = new StringBuilder(1024);
+
+        // Start rendering in a thread
+        new io.quarkus.qute.debug.RenderTemplateInThread(template, renderResult, instance -> {
+            instance.data("users", List.of(
+                    new User("Alice", List.of("Task1", "Task2")),
+                    new User("Bob", List.of("Task3"))));
+        });
+
+        int threadId = client.getThreads()[0].getId();
+
+        // --- Step through template using next ---
+        // Each step, we check the full list of stack frames
+
+        // <html>
+        assertFrames(client, threadId,
+                "TextNode [value=<html>\n]");
+
+        // {#for user in users}
+        client.next(threadId);
+        assertFrames(client, threadId,
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:2]]",
+                "TextNode [value=<html>\n]");
+
+        // Alice user...
+
+        // {user.name} with Alice
+        client.next(threadId);
+        assertFrames(client, threadId,
+                "ExpressionNode [expression=Expression [namespace=null, parts=[user, name], literal=null]]",
+                "TextNode [value=        ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:2]]",
+                "TextNode [value=<html>\n]");
+
+        // {#for task in user.tasks} with Alice
+        client.next(threadId);
+        assertFrames(client, threadId,
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:4]]",
+                "TextNode [value=\n]",
+                "ExpressionNode [expression=Expression [namespace=null, parts=[user, name], literal=null]]",
+                "TextNode [value=        ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:2]]",
+                "TextNode [value=<html>\n]");
+
+        // {task} with Alice/Task1
+        client.next(threadId);
+        assertFrames(client, threadId,
+                "ExpressionNode [expression=Expression [namespace=null, parts=[task], literal=null]]",
+                "TextNode [value=            ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:4]]",
+                "TextNode [value=\n]",
+                "ExpressionNode [expression=Expression [namespace=null, parts=[user, name], literal=null]]",
+                "TextNode [value=        ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:2]]",
+                "TextNode [value=<html>\n]");
+
+        // {#if user.task_done} with Alice/Task1
+        client.next(threadId);
+        assertFrames(client, threadId,
+                "SectionNode [helper=IfSectionHelper, origin=  template [nested.qute:6]]",
+                "TextNode [value=\n]",
+                "ExpressionNode [expression=Expression [namespace=null, parts=[task], literal=null]]",
+                "TextNode [value=            ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:4]]",
+                "TextNode [value=\n]",
+                "ExpressionNode [expression=Expression [namespace=null, parts=[user, name], literal=null]]",
+                "TextNode [value=        ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:2]]",
+                "TextNode [value=<html>\n]");
+
+        // Done with Alice/Task1
+        client.stepIn(threadId); // use stepIn to suspend to the Done text node
+        assertFrames(client, threadId,
+                "TextNode [value=                Done\n]",
+                "SectionNode [helper=IfSectionHelper, origin=  template [nested.qute:6]]",
+                "TextNode [value=\n]",
+                "ExpressionNode [expression=Expression [namespace=null, parts=[task], literal=null]]",
+                "TextNode [value=            ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:4]]",
+                "TextNode [value=\n]",
+                "ExpressionNode [expression=Expression [namespace=null, parts=[user, name], literal=null]]",
+                "TextNode [value=        ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:2]]",
+                "TextNode [value=<html>\n]");
+
+        // {task} with Alice/Task2
+        client.next(threadId);
+        assertFrames(client, threadId,
+                "ExpressionNode [expression=Expression [namespace=null, parts=[task], literal=null]]",
+                "TextNode [value=            ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:4]]",
+                "TextNode [value=\n]",
+                "ExpressionNode [expression=Expression [namespace=null, parts=[user, name], literal=null]]",
+                "TextNode [value=        ]",
+                "SectionNode [helper=LoopSectionHelper, origin=  template [nested.qute:2]]",
+                "TextNode [value=<html>\n]");
+
+        client.terminate();
+    }
+
+    private void assertFrames(DAPClient client, int threadId, String... expectedFrameNames) throws Exception {
+        Thread.sleep(500); // allow debugger to catch up
+        StackFrame[] frames = client.getStackFrames(threadId);
+        //java.util.stream.Stream.of(frames).map(sf -> "\"" + sf.getName() + "\"").toList()
+        assertEquals(expectedFrameNames.length, frames.length, "Frame count mismatch");
+        for (int i = 0; i < frames.length; i++) {
+            assertEquals(expectedFrameNames[i], frames[i].getName(), "Frame at index " + i);
+        }
+    }
+
+    // Simple helper class for the test
+    static class User {
+        public String name;
+        public List<String> tasks;
+        public boolean task_done = true;
+
+        User(String name, List<String> tasks) {
+            this.name = name;
+            this.tasks = tasks;
+        }
+
+    }
+}


### PR DESCRIPTION
Refactors the RemoteThread class to improve the handling of section frames during template rendering in the Qute debugger. This change ensures consistent management of frame stacks for all section types, including loops (#for, #each) and other sections like conditionals (#if).

The usecase is when you are debugging for instance expression, text nodes inside a `#for` . When you are iterating twice you will see twice iteration before this PR:

<img width="1021" height="462" alt="image" src="https://github.com/user-attachments/assets/d1aa208f-c7f3-4660-81e9-93d94bb7d0a0" />

With this PR you will see just the current iteration:

<img width="1005" height="317" alt="image" src="https://github.com/user-attachments/assets/bc0e2354-2128-4e79-8b73-5d84d100bf4a" />
