### PR TITLE
Make REST client request filter used for the default OIDC client singleton

### DIFF
--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc.client.reactive.filter.deployment;
 
+import static io.quarkus.arc.processor.DotNames.SINGLETON;
 import static io.quarkus.oidc.client.deployment.OidcClientFilterDeploymentHelper.DEFAULT_OIDC_REQUEST_FILTER_NAME;
 import static io.quarkus.oidc.client.deployment.OidcClientFilterDeploymentHelper.detectCustomFiltersThatRequireResponseFilter;
 
@@ -83,7 +84,8 @@ public class OidcClientReactiveFilterBuildStep {
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
-        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(OidcClientRequestReactiveFilter.class));
+        additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(OidcClientRequestReactiveFilter.class)
+                .setUnremovable().setDefaultScope(SINGLETON).build());
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(OidcClientRequestReactiveFilter.class.getName()));
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(OidcClientRequestReactiveFilter.class)


### PR DESCRIPTION
- hopefully mitigates https://github.com/quarkusio/quarkus/discussions/50373

I was trying to figure why could it happen that token is not refresh on the next attempt in concurrent scenarios that only our user could reproduce and mentioned that the client used for the default client is `@Dependent` bean. Everywhere else, we generate this filter as `@Singleton` and by nature, we should only make it singleton, so that we have "one" token producer per Oidc client when possible.

Re test - I have never reproduced the issue described in the discussion, so we can make this PR more about "this filter should be a singleton".