### PR TITLE
Trivial: Avoid string creation in test

### DIFF
--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/DeserializationUtil.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/DeserializationUtil.java
@@ -46,7 +46,7 @@ final class DeserializationUtil {
 
         while (nLine < lines.length) {
             if (lines[nLine].length() < DOCUMENT_DELIMITER.length()
-                    || !lines[nLine].substring(0, DOCUMENT_DELIMITER.length()).equals(DOCUMENT_DELIMITER)) {
+                    || !lines[nLine].regionMatches(0, DOCUMENT_DELIMITER, 0, DOCUMENT_DELIMITER.length())) {
                 builder.append(lines[nLine]).append(System.lineSeparator());
             } else {
                 documents.add(builder.toString());


### PR DESCRIPTION
Suggestion from @aloubyansky. See discussion here: https://github.ibm.com/quarkusio/quarkus-ibm-swidtag/pull/8#discussion_r11597208

I don't think many trees will be saved by this tiny efficiency improvement, but there's some value in keeping the two files in sync, even if it's just by dumb copy-paste ... and @aloubyansky's suggested code is better.