### PR TITLE
Stop using the fabric8 docker maven plugin for Oracle databases

### DIFF
--- a/integration-tests/hibernate-reactive-oracle/pom.xml
+++ b/integration-tests/hibernate-reactive-oracle/pom.xml
@@ -13,10 +13,6 @@
     <name>Quarkus - Integration Tests - Hibernate Reactive - Oracle</name>
     <description>Hibernate Reactive related tests running with the Oracle database</description>
 
-    <properties>
-        <reactive-oracle.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracle.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -179,59 +175,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${oracle.image}</name>
-                                    <run>
-                                        <ports>
-                                            <port>1521:1521</port>
-                                        </ports>
-                                        <env>
-                                            <ORACLE_PASSWORD>hibernate_orm_test</ORACLE_PASSWORD>
-                                        </env>
-                                        <log>
-                                            <prefix>Oracle Database: </prefix>
-                                            <date>default</date>
-                                            <color>red</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
-                                            <time>60000</time>
-                                            <!-- leverage the healthcheck in the image we use -->
-                                            <healthy>yes</healthy>
-                                            <!-- In case of any issues with the built-in healthcheck we can revert back to the original log check:-->
-                                            <!--<log>DATABASE IS READY TO USE!</log>-->
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all Oracle DB images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>

--- a/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 quarkus.datasource.db-kind=oracle
-quarkus.datasource.username=SYSTEM
-quarkus.datasource.password=hibernate_orm_test
 
 # Hibernate config
 #quarkus.hibernate-orm.log.sql=true
@@ -8,8 +6,6 @@ quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 # Reactive config
 quarkus.datasource.reactive=true
-quarkus.datasource.reactive.url=${reactive-oracle.url}
-
 
 quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.users.scott=jb0ss

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -13,10 +13,6 @@
     <name>Quarkus - Integration Tests - JPA - Oracle</name>
     <description>Module that contains JPA related tests running with the Oracle database</description>
 
-    <properties>
-        <oracledb.url>jdbc:oracle:thin:@localhost:1521/FREEPDB1</oracledb.url>
-    </properties>
-
     <dependencies>
         <!-- Enables the JPA capabilities -->
         <dependency>
@@ -188,59 +184,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${oracle.image}</name>
-                                    <run>
-                                        <ports>
-                                            <port>1521:1521</port>
-                                        </ports>
-                                        <env>
-                                            <ORACLE_PASSWORD>hibernate_orm_test</ORACLE_PASSWORD>
-                                        </env>
-                                        <log>
-                                            <prefix>Oracle Database: </prefix>
-                                            <date>default</date>
-                                            <color>red</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
-                                            <time>60000</time>
-                                            <!-- leverage the healthcheck in the image we use -->
-                                            <healthy>yes</healthy>
-                                            <!-- In case of any issues with the built-in healthcheck we can revert back to the original log check:-->
-                                            <!--<log>DATABASE IS READY TO USE!</log>-->
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all Oracle DB images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=oracle
-quarkus.datasource.username=SYSTEM
-quarkus.datasource.password=hibernate_orm_test
-quarkus.datasource.jdbc.url=${oracledb.url}
 quarkus.datasource.jdbc.max-size=1
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.datasource.jdbc.additional-jdbc-properties."oracle.jdbc.timezoneAsRegion"=false

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -14,10 +14,6 @@
 
     <name>Quarkus - Integration Tests - Reactive Oracle Client</name>
 
-    <properties>
-        <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -153,59 +149,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${oracle.image}</name>
-                                    <run>
-                                        <ports>
-                                            <port>1521:1521</port>
-                                        </ports>
-                                        <env>
-                                            <ORACLE_PASSWORD>hibernate_orm_test</ORACLE_PASSWORD>
-                                        </env>
-                                        <log>
-                                            <prefix>Oracle Database: </prefix>
-                                            <date>default</date>
-                                            <color>red</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
-                                            <time>60000</time>
-                                            <!-- leverage the healthcheck in the image we use -->
-                                            <healthy>yes</healthy>
-                                            <!-- In case of any issues with the built-in healthcheck we can revert back to the original log check:-->
-                                            <!--<log>DATABASE IS READY TO USE!</log>-->
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all Oracle DB images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>

--- a/integration-tests/reactive-oracle-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-oracle-client/src/main/resources/application.properties
@@ -1,7 +1,4 @@
 quarkus.datasource.db-kind=oracle
-quarkus.datasource.username=SYSTEM
-quarkus.datasource.password=hibernate_orm_test
-quarkus.datasource.reactive.url=${reactive-oracledb.url}
 #Uncomment to connect over SSL/TLS
 #quarkus.datasource.reactive.trust-all=true
 #quarkus.datasource.reactive.mssql.ssl=true


### PR DESCRIPTION
Partial resolution of https://github.com/quarkusio/quarkus/issues/44124.

I left the `opentelemetry-jdbc-instrumentation` project using fabric8, since it has a comment explaining it doesn't want to use dev services to avoid stressing the CI. This has the advantage of ensuring we keep some coverage of the 'external container' case. 

I also left the `extensions/reactive-oracle-client` tests using the fabric8 plugin (but not the `integration-tests/reactive-oracle-client`). This is partly because an extension-level test for a client maybe shouldn't have a dependency on dev services, and partly because the tests themselves do lots of variations of application.properties files that might not work so well with dev services. 

@yrodiere suggested moving non-dev-service tests to use testcontainers directly, but I think starting the container in the pom means it's up for the whole test suite, which has some advantages for slow starters like Oracle. It would also work to use a JUnit `@Suite` and a `@Before` in the suite, but I'm not sure that's less complex than using fabric8, so I just left it (for now).