### PR TITLE
Rework graceful shutdown to be more graceful WRT HTTP

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/filters/GracefulShutdownFilterTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/filters/GracefulShutdownFilterTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.vertx.http.filters;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.quarkus.runtime.shutdown.ShutdownRecorder;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.ext.web.Router;
+
+public class GracefulShutdownFilterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class, GracefulShutdownFilterTest.class))
+            .overrideConfigKey("quarkus.shutdown.timeout", "10");
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void test() throws URISyntaxException, IOException, InterruptedException {
+        get("/").then().statusCode(200)
+                .header(HttpHeaders.CONNECTION.toString(), is(not((HttpHeaderValues.CLOSE.toString()))))
+                .body(is("http/1.1"));
+
+        ShutdownRecorder.runShutdown();
+
+        testWithJdkHttpClientAndHttp2AfterShutdown();
+
+        testWithVertxHttpClientAndHttp2AfterShutdown();
+
+        testWithRestAssuredAndHttp11AfterShutdown();
+    }
+
+    private void testWithRestAssuredAndHttp11AfterShutdown() {
+        get("/").then().statusCode(200)
+                .header(HttpHeaders.CONNECTION.toString(), is(HttpHeaderValues.CLOSE.toString()))
+                .body(is("http/1.1"));
+    }
+
+    private void testWithVertxHttpClientAndHttp2AfterShutdown() throws InterruptedException {
+        HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+                .setProtocolVersion(HttpVersion.HTTP_2)
+                .setDefaultHost("localhost")
+                .setDefaultPort(RestAssured.port));
+
+        CountDownLatch responseLatch = new CountDownLatch(1);
+
+        // Send a GET request
+        Future<HttpClientResponse> response = client
+                .request(HttpMethod.GET, "/")
+                .compose(HttpClientRequest::send)
+                .andThen(r -> r.result().body().onComplete(buffer -> responseLatch.countDown()));
+
+        if (!responseLatch.await(10, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timeout waiting for response");
+        }
+
+        if (response.failed()) {
+            throw new RuntimeException(response.cause());
+        }
+
+        if (response.result().body().failed()) {
+            throw new RuntimeException(response.result().body().cause());
+        }
+
+        Assertions.assertThat(response.result().body().result().toString()).isEqualTo("h2");
+        Assertions.assertThat(response.result().headers().get(HttpHeaders.CONNECTION.toString())).isNull();
+        client.close();
+    }
+
+    private void testWithJdkHttpClientAndHttp2AfterShutdown()
+            throws URISyntaxException, IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI(RestAssured.baseURI + ":" + RestAssured.port))
+                .GET()
+                .build();
+        java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        Assertions.assertThat(response.headers().firstValue(HttpHeaders.CONNECTION.toString())).isEmpty();
+        Assertions.assertThat(response.body()).isEqualTo("h2");
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        public void register(@Observes Router router) {
+            router
+                    .get("/")
+                    .handler(rc -> rc.response().end(rc.request().version().alpnName()));
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/GracefulShutdownFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/GracefulShutdownFilter.java
@@ -1,15 +1,19 @@
 package io.quarkus.vertx.http.runtime.filters;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.logging.Logger;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.runtime.shutdown.ShutdownListener;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpVersion;
 
 public class GracefulShutdownFilter implements ShutdownListener, Handler<HttpServerRequest> {
 
@@ -40,15 +44,111 @@ public class GracefulShutdownFilter implements ShutdownListener, Handler<HttpSer
 
     @Override
     public void handle(HttpServerRequest event) {
-        if (!running) {
-            event.response().setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code())
-                    .putHeader(HttpHeaderNames.CONNECTION, "close").end();
-            return;
-        }
         currentRequestCount.incrementAndGet();
         //todo: some way to do this without a wrapper solution
         ((QuarkusRequestWrapper) event).addRequestDoneHandler(requestDoneHandler);
+
+        if (event.version() == HttpVersion.HTTP_1_1) {
+            // For HTTP/1.1, add the header as otherwise the client will consider the connection to be keep-alive.
+            // "Connection-specific header fields such as Connection and Keep-Alive are prohibited in HTTP/2 and HTTP/3"
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Connection
+            // Therefore only add it for HTTP/1.1
+            if (!running) {
+                event.response().headers().add(HttpHeaderNames.CONNECTION, "close");
+                ((QuarkusRequestWrapper) event).addRequestDoneHandler(unused -> event.connection().close());
+            }
+        } else if (event.version() == HttpVersion.HTTP_2) {
+            /*
+             * Only send GOAWAY and shutdown after completing the response, as the Vert.x 4.5.23 HttpClient does handle it
+             * badly.
+             * It doesn't proceed the last DATA frame well when a GOAWAY was sent.
+             * This is fixed in upstream issue https://github.com/eclipse-vertx/vert.x/issues/5693
+             */
+            if (!running) {
+                ((QuarkusRequestWrapper) event).addRequestDoneHandler(unused -> {
+                    sendGoAwayForHttp2(event.connection(), event.getHeader(HttpHeaderNames.USER_AGENT));
+                });
+            }
+        }
+
         next.handle(event);
+    }
+
+    private final Set<Object> connectionsWithGoAway = Collections.synchronizedSet(
+            Collections.newSetFromMap(
+                    new WeakHashMap<>()));
+
+    private void sendGoAwayForHttp2(HttpConnection connection, String userAgent) {
+        // First check if user agent supports GOAWAY. If we are connected to the client directly, we might trust it.
+        // If there is a proxy in the middle, let's wait for the next request to check again.
+        if (isAffectedByJDK8335181(userAgent)) {
+            return;
+        }
+
+        // Avoid sending multiple GOAWAYs for a single connection to avoid confusing the caller
+        if (!connectionsWithGoAway.add(connection)) {
+            return;
+        }
+
+        // GO_AWAY + 0 (NO_ERROR) = graceful shutdown; client will stop creating new streams on this connection
+        connection.goAway(0);
+
+        // Do not do a connection shutdown as OpenJDK 21.0.9 has problems and reports an "EOF reached while reading"
+        // when the connection close is received while messages are processed asynchronously which might take a while.
+        // See Http2Connection.Http2TubeSubscriber#onComplete()
+        // Problem persists in OpenJDK 25.0.1
+        // A workaround could be to add a delay here, but for now no vertx instance is at hand to set a timer.
+        // Tracked in upstream issue https://bugs.openjdk.org/browse/JDK-8374534
+        if (userAgent != null && userAgent.startsWith("Java-http-client/")) {
+            return;
+        }
+
+        connection.shutdown();
+    }
+
+    /**
+     * Test if the client is affected by <a href="https://bugs.openjdk.org/browse/JDK-8335181">JDK-8335181</a>.
+     * Affected clients do not support GOAWAY at all. Fixed in 21.0.8 and 17.0.17 which were released in mid-2025.
+     *
+     * @return true for all Java http clients that are known to be affected, and those where we can't parse the version header
+     */
+    protected static boolean isAffectedByJDK8335181(String userAgent) {
+        if (userAgent == null || !userAgent.startsWith("Java-http-client/")) {
+            return false;
+        }
+
+        String[] splitAgent = userAgent.split("/");
+        if (splitAgent.length != 2) {
+            return true;
+        }
+        String version = splitAgent[1];
+        String[] splitVersion = version.split("\\.");
+        if (splitVersion.length < 3) {
+            return true;
+        }
+        try {
+            int major = Integer.parseInt(splitVersion[0]);
+            if (major >= 25) {
+                return false;
+            }
+            int minor = Integer.parseInt(splitVersion[1]);
+            int patch = Integer.parseInt(splitVersion[2]);
+            if (major == 17 && minor == 0 && patch >= 17) {
+                return false;
+            }
+            if (major == 21 && minor == 0 && patch >= 8) {
+                return false;
+            }
+        } catch (NumberFormatException e) {
+            return true;
+        }
+        return true;
+    }
+
+    @Override
+    public void preShutdown(ShutdownNotification notification) {
+        running = false;
+        notification.done();
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/filters/GracefulShutdownFilterUnitTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/filters/GracefulShutdownFilterUnitTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.vertx.http.runtime.filters;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class GracefulShutdownFilterUnitTest {
+
+    @Test
+    public void testUserAgentForJDK8335181IsAffected() {
+        assertTrue(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/21.0.7"));
+        assertTrue(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/17.0.16"));
+    }
+
+    @Test
+    public void testUserAgentForJDK8335181IsNotAffected() {
+        assertFalse(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/21.0.8"));
+        assertFalse(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/17.0.17"));
+        assertFalse(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/25.0.0"));
+        assertFalse(GracefulShutdownFilter.isAffectedByJDK8335181(""));
+        assertFalse(GracefulShutdownFilter.isAffectedByJDK8335181("Mozilla"));
+        assertFalse(GracefulShutdownFilter.isAffectedByJDK8335181(null));
+    }
+
+    @Test
+    public void testUserAgentForJDK8335181NotSure() {
+        // Assume true if the patch version can't be parsed.f
+        assertTrue(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/21.0.8-something"));
+        // Assume false if the major version indicates it is not a problem.
+        assertFalse(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/25.0.0-something"));
+        // Assume true when it is a Java client, but we can't parse the version that should be separated by dots.
+        assertTrue(GracefulShutdownFilter.isAffectedByJDK8335181("Java-http-client/17-0-17-oops"));
+    }
+
+}


### PR DESCRIPTION
This make the graceful shutdown more graceful by avoiding SERVICE_UNAVAILABLE / 503 errors during the process as much as possible.

* Instead of rejecting requests, it will always answer to them, reducing the number of errors during shutdown
* During pre-shutdown phase, try to close as many connections as possible
* Improved handling of HTTP 1.1 vs. 2

----

- Closes: #50625