### PR TITLE
Fix application startup when gRPC is used with Quarkus REST and gRPC service has class-level security annotation

### DIFF
--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
@@ -16,6 +16,7 @@ import jakarta.interceptor.InvocationContext;
 
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.spi.runtime.AuthorizationController;
@@ -36,7 +37,9 @@ public abstract class StandardSecurityCheckInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
-        if (controller.isAuthorizationEnabled() && CurrentRequestManager.get() != null
+        if (controller.isAuthorizationEnabled() && Arc.container() != null
+                && Arc.container().requestContext().isActive()
+                && CurrentRequestManager.get() != null
                 && alreadyDoneByEagerSecurityHandler(
                         CurrentRequestManager.get().getProperty(STANDARD_SECURITY_CHECK_INTERCEPTOR), ic.getMethod())) {
             ic.getContextData().put(SECURITY_HANDLER, EXECUTED);

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/GreeterResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/GreeterResource.java
@@ -9,6 +9,9 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 import examples.HelloReply;
 import examples.HelloRequest;
 import examples.MutinyGreeterGrpc;
+import examples.MutinySaluterGrpc;
+import examples.SaluteReply;
+import examples.SaluteRequest;
 import io.grpc.Metadata;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.grpc.GrpcClientUtils;
@@ -26,6 +29,9 @@ public class GreeterResource {
     @GrpcClient("hello")
     MutinyGreeterGrpc.MutinyGreeterStub helloClient;
 
+    @GrpcClient("saluter")
+    MutinySaluterGrpc.MutinySaluterStub saluterClient;
+
     @Path("bearer")
     @GET
     public Uni<String> sayHello() {
@@ -33,6 +39,15 @@ public class GreeterResource {
         headers.put(AUTHORIZATION, "Bearer " + accessToken.getRawToken());
         return GrpcClientUtils.attachHeaders(helloClient, headers)
                 .bearer(HelloRequest.newBuilder().setName("Jonathan").build()).map(HelloReply::getMessage);
+    }
+
+    @Path("/other/bearer")
+    @GET
+    public Uni<String> sayHi() {
+        Metadata headers = new Metadata();
+        headers.put(AUTHORIZATION, "Bearer " + accessToken.getRawToken());
+        return GrpcClientUtils.attachHeaders(saluterClient, headers)
+                .bearer(SaluteRequest.newBuilder().setName("Jonathan").build()).map(SaluteReply::getMessage);
     }
 
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SaluterServiceImpl.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SaluterServiceImpl.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import examples.MutinySaluterGrpc;
+import examples.SaluteReply;
+import examples.SaluteRequest;
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@RolesAllowed("admin")
+@GrpcService
+public class SaluterServiceImpl extends MutinySaluterGrpc.SaluterImplBase {
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    @Override
+    public Uni<SaluteReply> bearer(SaluteRequest request) {
+        var principalName = securityIdentity.getPrincipal().getName();
+        return Uni.createFrom().item(SaluteReply.newBuilder()
+                .setMessage("Hi " + request.getName() + " from " + principalName).build());
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/proto/saluter.proto
+++ b/integration-tests/oidc-wiremock/src/main/proto/saluter.proto
@@ -1,0 +1,54 @@
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "examples";
+option java_outer_classname = "SaluterProto";
+option objc_class_prefix = "HLW";
+
+package saluter;
+
+// The greeting service definition.
+service Saluter {
+    // Sends a greeting
+    // Name is 'Bearer' in order to match tenant name
+    rpc bearer (SaluteRequest) returns (SaluteReply) {}
+}
+
+// The request message containing the user's name.
+message SaluteRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message SaluteReply {
+    string message = 1;
+}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -317,6 +317,8 @@ quarkus.native.additional-build-args=-H:IncludeResources=private.*\\.*,-H:Includ
 
 quarkus.grpc.clients.hello.host=localhost
 quarkus.grpc.clients.hello.port=8081
+quarkus.grpc.clients.saluter.host=localhost
+quarkus.grpc.clients.saluter.port=8081
 quarkus.grpc.server.use-separate-server=false
 
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.auth-server-url=http://localhost:8185/auth/realms/quarkus2

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -742,6 +742,22 @@ public class BearerTokenAuthorizationTest {
                 .body(Matchers.containsString("Hello Jonathan from alice"));
     }
 
+    @Test
+    public void testAuthorizationOnGrpcServiceClassLevel() {
+        String token = getAccessToken("alice", Set.of("user"));
+        RestAssured.given().auth().oauth2(token).when()
+                .get("/api/greeter/other/bearer")
+                .then()
+                .statusCode(500);
+
+        token = getAccessToken("alice", Set.of("admin"));
+        RestAssured.given().auth().oauth2(token).when()
+                .get("/api/greeter/other/bearer")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("Hi Jonathan from alice"));
+    }
+
     private static void assertSecurityIdentityAcquired(String tenant, String user, String role) {
         String jsonPath = tenant + "." + user + ".findAll{ it == \"" + role + "\"}.size()";
         RestAssured.given().when().get("/startup-service").then().statusCode(200)


### PR DESCRIPTION
- closes https://github.com/quarkusio/quarkus/issues/44414
- that security interceptor is meant to avoid duplicate security checks and we always activate CDI context request when we perform security check in Quarkus REST, therefore we can avoid following error:

```
[ERROR] io.quarkus.it.keycloak.BearerTokenAuthorizationTest.testGrpcAuthorizationWithCustomGrpcMechanism -- Time elapsed: 0.004 s <<< ERROR!
java.lang.RuntimeException: java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.test.junit.QuarkusTestExtension.throwBootFailureException(QuarkusTestExtension.java:666)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptTestClassConstructor(QuarkusTestExtension.java:761)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.runner.bootstrap.StartupActionImpl.run(StartupActionImpl.java:350)
	at io.quarkus.test.junit.QuarkusTestExtension.doJavaStart(QuarkusTestExtension.java:232)
	at io.quarkus.test.junit.QuarkusTestExtension.ensureStarted(QuarkusTestExtension.java:640)
	at io.quarkus.test.junit.QuarkusTestExtension.beforeAll(QuarkusTestExtension.java:685)
	... 1 more
Caused by: jakarta.enterprise.context.ContextNotActiveException: RequestScoped context was not active when trying to obtain a bean instance for a client proxy of CLASS bean [class=io.quarkus.vertx.http.runtime.CurrentVertxRequest, id=ZMes0Yo6HsWixdWYNWZOvMsRHzQ]
	- you can activate the request context for a specific method using the @ActivateRequestContext interceptor binding
	at io.quarkus.arc.impl.ClientProxies.notActive(ClientProxies.java:76)
	at io.quarkus.arc.impl.ClientProxies.getSingleContextDelegate(ClientProxies.java:32)
	at io.quarkus.vertx.http.runtime.CurrentVertxRequest_ClientProxy.arc$delegate(Unknown Source)
	at io.quarkus.vertx.http.runtime.CurrentVertxRequest_ClientProxy.getOtherHttpContextObject(Unknown Source)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusCurrentRequest.get(QuarkusCurrentRequest.java:21)
	at org.jboss.resteasy.reactive.server.core.CurrentRequestManager.get(CurrentRequestManager.java:8)
	at io.quarkus.resteasy.reactive.server.runtime.StandardSecurityCheckInterceptor.intercept(StandardSecurityCheckInterceptor.java:39)
	at io.quarkus.resteasy.reactive.server.runtime.StandardSecurityCheckInterceptor$AuthenticatedInterceptor_Bean.intercept(Unknown Source)
	at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:30)
	at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:27)
	at io.quarkus.it.keycloak.SaluterServiceImpl_Subclass.bindService(Unknown Source)
	at io.quarkus.grpc.runtime.GrpcServerRecorder.collectServiceDefinitions(GrpcServerRecorder.java:483)
	at io.quarkus.grpc.runtime.GrpcServerRecorder.buildGrpcServer(GrpcServerRecorder.java:211)
	at io.quarkus.grpc.runtime.GrpcServerRecorder.initializeGrpcServer(GrpcServerRecorder.java:176)
	at io.quarkus.runner.recorded.GrpcServerProcessor$initializeServer1655520967.deploy_0(Unknown Source)
	at io.quarkus.runner.recorded.GrpcServerProcessor$initializeServer1655520967.deploy(Unknown Source)
	... 8 more
```
