### PR TITLE
Bump to Mutiny 3.0.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,7 +138,7 @@
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <mutiny.version>3.0.0</mutiny.version>
+        <mutiny.version>3.0.1</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka3.version>4.0.0</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -47,7 +47,7 @@
         <version.gizmo>1.9.0</version.gizmo>
         <version.jandex>3.5.1</version.jandex>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
-        <version.mutiny>3.0.0</version.mutiny>
+        <version.mutiny>3.0.1</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.13.9</version.smallrye-common>
         <!-- test versions -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -44,7 +44,7 @@
         <version.gizmo2>2.0.0.Beta8</version.gizmo2>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.smallrye-common>2.13.9</version.smallrye-common>
-        <version.smallrye-mutiny>3.0.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>3.0.1</version.smallrye-mutiny>
         <version.lsp4j>0.24.0</version.lsp4j>
     </properties>
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -55,7 +55,7 @@
         <gizmo.version>1.9.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <mutiny.version>3.0.0</mutiny.version>
+        <mutiny.version>3.0.1</mutiny.version>
         <smallrye-common.version>2.13.9</smallrye-common.version>
         <vertx.version>4.5.21</vertx.version>
         <rest-assured.version>5.5.6</rest-assured.version>


### PR DESCRIPTION
This bumps to Mutiny 3.0.1 (bug fix release).

I will check for backports, because I have also released 2.9.5, so older versions of Quarkus using 2.9.x will be bumped to that instead of 3.0.1.