### PR TITLE
Filter for client imports on class level only when discovering Endpoints

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/reseasy/reactive/ResteasyReactiveProcessorFilterClientsTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/reseasy/reactive/ResteasyReactiveProcessorFilterClientsTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.reseasy.reactive;
+
+import static io.restassured.RestAssured.given;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResteasyReactiveProcessorFilterClientsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ResteasyReactiveProcessorFilterClientsTest.TestResource.class,
+                    ResteasyReactiveProcessorFilterClientsTest.TestSubResource.class));
+
+    @Path("test")
+    public static class TestResource {
+
+        @Inject
+        TestSubResource subResource;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String test() {
+            return "test";
+        }
+
+        @Path("subresource")
+        public TestSubResource subResource() {
+            return subResource;
+        }
+    }
+
+    // should not happen that a subresource is also a rest client
+    @Dependent
+    @RegisterRestClient
+    public static class TestSubResource {
+        @GET
+        public String hello() {
+            return "test/subresource";
+        }
+    }
+
+    @Test
+    public void testSimpleSubresource() {
+        given().when().get("/test/subresource")
+                .then()
+                .statusCode(405);
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/reseasy/reactive/ResteasyReactiveProcessorNoClientFilterTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/reseasy/reactive/ResteasyReactiveProcessorNoClientFilterTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.reseasy.reactive;
+
+import static io.restassured.RestAssured.given;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResteasyReactiveProcessorNoClientFilterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ResteasyReactiveProcessorNoClientFilterTest.TestResource.class,
+                    ResteasyReactiveProcessorNoClientFilterTest.TestSubResource.class));
+
+    @Path("test")
+    public static class TestResource {
+
+        @Inject
+        TestSubResource subResource;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String test() {
+            return "test";
+        }
+
+        @Path("subresource")
+        public TestSubResource subResource() {
+            return subResource;
+        }
+    }
+
+    @Dependent
+    public static class TestSubResource {
+
+        @RestClient
+        TestClient client;
+
+        @GET
+        public String hello() {
+            return "test/subresource";
+        }
+    }
+
+    @RegisterRestClient(baseUri = "test")
+    public interface TestClient {
+        @GET
+        String hello();
+    }
+
+    @Test
+    public void testSimpleSubresourceWithNoClientImportsOnClassLevel() {
+        given().when().get("/test/subresource")
+                .then()
+                .statusCode(200);
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -767,7 +767,7 @@ public class ResteasyReactiveProcessor {
                     ClassInfo classInfo = method.declaringClass();
 
                     // Reject known client interfaces (See predicate above)
-                    if (classInfo.annotations().stream().anyMatch(knownClientAnnotation)
+                    if (classInfo.asClass().declaredAnnotations().stream().anyMatch(knownClientAnnotation)
                             || method.annotations().stream().anyMatch(knownClientAnnotation)
                             || method.parameters().stream().flatMap(p -> p.annotations().stream())
                                     .anyMatch(knownClientAnnotation)) {
@@ -786,7 +786,7 @@ public class ResteasyReactiveProcessor {
                     ClassInfo classInfo = method.declaringClass();
 
                     // Reject known client interfaces (See predicate above)
-                    if (classInfo.annotations().stream().anyMatch(knownClientAnnotation)
+                    if (classInfo.asClass().declaredAnnotations().stream().anyMatch(knownClientAnnotation)
                             || method.annotations().stream().anyMatch(knownClientAnnotation)
                             || method.parameters().stream().flatMap(p -> p.annotations().stream())
                                     .anyMatch(knownClientAnnotation)) {

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/ResteasyReactiveProcessorTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/ResteasyReactiveProcessorTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static io.restassured.RestAssured.given;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResteasyReactiveProcessorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ResteasyReactiveProcessorTest.TestResource.class,
+                    ResteasyReactiveProcessorTest.TestSubResource.class));
+
+    @Path("test")
+    public static class TestResource {
+
+        @Inject
+        TestSubResource subResource;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String test() {
+            return "test";
+        }
+
+        @Path("subresource")
+        public TestSubResource subResource() {
+            return subResource;
+        }
+    }
+
+    @Dependent
+    public static class TestSubResource {
+        @GET
+        public String hello() {
+            return "test/subresource";
+        }
+    }
+
+    @Test
+    public void testSimpleSubresource() {
+        given().when().get("/test/subresource")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("test/subresource"));
+    }
+
+}


### PR DESCRIPTION
Improves filtering on sub resources when scanning for Rest Client annotations. Now only client annotations on class level will be included in filter.

* Fixes #50755