### PR TITLE
Reduce footprint of wiring classes generated by Gizmo 2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -583,7 +583,9 @@ public final class LoggingResourceProcessor {
     private static void generateMinLevelCompute(Map<String, CategoryBuildTimeConfig> categories,
             Map<String, InheritableLevel> categoryMinLevelDefaults, Level rootMinLevel,
             ClassOutput output) {
-        Gizmo g = Gizmo.create(output);
+        Gizmo g = Gizmo.create(output)
+                .withDebugInfo(false)
+                .withParameters(false);
         g.class_(MIN_LEVEL_COMPUTE_CLASS_NAME, cc -> {
             cc.final_();
             cc.staticMethod("isMinLevelEnabled", mc -> {
@@ -611,7 +613,9 @@ public final class LoggingResourceProcessor {
     }
 
     private static void generateDefaultLoggerNode(ClassOutput output) {
-        Gizmo g = Gizmo.create(output);
+        Gizmo g = Gizmo.create(output)
+                .withDebugInfo(false)
+                .withParameters(false);
         g.class_(LOGGER_NODE_CLASS_NAME, cc -> {
             cc.final_();
             cc.addAnnotation(TargetClass.class, ac -> ac.add(TargetClass::className, "org.jboss.logmanager.LoggerNode"));
@@ -630,7 +634,10 @@ public final class LoggingResourceProcessor {
 
     private static void generateLogManagerLogger(ClassOutput output,
             MinLevelEnabledFunction isMinLevelEnabledFunction) {
-        Gizmo.create(output).class_(LOGMANAGER_LOGGER_CLASS_NAME, cc -> {
+        Gizmo gizmo = Gizmo.create(output)
+                .withDebugInfo(false)
+                .withParameters(false);
+        gizmo.class_(LOGMANAGER_LOGGER_CLASS_NAME, cc -> {
             cc.final_();
             This this_ = cc.this_();
             cc.addAnnotation(TargetClass.class, ac -> ac.add(TargetClass::value, org.jboss.logmanager.Logger.class));
@@ -668,7 +675,9 @@ public final class LoggingResourceProcessor {
     }
 
     private static void generateDefaultLoggingLogger(Level minLevel, ClassOutput output) {
-        Gizmo gizmo = Gizmo.create(output);
+        Gizmo gizmo = Gizmo.create(output)
+                .withDebugInfo(false)
+                .withParameters(false);
         gizmo.class_(LOGGING_LOGGER_CLASS_NAME, cc -> {
             cc.final_();
             cc.addAnnotation(TargetClass.class, ac -> ac.add(TargetClass::className, "org.jboss.logging.Logger"));

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/AnnotationProxyProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/AnnotationProxyProvider.java
@@ -232,7 +232,10 @@ public class AnnotationProxyProvider {
 
         public A build(io.quarkus.gizmo2.ClassOutput classOutput) {
             generatedLiterals.computeIfAbsent(annotationLiteral, generatedName -> {
-                Gizmo.create(classOutput).class_(generatedName, cc -> {
+                Gizmo gizmo = Gizmo.create(classOutput)
+                        .withDebugInfo(false)
+                        .withParameters(false);
+                gizmo.class_(generatedName, cc -> {
                     ClassDesc annotationClassDesc = classDescOf(annotationInstance.name());
                     cc.extends_(GenericType.ofClass(AnnotationLiteral.class, TypeArgument.of(annotationClassDesc)));
                     cc.implements_(annotationClassDesc);

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CachedResultsProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CachedResultsProcessor.java
@@ -83,14 +83,16 @@ public class CachedResultsProcessor {
             BuildProducer<AdditionalCacheNameBuildItem> cacheNames,
             BuildProducer<CachedResultsDifferentiator> diffs) {
         ClassOutput classOutput = new GeneratedBeanGizmo2Adaptor(generatedBeans);
-        Gizmo gizmo = Gizmo.create(classOutput);
+        Gizmo gizmo = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
         // Generate a wrapper bean for each @CachedResults config
         // Note that config also includes the additional qualifiers declared at injection point
         // However, these qualifiers are only used to inject the delegate bean
         // The wrapper bean itself does not declare these additional qualifiers
         // Otherwise we would end up with ambiguous dependency while injecting the delegate
         // The injection point annotated with @CachedResults is transformed
-        // and additional qualifers are replaced with @CachedResultsDiff
+        // and additional qualifiers are replaced with @CachedResultsDiff
 
         for (CachedResultsInjectConfigBuildItem injectConfig : cachedResultsInjectConfigs) {
             CachedResultsInjectConfig config = injectConfig.getConfig();

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -343,7 +343,9 @@ class HibernateValidatorProcessor {
                 .methods().build());
 
         String builderClassName = HibernateBeanValidationConfigValidator.class.getName() + "Builder";
-        Gizmo gizmo = Gizmo.create(new GeneratedClassGizmo2Adaptor(generatedClass, generatedResource, true));
+        Gizmo gizmo = Gizmo.create(new GeneratedClassGizmo2Adaptor(generatedClass, generatedResource, true))
+                .withDebugInfo(false)
+                .withParameters(false);
         gizmo.class_(builderClassName, cc -> {
             cc.final_();
             cc.implements_(ConfigBuilder.class);

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -388,7 +388,9 @@ public class JacksonProcessor {
         }
 
         ClassOutput classOutput = new GeneratedBeanGizmo2Adaptor(generatedBeans);
-        Gizmo g = Gizmo.create(classOutput);
+        Gizmo g = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
         g.class_("io.quarkus.jackson.customizer.RegisterSerializersAndDeserializersCustomizer", cc -> {
             cc.implements_(ObjectMapperCustomizer.class);
             cc.defaultConstructor();

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -961,7 +961,10 @@ public class MessageBundleProcessor {
                 + SUFFIX;
         String resolveMethodPrefix = baseName + SUFFIX;
 
-        Gizmo.create(classOutput).class_(generatedClassName, cc -> {
+        Gizmo gizmo = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
+        gizmo.class_(generatedClassName, cc -> {
             // MyMessages_Bundle implements MyMessages, Resolver
             cc.implements_(classDescOf(bundleInterface));
             cc.implements_(Resolver.class);

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -306,7 +306,9 @@ class ReactiveRoutesProcessor {
                 return GeneratedClassGizmoAdaptor.isApplicationClass(className);
             }
         };
-        Gizmo gizmo = Gizmo.create(new GeneratedClassGizmo2Adaptor(generatedClass, generatedResource, appClassPredicate));
+        Gizmo gizmo = Gizmo.create(new GeneratedClassGizmo2Adaptor(generatedClass, generatedResource, appClassPredicate))
+                .withDebugInfo(false)
+                .withParameters(false);
         IndexView index = beanArchive.getIndex();
         Map<RouteMatcher, MethodInfo> matchers = new HashMap<>();
         boolean validatorAvailable = capabilities.isPresent(Capability.HIBERNATE_VALIDATOR);

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusInvokerFactory.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusInvokerFactory.java
@@ -60,7 +60,9 @@ public class QuarkusInvokerFactory implements EndpointInvokerFactory {
         }
         ClassOutput classOutput = new GeneratedClassGizmo2Adaptor(generatedClassBuildItemBuildProducer, null,
                 applicationClassPredicate.test(currentClassInfo.name().toString()));
-        Gizmo g = Gizmo.create(classOutput);
+        Gizmo g = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
         g.class_(baseName, cc -> {
             cc.defaultConstructor();
             cc.implements_(EndpointInvoker.class);

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -394,7 +394,9 @@ public class SchedulerProcessor {
         };
 
         ClassOutput classOutput = new GeneratedClassGizmo2Adaptor(generatedClasses, generatedResources, generatedToBaseNameFun);
-        Gizmo gizmo = Gizmo.create(classOutput);
+        Gizmo gizmo = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
 
         for (ScheduledBusinessMethodItem scheduledMethod : scheduledMethods) {
             MutableScheduledMethod metadata = new MutableScheduledMethod();

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
@@ -494,7 +494,9 @@ public class WebSocketProcessor {
                         return name;
                     }
                 });
-        Gizmo gizmo = Gizmo.create(classOutput);
+        Gizmo gizmo = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
         for (WebSocketEndpointBuildItem endpoint : endpoints) {
             // For each WebSocket endpoint bean we generate an implementation of WebSocketEndpoint
             // A new instance of this generated endpoint is created for each client connection

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/AbstractGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/AbstractGenerator.java
@@ -25,7 +25,9 @@ public abstract class AbstractGenerator {
     protected AbstractGenerator(IndexView index, ClassOutput classOutput) {
         this.generatedTypes = new HashSet<>();
         this.index = index;
-        this.gizmo = Gizmo.create(classOutput);
+        this.gizmo = Gizmo.create(classOutput)
+                .withDebugInfo(false)
+                .withParameters(false);
     }
 
     public Set<String> getGeneratedTypes() {


### PR DESCRIPTION
In all these wiring classes, we can do without parameters or debug info.

Gizmo 1 weren't adding parameters and debug info so we are on par with what we used to do with Gizmo 1.
