### PR TITLE
Downgrade Quartz version due to a regression

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -117,7 +117,7 @@
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
         <cronutils.version>9.2.1</cronutils.version>
-        <quartz.version>2.5.1</quartz.version>
+        <quartz.version>2.5.0</quartz.version>
         <h2.version>2.4.240</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions
                                               and the dependency jts-core needs to be updated in extensions/jdbc/jdbc-h2/runtime/pom.xml -->
         <postgresql-jdbc.version>42.7.8</postgresql-jdbc.version>


### PR DESCRIPTION
This is a revert of https://github.com/quarkusio/quarkus/commit/e8157ae503510a0a5f026dd3eb59f1cbd24ed96d

The newer version causes a regression when using Quartz in combination with PostgreSQL.
It was originally found in a CI run for quickstarts as we use this DB there, see https://github.com/quarkusio/quarkus/issues/6588#issuecomment-3501707134.

The Quartz PR causing this is https://github.com/quartz-scheduler/quartz/pull/1344#discussion_r2463800804 where there is a report of the very same issue.

FYI there is already a pending fix (https://github.com/quartz-scheduler/quartz/pull/1411) so we just need that to get merged and wait for newer version.