### PR TITLE
Fix version resolution in  CLI

### DIFF
--- a/devtools/cli-common/pom.xml
+++ b/devtools/cli-common/pom.xml
@@ -10,12 +10,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <properties>
-        <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
-    </properties>
-
     <artifactId>quarkus-cli-common</artifactId>
-    <name>Quarkus - Command Line Common Uitility Classes</name>
+    <name>Quarkus - Command Line Interface - Common Utility Classes</name>
     <description>Quarkus command line common utility classes</description>
 
     <dependencies>
@@ -34,6 +30,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-registry-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-project-core-extension-codestarts</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/VersionHelper.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/VersionHelper.java
@@ -34,7 +34,7 @@ public class VersionHelper {
                     props.load(is);
                 }
             }
-            version = props.getProperty("quarkus.version", "999-SNAPSHOT");
+            version = props.getProperty("quarkus-core-version", "999-SNAPSHOT");
         } catch (Exception e) {
             version = "999-SNAPSHOT"; // fallback version
         }

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/VersionHelper.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/VersionHelper.java
@@ -1,10 +1,12 @@
 package io.quarkus.cli.common;
 
-import java.io.InputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Properties;
+
+import io.quarkus.runtime.util.ClassPathUtils;
 
 /**
  * Helper class to get client version without circular dependencies
@@ -20,24 +22,31 @@ public class VersionHelper {
         final Properties props = new Properties();
         final URL quarkusPropertiesUrl = Thread.currentThread().getContextClassLoader().getResource("quarkus.properties");
         if (quarkusPropertiesUrl == null) {
-            return "999-SNAPSHOT"; // fallback version
+            throw new RuntimeException("Failed to locate quarkus.properties on the classpath");
         }
 
-        try {
-            // Handle file and jar URLs differently to avoid file locks on Windows
-            if (quarkusPropertiesUrl.getProtocol().equals("file")) {
-                try (InputStream is = Files.newInputStream(Paths.get(quarkusPropertiesUrl.toURI()))) {
-                    props.load(is);
+        // we have a special case for file and jar as using getResourceAsStream() on Windows might cause file locks
+        if ("file".equals(quarkusPropertiesUrl.getProtocol()) || "jar".equals(quarkusPropertiesUrl.getProtocol())) {
+            ClassPathUtils.consumeAsPath(quarkusPropertiesUrl, p -> {
+                try (BufferedReader reader = Files.newBufferedReader(p)) {
+                    props.load(reader);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to load quarkus.properties", e);
                 }
-            } else {
-                try (InputStream is = quarkusPropertiesUrl.openStream()) {
-                    props.load(is);
-                }
+            });
+        } else {
+            try {
+                props.load(Thread.currentThread().getContextClassLoader().getResourceAsStream("quarkus.properties"));
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to load quarkus.properties", e);
             }
-            version = props.getProperty("quarkus-core-version", "999-SNAPSHOT");
-        } catch (Exception e) {
-            version = "999-SNAPSHOT"; // fallback version
         }
+
+        version = props.getProperty("quarkus-core-version");
+        if (version == null) {
+            throw new RuntimeException("Failed to locate quarkus-core-version property in the bundled quarkus.properties");
+        }
+
         return version;
     }
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
@@ -18,6 +18,7 @@ public class CliVersionTest {
                 "Version output for command aliases should be the same.");
 
         CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "--version");
+        result2.echoSystemOut();
         Assertions.assertEquals(result.stdout, result2.stdout, "Version output for command aliases should be the same.");
     }
 }


### PR DESCRIPTION
This was broken in #49926 where the property name was changed mistakenly.

To be honest, I'm also not sure the new method is as safe as it used to be, especially on Windows as we also dropped the specific handling of the jar pattern. There was a specific comment about it in the preexisting method.
I suppose we will see how it goes...