### PR TITLE
Only add quotes to channel name if required

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -124,8 +124,11 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
     static String channelPropertyFormat = "mp.messaging.%s.%s.%s";
 
     static String getChannelPropertyKey(String channelName, String propertyName, boolean incoming) {
-        return String.format(channelPropertyFormat, incoming ? "incoming" : "outgoing",
-                channelName.contains(".") ? "\"" + channelName + "\"" : channelName, propertyName);
+        if ((channelName.charAt(0) != '"' || channelName.charAt(channelName.length() - 1) != '"')
+                && channelName.contains(".")) {
+            channelName = "\"" + channelName + "\"";
+        }
+        return String.format(channelPropertyFormat, incoming ? "incoming" : "outgoing", channelName, propertyName);
     }
 
     @BuildStep


### PR DESCRIPTION
The method `io.quarkus.smallrye.reactivemessaging.kafka.deployment.SmallRyeReactiveMessagingKafkaProcessor#getChannelPropertyKey` is adding quotes to the channel name if the name contains a `.`, but the channel parameter may already be quoted, causing double quotes.

The channel name coming from annotations is unquoted:

https://github.com/quarkusio/quarkus/blob/5c9d5e8bb2b8973f56f9b5ebbc6f38005e109fda/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java#L251-L255

And the channel name coming from `ChannelBuildItem` is quoted:

https://github.com/quarkusio/quarkus/blob/1b3b935e2e5ce6eb5d19b6f933b4a91c3e9f7a26/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java#L199-L212

https://github.com/quarkusio/quarkus/blob/1b3b935e2e5ce6eb5d19b6f933b4a91c3e9f7a26/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java#L63-L74

As a quick fix, I've changed `io.quarkus.smallrye.reactivemessaging.kafka.deployment.SmallRyeReactiveMessagingKafkaProcessor#getChannelPropertyKey` to handle both styles, but I think we should consider making the name style consistent, which requires some extra work.

- Fixes #50751
- Caused by #49861