### PR TITLE
Record runtime configuration in its own ConfigSource

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -217,7 +217,6 @@ public final class BuildTimeConfigurationReader {
         final ConfigTrackingInterceptor buildConfigTracker;
         final Map<String, ConfigValue> allBuildTimeValues = new TreeMap<>();
         final Map<String, ConfigValue> buildTimeRunTimeValues = new TreeMap<>();
-        final Map<String, ConfigValue> runTimeDefaultValues = new TreeMap<>();
         final Map<String, ConfigValue> runTimeValues = new TreeMap<>();
 
         ReadOperation(final SmallRyeConfig config, ConfigTrackingInterceptor buildConfigTracker) {
@@ -334,7 +333,6 @@ public final class BuildTimeConfigurationReader {
             return new ReadResult.Builder()
                     .setAllBuildTimeValues(allBuildTimeValues)
                     .setBuildTimeRunTimeValues(filterActiveProfileProperties(buildTimeRunTimeValues))
-                    .setRunTimeDefaultValues(filterActiveProfileProperties(runTimeDefaultValues))
                     .setRuntimeValues(runTimeValues)
                     .setBuildTimeMappings(buildTimeMappings)
                     .setBuildTimeRunTimeMappings(buildTimeRunTimeMappings)
@@ -540,7 +538,6 @@ public final class BuildTimeConfigurationReader {
     public static final class ReadResult {
         final Map<String, ConfigValue> allBuildTimeValues;
         final Map<String, ConfigValue> buildTimeRunTimeValues;
-        final Map<String, ConfigValue> runTimeDefaultValues;
         final Map<String, ConfigValue> runTimeValues;
 
         final List<ConfigClass> buildTimeMappings;
@@ -556,7 +553,6 @@ public final class BuildTimeConfigurationReader {
         public ReadResult(final Builder builder) {
             this.allBuildTimeValues = builder.getAllBuildTimeValues();
             this.buildTimeRunTimeValues = builder.getBuildTimeRunTimeValues();
-            this.runTimeDefaultValues = builder.getRunTimeDefaultValues();
             this.runTimeValues = builder.getRuntimeValues();
 
             this.buildTimeMappings = builder.getBuildTimeMappings();
@@ -591,10 +587,6 @@ public final class BuildTimeConfigurationReader {
 
         public Map<String, ConfigValue> getBuildTimeRunTimeValues() {
             return buildTimeRunTimeValues;
-        }
-
-        public Map<String, ConfigValue> getRunTimeDefaultValues() {
-            return runTimeDefaultValues;
         }
 
         public Map<String, ConfigValue> getRunTimeValues() {
@@ -636,7 +628,6 @@ public final class BuildTimeConfigurationReader {
         static class Builder {
             private Map<String, ConfigValue> allBuildTimeValues;
             private Map<String, ConfigValue> buildTimeRunTimeValues;
-            private Map<String, ConfigValue> runTimeDefaultValues;
             private Map<String, ConfigValue> runtimeValues;
             private List<ConfigClass> buildTimeMappings;
             private List<ConfigClass> buildTimeRunTimeMappings;
@@ -660,15 +651,6 @@ public final class BuildTimeConfigurationReader {
 
             Builder setBuildTimeRunTimeValues(final Map<String, ConfigValue> buildTimeRunTimeValues) {
                 this.buildTimeRunTimeValues = buildTimeRunTimeValues;
-                return this;
-            }
-
-            Map<String, ConfigValue> getRunTimeDefaultValues() {
-                return runTimeDefaultValues;
-            }
-
-            Builder setRunTimeDefaultValues(final Map<String, ConfigValue> runTimeDefaultValues) {
-                this.runTimeDefaultValues = runTimeDefaultValues;
                 return this;
             }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -9,6 +9,7 @@ import static io.quarkus.deployment.steps.ConfigBuildSteps.SERVICES_PREFIX;
 import static io.quarkus.deployment.util.ServiceUtil.classNamesNamedIn;
 import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_LOCATIONS;
 import static java.util.stream.Collectors.toSet;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -110,7 +112,6 @@ import io.smallrye.config.ConfigSourceInterceptor;
 import io.smallrye.config.ConfigSourceInterceptorFactory;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.DefaultValuesConfigSource;
-import io.smallrye.config.ProfileConfigSourceInterceptor;
 import io.smallrye.config.SecretKeysHandler;
 import io.smallrye.config.SecretKeysHandlerFactory;
 import io.smallrye.config.SmallRyeConfig;
@@ -148,10 +149,10 @@ public class ConfigGenerationBuildStep {
                 .build()) {
 
             FieldDescriptor source = FieldDescriptor.of(classCreator.getClassName(), "source", ConfigSource.class);
-            classCreator.getFieldCreator(source).setModifiers(Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
+            classCreator.getFieldCreator(source).setModifiers(ACC_STATIC | Opcodes.ACC_FINAL);
 
             MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class);
-            clinit.setModifiers(Opcodes.ACC_STATIC);
+            clinit.setModifiers(ACC_STATIC);
 
             ResultHandle map = clinit.newInstance(MethodDescriptor.ofConstructor(HashMap.class));
             MethodDescriptor put = MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class);
@@ -239,29 +240,8 @@ public class ConfigGenerationBuildStep {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass) throws Exception {
 
         Map<String, String> defaultValues = new HashMap<>();
-        // Default values from @ConfigRoot
-        for (Map.Entry<String, ConfigValue> entry : configItem.getReadResult().getRunTimeDefaultValues().entrySet()) {
-            defaultValues.put(entry.getKey(), entry.getValue().getRawValue());
-        }
-        // Default values from build item RunTimeConfigurationDefaultBuildItem override
         for (RunTimeConfigurationDefaultBuildItem e : runTimeDefaults) {
             defaultValues.put(e.getKey(), e.getValue());
-        }
-        // Recorded values from build time from any other source (higher ordinal then defaults, so override)
-        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
-        List<String> profiles = config.getProfiles();
-        for (Map.Entry<String, ConfigValue> entry : configItem.getReadResult().getRunTimeValues().entrySet()) {
-            if (DefaultValuesConfigSource.NAME.equals(entry.getValue().getConfigSourceName())) {
-                continue;
-            }
-            // Runtime values may contain active profiled names that override sames names in defaults
-            // We need to keep the original name definition in case a different profile is used to run the app
-            String activeName = ProfileConfigSourceInterceptor.activeName(entry.getKey(), profiles);
-            // But keep the default
-            if (!configItem.getReadResult().getRunTimeDefaultValues().containsKey(activeName)) {
-                defaultValues.remove(activeName);
-            }
-            defaultValues.put(entry.getKey(), entry.getValue().getRawValue());
         }
 
         Set<String> converters = discoverService(Converter.class, reflectiveClass);
@@ -303,6 +283,7 @@ public class ConfigGenerationBuildStep {
                 combinedIndex,
                 sharedFields,
                 defaultValues,
+                Map.of(),
                 converters,
                 interceptors,
                 staticSafeServices(interceptorFactories),
@@ -319,6 +300,10 @@ public class ConfigGenerationBuildStep {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(CONFIG_STATIC_NAME).build());
 
         // For RunTime Config
+        Map<String, String> runtimeValues = new HashMap<>();
+        for (Entry<String, ConfigValue> entry : configItem.getReadResult().getRunTimeValues().entrySet()) {
+            runtimeValues.put(entry.getKey(), entry.getValue().getRawValue());
+        }
         Set<ConfigClass> runTimeMappings = new LinkedHashSet<>();
         runTimeMappings.addAll(runtimeConfigMappings(configMappings));
         runTimeMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
@@ -331,6 +316,7 @@ public class ConfigGenerationBuildStep {
                 combinedIndex,
                 sharedFields,
                 defaultValues,
+                runtimeValues,
                 converters,
                 interceptors,
                 interceptorFactories,
@@ -609,6 +595,9 @@ public class ConfigGenerationBuildStep {
     private static final MethodDescriptor WITH_DEFAULTS = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
             "withDefaultValues",
             void.class, SmallRyeConfigBuilder.class, Map.class);
+    private static final MethodDescriptor WITH_RUNTIME_VALUES = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
+            "withRuntimeValues",
+            void.class, SmallRyeConfigBuilder.class, Map.class);
     private static final MethodDescriptor WITH_CONVERTER = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
             "withConverter",
             void.class, SmallRyeConfigBuilder.class, String.class, int.class, Converter.class);
@@ -654,6 +643,10 @@ public class ConfigGenerationBuildStep {
     private static final MethodDescriptor ENSURE_LOADED = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
             "ensureLoaded",
             void.class, String.class);
+    private static final MethodDescriptor MAP_NEW = MethodDescriptor.ofConstructor(HashMap.class, int.class);
+    private static final MethodDescriptor MAP_PUT = MethodDescriptor.ofMethod(HashMap.class,
+            "put",
+            Object.class, Object.class, Object.class);
 
     private static final DotName CONVERTER_NAME = DotName.createSimple(Converter.class.getName());
     private static final DotName PRIORITY_NAME = DotName.createSimple(Priority.class.getName());
@@ -672,13 +665,13 @@ public class ConfigGenerationBuildStep {
                 .build()) {
 
             MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class);
-            clinit.setModifiers(Opcodes.ACC_STATIC);
+            clinit.setModifiers(ACC_STATIC);
 
             int converterIndex = 0;
             for (String converter : converters) {
                 String fieldName = "conv$" + converterIndex++;
                 FieldDescriptor converterField = classCreator.getFieldCreator(fieldName, Converter.class)
-                        .setModifiers(Opcodes.ACC_STATIC).getFieldDescriptor();
+                        .setModifiers(ACC_STATIC).getFieldDescriptor();
                 clinit.writeStaticField(converterField, clinit.newInstance(MethodDescriptor.ofConstructor(converter)));
                 fields.put(converter, converterField);
             }
@@ -686,7 +679,7 @@ public class ConfigGenerationBuildStep {
             int mappingIndex = 0;
             for (ConfigClass mapping : mappings) {
                 FieldDescriptor mappingField = classCreator.getFieldCreator("mapping$" + mappingIndex++, ConfigClass.class)
-                        .setModifiers(Opcodes.ACC_STATIC).getFieldDescriptor();
+                        .setModifiers(ACC_STATIC).getFieldDescriptor();
                 clinit.writeStaticField(mappingField, clinit.invokeStaticMethod(CONFIG_CLASS,
                         clinit.load(mapping.getType().getName()), clinit.load(mapping.getPrefix())));
 
@@ -713,6 +706,7 @@ public class ConfigGenerationBuildStep {
             CombinedIndexBuildItem combinedIndex,
             Map<Object, FieldDescriptor> sharedFields,
             Map<String, String> defaultValues,
+            Map<String, String> runtimeValues,
             Set<String> converters,
             Set<String> interceptors,
             Set<String> interceptorFactories,
@@ -737,21 +731,30 @@ public class ConfigGenerationBuildStep {
                 .build()) {
 
             MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class);
-            clinit.setModifiers(Opcodes.ACC_STATIC);
+            clinit.setModifiers(ACC_STATIC);
 
             MethodCreator method = classCreator.getMethodCreator(BUILDER_CUSTOMIZER);
             ResultHandle configBuilder = method.getMethodParam(0);
 
-            FieldDescriptor defaultsField = classCreator.getFieldCreator("defaults", Map.class).setModifiers(Opcodes.ACC_STATIC)
+            FieldDescriptor defaultsField = classCreator.getFieldCreator("defaults", Map.class).setModifiers(ACC_STATIC)
                     .getFieldDescriptor();
-            clinit.writeStaticField(defaultsField, clinit.newInstance(MethodDescriptor.ofConstructor(HashMap.class, int.class),
-                    clinit.load((int) ((float) defaultValues.size() / 0.75f + 1.0f))));
-            MethodDescriptor put = MethodDescriptor.ofMethod(HashMap.class, "put", Object.class, Object.class, Object.class);
+            clinit.writeStaticField(defaultsField,
+                    clinit.newInstance(MAP_NEW, clinit.load((int) ((float) defaultValues.size() / 0.75f + 1.0f))));
             for (Map.Entry<String, String> entry : defaultValues.entrySet()) {
-                clinit.invokeVirtualMethod(put, clinit.readStaticField(defaultsField), clinit.load(entry.getKey()),
+                clinit.invokeVirtualMethod(MAP_PUT, clinit.readStaticField(defaultsField), clinit.load(entry.getKey()),
                         clinit.load(entry.getValue()));
             }
             method.invokeStaticMethod(WITH_DEFAULTS, configBuilder, method.readStaticField(defaultsField));
+
+            FieldDescriptor runtimeValuesField = classCreator.getFieldCreator("runtimeValues", Map.class)
+                    .setModifiers(ACC_STATIC).getFieldDescriptor();
+            clinit.writeStaticField(runtimeValuesField,
+                    clinit.newInstance(MAP_NEW, clinit.load((int) ((float) runtimeValues.size() / 0.75f + 1.0f))));
+            for (Map.Entry<String, String> entry : runtimeValues.entrySet()) {
+                clinit.invokeVirtualMethod(MAP_PUT, clinit.readStaticField(runtimeValuesField), clinit.load(entry.getKey()),
+                        clinit.load(entry.getValue()));
+            }
+            method.invokeStaticMethod(WITH_RUNTIME_VALUES, configBuilder, method.readStaticField(runtimeValuesField));
 
             for (String converter : converters) {
                 ClassInfo converterClass = combinedIndex.getComputingIndex().getClassByName(converter);

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
@@ -17,6 +17,7 @@ import io.smallrye.config.SecretKeysHandlerFactory;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+import io.smallrye.config.common.MapBackedConfigSource;
 
 /**
  * Convenience helper to generate the {@link SmallRyeConfigBuilderCustomizer} bytecode, by wrapping methods that
@@ -26,6 +27,11 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
 
     protected static void withDefaultValues(SmallRyeConfigBuilder builder, Map<String, String> values) {
         builder.withDefaultValues(values);
+    }
+
+    protected static void withRuntimeValues(SmallRyeConfigBuilder builder, Map<String, String> values) {
+        builder.withSources(new MapBackedConfigSource("Runtime Values", values, 0) {
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/extensions/picocli/deployment/src/test/java/io/quarkus/picocli/deployment/AvailableConfigSourcesTest.java
+++ b/extensions/picocli/deployment/src/test/java/io/quarkus/picocli/deployment/AvailableConfigSourcesTest.java
@@ -27,7 +27,7 @@ public class AvailableConfigSourcesTest {
     void sources() {
         ConfigValue value = config.getConfigValue("my.prop");
         assertEquals("1234", value.getValue());
-        assertEquals("DefaultValuesConfigSource", value.getConfigSourceName());
+        assertEquals("Runtime Values", value.getConfigSourceName());
 
         for (final ConfigSource configSource : config.getConfigSources()) {
             if (configSource.getName().contains("application.properties")) {

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
@@ -277,6 +277,10 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
         public String apply(final String name) {
             int indexOfRestClient = indexOfRestClient(name);
             if (indexOfRestClient != -1) {
+                int disableDefaultMapper = name.indexOf(".disable-default-mapper", indexOfRestClient);
+                if (disableDefaultMapper != -1) {
+                    return "microprofile.rest.client.disable.default.mapper";
+                }
                 for (Map.Entry<String, String> entry : names.entrySet()) {
                     String original = entry.getKey();
                     String target = entry.getValue();

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -675,7 +675,7 @@ public interface RestClientsConfig {
          * <p>
          * This property is not applicable to the RESTEasy Client.
          */
-        @WithDefault("${microprofile.rest.client.disable.default.mapper:false}")
+        @WithDefault("false")
         Boolean disableDefaultMapper();
 
         /**

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import io.quarkus.restclient.config.key.SharedOneConfigKeyRestClient;
 import io.quarkus.restclient.config.key.SharedThreeConfigKeyRestClient;
 import io.quarkus.restclient.config.key.SharedTwoConfigKeyRestClient;
 import io.quarkus.runtime.configuration.ConfigUtils;
+import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
@@ -69,6 +71,7 @@ class RestClientConfigTest {
         assertEquals(1, restClientsConfig.clients().size());
         assertTrue(restClientsConfig.clients().containsKey(ConfigKeyRestClient.class.getName()));
         verifyConfig(restClientsConfig.getClient(ConfigKeyRestClient.class));
+        assertTrue(restClientsConfig.getClient(ConfigKeyRestClient.class).disableDefaultMapper());
     }
 
     @Test
@@ -125,6 +128,7 @@ class RestClientConfigTest {
                         }.configBuilder(builder);
                     }
                 })
+                .withSources(new PropertiesConfigSource(Map.of("microprofile.rest.client.disable.default.mapper", "true"), ""))
                 .build();
 
         RestClientsConfig restClientsConfig = config.getConfigMapping(RestClientsConfig.class);
@@ -147,6 +151,7 @@ class RestClientConfigTest {
         assertTrue(clientConfig.proxyAddress().isPresent());
         assertTrue(clientConfig.queryParamStyle().isPresent());
         assertThat(clientConfig.queryParamStyle().get()).isEqualTo(QueryParamStyle.COMMA_SEPARATED);
+        assertThat(clientConfig.disableDefaultMapper()).isTrue();
     }
 
     @Test

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/resources/application.properties
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/resources/application.properties
@@ -29,6 +29,7 @@ quarkus.rest-client.key.hostname-verifier=io.quarkus.restclient.configuration.My
 quarkus.rest-client.key.connection-ttl=30000
 quarkus.rest-client.key.connection-pool-size=10
 quarkus.rest-client.key.max-chunk-size=1024
+quarkus.rest-client.key.disable-default-mapper=true
 
 quarkus.rest-client."io.quarkus.restclient.config.MPRestClient".url=http://localhost:8080
 io.quarkus.restclient.config.MPRestClient/mp-rest/url=http://localhost:8081

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientOverrideRuntimeConfigTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientOverrideRuntimeConfigTest.java
@@ -42,12 +42,12 @@ public class RestClientOverrideRuntimeConfigTest {
     @Test
     void overrideConfig() {
         // Build time property recording
-        Optional<ConfigSource> specifiedDefaultValues = config.getConfigSource("DefaultValuesConfigSource");
-        assertTrue(specifiedDefaultValues.isPresent());
-        assertTrue(specifiedDefaultValues.get().getPropertyNames()
+        Optional<ConfigSource> runtimeValues = config.getConfigSource("Runtime Values");
+        assertTrue(runtimeValues.isPresent());
+        assertTrue(runtimeValues.get().getPropertyNames()
                 .contains("io.quarkus.restclient.configuration.EchoClient/mp-rest/url"));
         assertEquals("http://nohost",
-                specifiedDefaultValues.get().getValue("io.quarkus.restclient.configuration.EchoClient/mp-rest/url"));
+                runtimeValues.get().getValue("io.quarkus.restclient.configuration.EchoClient/mp-rest/url"));
         assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).anyMatch(
                 property -> property.equals("quarkus.rest-client.\"io.quarkus.restclient.configuration.EchoClient\".url")));
 
@@ -59,9 +59,9 @@ public class RestClientOverrideRuntimeConfigTest {
         assertEquals(mpValue.getValue(), quarkusValue.getValue());
         assertEquals("RestClientRuntimeConfigSource", quarkusValue.getConfigSourceName());
         // There is no relocate for MP names, so it keeps the same name
-        assertEquals(mpValue.getName(), "io.quarkus.restclient.configuration.EchoClient/mp-rest/url");
+        assertEquals("io.quarkus.restclient.configuration.EchoClient/mp-rest/url", mpValue.getName());
         // We use the Quarkus name, because that is the one that has priority
-        assertEquals(quarkusValue.getName(), "quarkus.rest-client.\"io.quarkus.restclient.configuration.EchoClient\".url");
+        assertEquals("quarkus.rest-client.\"io.quarkus.restclient.configuration.EchoClient\".url", quarkusValue.getName());
 
         assertTrue(restClientsConfig.clients().containsKey("io.quarkus.restclient.configuration.EchoClient"));
         Optional<String> url = restClientsConfig.clients().get("io.quarkus.restclient.configuration.EchoClient").url();

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RecorderRuntimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RecorderRuntimeConfigTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.extest.runtime.config.TestMappingRunTime;
 import io.quarkus.test.QuarkusUnitTest;
-import io.smallrye.config.DefaultValuesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 
 public class RecorderRuntimeConfigTest {
@@ -38,12 +37,12 @@ public class RecorderRuntimeConfigTest {
         assertEquals("from-application", mappingRunTime.recordProfiled().get());
 
         // Make sure that when we merge all the defaults, we override the non-profiled name
-        Optional<ConfigSource> configSource = config.getConfigSource("DefaultValuesConfigSource");
+        Optional<ConfigSource> configSource = config.getConfigSource("Runtime Values");
         assertTrue(configSource.isPresent());
-        DefaultValuesConfigSource defaultValuesConfigSource = (DefaultValuesConfigSource) configSource.get();
-        assertEquals("from-application", defaultValuesConfigSource.getValue("%test.recorded.profiled.property"));
-        assertEquals("recorded", defaultValuesConfigSource.getValue("recorded.profiled.property"));
-        assertEquals("from-application", defaultValuesConfigSource.getValue("%test.quarkus.mapping.rt.record-profiled"));
-        assertEquals("recorded", defaultValuesConfigSource.getValue("quarkus.mapping.rt.record-profiled"));
+        ConfigSource runtimeValues = configSource.get();
+        assertEquals("from-application", runtimeValues.getValue("%test.recorded.profiled.property"));
+        assertEquals("recorded", runtimeValues.getValue("recorded.profiled.property"));
+        assertEquals("from-application", runtimeValues.getValue("%test.quarkus.mapping.rt.record-profiled"));
+        assertEquals("recorded", runtimeValues.getValue("quarkus.mapping.rt.record-profiled"));
     }
 }

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
@@ -91,11 +91,11 @@ public class ConfiguredBeanTest {
     }
 
     @Test
-    public void testConfigDefaultValuesSourceOrdinal() {
-        Optional<ConfigSource> source = config.getConfigSource("DefaultValuesConfigSource");
+    public void testConfigRuntimeValuesSourceOrdinal() {
+        Optional<ConfigSource> source = config.getConfigSource("Runtime Values");
         assertTrue(source.isPresent());
-        ConfigSource defaultValues = source.get();
-        assertEquals(Integer.MIN_VALUE, defaultValues.getOrdinal());
+        ConfigSource runtimeValues = source.get();
+        assertEquals(0, runtimeValues.getOrdinal());
 
         ConfigSource applicationProperties = null;
         for (ConfigSource configSource : config.getConfigSources()) {
@@ -107,32 +107,32 @@ public class ConfiguredBeanTest {
         assertNotNull(applicationProperties);
         assertEquals(1000, applicationProperties.getOrdinal());
 
-        assertEquals("9999", defaultValues.getValue("%test.my.prop"));
+        assertEquals("9999", runtimeValues.getValue("%test.my.prop"));
         assertEquals("9999", applicationProperties.getValue("%test.my.prop"));
-        assertEquals("1234", defaultValues.getValue("my.prop"));
+        assertEquals("1234", runtimeValues.getValue("my.prop"));
         assertEquals("1234", applicationProperties.getValue("my.prop"));
 
         assertEquals("9999", config.getConfigValue("my.prop").getValue());
     }
 
     @Test
-    public void testProfileDefaultValuesSource() {
-        Optional<ConfigSource> source = config.getConfigSource("DefaultValuesConfigSource");
+    public void testProfileRuntimeValuesSource() {
+        Optional<ConfigSource> source = config.getConfigSource("Runtime Values");
         assertTrue(source.isPresent());
-        ConfigSource defaultValues = source.get();
+        ConfigSource runtimeValues = source.get();
 
-        assertEquals("1234", defaultValues.getValue("%prod.my.prop"));
-        assertEquals("5678", defaultValues.getValue("%dev.my.prop"));
-        assertEquals("9999", defaultValues.getValue("%test.my.prop"));
+        assertEquals("1234", runtimeValues.getValue("%prod.my.prop"));
+        assertEquals("5678", runtimeValues.getValue("%dev.my.prop"));
+        assertEquals("9999", runtimeValues.getValue("%test.my.prop"));
         // this runs with the test profile
         assertEquals("9999", config.getValue("my.prop", String.class));
 
         // runtime properties coming from env must not be recorded
-        assertNull(defaultValues.getValue("should.not.be.recorded"));
-        assertNull(defaultValues.getValue("SHOULD_NOT_BE_RECORDED"));
-        assertNull(defaultValues.getValue("quarkus.mapping.rt.do-not-record"));
-        assertNull(defaultValues.getValue("%prod.quarkus.mapping.rt.do-not-record"));
-        assertNull(defaultValues.getValue("%dev.quarkus.mapping.rt.do-not-record"));
+        assertNull(runtimeValues.getValue("should.not.be.recorded"));
+        assertNull(runtimeValues.getValue("SHOULD_NOT_BE_RECORDED"));
+        assertNull(runtimeValues.getValue("quarkus.mapping.rt.do-not-record"));
+        assertNull(runtimeValues.getValue("%prod.quarkus.mapping.rt.do-not-record"));
+        assertNull(runtimeValues.getValue("%dev.quarkus.mapping.rt.do-not-record"));
         assertEquals("value", config.getConfigValue("quarkus.mapping.rt.do-not-record").getValue());
     }
 
@@ -143,11 +143,11 @@ public class ConfiguredBeanTest {
         assertEquals("quarkus.bt.bt-config-value", btConfigValue.getName());
         assertEquals("value", btConfigValue.getValue());
 
-        Optional<ConfigSource> source = config.getConfigSource("DefaultValuesConfigSource");
+        Optional<ConfigSource> source = config.getConfigSource("Runtime Values");
         assertTrue(source.isPresent());
-        ConfigSource defaultValues = source.get();
+        ConfigSource runtimeValues = source.get();
 
-        assertTrue(defaultValues.getPropertyNames().contains("quarkus.bt.bt-config-value"));
-        assertEquals("${test.record.expansion}", defaultValues.getValue("quarkus.bt.bt-config-value"));
+        assertTrue(runtimeValues.getPropertyNames().contains("quarkus.bt.bt-config-value"));
+        assertEquals("${test.record.expansion}", runtimeValues.getValue("quarkus.bt.bt-config-value"));
     }
 }

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeValuesTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeValuesTest.java
@@ -16,7 +16,7 @@ import io.quarkus.extest.runtime.config.EnvBuildTimeConfigSource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.config.SmallRyeConfig;
 
-public class RuntimeDefaultsTest {
+public class RuntimeValuesTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
@@ -27,44 +27,46 @@ public class RuntimeDefaultsTest {
     SmallRyeConfig config;
 
     @Test
-    void doNotRecordEnvRuntimeDefaults() {
-        Optional<ConfigSource> defaultValues = config.getConfigSource("DefaultValuesConfigSource");
-        assertTrue(defaultValues.isPresent());
+    void doNotRecordEnvRuntimeValues() {
+        Optional<ConfigSource> runtimeValues = config.getConfigSource("Runtime Values");
+        assertTrue(runtimeValues.isPresent());
         // Do not record Env values for runtime
-        assertNull(defaultValues.get().getValue("quarkus.mapping.rt.do-not-record"));
+        assertNull(runtimeValues.get().getValue("quarkus.mapping.rt.do-not-record"));
         assertEquals("value", config.getConfigValue("quarkus.mapping.rt.do-not-record").getValue());
         // Property available in both Env and application.properties, ok to record application.properties value
-        assertEquals("from-app", defaultValues.get().getValue("bt.ok.to.record"));
+        assertEquals("from-app", runtimeValues.get().getValue("bt.ok.to.record"));
         // You still get the value from Env
         assertEquals("from-env", config.getConfigValue("bt.ok.to.record").getValue());
         // Do not record any of the other properties
-        assertNull(defaultValues.get().getValue(("do.not.record")));
-        assertNull(defaultValues.get().getValue(("DO_NOT_RECORD")));
+        assertNull(runtimeValues.get().getValue(("do.not.record")));
+        assertNull(runtimeValues.get().getValue(("DO_NOT_RECORD")));
         assertEquals("value", config.getConfigValue("do.not.record").getValue());
     }
 
     @Test
-    void doNotRecordActiveUnprofiledPropertiesDefaults() {
-        Optional<ConfigSource> defaultValues = config.getConfigSource("DefaultValuesConfigSource");
-        assertTrue(defaultValues.isPresent());
+    void doNotRecordActiveUnprofiledRuntimeValues() {
+        Optional<ConfigSource> runtimeValues = config.getConfigSource("Runtime Values");
+        assertTrue(runtimeValues.isPresent());
         assertEquals("properties", config.getConfigValue("bt.profile.record").getValue());
         // Property needs to be recorded as is, including the profile name
-        assertEquals("properties", defaultValues.get().getValue("%test.bt.profile.record"));
-        assertNull(defaultValues.get().getValue("bt.profile.record"));
+        assertEquals("properties", runtimeValues.get().getValue("%test.bt.profile.record"));
+        assertNull(runtimeValues.get().getValue("bt.profile.record"));
     }
 
     @Test
-    void recordDefaultFromRootEvenIfInActiveProfile() {
+    void recordDefaultFromMappingEvenIfInActiveProfile() {
+        Optional<ConfigSource> runtimeValues = config.getConfigSource("Runtime Values");
+        assertTrue(runtimeValues.isPresent());
+        assertEquals("from-app", runtimeValues.get().getValue("%test.quarkus.mapping.rt.record-default"));
         Optional<ConfigSource> defaultValues = config.getConfigSource("DefaultValuesConfigSource");
         assertTrue(defaultValues.isPresent());
-        assertEquals("from-app", defaultValues.get().getValue("%test.quarkus.mapping.rt.record-default"));
         assertEquals("from-default", defaultValues.get().getValue("quarkus.mapping.rt.record-default"));
     }
 
     @Test
     void recordProfile() {
-        Optional<ConfigSource> defaultValues = config.getConfigSource("DefaultValuesConfigSource");
-        assertTrue(defaultValues.isPresent());
+        Optional<ConfigSource> runtimeValues = config.getConfigSource("Runtime Values");
+        assertTrue(runtimeValues.isPresent());
         assertEquals("record", config.getConfigValue("quarkus.profile").getValue());
     }
 }


### PR DESCRIPTION
This will now record eligible configuration values in a separate source. Previously, these values were being recorded in the `DefaultValuesConfigSource`.

Historically, we record values to reduce the number of sources during runtime (especially for native images). These include `application.properties`, `RunTimeConfigurationDefaultBuildItem`, old `@ConfigRoot` and `@ConfigMapping`. All of these were being recorded in the `DefaultValuesConfigSource` and did require some juggling to ensure that we were following the correct override order. This is now less relevant because we removed the old roots, and `@ConfigMapping` defaults are handled directly by SmallRyeConfig.

While this approach usually worked, it has some flaws when dealing with fallbacks / relocations that have defaults, since everything would end up in the same source, we would lose the expected ordering. See #50652.

Splitting the actual defaults from the runtime values in two separate sources ensures that any recorded value is still higher than the defaults, so it does not fallback/relocate to the default.

- Fixes #50652