### PR TITLE
Replace deprecated IsNormal in the guide for writing dev services

### DIFF
--- a/docs/src/main/asciidoc/extension-writing-dev-service.adoc
+++ b/docs/src/main/asciidoc/extension-writing-dev-service.adoc
@@ -48,7 +48,7 @@ Here, the https://hub.docker.com/_/hello-world[`hello-world`] image is used, but
 
 [source,java]
 ----
-@BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+@BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public DevServicesResultBuildItem createContainer() {
     DockerImageName dockerImageName = DockerImageName.parse("hello-world");
     GenericContainer container = new GenericContainer<>(dockerImageName)
@@ -118,7 +118,7 @@ For example,
 
 [source,java]
 ----
-@BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+@BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public DevServicesResultBuildItem createContainer(MyConfig config) {}
 ----
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

IsNormal is deprecated since v3.25, but is still used in the documentation for writing a dev service.

Made the documentation similar to other dev services, e.g. KeycloakDevServicesProcessor


<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

