### PR TITLE
Manually set `api.version` for TestContainers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsContainerRuntimeWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsContainerRuntimeWorking.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.runtime.ResettableSystemProperties;
 
 public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
     private static final Logger LOGGER = Logger.getLogger(IsContainerRuntimeWorking.class);
@@ -63,7 +64,7 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
             // this runs in threads that start with 'ducttape'
             StartupLogCompressor compressor = new StartupLogCompressor("Checking Docker Environment", Optional.empty(), null,
                     (s) -> s.getName().startsWith("ducttape"));
-            try {
+            try (ResettableSystemProperties ignored = ResettableSystemProperties.of("api.version", "1.44")) {
                 Class<?> dockerClientFactoryClass = Thread.currentThread().getContextClassLoader()
                         .loadClass("org.testcontainers.DockerClientFactory");
                 Object dockerClientFactoryInstance = dockerClientFactoryClass.getMethod("instance").invoke(null);


### PR DESCRIPTION
This is done to overcome:
```
UnixSocketClientProviderStrategy: failed with exception BadRequestException (Status 400: {"message":"client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"}
```

- Fixes: #51002