### PR TITLE
Update Derby to 10.16.1.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -126,7 +126,7 @@
         <mssql-jdbc.version>13.2.1.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
         <oracle-jdbc.version>23.6.0.24.10</oracle-jdbc.version>
-        <derby-jdbc.version>10.16.1.1</derby-jdbc.version>
+        <derby-jdbc.version>10.16.1.2</derby-jdbc.version>
         <db2-jdbc.version>12.1.0.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,17 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>nordix-artifactory</id>
+            <url>https://artifactory.nordix.org/artifactory/allies</url>
+            <name>allies</name>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
Derby 10.16.1.1 contains CVE-2022-46337

