### PR TITLE
Fix podman machine setup command order

### DIFF
--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -46,8 +46,8 @@ On systems which involve a Podman Machine managed VM (Mac & Windows), container 
 
 [source,bash]
 ----
-podman machine set --rootful=true # or false
 podman machine stop
+podman machine set --rootful=true # or false
 podman machine start
 ----
 


### PR DESCRIPTION
The machine needs to be stopped before being modified, otherwise:

```
$ podman machine set --rootful=true
Error: unable to change settings unless vm is stopped
```


