### PR TITLE
Bump version of Hibernate Reactive to 3.1.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.6</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>3.1.7.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.1.8.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.1.2.Final</hibernate-search.version>
         <hibernate-tools.version>7.1.6.Final</hibernate-tools.version>


### PR DESCRIPTION
Creating separately because #50924 is pending changes/clarification in Hibernate ORM, and this Hibernate Reactive upgrade does not require a Hibernate ORM upgrade AFAIK.

See https://github.com/hibernate/hibernate-reactive/releases/tag/3.1.8

Fixes in particular [QUARKUS-6792](https://issues.redhat.com/browse/QUARKUS-6792) Failed to validate Schema: Schema-validation: wrong column type encountered in column.

Must be backported to 3.27.

cc @DavideD 