### PR TITLE
Compose Dev services enable setting wait_for.logs.timeout label

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
@@ -22,6 +22,7 @@ public final class Labels {
 
     public static final String COMPOSE_WAIT_FOR = QUARKUS_COMPOSE_PREFIX + ".wait_for";
     public static final String COMPOSE_WAIT_FOR_LOGS = COMPOSE_WAIT_FOR + ".logs";
+    public static final String COMPOSE_WAIT_FOR_LOGS_TIMEOUT = COMPOSE_WAIT_FOR_LOGS + ".timeout";
     public static final String COMPOSE_WAIT_FOR_PORTS = COMPOSE_WAIT_FOR + ".ports";
     public static final String COMPOSE_WAIT_FOR_PORTS_DISABLE = COMPOSE_WAIT_FOR_PORTS + ".disable";
     public static final String COMPOSE_WAIT_FOR_PORTS_TIMEOUT = COMPOSE_WAIT_FOR_PORTS + ".timeout";

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
@@ -139,6 +139,9 @@ public class ComposeProject {
                     // Add wait for log message
                     if (e.getKey().startsWith(COMPOSE_WAIT_FOR_LOGS)) {
                         int times = 1;
+                        if (COMPOSE_WAIT_FOR_LOGS_TIMEOUT.equals(e.getKey())) {
+                            continue;
+                        }
                         if (e.getKey().length() > COMPOSE_WAIT_FOR_LOGS.length()) {
                             try {
                                 times = Integer.parseInt(e.getKey().replace(COMPOSE_WAIT_FOR_LOGS + ".", ""));
@@ -146,7 +149,10 @@ public class ComposeProject {
                                 LOG.warnv("Cannot parse label `{}`", e.getKey());
                             }
                         }
-                        addWaitStrategy(waitStrategies, serviceName, Wait.forLogMessage((String) e.getValue(), times));
+                        String waitForTimeout = (String) labels.get(COMPOSE_WAIT_FOR_LOGS_TIMEOUT);
+                        Duration timeout = waitForTimeout != null ? Duration.parse("PT" + waitForTimeout) : startupTimeout;
+                        addWaitStrategy(waitStrategies, serviceName, Wait.forLogMessage((String) e.getValue(), times)
+                                .withStartupTimeout(timeout));
                     }
                 }
                 // Add wait for port availability

--- a/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeFileTest.java
+++ b/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeFileTest.java
@@ -42,7 +42,7 @@ public class ComposeFileTest {
         assertNotNull(db);
         assertEquals("db", db.getServiceName());
         assertEquals("database system is ready to accept connections",
-                db.getLabels().get("io.quarkus.devservices.compose.wait_for.logs"));
+                db.getLabels().get("io.quarkus.devservices.compose.wait_for.logs.2"));
         assertFalse(db.hasHealthCheck());
 
         // Test Redis service
@@ -91,7 +91,7 @@ public class ComposeFileTest {
         // Test labels
         Map<String, Object> labels = db.getLabels();
         assertEquals("database system is ready to accept connections",
-                labels.get("io.quarkus.devservices.compose.wait_for.logs"));
+                labels.get("io.quarkus.devservices.compose.wait_for.logs.2"));
 
         // Test container name (should be null for valid compose)
         assertNull(db.getContainerName());

--- a/extensions/devservices/deployment/src/test/resources/valid-compose.yml
+++ b/extensions/devservices/deployment/src/test/resources/valid-compose.yml
@@ -7,12 +7,16 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
     labels:
-      io.quarkus.devservices.compose.wait_for.logs: "database system is ready to accept connections"
+      io.quarkus.devservices.compose.wait_for.logs.2: "database system is ready to accept connections"
+      io.quarkus.devservices.compose.wait_for.logs.timeout: 10s
+      io.quarkus.devservices.compose.wait_for.ports.disable: true
 
   redis:
     image: redis:6
     ports:
       - "6379:6379"
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: "The server is now ready to accept connections"
 
   kafka:
     profiles:


### PR DESCRIPTION
Enables setting the wait strategy startup timeout for wait_for.logs 

Seen by @vsevel : [#users > compose dev service wait for logs startup timeout](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/compose.20dev.20service.20wait.20for.20logs.20startup.20timeout/with/554260591)