### PR TITLE
Redis Client: add sentinel topology cache TTL configuration

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
@@ -100,7 +100,11 @@ public class VertxRedisClientFactory {
         options.setPassword(config.password().orElse(null));
         config.poolCleanerInterval().ifPresent(d -> options.setPoolCleanerInterval((int) d.toMillis()));
         config.poolRecycleTimeout().ifPresent(d -> options.setPoolRecycleTimeout((int) d.toMillis()));
-        options.setHashSlotCacheTTL(config.hashSlotCacheTtl().toMillis());
+        // the Vert.x Redis client will only unify `topologyCacheTTL` and `hashSlotCacheTTL` in version 5.1,
+        // but in Quarkus, we unify them already
+        long topologyCacheTtl = config.hashSlotCacheTtl().toMillis();
+        options.setHashSlotCacheTTL(topologyCacheTtl);
+        options.setTopologyCacheTTL(topologyCacheTtl);
 
         config.role().ifPresent(options::setRole);
         options.setType(config.clientType());

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
@@ -102,7 +102,7 @@ public class VertxRedisClientFactory {
         config.poolRecycleTimeout().ifPresent(d -> options.setPoolRecycleTimeout((int) d.toMillis()));
         // the Vert.x Redis client will only unify `topologyCacheTTL` and `hashSlotCacheTTL` in version 5.1,
         // but in Quarkus, we unify them already
-        long topologyCacheTtl = config.hashSlotCacheTtl().toMillis();
+        long topologyCacheTtl = config.topologyCacheTtl().orElse(config.hashSlotCacheTtl()).toMillis();
         options.setHashSlotCacheTTL(topologyCacheTtl);
         options.setTopologyCacheTTL(topologyCacheTtl);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -148,12 +148,12 @@ public interface RedisClientConfig {
     Optional<ProtocolVersion> preferredProtocolVersion();
 
     /**
-     * The TTL of the hash slot cache. A hash slot cache is used by the clustered Redis client
-     * to prevent constantly sending {@code CLUSTER SLOTS} commands to the first statically
-     * configured cluster node.
+     * The TTL of the topology cache. A topology cache is used by a clustered Redis client
+     * and a sentinel Redis client to prevent constantly sending topology discovery commands
+     * ({@code CLUSTER SLOTS} or {@code SENTINEL ...}).
      * <p>
-     * This setting is only meaningful in case of a clustered Redis client and has no effect
-     * otherwise.
+     * This setting is only meaningful in case of a clustered Redis client and a sentinel
+     * Redis client and has no effect otherwise.
      */
     @WithDefault("1s")
     Duration hashSlotCacheTtl();

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -148,6 +148,13 @@ public interface RedisClientConfig {
     Optional<ProtocolVersion> preferredProtocolVersion();
 
     /**
+     * @deprecated use {@code quarkus.redis.topology-cache-ttl}
+     */
+    @Deprecated(forRemoval = true, since = "3.30")
+    @WithDefault("1s")
+    Duration hashSlotCacheTtl();
+
+    /**
      * The TTL of the topology cache. A topology cache is used by a clustered Redis client
      * and a sentinel Redis client to prevent constantly sending topology discovery commands
      * ({@code CLUSTER SLOTS} or {@code SENTINEL ...}).
@@ -156,7 +163,7 @@ public interface RedisClientConfig {
      * Redis client and has no effect otherwise.
      */
     @WithDefault("1s")
-    Duration hashSlotCacheTtl();
+    Optional<Duration> topologyCacheTtl();
 
     /**
      * Whether automatic failover is enabled. This only makes sense for sentinel clients


### PR DESCRIPTION
Follows up on #50753.

I _think_ we should backport part of this to 3.27, just like #50753 is marked for backporting. For that reason, I split this change into 2 commits:

1. Doesn't add a new config option, just expands the scope of the already existing one.
2. Adds a new config option and deprecates the old one for removal.

It looks weird, but allows backporting just the 1st commit, which seems sensible to me. If you disagree with backporting any of this, I can squash the commits, which would make more sense.