### PR TITLE
Support runtime active / inactive Redis Clients

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -138,6 +138,70 @@ public class RedisExample {
 
 TIP: You can omit the `@Inject` annotation when using `@RedisClientName`.
 
+=== Activate or deactivate Redis Clients
+
+When a Redis Clients is configured at build time, and its URL is set at runtime, it is active by default. Quarkus
+starts the corresponding Redis Client when the application starts.
+
+To deactivate a Redis Client at runtime, either:
+
+* Do not set `quarkus.redis[.optional name].hosts` or `quarkus.redis[.optional name].hosts-provider-name`.
+* Set `quarkus.redis[.optional name].active` to `false`.
+
+If a Redis Client is not active:
+
+* The Redis Client does not attempt to connect to Redis during application startup.
+* The Redis Client does not contribute a <<redis-health-check,health check>>.
+* Static CDI injection points involving the Redis Client, such as `@Inject ReactiveRedisDataSource redis` or `@Inject RedisDataSource redis`, cause application startup to fail.
+* Dynamic retrieval of the Redis Client, such as through `CDI.getBeanContainer()`, `Arc.instance()`, or an injected `Instance<ReactiveRedisDataSource>`, causes an exception to be thrown.
+* Other Quarkus extensions that consume the Redis Client may cause application startup to fail.
+
+This feature is especially useful when the application must dynamically select a Redis Client from a predefined set at
+runtime.
+
+.An example of configuring multiple Redis Clients for runtime selection:
+
+[source,properties]
+----
+quarkus.redis.one.active=false
+quarkus.redis.one.hosts=redis://localhost:64251
+
+quarkus.redis.two.active=false
+quarkus.redis.two.hosts=redis://localhost:64251
+----
+
+[source,java]
+----
+import io.quarkus.arc.InjectableInstance;
+
+@ApplicationScoped
+public class MyConsumer {
+    @Inject
+    @RedisClientName("one")
+    InjectableInstance<ReactiveRedisDataSource> one;
+    @Inject
+    @RedisClientName("two")
+    InjectableInstance<ReactiveRedisDataSource> two;
+
+    public void doSomething() {
+        ReactiveRedisDataSource redis = one.getActive();
+        // ...
+    }
+}
+----
+
+Setting `quarkus.redis.one.active=true` xref:config-reference.adoc#configuration-sources[at runtime] makes only the
+Redis Client `one` available.
+Setting `quarkus.redis.two.active=true` at runtime makes only the Redis Client `two` available.
+
+[IMPORTANT]
+====
+A Redis Client (either default or named) must always be discoverable at build-time to be considered for runtime
+injection. This can be done by injecting the Redis Client name with `@RedisClientName`. If the Redis Client name may be
+active or inactive, it needs to use the wrapper `InjectableInstance<>`, or else Quarkus will throw an exception at
+startup time if the Redis Client is inactive. Alternatively, Redis Clients may also be discovered via configuration.
+====
+
 == Connect to the Redis server
 
 The Redis extension can operate in 4 distinct modes:
@@ -1014,6 +1078,7 @@ See xref:redis-dev-services.adoc[Redis Dev Service].
 
 == Configure Redis observability
 
+[[redis-health-check]]
 === Enable the health checks
 
 If you are using the `quarkus-smallrye-health` extension, `quarkus-redis` will automatically add a readiness health check to validate the connection to the Redis server.

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisBuildTimeConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisBuildTimeConfig.java
@@ -1,57 +1,90 @@
 package io.quarkus.redis.deployment.client;
 
+import static io.quarkus.redis.runtime.client.config.RedisConfig.DEFAULT_CLIENT_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.redis")
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public interface RedisBuildTimeConfig {
-
     /**
-     * The default redis client
-     */
-    @WithParentName
-    RedisClientBuildTimeConfig defaultRedisClient();
-
-    /**
-     * Configures additional (named) Redis clients.
+     * Configures the Redis clients.
      * <p>
-     * Each client has a unique name which must be identified to select the right client.
-     * For example:
+     * The default client does not have a name, and it is configured as:
+     *
+     * <pre>
+     * quarkus.redis.hosts = redis://localhost:6379
+     * </pre>
+     *
+     * And then use {@link jakarta.inject.Inject} to inject the client:
+     *
+     * <pre>
+     * &#64;Inject
+     * RedisAPI redis;
+     * </pre>
+     *
      * <p>
+     * Named clients must be identified to select the right client:
      *
      * <pre>
      * quarkus.redis.client1.hosts = redis://localhost:6379
      * quarkus.redis.client2.hosts = redis://localhost:6380
      * </pre>
-     * <p>
-     * And then use the {@link io.quarkus.redis.client.RedisClientName} annotation to select the
-     * {@link io.vertx.mutiny.redis.client.Redis},
-     * {@link io.vertx.redis.client.Redis}, {@link io.vertx.mutiny.redis.client.RedisAPI} and
-     * {@link io.vertx.redis.client.RedisAPI} beans.
-     * <p>
+     *
+     * And then use the {@link io.quarkus.redis.client.RedisClientName} annotation to select any of the beans:
+     * <ul>
+     * <li>{@link io.vertx.mutiny.redis.client.Redis}</li>
+     * <li>{@link io.vertx.redis.client.Redis}</li>
+     * <li>{@link io.vertx.mutiny.redis.client.RedisAPI}</li>
+     * <li>{@link io.vertx.redis.client.RedisAPI}</li>
+     * <li>{@link io.quarkus.redis.datasource.RedisDataSource}</li>
+     * <li>{@link io.quarkus.redis.datasource.ReactiveRedisDataSource}</li>
+     * </ul>
+     * And inject the client:
      *
      * <pre>
-     * {
-     *     &#64;code
-     *     &#64;RedisClientName("client1")
-     *     &#64;Inject
-     *     RedisAPI redis;
-     * }
+     * &#64;RedisClientName("client1")
+     * &#64;Inject
+     * RedisAPI redis;
      * </pre>
      */
     @WithParentName
+    @WithDefaults
+    @WithUnnamedKey(DEFAULT_CLIENT_NAME)
     @ConfigDocMapKey("redis-client-name")
-    Map<String, RedisClientBuildTimeConfig> namedRedisClients();
+    Map<String, RedisClientBuildTimeConfig> clients();
+
+    /**
+     * Returns a {@code List} of Redis Client names. The first element of the list is the default Redis Client if
+     * available. The remaining order is unspecified.
+     *
+     * @return a {@code List} of Redis Client names
+     */
+    default List<String> clientsNames() {
+        List<String> names = new ArrayList<>();
+        if (clients().containsKey(DEFAULT_CLIENT_NAME)) {
+            names.add(DEFAULT_CLIENT_NAME);
+        }
+        for (String name : clients().keySet()) {
+            if (name.equals(DEFAULT_CLIENT_NAME)) {
+                continue;
+            }
+            names.add(name);
+        }
+        return names;
+    }
 
     /**
      * Whether a health check is published in case the smallrye-health extension is present.
@@ -59,28 +92,4 @@ public interface RedisBuildTimeConfig {
     @WithName("health.enabled")
     @WithDefault("true")
     boolean healthEnabled();
-
-    /**
-     * Default Dev services configuration.
-     */
-    @WithParentName
-    DevServiceConfiguration defaultDevService();
-
-    /**
-     * Additional dev services configurations
-     */
-    @WithParentName
-    @ConfigDocMapKey("additional-redis-clients")
-    Map<String, DevServiceConfiguration> additionalDevServices();
-
-    @ConfigGroup
-    public interface DevServiceConfiguration {
-        /**
-         * Dev Services
-         * <p>
-         * Dev Services allows Quarkus to automatically start Redis in dev and test mode.
-         */
-        @ConfigDocSection(generated = true)
-        DevServicesConfig devservices();
-    }
 }

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientBuildTimeConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.WithConverter;
@@ -11,7 +12,6 @@ import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface RedisClientBuildTimeConfig {
-
     /**
      * A list of files allowing to pre-load data into the Redis server.
      * The file is formatted as follows:
@@ -38,4 +38,9 @@ public interface RedisClientBuildTimeConfig {
     @WithDefault("true")
     boolean loadOnlyIfEmpty();
 
+    /**
+     * Dev Services allows Quarkus to automatically start Redis in dev and test mode.
+     */
+    @ConfigDocSection(generated = true)
+    DevServicesConfig devservices();
 }

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisDatasourceProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisDatasourceProcessor.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
@@ -16,6 +17,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
+import io.quarkus.arc.ActiveResult;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
@@ -103,11 +105,12 @@ public class RedisDatasourceProcessor {
 
         // Create the supplier and define the beans.
         for (String name : names) {
+            Supplier<ActiveResult> checkActive = recorder.checkActive(name);
             // Data sources
             syntheticBeans.produce(configureAndCreateSyntheticBean(name, RedisDataSource.class,
-                    recorder.getBlockingDataSource(name)));
+                    checkActive, recorder.getBlockingDataSource(name)));
             syntheticBeans.produce(configureAndCreateSyntheticBean(name, ReactiveRedisDataSource.class,
-                    recorder.getReactiveDataSource(name)));
+                    checkActive, recorder.getReactiveDataSource(name)));
         }
 
         recorder.cleanup(shutdown);

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisActiveClientsMissingConfigTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisActiveClientsMissingConfigTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.redis.deployment.client;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class RedisActiveClientsMissingConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .assertException(e -> assertThat(e)// Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            """
+                                    Redis Client 'active' was deactivated automatically because neither the \
+                                    hosts nor the hostsProviderName is set. \
+                                    To activate the Redis Client, set the configuration property 'quarkus.redis.active.hosts' \
+                                    or 'quarkus.redis.active.hosts-provider-name'. \
+                                    Refer to https://quarkus.io/guides/redis-reference for guidance.
+                                    """));
+
+    @Inject
+    @RedisClientName("active")
+    Redis active;
+    @Inject
+    @RedisClientName("active")
+    io.vertx.redis.client.Redis activeBare;
+    @Inject
+    @RedisClientName("active")
+    RedisAPI activeApi;
+    @Inject
+    @RedisClientName("active")
+    io.vertx.redis.client.RedisAPI activeBareApi;
+    @Inject
+    @RedisClientName("active")
+    RedisDataSource activeDataSource;
+    @Inject
+    @RedisClientName("active")
+    ReactiveRedisDataSource activeReactiveDataSource;
+
+    @Test
+    void missingConfig() {
+        Assertions.fail();
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisActiveClientsTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisActiveClientsTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.redis.deployment.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class RedisActiveClientsTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.redis.active.hosts", "${quarkus.redis.tr}/1");
+
+    @Inject
+    InjectableInstance<Redis> defaultActive;
+    @Inject
+    InjectableInstance<io.vertx.redis.client.Redis> defaultActiveBare;
+    @Inject
+    InjectableInstance<RedisAPI> defaultActiveApi;
+    @Inject
+    InjectableInstance<io.vertx.redis.client.RedisAPI> defaultActiveBareApi;
+    @Inject
+    InjectableInstance<RedisDataSource> defaultActiveDataSource;
+    @Inject
+    InjectableInstance<ReactiveRedisDataSource> defaultActiveReactiveDataSource;
+
+    @Inject
+    @RedisClientName("active")
+    InjectableInstance<Redis> active;
+    @Inject
+    @RedisClientName("active")
+    InjectableInstance<io.vertx.redis.client.Redis> activeBare;
+    @Inject
+    @RedisClientName("active")
+    InjectableInstance<RedisAPI> activeApi;
+    @Inject
+    @RedisClientName("active")
+    InjectableInstance<io.vertx.redis.client.RedisAPI> activeBareApi;
+    @Inject
+    @RedisClientName("active")
+    InjectableInstance<RedisDataSource> activeDataSource;
+    @Inject
+    @RedisClientName("active")
+    InjectableInstance<ReactiveRedisDataSource> activeReactiveDataSource;
+
+    @Inject
+    @Any
+    InjectableInstance<Redis> all;
+    @Inject
+    @Any
+    InjectableInstance<io.vertx.redis.client.Redis> allBare;
+    @Inject
+    @Any
+    InjectableInstance<RedisAPI> allApi;
+    @Inject
+    @Any
+    InjectableInstance<io.vertx.redis.client.RedisAPI> allBareApi;
+    @Inject
+    @Any
+    InjectableInstance<RedisDataSource> allDataSource;
+    @Inject
+    @Any
+    InjectableInstance<ReactiveRedisDataSource> allReactiveDataSource;
+
+    @Test
+    void activeClients() {
+        assertEquals(1, defaultActive.listActive().size());
+        assertEquals(1, defaultActiveBare.listActive().size());
+        assertEquals(1, defaultActiveApi.listActive().size());
+        assertEquals(1, defaultActiveBareApi.listActive().size());
+        assertEquals(1, defaultActiveDataSource.listActive().size());
+        assertEquals(1, defaultActiveReactiveDataSource.listActive().size());
+
+        assertEquals(1, active.listActive().size());
+        assertEquals(1, activeBare.listActive().size());
+        assertEquals(1, activeApi.listActive().size());
+        assertEquals(1, activeBareApi.listActive().size());
+        assertEquals(1, activeDataSource.listActive().size());
+        assertEquals(1, activeReactiveDataSource.listActive().size());
+
+        assertEquals(2, all.listActive().size());
+        assertEquals(2, allBare.listActive().size());
+        assertEquals(2, allApi.listActive().size());
+        assertEquals(2, allBareApi.listActive().size());
+        assertEquals(2, allDataSource.listActive().size());
+        assertEquals(2, allReactiveDataSource.listActive().size());
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisInactiveClientsByConfigExceptionTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisInactiveClientsByConfigExceptionTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.redis.deployment.client;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InactiveBeanException;
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class RedisInactiveClientsByConfigExceptionTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.redis.active.active", "false")
+            .overrideConfigKey("quarkus.redis.active.hosts", "${quarkus.redis.tr}/1")
+            .assertException(e -> assertThat(e)// Can't use isInstanceOf due to weird classloading in tests
+                    .satisfies(t -> assertThat(t.getClass().getName()).isEqualTo(InactiveBeanException.class.getName()))
+                    .hasMessageContainingAll(
+                            """
+                                    Redis Client 'active' was deactivated through configuration properties. \
+                                    To activate the Redis Client, set configuration property \
+                                    'quarkus.redis.active.active' to 'true' and configure the Redis Client 'active'. \
+                                    Refer to https://quarkus.io/guides/redis-reference for guidance.
+                                    """));
+
+    @Inject
+    @RedisClientName("active")
+    Redis active;
+    @Inject
+    @RedisClientName("active")
+    io.vertx.redis.client.Redis activeBare;
+    @Inject
+    @RedisClientName("active")
+    RedisAPI activeApi;
+    @Inject
+    @RedisClientName("active")
+    io.vertx.redis.client.RedisAPI activeBareApi;
+    @Inject
+    @RedisClientName("active")
+    RedisDataSource activeDataSource;
+    @Inject
+    @RedisClientName("active")
+    ReactiveRedisDataSource activeReactiveDataSource;
+
+    @Test
+    void inactive() {
+
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisInactiveClientsByConfigTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisInactiveClientsByConfigTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.redis.deployment.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class RedisInactiveClientsByConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.redis.inactive.active", "false")
+            .overrideConfigKey("quarkus.redis.inactive.hosts", "${quarkus.redis.tr}/1");
+
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<Redis> inactive;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<io.vertx.redis.client.Redis> inactiveBare;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<RedisAPI> inactiveApi;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<io.vertx.redis.client.RedisAPI> inactiveBareApi;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<RedisDataSource> inactiveDataSource;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<ReactiveRedisDataSource> inactiveReactiveDataSource;
+
+    @Test
+    void inactiveClients() {
+        assertEquals(0, inactive.listActive().size());
+        assertEquals(0, inactiveBare.listActive().size());
+        assertEquals(0, inactiveApi.listActive().size());
+        assertEquals(0, inactiveBareApi.listActive().size());
+        assertEquals(0, inactiveDataSource.listActive().size());
+        assertEquals(0, inactiveReactiveDataSource.listActive().size());
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisInactiveClientsTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisInactiveClientsTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.redis.deployment.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class RedisInactiveClientsTest {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<Redis> inactive;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<io.vertx.redis.client.Redis> inactiveBare;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<RedisAPI> inactiveApi;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<io.vertx.redis.client.RedisAPI> inactiveBareApi;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<RedisDataSource> inactiveDataSource;
+    @Inject
+    @RedisClientName("inactive")
+    InjectableInstance<ReactiveRedisDataSource> inactiveReactiveDataSource;
+
+    @Test
+    void inactiveClients() {
+        assertEquals(0, inactive.listActive().size());
+        assertEquals(0, inactiveBare.listActive().size());
+        assertEquals(0, inactiveApi.listActive().size());
+        assertEquals(0, inactiveBareApi.listActive().size());
+        assertEquals(0, inactiveDataSource.listActive().size());
+        assertEquals(0, inactiveReactiveDataSource.listActive().size());
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
@@ -1,18 +1,20 @@
 package io.quarkus.redis.runtime.client;
 
-import static io.quarkus.redis.runtime.client.config.RedisConfig.DEFAULT_CLIENT_NAME;
+import static io.quarkus.redis.runtime.client.config.RedisConfig.HOSTS;
+import static io.quarkus.redis.runtime.client.config.RedisConfig.HOSTS_PROVIDER_NAME;
+import static io.quarkus.redis.runtime.client.config.RedisConfig.getPropertyName;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 
+import io.quarkus.arc.ActiveResult;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.redis.client.RedisClient;
 import io.quarkus.redis.client.reactive.ReactiveRedisClient;
@@ -27,7 +29,6 @@ import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.redis.client.Command;
@@ -37,16 +38,15 @@ import io.vertx.mutiny.redis.client.Request;
 
 @Recorder
 public class RedisClientRecorder {
-
     // Split client and DS recorders
-    private final RuntimeValue<RedisConfig> config;
+    private final RuntimeValue<RedisConfig> runtimeConfig;
     private static final Map<String, RedisClientAndApi> clients = new HashMap<>();
     private static final Map<String, ReactiveRedisDataSourceImpl> dataSources = new HashMap<>();
     private Vertx vertx;
     private ObservableRedisMetrics metrics;
 
-    public RedisClientRecorder(RuntimeValue<RedisConfig> rc) {
-        this.config = rc;
+    public RedisClientRecorder(RuntimeValue<RedisConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
     }
 
     public void initialize(RuntimeValue<io.vertx.core.Vertx> vertx, Set<String> names,
@@ -78,47 +78,12 @@ public class RedisClientRecorder {
     public void _initialize(io.vertx.core.Vertx vertx, Set<String> names, TlsConfigurationRegistry tlsRegistry,
             ProxyConfigurationRegistry proxyRegistry) {
         for (String name : names) {
-            // Search if we have an associated config:
-            // - if default -> Default
-            // - if named -> Look for that config
-            // - if not found -> ConfigurationException
-            Optional<RedisClientConfig> maybe = getConfigForName(config.getValue(), name);
-            if (!RedisConfig.isDefaultClient(name)) {
-                RedisClientConfig actualConfig = maybe
-                        .orElseThrow(new Supplier<ConfigurationException>() {
-                            @Override
-                            public ConfigurationException get() {
-                                return new ConfigurationException("The application contains a " +
-                                        "@RedisClientName(\"" + name
-                                        + "\"), but the application configuration does not configure this " +
-                                        "redis client configuration with that name. " +
-                                        "You must at least configure `quarkus.redis." + name + ".hosts`.");
-                            }
-                        });
-                clients.computeIfAbsent(name, x -> new RedisClientAndApi(name,
-                        VertxRedisClientFactory.create(name, vertx, actualConfig, tlsRegistry, proxyRegistry),
-                        metrics));
-            } else if (DEFAULT_CLIENT_NAME.equalsIgnoreCase(name) && maybe.isPresent()) {
-                clients.computeIfAbsent(name, x -> new RedisClientAndApi(name,
-                        VertxRedisClientFactory.create(DEFAULT_CLIENT_NAME, vertx, maybe.get(), tlsRegistry, proxyRegistry),
-                        metrics));
-            }
-            // Do not throw an error. We would need to check if the default redis client is used.
-        }
-
-    }
-
-    static Optional<RedisClientConfig> getConfigForName(RedisConfig cfg, String name) {
-        if (RedisConfig.isDefaultClient(name)) {
-            return Optional.ofNullable(cfg.defaultRedisClient());
-        }
-
-        for (Map.Entry<String, RedisClientConfig> entry : cfg.namedRedisClients().entrySet()) {
-            if (entry.getKey().equalsIgnoreCase(name)) {
-                return Optional.of(entry.getValue());
+            if (checkActive(name).get().value()) {
+                RedisClientConfig redisClientConfig = runtimeConfig.getValue().clients().get(name);
+                clients.putIfAbsent(name, new RedisClientAndApi(name,
+                        VertxRedisClientFactory.create(name, vertx, redisClientConfig, tlsRegistry, proxyRegistry), metrics));
             }
         }
-        return Optional.empty();
     }
 
     public Supplier<Redis> getRedisClient(String name) {
@@ -175,7 +140,7 @@ public class RedisClientRecorder {
         return new Supplier<RedisDataSource>() {
             @Override
             public RedisDataSource get() {
-                Duration timeout = RedisClientRecorder.this.getTimeoutForClient(name);
+                Duration timeout = runtimeConfig.getValue().clients().get(name).timeout();
                 return new BlockingRedisDataSourceImpl(
                         (ReactiveRedisDataSourceImpl) RedisClientRecorder.this.getReactiveDataSource(name).get(), timeout);
             }
@@ -187,7 +152,7 @@ public class RedisClientRecorder {
         return new Supplier<RedisClient>() {
             @Override
             public RedisClient get() {
-                Duration timeout = getTimeoutForClient(name);
+                Duration timeout = runtimeConfig.getValue().clients().get(name).timeout();
                 return new RedisClientImpl(
                         RedisClientRecorder.this.getRedisClient(name).get(),
                         RedisClientRecorder.this.getRedisAPI(name).get(),
@@ -196,22 +161,40 @@ public class RedisClientRecorder {
         };
     }
 
-    private Duration getTimeoutForClient(String name) {
-        Duration timeout;
-        if (RedisConfig.isDefaultClient(name)) {
-            timeout = config.getValue().defaultRedisClient().timeout();
-        } else {
-            timeout = config.getValue().namedRedisClients().get(name).timeout();
-        }
-        return timeout;
-    }
-
     public Supplier<ReactiveRedisClient> getLegacyReactiveRedisClient(String name) {
         return new Supplier<ReactiveRedisClient>() {
             @Override
             public ReactiveRedisClient get() {
                 return new ReactiveRedisClientImpl(RedisClientRecorder.this.getRedisClient(name).get(),
                         RedisClientRecorder.this.getRedisAPI(name).get());
+            }
+        };
+    }
+
+    public Supplier<ActiveResult> checkActive(final String name) {
+        return new Supplier<>() {
+            @Override
+            public ActiveResult get() {
+                RedisClientConfig redisClientConfig = runtimeConfig.getValue().clients().get(name);
+                if (!redisClientConfig.active()) {
+                    return ActiveResult.inactive(String.format(
+                            """
+                                    Redis Client '%s' was deactivated through configuration properties. \
+                                    To activate the Redis Client, set configuration property '%s' to 'true' and configure the Redis Client '%s'. \
+                                    Refer to https://quarkus.io/guides/redis-reference for guidance.
+                                    """,
+                            name, getPropertyName(name, "active"), name));
+                }
+                if (redisClientConfig.hosts().isEmpty() && redisClientConfig.hostsProviderName().isEmpty()) {
+                    return ActiveResult.inactive(String.format(
+                            """
+                                    Redis Client '%s' was deactivated automatically because neither the hosts nor the hostsProviderName is set. \
+                                    To activate the Redis Client, set the configuration property '%s' or '%s'. \
+                                    Refer to https://quarkus.io/guides/redis-reference for guidance.
+                                    """,
+                            name, getPropertyName(name, HOSTS), getPropertyName(name, HOSTS_PROVIDER_NAME)));
+                }
+                return ActiveResult.active();
             }
         };
     }
@@ -263,5 +246,4 @@ public class RedisClientRecorder {
             this.api = RedisAPI.api(this.redis);
         }
     }
-
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -19,6 +19,11 @@ import io.vertx.redis.client.RedisTopology;
 
 @ConfigGroup
 public interface RedisClientConfig {
+    /**
+     * Whether this Redis Client should be active at runtime.
+     */
+    @WithDefault("true")
+    boolean active();
 
     /**
      * The Redis hosts to use while connecting to the Redis server. Only the cluster and sentinel modes will consider more than
@@ -287,5 +292,4 @@ public interface RedisClientConfig {
                 ", configureClientName=" + configureClientName() +
                 '}';
     }
-
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
@@ -6,60 +6,72 @@ import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.redis")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface RedisConfig {
-    String REDIS_CONFIG_ROOT_NAME = "redis";
-    String HOSTS_CONFIG_NAME = "hosts";
     String DEFAULT_CLIENT_NAME = "<default>";
+    String HOSTS = "hosts";
+    String HOSTS_PROVIDER_NAME = "hosts-provider-name";
 
     /**
-     * The default redis client
-     */
-    @WithParentName
-    RedisClientConfig defaultRedisClient();
-
-    /**
-     * Configures additional (named) Redis clients.
+     * Configures the Redis clients.
      * <p>
-     * Each client has a unique name which must be identified to select the right client.
-     * For example:
+     * The default client does not have a name, and it is configured as:
+     *
+     * <pre>
+     * quarkus.redis.hosts = redis://localhost:6379
+     * </pre>
+     *
+     * And then use {@link jakarta.inject.Inject} to inject the client:
+     *
+     * <pre>
+     * &#64;Inject
+     * RedisAPI redis;
+     * </pre>
+     *
      * <p>
+     * Named clients must be identified to select the right client:
      *
      * <pre>
      * quarkus.redis.client1.hosts = redis://localhost:6379
      * quarkus.redis.client2.hosts = redis://localhost:6380
      * </pre>
-     * <p>
-     * And then use the {@link io.quarkus.redis.client.RedisClientName} annotation to select the
-     * {@link io.vertx.mutiny.redis.client.Redis},
-     * {@link io.vertx.redis.client.Redis}, {@link io.vertx.mutiny.redis.client.RedisAPI} and
-     * {@link io.vertx.redis.client.RedisAPI} beans.
-     * <p>
+     *
+     * And then use the {@link io.quarkus.redis.client.RedisClientName} annotation to select any of the beans:
+     * <ul>
+     * <li>{@link io.vertx.mutiny.redis.client.Redis}</li>
+     * <li>{@link io.vertx.redis.client.Redis}</li>
+     * <li>{@link io.vertx.mutiny.redis.client.RedisAPI}</li>
+     * <li>{@link io.vertx.redis.client.RedisAPI}</li>
+     * <li>{@link io.quarkus.redis.datasource.RedisDataSource}</li>
+     * <li>{@link io.quarkus.redis.datasource.ReactiveRedisDataSource}</li>
+     * </ul>
+     * And inject the client:
      *
      * <pre>
-     * {
-     *     &#64;code
-     *     &#64;RedisClientName("client1")
-     *     &#64;Inject
-     *     RedisAPI redis;
-     * }
+     * &#64;RedisClientName("client1")
+     * &#64;Inject
+     * RedisAPI redis;
      * </pre>
      */
     @WithParentName
+    @WithDefaults
+    @WithUnnamedKey(DEFAULT_CLIENT_NAME)
     @ConfigDocMapKey("redis-client-name")
-    Map<String, RedisClientConfig> namedRedisClients();
+    Map<String, RedisClientConfig> clients();
 
-    static boolean isDefaultClient(String name) {
+    static boolean isDefaultClient(final String name) {
         return DEFAULT_CLIENT_NAME.equalsIgnoreCase(name);
     }
 
-    static String propertyKey(String name, String radical) {
+    static String getPropertyName(final String name, final String attribute) {
         String prefix = DEFAULT_CLIENT_NAME.equals(name)
                 ? "quarkus.redis."
-                : "quarkus.redis.\"" + name + "\".";
-        return prefix + radical;
+                : "quarkus.redis." + (name.contains(".") ? "\"" + name + "\"" : name) + ".";
+        return prefix + attribute;
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/health/RedisHealthCheck.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/health/RedisHealthCheck.java
@@ -1,6 +1,6 @@
 package io.quarkus.redis.runtime.client.health;
 
-import static io.quarkus.redis.runtime.client.VertxRedisClientFactory.DEFAULT_CLIENT;
+import static io.quarkus.redis.runtime.client.config.RedisConfig.DEFAULT_CLIENT_NAME;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -10,17 +10,16 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
 
-import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.redis.client.RedisClientName;
-import io.quarkus.redis.datasource.ReactiveRedisDataSource;
-import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.smallrye.mutiny.TimeoutException;
 import io.vertx.mutiny.redis.client.Command;
@@ -33,48 +32,18 @@ import io.vertx.mutiny.redis.client.Response;
 class RedisHealthCheck implements HealthCheck {
     private final Map<String, Redis> clients = new HashMap<>();
 
-    private final RedisConfig config;
-
-    public RedisHealthCheck(RedisConfig config) {
-        this.config = config;
-    }
+    @Inject
+    RedisConfig config;
+    @Inject
+    @Any
+    InjectableInstance<Redis> redis;
 
     @PostConstruct
     protected void init() {
-        for (InstanceHandle<Redis> handle : Arc.container().select(Redis.class, Any.Literal.INSTANCE).handles()) {
-            String clientName = getClientName(handle.getBean());
-            clients.putIfAbsent(clientName == null ? DEFAULT_CLIENT : clientName, handle.get());
-        }
-
-        for (InstanceHandle<ReactiveRedisDataSource> handle : Arc.container()
-                .select(ReactiveRedisDataSource.class, Any.Literal.INSTANCE).handles()) {
-            String clientName = getClientName(handle.getBean());
-            Redis redis = handle.get().getRedis();
-            clients.putIfAbsent(clientName == null ? DEFAULT_CLIENT : clientName, redis);
-        }
-
-        for (InstanceHandle<RedisDataSource> handle : Arc.container().select(RedisDataSource.class, Any.Literal.INSTANCE)
-                .handles()) {
-            String clientName = getClientName(handle.getBean());
-            Redis redis = handle.get().getReactive().getRedis();
-            clients.putIfAbsent(clientName == null ? DEFAULT_CLIENT : clientName, redis);
-        }
-    }
-
-    private String getClientName(Bean<?> bean) {
-        for (Object qualifier : bean.getQualifiers()) {
-            if (qualifier instanceof RedisClientName) {
-                return ((RedisClientName) qualifier).value();
+        for (InstanceHandle<Redis> handle : redis.handles()) {
+            if (handle.getBean().isActive()) {
+                clients.putIfAbsent(getClientName(handle.getBean()), handle.get());
             }
-        }
-        return null;
-    }
-
-    private Duration getTimeout(String name) {
-        if (RedisConfig.isDefaultClient(name)) {
-            return config.defaultRedisClient().timeout();
-        } else {
-            return config.namedRedisClients().get(name).timeout();
         }
     }
 
@@ -82,22 +51,33 @@ class RedisHealthCheck implements HealthCheck {
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Redis connection health check").up();
         for (Map.Entry<String, Redis> client : clients.entrySet()) {
+            String clientName = client.getKey().equals(DEFAULT_CLIENT_NAME) ? "default" : client.getKey();
+            Redis redisClient = client.getValue();
+            Duration timeout = config.clients().get(clientName).timeout();
             try {
-                boolean isDefault = DEFAULT_CLIENT.equals(client.getKey());
-                Redis redisClient = client.getValue();
-                String redisClientName = isDefault ? "default" : client.getKey();
-                Duration timeout = getTimeout(client.getKey());
                 Response response = redisClient.send(Request.cmd(Command.PING)).await().atMost(timeout);
-                builder.up().withData(redisClientName, response.toString());
+                builder.up().withData(clientName, response.toString());
             } catch (TimeoutException e) {
-                return builder.down().withData("reason", "client [" + client.getKey() + "]: timeout").build();
+                builder.down().withData(clientName,
+                        "Unable to execute the validation check for the Redis Client due to timeout");
             } catch (Exception e) {
                 if (e.getMessage() == null) {
-                    return builder.down().withData("reason", "client [" + client.getKey() + "]: " + e).build();
+                    builder.down().withData(clientName, "Unable to execute the validation check for the Redis Client: " + e);
+                } else {
+                    builder.down().withData(clientName,
+                            "Unable to execute the validation check for the Redis Client: " + e.getMessage());
                 }
-                return builder.down().withData("reason", "client [" + client.getKey() + "]: " + e.getMessage()).build();
             }
         }
         return builder.build();
+    }
+
+    private static String getClientName(final Bean<?> bean) {
+        for (Object qualifier : bean.getQualifiers()) {
+            if (qualifier instanceof RedisClientName redisClientName) {
+                return redisClientName.value();
+            }
+        }
+        return DEFAULT_CLIENT_NAME;
     }
 }


### PR DESCRIPTION
As discussed in https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Redis.20enable.20.2F.20disable.20Clients/with/553848085 and related to https://github.com/quarkusio/quarkus/discussions/50810

- This adds a new runtime configuration `quarkus.redis[.optional name].active` (default to `true`), to allow disabling a Redis Client at runtime.
- Adjusted Redis CDI beans and Health checks to check if it is active / inactive. Also, a Redis Client is considered inactive if neither `quarkus.redis[.optional name].hosts` or `quarkus.redis[.optional name].hosts-provider-name` are set.
- Moved the old style configuration of split default and named `Map` to a simple `Map`.