### PR TITLE
Unquoted configuration channel names in build items

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
@@ -1,6 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.kafka.deployment;
 
-import static io.quarkus.smallrye.reactivemessaging.kafka.deployment.SmallRyeReactiveMessagingKafkaProcessor.getChannelPropertyKey;
+import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelPropertyName;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -60,7 +60,7 @@ class DefaultSerdeDiscoveryState {
 
         String channelType = incoming ? "incoming" : "outgoing";
         return isKafkaConnector.computeIfAbsent(channelType + "|" + channelName, ignored -> {
-            String connectorKey = getChannelPropertyKey(channelName, "connector", incoming);
+            String connectorKey = getChannelPropertyName(channelName, "connector", incoming);
             String connector = getConfig()
                     .getOptionalValue(connectorKey, String.class)
                     .orElse("ignored");

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/DefaultSchemaDiscoveryState.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/DefaultSchemaDiscoveryState.java
@@ -1,6 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.pulsar.deployment;
 
-import static io.quarkus.smallrye.reactivemessaging.deployment.SmallRyeReactiveMessagingProcessor.getChannelPropertyKey;
+import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelPropertyName;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,7 +52,7 @@ class DefaultSchemaDiscoveryState {
 
         String channelType = incoming ? "incoming" : "outgoing";
         return isPulsarConnector.computeIfAbsent(channelType + "|" + channelName, ignored -> {
-            String connectorKey = getChannelPropertyKey(channelName, "connector", incoming);
+            String connectorKey = getChannelPropertyName(channelName, "connector", incoming);
             String connector = getConfig()
                     .getOptionalValue(connectorKey, String.class)
                     .orElse("ignored");
@@ -108,7 +108,7 @@ class DefaultSchemaDiscoveryState {
     }
 
     boolean hasObjectMapperConfigSchema(Type type, String channelName, boolean incoming) {
-        String key = getChannelPropertyKey(channelName, "schema", incoming);
+        String key = getChannelPropertyName(channelName, "schema", incoming);
         Optional<String> schema = getConfig().getOptionalValue(key, String.class);
         return schema.isPresent() && schema.get().equals(SyntheticBeanBuilder.objectMapperSchemaId(type));
     }

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarSchemaDiscoveryProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarSchemaDiscoveryProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.smallrye.reactivemessaging.pulsar.deployment;
 
-import static io.quarkus.smallrye.reactivemessaging.deployment.SmallRyeReactiveMessagingProcessor.getChannelPropertyKey;
+import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelIncomingPropertyName;
+import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelOutgoingPropertyName;
 
 import java.util.List;
 import java.util.Map;
@@ -102,16 +103,12 @@ public class PulsarSchemaDiscoveryProcessor {
         }
     }
 
-    private static String outgoingSchemaKey(String channelName) {
-        return getChannelPropertyKey(channelName, "schema", false);
-    }
-
     private void processPulsarTransactions(DefaultSchemaDiscoveryState discovery,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> config,
             String channelName,
             Type injectionPointType) {
         if (injectionPointType != null && isPulsarEmitter(injectionPointType)) {
-            String enableTransactionKey = getChannelPropertyKey(channelName, "enableTransaction", false);
+            String enableTransactionKey = getChannelOutgoingPropertyName(channelName, "enableTransaction");
             log.infof("Transactional producer detected for channel '%s', setting following default config values: "
                     + "'" + enableTransactionKey + "=true'", channelName);
             produceRuntimeConfigurationDefaultBuildItem(discovery, config, enableTransactionKey, "true");
@@ -129,18 +126,15 @@ public class PulsarSchemaDiscoveryProcessor {
                     objectMapperSchemaFor(SyntheticBeanBuilder.objectMapperSchemaId(value), value, syntheticBean);
                 } else {
                     String schema = schemaFor(discovery, value, syntheticBean);
-                    produceRuntimeConfigurationDefaultBuildItem(discovery, config, incomingSchemaKey(channelName), schema);
+                    produceRuntimeConfigurationDefaultBuildItem(discovery, config,
+                            getChannelIncomingPropertyName(channelName, "schema"), schema);
                 }
             }
             if (Boolean.TRUE.equals(isBatch)) {
                 produceRuntimeConfigurationDefaultBuildItem(discovery, config,
-                        getChannelPropertyKey(channelName, "batchReceive", true), "true");
+                        getChannelIncomingPropertyName(channelName, "batchReceive"), "true");
             }
         });
-    }
-
-    private static String incomingSchemaKey(String channelName) {
-        return getChannelPropertyKey(channelName, "schema", true);
     }
 
     private Type getInjectionPointType(AnnotationInstance annotation) {
@@ -318,7 +312,8 @@ public class PulsarSchemaDiscoveryProcessor {
                     objectMapperSchemaFor(SyntheticBeanBuilder.objectMapperSchemaId(value), value, syntheticBean);
                 } else {
                     String schema = schemaFor(discovery, value, syntheticBean);
-                    produceRuntimeConfigurationDefaultBuildItem(discovery, config, outgoingSchemaKey(channelName), schema);
+                    produceRuntimeConfigurationDefaultBuildItem(discovery, config,
+                            getChannelOutgoingPropertyName(channelName, "schema"), schema);
                 }
             }
         });

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -102,13 +102,6 @@ public class SmallRyeReactiveMessagingProcessor {
     static final String DEFAULT_VIRTUAL_THREADS_MAX_CONCURRENCY = "1024";
     static final String INVOKER_SUFFIX = "_SmallRyeMessagingInvoker";
 
-    static String channelPropertyFormat = "mp.messaging.%s.%s.%s";
-
-    public static String getChannelPropertyKey(String channelName, String propertyName, boolean incoming) {
-        return String.format(channelPropertyFormat, incoming ? "incoming" : "outgoing",
-                channelName.contains(".") ? "\"" + channelName + "\"" : channelName, propertyName);
-    }
-
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.MESSAGING);

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
@@ -25,6 +25,10 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ChannelBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ChannelDirection;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ConnectorBuildItem;
+import io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration;
+import io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.Incoming;
+import io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.Outgoing;
+import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 
 public class WiringHelper {
@@ -48,58 +52,23 @@ public class WiringHelper {
     }
 
     static void produceIncomingChannel(BuildProducer<ChannelBuildItem> producer, String name) {
-        String channelName = normalizeChannelName(name);
-
-        Optional<String> managingConnector = getManagingConnector(ChannelDirection.INCOMING, channelName);
-        if (managingConnector.isPresent()) {
-            if (isChannelEnabled(ChannelDirection.INCOMING, channelName)) {
-                producer.produce(ChannelBuildItem.incoming(channelName, managingConnector.get()));
-            }
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        Incoming incoming = config.getConfigMapping(ReactiveMessagingConfiguration.class).incoming().get(name);
+        if (incoming != null && incoming.enabled() && incoming.connector().isPresent()) {
+            producer.produce(ChannelBuildItem.incoming(name, incoming.connector().get()));
         } else {
-            producer.produce(ChannelBuildItem.incoming(channelName, null));
+            producer.produce(ChannelBuildItem.incoming(name, null));
         }
     }
 
     static void produceOutgoingChannel(BuildProducer<ChannelBuildItem> producer, String name) {
-        String channelName = normalizeChannelName(name);
-
-        Optional<String> managingConnector = getManagingConnector(ChannelDirection.OUTGOING, channelName);
-        if (managingConnector.isPresent()) {
-            if (isChannelEnabled(ChannelDirection.OUTGOING, channelName)) {
-                producer.produce(ChannelBuildItem.outgoing(channelName, managingConnector.get()));
-            }
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        Outgoing outgoing = config.getConfigMapping(ReactiveMessagingConfiguration.class).outgoing().get(name);
+        if (outgoing != null && outgoing.enabled() && outgoing.connector().isPresent()) {
+            producer.produce(ChannelBuildItem.outgoing(name, outgoing.connector().get()));
         } else {
-            producer.produce(ChannelBuildItem.outgoing(channelName, null));
+            producer.produce(ChannelBuildItem.outgoing(name, null));
         }
-    }
-
-    /**
-     * Gets the name of the connector managing the channel if any.
-     * This method looks inside the application configuration.
-     *
-     * @param direction the direction (incoming or outgoing)
-     * @param channel the channel name
-     * @return an optional with the connector name if the channel is managed, empty otherwise
-     */
-    static Optional<String> getManagingConnector(ChannelDirection direction, String channel) {
-        return ConfigProvider.getConfig().getOptionalValue(
-                "mp.messaging." + direction.name().toLowerCase() + "." + normalizeChannelName(channel) + ".connector",
-                String.class);
-    }
-
-    /**
-     * Checks if the given channel is enabled / disabled in the configuration
-     *
-     * @param direction the direction (incoming or outgoing)
-     * @param channel the channel name
-     * @return {@code true} if the channel is enabled, {@code false} otherwise
-     */
-    static boolean isChannelEnabled(ChannelDirection direction, String channel) {
-        return ConfigProvider.getConfig()
-                .getOptionalValue(
-                        "mp.messaging." + direction.name().toLowerCase() + "." + normalizeChannelName(channel) + ".enabled",
-                        Boolean.class)
-                .orElse(true);
     }
 
     /**
@@ -197,21 +166,6 @@ public class WiringHelper {
     }
 
     /**
-     * Normalize the name of a given channel.
-     *
-     * Concatenate the channel name with double quotes when it contains dots.
-     * <p>
-     * Otherwise, the SmallRye Reactive Messaging only considers the
-     * text up to the first occurrence of a dot as the channel name.
-     *
-     * @param name the channel name.
-     * @return normalized channel name.
-     */
-    private static String normalizeChannelName(String name) {
-        return name != null && !name.startsWith("\"") && name.contains(".") ? "\"" + name + "\"" : name;
-    }
-
-    /**
      * Finds a connector by name and direction in the given list.
      *
      * @param connectors the list of connectors
@@ -230,29 +184,6 @@ public class WiringHelper {
 
     static boolean hasConnector(List<ConnectorBuildItem> connectors, ChannelDirection direction, String name) {
         return connectors.stream().anyMatch(c -> c.getName().equalsIgnoreCase(name) && c.getDirection() == direction);
-    }
-
-    static Class<?> toType(String type) throws ClassNotFoundException {
-        switch (type.toLowerCase()) {
-            case "boolean":
-                return Boolean.class;
-            case "int":
-                return Integer.class;
-            case "string":
-                return String.class;
-            case "double":
-                return Double.class;
-            case "float":
-                return Float.class;
-            case "short":
-                return Short.class;
-            case "long":
-                return Long.class;
-            case "byte":
-                return Byte.class;
-            default:
-                return WiringHelper.class.getClassLoader().loadClass(type);
-        }
     }
 
     static boolean isSynthetic(MethodInfo method) {

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringProcessor.java
@@ -9,6 +9,9 @@ import static io.quarkus.smallrye.reactivemessaging.deployment.WiringHelper.isIn
 import static io.quarkus.smallrye.reactivemessaging.deployment.WiringHelper.isOutboundConnector;
 import static io.quarkus.smallrye.reactivemessaging.deployment.WiringHelper.produceIncomingChannel;
 import static io.quarkus.smallrye.reactivemessaging.deployment.WiringHelper.produceOutgoingChannel;
+import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelIncomingPropertyName;
+import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelOutgoingPropertyName;
+import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelPropertyName;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -215,10 +218,10 @@ public class WiringProcessor {
         }
         if (outgoing != null) {
             configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                    "mp.messaging.outgoing." + outgoing.value().asString() + ".tls-configuration-name", null,
+                    getChannelOutgoingPropertyName(outgoing.value().asString(), "tls-configuration-name"), null,
                     "The tls-configuration to use", null, null, ConfigPhase.RUN_TIME));
             configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                    "mp.messaging.outgoing." + outgoing.value().asString() + ".connector", null,
+                    getChannelOutgoingPropertyName(outgoing.value().asString(), "connector"), null,
                     "The connector to use", null, null, ConfigPhase.BUILD_TIME));
 
             produceOutgoingChannel(appChannels, outgoing.value().asString());
@@ -236,10 +239,10 @@ public class WiringProcessor {
                             new DeploymentException("Empty @Outgoing annotation on method " + method)));
                 }
                 configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                        "mp.messaging.outgoing." + instance.value().asString() + ".tls-configuration-name", null,
+                        getChannelOutgoingPropertyName(instance.value().asString(), "tls-configuration-name"), null,
                         "The tls-configuration to use", null, null, ConfigPhase.RUN_TIME));
                 configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                        "mp.messaging.outgoing." + instance.value().asString() + ".connector", null,
+                        getChannelOutgoingPropertyName(instance.value().asString(), "connector"), null,
                         "The connector to use", null, null, ConfigPhase.BUILD_TIME));
                 produceOutgoingChannel(appChannels, instance.value().asString());
             }
@@ -257,10 +260,10 @@ public class WiringProcessor {
                             new DeploymentException("Empty @Incoming annotation on method " + method)));
                 }
                 configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                        "mp.messaging.incoming." + instance.value().asString() + ".tls-configuration-name", null,
+                        getChannelIncomingPropertyName(instance.value().asString(), "tls-configuration-name"), null,
                         "The tls-configuration to use", null, null, ConfigPhase.RUN_TIME));
                 configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                        "mp.messaging.incoming." + instance.value().asString() + ".connector", null,
+                        getChannelIncomingPropertyName(instance.value().asString(), "connector"), null,
                         "The connector to use", null, null, ConfigPhase.BUILD_TIME));
                 produceIncomingChannel(appChannels, instance.value().asString());
             }
@@ -277,10 +280,10 @@ public class WiringProcessor {
         }
         if (incoming != null) {
             configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                    "mp.messaging.incoming." + incoming.value().asString() + ".tls-configuration-name", null,
+                    getChannelIncomingPropertyName(incoming.value().asString(), "tls-configuration-name"), null,
                     "The tls-configuration to use", null, null, ConfigPhase.RUN_TIME));
             configDescriptionBuildItemBuildProducer.produce(new ConfigDescriptionBuildItem(
-                    "mp.messaging.incoming." + incoming.value().asString() + ".connector", null,
+                    getChannelIncomingPropertyName(incoming.value().asString(), "connector"), null,
                     "The connector to use", null, null, ConfigPhase.BUILD_TIME));
             produceIncomingChannel(appChannels, incoming.value().asString());
         }
@@ -327,9 +330,7 @@ public class WiringProcessor {
         HtmlRenderer renderer = HtmlRenderer.builder().build();
         for (ConnectorManagedChannelBuildItem channel : channels) {
             ConnectorBuildItem connector = find(connectors, channel.getConnector(), channel.getDirection());
-            String prefix = "mp.messaging."
-                    + (channel.getDirection() == ChannelDirection.INCOMING ? "incoming" : "outgoing") + "."
-                    + channel.getName() + ".";
+            String prefix = getChannelPropertyName(channel.getName(), "", channel.isIncoming());
             if (connector != null) {
                 for (ConnectorAttribute attribute : connector.getAttributes()) {
                     ConfigDescriptionBuildItem cfg = new ConfigDescriptionBuildItem(
@@ -369,7 +370,7 @@ public class WiringProcessor {
             for (OrphanChannelBuildItem orphan : orphans) {
                 if (orphan.getDirection() == ChannelDirection.INCOMING) {
                     config.produce(new RunTimeConfigurationDefaultBuildItem(
-                            "mp.messaging.incoming." + orphan.getName() + ".connector", connector));
+                            getChannelIncomingPropertyName(orphan.getName(), "connector"), connector));
                     LOGGER.infof("Configuring the channel '%s' to be managed by the connector '%s'", orphan.getName(),
                             connector);
                     connectorManagedChannels.produce(new ConnectorManagedChannelBuildItem(orphan.getName(),
@@ -384,7 +385,7 @@ public class WiringProcessor {
             for (OrphanChannelBuildItem orphan : orphans) {
                 if (orphan.getDirection() == ChannelDirection.OUTGOING) {
                     config.produce(new RunTimeConfigurationDefaultBuildItem(
-                            "mp.messaging.outgoing." + orphan.getName() + ".connector", connector));
+                            getChannelOutgoingPropertyName(orphan.getName(), "connector"), connector));
                     LOGGER.infof("Configuring the channel '%s' to be managed by the connector '%s'", orphan.getName(),
                             connector);
                     connectorManagedChannels.produce(new ConnectorManagedChannelBuildItem(orphan.getName(),

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/items/ConnectorManagedChannelBuildItem.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/items/ConnectorManagedChannelBuildItem.java
@@ -1,5 +1,8 @@
 package io.quarkus.smallrye.reactivemessaging.deployment.items;
 
+import static io.quarkus.smallrye.reactivemessaging.deployment.items.ChannelDirection.INCOMING;
+import static io.quarkus.smallrye.reactivemessaging.deployment.items.ChannelDirection.OUTGOING;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
@@ -27,5 +30,13 @@ public final class ConnectorManagedChannelBuildItem extends MultiBuildItem {
 
     public ChannelDirection getDirection() {
         return direction;
+    }
+
+    public boolean isIncoming() {
+        return INCOMING.equals(direction);
+    }
+
+    public boolean isOutgoing() {
+        return OUTGOING.equals(direction);
     }
 }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigBuilderCustomizer.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigBuilderCustomizer.java
@@ -1,0 +1,56 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.Set;
+import java.util.function.Function;
+
+import io.smallrye.config.FallbackConfigSourceInterceptor;
+import io.smallrye.config.RelocateConfigSourceInterceptor;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+public class ReactiveMessagingConfigBuilderCustomizer implements SmallRyeConfigBuilderCustomizer {
+
+    @Override
+    public void configBuilder(SmallRyeConfigBuilder builder) {
+        builder.withInterceptors(new FallbackConfigSourceInterceptor(new Fallback()));
+        builder.withInterceptors(new RelocateConfigSourceInterceptor(new Relocate()));
+    }
+
+    private static final String REACTIVE_MESSAGING_PREFIX = "quarkus.messaging.";
+    private static final String MP_MESSAGING_PREFIX = "mp.messaging.";
+    private static final String INCOMING = "incoming.";
+    private static final String OUTGOING = "outgoing.";
+    private static final Set<String> PROPERTIES = Set.of(".connector", ".enabled");
+
+    private record Fallback() implements Function<String, String> {
+        @Override
+        public String apply(String name) {
+            if (name.startsWith(REACTIVE_MESSAGING_PREFIX)
+                    && (name.regionMatches(18, INCOMING, 0, 9) || name.regionMatches(18, OUTGOING, 0, 9))) {
+                for (String property : PROPERTIES) {
+                    if (name.endsWith(property)) {
+                        // replaces quarkus with mp
+                        return "mp" + name.substring(7);
+                    }
+                }
+            }
+            return name;
+        }
+    }
+
+    private record Relocate() implements Function<String, String> {
+        @Override
+        public String apply(String name) {
+            if (name.startsWith(MP_MESSAGING_PREFIX)
+                    && (name.regionMatches(13, INCOMING, 0, 9) || name.regionMatches(13, OUTGOING, 0, 9))) {
+                for (String property : PROPERTIES) {
+                    if (name.endsWith(property)) {
+                        // replaces mp with quarkus
+                        return "quarkus" + name.substring(2);
+                    }
+                }
+            }
+            return name;
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfigBuilderCustomizer


### PR DESCRIPTION
- Follow up to #50767

This removes the quotes of the channel names in build items and adds a standard API to reconstruct a `mp.messaging` property with the appropriate channel name (either quoted or unquoted)

Additionally, this adds `quarkus.messaging.incoming.*` and `quarkus.messaging.outgoing.*` with relocates and fallbacks to the `mp` namespace. These are hidden from the user and are used internally in a `@ConfigMapping` to validate channels to avoid manual queries and string manipulations. There are other places where we can leverage the same pattern, but I didn't want to be too disruptive.

