### PR TITLE
Elytron Security Properties File - set password hashing algorithm to SHA512

### DIFF
--- a/extensions/elytron-security-properties-file/deployment/src/test/resources/application-custom-auth-embedded-encrypted.properties
+++ b/extensions/elytron-security-properties-file/deployment/src/test/resources/application-custom-auth-embedded-encrypted.properties
@@ -1,14 +1,15 @@
-#passwords generated with `echo -n username:realm:password | md5`
+#passwords generated with `echo -n username:realm:password | sha256sum`
 
 quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.algorithm=digest-sha-256
 #jb0ss
-quarkus.security.users.embedded.users.scott=7861e1b73a3bf980a7505bcc156f2cdc
+quarkus.security.users.embedded.users.scott=5e3bb937a3847692ef98fd74733c3711b2a6e024a0f954bbd99dc166c5fa4163
 #test
-quarkus.security.users.embedded.users.stuart=0f1f62b147e724bae51e4079c97cd199
+quarkus.security.users.embedded.users.stuart=7d45ca4b4b18ab8cdf1d70c15b18a59a4977eb912e8909f7d8b194df570b398a
 #p4ssw0rd
-quarkus.security.users.embedded.users.jdoe=7b1bc0186206a7c7bb2009406f43cad6
+quarkus.security.users.embedded.users.jdoe=2c4a1b2ee85f00ebefe617cda4139c1d1a83e3ed6336db7e50de01a35e2a72f2
 #n0Adm1n
-quarkus.security.users.embedded.users.noadmin=4fbab5d88ae52c698e0452fdbf135969
+quarkus.security.users.embedded.users.noadmin=2f0211b0516de610a77a88d967f80686537fbb20aa532bd932c8dc2b7c27d0f1
 quarkus.security.users.embedded.roles.scott=Admin,admin,Tester,user
 quarkus.security.users.embedded.roles.stuart=admin,user
 quarkus.security.users.embedded.roles.jdoe=NoRolesUser

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/properties/runtime/MPRealmRuntimeConfig.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/properties/runtime/MPRealmRuntimeConfig.java
@@ -21,18 +21,25 @@ import io.smallrye.config.WithDefault;
 public interface MPRealmRuntimeConfig {
 
     /**
-     * If the properties are stored in plain text. If this is false (the default) then it is expected
-     * that the passwords are of the form HEX( MD5( username ":" realm ":" password ) )
+     * If the passwords are stored in the property file as plain text, e.g.
+     * {@code quarkus.security.users.embedded.users.alice=AlicesSecretPassword}.
+     * If this is false (the default) then it is expected that passwords are hashed as per the {@code algorithm} config
+     * property.
      */
     @WithDefault("false")
     boolean plainText();
 
     /**
-     * Determine which algorithm to use.
+     * The algorithm with which user password is hashed. The library expects a password prepended with the username and the
+     * realm,
+     * in the form ALG( username ":" realm ":" password ) in hexadecimal format.
      * <p>
+     * For example, on a Unix-like system we can produce the expected hash for Alice logging in to the Quarkus realm with
+     * password AlicesSecretPassword using {@code echo -n "alice:Quarkus:AlicesSecretPassword" | sha512sum}, and thus set
+     * {@code quarkus.security.users.embedded.users.alice=c8131...4546} (full hash output abbreviated here).
      * This property is ignored if {@code plainText} is true.
      */
-    @WithDefault(DigestPassword.ALGORITHM_DIGEST_MD5)
+    @WithDefault(DigestPassword.ALGORITHM_DIGEST_SHA_512)
     DigestAlgorithm algorithm();
 
     /**


### PR DESCRIPTION
Updated comments to reflect changes in password storage format and algorithm recommendations.

I was slightly confused by the documentation of `quarkus.security.users.embedded.plain-text`, which suggests only MD5 hashes are supported in embedded mode. I found https://github.com/quarkusio/quarkus/issues/9122 and the related PRs - it seems to me at that time it was forgotten to update the documentation to make it more clear that other algorithms are supported too.

I've also taken the liberty to add a suggestion as to not use MD5 in any case. _Related as a question to the maintainers: perhaps we should stop supporting MD5 hashes as they really have no place anymore in modern cryptography? **I would suggest a breaking change by removing support and making the default SHA256**._ 

