### PR TITLE
Fix Quotes for Kotlin example in gradle-tooling.adoc

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -798,10 +798,10 @@ plugins {
 
 quarkus {
     buildForkOptions {
-        maxHeapSize = '2g'
+        maxHeapSize = "2g"
     }
     codeGenForkOptions {
-        maxHeapSize = '128m'
+        maxHeapSize = "128m"
     }
 }
 ----


### PR DESCRIPTION
SSIA

I don't know why GitHub shows a diff for line 936. I think it might be a bug in Github?
