### PR TITLE
Improve DevUI hosts configuration documentation

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
@@ -37,8 +37,10 @@ public interface DevUIConfig {
      * More hosts allowed for Dev UI
      *
      * Comma separated list of valid URLs, e.g.: www.quarkus.io, myhost.com
-     * (This can also be a regex)
+     * (This can also be a regex, e.g.: ^([A-Za-z0-9-]+).apps.myhost.com)
      * By default localhost and 127.0.0.1 will always be allowed
+     *
+     * Note: Wildcards are not supported (e.g.: *.apps.myhost.com)
      */
     Optional<List<String>> hosts();
 


### PR DESCRIPTION
Enhanced the JavaDoc documentation for the `quarkus.dev-ui.hosts` configuration property to provide clearer guidance on regex usage and wildcard limitations.

Why This Change?
The previous documentation mentioned that regex patterns were supported but didn't provide any examples, which could lead to confusion about the expected syntax. Additionally, users might assume that shell-style wildcards are supported when they are not.

Impact
- Developer Experience: Developers will now have a clear example of how to write regex patterns for host matching
- Error Prevention: The explicit note about wildcard limitations will prevent common configuration errors
- Documentation Quality: More comprehensive and user-friendly configuration documentation