### PR TITLE
Use existing Maven BootstrapSessionListener to hint Surefire about required JVM parameters

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
@@ -1,6 +1,7 @@
 package io.quarkus.maven.components;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -9,6 +10,9 @@ import javax.inject.Singleton;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
 
 import io.quarkus.maven.BuildAnalyticsProvider;
 import io.quarkus.maven.QuarkusBootstrapProvider;
@@ -17,13 +21,16 @@ import io.quarkus.maven.QuarkusBootstrapProvider;
 @Named("quarkus-bootstrap")
 public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant {
 
+    private final Logger logger;
     private final QuarkusBootstrapProvider bootstrapProvider;
     private final BuildAnalyticsProvider buildAnalyticsProvider;
 
     private boolean enabled;
 
     @Inject
-    public BootstrapSessionListener(QuarkusBootstrapProvider bootstrapProvider, BuildAnalyticsProvider buildAnalyticsProvider) {
+    public BootstrapSessionListener(Logger logger, QuarkusBootstrapProvider bootstrapProvider,
+            BuildAnalyticsProvider buildAnalyticsProvider) {
+        this.logger = logger;
         this.bootstrapProvider = bootstrapProvider;
         this.buildAnalyticsProvider = buildAnalyticsProvider;
     }
@@ -39,10 +46,65 @@ public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant 
     }
 
     @Override
-    public void afterProjectsRead(MavenSession session)
-            throws MavenExecutionException {
+    public void afterProjectsRead(MavenSession session) {
         // if this method is called then Maven plugin extensions are enabled
         enabled = true;
+
+        // Now let's automatically apply the required JVM flags to Surefire;
+        // bear in mind that this is just a convenience: we can't rely on Maven
+        // extensions to be enabled - but when they are, we can make it more useful.
+        injectSurefireTuning(session);
+    }
+
+    private void injectSurefireTuning(MavenSession session) {
+        logger.debug("Quarkus Maven extension: inspecting Surefire configuration");
+        for (MavenProject project : session.getProjects()) {
+            //Let's not interfere with non-Quarkus modules:
+            if (isQuarkusPluginConfigured(project)) {
+                injectSurefireArgs(project);
+            }
+        }
+    }
+
+    private void injectSurefireArgs(MavenProject project) {
+        Properties props = project.getProperties();
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "Found quarkus-maven-plugin in " + project.getArtifactId() + ": inspecting for missing Surefire arguments");
+        }
+        final String originalArgLine = props.getProperty("argLine", "");
+        String newArgLine = originalArgLine;
+        //We need these parameters set in advance; N.B. this approach won't scale efficiently.
+        newArgLine = possiblyInject(newArgLine, "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+        newArgLine = possiblyInject(newArgLine, "--add-opens=java.base/java.lang=ALL-UNNAMED");
+        newArgLine = possiblyInject(newArgLine, "--add-exports=java.base/jdk.internal.module=ALL-UNNAMED");
+        newArgLine = newArgLine.trim(); // micro cleanup
+        props.setProperty("argLine", newArgLine);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Quarkus Maven extension: injected 'argLine' for Surefire: " + newArgLine);
+        }
+    }
+
+    private String possiblyInject(final String existingArgLine, final String requiredJvmParameter) {
+        if (!existingArgLine.contains(requiredJvmParameter)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Quarkus Maven extension: injecting JVM parameter '" + requiredJvmParameter + "' into Surefire");
+            }
+            return existingArgLine + " " + requiredJvmParameter;
+        }
+        return existingArgLine;
+    }
+
+    private boolean isQuarkusPluginConfigured(MavenProject project) {
+        if (project.getBuild() == null || project.getBuild().getPlugins() == null) {
+            return false;
+        }
+        for (Plugin plugin : project.getBuild().getPlugins()) {
+            if ("quarkus-maven-plugin".equals(plugin.getArtifactId())) {
+                return true; // it's enabled on this project
+            }
+        }
+        return false;
     }
 
     public boolean isEnabled() {


### PR DESCRIPTION
As I make progress on #49920 , it's becoming clear that we'll need all JVM modes to start with some new JVM flags.
In some cases we can automate this transparently, in others it's harder - it seems likely that we'll end up with needing people to apply some minor migration steps to set necessary parameters.

Among all "modes" which I'm trying to cover - Surefire is particularly problematic.

This particular PR is an attempt to mitigate some such needs, by setting the required parameters to Surefire automatically.

N.B.

### This is only effective if people use `<extensions>true</extensions>` in their pom.xml (Quarkus plugin config)

#### But at least those who do would have a better experience

I'm fairly annoyed by this limitation, but couldn't find a way to make it work universally and transparently. An alternative would be for people to add the required settings in `.mvn/maven.config` - but I'm inclined to pursue all such venues, so that at least those having Maven extensions enabled have some additional benefits deriving from it.

For these reasons this PR is independent from #49920 : it's not requiring it, and the other patch can't rely on it.
For those people not having extensions enabled, I'm afraid they'll have to add some JVM flags expicitly in their pom (to be defined, and documented, as I finish #49920).

Finally, since it might be detabable if we want to apply this - I'd rather debate this approach separately and in isolation from the larger work, so I'd start by merging this if there are no objections: should be harmless when it's not useful.

WDYT, @aloubyansky , @gsmet , @geoand ?
