### PR TITLE
Fix issues displaying code blocks

### DIFF
--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -680,7 +680,7 @@ TLS 1.3 completely removes support for renegotiation, effectively closing this p
 
 * To secure TLS 1.2 and earlier, set `jdk.tls.rejectClientInitiatedRenegotiation` to `true` to prevent client-initiated renegotiation.
 +
-[source]
+[source,bash]
 ----
 # JVM mode:
 java -Djdk.tls.rejectClientInitiatedRenegotiation=true -jar ...
@@ -690,7 +690,7 @@ java -Djdk.tls.rejectClientInitiatedRenegotiation=true -jar ...
 +
 If you are using the Quarkus-provided `Dockerfile` in JVM mode, you can disable renegotiation by adding the property to the `JAVA_OPTS_APPEND` environment variable:
 +
-[source]
+[source,dockerfile]
 ----
 ENV JAVA_OPTS_APPPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Djdk.tls.rejectClientInitiatedRenegotiation=true"
 ----


### PR DESCRIPTION
Adding the language to the source directive fixes issues with code blocks not displaying correctly on some downstream publishing platforms.

<img width="1030" height="294" alt="image" src="https://github.com/user-attachments/assets/615a5c0d-99f9-4fb6-971e-d69eb9f68ca3" />
