### PR TITLE
Allow forcing exception unwrapping even when parent type mappers exist

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -2422,6 +2422,36 @@ public class Mapper {
 
 }
 ----
+
+By default, `@UnwrapException` only unwraps exceptions when no exception mapper exists for the wrapper exception or its parent types.
+You can control the unwrapping behavior using the `strategy` attribute with one of the following values:
+
+* `ExceptionUnwrapStrategy.UNWRAP_IF_NO_MATCH` (default): Unwraps only if neither the thrown exception nor any of its supertypes have a registered mapper. Checks the entire type hierarchy before unwrapping.
+* `ExceptionUnwrapStrategy.UNWRAP_IF_NO_EXACT_MATCH`: Unwraps if the thrown exception type itself has no exact mapper registered. Checks for an exact match first, then unwraps if none is found.
+* `ExceptionUnwrapStrategy.ALWAYS`: Always unwraps exception before checking mappers. Only falls back to checking mappers for the wrapper exception if no mapper is found for any unwrapped cause.
+
+[source,java]
+----
+@UnwrapException(value = {WebApplicationException.class}, strategy = ExceptionUnwrapStrategy.UNWRAP_IF_NO_EXACT_MATCH)
+public class Mappers {
+
+    @ServerExceptionMapper
+    public Response handleRuntimeException(RuntimeException ex) {
+        // Handles RuntimeException and its subclasses
+        return Response.status(599).build();
+    }
+
+    @ServerExceptionMapper
+    public Response handleJsonProcessingException(JsonProcessingException ex) {
+        // This will be called for JsonProcessingException wrapped in WebApplicationException
+        // because UNWRAP_IF_NO_EXACT_MATCH forces unwrapping even though RuntimeException mapper that would match WebApplicationException exists
+        return Response.status(400).entity("Invalid JSON").build();
+    }
+
+}
+----
+
+This is useful when you have a general exception mapper for a parent type (like `RuntimeException`) but want to handle specific wrapped exceptions differently.
 ====
 
 [NOTE]

--- a/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/UnwrappedExceptionBuildItem.java
+++ b/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/UnwrappedExceptionBuildItem.java
@@ -1,21 +1,35 @@
 package io.quarkus.resteasy.reactive.server.spi;
 
+import org.jboss.resteasy.reactive.server.ExceptionUnwrapStrategy;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * When an {@link Exception} of this type is thrown and no {@code jakarta.ws.rs.ext.ExceptionMapper} exists,
  * then RESTEasy Reactive will attempt to locate an {@code ExceptionMapper} for the cause of the Exception.
