### PR TITLE
Disable warnings about unsafe usage of Unsafe in native

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -54,6 +54,7 @@ import io.quarkus.deployment.steps.NativeImageFeatureStep;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
 import io.quarkus.runtime.graal.DisableLoggingFeature;
+import io.quarkus.runtime.graal.JVMChecksFeature;
 import io.quarkus.sbom.ApplicationComponent;
 import io.quarkus.sbom.ApplicationManifestConfig;
 import io.smallrye.common.cpu.CPU;
@@ -88,6 +89,7 @@ public class NativeImageBuildStep {
     void nativeImageFeatures(BuildProducer<NativeImageFeatureBuildItem> features) {
         features.produce(new NativeImageFeatureBuildItem(NativeImageFeatureStep.GRAAL_FEATURE));
         features.produce(new NativeImageFeatureBuildItem(DisableLoggingFeature.class));
+        features.produce(new NativeImageFeatureBuildItem(JVMChecksFeature.class));
     }
 
     @BuildStep(onlyIf = NativeBuild.class)

--- a/core/runtime/src/main/java/io/quarkus/runtime/JVMChecksRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/JVMChecksRecorder.java
@@ -13,7 +13,7 @@ public class JVMChecksRecorder {
      * we know about the problem, we're working on it, and there's no need to print a warning scaring our
      * users with it.
      */
-    public void disableUnsafeRelatedWarnings() {
+    public static void disableUnsafeRelatedWarnings() {
         if (Runtime.version().feature() < 24) {
             return;
         }

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/JVMChecksFeature.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/JVMChecksFeature.java
@@ -1,0 +1,19 @@
+package io.quarkus.runtime.graal;
+
+import org.graalvm.nativeimage.hosted.Feature;
+
+import io.quarkus.runtime.JVMChecksRecorder;
+
+/**
+ * This is a horrible hack to disable the Unsafe-related warnings that are printed on startup:
+ * we know about the problem, we're working on it, and there's no need to print a warning scaring our
+ * users with it.
+ */
+public class JVMChecksFeature implements Feature {
+
+    @Override
+    public void duringSetup(Feature.DuringSetupAccess access) {
+        JVMChecksRecorder.disableUnsafeRelatedWarnings();
+    }
+
+}


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/49979 for native mode

Related to https://github.com/quarkusio/quarkus/issues/49978
