### PR TITLE
Use simplified AOT file creation workflow provided by JEP-514

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
@@ -226,68 +226,18 @@ public class JvmStartupOptimizerArchiveBuildStep {
     private Path createAot(JarBuildItem jarResult,
             OutputTargetBuildItem outputTarget, String javaBinPath, String containerImage,
             boolean isFastJar) {
-        // first we run java -XX:AOTMode=record -XX:AOTConfiguration=app.aotconf -jar ...
-        ArchivePathsContainer aotConfigPathContainers = ArchivePathsContainer.aotConfFromQuarkusJar(jarResult.getPath());
-        Path aotConfPath = launchArchiveCreateCommand(aotConfigPathContainers.workingDirectory,
-                aotConfigPathContainers.resultingFile,
-                recordAotConfCommand(jarResult, outputTarget, javaBinPath, containerImage, isFastJar, aotConfigPathContainers));
-        if (aotConfPath == null) {
-            // something went wrong, bail as the issue has already been logged
-            return null;
-        }
-
-        // now we run java -XX:AOTMode=create -XX:AOTConfiguration=app.aotconf -jar ...
         ArchivePathsContainer aotPathContainers = ArchivePathsContainer.aotFromQuarkusJar(jarResult.getPath());
         return launchArchiveCreateCommand(aotPathContainers.workingDirectory, aotPathContainers.resultingFile,
-                createAotCommand(jarResult, outputTarget, javaBinPath, containerImage, isFastJar, aotConfPath));
+                createAotCommand(jarResult, outputTarget, javaBinPath, containerImage, isFastJar, aotPathContainers));
 
-    }
-
-    private List<String> recordAotConfCommand(JarBuildItem jarResult, OutputTargetBuildItem outputTarget, String javaBinPath,
-            String containerImage, boolean isFastJar,
-            ArchivePathsContainer aotConfigPathContainers) {
-        List<String> javaArgs = new ArrayList<>();
-        javaArgs.add("-XX:AOTMode=record");
-        javaArgs.add("-XX:AOTConfiguration=" + aotConfigPathContainers.resultingFile.getFileName().toString());
-        javaArgs.add(String.format("-D%s=true", MainClassBuildStep.GENERATE_APP_CDS_SYSTEM_PROPERTY));
-        javaArgs.add("-jar");
-
-        List<String> command;
-        if (containerImage != null) {
-            List<String> dockerRunCommand = dockerRunCommands(outputTarget, containerImage,
-                    isFastJar ? CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME
-                            : CONTAINER_IMAGE_BASE_BUILD_DIR + "/" + jarResult.getPath().getFileName().toString());
-            command = new ArrayList<>(dockerRunCommand.size() + 1 + javaArgs.size());
-            command.addAll(dockerRunCommand);
-            command.add("java");
-            command.addAll(javaArgs);
-            if (isFastJar) {
-                command.add(FastJarFormat.QUARKUS_RUN_JAR);
-            } else {
-                command.add(jarResult.getPath().getFileName().toString());
-            }
-        } else {
-            command = new ArrayList<>(2 + javaArgs.size());
-            command.add(javaBinPath);
-            command.addAll(javaArgs);
-            if (isFastJar) {
-                command
-                        .add(jarResult.getLibraryDir().getParent().resolve(FastJarFormat.QUARKUS_RUN_JAR)
-                                .getFileName().toString());
-            } else {
-                command.add(jarResult.getPath().getFileName().toString());
-            }
-        }
-        return command;
     }
 
     private List<String> createAotCommand(JarBuildItem jarResult, OutputTargetBuildItem outputTarget, String javaBinPath,
             String containerImage, boolean isFastJar,
-            Path aotConfPath) {
+            ArchivePathsContainer aotPathContainers) {
         List<String> javaArgs = new ArrayList<>();
-        javaArgs.add("-XX:AOTMode=create");
-        javaArgs.add("-XX:AOTConfiguration=" + aotConfPath.getFileName().toString());
-        javaArgs.add("-XX:AOTCache=app.aot");
+        javaArgs.add("-XX:AOTCacheOutput=" + aotPathContainers.resultingFile.getFileName().toString());
+        javaArgs.add(String.format("-D%s=true", MainClassBuildStep.GENERATE_APP_CDS_SYSTEM_PROPERTY));
         javaArgs.add("-jar");
 
         List<String> command;
@@ -367,10 +317,6 @@ public class JvmStartupOptimizerArchiveBuildStep {
 
         public static ArchivePathsContainer appCDSFromQuarkusJar(Path jar) {
             return doCreate(jar, "app-cds.jsa");
-        }
-
-        public static ArchivePathsContainer aotConfFromQuarkusJar(Path jar) {
-            return doCreate(jar, "app.aotconf");
         }
 
         public static ArchivePathsContainer aotFromQuarkusJar(Path jar) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
@@ -226,6 +226,10 @@ public class JvmStartupOptimizerArchiveBuildStep {
     private Path createAot(JarBuildItem jarResult,
             OutputTargetBuildItem outputTarget, String javaBinPath, String containerImage,
             boolean isFastJar) {
+        if (Runtime.version().feature() < 25) {
+            throw new IllegalStateException(
+                    "AOT cache generation requires building with JDK 25 or newer (see JEP 514). ");
+        }
         ArchivePathsContainer aotPathContainers = ArchivePathsContainer.aotFromQuarkusJar(jarResult.getPath());
         return launchArchiveCreateCommand(aotPathContainers.workingDirectory, aotPathContainers.resultingFile,
                 createAotCommand(jarResult, outputTarget, javaBinPath, containerImage, isFastJar, aotPathContainers));

--- a/docs/src/main/asciidoc/appcds.adoc
+++ b/docs/src/main/asciidoc/appcds.adoc
@@ -98,15 +98,14 @@ AppCDS has improved significantly in the latest JDK releases. This means that to
 [TIP]
 ====
 Starting with JDK 24, the JVM provides an evolution of the class-data sharing in the form of the AOT cache.
-If you are building an application that will target JDK 24+ you can take advantage of this feature by adding the following system property when packaging your application:
+If you are building an application that will target JDK 25+ you can take advantage of this feature by adding the following system property when packaging your application:
 
 [source,bash]
 ----
--Dquarkus.package.jar.appcds.use-aot=true
+-Dquarkus.package.jar.appcds.enabled=true -Dquarkus.package.jar.appcds.use-aot=true
 ----
 
-The result of this flag (plus the `-Dquarkus.package.jar.appcds.enabled=true` original one) is the creation of an AOT cache file
-named `app.aot`.
+The result of using these flags is the creation of an AOT cache file named `app.aot`.
 
 You can use this AOT cache when launching the application like so:
 


### PR DESCRIPTION
Quarkus had support for generating the JDK's AOT file
using the two-step workflow specified in [JEP-483](https://openjdk.org/jeps/483).
With the advent of JDK 25, however, there is now
a simpler workflow for creating the AOT file, which
has been specified by [JEP-514.](https://openjdk.org/jeps/514)
This change shouldn't have any effect on users (except for requiring JDK 25 for the AOT file),
but it does simplify the Quarkus code

P.S. This is technically a breaking change because the AOT file generation feature now requires JDK 25 instead of 25