### PR TITLE
Make @SpringBootTest annotation work

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -175,6 +175,7 @@
         <quarkus-spring-data-api.version>3.5</quarkus-spring-data-api.version>
         <quarkus-spring-security-api.version>6.4</quarkus-spring-security-api.version>
         <quarkus-spring-boot-api.version>3.4</quarkus-spring-boot-api.version>
+        <quarkus-spring-test-api.version>3.5.Alpha1</quarkus-spring-test-api.version>
         <mockito.version>5.21.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <quarkus-security.version>2.3.2</quarkus-security.version>
@@ -3675,6 +3676,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-spring</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-test-vertx</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -6309,6 +6315,11 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-spring-boot-properties-api</artifactId>
                 <version>${quarkus-spring-boot-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-spring-boot-test-api</artifactId>
+                <version>${quarkus-spring-test-api.version}</version>
             </dependency>
 
             <dependency>

--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -399,3 +399,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-cache.adoc[Quarkus - Extension for Spring Cache]
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -272,3 +272,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-boot-properties.adoc[Quarkus - Extension for Spring Boot properties]
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/docs/src/main/asciidoc/spring-cloud-config-client.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config-client.adoc
@@ -157,6 +157,7 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-cache.adoc[Quarkus - Extension for Spring Cache]
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]
 
 [[spring-cloud-config-client-configuration-reference]]
 == Spring Cloud Config Client Reference

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -621,3 +621,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-data-rest.adoc[Quarkus - Extension for Spring Data REST]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -464,3 +464,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-cache.adoc[Quarkus - Extension for Spring Cache]
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -353,3 +353,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-cache.adoc[Quarkus - Extension for Spring Cache]
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -245,3 +245,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-cache.adoc[Quarkus - Extension for Spring Cache]
 * xref:spring-security.adoc[Quarkus - Extension for Spring Security]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -463,3 +463,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-cache.adoc[Quarkus - Extension for Spring Cache]
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/docs/src/main/asciidoc/spring-test.adoc
+++ b/docs/src/main/asciidoc/spring-test.adoc
@@ -1,0 +1,155 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Testing Spring-style Applications in Quarkus
+include::_attributes.adoc[]
+:categories: compatibility,testing
+:summary: Quarkus supports the @SpringBootTest annotation out of the box, letting Spring developers write tests in a familiar style while running on the Quarkus runtime.
+:topics: spring,testing,compatibility
+:extensions: io.quarkus:quarkus-test-spring
+
+Spring developers migrating to Quarkus can keep using `@SpringBootTest` as they do in Spring Boot — no import change required.
+Under the hood, Quarkus treats `@SpringBootTest` as an alias for xref:getting-started-testing.adoc[`@QuarkusTest`]: it starts the Quarkus runtime and CDI container, not a Spring Application Context.
+
+[IMPORTANT]
+====
+`@SpringBootTest` in Quarkus is cosmetic. It is equivalent to `@QuarkusTest` and starts the Quarkus CDI container (ArC), not a Spring Application Context. Spring classes and annotations are used only for reading metadata.
+====
+
+== Prerequisites
+
+include::{includes}/prerequisites.adoc[]
+
+== Adding the dependency
+
+Add `quarkus-test-spring` to your project as a test-scoped dependency:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-test-spring</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+testImplementation("io.quarkus:quarkus-test-spring")
+----
+
+== Writing a test
+
+Use `@SpringBootTest` as you would in a Spring Boot project — the import stays the same:
+
+[source,java]
+----
+import org.springframework.boot.test.context.SpringBootTest; // <1>
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest // <2>
+public class GreetingServiceTest {
+
+    @Autowired // <3>
+    GreetingService greetingService;
+
+    @Test
+    public void testGreeting() {
+        assertEquals("Hello, Quarkus!", greetingService.greet("Quarkus"));
+    }
+}
+----
+<1> Keep the original Spring Boot import — no change needed.
+<2> Quarkus starts the application and makes CDI beans available for injection.
+<3> Use `@Autowired` if you have `quarkus-spring-di` on the classpath (or standard CDI `@Inject` otherwise).
+
+=== HTTP endpoint testing
+
+For testing REST endpoints, use https://rest-assured.io/[RestAssured] exactly as you would with `@QuarkusTest`:
+
+[source,java]
+----
+import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@SpringBootTest
+public class GreetingControllerTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+            .when().get("/greeting")
+            .then()
+                .statusCode(200)
+                .body(is("Hello, Quarkus!"));
+    }
+}
+----
+
+=== Native executable testing
+
+To run the same tests against the packaged application (JVM or native mode), create a companion class annotated with `@QuarkusIntegrationTest` that extends your test:
+
+[source,java]
+----
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class GreetingControllerIT extends GreetingControllerTest {
+}
+----
+
+== Differences from Spring Boot's `@SpringBootTest`
+
+`@SpringBootTest` in Quarkus is intentionally simpler than in Spring Boot. The table below summarises the main differences:
+
+|===
+|Feature |Spring Boot |Quarkus
+
+|Application context
+|Spring Application Context
+|Quarkus CDI container (ArC)
+
+|Annotation attributes (`webEnvironment`, `classes`, `properties`, `args`)
+|Supported
+|Not supported — configure via xref:config-reference.adoc[Quarkus configuration] and xref:getting-started-testing.adoc#testing_different_profiles[test profiles]
+
+|Dependency injection in tests
+|`@Autowired`
+|`@Autowired` (needs `quarkus-spring-di`)
+
+|Dev Services (databases, messaging, etc.)
+|Testcontainers via Spring Boot autoconfiguration
+|xref:dev-services.adoc[Quarkus Dev Services] — zero configuration required
+
+|MockBean
+|`@MockBean`
+|xref:getting-started-testing.adoc#mock-support[`@InjectMock`] from `quarkus-junit-mockito`
+
+|Test profiles
+|Spring profiles via `@ActiveProfiles`
+|xref:getting-started-testing.adoc#testing_different_profiles[`@TestProfile`]
+|===
+
+== More Spring guides
+
+Quarkus has more Spring compatibility features. See the following guides for more details:
+
+* xref:spring-di.adoc[Quarkus Extension for Spring DI]
+* xref:spring-web.adoc[Quarkus Extension for Spring Web API]
+* xref:spring-data-jpa.adoc[Quarkus Extension for Spring Data JPA]
+* xref:spring-data-rest.adoc[Quarkus Extension for Spring Data REST]
+* xref:spring-security.adoc[Quarkus Extension for Spring Security]
+* xref:spring-boot-properties.adoc[Quarkus Extension for Spring Boot properties]
+* xref:spring-cache.adoc[Quarkus Extension for Spring Cache]
+* xref:spring-scheduled.adoc[Quarkus Extension for Spring Scheduled]
+* xref:spring-cloud-config-client.adoc[Reading properties from Spring Cloud Config Server]

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -577,3 +577,4 @@ Quarkus has more Spring compatibility features. See the following guides for mor
 * xref:spring-cache.adoc[Quarkus - Extension for Spring Cache]
 * xref:spring-scheduled.adoc[Quarkus - Extension for Spring Scheduled]
 * xref:spring-tx.adoc[Quarkus - Extension for Spring Transaction]
