### PR TITLE
Filter for client imports on class level only when discovering Endpoints

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -767,7 +767,7 @@ public class ResteasyReactiveProcessor {
                     ClassInfo classInfo = method.declaringClass();
 
                     // Reject known client interfaces (See predicate above)
-                    if (classInfo.annotations().stream().anyMatch(knownClientAnnotation)
+                    if (classInfo.asClass().declaredAnnotations().stream().anyMatch(knownClientAnnotation)
                             || method.annotations().stream().anyMatch(knownClientAnnotation)
                             || method.parameters().stream().flatMap(p -> p.annotations().stream())
                                     .anyMatch(knownClientAnnotation)) {
@@ -786,7 +786,7 @@ public class ResteasyReactiveProcessor {
                     ClassInfo classInfo = method.declaringClass();
 
                     // Reject known client interfaces (See predicate above)
-                    if (classInfo.annotations().stream().anyMatch(knownClientAnnotation)
+                    if (classInfo.asClass().declaredAnnotations().stream().anyMatch(knownClientAnnotation)
                             || method.annotations().stream().anyMatch(knownClientAnnotation)
                             || method.parameters().stream().flatMap(p -> p.annotations().stream())
                                     .anyMatch(knownClientAnnotation)) {


### PR DESCRIPTION
Improves filtering on sub resources when scanning for Rest Client annotations. Now only client annotations on class level will be included in filter.

* Fixes #50755
