### PR TITLE
Use Path.resolve to check for unknown configuration files

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -284,7 +284,7 @@ public final class ConfigDiagnostic {
                     String unprofiledConfigFile = APPLICATION + "." + filename.substring(filename.lastIndexOf('.') + 1);
                     String profile = filename.substring(APPLICATION_LENGTH + 1, filename.lastIndexOf('.'));
                     if (config.getProfiles().contains(profile)
-                            && !Files.exists(Path.of(configFile.getParent().toString(), unprofiledConfigFile))) {
+                            && !Files.exists(configFile.getParent().resolve(unprofiledConfigFile))) {
                         log.warnf(
                                 "Profiled configuration file %s is ignored; a main %s configuration file must exist in the same location to load %s",
                                 configFile, unprofiledConfigFile, filename);


### PR DESCRIPTION
The way we resolve paths in the Maven plugin differs if using `<extensions>true</extensions>` (plain directory if `true` or jar if `false`). 

In Windows, when `extensions` is omitted or `false`, the unknown configuration files checking would fail with an InvalidPathException when trying to validate if a profile file has a main file.

- Fixes #50322