### PR TITLE
Bump smallrye-open-api.version from 4.2.1 to 4.2.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-config.version>3.14.1</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.2.1</smallrye-open-api.version>
+        <smallrye-open-api.version>4.2.2</smallrye-open-api.version>
         <smallrye-graphql.version>2.16.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.9.3</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.2</smallrye-jwt.version>


### PR DESCRIPTION
Bump smallrye-open-api.version from 4.2.1 to [4.2.2](https://github.com/smallrye/smallrye-open-api/releases/tag/4.2.2)

Fixes #49474