### PR TITLE
Fix native applications built with GraalVM 25 `--future-defaults` options

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/FileSystemResourcesBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/FileSystemResourcesBuildStep.java
@@ -13,6 +13,8 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedFileSystemResourceBuildItem;
 import io.quarkus.deployment.builditem.GeneratedFileSystemResourceHandledBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.runtime.LaunchMode;
@@ -28,6 +30,16 @@ public class FileSystemResourcesBuildStep {
             write(generatedFileSystemResources, outputTargetBuildItem.getOutputDirectory());
         }
         producer.produce(new GeneratedFileSystemResourceHandledBuildItem());
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeFileSystemProvider.class)
+    RuntimeInitializedPackageBuildItem runtimeInitialized() {
+        return new RuntimeInitializedPackageBuildItem("io.quarkus.fs.util");
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeFileSystemProvider.class)
+    ReflectiveClassBuildItem setupReflectionClasses() {
+        return ReflectiveClassBuildItem.builder("jdk.nio.zipfs.ZipFileSystemProvider").build();
     }
 
     @BuildStep(onlyIf = IsProduction.class)

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -36,6 +36,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageEnableModule;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSecurityProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeMinimalJavaVersionBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.PackageConfig;
@@ -185,6 +186,11 @@ public class NativeImageBuildStep {
                                 .setResolvedDependency(curateOutcomeBuildItem.getApplicationModel().getAppArtifact()))
                         .setRunnerPath(nativeImageSourceJarBuildItem.getPath())
                         .build());
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeFileSystemProvider.class)
+    RuntimeInitializedPackageBuildItem runtimeInitialized() {
+        return new RuntimeInitializedPackageBuildItem("io.smallrye.common.classloader");
     }
 
     @BuildStep

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
@@ -1,0 +1,101 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.deployment.pkg.NativeConfig;
+
+public enum NativeImageFutureDefault {
+    COMPLETE_REFLECTION_TYPES,
+    RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS,
+    RUN_TIME_INITIALIZE_SECURITY_PROVIDERS;
+
+    private static final String FUTURE_DEFAULTS_MARKER = "--future-defaults=";
+
+    public boolean isEnabled(NativeConfig nativeConfig) {
+        return isFutureDefault(this, nativeConfig);
+    }
+
+    private static boolean isFutureDefault(NativeImageFutureDefault futureDefault, NativeConfig nativeConfig) {
+        Optional<List<String>>[] additionalBuildArgs = new Optional[] { nativeConfig.additionalBuildArgs(),
+                nativeConfig.additionalBuildArgsAppend() };
+
+        for (Optional<List<String>> args : additionalBuildArgs) {
+            if (args.isEmpty()) {
+                continue;
+            }
+            List<String> strings = args.get();
+            for (String buildArg : strings) {
+                String trimmedBuildArg = buildArg.trim();
+                if (trimmedBuildArg.contains(FUTURE_DEFAULTS_MARKER)) {
+                    int index = trimmedBuildArg.indexOf('=');
+                    String[] futureDefaultStringArgs = trimmedBuildArg.substring(index + 1).split(",");
+                    for (String futureDefaultString : futureDefaultStringArgs) {
+                        if ("all".equals(futureDefaultString)) {
+                            return true;
+                        }
+
+                        if ("run-time-initialize-jdk".equals(futureDefaultString)) {
+                            switch (futureDefault) {
+                                case RUN_TIME_INITIALIZE_SECURITY_PROVIDERS:
+                                case RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS:
+                                    return true;
+                            }
+                        }
+
+                        final NativeImageFutureDefault futureDefaultArg = NativeImageFutureDefault
+                                .valueOf(futureDefaultString.toUpperCase(Locale.ROOT).replace('-', '_'));
+                        if (futureDefaultArg == futureDefault) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static abstract class AbstractNativeImageFutureDefaultBooleanSupplier implements BooleanSupplier {
+        protected final NativeConfig nativeConfig;
+
+        public AbstractNativeImageFutureDefaultBooleanSupplier(final NativeConfig nativeConfig) {
+            this.nativeConfig = nativeConfig;
+        }
+    }
+
+    public static final class RunTimeInitializeFileSystemProvider extends AbstractNativeImageFutureDefaultBooleanSupplier {
+        public RunTimeInitializeFileSystemProvider(NativeConfig nativeConfig) {
+            super(nativeConfig);
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return isFutureDefault(NativeImageFutureDefault.RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS, nativeConfig);
+        }
+    }
+
+    public static final class RunTimeInitializeSecurityProvider extends AbstractNativeImageFutureDefaultBooleanSupplier {
+        public RunTimeInitializeSecurityProvider(NativeConfig nativeConfig) {
+            super(nativeConfig);
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return isFutureDefault(NativeImageFutureDefault.RUN_TIME_INITIALIZE_SECURITY_PROVIDERS, nativeConfig);
+        }
+    }
+
+    public static final class CompleteReflectionTypes extends AbstractNativeImageFutureDefaultBooleanSupplier {
+        public CompleteReflectionTypes(NativeConfig nativeConfig) {
+            super(nativeConfig);
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return isFutureDefault(NativeImageFutureDefault.COMPLETE_REFLECTION_TYPES, nativeConfig);
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -73,6 +73,7 @@ import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
 import io.quarkus.deployment.configuration.tracker.ConfigTrackingConfig;
 import io.quarkus.deployment.configuration.tracker.ConfigTrackingWriter;
+import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
@@ -197,6 +198,7 @@ public class ConfigGenerationBuildStep {
 
     @BuildStep
     void generateMappings(
+            NativeConfig nativeConfig,
             ConfigurationBuildItem configItem,
             CombinedIndexBuildItem combinedIndex,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
@@ -207,18 +209,21 @@ public class ConfigGenerationBuildStep {
 
         Map<String, GeneratedClassBuildItem> generatedConfigClasses = new HashMap<>();
 
-        processConfigMapping(configItem, combinedIndex, generatedConfigClasses, reflectiveClasses, reflectiveMethods,
+        processConfigMapping(nativeConfig, configItem, combinedIndex, generatedConfigClasses, reflectiveClasses,
+                reflectiveMethods,
                 configClasses, additionalConstrainedClasses);
 
         List<ConfigClass> buildTimeRunTimeMappings = configItem.getReadResult().getBuildTimeRunTimeMappings();
         for (ConfigClass buildTimeRunTimeMapping : buildTimeRunTimeMappings) {
-            processExtensionConfigMapping(buildTimeRunTimeMapping, combinedIndex, generatedConfigClasses, reflectiveClasses,
+            processExtensionConfigMapping(nativeConfig, buildTimeRunTimeMapping, combinedIndex, generatedConfigClasses,
+                    reflectiveClasses,
                     reflectiveMethods, configClasses, additionalConstrainedClasses);
         }
 
         List<ConfigClass> runTimeMappings = configItem.getReadResult().getRunTimeMappings();
         for (ConfigClass runTimeMapping : runTimeMappings) {
-            processExtensionConfigMapping(runTimeMapping, combinedIndex, generatedConfigClasses, reflectiveClasses,
+            processExtensionConfigMapping(nativeConfig, runTimeMapping, combinedIndex, generatedConfigClasses,
+                    reflectiveClasses,
                     reflectiveMethods,
                     configClasses, additionalConstrainedClasses);
         }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -67,6 +67,7 @@ import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
+import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
 import io.smallrye.config.ConfigMappings.ConfigClass;
@@ -262,6 +263,7 @@ public class ConfigBuildStep {
 
     @BuildStep
     void generateConfigProperties(
+            NativeConfig nativeConfig,
             ConfigurationBuildItem configItem,
             CombinedIndexBuildItem combinedIndex,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
@@ -271,7 +273,8 @@ public class ConfigBuildStep {
             BuildProducer<AdditionalConstrainedClassBuildItem> additionalConstrainedClasses) {
 
         Map<String, GeneratedClassBuildItem> generatedConfigClasses = new HashMap<>();
-        processConfigClasses(configItem, combinedIndex, generatedConfigClasses, reflectiveClasses, reflectiveMethods,
+        processConfigClasses(nativeConfig, configItem, combinedIndex, generatedConfigClasses, reflectiveClasses,
+                reflectiveMethods,
                 configClasses, additionalConstrainedClasses, MP_CONFIG_PROPERTIES_NAME);
 
         for (GeneratedClassBuildItem generatedConfigClass : generatedConfigClasses.values()) {

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -26,6 +26,7 @@ import io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageRunnerBuildItem;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabledBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.pkg.steps.NoopNativeImageBuildRunner;
 import io.quarkus.runtime.graal.GraalVM;
@@ -306,5 +307,10 @@ class AwtProcessor {
                 .map(RuntimeInitializedPackageBuildItem::new)
                 .forEach(runtimeInitilizedPackages::produce);
         //@formatter:on
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.CompleteReflectionTypes.class)
+    RuntimeInitializedPackageBuildItem runtimeInitializedClassesForCompleteReflectionTypes() {
+        return new RuntimeInitializedPackageBuildItem("sun.datatransfer");
     }
 }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -84,9 +84,11 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSecurityProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassConditionBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.kafka.client.runtime.KafkaAdminClient;
 import io.quarkus.kafka.client.runtime.KafkaBindingConverter;
@@ -528,6 +530,11 @@ public class KafkaProcessor {
                 .addBeanClass(KafkaAdminClient.class)
                 .setUnremovable()
                 .build();
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeSecurityProvider.class)
+    RuntimeInitializedPackageBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedPackageBuildItem("org.apache.kafka.common.security.ssl");
     }
 
     // Kafka UI related stuff

--- a/extensions/schema-registry/confluent/common/deployment/src/main/java/io/quarkus/confluent/registry/common/ConfluentRegistryClientProcessor.java
+++ b/extensions/schema-registry/confluent/common/deployment/src/main/java/io/quarkus/confluent/registry/common/ConfluentRegistryClientProcessor.java
@@ -5,8 +5,10 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 
 public class ConfluentRegistryClientProcessor {
 
@@ -71,5 +73,10 @@ public class ConfluentRegistryClientProcessor {
                             "io.confluent.kafka.schemaregistry.client.security.basicauth.UrlBasicAuthCredentialProvider",
                             "io.confluent.kafka.schemaregistry.client.security.basicauth.UserInfoCredentialProvider"));
         }
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeSecurityProvider.class)
+    RuntimeInitializedPackageBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedPackageBuildItem("io.confluent.kafka.schemaregistry.client.security");
     }
 }

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -93,6 +93,7 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildI
 import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
@@ -172,6 +173,23 @@ public class SecurityProcessor {
                         .produce(new JCAProviderBuildItem(providerName, security.securityProviderConfig().get(providerName)));
             }
             log.debugf("Added providerName: %s", providerName);
+        }
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeSecurityProvider.class)
+    void registerBouncyCastleReflection(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            BuildProducer<ReflectiveClassBuildItem> reflection) {
+        if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
+                x -> x.getGroupId().equals("org.bouncycastle") && x.getArtifactId().startsWith("bcprov-"))) {
+            reflection.produce(ReflectiveClassBuildItem.builder("org.bouncycastle.jcajce.provider.symmetric.AES",
+                    "org.bouncycastle.jcajce.provider.symmetric.AES$Mappings",
+                    "org.bouncycastle.jcajce.provider.asymmetric.EC",
+                    "org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings",
+                    "org.bouncycastle.jcajce.provider.asymmetric.RSA",
+                    "org.bouncycastle.jcajce.provider.asymmetric.RSA$Mappings",
+                    "org.bouncycastle.jcajce.provider.drbg.DRBG",
+                    "org.bouncycastle.jcajce.provider.drbg.DRBG$Mappings").methods().fields()
+                    .build());
         }
     }
 
@@ -305,8 +323,22 @@ public class SecurityProcessor {
         runtimeReInitialized.produce(new RuntimeInitializedClassBuildItem("sun.security.pkcs11.P11Util"));
     }
 
-    @BuildStep
+    @BuildStep(onlyIfNot = NativeImageFutureDefault.RunTimeInitializeSecurityProvider.class)
     @Record(ExecutionTime.STATIC_INIT)
+    void recordBouncyCastleProvidersStaticInit(SecurityProviderRecorder recorder,
+            List<BouncyCastleProviderBuildItem> bouncyCastleProviders,
+            List<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProviders) {
+        recordBouncyCastleProviders(recorder, bouncyCastleProviders, bouncyCastleJsseProviders);
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeSecurityProvider.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void recordBouncyCastleProvidersRuntimeInit(SecurityProviderRecorder recorder,
+            List<BouncyCastleProviderBuildItem> bouncyCastleProviders,
+            List<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProviders) {
+        recordBouncyCastleProviders(recorder, bouncyCastleProviders, bouncyCastleJsseProviders);
+    }
+
     void recordBouncyCastleProviders(SecurityProviderRecorder recorder,
             List<BouncyCastleProviderBuildItem> bouncyCastleProviders,
             List<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProviders) {

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
@@ -29,6 +29,8 @@ import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.gizmo.Gizmo;
 import io.quarkus.pulsar.PulsarClientConfigCustomizer;
 import io.quarkus.pulsar.PulsarRuntimeConfigProducer;
@@ -204,4 +206,8 @@ public class SmallRyeReactiveMessagingPulsarProcessor {
         return nativeImageConfig.build();
     }
 
+    @BuildStep(onlyIf = NativeImageFutureDefault.RunTimeInitializeSecurityProvider.class)
+    RuntimeInitializedPackageBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedPackageBuildItem("org.apache.pulsar.common.util.SecurityUtility");
+    }
 }

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -1,7 +1,6 @@
 package io.quarkus.spring.data.deployment;
 
 import static io.quarkus.hibernate.orm.panache.deployment.EntityToPersistenceUnitUtil.determineEntityPersistenceUnits;
-import static java.util.stream.Collectors.toList;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -45,6 +44,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.hibernate.orm.deployment.IgnorableNonIndexedClasses;
 import io.quarkus.hibernate.orm.deployment.JpaModelPersistenceUnitMappingBuildItem;
@@ -95,6 +95,12 @@ public class SpringDataJPAProcessor {
         ignorable.add(Auditable.class.getName());
         ignorable.add(Persistable.class.getName());
         return new IgnorableNonIndexedClasses(ignorable);
+    }
+
+    @BuildStep(onlyIf = NativeImageFutureDefault.CompleteReflectionTypes.class)
+    void registerReflectionForCompleteReflectionTypes(BuildProducer<ReflectiveClassBuildItem> producer) {
+        producer.produce(ReflectiveClassBuildItem.builder(
+                "org.springframework.data.util.Streamable").methods().build());
     }
 
     @BuildStep

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/ReflectionResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/ReflectionResource.java
@@ -30,4 +30,9 @@ public class ReflectionResource {
         }
     }
 
+    @GET
+    @Path("/completeReflectionTypes")
+    public boolean isCompleteReflectionTypes() {
+        return Boolean.getBoolean("org.graalvm.nativeimage.future-defaults.complete-reflection-types");
+    }
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionITCase.java
@@ -21,9 +21,10 @@ public class RegisterForReflectionITCase {
         final String resourceA = BASE_PKG + ".ResourceA";
 
         assertRegistration("ResourceA", resourceA);
-        assertRegistration("FAILED", resourceA + "$InnerClassOfA");
-        assertRegistration("FAILED", resourceA + "$StaticClassOfA");
-        assertRegistration("FAILED", resourceA + "$InterfaceOfA");
+        final boolean isCompleteReflectionTypes = isCompleteReflectionTypes();
+        assertRegistration(isCompleteReflectionTypes ? "InnerClassOfA" : "FAILED", resourceA + "$InnerClassOfA");
+        assertRegistration(isCompleteReflectionTypes ? "StaticClassOfA" : "FAILED", resourceA + "$StaticClassOfA");
+        assertRegistration(isCompleteReflectionTypes ? "InterfaceOfA" : "FAILED", resourceA + "$InterfaceOfA");
     }
 
     @Test
@@ -54,7 +55,9 @@ public class RegisterForReflectionITCase {
 
         assertRegistration("FAILED", resourceD);
         assertRegistration("StaticClassOfD", resourceD + "$StaticClassOfD");
-        assertRegistration("FAILED", resourceD + "$StaticClassOfD$OtherAccessibleClassOfD");
+        final boolean isCompleteReflectionTypes = isCompleteReflectionTypes();
+        assertRegistration(isCompleteReflectionTypes ? "OtherAccessibleClassOfD" : "FAILED",
+                resourceD + "$StaticClassOfD$OtherAccessibleClassOfD");
     }
 
     // NOTE: This test is expected to fail with GraalVM >= 23.1.0 and < 23.1.3 yet we enable it for all 23.1 versions
@@ -69,5 +72,10 @@ public class RegisterForReflectionITCase {
 
     private void assertRegistration(String expected, String queryParam) {
         RestAssured.given().queryParam("className", queryParam).when().get(ENDPOINT).then().body(is(expected));
+    }
+
+    private boolean isCompleteReflectionTypes() {
+        return Boolean.valueOf(
+                RestAssured.given().when().get("/reflection/completeReflectionTypes").then().extract().body().asString());
     }
 }


### PR DESCRIPTION
Closes #46092

The changes in this PR adapt Quarkus to be able to run natives built with `--future-defaults` values available in GraalVM 25.0.

The changes do not affect Quarkus unless the additional native build time argument via the given parameter is passed in. The possible values can be found in the [GraalVM 25.0 release notes](https://www.graalvm.org/release-notes/JDK_25/). Each of the necessary changes is protected by some build time check that indicates which future defaults are responsible for which changes.

I have tested the flag in [this custom Mandrel CI run](https://github.com/galderz/mandrel/actions/runs/19068758868), which includes Quarkus testsuite (the failures seen in the run are strictly limited to the Mandrel testsuite which has no yet been adjusted for JDK 25 /cc @Karm). To test the flag, I set the additional native build time argument env variable to relevant values to make sure the test passes. The Mandrel team will create a periodic CI that verifies that the testsuite still passes with these arguments.

I run peak and startup performance tests for the `getting-started-reactive` and `security-jpa-reactive quickstarts`. I didn't see any signinificant changes in peak throughtput. Startup times are unchanged but I've noticed a ~2MB additional startup RSS and this decreases to around ~1MB at peak performance. There is a 1-2 MB increase in binary file size increase too.