### PR TITLE
Allow forcing a RequestParam explicitly required

### DIFF
--- a/extensions/spring-web/resteasy-reactive/deployment/src/main/java/io/quarkus/spring/web/resteasy/reactive/deployment/SpringWebResteasyReactiveProcessor.java
+++ b/extensions/spring-web/resteasy-reactive/deployment/src/main/java/io/quarkus/spring/web/resteasy/reactive/deployment/SpringWebResteasyReactiveProcessor.java
@@ -303,15 +303,6 @@ public class SpringWebResteasyReactiveProcessor {
                             AnnotationValue defaultValue = annotation.value("defaultValue");
                             if (defaultValue != null) {
                                 defaultValueStr = defaultValue.asString();
-                            } else {
-                                AnnotationValue requiredValue = annotation.value("required");
-                                if (requiredValue != null) {
-                                    if (requiredValue.asBoolean()) {
-                                        throw new IllegalArgumentException(
-                                                "Using required @RequestMapping is not supported. Offending method is '"
-                                                        + methodInfo.declaringClass().name() + "#" + methodInfo.name() + "'");
-                                    }
-                                }
                             }
                             if (defaultValueStr != null) {
                                 transform.add(create(DEFAULT_VALUE, annotation.target(),

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamController.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamController.java
@@ -80,6 +80,11 @@ public class RequestParamController {
         throw new IllegalStateException("Unexpected state. Should have not been called");
     }
 
+    @GetMapping("/api/foos/paramExplicitlyRequired")
+    public String getFoosParamExplicitlyRequired(@RequestParam(required = true) String id) {
+        throw new IllegalStateException("Unexpected state. Should have not been called");
+    }
+
     @RestControllerAdvice
     public static class RestExceptionHandler {
 
@@ -87,6 +92,7 @@ public class RequestParamController {
         public ResponseEntity<Object> handleException(Exception ex) {
             return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
         }
+
     }
 
 }

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamControllerTest.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamControllerTest.java
@@ -129,6 +129,10 @@ public class RequestParamControllerTest {
         when().get("/api/foos/paramRequired")
                 .then()
                 .statusCode(400).body(containsString("Missing required param in method"));
+
+        when().get("/api/foos/paramExplicitlyRequired")
+                .then()
+                .statusCode(400).body(containsString("Missing required param in method"));
     }
 
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->
After fixing #50321, it turns out that forcing required=true in an @RequestParam resulted in an error, which should not be the case. Even if it is redundant, as in Spring, we must have the option to force this value. 

cc @geoand 
