### PR TITLE
Use upstream readiness check for Kubernetes

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import io.fabric8.kubernetes.client.readiness.Readiness;
 import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.ContainerState;
@@ -45,9 +44,11 @@ import com.dajudge.kindcontainer.client.config.UserSpec;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
-import io.fabric8.kubernetes.api.model.*;
-import io.fabric8.kubernetes.client.*;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsDevServicesSupportedByLaunchMode;
 import io.quarkus.deployment.annotations.BuildProducer;

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.fabric8.kubernetes.client.readiness.Readiness;
 import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.ContainerState;
@@ -45,9 +46,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.fabric8.kubernetes.api.model.*;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
-import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.*;
 import io.fabric8.kubernetes.client.Config;
 import io.quarkus.deployment.Feature;
@@ -218,7 +216,7 @@ public class DevServicesKubernetesProcessor {
                             resources.forEach(resource -> {
                                 client.resource(resource).create();
 
-                                if (isReadinessApplicable(resource)) {
+                                if (Readiness.getInstance().isReadinessApplicable(resource)) {
                                     resourcesWithReadiness.add(resource);
                                 }
                             });
@@ -240,17 +238,6 @@ public class DevServicesKubernetesProcessor {
         } catch (Exception e) {
             log.error("Failed to create Kubernetes client while trying to apply manifests.", e);
         }
-    }
-
-    private boolean isReadinessApplicable(HasMetadata item) {
-        return (item instanceof Deployment ||
-                item instanceof io.fabric8.kubernetes.api.model.extensions.Deployment ||
-                item instanceof ReplicaSet ||
-                item instanceof Pod ||
-                item instanceof ReplicationController ||
-                item instanceof Endpoints ||
-                item instanceof Node ||
-                item instanceof StatefulSet);
     }
 
     private InputStream getManifestStream(String manifestPath) throws IOException {


### PR DESCRIPTION
This is a follow-up of https://github.com/quarkusio/quarkus/pull/48990#discussion_r2252230985, where we merged a duplicated implementation of an upstream function as the upstream implementation was private. Now that the latest version of the fabric8 client has this method public, we can get rid of the internal Quarkus duplicate implementation.