### PR TITLE
Bump to Vert.x 4.5.22

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.20.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.20.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.30.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
@@ -112,7 +112,7 @@
         <wildfly-elytron.version>2.7.0.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.3.Final</jboss-marshalling.version>
         <jboss-threads.version>3.9.1</jboss-threads.version>
-        <vertx.version>4.5.21</vertx.version>
+        <vertx.version>4.5.22</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -134,7 +134,7 @@
         <infinispan.version>15.0.19.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.2.2</caffeine.version>
-        <netty.version>4.1.127.Final</netty.version>
+        <netty.version>4.1.128.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -35,6 +35,13 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/graal/RedisClientSubstitutions.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/graal/RedisClientSubstitutions.java
@@ -1,0 +1,19 @@
+package io.quarkus.redis.runtime.client.graal;
+
+import java.util.Random;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+
+class RedisClientSubstitutions {
+
+}
+
+@TargetClass(className = "io.vertx.redis.client.impl.SentinelTopology")
+final class Target_io_vertx_redis_client_impl_SentinelTopology {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    static Random RANDOM;
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/graal/RedisClientSubstitutions.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/graal/RedisClientSubstitutions.java
@@ -17,3 +17,27 @@ final class Target_io_vertx_redis_client_impl_SentinelTopology {
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
     static Random RANDOM;
 }
+
+@TargetClass(className = "io.vertx.redis.client.impl.RedisClusterConnection")
+final class Target_io_vertx_redis_client_impl_RedisClusterConnection {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    static Random RANDOM;
+}
+
+@TargetClass(className = "io.vertx.redis.client.impl.RedisReplicationConnection")
+final class Target_io_vertx_redis_client_impl_RedisReplicationConnection {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    static Random RANDOM;
+}
+
+@TargetClass(className = "io.vertx.redis.client.impl.Slots")
+final class Target_io_vertx_redis_client_impl_Slots {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    static Random RANDOM;
+}

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,7 +57,7 @@
 
         <mutiny.version>3.0.1</mutiny.version>
         <smallrye-common.version>2.13.9</smallrye-common.version>
-        <vertx.version>4.5.21</vertx.version>
+        <vertx.version>4.5.22</vertx.version>
         <rest-assured.version>5.5.6</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.20.0</jackson-bom.version>
@@ -66,7 +66,7 @@
         <yasson.version>3.0.4</yasson.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <smallrye-mutiny-vertx-core.version>3.20.0</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.20.1</smallrye-mutiny-vertx-core.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <mockito.version>5.20.0</mockito.version>
         <wiremock.version>3.13.1</wiremock.version>


### PR DESCRIPTION
This aligns to:
- Vert.x 4.5.22
- Vert.x Mutiny Bindings 3.20.1
- Mutiny 3.0.1
- Netty 4.1.128.Final

See https://github.com/vert-x3/wiki/wiki/4.5.22-Release-Notes for the Vert.x release notes.

Noteworthy: this Vert.x release fixes CVE-2025-11965 and CVE-2025-11966
