### PR TITLE
Use `@QuarkusIntegrationTest` tests as a test run for AOT file generation

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -50,6 +50,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     private List<String> argLine;
     private Map<String, String> env;
     private Path jarPath;
+    private boolean generateAotFile;
 
     private final Map<String, String> systemProps = new HashMap<>();
     private Process quarkusProcess;
@@ -65,6 +66,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         this.argLine = initContext.argLine();
         this.env = initContext.env();
         this.jarPath = initContext.jarPath();
+        this.generateAotFile = initContext.generateAotFile();
     }
 
     public void start() throws IOException {
@@ -111,6 +113,9 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         args.add(determineJavaPath());
         if (!argLine.isEmpty()) {
             args.addAll(argLine);
+        }
+        if (generateAotFile) {
+            args.add("-XX:AOTCacheOutput=%s".formatted(jarPath.resolveSibling("app.aot")));
         }
         if (HTTP_PRESENT) {
             args.add("-Dquarkus.http.port=" + httpPort);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/JarArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/JarArtifactLauncher.java
@@ -11,5 +11,7 @@ public interface JarArtifactLauncher extends ArtifactLauncher<JarArtifactLaunche
     interface JarInitContext extends InitContext {
 
         Path jarPath();
+
+        boolean generateAotFile();
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
@@ -51,7 +51,9 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
                     TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                     testConfig.env(),
                     context.devServicesLaunchResult(),
-                    context.buildOutputDirectory().resolve(pathStr)));
+                    context.buildOutputDirectory().resolve(pathStr),
+                    config.getOptionalValue("quarkus.package.jar.appcds.use-aot", Boolean.class)
+                            .orElse(Boolean.FALSE)));
             return launcher;
         } else {
             throw new IllegalStateException("The path of the native binary could not be determined");
@@ -61,17 +63,25 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
     static class DefaultJarInitContext extends DefaultInitContextBase implements JarArtifactLauncher.JarInitContext {
 
         private final Path jarPath;
+        private final boolean generateAotFile;
 
         DefaultJarInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
                 List<String> argLine, Map<String, String> env,
-                ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult, Path jarPath) {
+                ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult, Path jarPath,
+                boolean generateAotFile) {
             super(httpPort, httpsPort, waitTime, testProfile, argLine, env, devServicesLaunchResult);
             this.jarPath = jarPath;
+            this.generateAotFile = generateAotFile;
         }
 
         @Override
         public Path jarPath() {
             return jarPath;
+        }
+
+        @Override
+        public boolean generateAotFile() {
+            return generateAotFile;
         }
     }
 


### PR DESCRIPTION
This uses the process outlined by https://openjdk.org/jeps/514
to generate a file named `app.aot` inside the `quarkus-app` directory
(i.e. next to the jar) when `-Dquarkus.package.jar.appcds.use-aot=true`
has been set.

This only works when the target artifact is a jar file.

When I tried this on the Hibernate ORM Panache quickstart, it cut the startup time of the prod jar by half