### PR TITLE
Docs: Fix AcrValueValidator example to handle String 'acr' claim

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -1706,10 +1706,13 @@ Or, if you need more flexibility, write a <<jose4j-validator-bearer>>:
 ----
 package io.quarkus.it.oidc;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.jwt.Claims;
 import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.consumer.JwtContext;
 import org.jose4j.jwt.consumer.Validator;
@@ -1727,9 +1730,19 @@ public class AcrValueValidator implements Validator {
     @Override
     public String validate(JwtContext jwtContext) throws MalformedClaimException {
         var jwtClaims = jwtContext.getJwtClaims();
-        if (jwtClaims.hasClaim("acr")) {
-            var acrClaim = jwtClaims.getStringListClaimValue("acr");
-            if (acrClaim.contains("myACR") && acrClaim.contains("yourACR")) {
+        var acrClaimName = Claims.acr.name();
+
+        if (jwtClaims.hasClaim(acrClaimName)) {
+            // The claim 'acr' could be a String or a list
+            List<String> acrClaimValues;
+            if (jwtClaims.isClaimValueStringList(acrClaimName)) {
+               acrClaimValues = jwtClaims.getStringListClaimValue(acrClaimName);
+            } else if (jwtClaims.isClaimValueString(acrClaimName)) {
+               acrClaimValues = List.of(jwtClaims.getStringClaimValue(acrClaimName));
+            } else {
+                throw new MalformedClaimException("Claim '" + acrClaimName + "' is not a String or List of Strings.");
+            }
+            if (acrClaimValues.contains("myACR") && acrClaimValues.contains("yourACR")) {
                 return null;
             }
         }


### PR DESCRIPTION
This PR fixes the `AcrValueValidator` code example in the OIDC Step-Up Authentication guide.

The previous example incorrectly assumed the `acr` claim is always a `List<String>`. It used `jwtClaims.getStringListClaimValue("acr")`, which throws a `MalformedClaimException` if the `acr` claim is a single `String` (e.g., `"acr": "silver"`).

This exception was thrown before the validator's step-up logic (the `AuthenticationFailedException`) could be reached, causing the server to return a generic 401 `Bearer` challenge instead of the expected `insufficient_user_authentication` challenge.

This change updates the example to robustly handle both `String` and `List<String>` values for the `acr` claim, ensuring the step-up logic is correctly triggered in all cases.

Fixes https://github.com/quarkusio/quarkus/issues/50707 