### PR TITLE
Make sure that Mutiny can use SR-CP to propagate `cancel()` up from `CompletableFuture`

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-graphql.version>2.16.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.10.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.2</smallrye-jwt.version>
-        <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
+        <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.20.3</smallrye-mutiny-vertx-binding.version>
@@ -137,7 +137,7 @@
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <mutiny.version>3.0.1</mutiny.version>
+        <mutiny.version>3.0.2</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka3.version>4.0.1</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/cache/CacheTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/cache/CacheTest.java
@@ -44,9 +44,9 @@ public class CacheTest {
         assertEquals("4::5", render(true, null));
         cache.invalidateAll().await().indefinitely();
         assertThrows(IllegalStateException.class, () -> render(true, null));
-        // The failure is cached
-        assertThrows(IllegalStateException.class, () -> render(false, null));
-        assertEquals("6::7", render(false, "bravo"));
+        // The failure is not cached
+        assertEquals("6::7", render(false, null));
+        assertEquals("6::8", render(false, "bravo"));
     }
 
     private String render(boolean fail, String key) {

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerFailureTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerFailureTest.java
@@ -46,14 +46,14 @@ public class MessageConsumerFailureTest {
         verifyFailure("foo-completion-stage", "java.lang.NullPointerException: Something is null", false);
         verifyFailure("foo-completion-stage-failure", "boom", true);
         verifyFailure("foo-uni", "java.lang.NullPointerException: Something is null", false);
-        verifyFailure("foo-uni-failure", "java.io.IOException: boom", true);
+        verifyFailure("foo-uni-failure", "boom", true);
 
         verifyFailure("foo-blocking", "java.lang.IllegalStateException: Red is dead", false);
         verifyFailure("foo-message-blocking", "java.lang.NullPointerException", false);
         verifyFailure("foo-completion-stage-blocking", "java.lang.NullPointerException: Something is null", false);
         verifyFailure("foo-completion-stage-failure-blocking", "boom", true);
         verifyFailure("foo-uni-blocking", "java.lang.NullPointerException: Something is null", false);
-        verifyFailure("foo-uni-failure-blocking", "java.io.IOException: boom", true);
+        verifyFailure("foo-uni-failure-blocking", "boom", true);
     }
 
     @Test

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
@@ -47,6 +47,7 @@ final class MethodsCandidate implements AccessorCandidate {
                                 }
                             } catch (Exception e) {
                                 result.completeExceptionally(e);
+                                return;
                             }
                         }
                         // No method matches the parameter types


### PR DESCRIPTION
Upgrade Mutiny and SR-CP to fix `cancel()` semantics.

- Fixes: #50513