### PR TITLE
Do not copy `quarkus` configuration to Gradle plugin forced properties

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -105,7 +105,6 @@ public class BeforeTestAction implements Action<Task> {
                 extensionView.getForcedProperties(),
                 extensionView.getProjectProperties(),
                 extensionView.getQuarkusBuildProperties(),
-                extensionView.getQuarkusRelevantProjectProperties(),
                 manifestAttributes,
                 manifestSections,
                 extensionView.getNativeBuild(),

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
@@ -24,7 +24,6 @@ public class EffectiveConfigProvider {
     final MapProperty<String, String> forcedProperties;
     final MapProperty<String, Object> projectProperties;
     final MapProperty<String, String> quarkusBuildProperties;
-    final MapProperty<String, String> quarkusRelevantProjectProperties;
     final MapProperty<String, Object> manifestAttributes;
     final MapProperty<String, Attributes> manifestSections;
     final Property<Boolean> nativeBuild;
@@ -36,7 +35,6 @@ public class EffectiveConfigProvider {
             MapProperty<String, String> forcedProperties,
             MapProperty<String, Object> projectProperties,
             MapProperty<String, String> quarkusBuildProperties,
-            MapProperty<String, String> quarkusRelevantProjectProperties,
             MapProperty<String, Object> manifestAttributes,
             MapProperty<String, Attributes> manifestSections,
             Property<Boolean> nativeBuild,
@@ -47,7 +45,6 @@ public class EffectiveConfigProvider {
         this.forcedProperties = forcedProperties;
         this.projectProperties = projectProperties;
         this.quarkusBuildProperties = quarkusBuildProperties;
-        this.quarkusRelevantProjectProperties = quarkusRelevantProjectProperties;
         this.manifestAttributes = manifestAttributes;
         this.manifestSections = manifestSections;
         this.nativeBuild = nativeBuild;
@@ -72,10 +69,6 @@ public class EffectiveConfigProvider {
         defaultProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
 
         Map<String, String> forced = new HashMap<>(forcedProperties.get());
-        projectProperties.get().forEach((k, v) -> {
-            forced.put(k, v.toString());
-
-        });
         additionalForcedProperties.forEach((k, v) -> {
             forced.put(k, v.toString());
         });
@@ -87,7 +80,7 @@ public class EffectiveConfigProvider {
                 .withForcedProperties(forced)
                 .withTaskProperties(properties)
                 .withBuildProperties(quarkusBuildProperties.get())
-                .withProjectProperties(quarkusRelevantProjectProperties.get())
+                .withProjectProperties(projectProperties.get())
                 .withDefaultProperties(defaultProperties)
                 .withSourceDirectories(resourcesDirs)
                 .withProfile(getQuarkusProfile())
@@ -117,7 +110,7 @@ public class EffectiveConfigProvider {
             profile = quarkusBuildProperties.get().get(QUARKUS_PROFILE);
         }
         if (profile == null) {
-            Object p = quarkusRelevantProjectProperties.get().get(QUARKUS_PROFILE);
+            Object p = projectProperties.get().get(QUARKUS_PROFILE);
             if (p != null) {
                 profile = p.toString();
             }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -45,7 +45,6 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
                 getExtensionView().getForcedProperties(),
                 getExtensionView().getProjectProperties(),
                 getExtensionView().getQuarkusBuildProperties(),
-                getExtensionView().getQuarkusRelevantProjectProperties(),
                 getManifestAttributes(),
                 getManifestSections(),
                 getExtensionView().getNativeBuild(),

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConfigSystemOverrideProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConfigSystemOverrideProjectTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class ConfigSystemOverrideProjectTest extends QuarkusGradleWrapperTestBase {
+    @Test
+    void configSystemOverrideProject() throws Exception {
+        File projectDir = getProjectDir("custom-config-sources");
+
+        runGradleWrapper(projectDir, "clean", "build", "--no-build-cache", "-Dquarkus.package.jar.type=fast-jar",
+                "-Pquarkus.package.jar.type=uber-jar");
+
+        var p = projectDir.toPath().resolve("build").resolve("quarkus-app").resolve("quarkus-run.jar");
+        assertThat(p).exists();
+    }
+}


### PR DESCRIPTION
For some reason, we were copying `quarkus.*` configuration to the Gradle plugin forced properties Config Source, which is set to `600` in ordinality, being the highest of all sources.

I believe this started with https://github.com/quarkusio/quarkus/pull/41337, where I've copied what was already there in https://github.com/quarkusio/quarkus/commit/f10a208b09a8b50f48c6724586876e74436ecacd#diff-2c6f0d62b0763af665a1bc242ad078ce25794f20632651181549d838e3452998R113-R118

Now, I don't think this is required, because Project Properties also contains the same configuration, so we shouldn't be missing anything, but this approach causes #46456.

Subsequent code changes probably just followed the same pattern. Also, in #48769 added yet a new way of doing things and a `quarkusRelevantProjectProperties`, which filters `quarkus.*` properties from Project Properties, causing inconsistencies in the available configuration when used. I've changed that to just pass all Project Properties like we are doing in other places.

- Fixes #46456