### PR TITLE
Better error message for Funq when using `Byte[]` instead of `byte[]`

### DIFF
--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryArrayTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryArrayTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.funqy.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BadBinaryArrayTest {
+    @RegisterExtension
+    static QuarkusUnitTest test1 = assertException(BadBinaryOutputCE.class);
+    @RegisterExtension
+    static QuarkusUnitTest test2 = assertException(BadBinaryOutputRaw.class);
+    @RegisterExtension
+    static QuarkusUnitTest test3 = assertException(BadBinaryInputCE.class);
+    @RegisterExtension
+    static QuarkusUnitTest test4 = assertException(BadBinaryInputRaw.class);
+
+    private static QuarkusUnitTest assertException(Class<?> clazz) {
+        return new QuarkusUnitTest()
+                .withApplicationRoot(jar -> jar.addClass(clazz))
+                .assertException(throwable -> {
+                    // Traverse the cause chain to find the IllegalStateException
+                    Throwable current = throwable;
+                    IllegalStateException foundException = null;
+
+                    while (current != null) {
+                        if (current instanceof IllegalStateException) {
+                            foundException = (IllegalStateException) current;
+                            break;
+                        }
+                        current = current.getCause();
+                    }
+
+                    if (foundException == null) {
+                        fail("Expected IllegalStateException but got: " + throwable);
+                    }
+
+                    String message = foundException.getMessage();
+                    if (message == null) {
+                        fail("Exception message is null");
+                    }
+
+                    // Verify the exception message mentions the issue with Byte[] vs byte[]
+                    if (!message.contains("Byte[]") || !message.contains("byte[]")) {
+                        fail("Exception message should mention both 'Byte[]' and 'byte[]'. Got: " + message);
+                    }
+                });
+    }
+
+    @Test
+    void test() {
+        assertTrue(true);
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryInputCE.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryInputCE.java
@@ -1,0 +1,12 @@
+package io.quarkus.funqy.test;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEvent;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+
+public class BadBinaryInputCE {
+    @Funq
+    @CloudEventMapping(trigger = "test-bad-input-ce")
+    public void badInputCE(CloudEvent<Byte[]> data) {
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryInputRaw.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryInputRaw.java
@@ -1,0 +1,11 @@
+package io.quarkus.funqy.test;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+
+public class BadBinaryInputRaw {
+    @Funq
+    @CloudEventMapping(trigger = "test-bad-input-raw")
+    public void badInputRaw(Byte[] data) {
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryOutputCE.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryOutputCE.java
@@ -1,0 +1,19 @@
+package io.quarkus.funqy.test;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEvent;
+import io.quarkus.funqy.knative.events.CloudEventBuilder;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+
+public class BadBinaryOutputCE {
+    @Funq
+    @CloudEventMapping(trigger = "test-bad-output-ce")
+    public CloudEvent<Byte[]> badOutputCE() {
+        return CloudEventBuilder.create()
+                .specVersion("1.0")
+                .id("test-bad-output-ce")
+                .type("badOutputCE")
+                .source("/badOutputCE")
+                .build(new Byte[] {});
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryOutputRaw.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/BadBinaryOutputRaw.java
@@ -1,0 +1,12 @@
+package io.quarkus.funqy.test;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+
+public class BadBinaryOutputRaw {
+    @Funq
+    @CloudEventMapping(trigger = "test-bad-output-raw")
+    public Byte[] badOutputRaw() {
+        return new Byte[] {};
+    }
+}


### PR DESCRIPTION
A funq function may accept/return array of primitive bytes (`byte[]`).
However array of boxed bytes (`Byte[]`) is not allowed.

Sometimes some users mistakenly use the boxed variant. That resulted in non-descriptive exception when invoking the function.

This PR ensures that the exception is descriptive and thrown even before the function is invoked -- at static initialization time.