### PR TITLE
Support quarkus.kubernetes-client.kubeconfig-file for kubernetes-client extension

### DIFF
--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientBuildConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientBuildConfig.java
@@ -47,6 +47,12 @@ public interface KubernetesClientBuildConfig {
     Optional<String> caCertData();
 
     /**
+     * Path to a kubeconfig file to use for configuring the client. When set, the file will be read and used as the base
+     * configuration.
+     */
+    Optional<String> kubeconfigFile();
+
+    /**
      * Client certificate file
      */
     Optional<String> clientCertFile();


### PR DESCRIPTION
### Summary

Add support for a new configuration property `quarkus.kubernetes-client.kubeconfig-file` that lets users point the kubernetes-client at an existing kubeconfig file on disk.

When provided, the extension reads the kubeconfig and initializes the fabric8 Config via` Config.fromKubeconfig(...)`. If not provided, behavior falls back to existing auto-configuration.
Keeps existing cert/key/ca and other config properties and applies them on top of the parsed kubeconfig.

### Why

Many users have a kubeconfig file with contexts and embedded creds that are hard to split into individual properties. This change simplifies configuration and improves usability.

### What changed

- New config property added to runtime build config (extensions/kubernetes-client/runtime-internal).
- KubernetesClientUtils.createConfig(...) updated to read and parse kubeconfig-file and build the final Config.
- Error handling: reading failure results in a clear RuntimeException with message.

- Closes: #51021

