### PR TITLE
Registry client option to set a low boundary for recommended streams on the client side

### DIFF
--- a/docs/src/main/asciidoc/extension-registry-user.adoc
+++ b/docs/src/main/asciidoc/extension-registry-user.adoc
@@ -221,19 +221,55 @@ Applications using a registry client can be configured using environment variabl
 
 `QUARKUS_REGISTRIES` environment variable can be used to specify which registries should be enabled as a comma-separated list of registry IDs.
 For example
-```
+----
 QUARKUS_REGISTRIES=registry.acme.org,registry.quarkus.io
-```
+----
 That alone will be enough to initialize a registry client to pull extension catalogs from two registries using their default configurations.
 
 Certain registry options could be initialized with their specific environment variables. Each such option will have the following environment variable prefix:
-```
+----
 QUARKUS_REGISTRY_<UPPERCASED_AND_UNDERSCORED_REGISTRY_ID>_
-```
+----
 where `<UPPERCASED_AND_UNDERSCORED_REGISTRY_ID>` is a registry ID with each character converted to uppercase and a `.` replaced with `_`. For example, `REGISTRY_ACME_ORG`.
 
-The following options can be configured with this approach:
+Below are examples of various options that can be configured following this approach.
 
-- Repository URL, for example `QUARKUS_REGISTRY_REGISTRY_ACME_ORG_REPO_URL=https://internal.registry.acme.org/maven`
-- Update policy, for example `QUARKUS_REGISTRY_REGISTRY_ACME_ORG_UPDATE_POLICY=always`
-- Offering, for example `QUARKUS_REGISTRY_REGISTRY_ACME_ORG_OFFERING=acme-magic`
+===== Repository URL
+
+`QUARKUS_REGISTRY_<UPPERCASED_AND_UNDERSCORED_REGISTRY_ID>_REPO_URL=<REPO_URL>`
+
+Example:
+----
+QUARKUS_REGISTRY_REGISTRY_ACME_ORG_REPO_URL=https://internal.registry.acme.org/maven
+----
+
+===== Update policy
+
+`QUARKUS_REGISTRY_<UPPERCASED_AND_UNDERSCORED_REGISTRY_ID>_UPDATE_POLICY=<UPDATE_POLICY>`
+
+Example:
+----
+QUARKUS_REGISTRY_REGISTRY_ACME_ORG_UPDATE_POLICY=always
+----
+
+===== Offering
+
+`QUARKUS_REGISTRY_<UPPERCASED_AND_UNDERSCORED_REGISTRY_ID>_OFFERING=<OFFERING>`
+
+Example:
+----
+QUARKUS_REGISTRY_REGISTRY_ACME_ORG_OFFERING=acme-magic
+----
+
+===== Recommend Streams From
+
+Set the oldest acceptable stream value per platform. Streams older than the configured values will be ignored by the client.
+
+`QUARKUS_REGISTRY_<UPPERCASED_AND_UNDERSCORED_REGISTRY_ID>_RECOMMEND_STREAMS_FROM_<UPPERCASED_AND_UNDERSCORED_PLATFORM_KEY>=<STREAM_ID>`
+
+Where `UPPERCASED_AND_UNDERSCORED_PLATFORM_KEY` is a platform key with each character converted to uppercase and a `.` replaced with `_`. For example, `IO_QUARKUS_PLATFORM`.
+
+Example:
+----
+QUARKUS_REGISTRY_REGISTRY_ACME_ORG_RECOMMEND_STREAMS_FROM_IO_QUARKUS_PLATFORM=3.27
+----

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -99,14 +99,15 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
             // necessary to set the versions from the selected origins
             this.dataCatalog = CatalogMergeUtility.merge(extensionOrigins);
             // collect platform BOMs to import
