### PR TITLE
Dump heap on OOM during test executions

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -458,7 +458,8 @@
                              the propertiesCache in com.sun.naming.internal.ResourceManager -->
                         <!-- the add-opens java.base/java.lang=ALL-UNNAMED is here for
                              org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals() -->
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        <!-- set -XX:+HeapDumpOnOutOfMemoryError to provide some useful debugging info, should this happen -->
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
I'm suggesting to enable these two options in the Surefire configuration:

1. `-XX:+HeapDumpOnOutOfMemoryError`  so to have some diagnostics we can investigate, should an OOM happen.
2. `-XX:+ExitOnOutOfMemoryError` to terminate a (specific module) aggressively when an OOM happens, as the test output is usually confusing anyway.

They should generally have no impact when there are no such issues, and simplifies our work when such issues do manifest (we do have some of those currently).

I'm not entirely sure how easy it would be to fetch the heap dumps from CI? Hopefully I can figure it out when some are produced.