### PR TITLE
Add test to command codestart

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/java/src/test/java/org/acme/GreetingCommandTest.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/java/src/test/java/org/acme/GreetingCommandTest.java
@@ -1,0 +1,29 @@
+package org.acme;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
+public class GreetingCommandTest {
+
+    @Test
+    public void testBasicLaunch(QuarkusMainLauncher launcher) {
+        LaunchResult result = launcher.launch();
+        assertTrue(result.getOutput().contains("Hello picocli, go go commando!"), result.getOutput());
+        assertEquals(result.exitCode(), 0);
+    }
+
+    @Test
+    @Launch({ "Alice" })
+    public void testLaunchWithArguments(LaunchResult result) {
+        assertTrue(result.getOutput().contains("Hello Alice, go go commando!"), result.getOutput());
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/kotlin/src/test/kotlin/org/acme/GreetingCommandTest.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/kotlin/src/test/kotlin/org/acme/GreetingCommandTest.kt
@@ -1,0 +1,28 @@
+package org.acme
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.Test
+
+import io.quarkus.test.junit.main.Launch
+import io.quarkus.test.junit.main.LaunchResult
+import io.quarkus.test.junit.main.QuarkusMainLauncher
+import io.quarkus.test.junit.main.QuarkusMainTest
+
+@QuarkusMainTest
+class GreetingCommandTest {
+
+    @Test
+    fun testBasicLaunch(launcher: QuarkusMainLauncher) {
+        val result = launcher.launch()
+        assertTrue(result.output.contains("Hello picocli, go go commando!"), result.output)
+        assertEquals(0, result.exitCode)
+    }
+
+    @Test
+    @Launch(["Alice"])
+    fun testLaunchWithArguments(result: LaunchResult) {
+        assertTrue(result.output.contains("Hello Alice, go go commando!"), result.output)
+    }
+}

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/PicocliCodestartTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/PicocliCodestartTest.java
@@ -29,6 +29,7 @@ public class PicocliCodestartTest {
     @Test
     void testContent() throws Throwable {
         codestartTest.checkGeneratedSource("org.acme.GreetingCommand");
+        codestartTest.checkGeneratedTestSource("org.acme.GreetingCommandTest");
 
         codestartTest.assertThatGeneratedFile(JAVA, "README.md")
                 .satisfies(checkContains("./mvnw quarkus:dev -Dquarkus.args='Quarky"));

--- a/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_test_java_ilove_quark_us_GreetingCommandTest.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_test_java_ilove_quark_us_GreetingCommandTest.java
@@ -1,0 +1,29 @@
+package ilove.quark.us;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
+public class GreetingCommandTest {
+
+    @Test
+    public void testBasicLaunch(QuarkusMainLauncher launcher) {
+        LaunchResult result = launcher.launch();
+        assertTrue(result.getOutput().contains("Hello picocli, go go commando!"), result.getOutput());
+        assertEquals(result.exitCode(), 0);
+    }
+
+    @Test
+    @Launch({ "Alice" })
+    public void testLaunchWithArguments(LaunchResult result) {
+        assertTrue(result.getOutput().contains("Hello Alice, go go commando!"), result.getOutput());
+    }
+
+}

--- a/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_test_kotlin_ilove_quark_us_GreetingCommandTest.kt
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_test_kotlin_ilove_quark_us_GreetingCommandTest.kt
@@ -1,0 +1,28 @@
+package ilove.quark.us
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.Test
+
+import io.quarkus.test.junit.main.Launch
+import io.quarkus.test.junit.main.LaunchResult
+import io.quarkus.test.junit.main.QuarkusMainLauncher
+import io.quarkus.test.junit.main.QuarkusMainTest
+
+@QuarkusMainTest
+class GreetingCommandTest {
+
+    @Test
+    fun testBasicLaunch(launcher: QuarkusMainLauncher) {
+        val result = launcher.launch()
+        assertTrue(result.output.contains("Hello picocli, go go commando!"), result.output)
+        assertEquals(0, result.exitCode)
+    }
+
+    @Test
+    @Launch(["Alice"])
+    fun testLaunchWithArguments(result: LaunchResult) {
+        assertTrue(result.output.contains("Hello Alice, go go commando!"), result.output)
+    }
+}


### PR DESCRIPTION
A couple of times in the past few weeks I've tripped over the fact that the command codestart didn't have tests, and had to write some manually. This would be harder for people who didn't already know the structure of our testing framework.