### PR TITLE
Stablize flaky StreamingOutputErrorHandlingTest

### DIFF
--- a/independent-projects/vertx-utils/src/main/java/io/quarkus/vertx/utils/VertxOutputStream.java
+++ b/independent-projects/vertx-utils/src/main/java/io/quarkus/vertx/utils/VertxOutputStream.java
@@ -229,12 +229,12 @@ public class VertxOutputStream extends OutputStream {
     private record DrainHandler(VertxOutputStream out) implements Handler<Void> {
 
         @Override
-            public void handle(Void event) {
-                synchronized (out.request.connection()) {
-                    if (out.waitingForDrain) {
-                        out.request.connection().notifyAll();
-                    }
+        public void handle(Void event) {
+            synchronized (out.request.connection()) {
+                if (out.waitingForDrain) {
+                    out.request.connection().notifyAll();
                 }
             }
         }
+    }
 }

--- a/integration-tests/elytron-resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/elytron/StreamingOutputErrorHandlingIT.java
+++ b/integration-tests/elytron-resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/elytron/StreamingOutputErrorHandlingIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.resteasy.reactive.elytron;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class StreamingOutputErrorHandlingIT extends StreamingOutputErrorHandlingTest {
+}


### PR DESCRIPTION
This PR addresses a flaky test observed in `StreamingOutputErrorHandlingTest` (Integration Tests - Elytron RESTEasy Reactive).
CI Jobs was failing intermittently here https://github.com/quarkusio/quarkus/actions/runs/19071792608/job/54477720661?pr=50841



