### PR TITLE
Fix overrides of deprecated `provideArguments` method

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractPathCustomisationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractPathCustomisationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import io.restassured.response.Response;
 
@@ -51,7 +52,7 @@ public abstract class AbstractPathCustomisationTest {
 
     static class TestArgumentsProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
             return Stream.of(
                     Arguments.of("/collections", "application/json"),
                     Arguments.of("/custom-collections/api", "application/json"),

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/AbstractPathCustomisationTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/AbstractPathCustomisationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import io.restassured.response.Response;
 
@@ -51,7 +52,7 @@ public abstract class AbstractPathCustomisationTest {
 
     static class TestArgumentsProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
             return Stream.of(
                     Arguments.of("/collections", "application/json"),
                     Arguments.of("/custom-collections/api", "application/json"),

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/testing/repro42006/Repro42006Test.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/testing/repro42006/Repro42006Test.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -25,7 +26,7 @@ public class Repro42006Test {
 
     private static class LambdaProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
             return Stream.of(
                     Arguments.of("SerializableSupplier", (SerializableSupplier) () -> "foo"),
                     Arguments.of("SerializableCustom", (SerializableCustom) () -> "bar"));


### PR DESCRIPTION
Removes build time warnings like the following:

```
 Warning: /home/runner/work/mandrel/mandrel/quarkus/integration-tests/main/src/test/java/io/quarkus/it/main/testing/repro42006/Repro42006Test.java:[28,44] provideArguments(org.junit.jupiter.api.extension.ExtensionContext) in  org.junit.jupiter.params.provider.ArgumentsProvider has been deprecated
```
