### PR TITLE
Fix display issues caused by missing source directives for code blocks

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -273,6 +273,8 @@ This identifies code like `if(logger.isDebug()) callMethod();` that will never b
 [WARNING]
 ====
 If you add these properties on the command line, ensure the `"` character is escaped properly:
+
+[source,properties]
 ----
 -Dquarkus.log.category.\"org.hibernate\".level=TRACE
 ----

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -365,6 +365,7 @@ For more information about customizing `SecurityIdentity`, see the xref:security
 
 In the <<mutual-tls>> section we configured the mutual TLS client authentication in the `application.properties` file like this:
 
+[source,properties]
 ----
 quarkus.tls.tls-config-1.key-store.p12.path=server-keystore.p12
 quarkus.tls.tls-config-1.key-store.p12.password=the_key_store_secret

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -1677,6 +1677,7 @@ quarkus.http.auth.proactive=false <1>
 
 If the bearer access token claim `acr` does not contain `myACR`, Quarkus returns an authentication requirements challenge indicating required `acr_values`:
 
+[source,text]
 ----
 HTTP/1.1 401 Unauthorized
 WWW-Authenticate: Bearer error="insufficient_user_authentication",

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1713,6 +1713,7 @@ The OIDC client will also refresh expired access tokens.
 
 To configure which OIDC client should be used by the GraphQL client, select one of the configured OIDC clients with the `quarkus.oidc-client-graphql.client-name` property, for example:
 
+[source,properties]
 ----
 quarkus.oidc-client-graphql.client-name=oidc-client-for-graphql
 


### PR DESCRIPTION
Missing source directives break code block formatting on some downstream documentation platforms. 

For example, the fix in `docs/src/main/asciidoc/logging.adoc` solves the following broken formatting:
<img width="1029" height="249" alt="image" src="https://github.com/user-attachments/assets/7d36b903-e4d6-403d-a8b3-67db8e2288dc" />

The current changes fix all such issues. 
It would be nice if we could backport these to `3.27`.