### PR TITLE
Handle gradle include build null project in dependency collection

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -518,7 +518,10 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
 
     private void initProjectModuleAndBuildPaths(final Project project,
             ResolvedArtifact resolvedArtifact, ApplicationModelBuilder appModel, final ResolvedDependencyBuilder appDep) {
-
+        if (project == null) {
+            System.err.println("Error: could not find project for " + resolvedArtifact.getId().getDisplayName());
+            throw new IllegalStateException("Could not find project for " + resolvedArtifact.getId().getDisplayName());
+        }
         appDep.setWorkspaceModule().setReloadable();
 
         if (appDep.getWorkspaceModule() == null) {


### PR DESCRIPTION
Ensure that `initProjectModuleAndBuildPaths` throws an` IllegalStateException` with a clear message if the provided Gradle Project is null.

This will help in diagnosing issues related to missing projects when resolving project dependencies in Gradle builds, especially in the context of included builds.

Before this change, it simply throws a `NullPointerException` without any information about what went wrong. So, on a missing `includeBuild`, you don't know which project can't be resolved. The only solution to resolve this issue in a large multi-module project was to debug the `quarkus-plugin`.

With this change, it will fail with more information about the missing dependency, for example:
```
Error: could not find project for project-dependency.jar (project :include-build:project-dependency)
```


