### PR TITLE
Disable the nagging about sun.misc.Unsafe in dev-mode as well

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
@@ -27,6 +27,7 @@ import io.quarkus.dev.appstate.ApplicationStateNotification;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.paths.PathList;
+import io.quarkus.runtime.JVMChecksRecorder;
 import io.smallrye.common.os.OS;
 
 /**
@@ -71,6 +72,7 @@ public class DevModeMain implements Closeable {
     public void start() throws Exception {
         //propagate system props
         propagateSystemProperties();
+        prepareJVMSettings();
 
         try {
             QuarkusBootstrap.Builder bootstrapBuilder = QuarkusBootstrap.builder()
@@ -110,6 +112,11 @@ public class DevModeMain implements Closeable {
             throw (t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t));
             //System.exit(1);
         }
+    }
+
+    private void prepareJVMSettings() {
+        //Disable the sun.misc.Unsafe warnings in dev-mode:
+        JVMChecksRecorder.disableUnsafeRelatedWarnings();
     }
 
     private PathList getApplicationBuildDirs() {


### PR DESCRIPTION
This is a follow-up to #49979 , apparently it wasn't triggered early enough to be effective when running in dev-mode.

