### PR TITLE
Set default image name for Keycloak Devservices

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -40,8 +40,7 @@ public interface KeycloakDevServicesConfig {
      * ends with `-legacy`.
      * Override with `quarkus.keycloak.devservices.keycloak-x-image`.
      */
-    @WithDefault("quay.io/keycloak/keycloak:26.4.5")
-    String imageName();
+    Optional<String> imageName();
 
     /**
      * Indicates if a Keycloak-X image is used.

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.devservices.keycloak;
 
+import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesConfigBuildItem.getKeycloakUrl;
@@ -406,7 +407,7 @@ public class KeycloakDevServicesProcessor {
                 capturedDevServicesConfiguration.shared(),
                 LaunchMode.current());
 
-        String imageName = capturedDevServicesConfiguration.imageName();
+        String imageName = capturedDevServicesConfiguration.imageName().orElseGet(() -> getDefaultImageNameFor("keycloak"));
         DockerImageName dockerImageName = DockerImageName.parse(imageName).asCompatibleSubstituteFor(imageName);
 
         final Supplier<RunningDevService> defaultKeycloakContainerSupplier = () -> {

--- a/extensions/devservices/keycloak/src/main/resources/keycloak-devservice.properties
+++ b/extensions/devservices/keycloak/src/main/resources/keycloak-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${keycloak.docker.image}


### PR DESCRIPTION
Use the `io.quarkus.devservices.common.ConfigureUtil` like we do for the datasource devservices to provide a docker image name that's configured in the Maven POM.

Follow up of https://github.com/quarkusio/quarkus/pull/51019#issuecomment-3527829775

Verified on a local build in dev mode:

```
2025-11-13 17:52:32,114 INFO  [org.testcontainers.DockerClientFactory] (build-14) Testcontainers version: 1.21.3
2025-11-13 17:52:32,191 INFO  [org.testcontainers.dockerclient.DockerClientProviderStrategy] (build-14) Loaded org.testcontainers.dockerclient.UnixSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
2025-11-13 17:52:32,316 INFO  [org.testcontainers.dockerclient.DockerClientProviderStrategy] (build-14) Found Docker environment with local Unix socket (unix:///var/run/docker.sock)
2025-11-13 17:52:32,317 INFO  [org.testcontainers.DockerClientFactory] (build-14) Docker host IP address is localhost
2025-11-13 17:52:32,351 INFO  [org.testcontainers.DockerClientFactory] (build-14) Connected to docker: 
  Server Version: 5.3.1
  API Version: 1.41
  Operating System: fedora
  Total Memory: 14840 MB

2025-11-13 17:52:32,362 INFO  [org.testcontainers.images.PullPolicy] (build-14) Image pull policy will be performed by: DefaultPullPolicy()
2025-11-13 17:52:32,364 INFO  [org.testcontainers.utility.ImageNameSubstitutor] (build-14) Image name substitution will be performed by: DefaultImageNameSubstitutor (composite of 'ConfigurationFileImageNameSubstitutor' and 'PrefixingImageNameSubstitutor')
2025-11-13 17:52:32,368 INFO  [org.testcontainers.DockerClientFactory] (build-14) Checking the system...
2025-11-13 17:52:32,369 INFO  [org.testcontainers.DockerClientFactory] (build-14) ✔︎ Docker server version should be at least 1.6.0
2025-11-13 17:52:43,794 INFO  [io.quarkus.devservices.keycloak.KeycloakDevServicesProcessor] (build-16) Dev Services for Keycloak started.
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2025-11-13 17:52:44,380 INFO  [io.quarkus] (Quarkus Main Thread) quarkus-oidc-sso 1.0.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 12.620s. Listening on: http://localhost:8080
2025-11-13 17:52:44,381 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
2025-11-13 17:52:44,381 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, compose, oidc, rest, security, smallrye-context-propagation, smallrye-openapi, swagger-ui, vertx]
```

<img width="1744" height="515" alt="image" src="https://github.com/user-attachments/assets/0e81bf74-8998-4ba2-baa8-4ddc56e80390" />