-            boolean sawFirstPlatform = false;
             ExtensionCatalog primaryCatalog = null;
             this.platformBoms = new ArrayList<>(extensionOrigins.size());
             for (ExtensionCatalog c : extensionOrigins) {
                 if (c.isPlatform()) {
-                    if (c.getBom().getArtifactId().equals(QUARKUS_BOM) || !sawFirstPlatform) {
+                    // use either the first platform catalog or the first quarkus-bom catalog, if found
+                    if (primaryCatalog == null
+                            || !primaryCatalog.getBom().getArtifactId().equals(QUARKUS_BOM)
+                                    && c.getBom().getArtifactId().equals(QUARKUS_BOM)) {
                         primaryCatalog = c;
-                        sawFirstPlatform = true;
                     }
                     platformBoms.add(c.getBom());
                 }

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -1,5 +1,8 @@
 package io.quarkus.devtools.testing.registry.client;
 
+import static io.quarkus.registry.Constants.OFFERING;
+import static io.quarkus.registry.Constants.RECOMMEND_STREAMS_FROM;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -390,12 +393,26 @@ public class TestRegistryClientBuilder {
         }
 
         public TestRegistryBuilder setOffering(String offering) {
+            return setExtraOption(OFFERING, offering);
+        }
+
+        public TestRegistryBuilder setRecommendStreamsFrom(String platformKey, String streamId) {
+            Map<String, String> recommendStreamsFrom = (Map<String, String>) config.getExtra().get(RECOMMEND_STREAMS_FROM);
+            if (recommendStreamsFrom == null) {
+                recommendStreamsFrom = new HashMap<>(2);
+                setExtraOption(RECOMMEND_STREAMS_FROM, recommendStreamsFrom);
+            }
+            recommendStreamsFrom.put(platformKey, streamId);
+            return this;
+        }
+
+        private TestRegistryBuilder setExtraOption(String name, Object value) {
             var extra = config.getExtra();
             if (extra == null || extra.isEmpty()) {
-                extra = new HashMap<>(1);
+                extra = new HashMap<>(4);
                 config.setExtra(extra);
             }
-            extra.put(Constants.OFFERING, offering);
+            extra.put(name, value);
             return this;
         }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario1Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario1Test.java
@@ -1,0 +1,31 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+/**
+ * This test does not configure the recommend-streams-from but tests the default setup
+ */
+public class RecommendStreamsFromScenario1Test extends RecommendStreamsFromScenarioBase {
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir(getClass().getSimpleName());
+        createProject(projectDir, List.of("ext-a", "ext-b"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom"),
+                        platformMemberBomCoords("acme-b-bom")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null)),
+                Map.of("quarkus.platform.group-id", DOWNSTREAM_PLATFORM_KEY,
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "2.2.2.downstream"));
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario2Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario2Test.java
@@ -1,0 +1,38 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+/**
+ * This test does not configure the recommend-streams-from but configures an offering, which makes the tools give preference to
+ * an older stream
+ */
+public class RecommendStreamsFromScenario2Test extends RecommendStreamsFromScenarioBase {
+
+    @Override
+    protected void setDownstreamRegistryExtraOptions(TestRegistryClientBuilder.TestRegistryBuilder registry) {
+        registry.setOffering("offering-a");
+    }
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir(getClass().getSimpleName());
+        createProject(projectDir, List.of("ext-a", "ext-b"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom"),
+                        platformMemberBomCoords("acme-b-bom")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null)),
+                Map.of("quarkus.platform.group-id", DOWNSTREAM_PLATFORM_KEY,
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "1.1.1.downstream"));
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario3Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario3Test.java
@@ -1,0 +1,35 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class RecommendStreamsFromScenario3Test extends RecommendStreamsFromScenarioBase {
+
+    @Override
+    protected void setDownstreamRegistryExtraOptions(TestRegistryClientBuilder.TestRegistryBuilder registry) {
+        registry.setOffering("offering-a")
+                .setRecommendStreamsFrom(DOWNSTREAM_PLATFORM_KEY, "2.2");
+    }
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir(getClass().getSimpleName());
+        createProject(projectDir, List.of("ext-a", "ext-b"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom"),
+                        ArtifactCoords.pom(UPSTREAM_PLATFORM_KEY, "acme-b-bom", "2.2.2")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null)),
+                Map.of("quarkus.platform.group-id", DOWNSTREAM_PLATFORM_KEY,
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "2.2.2.downstream"));
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario4Test.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenario4Test.java
@@ -1,0 +1,40 @@
+package io.quarkus.devtools.project.create;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class RecommendStreamsFromScenario4Test extends RecommendStreamsFromScenarioBase {
+
+    @Override
+    protected void setDownstreamRegistryExtraOptions(TestRegistryClientBuilder.TestRegistryBuilder registry) {
+        registry.setOffering("offering-a")
+                .setRecommendStreamsFrom(DOWNSTREAM_PLATFORM_KEY, "2.2");
+    }
+
+    @Override
+    protected void setUpstreamRegistryExtraOptions(TestRegistryClientBuilder.TestRegistryBuilder registry) {
+        registry.setRecommendStreamsFrom(UPSTREAM_PLATFORM_KEY, "3.3");
+    }
+
+    @Test
+    public void createOfferingA() throws Exception {
+        final Path projectDir = newProjectDir(getClass().getSimpleName());
+        createProject(projectDir, List.of("ext-a", "ext-b"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom"),
+                        platformMemberBomCoords("acme-b-bom")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null)),
+                Map.of("quarkus.platform.group-id", UPSTREAM_PLATFORM_KEY,
+                        "quarkus.platform.artifact-id", "quarkus-bom",
+                        "quarkus.platform.version", "3.3.3"));
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenarioBase.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/RecommendStreamsFromScenarioBase.java
@@ -1,0 +1,111 @@
+package io.quarkus.devtools.project.create;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+
+public class RecommendStreamsFromScenarioBase extends MultiplePlatformBomsTestBase {
+    protected static final String UPSTREAM_PLATFORM_KEY = "io.upstream.platform";
+    protected static final String DOWNSTREAM_PLATFORM_KEY = "io.downstream.platform";
+
+    @BeforeEach
+    public void setup() throws Exception {
+        TestRegistryClientBuilder registryClientBuilder = TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir());
+
+        var downstreamRegistry = registryClientBuilder
+                // registry
+                .newRegistry("downstream.registry.test")
+                .recognizedQuarkusVersions("*downstream");
+        setDownstreamRegistryExtraOptions(downstreamRegistry);
+
+        downstreamRegistry
+                // platform key
+                .newPlatform(DOWNSTREAM_PLATFORM_KEY)
+                .newStream("2.2")
+                // 2.2.2 release
+                .newRelease("2.2.2.downstream")
+                .quarkusVersion("2.2.2.downstream")
+                .upstreamQuarkusVersion("2.2.2")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // platform member
+                .newMember("acme-a-bom")
+                .addExtensionWithMetadata("io.acme", "ext-a", "2.2.2.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .release()
+                .newMember("acme-b-bom")
+                .addExtensionWithMetadata("io.acme", "ext-b", "2.2.2.downstream",
+                        Map.of("offering-b-support", List.of("supported")))
+                .release().stream().platform()
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1.downstream")
+                .quarkusVersion("1.1.1.downstream")
+                .upstreamQuarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // platform member
+                .newMember("acme-a-bom")
+                .addExtensionWithMetadata("io.acme", "ext-a", "1.1.1.downstream",
+                        Map.of("offering-a-support", List.of("supported")))
+                .release()
+                .newMember("acme-b-bom")
+                .addExtensionWithMetadata("io.acme", "ext-b", "1.1.1.downstream",
+                        // on purpose included in offering-a
+                        Map.of("offering-a-support", List.of("supported")));
+
+        var upstreamRegistry = registryClientBuilder.newRegistry("upstream.registry.test");
+        setUpstreamRegistryExtraOptions(upstreamRegistry);
+
+        upstreamRegistry
+                // platform key
+                .newPlatform(UPSTREAM_PLATFORM_KEY)
+                // 3.3 STREAM
+                .newStream("3.3")
+                // 3.3.3 release
+                .newRelease("3.3.3")
+                .quarkusVersion("3.3.3")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "3.3.3").release()
+                .newMember("acme-b-bom").addExtension("io.acme", "ext-b", "3.3.3").release()
+                .stream().platform()
+                // 2.2 STREAM
+                .newStream("2.2")
+                // 2.2.2 release
+                .newRelease("2.2.2")
+                .quarkusVersion("2.2.2")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "2.2.2").release()
+                .newMember("acme-b-bom").addExtension("io.acme", "ext-b", "2.2.2").release()
+                .stream().platform()
+                // 1.1 STREAM
+                .newStream("1.1")
+                // 1.1.1 release
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "1.1.1").release()
+                .newMember("acme-b-bom").addExtension("io.acme", "ext-b", "1.1.1");
+
+        registryClientBuilder.build();
+        enableRegistryClient();
+    }
+
+    protected void setDownstreamRegistryExtraOptions(TestRegistryClientBuilder.TestRegistryBuilder registry) {
+    }
+
+    protected void setUpstreamRegistryExtraOptions(TestRegistryClientBuilder.TestRegistryBuilder registry) {
+    }
+
+    protected String getMainPlatformKey() {
+        return DOWNSTREAM_PLATFORM_KEY;
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
@@ -22,9 +22,14 @@ public interface Constants {
     String LAST_UPDATED = "last-updated";
 
     /**
-     * Registry configuration option allowing users to limit the extension catalog from a registry to a specific offering
+     * Registry client configuration option allowing users to limit the extension catalog from a registry to a specific offering
      */
     String OFFERING = "offering";
+
+    /**
+     * Registry client configuration option allowing users to set a low boundary for the recommended streams per platform
+     */
+    String RECOMMEND_STREAMS_FROM = "recommend-streams-from";
 
     /**
      * An internal key optionally added to extension metadata by a registry client

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -1,11 +1,13 @@
 package io.quarkus.registry;
 
 import static io.quarkus.registry.Constants.OFFERING;
+import static io.quarkus.registry.Constants.RECOMMEND_STREAMS_FROM;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -18,6 +20,7 @@ import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.Platform;
 import io.quarkus.registry.catalog.PlatformCatalog;
+import io.quarkus.registry.catalog.PlatformStream;
 import io.quarkus.registry.client.RegistryClient;
 import io.quarkus.registry.config.RegistryConfig;
 import io.quarkus.util.GlobUtil;
@@ -32,6 +35,30 @@ class RegistryExtensionResolver {
     private static final String DASH_SUPPORT = "-support";
 
     /**
+     * Returns an extra config option value with an expected type.
+     * If an option was not configured, the returned value will be null.
+     * If the configured value cannot be cast to an expected type, the method will throw an error.
+     *
+     * @param config registry configuration
+     * @param name option name
+     * @param type expected value type
+     * @return configured value or null
+     * @param <T> expected value type
+     */
+    private static <T> T getExtraConfigOption(RegistryConfig config, String name, Class<T> type) {
+        Object o = config.getExtra().get(name);
+        if (o == null) {
+            return null;
+        }
+        if (type.isInstance(o)) {
+            return (T) o;
+        }
+        throw new IllegalArgumentException(
+                "Expected a value of type " + type.getName() + " for option " + name + " but got " + o
+                        + " of type " + o.getClass().getName());
+    }
+
+    /**
      * Returns offering configured by the user in the registry configuration or null, in case
      * no offering was configured.
      *
@@ -41,30 +68,73 @@ class RegistryExtensionResolver {
      * @return user configured offering or null
      */
     private static String getConfiguredOfferingOrNull(RegistryConfig config) {
-        var offering = config.getExtra().get(OFFERING);
-        if (offering == null) {
-            return null;
+        var offering = getExtraConfigOption(config, OFFERING, String.class);
+        return offering == null || offering.isBlank() ? null : offering;
+    }
+
+    /**
+     * Returns the lowest boundaries for recommended streams, if configured.
+     * The returned map will have platform keys as the map keys and stream IDs split using dot as a separator.
+     * If the lowest boundaries have not been configured, this method will return an empty map.
+     *
+     * @param config registry configuration
+     * @return lowest boundaries for recommended streams per platform key or an empty map, if not configured
+     */
+    private static Map<String, String[]> getRecommendStreamsFromOrNull(RegistryConfig config) {
+        final Map<String, String> recommendStreamsStarting = getExtraConfigOption(config, RECOMMEND_STREAMS_FROM, Map.class);
+        if (recommendStreamsStarting == null) {
+            return Map.of();
         }
-        if (!(offering instanceof String)) {
-            throw new IllegalArgumentException("Expected a string value for option " + OFFERING + " but got " + offering
-                    + " of type " + offering.getClass().getName());
+        final Map<String, String[]> result = new HashMap<>(recommendStreamsStarting.size());
+        for (Map.Entry<String, String> e : recommendStreamsStarting.entrySet()) {
+            result.put(e.getKey(), e.getValue().split("\\."));
         }
-        final String str = offering.toString();
-        return str.isBlank() ? null : str;
+        return result;
+    }
+
+    /**
+     * Compares two streams as versions.
+     *
+     * @param streamParts1 stream one
+     * @param streamParts2 stream two
+     * @return 1 if stream one is newer than stream two, -1 if stream two is newer than stream 1, otherwise 0
+     */
+    private static int compareStreams(String[] streamParts1, String[] streamParts2) {
+        int partI = 0;
+        while (true) {
+            if (partI == streamParts1.length) {
+                return partI == streamParts2.length ? 0 : -1;
+            }
+            if (partI == streamParts2.length) {
+                return 1;
+            }
+            final int result = streamParts1[partI].compareTo(streamParts2[partI]);
+            if (result != 0) {
+                return result;
+            }
+            ++partI;
+        }
     }
 
     private final RegistryConfig config;
-    private final RegistryClient extensionResolver;
+    private final RegistryClient registry;
 
     private final Pattern recognizedQuarkusVersions;
     private final Collection<String> recognizedGroupIds;
+
     /**
      * {@code -support} extension metadata key that corresponds to the user selected offering, can be null
      */
     private final String offeringSupportKey;
 
+    /**
+     * If configured, this will be the lowest boundary for stream recommendations.
+     * IOW, streams before this value will be ignored.
+     */
+    private final Map<String, String[]> recommendStreamsFrom;
+
     RegistryExtensionResolver(RegistryClient registryClient, MessageWriter log) throws RegistryResolutionException {
-        this.extensionResolver = Objects.requireNonNull(registryClient, "Registry extension resolver is null");
+        this.registry = Objects.requireNonNull(registryClient, "Registry extension resolver is null");
         this.config = registryClient.resolveRegistryConfig();
 
         final String versionExpr = config.getQuarkusVersions() == null ? null
@@ -79,6 +149,11 @@ class RegistryExtensionResolver {
             this.offeringSupportKey = offering + DASH_SUPPORT;
         } else {
             offeringSupportKey = null;
+        }
+
+        recommendStreamsFrom = getRecommendStreamsFromOrNull(config);
+        if (!recommendStreamsFrom.isEmpty()) {
+            log.debug("Streams before %s recommended by %s will be ignored", recommendStreamsFrom, config.getId());
         }
     }
 
@@ -120,7 +195,43 @@ class RegistryExtensionResolver {
     }
 
     PlatformCatalog.Mutable resolvePlatformCatalog(String quarkusCoreVersion) throws RegistryResolutionException {
-        return extensionResolver.resolvePlatforms(quarkusCoreVersion);
+        PlatformCatalog.Mutable platformCatalog = registry.resolvePlatforms(quarkusCoreVersion);
+        if (!recommendStreamsFrom.isEmpty()) {
+            final Iterator<Platform> platformI = platformCatalog.getPlatforms().iterator();
+            boolean allPlatformsIgnored = true;
+            while (platformI.hasNext()) {
+                var platform = platformI.next();
+                final String[] fromStream = recommendStreamsFrom.get(platform.getPlatformKey());
+                if (fromStream != null) {
+                    final Iterator<PlatformStream> streamI = platform.getStreams().iterator();
+                    boolean allStreamsIgnored = true;
+                    while (streamI.hasNext()) {
+                        var stream = streamI.next();
+                        if (compareStreams(fromStream, stream.getId().split("\\.")) > 0) {
+                            streamI.remove();
+                            break;
+                        } else {
+                            allStreamsIgnored = false;
+                        }
+                    }
+                    while (streamI.hasNext()) {
+                        streamI.next();
+                        streamI.remove();
+                    }
+                    if (allStreamsIgnored) {
+                        platformI.remove();
+                    } else {
+                        allPlatformsIgnored = false;
+                    }
+                } else {
+                    allPlatformsIgnored = false;
+                }
+            }
+            if (allPlatformsIgnored) {
+                return null;
+            }
+        }
+        return platformCatalog;
     }
 
     Platform resolveRecommendedPlatform() throws RegistryResolutionException {
@@ -128,7 +239,7 @@ class RegistryExtensionResolver {
     }
 
     ExtensionCatalog.Mutable resolveNonPlatformExtensions(String quarkusCoreVersion) throws RegistryResolutionException {
-        return applyOfferingFilter(extensionResolver.resolveNonPlatformExtensions(quarkusCoreVersion));
+        return applyOfferingFilter(registry.resolveNonPlatformExtensions(quarkusCoreVersion));
     }
 
     /**
@@ -145,7 +256,7 @@ class RegistryExtensionResolver {
      * @throws RegistryResolutionException in case of a failure
      */
     ExtensionCatalog.Mutable resolvePlatformExtensions(ArtifactCoords platform) throws RegistryResolutionException {
-        return applyOfferingFilter(extensionResolver.resolvePlatformExtensions(platform));
+        return applyOfferingFilter(registry.resolvePlatformExtensions(platform));
     }
 
     private ExtensionCatalog.Mutable applyOfferingFilter(ExtensionCatalog.Mutable catalog) {
@@ -176,6 +287,6 @@ class RegistryExtensionResolver {
     }
 
     void clearCache() throws RegistryResolutionException {
-        extensionResolver.clearCache();
+        registry.clearCache();
     }
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
@@ -6,6 +6,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.quarkus.registry.Constants;
@@ -23,6 +24,7 @@ public class RegistriesConfigLocator {
 
     static final String QUARKUS_REGISTRIES = "QUARKUS_REGISTRIES";
     static final String QUARKUS_REGISTRY_ENV_VAR_PREFIX = "QUARKUS_REGISTRY_";
+    static final String RECOMMEND_STREAMS_FROM_ = "RECOMMEND_STREAMS_FROM_";
 
     /**
      * Locate the registry client configuration file and deserialize it.
@@ -178,20 +180,31 @@ public class RegistriesConfigLocator {
 
             final String envvarPrefix = getEnvVarPrefix(registryId);
             for (Map.Entry<String, String> var : map.entrySet()) {
-                if (!var.getKey().startsWith(envvarPrefix)) {
+                final String envvarName = var.getKey();
+                if (!envvarName.startsWith(envvarPrefix)) {
                     continue;
                 }
-                if (isEnvVarOption(var.getKey(), envvarPrefix, "UPDATE_POLICY")) {
+                if (isEnvVarOption(envvarName, envvarPrefix, "UPDATE_POLICY")) {
                     builder.setUpdatePolicy(var.getValue());
-
-                } else if (isEnvVarOption(var.getKey(), envvarPrefix, "REPO_URL")) {
+                } else if (isEnvVarOption(envvarName, envvarPrefix, "REPO_URL")) {
                     builder.setMaven(RegistryMavenConfig.builder()
                             .setRepository(RegistryMavenRepoConfig.builder()
                                     .setUrl(var.getValue())
                                     .build())
                             .build());
-                } else if (isEnvVarOption(var.getKey(), envvarPrefix, "OFFERING")) {
-                    builder.setExtra(Map.of(Constants.OFFERING, var.getValue()));
+                } else if (isEnvVarOption(envvarName, envvarPrefix, "OFFERING")) {
+                    builder.setExtra(Constants.OFFERING, var.getValue());
+                } else if (isEnvVarOption(envvarName, envvarPrefix, RECOMMEND_STREAMS_FROM_)) {
+                    // the format for recommend-streams-from is
+                    // QUARKUS_REGISTRY_<REGISTRY_ID>_RECOMMEND_STREAMS_FROM_<PLATFORM_KEY>=<STREAM_ID>
+                    int i = envvarPrefix.length() + RECOMMEND_STREAMS_FROM_.length();
+                    final StringBuilder platformKey = new StringBuilder(envvarName.length() - i);
+                    while (i < envvarName.length()) {
+                        final char ch = envvarName.charAt(i++);
+                        platformKey.append(ch == '_' ? '.' : Character.toLowerCase(ch));
+                    }
+                    builder.computeExtraIfAbsent(Constants.RECOMMEND_STREAMS_FROM, RegistriesConfigLocator::newMap)
+                            .put(platformKey.toString(), var.getValue());
                 }
             }
 
@@ -208,7 +221,8 @@ public class RegistriesConfigLocator {
     }
 
     private static String getEnvVarPrefix(String registryId) {
-        final StringBuilder buf = new StringBuilder(QUARKUS_REGISTRY_ENV_VAR_PREFIX);
+        final StringBuilder buf = new StringBuilder(QUARKUS_REGISTRY_ENV_VAR_PREFIX.length() + registryId.length() + 1)
+                .append(QUARKUS_REGISTRY_ENV_VAR_PREFIX);
         for (int i = 0; i < registryId.length(); ++i) {
             final char c = registryId.charAt(i);
             if (c == '.') {
@@ -218,5 +232,9 @@ public class RegistriesConfigLocator {
             }
         }
         return buf.append('_').toString();
+    }
+
+    private static Map<String, String> newMap(String key) {
+        return new HashMap<>(1);
     }
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryConfigImpl.java
@@ -307,11 +307,17 @@ public class RegistryConfigImpl implements RegistryConfig {
 
         @JsonAnySetter
         public Builder setExtra(String name, Object value) {
-            if (extra == null) {
-                extra = new HashMap<>();
-            }
-            extra.put(name, value);
+            mutableExtra().put(name, value);
             return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public <V> V computeExtraIfAbsent(String name, Function<String, ? extends V> func) {
+            return (V) mutableExtra().computeIfAbsent(name, func);
+        }
+
+        private Map<String, Object> mutableExtra() {
+            return extra == null ? extra = new HashMap<>(4) : extra;
         }
 
         @Override

--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/RegistriesConfigLocatorTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/RegistriesConfigLocatorTest.java
@@ -161,6 +161,38 @@ public class RegistriesConfigLocatorTest {
         assertThat(completeConfig).isEqualTo(expectedConfig);
     }
 
+    @Test
+    void testRecommendStreamsFrom() throws Exception {
+        final Map<String, String> env = new HashMap<>();
+        env.put(RegistriesConfigLocator.QUARKUS_REGISTRIES, "registry.acme.org,registry.other.io");
+        env.put(RegistriesConfigLocator.QUARKUS_REGISTRY_ENV_VAR_PREFIX + "REGISTRY_ACME_ORG_"
+                + RegistriesConfigLocator.RECOMMEND_STREAMS_FROM_ + "ORG_ACME_PLATFORM", "1.1");
+        env.put(RegistriesConfigLocator.QUARKUS_REGISTRY_ENV_VAR_PREFIX + "REGISTRY_OTHER_IO_"
+                + RegistriesConfigLocator.RECOMMEND_STREAMS_FROM_ + "IO_OTHER_PLATFORM", "2.2");
+        env.put(RegistriesConfigLocator.QUARKUS_REGISTRY_ENV_VAR_PREFIX + "REGISTRY_OTHER_IO_"
+                + RegistriesConfigLocator.RECOMMEND_STREAMS_FROM_ + "IO_ANOTHER_PLATFORM", "3.3");
+
+        final RegistriesConfig actualConfig = RegistriesConfigLocator.initFromEnvironmentOrNull(env);
+
+        final RegistriesConfig expectedConfig = RegistriesConfig.builder()
+                .setRegistry(RegistryConfig.builder()
+                        .setId("registry.acme.org")
+                        .setExtra(Constants.RECOMMEND_STREAMS_FROM, Map.of("org.acme.platform", "1.1"))
+                        .build())
+                .setRegistry(RegistryConfig.builder()
+                        .setId("registry.other.io")
+                        .setExtra(Constants.RECOMMEND_STREAMS_FROM, Map.of(
+                                "io.other.platform", "2.2",
+                                "io.another.platform", "3.3"))
+                        .build())
+                .build();
+
+        assertThat(actualConfig).isEqualTo(expectedConfig);
+
+        final RegistriesConfig completeConfig = serializeDeserialize(actualConfig);
+        assertThat(completeConfig).isEqualTo(expectedConfig);
+    }
+
     private static RegistriesConfig serializeDeserialize(RegistriesConfig config) throws Exception {
         final StringWriter buf = new StringWriter();
         RegistriesConfigMapperHelper.toYaml(config, buf);


### PR DESCRIPTION
This change allows configuring the oldest acceptable stream per platform on the client side.
For example, a client may choose not to see streams older than 3.27 even if the registry still lists them as supported.

Helps https://github.com/redhat-developer/code.quarkus.redhat.com/issues/204

FYI @ia3andy @gastaldi 