### PR TITLE
Fix flaky recovery lra

### DIFF
--- a/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
+++ b/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
@@ -32,6 +32,8 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.lra.tck.service.spi.LRARecoveryService;
 import org.jboss.logging.Logger;
 
@@ -39,10 +41,25 @@ import io.narayana.lra.LRAConstants;
 
 public class NarayanaLRARecovery implements LRARecoveryService {
     private static final Logger log = Logger.getLogger(NarayanaLRARecovery.class);
+    private static final long WAIT_CALLBACK_TIMEOUT = initWaitForCallbackTimeout();
+    private static final String WAIT_CALLBACK_TIMEOUT_PROPERTY = "lra.tck.callback.timeout";
+    private static final int DEFAULT_CALLBACK_TIMEOUT = 1000;
 
+    /*
+     * Wait for the participant to return the callback. This method does not
+     * guarantee callbacks to finish. The Participant status is not immediately
+     * reflected to the LRA status, but only after a recovery scan which executes an
+     * enlistment. The waiting time can be configurable by
+     * lra.tck.callback.timeout property.
+     */
     @Override
     public void waitForCallbacks(URI lraId) {
-        // no action needed
+        log.trace("waitForCallbacks for: " + lraId.toASCIIString());
+        try {
+            Thread.sleep(WAIT_CALLBACK_TIMEOUT);
+        } catch (InterruptedException e) {
+            log.error("waitForCallbacks interrupted by " + e.getMessage());
+        }
     }
 
     @Override
@@ -82,5 +99,18 @@ public class NarayanaLRARecovery implements LRARecoveryService {
         } finally {
             recoveryCoordinatorClient.close();
         }
+    }
+
+    private static Integer initWaitForCallbackTimeout() {
+        Config config = ConfigProvider.getConfig();
+        if (config != null) {
+            try {
+                return config.getOptionalValue(WAIT_CALLBACK_TIMEOUT_PROPERTY, Integer.class).orElse(DEFAULT_CALLBACK_TIMEOUT);
+            } catch (IllegalArgumentException e) {
+                log.error("property " + WAIT_CALLBACK_TIMEOUT_PROPERTY + " not set correctly, using the default value: "
+                        + DEFAULT_CALLBACK_TIMEOUT);
+            }
+        }
+        return DEFAULT_CALLBACK_TIMEOUT;
     }
 }


### PR DESCRIPTION
Fixes the flaky recovery test in Develocity: https://ge.quarkus.io/scans/tests?search.timeZoneId=Europe%2FPrague&tests.container=org.eclipse.microprofile.lra.tck.TckRecoveryTests&tests.test=testCancelWhenParticipantIsUnavailable

- Fixes: https://github.com/quarkusio/quarkus/issues/51016