+ * <p>
+ * The unwrapping behavior is controlled by the {@link ExceptionUnwrapStrategy}.
  */
 public final class UnwrappedExceptionBuildItem extends MultiBuildItem {
 
     private final String throwableClassName;
+    private final ExceptionUnwrapStrategy strategy;
 
     public UnwrappedExceptionBuildItem(String throwableClassName) {
+        this(throwableClassName, ExceptionUnwrapStrategy.UNWRAP_IF_NO_MATCH);
+    }
+
+    public UnwrappedExceptionBuildItem(String throwableClassName, ExceptionUnwrapStrategy strategy) {
         this.throwableClassName = throwableClassName;
+        this.strategy = strategy;
     }
 
     public UnwrappedExceptionBuildItem(Class<? extends Throwable> throwableClassName) {
-        this.throwableClassName = throwableClassName.getName();
+        this(throwableClassName.getName(), ExceptionUnwrapStrategy.UNWRAP_IF_NO_MATCH);
+    }
+
+    public UnwrappedExceptionBuildItem(Class<? extends Throwable> throwableClassName, ExceptionUnwrapStrategy strategy) {
+        this(throwableClassName.getName(), strategy);
     }
 
     @Deprecated(forRemoval = true)
@@ -30,5 +44,9 @@ public final class UnwrappedExceptionBuildItem extends MultiBuildItem {
 
     public String getThrowableClassName() {
         return throwableClassName;
+    }
+
+    public ExceptionUnwrapStrategy getStrategy() {
+        return strategy;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ExceptionUnwrapStrategy.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ExceptionUnwrapStrategy.java
@@ -1,0 +1,24 @@
+package org.jboss.resteasy.reactive.server;
+
+/**
+ * Defines the strategy for unwrapping exceptions during exception handling.
+ */
+public enum ExceptionUnwrapStrategy {
+    /**
+     * Always unwraps exception of this type before checking mappers.
+     * Only falls back to checking mappers for the wrapper exception if no mapper is found for any unwrapped cause.
+     */
+    ALWAYS,
+
+    /**
+     * Unwraps exception only if the thrown exception type itself has no exact mapper registered.
+     * Checks for an exact match first, then unwraps if none is found.
+     */
+    UNWRAP_IF_NO_EXACT_MATCH,
+
+    /**
+     * Unwraps exceptions only if neither the thrown exception nor any of its supertypes have a registered mapper.
+     * Checks the entire type hierarchy before unwrapping.
+     */
+    UNWRAP_IF_NO_MATCH
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/UnwrapException.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/UnwrapException.java
@@ -8,9 +8,36 @@ import java.lang.annotation.Target;
 /**
  * Used to configure that an exception (or exceptions) should be unwrapped during exception handling.
  * <p>
- * Unwrapping means that when an {@link Exception} of the configured type is thrown and no
- * {@code jakarta.ws.rs.ext.ExceptionMapper} exists,
- * then RESTEasy Reactive will attempt to locate an {@code ExceptionMapper} for the cause of the Exception.
+ * Unwrapping means that when an {@link Exception} of the configured type is thrown,
+ * RESTEasy Reactive will attempt to locate an {@code ExceptionMapper} for the cause of the Exception.
+ * <p>
+ * The unwrapping behavior is controlled by the {@link #strategy()} attribute:
+ * <ul>
+ * <li>{@link ExceptionUnwrapStrategy#ALWAYS}: Always unwraps before checking mappers. Only falls back to
+ * checking mappers for the wrapper if no mapper is found for any unwrapped cause.</li>
+ * <li>{@link ExceptionUnwrapStrategy#UNWRAP_IF_NO_EXACT_MATCH}: Unwraps only if the thrown exception type
+ * itself has no exact mapper. Checks for exact match first, then unwraps if none found.</li>
+ * <li>{@link ExceptionUnwrapStrategy#UNWRAP_IF_NO_MATCH} (default): Unwraps only if neither the thrown
+ * exception nor any of its supertypes have a registered mapper.</li>
+ * </ul>
+ * <p>
+ * Example:
+ *
+ * <pre>
+ * &#64;UnwrapException(value = { WebApplicationException.class }, strategy = ExceptionUnwrapStrategy.UNWRAP_IF_NO_EXACT_MATCH)
+ * public class ExceptionsMappers {
+ *     &#64;ServerExceptionMapper
+ *     public RestResponse&lt;Error&gt; mapUnhandledException(RuntimeException ex) {
+ *         // Handles RuntimeException and its subclasses
+ *     }
+ *
+ *     &#64;ServerExceptionMapper
+ *     public RestResponse&lt;Error&gt; mapJsonProcessingException(JsonProcessingException ex) {
+ *         // This will be called for JsonProcessingException wrapped in WebApplicationException
+ *         // because UNWRAP_IF_NO_EXACT_MATCH forces unwrapping even though RuntimeException mapper exists
+ *     }
+ * }
+ * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -20,4 +47,11 @@ public @interface UnwrapException {
      * If this is not set, the value is assumed to be the exception class where the annotation is placed
      */
     Class<? extends Exception>[] value() default {};
+
+    /**
+     * The unwrapping strategy to use for this exception.
+     * <p>
+     * Defaults to {@link ExceptionUnwrapStrategy#UNWRAP_IF_NO_MATCH}.
+     */
+    ExceptionUnwrapStrategy strategy() default ExceptionUnwrapStrategy.UNWRAP_IF_NO_MATCH;
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ExceptionMapping.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ExceptionMapping.java
@@ -3,15 +3,14 @@ package org.jboss.resteasy.reactive.server.core;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.jboss.resteasy.reactive.common.model.ResourceExceptionMapper;
+import org.jboss.resteasy.reactive.server.ExceptionUnwrapStrategy;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 
 @SuppressWarnings({ "unchecked", "unused" })
@@ -39,7 +38,7 @@ public class ExceptionMapping {
      */
     final List<Predicate<Throwable>> blockingProblemPredicates = new ArrayList<>();
     final List<Predicate<Throwable>> nonBlockingProblemPredicate = new ArrayList<>();
-    final Set<String> unwrappedExceptions = new HashSet<>();
+    final Map<String, ExceptionUnwrapStrategy> unwrappedExceptions = new HashMap<>();
 
     public void addBlockingProblem(Class<? extends Throwable> throwable) {
         blockingProblemPredicates.add(new ExceptionTypePredicate(throwable));
@@ -57,11 +56,11 @@ public class ExceptionMapping {
         nonBlockingProblemPredicate.add(predicate);
     }
 
-    public void addUnwrappedException(String className) {
-        unwrappedExceptions.add(className);
+    public void addUnwrappedException(String className, ExceptionUnwrapStrategy strategy) {
+        unwrappedExceptions.put(className, strategy);
     }
 
-    public Set<String> getUnwrappedExceptions() {
+    public Map<String, ExceptionUnwrapStrategy> getUnwrappedExceptions() {
         return unwrappedExceptions;
     }
 

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/customexceptions/UnwrappedExceptionTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/customexceptions/UnwrappedExceptionTest.java
@@ -10,7 +10,9 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.jandex.IndexView;
+import org.jboss.resteasy.reactive.server.ExceptionUnwrapStrategy;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.server.core.ExceptionMapping;
 import org.jboss.resteasy.reactive.server.processor.ResteasyReactiveDeploymentManager;
 import org.jboss.resteasy.reactive.server.processor.ScannedApplication;
 import org.jboss.resteasy.reactive.server.processor.scanning.FeatureScanner;
@@ -24,6 +26,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.restassured.RestAssured;
 
 public class UnwrappedExceptionTest {
+    public static final int NO_MAPPER_FOUND_STATUS = 500;
+    public static final int WRAPPER_MAPPER_USED_STATUS = 977;
+    public static final int INTERMEDIATE_MAPPER_USED_STATUS = 988;
+    public static final int WRAPPED_MAPPER_USED_STATUS = 999;
 
     @RegisterExtension
     static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
@@ -33,7 +39,22 @@ public class UnwrappedExceptionTest {
                     scanStep.addFeatureScanner(new FeatureScanner() {
                         @Override
                         public FeatureScanResult integrate(IndexView application, ScannedApplication scannedApplication) {
-                            scannedApplication.getExceptionMappers().addUnwrappedException(TestUnwrapException.class.getName());
+                            ExceptionMapping exceptionMapping = scannedApplication.getExceptionMappers();
+                            exceptionMapping.addUnwrappedException(
+                                    UnwrapIfNoMatchException.class.getName(),
+                                    ExceptionUnwrapStrategy.UNWRAP_IF_NO_MATCH);
+                            exceptionMapping.addUnwrappedException(
+                                    UnwrapIfNoMatchWithIntermediateException.class.getName(),
+                                    ExceptionUnwrapStrategy.UNWRAP_IF_NO_MATCH);
+                            exceptionMapping.addUnwrappedException(
+                                    UnwrapIfNoExactMatchException.class.getName(),
+                                    ExceptionUnwrapStrategy.UNWRAP_IF_NO_EXACT_MATCH);
+                            exceptionMapping.addUnwrappedException(
+                                    UnwrapIfNoExactMatchDirectlyMappedException.class.getName(),
+                                    ExceptionUnwrapStrategy.UNWRAP_IF_NO_EXACT_MATCH);
+                            exceptionMapping.addUnwrappedException(
+                                    UnwrapAlwaysException.class.getName(),
+                                    ExceptionUnwrapStrategy.ALWAYS);
                             return new FeatureScanResult(List.of());
                         }
                     });
@@ -44,85 +65,209 @@ public class UnwrappedExceptionTest {
                 public JavaArchive get() {
                     return ShrinkWrap.create(JavaArchive.class)
                             .addClasses(ExceptionResource.class, ExceptionMappers.class, ExceptionUtil.class,
-                                    TestUnwrapException.class);
+                                    UnwrapIfNoMatchException.class);
                 }
             });
 
     @Test
-    public void testWrapperWithUnmappedException() {
-        RestAssured.get("/hello/wrapperOfIAE")
-                .then().statusCode(500);
+    public void testWrapperOfUnmapped() {
+        // Exception is wrapping an unmapped exception
+        // => No mapper should be used, error 500
+        RestAssured.get("/hello/wrapperOfUnmapped")
+                .then().statusCode(NO_MAPPER_FOUND_STATUS);
     }
 
     @Test
-    public void testWrapperWithMappedException() {
-        RestAssured.get("/hello/wrapperOfISE")
-                .then().statusCode(999);
+    public void testWrapperIfNoMatchOfMapped() {
+        // Exception is wrapping a mapped exception with UNWRAP_IF_NO_MATCH strategy
+        // => Wrapped exception mapper should be used since UnwrapIfNoMatchException is not mapped directly
+        RestAssured.get("/hello/wrapperIfNoMatchOfMapped")
+                .then().statusCode(WRAPPED_MAPPER_USED_STATUS);
     }
 
     @Test
-    public void testUnmappedException() {
-        RestAssured.get("/hello/iae")
-                .then().statusCode(500);
+    public void testWrapperIfNoMatchWithIntermediateOfMapped() {
+        // Exception is wrapping a mapped exception with UNWRAP_IF_NO_MATCH strategy
+        // => Intermediate exception mapper should be used since UnwrapIfNoMatchWithIntermediateException is not mapped directly but its child is
+        RestAssured.get("/hello/wrapperIfNoMatchWithIntermediateOfMapped")
+                .then().statusCode(INTERMEDIATE_MAPPER_USED_STATUS);
     }
 
     @Test
-    public void testMappedException() {
-        RestAssured.get("/hello/ise")
-                .then().statusCode(999);
+    public void testUnmapped() {
+        // Exception is unmapped
+        // => No mapper should be used, error 500
+        RestAssured.get("/hello/unmapped")
+                .then().statusCode(NO_MAPPER_FOUND_STATUS);
+    }
+
+    @Test
+    public void testWrappedDirectlyThrown() {
+        // Exception is thrown directly
+        // => Its specific exception mapper should be used
+        RestAssured.get("/hello/wrappedDirectlyThrown")
+                .then().statusCode(WRAPPED_MAPPER_USED_STATUS);
+    }
+
+    @Test
+    public void testIntermediateThrownWithoutWrappedChild() {
+        // Exception is thrown without a wrapped child
+        // => Its specific exception mapper should be used
+        RestAssured.get("/hello/intermediateThrownWithoutWrappedChild")
+                .then().statusCode(INTERMEDIATE_MAPPER_USED_STATUS);
+    }
+
+    @Test
+    public void testWrapperIfNoExactMatchOfMapped() {
+        // Exception is wrapping a mapped exception with UNWRAP_IF_NO_EXACT_MATCH strategy
+        // => Wrapped exception mapper should be used
+        RestAssured.get("/hello/wrapperIfNoExactMatchOfMapped")
+                .then().statusCode(WRAPPED_MAPPER_USED_STATUS);
+    }
+
+    @Test
+    public void testWrapperIfNoExactMatchDirectlyMapped() {
+        // Exception is wrapping a mapped exception with UNWRAP_IF_NO_EXACT_MATCH strategy, but is also directly mapped
+        // => Direct mapper should be used
+        RestAssured.get("/hello/wrapperIfNoExactMatchDirectlyMapped")
+                .then().statusCode(WRAPPER_MAPPER_USED_STATUS);
+    }
+
+    @Test
+    public void testAlwaysUnwrapsEvenWithParentMapper() {
+        // Exception with ALWAYS strategy wrapping a specific mapped exception
+        // Even though UnwrapAlwaysException extends IntermediateMappedException (which has a mapper),
+        // it should unwrap and use the SpecificException mapper
+        RestAssured.get("/hello/alwaysUnwrapsEvenWithParentMapper")
+                .then().statusCode(WRAPPED_MAPPER_USED_STATUS);
+    }
+
+    @Test
+    public void testAlwaysFallsBackToWrapperWhenNoCauseMapper() {
+        // Exception with ALWAYS strategy wrapping an unmapped exception
+        // Should fall back to the wrapper's parent mapper (IntermediateMappedException)
+        RestAssured.get("/hello/alwaysFallsBackToWrapperWhenNoCauseMapper")
+                .then().statusCode(WRAPPER_MAPPER_USED_STATUS);
     }
 
     @Path("hello")
     public static class ExceptionResource {
 
-        @Path("wrapperOfIAE")
-        public String wrapperOfIAE() {
-            throw removeStackTrace(new TestUnwrapException(removeStackTrace(new IllegalArgumentException())));
+        @Path("wrapperOfUnmapped")
+        public String wrapperOfUnmapped() {
+            throw removeStackTrace(new UnwrapIfNoMatchException(removeStackTrace(new IllegalArgumentException())));
         }
 
-        @Path("wrapperOfISE")
-        public String wrapperOfISE() {
-            throw removeStackTrace(new TestUnwrapException(removeStackTrace(new IllegalStateException())));
+        @Path("wrapperIfNoMatchOfMapped")
+        public String wrapperIfNoMatchOfMapped() {
+            throw removeStackTrace(new UnwrapIfNoMatchException(removeStackTrace(new WrappedException())));
         }
 
-        @Path("iae")
-        public String iae() {
+        @Path("wrapperIfNoMatchWithIntermediateOfMapped")
+        public String wrapperIfNoMatchWithIntermediateOfMapped() {
+            throw removeStackTrace(new UnwrapIfNoMatchWithIntermediateException(removeStackTrace(new WrappedException())));
+        }
+
+        @Path("unmapped")
+        public String unmapped() {
             throw removeStackTrace(new IllegalArgumentException());
         }
 
-        @Path("ise")
-        public String ise() {
-            throw removeStackTrace(new IllegalStateException());
+        @Path("wrappedDirectlyThrown")
+        public String wrappedDirectlyThrown() {
+            throw removeStackTrace(new WrappedException());
+        }
+
+        @Path("intermediateThrownWithoutWrappedChild")
+        public String intermediateThrownWithoutWrappedChild() {
+            throw removeStackTrace(new UnwrapIfNoExactMatchException());
+        }
+
+        @Path("wrapperIfNoExactMatchOfMapped")
+        public String wrapperIfNoExactMatchOfMapped() {
+            throw removeStackTrace(new UnwrapIfNoExactMatchException(removeStackTrace(new WrappedException())));
+        }
+
+        @Path("wrapperIfNoExactMatchDirectlyMapped")
+        public String wrapperIfNoExactMatchDirectlyMapped() {
+            throw removeStackTrace(new UnwrapIfNoExactMatchDirectlyMappedException(removeStackTrace(new WrappedException())));
+        }
+
+        @Path("alwaysUnwrapsEvenWithParentMapper")
+        public String alwaysUnwrapsEvenWithParentMapper() {
+            throw removeStackTrace(new UnwrapAlwaysException(removeStackTrace(new WrappedException())));
+        }
+
+        @Path("alwaysFallsBackToWrapperWhenNoCauseMapper")
+        public String alwaysFallsBackToWrapperWhenNoCauseMapper() {
+            throw removeStackTrace(new UnwrapAlwaysException(removeStackTrace(new IllegalArgumentException())));
         }
     }
 
     public static class ExceptionMappers {
+        @ServerExceptionMapper
+        Response map(WrappedException e) {
+            return Response.status(WRAPPED_MAPPER_USED_STATUS).build();
+        }
 
         @ServerExceptionMapper
-        Response mapISE(IllegalStateException e) {
-            return Response.status(999).build();
+        Response map(IntermediateMappedException e) {
+            return Response.status(INTERMEDIATE_MAPPER_USED_STATUS).build();
+        }
+
+        @ServerExceptionMapper
+        Response map(UnwrapIfNoExactMatchDirectlyMappedException e) {
+            return Response.status(WRAPPER_MAPPER_USED_STATUS).build();
+        }
+
+        @ServerExceptionMapper
+        Response map(UnwrapAlwaysException e) {
+            return Response.status(WRAPPER_MAPPER_USED_STATUS).build();
         }
     }
 
-    public static class TestUnwrapException extends RuntimeException {
-        public TestUnwrapException() {
-        }
+    public static class WrappedException extends RuntimeException {
+    }
 
-        public TestUnwrapException(String message) {
-            super(message);
-        }
-
-        public TestUnwrapException(String message, Throwable cause) {
-            super(message, cause);
-        }
-
-        public TestUnwrapException(Throwable cause) {
+    public static class UnwrapIfNoMatchException extends RuntimeException {
+        public UnwrapIfNoMatchException(Throwable cause) {
             super(cause);
         }
+    }
 
-        public TestUnwrapException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-            super(message, cause, enableSuppression, writableStackTrace);
+    public static class UnwrapIfNoMatchWithIntermediateException extends IntermediateMappedException {
+        public UnwrapIfNoMatchWithIntermediateException(Throwable cause) {
+            super(cause);
         }
     }
 
+    public static class IntermediateMappedException extends RuntimeException {
+        public IntermediateMappedException() {
+        }
+
+        public IntermediateMappedException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class UnwrapIfNoExactMatchException extends IntermediateMappedException {
+        public UnwrapIfNoExactMatchException() {
+        }
+
+        public UnwrapIfNoExactMatchException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class UnwrapIfNoExactMatchDirectlyMappedException extends IntermediateMappedException {
+        public UnwrapIfNoExactMatchDirectlyMappedException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class UnwrapAlwaysException extends IntermediateMappedException {
+        public UnwrapAlwaysException(Throwable cause) {
+            super(cause);
+        }
+    }
 }


### PR DESCRIPTION
Adds support for the strategy attribute in @UnwrapException annotation to control exception unwrapping behaviour.

This makes tests in the reproducer pass with following annotation:
```java
@UnwrapException(value={ WebApplicationException.class }, strategy=ExceptionUnwrapStrategy.UNWRAP_IF_NO_EXACT_MATCH)
```
https://github.com/user-attachments/files/20574949/quarkus-48197-reproducer.zip


Main Changes:
- Added strategy boolean parameter to @UnwrapException annotation (default: UNWRAP_IF_NO_MATCH) and propagated it.
- Updated RuntimeExceptionMapper exception mapping strategy to handle it:
  - If strategy=ALWAYS, unwrap even if exception is directly mapped in a mapper
  - If strategy=UNWRAP_IF_NO_EXACT_MATCH and exception is not directly mapped anywhere, unwrap
  - If strategy=UNWRAP_IF_NO_MATCH, check if the exception or one of its subtypes is mapped (existing behaviour)
  - If exception couldnt be mapped, unwrap it and repeat the process for the wrapped exception (existing behaviour)
- Reworked UnwrappedExceptionTest to add more cases and more explicit names, and achieve 100% coverage on new code in RuntimeExceptionMapper.

- Closes: #48197