### PR TITLE
[3.27] Avoid using COPY_ATTRIBUTES when copying the jars of fast jar

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -953,8 +953,9 @@ public class JarResultBuildStep {
                         .setPath(targetPath)
                         .setResolvedDependency(appDep);
                 if (removedFromThisArchive.isEmpty()) {
-                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING,
-                            StandardCopyOption.COPY_ATTRIBUTES);
+                    // let's not use COPY_ATTRIBUTES to make sure we respect the system umask
+                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                    Files.setLastModifiedTime(targetPath, Files.getLastModifiedTime(resolvedDep));
                 } else {
                     // we copy jars for which we remove entries to the same directory
                     // which seems a bit odd to me


### PR DESCRIPTION
This is a backport of:
https://github.com/quarkusio/quarkus/pull/50557