### PR TITLE
Fix Kafka consumer group.id to default to quarkus.application.name in production

### DIFF
--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/KafkaRuntimeConfigProducer.java
@@ -52,7 +52,7 @@ public class KafkaRuntimeConfigProducer {
             }
         }
 
-        if (!result.isEmpty() && !result.containsKey(GROUP_ID) && app.name().isPresent()) {
+        if (!result.containsKey(GROUP_ID) && app.name().isPresent()) {
             result.put(GROUP_ID, app.name().get());
         }
 


### PR DESCRIPTION
The `group.id` was only defaulting to `quarkus.application.name` when at least one `kafka.*` property was configured. 
This worked in dev mode (where dev services set Kafka properties), but failed in production, where no Kafka properties were be configured.