### PR TITLE
Make sure local quarkus-versions config are effective when the default registry provides its own

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -63,9 +63,9 @@ class RegistryExtensionResolver {
      */
     private final String offeringSupportKey;
 
-    RegistryExtensionResolver(RegistryClient extensionResolver, MessageWriter log) throws RegistryResolutionException {
-        this.extensionResolver = Objects.requireNonNull(extensionResolver, "Registry extension resolver is null");
-        this.config = extensionResolver.resolveRegistryConfig();
+    RegistryExtensionResolver(RegistryClient registryClient, MessageWriter log) throws RegistryResolutionException {
+        this.extensionResolver = Objects.requireNonNull(registryClient, "Registry extension resolver is null");
+        this.config = registryClient.resolveRegistryConfig();
 
         final String versionExpr = config.getQuarkusVersions() == null ? null
                 : config.getQuarkusVersions().getRecognizedVersionsExpression();

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfigImpl.java
@@ -56,7 +56,10 @@ public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersion
 
     @Override
     public int hashCode() {
-        return Objects.hash(exclusiveProvider, recognizedVersionsExpression);
+        int result = Objects.hashCode(recognizedVersionsExpression);
+        result = 31 * result + Objects.hashCode(recognizedGroupIds);
+        result = 31 * result + Boolean.hashCode(exclusiveProvider);
+        return result;
     }
 
     @Override
@@ -142,19 +145,25 @@ public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersion
     }
 
     static boolean quarkusVersionConfigEquals(RegistryQuarkusVersionsConfig v, Object o) {
-        if (v == o)
+        if (v == o) {
             return true;
-        if (!(o instanceof RegistryQuarkusVersionsConfig))
+        }
+        if (!(o instanceof RegistryQuarkusVersionsConfig that)) {
             return false;
-        RegistryQuarkusVersionsConfig that = (RegistryQuarkusVersionsConfig) o;
-        return v.isExclusiveProvider() == that.isExclusiveProvider()
-                && Objects.equals(v.getRecognizedVersionsExpression(), that.getRecognizedVersionsExpression());
+        }
+        if (v.isExclusiveProvider() != that.isExclusiveProvider()
+                || !Objects.equals(v.getRecognizedVersionsExpression(), that.getRecognizedVersionsExpression())
+                || v.getRecognizedGroupIds().size() != that.getRecognizedGroupIds().size()) {
+            return false;
+        }
+        return v.getRecognizedGroupIds().containsAll(that.getRecognizedGroupIds());
     }
 
     static String quarkusVersionConfigToString(RegistryQuarkusVersionsConfig v) {
         return "RegistryQuarkusVersionsConfig{" +
                 "exclusiveProvider=" + v.isExclusiveProvider() +
                 ", recognizedVersionsExpression='" + v.getRecognizedVersionsExpression() + '\'' +
+                ", recognizedGroupIds=" + v.getRecognizedGroupIds() +
                 '}';
     }
 }

--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/client/maven/MavenRegistryClientCompleteConfigTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/client/maven/MavenRegistryClientCompleteConfigTest.java
@@ -11,11 +11,12 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.config.RegistryConfig;
 import io.quarkus.registry.config.RegistryDescriptorConfig;
 import io.quarkus.registry.config.RegistryPlatformsConfig;
+import io.quarkus.registry.config.RegistryQuarkusVersionsConfig;
 
 public class MavenRegistryClientCompleteConfigTest {
 
     @Test
-    public void testCompletePlatformsConfig() throws Exception {
+    public void testCompletePlatformsConfig() {
 
         final RegistryDescriptorConfig descriptorConfig = RegistryDescriptorConfig.builder()
                 .setArtifact(ArtifactCoords.fromString("org.acme.registry:acme-registry-descriptor::json:1.0-SNAPSHOT"))
@@ -49,5 +50,48 @@ public class MavenRegistryClientCompleteConfigTest {
         assertThat(completePlatforms.getArtifact())
                 .isEqualTo(ArtifactCoords.fromString("org.acme.registry:acme-platforms::json:1.0-SNAPSHOT"));
         assertThat(completePlatforms.getExtensionCatalogsIncluded()).isTrue();
+    }
+
+    @Test
+    public void testRecognizedVersionOverride() {
+
+        final RegistryDescriptorConfig descriptorConfig = RegistryDescriptorConfig.builder()
+                .setArtifact(ArtifactCoords.fromString("org.acme.registry:acme-registry-descriptor::json:1.0-SNAPSHOT"))
+                .build();
+
+        final RegistryConfig.Mutable originalRegistryConfig = RegistryConfig.builder();
+        originalRegistryConfig.setId("acme-registry")
+                .setDescriptor(descriptorConfig)
+                .setPlatforms(RegistryPlatformsConfig.builder()
+                        .setArtifact(ArtifactCoords.fromString("org.acme.registry:acme-platforms::json:1.0-SNAPSHOT"))
+                        .build())
+                .setQuarkusVersions(RegistryQuarkusVersionsConfig.builder()
+                        .setRecognizedVersionsExpression("*acme-acme*")
+                        .setExclusiveProvider(true));
+
+        final RegistryConfig.Mutable registryDescriptor = RegistryConfig.builder();
+        registryDescriptor.setId("acme-registry")
+                .setDescriptor(descriptorConfig)
+                .setPlatforms(RegistryPlatformsConfig.builder()
+                        .setArtifact(ArtifactCoords.fromString("org.acme.registry:acme-platforms::json:1.0-SNAPSHOT"))
+                        .build())
+                .setQuarkusVersions(RegistryQuarkusVersionsConfig.builder()
+                        .setRecognizedGroupIds(List.of("org.acme"))
+                        .setRecognizedVersionsExpression("*acme*"));
+
+        final RegistryConfig.Mutable completeConfig = MavenRegistryClientFactory.completeRegistryConfig(originalRegistryConfig,
+                registryDescriptor);
+        assertThat(completeConfig.getId()).isEqualTo("acme-registry");
+        assertThat(completeConfig.getDescriptor().getArtifact())
+                .isEqualTo(ArtifactCoords.fromString("org.acme.registry:acme-registry-descriptor::json:1.0-SNAPSHOT"));
+        final RegistryPlatformsConfig completePlatforms = completeConfig.getPlatforms();
+        assertThat(completePlatforms).isNotNull();
+        assertThat(completePlatforms.getArtifact())
+                .isEqualTo(ArtifactCoords.fromString("org.acme.registry:acme-platforms::json:1.0-SNAPSHOT"));
+        assertThat(completeConfig.getQuarkusVersions())
+                .isEqualTo(RegistryQuarkusVersionsConfig.builder()
+                        .setRecognizedVersionsExpression("*acme-acme*")
+                        .setExclusiveProvider(true)
+                        .setRecognizedGroupIds(List.of("org.acme")));
     }
 }


### PR DESCRIPTION
This change makes sure a user can override `quarkus-versions` in the local registry client configuration.

Such as
```
registries:
  - registry.quarkus.redhat.com:
      quarkus-versions:
        recognized-versions-expression: "*redhat-*"
```