+* xref:spring-test.adoc[Testing Spring-style Applications in Quarkus]

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -250,6 +250,7 @@
                 <module>spring-cloud-config-client</module>
                 <module>spring-data-rest</module>
                 <module>spring-tx</module>
+                <module>spring-test</module>
                 <module>infinispan-cache</module>
                 <module>elytron-security</module>
                 <module>elytron-security-oauth2</module>

--- a/integration-tests/spring-test/pom.xml
+++ b/integration-tests/spring-test/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-spring-test</artifactId>
+    <name>Quarkus - Integration Tests - Spring Style Test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-di</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-spring</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-di-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/spring-test/src/main/java/io/quarkus/it/spring/test/GreetingResource.java
+++ b/integration-tests/spring-test/src/main/java/io/quarkus/it/spring/test/GreetingResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.spring.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Path("/greeting")
+public class GreetingResource {
+
+    @Autowired
+    GreetingService greetingService;
+
+    @GET
+    public String greeting(@QueryParam("name") String name) {
+        return greetingService.greet(name);
+    }
+}

--- a/integration-tests/spring-test/src/main/java/io/quarkus/it/spring/test/GreetingService.java
+++ b/integration-tests/spring-test/src/main/java/io/quarkus/it/spring/test/GreetingService.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.spring.test;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class GreetingService {
+
+    public String greet(String name) {
+        return "hello " + name;
+    }
+}

--- a/integration-tests/spring-test/src/test/java/io/quarkus/it/spring/test/SpringBootTestAnnotationIT.java
+++ b/integration-tests/spring-test/src/test/java/io/quarkus/it/spring/test/SpringBootTestAnnotationIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.spring.test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class SpringBootTestAnnotationIT extends SpringBootTestAnnotationTest {
+}

