### PR TITLE
Re-enable Agroal datasource metrics

### DIFF
--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/AgroalMetricsOnlyTestCase.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/AgroalMetricsOnlyTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.agroal.test;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.metrics.*;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test to verify that Agroal metrics are exposed when only quarkus.datasource.metrics.enabled=true is set
+ */
+public class AgroalMetricsOnlyTestCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("base.properties")
+            .overrideConfigKey("quarkus.datasource.metrics.enabled", "true");
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    MetricRegistry registry;
+
+    @Test
+    public void testMetricsAreExposed() {
+        Counter acquireCount = registry.getCounters()
+                .get(new MetricID("agroal.acquire.count", new Tag("datasource", "default")));
+        Gauge<?> maxUsed = registry.getGauges()
+                .get(new MetricID("agroal.max.used.count", new Tag("datasource", "default")));
+
+        Assertions.assertNotNull(acquireCount, "Agroal metrics should be registered eagerly");
+        Assertions.assertNotNull(maxUsed, "Agroal metrics should be registered eagerly");
+    }
+
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
@@ -45,7 +45,6 @@ public interface DataSourceJdbcBuildTimeConfig {
         /**
          * Enable metrics collection for this datasource.
          */
-        @WithDefault("false")
         Optional<Boolean> enabled();
 
     }


### PR DESCRIPTION
- Introduce a new test to validate Agroal metrics functionality when metrics are enabled.
- Remove default `false` value for `enabled` configuration in `DataSourceJdbcMetrics` to allow explicit control.
- Fixes #50956
