### PR TITLE
Fix OCP build and deploy command

### DIFF
--- a/docs/src/main/asciidoc/_includes/devtools/build.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build.adoc
@@ -2,7 +2,8 @@
 .CLI
 ----
 ifdef::build-additional-parameters[]
-quarkus build quarkus deploy openshift
+quarkus build
+quarkus deploy openshift
 endif::[]
 ifndef::build-additional-parameters[]
 quarkus build


### PR DESCRIPTION
Fix OCP build and deploy command for CLI, they are 2 commands

Examples where the one line command is shown:
 * https://quarkus.io/guides/deploying-to-openshift#logging-in-to-an-openshift-cluster
 * https://quarkus.io/guides/deploying-to-openshift-howto