--- a/integration-tests/spring-test/src/test/java/io/quarkus/it/spring/test/SpringBootTestAnnotationTest.java
+++ b/integration-tests/spring-test/src/test/java/io/quarkus/it/spring/test/SpringBootTestAnnotationTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.spring.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class SpringBootTestAnnotationTest {
+
+    @Autowired
+    GreetingService greetingService;
+
+    @Test
+    public void testCdiInjection() {
+        assertNotNull(greetingService);
+        assertEquals("hello quarkus", greetingService.greet("quarkus"));
+    }
+
+    @Test
+    public void testHttpEndpoint() {
+        given()
+                .queryParam("name", "spring")
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("hello spring"));
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResourceManager.java
@@ -17,6 +17,7 @@ import io.quarkus.test.common.ListeningAddress;
 import io.quarkus.value.registry.ValueRegistry;
 import io.quarkus.value.registry.ValueRegistry.RuntimeKey;
 import io.smallrye.config.Config;
+import io.smallrye.config.SmallRyeConfig;
 
 public class TestHTTPResourceManager {
 
@@ -76,13 +77,19 @@ public class TestHTTPResourceManager {
             Config config,
             List<Function<Class<?>, String>> endpointProviders) {
 
-        Map<Class<?>, TestHTTPResourceProvider<?>> providers = getProviders();
+        Map<Class<?>, TestHTTPResourceProvider<?>> providers = null;
         Class<?> c = testCase.getClass();
         while (c != Object.class) {
             TestHTTPEndpoint classEndpointAnnotation = c.getAnnotation(TestHTTPEndpoint.class);
             for (Field f : c.getDeclaredFields()) {
                 TestHTTPResource resource = f.getAnnotation(TestHTTPResource.class);
                 if (resource != null) {
+                    if (config == null) {
+                        config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+                    }
+                    if (providers == null) {
+                        providers = getProviders();
+                    }
                     TestHTTPResourceProvider<?> provider = providers.get(f.getType());
                     if (provider == null) {
                         throw new RuntimeException(

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -43,6 +43,7 @@
         <module>kafka-companion</module>
         <module>google-cloud-functions</module>
         <module>observability</module>
+        <module>spring-test</module>
         <module>aesh</module>
     </modules>
 

--- a/test-framework/spring-test/pom.xml
+++ b/test-framework/spring-test/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-test-spring</artifactId>
+    <name>Quarkus - Test Framework - Spring</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-boot-test-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/spring-test/src/main/java/io/quarkus/test/spring/SpringBootTestBuildChainCustomizerProducer.java
+++ b/test-framework/spring-test/src/main/java/io/quarkus/test/spring/SpringBootTestBuildChainCustomizerProducer.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.spring;
+
+import java.util.function.Consumer;
+
+import org.jboss.jandex.Index;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.deployment.builditem.TestAnnotationBuildItem;
+import io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer;
+
+/**
+ * Registers {@link SpringBootTest} as a Quarkus test annotation so that test classes
+ * annotated with it are treated as CDI beans by the Quarkus build pipeline, exactly as
+ * test classes annotated with {@code @QuarkusTest} are.
+ */
+public class SpringBootTestBuildChainCustomizerProducer implements TestBuildChainCustomizerProducer {
+
+    @Override
+    public Consumer<BuildChainBuilder> produce(Index testClassesIndex) {
+        return buildChainBuilder -> buildChainBuilder
+                .addBuildStep(context -> context.produce(new TestAnnotationBuildItem(SpringBootTest.class.getName())))
+                .produces(TestAnnotationBuildItem.class)
+                .build();
+    }
+}

--- a/test-framework/spring-test/src/main/resources/META-INF/services/io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer
+++ b/test-framework/spring-test/src/main/resources/META-INF/services/io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer
@@ -1,0 +1,1 @@
+io.quarkus.test.spring.SpringBootTestBuildChainCustomizerProducer


### PR DESCRIPTION
Support for Spring Boot-style testing in Quarkus by recognizing @SpringBootTest (from `quarkus-spring-test-api`) as a valid Quarkus test annotation, so that existing Spring Boot test classes work without modification.                                                                                                                                                                                                

- A new `test-framework/spring-test` module that registers `@SpringBootTest` as a Quarkus test annotation via the `TestBuildChainCustomizerProducer` SPI. This makes Quarkus treat test classes annotated with
`@SpringBootTes`t as CDI beans during the build pipeline, as `@QuarkusTest`annotated classes are.
  - A new `integration-tests/spring-test` module with tests that verify the Quarkus `@SpringBootTest`works correctly
  - Documentation in docs/src/main/asciidoc/spring-test.adoc.

Bug fix: lazy initialization in TestHTTPResourceManager
During development, I discovered that, in `TestHTTPResourceManager`, the call to ConfigProvider.getConfig() was made before any check for whether @TestHTTPResource-annotated fields actually exist on the test class. This caused a failure when `@SpringBootTest` tests were run, it seems the Quarkus config system is not yet initialized at the point `TestHTTPResourceManager#inject()` is called for tests that don't use `@TestHTTPResource`, so the call would throw.
The fix makes both `ConfigProvider.getConfig()` and `getProviders()` lazy: they are only invoked the first time a `@TestHTTPResource`annotated field is encountered in the loop.

This needs https://github.com/quarkusio/quarkus-spring-test-api/pull/17 to be merged and released, update then the corresponding version here.

The corresponding quickstart has been also added: https://github.com/quarkusio/quarkus-quickstarts/pull/1625

Fixes https://github.com/quarkusio/quarkus/issues/50151
