### PR TITLE
Bump Keycloak version to 26.4.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,8 @@ updates:
       # Quarkus
       - dependency-name: io.quarkus.*:*
       - dependency-name: io.quarkus:*
+      # Keycloak
+      - dependency-name: org.keycloak:*
       # Elytron
       - dependency-name: org.wildfly.security:*
       - dependency-name: org.wildfly.openssl:*

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -97,7 +97,7 @@
         <junit4.version>4.13.2</junit4.version>
 
         <!-- The image to use for tests that run Keycloak -->
-        <keycloak.server.version>26.4.0</keycloak.server.version>
+        <keycloak.server.version>26.4.5</keycloak.server.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.server.version}</keycloak.docker.image>
 
         <unboundid-ldap.version>7.0.3</unboundid-ldap.version>

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -319,7 +319,7 @@ docker run --name keycloak \
   quay.io/keycloak/keycloak:{keycloak.version} \ <1>
   start --hostname-strict=false --https-key-store-file=/etc/keycloak-keystore.jks <2>
 ----
-<1> For `keycloak.version`, ensure the version is `26.4.0` or later.
+<1> For `keycloak.version`, ensure the version is `26.4.5` or later.
 <2> For Keycloak keystore, use the `keycloak-keystore.jks` file located at https://github.com/quarkusio/quarkus-quickstarts/blob/main/security-keycloak-authorization-quickstart/config/keycloak-keystore.jks[quarkus-quickstarts/security-keycloak-authorization-quickstart/config].
 
 .Accessing the Keycloak server

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -217,7 +217,7 @@ For more information, see the <<bearer-token-tutorial-keycloak-dev-mode>> sectio
 docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 ====
-* Where the `keycloak.version` is set to version `26.4.0` or later.
+* Where the `keycloak.version` is set to version `26.4.5` or later.
 . You can access your Keycloak server at http://localhost:8180[localhost:8180].
 . To access the Keycloak Administration console, log in as the `admin` user by using the following login credentials:
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -201,7 +201,7 @@ To start a Keycloak server, use Docker and run the following command:
 docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-where `keycloak.version` is set to `26.4.0` or later.
+where `keycloak.version` is set to `26.4.5` or later.
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].
 

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -505,7 +505,7 @@ To start a Keycloak Server, you can use Docker and just run the following comman
 docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-Set `{keycloak.version}` to `26.4.0` or later.
+Set `{keycloak.version}` to `26.4.5` or later.
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -247,7 +247,7 @@ For more information, see xref:security-oidc-bearer-token-authentication.adoc#be
 [[keycloak-initialization]]
 === Keycloak initialization
 
-The `quay.io/keycloak/keycloak:26.4.0` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+The `quay.io/keycloak/keycloak:26.4.5` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
 `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name.
 For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
 Be aware that a Quarkus-based Keycloak distribution is only available starting from Keycloak `20.0.0`.

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -346,7 +346,7 @@ To start a Keycloak server, you can use Docker and run the following command:
 docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-where `keycloak.version` is set to `26.0.7` or higher.
+where `keycloak.version` is set to `26.4.5` or higher.
 
 Access your Keycloak server at http://localhost:8180[localhost:8180].
 

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -40,7 +40,7 @@ public interface KeycloakDevServicesConfig {
      * ends with `-legacy`.
      * Override with `quarkus.keycloak.devservices.keycloak-x-image`.
      */
-    @WithDefault("quay.io/keycloak/keycloak:26.4.0")
+    @WithDefault("quay.io/keycloak/keycloak:26.4.5")
     String imageName();
 
     /**


### PR DESCRIPTION
Bump Keycloak version to 26.4.5

https://www.keycloak.org/2025/11/keycloak-2645-released

Also enables Dependabot updates to automatically update Keycloak in the future. The PRs might need some manual work sometimes, but would be good to get notified for the updates.

Open question, can we somehow use variables in the documentation to use `${keyloak.server.version}` there directly?