### PR TITLE
Support @Transactional for Hibernate Reactive

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1384,6 +1384,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-reactive-transactions</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-reactive-transactions-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-panache-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -2145,6 +2145,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-reactive-transactions</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-redis-cache</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2109,6 +2109,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-redis-cache-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -767,21 +767,34 @@ For configuration details on setting up multiple persistence units, refer to the
 First of all, most of the methods of a Panache entity must be invoked within the scope of a reactive `Mutiny.Session`.
 In some cases, the session is opened automatically on demand.
 For example, if a Panache entity method is invoked in a Jakarta REST resource method in an application that includes the `quarkus-rest` extension.
-For other cases, there are both a declarative and a programmatic way to ensure the session is opened.
-You can annotate a CDI business method that returns `Uni` with the `@WithSession` annotation.
-The method will be intercepted and the returned `Uni` will be triggered within a scope of a reactive session.
+For other cases, there are two declarative ways and a programmatic way to ensure a session is available:
+
+* The first method is to use a method annotated with `@Transactional`.
+* Alternatively, you can annotate a CDI business method that returns `Uni` with the `@WithSession` annotation.
 If you have multiple persistence units, you can specify which one to use by providing the persistence unit name as the annotation value: `@WithSession("my-persistence-unit")`. If not specified, the default persistence unit is used.
-Alternatively, you can use the `Panache.withSession()` method to achieve the same effect.
+* The programmatic way to achieve the same effect is to use the `Panache.withSession()` method.
 
 NOTE: Note that a Panache entity may not be used from a blocking thread. See also xref:getting-started-reactive.adoc[Getting Started With Reactive] guide that explains the basics of reactive principles in Quarkus.
 
 Also make sure to wrap methods that modify the database or involve multiple queries (e.g. `entity.persist()`) within a transaction.
-You can annotate a CDI business method that returns `Uni` with the `@WithTransaction` annotation.
+
+You can annotate the method with `@jakarta.transaction.Transactional` as you would in Hibernate ORM to specify declarative transaction management.
+
+You can also annotate a CDI business method that returns `Uni` with the `@WithTransaction` annotation.
 The method will be intercepted and the returned `Uni` is triggered within a transaction boundary.
 If you have multiple persistence units, you can specify which one to use by providing the persistence unit name as the annotation value: `@WithTransaction("my-persistence-unit")`. If not specified, the default persistence unit is used.
 Alternatively, you can use the `Panache.withTransaction()` method for the same effect.
 
-IMPORTANT: You cannot use the `@Transactional` annotation with Hibernate Reactive for your transactions: you must use `@WithTransaction`, and your annotated method must return a `Uni` to be non-blocking.
+[NOTE]
+====
+You should not mix `@Transactional` with Panache transaction annotations (`@WithTransaction`, `@WithSession`, `@WithSessionOnDemand`) in the same application. Choose one approach and use it consistently throughout your application. Mixing these annotations in a single reactive pipeline will result in an `UnsupportedOperationException`.
+
+See the xref:hibernate-reactive.adoc[Hibernate Reactive guide] for more details on using `@Transactional` with Hibernate Reactive.
+====
+[WARNING]
+====
+There are some limitations when using different pipelines with `@Transactional`, refer to xref:hibernate-reactive.adoc#transactional-different-pipelines[the limitations section in the Hibernate Reactive guide]
+====
 
 Hibernate Reactive batches changes you make to your entities and sends changes (it is called flush) at the end of the transaction or before a query.
 This is usually a good thing as it is more efficient.

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -183,6 +183,70 @@ Make sure to terminate each statement with a semicolon.
 
 This is useful to have a data set ready for your tests or demos.
 
+=== Using `@Transactional` with Hibernate Reactive
+
+You can use the standard `jakarta.transaction.Transactional` annotation with Hibernate Reactive.
+This provides a more familiar programming model for developers coming from Hibernate ORM.
+
+While defining transaction handling using the annotation, you should inject `Mutiny.Session` or `Mutiny.StatelessSession` using CDI and use them in methods annotated with `@Transactional`.
+
+Here's an example showing how to use `@Transactional` in a REST resource:
+
+[source,java]
+.Example REST resource using @Transactional
+----
+@Path("/fruits")
+public class FruitResource {
+
+    @Inject
+    Mutiny.Session session; <1>
+
+    @GET
+    @Path("/{id}")
+    public Uni<Fruit> getFruit(Long id) {
+        return session.find(Fruit.class, id);
+    }
+
+    @POST
+    @Transactional <2>
+    public Uni<Fruit> createFruit(Fruit fruit) {
+        return session.persist(fruit)
+                .chain(() -> session.find(Fruit.class, fruit.getId()));
+    }
+
+    @PUT
+    @Path("/{id}")
+    @Transactional <3>
+    public Uni<Fruit> updateFruit(Long id, @QueryParam("name") String newName) {
+        return session.find(Fruit.class, id)
+                .map(fruit -> {
+                    fruit.setName(newName);
+                    return fruit;
+                });
+    }
+
+}
+----
+
+<1> Inject the reactive session directly
+<2> Use `@Transactional` for persist operations - creates new entities in the database
+<3> Use `@Transactional` for update operations - modifies existing entities
+
+The `@Transactional` interceptor will:
+
+* Lazily open a Hibernate Reactive session when first accessed
+* Begin a transaction automatically
+* Commit the transaction when the `Uni` completes successfully
+* Roll back the transaction if an exception is thrown or the `Uni` is cancelled
+* Close the session and release the database connection when the reactive chain completes
+
+[IMPORTANT]
+====
+There are some limitations when using `@Transactional` with Hibernate Reactive, in particular not being able to use a specific `TxType`, not being able to use multiple persistence units / datasources, or non-functional `Uni.combine()`/`Uni.joining()`.
+
+See <<hr-limitations>> for more information.
+====
+
 [[hr-configuration-properties]]
 === Hibernate Reactive configuration properties
 
@@ -404,7 +468,7 @@ But while they share the same code, Quarkus does configure some components autom
 for some extension points; this should be transparent and useful but if you're an expert of Hibernate Reactive you might want to
 know what is being done.
 
-Here's a list of things to pay attention when using Hibernate Reactive in Quarkus:
+=== General limitations
 
 * Hibernate Reactive is not configurable via a `persistence.xml` file.
 * This extension only considers the default persistence unit at the moment:
@@ -415,9 +479,39 @@ or xref:hibernate-orm.adoc#schema-approach[schema-based multitenancy] at the mom
 xref:hibernate-orm.adoc#discriminator-approach[Discriminator-based multitenancy], on the other hand, is expected to work correctly.
 See https://github.com/quarkusio/quarkus/issues/15959.
 * Integration with the Envers extension is not supported.
-* Transaction demarcation cannot be done using `jakarta.transaction.Transactional` or `QuarkusTransaction`;
-if you use xref:hibernate-reactive-panache.adoc[Hibernate Reactive with Panache],
-consider xref:hibernate-reactive-panache.adoc#transactions[using `@WithTransaction` or `Panache.withTransaction()`] instead.
+
+=== Transaction management: choosing between `@Transactional` and Panache annotations
+
+With the introduction of the `quarkus-reactive-transactions` extension, you now have two options for managing transactions in Hibernate Reactive applications:
+
+1. Use `jakarta.transaction.Transactional` for declarative transaction management
+2. Use Panache's transaction annotations (`@WithTransaction`, `@WithSession`, `@WithSessionOnDemand`, or the programmatic `Panache.withTransaction()`)
+
+You must choose one approach and use it consistently throughout your application.
+Mixing both transaction management styles in the same reactive pipeline is not supported and will result in an `UnsupportedOperationException`.
+In the future, we'll deprecate the previous annotations provided by Panache and and support only `@Transactional`.
+
+You can inject either `Mutiny.Session` or `Mutiny.StatelessSession`.
+Be careful of injecting both session types in the same bean. Attempting to use both session types within the same transaction will throw an `IllegalStateException`.
+
+[[transactional-different-pipelines]]
+=== Using Declarative Transaction Management in different reactive pipelines
+
+When using declarative transaction management with Vert.x context-based interceptors (`@Transactional`, `@WithTransaction`, `@WithSession`, `@WithSessionOnDemand`) in multiple methods and combining such methods with either `Uni.combine().all().unis()` or `Uni.join().all()` the same transaction might be shared by different reactive pipelines causing unpredictable behavior.
+
+For this reason, **avoid using declarative transactional management with those methods**.
+
+[[transactional-others]]
+=== Other Declarative Transactional Management limitations
+
+Reactive transactions does not use `TransactionManager`, thus they are local only and do not support XA transactions. Every parameter defined on the `TransactionManager` (such as `quarkus.transaction-manager.default-transaction-timeout`) will be ignored. Only a single datasource can participate in a transaction.
+
+Reactive transactions also work exclusively within the reactive pipeline.
+If blocking code is executed (for example on a worker thread) as part of that pipeline, it will not be able to participate in the transaction.
+
+Declarative reactive transactions with `@Transactional` can only be applied to methods returning `Uni`, not `Multi`, `CompletionStage`, or `CompletableFuture`.
+
+Currently, only `Transactional.TxType.REQUIRED` is supported with reactive transactions. Other transaction types (`REQUIRES_NEW`, `MANDATORY`, etc.) will throw an `UnsupportedOperationException`.
 
 == Simplifying Hibernate Reactive with Panache
 

--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-reactive</artifactId>
         </dependency>
         <dependency>

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/ClassNames.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/ClassNames.java
@@ -17,6 +17,9 @@ public final class ClassNames {
         return result;
     }
 
+    public static final DotName MUTINY_SESSION = createConstant("org.hibernate.reactive.mutiny.Mutiny$Session");
+    public static final DotName MUTINY_STATELESS_SESSION = createConstant(
+            "org.hibernate.reactive.mutiny.Mutiny$StatelessSession");
     public static final DotName MUTINY_SESSION_FACTORY = createConstant("org.hibernate.reactive.mutiny.Mutiny$SessionFactory");
     public static final DotName IMPLEMENTOR = createConstant("org.hibernate.reactive.common.spi.Implementor");
 }

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveCdiProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveCdiProcessor.java
@@ -1,10 +1,13 @@
 package io.quarkus.hibernate.reactive.deployment;
 
 import static io.quarkus.hibernate.reactive.deployment.ClassNames.IMPLEMENTOR;
+import static io.quarkus.hibernate.reactive.deployment.ClassNames.MUTINY_SESSION;
 import static io.quarkus.hibernate.reactive.deployment.ClassNames.MUTINY_SESSION_FACTORY;
+import static io.quarkus.hibernate.reactive.deployment.ClassNames.MUTINY_STATELESS_SESSION;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
@@ -13,12 +16,14 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 
+import io.quarkus.arc.ActiveResult;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.hibernate.orm.deployment.ClassNames;
+import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.runtime.JPAConfig;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
@@ -29,9 +34,15 @@ public class HibernateReactiveCdiProcessor {
     private static final List<DotName> MUTINY_SESSION_FACTORY_EXPOSED_TYPES = Arrays.asList(
             MUTINY_SESSION_FACTORY, IMPLEMENTOR);
 
+    private static final List<DotName> MUTINY_SESSION_EXPOSED_TYPES = Arrays.asList(
+            MUTINY_SESSION);
+
+    private static final List<DotName> MUTINY_STATELESS_SESSION_EXPOSED_TYPES = Arrays.asList(
+            MUTINY_STATELESS_SESSION);
+
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    void produceSessionFactoryBean(
+    void registerBeans(
             HibernateReactiveRecorder recorder,
             List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
@@ -46,39 +57,87 @@ public class HibernateReactiveCdiProcessor {
             boolean isReactive = persistenceUnitDescriptor.isReactive();
 
             if (isReactive) {
-                SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
-                        .configure(Mutiny.SessionFactory.class)
-                        // NOTE: this is using ApplicationScope and not Singleton, by design, in order to be mockable
-                        // See https://github.com/quarkusio/quarkus/issues/16437
-                        .scope(ApplicationScoped.class)
-                        .unremovable()
-                        .setRuntimeInit()
-                        // Note persistence units _actually_ get started a bit earlier, each in its own thread. See JPAConfig#startAll.
-                        // This startup() call is only necessary in order to trigger Arc's usage checks (fail startup if bean injected when a PU is inactive).
-                        .startup()
-                        .checkActive(recorder.checkActiveSupplier(persistenceUnitName,
+                PersistenceUnitReference puRef = new PersistenceUnitReference(
+                        persistenceUnitName,
+                        recorder.checkActiveSupplier(
+                                persistenceUnitDescriptor.getPersistenceUnitName(),
                                 persistenceUnitDescriptor.getConfig().getDataSource(),
-                                persistenceUnitDescriptor.getConfig().getEntityClassNames()))
-                        .createWith(recorder.mutinySessionFactory(persistenceUnitName))
-                        .addInjectionPoint(ClassType.create(DotName.createSimple(JPAConfig.class)));
+                                persistenceUnitDescriptor.getConfig().getEntityClassNames()));
 
-                for (DotName exposedType : MUTINY_SESSION_FACTORY_EXPOSED_TYPES) {
-                    configurator.addType(exposedType);
-                }
+                produceSessionFactoryBean(syntheticBeanBuildItemBuildProducer, recorder, puRef);
 
-                configurator.defaultBean();
-
-                if (isDefaultPU) {
-                    configurator.addQualifier(Default.class);
-                } else {
-                    configurator.addQualifier().annotation(ClassNames.QUARKUS_PERSISTENCE_UNIT)
-                            .addValue("value", persistenceUnitName).done();
-                }
-
-                syntheticBeanBuildItemBuildProducer.produce(configurator.done());
+                produceSessionBeans(syntheticBeanBuildItemBuildProducer, recorder, puRef);
             }
 
         }
+    }
+
+    private void produceSessionFactoryBean(
+            BuildProducer<SyntheticBeanBuildItem> producer,
+            HibernateReactiveRecorder recorder,
+            PersistenceUnitReference puRef) {
+
+        producer.produce(createSyntheticBean(puRef,
+                Mutiny.SessionFactory.class, MUTINY_SESSION_FACTORY_EXPOSED_TYPES, true)
+                .createWith(recorder.mutinySessionFactory(puRef.persistenceUnitName))
+                .addInjectionPoint(ClassType.create(DotName.createSimple(JPAConfig.class)))
+                .done());
+    }
+
+    private void produceSessionBeans(
+            BuildProducer<SyntheticBeanBuildItem> producer,
+            HibernateReactiveRecorder recorder,
+            PersistenceUnitReference puRef) {
+
+        // Create Session bean
+        producer.produce(createSyntheticBean(puRef,
+                Mutiny.Session.class, MUTINY_SESSION_EXPOSED_TYPES, false)
+                .createWith(recorder.sessionSupplier(puRef.persistenceUnitName))
+                .done());
+
+        // Create StatelessSession bean
+        producer.produce(createSyntheticBean(puRef,
+                Mutiny.StatelessSession.class, MUTINY_STATELESS_SESSION_EXPOSED_TYPES, false)
+                .createWith(recorder.statelessSessionSupplier(puRef.persistenceUnitName))
+                .done());
+    }
+
+    private static <T> SyntheticBeanBuildItem.ExtendedBeanConfigurator createSyntheticBean(PersistenceUnitReference puRef,
+            Class<T> type, List<DotName> allExposedTypes, boolean defaultBean) {
+        SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
+                .configure(type)
+                // NOTE: this is using ApplicationScope and not Singleton, by design, in order to be mockable
+                // See https://github.com/quarkusio/quarkus/issues/16437
+                .scope(ApplicationScoped.class)
+                .unremovable()
+                .setRuntimeInit()
+                // Note persistence units _actually_ get started a bit earlier, each in its own thread. See JPAConfig#startAll.
+                // This startup() call is only necessary in order to trigger Arc's usage checks (fail startup if bean injected when a PU is inactive).
+                .startup()
+                .checkActive(puRef.checkActiveSupplier);
+
+        for (DotName exposedType : allExposedTypes) {
+            configurator.addType(exposedType);
+        }
+
+        if (defaultBean) {
+            configurator.defaultBean();
+        }
+
+        boolean defaultPuName = PersistenceUnitUtil.isDefaultPersistenceUnit(puRef.persistenceUnitName);
+        if (defaultPuName) {
+            configurator.addQualifier(Default.class);
+        }
+
+        configurator.addQualifier().annotation(DotNames.NAMED).addValue("value", puRef.persistenceUnitName).done();
+        configurator.addQualifier().annotation(PersistenceUnit.class).addValue("value", puRef.persistenceUnitName).done();
+
+        return configurator;
+    }
+
+    private record PersistenceUnitReference(
+            String persistenceUnitName,
+            Supplier<ActiveResult> checkActiveSupplier) {
     }
 
 }

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -27,6 +27,7 @@ import org.hibernate.reactive.provider.impl.ReactiveIntegrator;
 import org.jboss.logging.Logger;
 
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.RecorderBeanInitializedBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
@@ -68,6 +69,7 @@ import io.quarkus.hibernate.orm.runtime.recording.RecordedConfig;
 import io.quarkus.hibernate.reactive.runtime.FastBootHibernateReactivePersistenceProvider;
 import io.quarkus.hibernate.reactive.runtime.HibernateReactivePersistenceUnitProviderHelper;
 import io.quarkus.hibernate.reactive.runtime.HibernateReactiveRecorder;
+import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
 import io.quarkus.reactive.datasource.deployment.ReactiveDataSourceBuildItem;
 import io.quarkus.reactive.datasource.deployment.VertxPoolBuildItem;
 import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveBuildTimeConfig;
@@ -92,6 +94,11 @@ public final class HibernateReactiveProcessor {
         services.produce(new ServiceProviderBuildItem(
                 "io.vertx.core.spi.VertxServiceProvider",
                 "org.hibernate.reactive.context.impl.ContextualDataStorage"));
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem produceDatabaseActionsStrategy() {
+        return AdditionalBeanBuildItem.unremovableOf(HibernateActionsStrategy.class);
     }
 
     @BuildStep

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/ConfigEnabledFalseAndActiveTrueTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/ConfigEnabledFalseAndActiveTrueTest.java
@@ -12,7 +12,7 @@ public class ConfigEnabledFalseAndActiveTrueTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot(jar -> jar.addClass(MyEntity.class))
+            .withApplicationRoot(jar -> jar.addClasses(MyEntity.class))
             .withConfigurationResource("application.properties")
             .overrideConfigKey("quarkus.hibernate-orm.enabled", "false")
             .overrideConfigKey("quarkus.hibernate-orm.active", "true")

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/multiplepersistenceunits/MultiplePersistenceUnitsDefaultDisabledTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/multiplepersistenceunits/MultiplePersistenceUnitsDefaultDisabledTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,6 @@ public class MultiplePersistenceUnitsDefaultDisabledTest extends BaseMultiplePer
     }
 
     @Test
-    @Transactional
     @RunOnVertxContext
     public void createEntityAndRefetch(UniAsserter uniAsserter) {
         assertNotNull(usersEntityManager);

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/multiplepersistenceunits/MultiplePersistenceUnitsTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/multiplepersistenceunits/MultiplePersistenceUnitsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,6 @@ public class MultiplePersistenceUnitsTest extends BaseMultiplePersistenceUnitTes
     Mutiny.SessionFactory inventoryEntityManager;
 
     @Test
-    @Transactional
     @RunOnVertxContext
     public void createEntityAndRefetch(UniAsserter uniAsserter) {
         assertNotNull(defaultEntityManager);

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/DisableJTATransactionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/DisableJTATransactionTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.Transactional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class DisableJTATransactionTest {
+
+    @Inject
+    TransactionManager transactionManager;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-narayana-jta", Version.getVersion())));
+
+    @Test
+    @RunOnVertxContext
+    public void doNotCreateTransactionIfMethodRunsOnVertxContext(UniAsserter asserter) throws SystemException {
+        asserter.assertThat(() -> transactionUniMethod(), h -> {
+            try {
+                assertNull(transactionManager.getTransaction());
+            } catch (SystemException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    Uni<String> transactionUniMethod() {
+        return Uni.createFrom().item("transactionalUniMethod");
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/Hero.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/Hero.java
@@ -1,0 +1,34 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Hero")
+@Table(name = "hero")
+public class Hero {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column
+    public String name;
+
+    public Hero() {
+    }
+
+    public Hero(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveStatelessTransactionsTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveStatelessTransactionsTest.java
@@ -1,0 +1,193 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.quarkus.transaction.annotations.Rollback;
+import io.smallrye.mutiny.Uni;
+
+public class HibernateReactiveStatelessTransactionsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(Hero.class)
+                    .addClasses(TransactionalInterceptorRequired.class)
+                    .addAsResource("initialTransactionData.sql", "import.sql"))
+            .withConfigurationResource("application-reactive-transaction.properties");
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    /**
+     * This test shows how to use hibernate reactive .withStatelessTransaction to set transactional boundaries
+     * Below there's testReactiveAnnotationTransaction which is the same test but with @Transactional
+     *
+     * @param asserter
+     */
+    @Test
+    @RunOnVertxContext
+    public void testReactiveManualTransaction(UniAsserter asserter) {
+        // initialTransactionData.sql
+        Long heroId = 50L;
+
+        // First update, make sure it's committed
+        asserter.assertThat(
+                () -> sessionFactory.withStatelessTransaction(session -> updateHero(session, heroId, "updatedNameCommitted"))
+                        // 2nd endpoint call
+                        .chain(() -> sessionFactory.withStatelessTransaction(session -> session.get(Hero.class, heroId))),
+                h -> assertThat(h.name).isEqualTo("updatedNameCommitted"));
+
+        // Second update, make sure there's a rollback
+        asserter.assertThat(
+                () -> sessionFactory.withStatelessTransaction(session -> {
+                    return updateHero(session, heroId, "this name won't appear")
+                            .onItem().invoke(h -> {
+                                throw new RuntimeException("Failing update");
+                            });
+                }).onFailure().recoverWithNull()
+                        .chain(() -> sessionFactory.withStatelessTransaction(session -> session.get(Hero.class, heroId))),
+                h -> {
+                    assertThat(h.name).isEqualTo("updatedNameCommitted");
+                });
+    }
+
+    @Inject
+    Mutiny.StatelessSession session;
+
+    /*
+     * This is the same test as #testReactiveManualTransaction but instead of manually calling
+     * sessionFactory.withStatelessTransaction
+     * We use the annotation @Transactional
+     */
+    @Test
+    @RunOnVertxContext
+    public void testReactiveAnnotationTransaction(UniAsserter asserter) {
+        // initialTransactionData.sql
+        Long heroId = 50L;
+
+        // First update, make sure it's committed
+        asserter.assertThat(
+                () -> updateWithCommit(heroId, "updatedNameCommitted")
+                        .chain(() -> findHero(heroId)),
+                h -> {
+                    assertThat(h.name).isEqualTo("updatedNameCommitted");
+                });
+
+        // Second update, make sure there's a rollback
+        asserter.assertThat(
+                () -> transactionalUpdateWithRollback(heroId, "this name won't appear")
+                        .onFailure().recoverWithNull()
+                        .chain(() -> findHero(heroId)),
+                h -> {
+                    assertThat(h.name).isEqualTo("updatedNameCommitted");
+                });
+    }
+
+    @Transactional
+    public Uni<Hero> findHero(Long previousHeroId) {
+        return session.get(Hero.class, previousHeroId);
+    }
+
+    @Transactional
+    public Uni<Hero> updateWithCommit(Long previousHeroId, String newName) {
+        return updateHero(session, previousHeroId, newName);
+    }
+
+    @Transactional
+    public Uni<Hero> transactionalUpdateWithRollback(Long previousHeroId, String newName) {
+        return updateHero(session, previousHeroId, newName)
+                .onItem().invoke(h -> {
+                    throw new RuntimeException("Failing update");
+                });
+    }
+
+    public Uni<Hero> updateHero(Mutiny.StatelessSession session, Long id, String newName) {
+        return session.get(Hero.class, id)
+                .map(h -> {
+                    h.setName(newName);
+                    return h;
+                }).onItem().call(h -> session.update(h));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testDontRollbackOnException(UniAsserter asserter) {
+        Long heroId = 50L;
+
+        // First update, make sure it's committed
+        asserter.assertThat(
+                () -> updateWithCommit(heroId, "updatedNameCommitted")
+                        .chain(() -> findHero(heroId)),
+                h -> assertThat(h.name).isEqualTo("updatedNameCommitted"));
+
+        // Update with dontRollbackOn exception - should commit despite exception
+        asserter.assertThat(
+                () -> updateWithDontRollbackException(heroId, "committedDespiteException")
+                        .onFailure().recoverWithNull()
+                        .chain(() -> findHero(heroId)),
+                h -> assertThat(h.name).isEqualTo("committedDespiteException"));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testRollbackFalseAnnotation(UniAsserter asserter) {
+        Long heroId = 50L;
+
+        // First update to set baseline
+        asserter.assertThat(
+                () -> updateWithCommit(heroId, "baselineName")
+                        .chain(() -> findHero(heroId)),
+                h -> assertThat(h.name).isEqualTo("baselineName"));
+
+        // Update with @Rollback(false) exception - should commit despite being RuntimeException
+        asserter.assertThat(
+                () -> updateWithRollbackFalseException(heroId, "committedWithRollbackFalse")
+                        .onFailure().recoverWithNull()
+                        .chain(() -> findHero(heroId)),
+                h -> assertThat(h.name).isEqualTo("committedWithRollbackFalse"));
+    }
+
+    @Transactional(dontRollbackOn = DontRollbackException.class)
+    public Uni<Hero> updateWithDontRollbackException(Long heroId, String newName) {
+        return updateHero(session, heroId, newName)
+                .onItem().invoke(h -> {
+                    throw new DontRollbackException("This should not trigger rollback");
+                });
+    }
+
+    @Transactional
+    public Uni<Hero> updateWithRollbackFalseException(Long heroId, String newName) {
+        return updateHero(session, heroId, newName)
+                .onItem().invoke(h -> {
+                    throw new NoRollbackException("Exception with @Rollback(false)");
+                });
+    }
+
+    static class DontRollbackException extends RuntimeException {
+        public DontRollbackException(String message) {
+            super(message);
+        }
+    }
+
+    static class CheckedExceptionWrapper extends Exception {
+
+    }
+
+    @Rollback(false)
+    static class NoRollbackException extends RuntimeException {
+        public NoRollbackException(String message) {
+            super(message);
+        }
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveTransactionsTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveTransactionsTest.java
@@ -1,0 +1,169 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.sqlclient.Pool;
+
+public class HibernateReactiveTransactionsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(Hero.class)
+                    .addClasses(TransactionalInterceptorRequired.class)
+                    .addAsResource("initialTransactionData.sql", "import.sql"))
+            .withConfigurationResource("application-reactive-transaction.properties");
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Inject
+    Pool pool;
+
+    /**
+     * This test shows how to use hibernate reactive .withTransaction to set transactional boundaries
+     * Below there's testReactiveAnnotationTransaction which is the same test but with @Transactional
+     *
+     * @param asserter
+     */
+    @Test
+    @RunOnVertxContext
+    public void testReactiveManualTransaction(UniAsserter asserter) {
+        // initialTransactionData.sql
+        Long heroId = 50L;
+
+        int originalPoolSize = pool.size();
+
+        // First update, make sure it's committed
+        asserter.assertThat(
+                () -> sessionFactory.withTransaction(session -> updateHero(session, heroId, "updatedNameCommitted"))
+                        // 2nd endpoint call
+                        .chain(() -> sessionFactory.withTransaction(session -> session.find(Hero.class, heroId))),
+                h -> assertThat(h.name).isEqualTo("updatedNameCommitted"));
+
+        // Second update, make sure there's a rollback
+        asserter.assertThat(
+                () -> sessionFactory.withTransaction(session -> {
+                    return updateHero(session, heroId, "this name won't appear")
+                            .onItem().invoke(h -> {
+                                throw new RuntimeException("Failing update");
+                            });
+                }).onFailure().recoverWithNull()
+                        .chain(() -> sessionFactory.withTransaction(session -> session.find(Hero.class, heroId))),
+                h -> {
+                    assertThat(h.name).isEqualTo("updatedNameCommitted");
+                });
+
+        // Verify pool size is back to initial (connection returned)
+        asserter.execute(() -> {
+            int nowSize = pool.size();
+            assertThat(originalPoolSize).isEqualTo(nowSize);
+        });
+
+    }
+
+    @Inject
+    Mutiny.Session session;
+
+    /*
+     * This is the same test as #testReactiveManualTransaction but instead of manually calling sessionFactory.withTransaction
+     * We use the annotation @Transactional
+     */
+    @Test
+    @RunOnVertxContext
+    public void testReactiveAnnotationTransaction(UniAsserter asserter) {
+        // initialTransactionData.sql
+        Long heroId = 50L;
+
+        int originalPoolSize = pool.size();
+
+        // First update, make sure it's committed
+        asserter.assertThat(
+                () -> updateWithCommit(heroId, "updatedNameCommitted")
+                        .chain(() -> findHeroWithNewSession(heroId)), // Use another PU as in the other one we threw an exception
+                h -> {
+                    assertThat(h.name).isEqualTo("updatedNameCommitted");
+                });
+
+        // Second update, make sure there's a rollback
+        asserter.assertThat(
+                () -> transactionalUpdateWithRollback(heroId, "this name won't appear")
+                        .onFailure().recoverWithNull()
+                        .chain(() -> findHero(heroId)),
+                h -> {
+                    assertThat(h.name).isEqualTo("updatedNameCommitted");
+                });
+
+        // Verify pool size is back to initial (connection returned)
+        // Actually with quarkus.datasource.reactive.max-size=1 specified in application-reactive-transaction.properties
+        // if we don't close the connections the test will hang while acquiring the new connection after the first update
+        // Better test it anyway
+        asserter.execute(() -> {
+            int nowSize = pool.size();
+            assertThat(originalPoolSize).isEqualTo(nowSize);
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testReactiveAnnotationTransactionWithTwoMethods(UniAsserter asserter) {
+        // initialTransactionData.sql
+        Long heroId = 50L;
+
+        asserter.assertThat(
+                () -> updateCallingAnotherTransactionalMethod(heroId, "updatedNameTwiceCommitted")
+                        .chain(() -> findHero(heroId)),
+                h -> {
+                    assertThat(h.name).isEqualTo("updatedNameTwiceCommitted");
+                });
+
+    }
+
+    @Transactional
+    public Uni<Hero> findHero(Long heroId) {
+        return session.find(Hero.class, heroId);
+    }
+
+    public Uni<Hero> findHeroWithNewSession(Long heroId) {
+        return sessionFactory.withSession(s -> s.find(Hero.class, heroId));
+    }
+
+    @Transactional
+    public Uni<Hero> updateWithCommit(Long heroId, String newName) {
+        return updateHero(session, heroId, newName);
+    }
+
+    @Transactional
+    public Uni<Hero> updateCallingAnotherTransactionalMethod(Long heroId, String newName) {
+        return updateHero(session, heroId, newName + "thisShouldntAppear")
+                .chain(h -> updateWithCommit(heroId, newName));
+    }
+
+    @Transactional
+    public Uni<Hero> transactionalUpdateWithRollback(Long heroId, String newName) {
+        return updateHero(session, heroId, newName)
+                .onItem().invoke(h -> {
+                    throw new RuntimeException("Failing update");
+                });
+    }
+
+    public Uni<Hero> updateHero(Mutiny.Session session, Long id, String newName) {
+        return session.find(Hero.class, id)
+                .map(h -> {
+                    h.setName(newName);
+                    return h;
+                });
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/InterleaveTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/InterleaveTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
+import static io.quarkus.hibernate.reactive.runtime.HibernateReactiveRecorder.OPENED_SESSIONS_STATE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.runtime.OpenedSessionsState;
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+
+/**
+ * Test to demonstrate transaction context leakage when combining declarative transactional methods
+ * with non-transactional methods in parallel reactive chains.
+ *
+ * The test shows the symptom of the problem, but not from the user perspective: the user will have problems
+ * using different pipelines as described in "Using Declarative Transaction Management in different reactive pipelines"
+ * in the Hibernate Reactive documentation.
+ * The transaction will be shared between the pipelines and this will lead to unpredictable behavior.
+ *
+ * This test is disabled because it's not fixed yet. The transaction context leaks between method calls
+ * when they are combined in parallel using Uni.combine().all().unis(). This is a known limitation of
+ * declarative transaction management using Vert.x context-based interceptors:
+ * - @Transactional (jakarta.transaction.Transactional / io.quarkus.reactive.transaction.Transactional)
+ * - Panache @WithTransaction / @WithSession / @WithSessionOnDemand
+ *
+ * Workaround: Use programmatic transaction management (sessionFactory.withTransaction() or
+ * Panache.withTransaction()) which doesn't have this problem because you explicitly control where
+ * the transaction is created.
+ *
+ * See documentation in hibernate-reactive.adoc for details on this limitation and workarounds.
+ *
+ * See also <a href="https://github.com/quarkusio/quarkus/issues/52815">the issue on the Quarkus Issue tracker</a>
+ */
+@Disabled("Known issue: Transaction context leaks with declarative transaction management in parallel chains - not fixed yet")
+public class InterleaveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(Hero.class)
+                    .addClasses(TransactionalInterceptorRequired.class)
+                    .addAsResource("initialTransactionData.sql", "import.sql"))
+            .withConfigurationResource("application-reactive-transaction.properties");
+
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    @RunOnVertxContext
+    public void testTransactionLeakageBetweenMethods(UniAsserter asserter) {
+        // This test demonstrates that when combining @Transactional and non-transactional methods
+        // in parallel, the transaction context leaks to the non-transactional method.
+        // The assertion in nonTransactionalMethod() will fail because it expects no session,
+        // but the session from findHero() will leak.
+        asserter.execute(() -> Uni.combine().all().unis(findHero(50L), simulateInterleavedTransactionalMethod()));
+    }
+
+    @Transactional
+    public Uni<Hero> findHero(Long heroId) {
+
+        Uni<Hero> heroUni = session.find(Hero.class, heroId).invoke(s -> {
+            Optional<OpenedSessionsState.SessionWithKey<Mutiny.Session>> openedSessionsState = OPENED_SESSIONS_STATE
+                    .getOpenedSession(Vertx.currentContext(), DEFAULT_PERSISTENCE_UNIT_NAME);
+
+            System.out.println(openedSessionsState.get());
+
+        });
+        return heroUni.chain(s -> Uni.createFrom().nothing());
+    }
+
+    public Uni<Void> simulateInterleavedTransactionalMethod() {
+
+        Optional<OpenedSessionsState.SessionWithKey<Mutiny.Session>> openedSessionsState = OPENED_SESSIONS_STATE
+                .getOpenedSession(Vertx.currentContext(), DEFAULT_PERSISTENCE_UNIT_NAME);
+
+        // This will fail as the transaction will leak here.
+        // This method shouldn't be able to access the transaction
+        assertThat(openedSessionsState).isEmpty();
+
+        return Uni.createFrom().nullItem();
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/SupportOnlyRequiredTransactionTypeTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/SupportOnlyRequiredTransactionTypeTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.transaction.TransactionalInterceptorMandatory;
+import io.quarkus.reactive.transaction.TransactionalInterceptorNever;
+import io.quarkus.reactive.transaction.TransactionalInterceptorNotSupported;
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequiresNew;
+import io.quarkus.reactive.transaction.TransactionalInterceptorSupports;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.smallrye.mutiny.Uni;
+
+public class SupportOnlyRequiredTransactionTypeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addDefaultPackage()
+                    .addClasses(
+                            TransactionalInterceptorNever.class,
+                            TransactionalInterceptorSupports.class,
+                            TransactionalInterceptorRequiresNew.class,
+                            TransactionalInterceptorMandatory.class,
+                            TransactionalInterceptorNotSupported.class)
+
+            );
+
+    private static final String ERROR_MESSAGE = "@Transactional on Reactive methods supports only Transactional.TxType.REQUIRED";
+
+    @Test
+    @RunOnVertxContext
+    public void testMandatory() {
+        assertThatThrownBy(() -> mandatory())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(ERROR_MESSAGE);
+    }
+
+    @Transactional(Transactional.TxType.MANDATORY)
+    public Uni<?> mandatory() {
+        return Uni.createFrom().item("mandatory");
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testNever() {
+        assertThatThrownBy(() -> never())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(ERROR_MESSAGE);
+    }
+
+    @Transactional(Transactional.TxType.NEVER)
+    public Uni<?> never() {
+        return Uni.createFrom().item("never");
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testNotSupported() {
+        assertThatThrownBy(() -> notSupported())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(ERROR_MESSAGE);
+    }
+
+    @Transactional(Transactional.TxType.NOT_SUPPORTED)
+    @RunOnVertxContext
+    public Uni<?> notSupported() {
+        return Uni.createFrom().item("not_supported");
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testRequiresNew() {
+        assertThatThrownBy(() -> requiresNew())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(ERROR_MESSAGE);
+    }
+
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public Uni<?> requiresNew() {
+        return Uni.createFrom().item("requiresNew");
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testSupports() {
+        assertThatThrownBy(() -> supports())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(ERROR_MESSAGE);
+    }
+
+    @Transactional(Transactional.TxType.SUPPORTS)
+    public Uni<String> supports() {
+        return Uni.createFrom().item("supports");
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/mixing/MixStatelessStatefulSessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/mixing/MixStatelessStatefulSessionTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.hibernate.reactive.transaction.mixing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.transaction.Hero;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class MixStatelessStatefulSessionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(Hero.class))
+            .withConfigurationResource("application.properties");
+
+    @Inject
+    Mutiny.Session session;
+
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
+    @Test
+    @RunOnVertxContext
+    public void testStatelessSessionThenRegularSessionInTransactional(UniAsserter asserter) {
+        asserter.assertFailedWith(
+                () -> transactionalMethodUsingStatelessSessionThenRegularSession(),
+                e -> assertThat(e)
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("stateless session for the same Persistence Unit is already opened")
+                        .hasMessageContaining(
+                                "Mixing different kinds of sessions in the same transaction is not supported yet"));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testRegularSessionThenStatelessSessionInTransactional(UniAsserter asserter) {
+        asserter.assertFailedWith(
+                () -> transactionalMethodUsingRegularSessionThenStatelessSession(),
+                e -> assertThat(e)
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("session for the same Persistence Unit is already opened")
+                        .hasMessageContaining(
+                                "Mixing different kinds of sessions in the same transaction is not supported yet"));
+    }
+
+    @Transactional
+    public Uni<Object> transactionalMethodUsingRegularSessionThenStatelessSession() {
+        return session.createQuery("select count(1) from Hero h", Long.class).getSingleResult()
+                .chain(count -> statelessSession.createQuery("select count(1) from Hero h", Long.class)
+                        .getSingleResult());
+    }
+
+    @Transactional
+    public Uni<Object> transactionalMethodUsingStatelessSessionThenRegularSession() {
+        return statelessSession.createQuery("select count(1) from Hero h", Long.class).getSingleResult()
+                .chain(count -> session.createQuery("select count(1) from Hero h", Long.class)
+                        .getSingleResult());
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-reactive-transaction.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-reactive-transaction.properties
@@ -1,0 +1,11 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.reactive=true
+quarkus.datasource.reactive.max-size=1
+
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+
+quarkus.log.min-level=TRACE
+quarkus.log.category."io.quarkus.reactive.transaction".level=TRACE
+quarkus.log.category."io.quarkus.hibernate.reactive.runtime".level=TRACE
+quarkus.log.console.level=TRACE

--- a/extensions/hibernate-reactive/deployment/src/test/resources/initialTransactionData.sql
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/initialTransactionData.sql
@@ -1,0 +1,1 @@
+insert into Hero (id, name) values (50, 'initialName');

--- a/extensions/hibernate-reactive/runtime/pom.xml
+++ b/extensions/hibernate-reactive/runtime/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>nativeimage</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
@@ -1,5 +1,8 @@
 package io.quarkus.hibernate.reactive.runtime;
 
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.PERSISTENCE_UNIT_NAME_KEY;
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -10,6 +13,8 @@ import java.util.function.Supplier;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.delegation.MutinySessionDelegator;
+import org.hibernate.reactive.mutiny.delegation.MutinyStatelessSessionDelegator;
 
 import io.quarkus.arc.ActiveResult;
 import io.quarkus.arc.SyntheticCreationalContext;
@@ -20,6 +25,8 @@ import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationRunti
 import io.quarkus.reactive.datasource.runtime.ReactiveDataSourceUtil;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 
 @Recorder
 public class HibernateReactiveRecorder {
@@ -27,6 +34,16 @@ public class HibernateReactiveRecorder {
 
     public HibernateReactiveRecorder(final RuntimeValue<HibernateOrmRuntimeConfig> runtimeConfig) {
         this.runtimeConfig = runtimeConfig;
+    }
+
+    public static final OpenedSessionsState<Mutiny.Session> OPENED_SESSIONS_STATE = new OpenedSessionsStateStatefulImpl();
+    public static final OpenedSessionsState<Mutiny.StatelessSession> OPENED_SESSIONS_STATE_STATELESS = new OpenedSessionsStateStatelessImpl();
+
+    private static String noSessionFoundErrorMessage() {
+        return "No current Mutiny.Session found"
+                + "\n\t- you need to annotate your method with @Transactional to open a reactive session"
+                + "\n\t- alternatively, you can use @WithSessionOnDemand, @WithSession, or @WithTransaction"
+                + "\n\t- for JAX-RS resources, annotate the method directly with an HTTP method (@GET, @POST, etc.) to automatically open a session";
     }
 
     /**
@@ -88,6 +105,96 @@ public class HibernateReactiveRecorder {
                 return sessionFactory.unwrap(Mutiny.SessionFactory.class);
             }
         };
+    }
+
+    public Function<SyntheticCreationalContext<Mutiny.Session>, Mutiny.Session> sessionSupplier(String persistenceUnitName) {
+        return new Function<SyntheticCreationalContext<Mutiny.Session>, Mutiny.Session>() {
+
+            @Override
+            public Mutiny.Session apply(SyntheticCreationalContext<Mutiny.Session> context) {
+                return new MutinySessionDelegator() {
+                    @Override
+                    public Mutiny.Session delegate() {
+                        return getSession(persistenceUnitName);
+                    }
+                };
+            }
+        };
+    }
+
+    public static Mutiny.Session getSession(String persistenceUnitName) {
+        Context context = Vertx.currentContext();
+
+        Optional<OpenedSessionsState.SessionWithKey<Mutiny.Session>> openedSession = OPENED_SESSIONS_STATE.getOpenedSession(
+                context,
+                persistenceUnitName);
+        // reuse the existing reactive session
+        if (openedSession.isPresent()) {
+            return openedSession.get().session();
+        } else if (context.getLocal(TRANSACTIONAL_METHOD_KEY) == null) {
+            throw new IllegalStateException(noSessionFoundErrorMessage());
+        } else {
+
+            Optional<OpenedSessionsState.SessionWithKey<Mutiny.StatelessSession>> openedStatelessSession = OPENED_SESSIONS_STATE_STATELESS
+                    .getOpenedSession(
+                            context,
+                            persistenceUnitName);
+
+            if (openedStatelessSession.isPresent()) {
+                throw new IllegalStateException("A stateless session for the same Persistence Unit is already opened."
+                        + "\n\t- Mixing different kinds of sessions in the same transaction is not supported yet.");
+            }
+
+            // Store the persistence unit name so that we can close only this session at the end of the interceptor
+            context.putLocal(PERSISTENCE_UNIT_NAME_KEY, persistenceUnitName);
+
+            return OPENED_SESSIONS_STATE.createNewSession(persistenceUnitName, context);
+        }
+    }
+
+    public Function<SyntheticCreationalContext<Mutiny.StatelessSession>, Mutiny.StatelessSession> statelessSessionSupplier(
+            String persistenceUnitName) {
+        return new Function<SyntheticCreationalContext<Mutiny.StatelessSession>, Mutiny.StatelessSession>() {
+
+            @Override
+            public Mutiny.StatelessSession apply(SyntheticCreationalContext<Mutiny.StatelessSession> context) {
+                return new MutinyStatelessSessionDelegator() {
+                    @Override
+                    public Mutiny.StatelessSession delegate() {
+                        return getStatelessSession(persistenceUnitName);
+                    }
+                };
+            }
+        };
+    }
+
+    public static Mutiny.StatelessSession getStatelessSession(String persistenceUnitName) {
+        Context context = Vertx.currentContext();
+
+        Optional<OpenedSessionsState.SessionWithKey<Mutiny.StatelessSession>> openedSession = OPENED_SESSIONS_STATE_STATELESS
+                .getOpenedSession(context, persistenceUnitName);
+        // reuse the existing reactive session
+        if (openedSession.isPresent()) {
+            return openedSession.get().session();
+        } else if (context.getLocal(TRANSACTIONAL_METHOD_KEY) == null) {
+            throw new IllegalStateException(noSessionFoundErrorMessage());
+        } else {
+
+            Optional<OpenedSessionsState.SessionWithKey<Mutiny.Session>> openedRegularSession = OPENED_SESSIONS_STATE
+                    .getOpenedSession(
+                            context,
+                            persistenceUnitName);
+
+            if (openedRegularSession.isPresent()) {
+                throw new IllegalStateException("A (non-stateless) session for the same Persistence Unit is already opened."
+                        + "\n\t- Mixing different kinds of sessions in the same transaction is not supported yet.");
+            }
+
+            // Store the persistence unit name so that we can close only this session at the end of the interceptor
+            context.putLocal(PERSISTENCE_UNIT_NAME_KEY, persistenceUnitName);
+
+            return OPENED_SESSIONS_STATE_STATELESS.createNewSession(persistenceUnitName, context);
+        }
     }
 
 }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/OpenedSessionsState.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/OpenedSessionsState.java
@@ -1,0 +1,127 @@
+package io.quarkus.hibernate.reactive.runtime;
+
+import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.hibernate.reactive.common.spi.Implementor;
+import org.hibernate.reactive.context.Context.Key;
+import org.hibernate.reactive.context.impl.BaseKey;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.arc.impl.ComputingCache;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+
+public abstract class OpenedSessionsState<T extends Mutiny.Closeable> {
+    // This key is used to keep track of the Set<String> sessions created on demand
+    private final String sessionOnDemandKey;
+
+    private static final Logger LOG = Logger.getLogger(OpenedSessionsState.class);
+
+    protected abstract T newSessionMethod(Mutiny.SessionFactory sessionFactory);
+
+    protected abstract Class<T> getSessionType();
+
+    protected abstract boolean isSessionOpen(T session);
+
+    protected abstract Uni<Void> flushSession(T session);
+
+    private final ComputingCache<String, Key<T>> sessionKeys = new ComputingCache<>(
+            k -> createKeyForSessionType(k));
+
+    private final ComputingCache<String, Mutiny.SessionFactory> sessionFactories = new ComputingCache<>(
+            k -> createSessionFactory(k));
+
+    protected OpenedSessionsState() {
+        sessionOnDemandKey = "hibernate.reactive.openedSessionState." + getSessionType().getName();
+    }
+
+    public record SessionWithKey<T>(org.hibernate.reactive.context.Context.Key<T> key, T session) {
+    }
+
+    public Optional<SessionWithKey<T>> getOpenedSession(Context context, String persistenceUnitName) {
+        Key<T> sessionKey = sessionKeys.getValue(persistenceUnitName);
+        return getOpenedSession(context, sessionKey);
+    }
+
+    private Optional<SessionWithKey<T>> getOpenedSession(Context context, Key<T> sessionKey) {
+        T current = context.getLocal(sessionKey);
+        return Optional.ofNullable(current)
+                .filter(s -> isSessionOpen(s))
+                .map(s -> new SessionWithKey<>(sessionKey, s));
+    }
+
+    public Uni<Void> flushSession(Context context, String persistenceUnitName) {
+        return getOpenedSession(context, persistenceUnitName)
+                .map(session -> flushSession(session.session()))
+                .orElse(Uni.createFrom().voidItem());
+    }
+
+    public Uni<Void> closeSession(Context context, String persistenceUnitName) {
+        return getOpenedSession(context, persistenceUnitName)
+                .map(session -> closeAndRemoveSession(context, session))
+                .orElse(Uni.createFrom().voidItem());
+    }
+
+    public T createNewSession(String persistenceUnitName, Context context) {
+        Mutiny.SessionFactory sessionFactory = sessionFactories.getValue(persistenceUnitName);
+        T session = newSessionMethod(sessionFactory);
+        Key<T> sessionKey = sessionKeys.getValue(persistenceUnitName);
+
+        storeSession(context, persistenceUnitName, sessionKey, session);
+        return session;
+    }
+
+    private void storeSession(Context context, String persistenceUnitName, Key<T> sessionKey, T session) {
+        Set<String> openedSession = openedSessionContextSet(context);
+        // open a new reactive session and store it in the vertx duplicated context
+        // the context was marked as "lazy" which means that the session will be eventually closed
+        openedSession.add(persistenceUnitName);
+        context.putLocal(sessionKey, session);
+    }
+
+    private Set<String> openedSessionContextSet(Context context) {
+        // This will keep track of all on-demand opened sessions
+        Set<String> onDemandSessionsCreated = context.getLocal(sessionOnDemandKey);
+        if (onDemandSessionsCreated == null) {
+            onDemandSessionsCreated = new HashSet<>();
+            context.putLocal(sessionOnDemandKey, onDemandSessionsCreated);
+        }
+        return onDemandSessionsCreated;
+    }
+
+    private Uni<Void> closeAndRemoveSession(Context context, SessionWithKey<T> openSession) {
+        return openSession.session.close()
+                .eventually(() -> context.removeLocal(openSession.key));
+    }
+
+    private Key<T> createKeyForSessionType(String persistenceUnitName) {
+        Mutiny.SessionFactory value = createSessionFactory(persistenceUnitName);
+        Implementor implementor = (Implementor) ClientProxy.unwrap(value);
+        return new BaseKey<>(getSessionType(), implementor.getUuid());
+    }
+
+    private static Mutiny.SessionFactory createSessionFactory(String persistenceunitname) {
+        Mutiny.SessionFactory sessionFactory;
+
+        // Note that Mutiny.SessionFactory is @ApplicationScoped bean - it's safe to use the cached client proxy
+        if (DEFAULT_PERSISTENCE_UNIT_NAME.equals(persistenceunitname)) {
+            sessionFactory = Arc.container().instance(Mutiny.SessionFactory.class).get();
+        } else {
+            sessionFactory = Arc.container().instance(Mutiny.SessionFactory.class,
+                    new PersistenceUnit.PersistenceUnitLiteral(persistenceunitname)).get();
+        }
+
+        if (sessionFactory == null) {
+            throw new IllegalStateException("Mutiny.SessionFactory bean not found");
+        }
+        return sessionFactory;
+    }
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/OpenedSessionsStateStatefulImpl.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/OpenedSessionsStateStatefulImpl.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.reactive.runtime;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.smallrye.mutiny.Uni;
+
+public class OpenedSessionsStateStatefulImpl extends OpenedSessionsState<Mutiny.Session> {
+
+    @Override
+    protected Mutiny.Session newSessionMethod(Mutiny.SessionFactory sessionFactory) {
+        return sessionFactory.createSession();
+    }
+
+    @Override
+    protected Class<Mutiny.Session> getSessionType() {
+        return Mutiny.Session.class;
+    }
+
+    @Override
+    protected boolean isSessionOpen(Mutiny.Session session) {
+        return session.isOpen();
+    }
+
+    @Override
+    protected Uni<Void> flushSession(Mutiny.Session session) {
+        return session.flush();
+    }
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/OpenedSessionsStateStatelessImpl.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/OpenedSessionsStateStatelessImpl.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.reactive.runtime;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.smallrye.mutiny.Uni;
+
+public class OpenedSessionsStateStatelessImpl extends OpenedSessionsState<Mutiny.StatelessSession> {
+    @Override
+    protected Mutiny.StatelessSession newSessionMethod(Mutiny.SessionFactory sessionFactory) {
+        return sessionFactory.createStatelessSession();
+    }
+
+    @Override
+    protected Class<Mutiny.StatelessSession> getSessionType() {
+        return Mutiny.StatelessSession.class;
+    }
+
+    @Override
+    protected boolean isSessionOpen(Mutiny.StatelessSession session) {
+        return session.isOpen();
+    }
+
+    @Override
+    protected Uni<Void> flushSession(Mutiny.StatelessSession session) {
+        return Uni.createFrom().voidItem();
+    }
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/QuarkusReactiveConnectionPoolInitiator.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/QuarkusReactiveConnectionPoolInitiator.java
@@ -31,7 +31,7 @@ public final class QuarkusReactiveConnectionPoolInitiator
             // nothing to do, but given the separate hierarchies have to handle this here.
             return null;
         }
-        return new QuarkusSqlClientPool(pool);
+        return new QuarkusSqlClientPool(new TransactionalContextPool(pool));
     }
 
 }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/TransactionalContextConnection.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/TransactionalContextConnection.java
@@ -1,0 +1,117 @@
+package io.quarkus.hibernate.reactive.runtime.customized;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.PrepareOptions;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.PreparedStatement;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
+import io.vertx.sqlclient.spi.DatabaseMetadata;
+
+/**
+ * This is a delegate for a simple SqlConnection that avoids closing the connection before
+ * the transaction is committed. See Future<Void> close()
+ **/
+public class TransactionalContextConnection implements SqlConnection {
+
+    private static final Logger LOG = Logger.getLogger(TransactionalContextConnection.class);
+
+    private final SqlConnection connection;
+
+    public TransactionalContextConnection(SqlConnection connection) {
+        this.connection = connection;
+    }
+
+    @Fluent
+    @Override
+    public SqlConnection prepare(String sql, Handler<AsyncResult<PreparedStatement>> handler) {
+        return connection.prepare(sql, handler);
+    }
+
+    @Override
+    public Future<PreparedStatement> prepare(String sql) {
+        return connection.prepare(sql);
+    }
+
+    @Fluent
+    @Override
+    public SqlConnection prepare(String sql, PrepareOptions options, Handler<AsyncResult<PreparedStatement>> handler) {
+        return connection.prepare(sql, options, handler);
+    }
+
+    @Override
+    public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
+        return connection.prepare(sql, options);
+    }
+
+    @Fluent
+    @Override
+    public SqlConnection exceptionHandler(Handler<Throwable> handler) {
+        return connection.exceptionHandler(handler);
+    }
+
+    @Fluent
+    @Override
+    public SqlConnection closeHandler(Handler<Void> handler) {
+        return connection.closeHandler(handler);
+    }
+
+    @Override
+    public void begin(Handler<AsyncResult<Transaction>> handler) {
+        connection.begin(handler);
+    }
+
+    @Override
+    public Future<Transaction> begin() {
+        return connection.begin();
+    }
+
+    @Override
+    public Transaction transaction() {
+        return connection.transaction();
+    }
+
+    @Override
+    public boolean isSSL() {
+        return connection.isSSL();
+    }
+
+    @Override
+    public void close(Handler<AsyncResult<Void>> handler) {
+        connection.close(handler);
+    }
+
+    @Override
+    public DatabaseMetadata databaseMetadata() {
+        return connection.databaseMetadata();
+    }
+
+    @Override
+    public Query<RowSet<Row>> query(String sql) {
+        return connection.query(sql);
+    }
+
+    @Override
+    public PreparedQuery<RowSet<Row>> preparedQuery(String sql) {
+        return connection.preparedQuery(sql);
+    }
+
+    @Override
+    public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
+        return connection.preparedQuery(sql, options);
+    }
+
+    @Override
+    public Future<Void> close() {
+        LOG.tracef("Calling no-op close on TransactionalContextConnection it will close after the closing of session");
+        return Future.succeededFuture();
+    }
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/TransactionalContextPool.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/TransactionalContextPool.java
@@ -1,0 +1,137 @@
+package io.quarkus.hibernate.reactive.runtime.customized;
+
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.CURRENT_CONNECTION_KEY;
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+
+import java.util.function.Function;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PrepareOptions;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+
+/**
+ * A connection pool that handles transaction based on Vert.x context set by the @Transactional interceptor.
+ */
+public class TransactionalContextPool implements Pool {
+
+    private static final Logger LOG = Logger.getLogger(TransactionalContextPool.class);
+
+    private final Pool delegate;
+
+    public TransactionalContextPool(Pool delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+        if (!shouldOpenTransaction()) {
+            delegate.getConnection(handler);
+        } else {
+            delegate.getConnection(result -> {
+                if (result.failed()) {
+                    handler.handle(result);
+                    return;
+                }
+                var connection = result.result();
+                connection.begin()
+                        .map(transaction -> {
+                            storeConnectionInVertxContext(connection);
+                            return (SqlConnection) new TransactionalContextConnection(connection);
+                        })
+                        .andThen(handler);
+            });
+        }
+    }
+
+    @Override
+    public Future<SqlConnection> getConnection() {
+        if (!shouldOpenTransaction()) {
+            return delegate.getConnection();
+        } else {
+            return delegate.getConnection()
+                    .compose(connection -> {
+                        LOG.tracef("New connection, about to start transaction: %s", connection);
+                        return connection.begin().map(t -> {
+                            LOG.tracef("Transaction started: %s", connection);
+                            storeConnectionInVertxContext(connection);
+                            return new TransactionalContextConnection(connection);
+                        });
+                    });
+        }
+    }
+
+    private static void storeConnectionInVertxContext(SqlConnection connection) {
+        Vertx.currentContext().putLocal(CURRENT_CONNECTION_KEY, connection);
+    }
+
+    private boolean shouldOpenTransaction() {
+
+        Context context = Vertx.currentContext();
+
+        // Vert.x context during DB Validation in startup is null
+        // When using reactive in a @Transactional method, the context is surely duplicated
+        if (context != null && ((ContextInternal) context).isDuplicate()) {
+            Object createTransaction = context.getLocal(TRANSACTIONAL_METHOD_KEY);
+            return createTransaction != null && (boolean) createTransaction;
+        } else {
+            LOG.tracef("Vert.x context is either null or non duplicated, won't create a new transaction");
+            return false;
+        }
+    }
+
+    @Override
+    public Query<RowSet<Row>> query(String sql) {
+        return delegate.query(sql);
+    }
+
+    @Override
+    public PreparedQuery<RowSet<Row>> preparedQuery(String sql) {
+        return delegate.preparedQuery(sql);
+    }
+
+    @Override
+    public void close(Handler<AsyncResult<Void>> handler) {
+        delegate.close(handler);
+    }
+
+    @Override
+    @Deprecated
+    public Pool connectHandler(Handler<SqlConnection> handler) {
+        // Deprecated, and not needed by Reactive, and no idea how it affects auto-transactions.
+        throw new UnsupportedOperationException("This operation is not supported");
+    }
+
+    @Override
+    @Deprecated
+    public Pool connectionProvider(Function<Context, Future<SqlConnection>> provider) {
+        // Deprecated, and not needed by Reactive, and no idea how it affects auto-transactions.
+        throw new UnsupportedOperationException("This operation is not supported");
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
+        return delegate.preparedQuery(sql, options);
+    }
+
+    @Override
+    public Future<Void> close() {
+        return delegate.close();
+    }
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/transaction/HibernateActionsStrategy.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/transaction/HibernateActionsStrategy.java
@@ -1,0 +1,54 @@
+package io.quarkus.hibernate.reactive.runtime.transaction;
+
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.PERSISTENCE_UNIT_NAME_KEY;
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.reactive.runtime.HibernateReactiveRecorder;
+import io.quarkus.reactive.transaction.ReactiveResource;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+
+@ApplicationScoped
+public class HibernateActionsStrategy implements ReactiveResource {
+
+    // This can be null if a method is annotated with @Transactional but doesn't inject a session
+    private static Optional<String> getPersistenceUnitName(Context context) {
+        return Optional.ofNullable(context.getLocal(PERSISTENCE_UNIT_NAME_KEY));
+    }
+
+    /**
+     * Flush all opened sessions. This must be called before commit/rollback
+     * so that dirty state is written to the DB within the open transaction.
+     */
+    @Override
+    public Uni<Void> beforeCommit(Context context) {
+        Optional<String> optPersistenceUnitName = getPersistenceUnitName(context);
+        return optPersistenceUnitName.map(persistenceUnitName -> Uni.combine().all().unis(
+                HibernateReactiveRecorder.OPENED_SESSIONS_STATE.flushSession(context, persistenceUnitName),
+                HibernateReactiveRecorder.OPENED_SESSIONS_STATE_STATELESS.flushSession(context, persistenceUnitName))
+                .discardItems()).orElse(Uni.createFrom().voidItem());
+    }
+
+    /**
+     * Close all opened sessions and clean up.
+     * This must be called after commit/rollback to avoid Hibernate Reactive HR000090 validation
+     */
+    @Override
+    public Uni<Void> afterCommit(Context context) {
+        Optional<String> optPersistenceUnitName = getPersistenceUnitName(context);
+        return optPersistenceUnitName.map(persistenceUnitName -> Uni.combine().all().unis(
+                HibernateReactiveRecorder.OPENED_SESSIONS_STATE.closeSession(context, persistenceUnitName),
+                HibernateReactiveRecorder.OPENED_SESSIONS_STATE_STATELESS.closeSession(context, persistenceUnitName))
+                .discardItems()).orElse(Uni.createFrom().voidItem())
+                .eventually(() -> {
+                    // We want to make sure that we clear the state after the closing (and after the flushing) as well
+                    context.removeLocal(TRANSACTIONAL_METHOD_KEY);
+                    context.removeLocal(PERSISTENCE_UNIT_NAME_KEY);
+                });
+
+    }
+}

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -2,6 +2,9 @@ package io.quarkus.narayana.jta.runtime.interceptor;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Optional;
@@ -42,13 +45,28 @@ import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 public abstract class TransactionalInterceptorBase implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger log = Logger.getLogger(TransactionalInterceptorBase.class);
+    protected static final Logger log = Logger.getLogger(TransactionalInterceptorBase.class);
     private final Map<Method, Integer> methodTransactionTimeoutDefinedByPropertyCache = new ConcurrentHashMap<>();
 
     @Inject
     TransactionManager transactionManager;
 
     private final boolean userTransactionAvailable;
+
+    // Test whether both Vertx and reactive-transactions modules are in the class path
+    private static final MethodHandle REACTIVE_INTERCEPTOR_SHOULD_RUN = reactiveInterceptorShouldRun();
+
+    private static MethodHandle reactiveInterceptorShouldRun() {
+        try {
+            Class<?> vertxContext = Class.forName("io.quarkus.reactive.transaction.TransactionalInterceptorBase", true,
+                    Thread.currentThread().getContextClassLoader());
+            return MethodHandles.publicLookup().findStatic(vertxContext, "reactiveInterceptorShouldRun",
+                    MethodType.methodType(boolean.class));
+        } catch (NoClassDefFoundError | NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
+            // This means Vert.x is not on the classpath
+            return null;
+        }
+    }
 
     protected TransactionalInterceptorBase(boolean userTransactionAvailable) {
         this.userTransactionAvailable = userTransactionAvailable;
@@ -70,9 +88,9 @@ public abstract class TransactionalInterceptorBase implements Serializable {
         if (!BlockingOperationControl.isBlockingAllowed()) {
             throw new BlockingOperationNotAllowedException(
                     "@Transactional cannot start a JTA transaction within a reactive pipeline." +
-                            " If the annotated method is intended to be blocking, ensure it is executed on a worker thread, for example by annotating it with @Blocking.");
-            // TODO mention reactive transactions as an alternative?
-            //  e.g.: If the annotated method is intended to be reactive, use Hibernate Reactive, which is currently the only extension supporting @Transactional in a reactive context
+                            " If the annotated method is intended to be blocking, ensure it is executed on a worker thread, for example by annotating it with @Blocking."
+                            +
+                            " If the annotated method is intended to be reactive, consider using Hibernate Reactive, which supports @Transactional in a reactive context.");
         }
     }
 
@@ -444,5 +462,13 @@ public abstract class TransactionalInterceptorBase implements Serializable {
     @SuppressWarnings("unchecked")
     private static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
         throw (E) e;
+    }
+
+    protected boolean willReactiveTransactionalInterceptorRun() throws Exception {
+        try {
+            return REACTIVE_INTERCEPTOR_SHOULD_RUN == null ? false : (boolean) REACTIVE_INTERCEPTOR_SHOULD_RUN.invokeExact();
+        } catch (Throwable e) {
+            return false;
+        }
     }
 }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorMandatory.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorMandatory.java
@@ -32,6 +32,10 @@ public class TransactionalInterceptorMandatory extends TransactionalInterceptorB
 
     @Override
     protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+        if (willReactiveTransactionalInterceptorRun()) {
+            return ic.proceed(); // Skip the blocking interceptor
+        }
+
         if (tx == null) {
             throw new TransactionalException(jtaLogger.i18NLogger.get_tx_required(), new TransactionRequiredException());
         }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorRequired.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorRequired.java
@@ -23,6 +23,10 @@ public class TransactionalInterceptorRequired extends TransactionalInterceptorBa
     @Override
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
+        if (willReactiveTransactionalInterceptorRun()) {
+            return ic.proceed();
+        }
+
         checkBlockingAllowed();
         return super.intercept(ic);
     }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorRequiresNew.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorRequiresNew.java
@@ -23,6 +23,10 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
     @Override
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
+        if (willReactiveTransactionalInterceptorRun()) {
+            return ic.proceed();
+        }
+
         checkBlockingAllowed();
         return super.intercept(ic);
     }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
@@ -1,19 +1,38 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.REACTIVE_TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.proceedUni;
+
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+
 @ReactiveTransactional
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
-public class ReactiveTransactionalInterceptor extends AbstractUniInterceptor {
+public class ReactiveTransactionalInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
         // Note that intercepted methods annotated with @ReactiveTransactional are validated at build time
         // The build fails if the method does not return Uni
+        Context vertxContext = SessionOperations.vertxContext();
+        if (vertxContext.getLocal(TRANSACTIONAL_METHOD_KEY) != null) {
+            return Uni.createFrom().failure(
+                    new UnsupportedOperationException(
+                            "Calling a method annotated with @ReactiveTransactional from a method annotated with @Transactional is not supported. "
+                                    + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "
+                                    + "but not both, throughout your whole application."));
+        }
+
+        // Annotate current method so that we can validate mixing of @ReactiveTransactional with @Transactional
+        vertxContext.putLocal(REACTIVE_TRANSACTIONAL_METHOD_KEY, true);
+
         return SessionOperations.withTransaction(() -> proceedUni(context));
     }
 

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.proceedUni;
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.reactiveInterceptorShouldRun;
+
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
@@ -10,13 +13,14 @@ import io.quarkus.hibernate.reactive.panache.common.WithSessionOnDemand;
 @WithSessionOnDemand
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
-public class WithSessionOnDemandInterceptor extends AbstractUniInterceptor {
+public class WithSessionOnDemandInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
         // Bindings are validated at build time - method-level binding declared on a method that does not return Uni results in a build failure
         // However, a class-level binding implies that methods that do not return Uni are just a no-op
-        if (isUniReturnType(context)) {
+        if (reactiveInterceptorShouldRun()) {
+
             return SessionOperations.withSessionOnDemand(() -> proceedUni(context));
         }
         return context.proceed();

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
@@ -1,11 +1,16 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.WITH_TRANSACTION_METHOD_KEY;
+
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
 
 @WithTransaction
 @Interceptor
@@ -17,15 +22,33 @@ public class WithTransactionInterceptor extends AbstractUniInterceptor {
         // Bindings are validated at build time - method-level binding declared on a method that does not return Uni results in a build failure
         // However, a class-level binding implies that methods that do not return Uni are just a no-op
         if (isUniReturnType(context)) {
+            Context vertxContext = SessionOperations.vertxContext();
+            if (vertxContext.getLocal(TRANSACTIONAL_METHOD_KEY) != null) {
+                return Uni.createFrom().failure(
+                        new UnsupportedOperationException(
+                                "Calling a method annotated with @WithTransaction from a method annotated with @Transactional is not supported. "
+                                        + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "
+                                        + "but not both, throughout your whole application."));
+            }
+
+            // Annotate current method so that we can validate mixing of @WithTransaction and @Transactional
+            vertxContext.putLocal(WITH_TRANSACTION_METHOD_KEY, true);
+
             WithTransaction withTransaction = getAnnotation(context);
             String persistenceUnitName = withTransaction.value();
             if (withTransaction.stateless()) {
-                return SessionOperations.withStatelessTransaction(persistenceUnitName, () -> proceedUni(context));
+                return SessionOperations.withStatelessTransaction(persistenceUnitName, () -> proceedUni(context))
+                        .eventually(() -> clearWithTransactionMethod(vertxContext));
             } else {
-                return SessionOperations.withTransaction(persistenceUnitName, () -> proceedUni(context));
+                return SessionOperations.withTransaction(persistenceUnitName, () -> proceedUni(context))
+                        .eventually(() -> clearWithTransactionMethod(vertxContext));
             }
         }
         return context.proceed();
+    }
+
+    private static boolean clearWithTransactionMethod(Context vertxContext) {
+        return vertxContext.removeLocal(WITH_TRANSACTION_METHOD_KEY);
     }
 
     private WithTransaction getAnnotation(InvocationContext context) {

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -28,6 +28,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-panache-hibernate-common-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions-deployment</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixReactiveTransactionalTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixReactiveTransactionalTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.hibernate.reactive.panache.test.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.panache.common.runtime.ReactiveTransactional;
+import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class MixReactiveTransactionalTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TransactionalInterceptorRequired.class, HibernateActionsStrategy.class));
+
+    @Test
+    @RunOnVertxContext
+    public void testTransactionalCallingReactiveTransactional(UniAsserter asserter) {
+        asserter.assertFailedWith(
+                () -> methodAnnotatedWithTransactionalCallingReactiveTransactional(),
+                t -> assertThat(t)
+                        .hasMessageContaining(
+                                "Calling a method annotated with @ReactiveTransactional from a method annotated with @Transactional is not supported"));
+    }
+
+    @Transactional
+    public Uni<?> methodAnnotatedWithTransactionalCallingReactiveTransactional() {
+        Uni<?> a = Uni.createFrom().item("transactional_method");
+        return a.flatMap(b -> methodAnnotatedWithReactiveTransactional());
+    }
+
+    @ReactiveTransactional
+    public Uni<String> methodAnnotatedWithReactiveTransactional() {
+        return Uni.createFrom().item("reactive_transactional");
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testReactiveTransactionalCallingTransactional(UniAsserter asserter) {
+        asserter.assertFailedWith(
+                () -> methodAnnotatedWithReactiveTransactionalCallingTransactional(),
+                t -> assertThat(t)
+                        .hasMessageContaining(
+                                "Calling a method annotated with @Transactional from a method annotated with @ReactiveTransactional is not supported"));
+    }
+
+    @ReactiveTransactional
+    public Uni<?> methodAnnotatedWithReactiveTransactionalCallingTransactional() {
+        Uni<?> a = Uni.createFrom().item("reactive_transactional");
+        return a.flatMap(b -> methodAnnotatedWithTransactional());
+    }
+
+    @Transactional
+    public Uni<String> methodAnnotatedWithTransactional() {
+        return Uni.createFrom().item("transactional_method");
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithSessionOnDemandTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithSessionOnDemandTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.hibernate.reactive.panache.test.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.panache.common.WithSessionOnDemand;
+import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class MixWithSessionOnDemandTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TransactionalInterceptorRequired.class, HibernateActionsStrategy.class));
+
+    @Test
+    @RunOnVertxContext
+    public void testTransactionalCallingSessionOnDemand(UniAsserter asserter) {
+        asserter.assertFailedWith(
+                () -> methodAnnotatedWithTransactionalCallingSessionOnDemand(),
+                t -> assertThat(t)
+                        .hasMessageContaining(
+                                "Calling a method annotated with @WithSessionOnDemand from a method annotated with @Transactional is not supported"));
+    }
+
+    @Transactional
+    public Uni<?> methodAnnotatedWithTransactionalCallingSessionOnDemand() {
+        Uni<?> a = Uni.createFrom().item("transactional_method");
+        return a.flatMap(b -> methodAnnotatedWithSessionOnDemand());
+    }
+
+    @WithSessionOnDemand
+    public Uni<String> methodAnnotatedWithSessionOnDemand() {
+        return Uni.createFrom().item("whatever");
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testSessionOnDemandCallingTransactional(UniAsserter asserter) {
+        // This should tell users do not do this and migrate to @Transactional
+        asserter.assertFailedWith(
+                () -> methodAnnotatedWithSessionOnDemandCallingTransactional(),
+                t -> assertThat(t)
+                        .hasMessageContaining(
+                                "Calling a method annotated with @Transactional from a method annotated with @WithSessionOnDemand is not supported"));
+    }
+
+    @WithSessionOnDemand
+    public Uni<?> methodAnnotatedWithSessionOnDemandCallingTransactional() {
+        Uni<?> a = Uni.createFrom().item("with_session_on_demand_method");
+        return a.flatMap(b -> methodAnnotatedWithTransactional());
+    }
+
+    @Transactional
+    public Uni<String> methodAnnotatedWithTransactional() {
+        return Uni.createFrom().item("transactional_method");
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithTransactionTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithTransactionTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.hibernate.reactive.panache.test.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class MixWithTransactionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TransactionalInterceptorRequired.class, HibernateActionsStrategy.class));
+
+    @Test
+    @RunOnVertxContext
+    public void testTransactionalCallingWithTransaction(UniAsserter asserter) {
+        asserter.assertFailedWith(
+                () -> methodAnnotatedWithTransactionalCallingWithTransaction(),
+                t -> assertThat(t)
+                        .hasMessageContaining(
+                                "Calling a method annotated with @WithTransaction from a method annotated with @Transactional is not supported"));
+    }
+
+    @Transactional
+    public Uni<?> methodAnnotatedWithTransactionalCallingWithTransaction() {
+        Uni<?> a = Uni.createFrom().item("transactional_method");
+        return a.flatMap(b -> methodAnnotatedWithTransaction());
+    }
+
+    @WithTransaction
+    public Uni<String> methodAnnotatedWithTransaction() {
+        return Uni.createFrom().item("with_transaction");
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testWithTransactionCallingTransactional(UniAsserter asserter) {
+        // This should tell users do not do this and migrate to @Transactional
+        asserter.assertFailedWith(
+                () -> methodAnnotatedWithTransactionCallingTransactional(),
+                t -> assertThat(t)
+                        .hasMessageContaining(
+                                "Calling a method annotated with @Transactional from a method annotated with @WithTransaction is not supported"));
+    }
+
+    @WithTransaction
+    public Uni<?> methodAnnotatedWithTransactionCallingTransactional() {
+        Uni<?> a = Uni.createFrom().item("with_transaction");
+        return a.flatMap(b -> methodAnnotatedWithTransactional());
+    }
+
+    @Transactional
+    public Uni<String> methodAnnotatedWithTransactional() {
+        return Uni.createFrom().item("transactional_method");
+    }
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -83,6 +83,7 @@
         <module>reactive-mysql-client</module>
         <module>reactive-mssql-client</module>
         <module>reactive-oracle-client</module>
+        <module>reactive-transactions</module>
         <module>mailer</module>
         <module>grpc</module>
         <module>redis-client</module>

--- a/extensions/reactive-transactions/deployment/pom.xml
+++ b/extensions/reactive-transactions/deployment/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-reactive-transactions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-reactive-transactions-deployment</artifactId>
+    <name>Quarkus - Reactive Transactions - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${quarkus.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/reactive-transactions/deployment/src/main/java/io/quarkus/hibernate/reactive/transactions/deployment/QuarkusReactiveTransactionsProcessor.java
+++ b/extensions/reactive-transactions/deployment/src/main/java/io/quarkus/hibernate/reactive/transactions/deployment/QuarkusReactiveTransactionsProcessor.java
@@ -1,0 +1,25 @@
+package io.quarkus.hibernate.reactive.transactions.deployment;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.reactive.transaction.TransactionalInterceptorMandatory;
+import io.quarkus.reactive.transaction.TransactionalInterceptorNever;
+import io.quarkus.reactive.transaction.TransactionalInterceptorNotSupported;
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.TransactionalInterceptorRequiresNew;
+import io.quarkus.reactive.transaction.TransactionalInterceptorSupports;
+
+public class QuarkusReactiveTransactionsProcessor {
+
+    @BuildStep
+    AdditionalBeanBuildItem produceItems() {
+        return new AdditionalBeanBuildItem(
+                TransactionalInterceptorMandatory.class,
+                TransactionalInterceptorNever.class,
+                TransactionalInterceptorNotSupported.class,
+                TransactionalInterceptorRequired.class,
+                TransactionalInterceptorRequiresNew.class,
+                TransactionalInterceptorSupports.class);
+
+    }
+}

--- a/extensions/reactive-transactions/pom.xml
+++ b/extensions/reactive-transactions/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-reactive-transactions-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Reactive Transactions - Parent</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/extensions/reactive-transactions/runtime/pom.xml
+++ b/extensions/reactive-transactions/runtime/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-reactive-transactions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-reactive-transactions</artifactId>
+    <name>Quarkus - Reactive Transactions - Runtime</name>
+    <description>Quarkus - Reactive Transaction manager</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-sql-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-transaction-annotations</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                </path>
+                            </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/ReactiveResource.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/ReactiveResource.java
@@ -1,0 +1,11 @@
+package io.quarkus.reactive.transaction;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+
+public interface ReactiveResource {
+
+    Uni<?> beforeCommit(Context context);
+
+    Uni<?> afterCommit(Context context);
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorBase.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorBase.java
@@ -1,0 +1,310 @@
+package io.quarkus.reactive.transaction;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.Transactional;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.runtime.InterceptorBindings;
+import io.quarkus.transaction.annotations.Rollback;
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
+
+/**
+ * The base interceptor which manages reactive transactions for methods
+ * annotated with {@link Transactional}.
+ * Each Transaction Type (REQUIRED, MANDATORY, NEVER, etc...)
+ * has its own class as the QuarkusReactiveTransaction is a binding type so requires exact match
+ */
+public abstract class TransactionalInterceptorBase {
+
+    // Used in this class and in TransactionalContextPool to store and get
+    // the connection with the lazily created Transaction inside the Vert.x Context
+    public static final String CURRENT_CONNECTION_KEY = "reactive.transaction.currentConnection";
+
+    // This key is used to indicate the method was annotated with @Transactional
+    // And will open a session and a transaction lazily when the first operation requires a reactive session
+    // Check HibernateReactiveRecorder.sessionSupplier to see where the session is injected
+    public static final String TRANSACTIONAL_METHOD_KEY = "hibernate.reactive.methodTransactional";
+
+    // This key is used to store the name of the session that is currently injected with @Inject
+    public static final String PERSISTENCE_UNIT_NAME_KEY = "hibernate.reactive.persistenceUnitNameKey";
+
+    // This key is used by Panache internally it's the marker key the WithSessionOnDemand interceptor uses
+    public static final String SESSION_ON_DEMAND_KEY = "hibernate.reactive.panache.sessionOnDemand";
+
+    // This key is used by Panache internally it's the marker key the WithTransaction interceptor uses
+    public static final String WITH_TRANSACTION_METHOD_KEY = "hibernate.reactive.withTransaction";
+
+    // This key is used by Panache internally it's the marker key the ReactiveTransactional interceptor uses
+    public static final String REACTIVE_TRANSACTIONAL_METHOD_KEY = "hibernate.reactive.reactiveTransactional";
+
+    private static final Logger LOG = Logger.getLogger(TransactionalInterceptorBase.class);
+
+    private static final String ERROR_MSG = "@Transactional reactive support requires a safe (isolated) Vert.x sub-context, but the current context hasn't been flagged as such.";
+
+    private ReactiveResource reactiveResource;
+
+    public Object doIntercept(InvocationContext context, ReactiveResource reactiveResource) throws Exception {
+        Method method = context.getMethod();
+        LOG.tracef("Starting Transactional interceptor from method %s", method);
+        this.reactiveResource = reactiveResource;
+
+        if (reactiveInterceptorShouldRun()) {
+            validateTransactionalType(context); // So far only REQUIRED is supported
+            validateLegacyPanacheAnnotations();
+
+            Transactional annotation = getTransactionalAnnotation(context);
+            return defineReactiveTransactionalChain(annotation, method, () -> {
+                return proceedUni(context);
+            });
+        }
+        LOG.tracef("Transactional interceptor end from method %s", method);
+        return context.proceed();
+    }
+
+    protected <T> Uni<T> defineReactiveTransactionalChain(Transactional annotation, Method method, Supplier<Uni<T>> work) {
+        Context context = vertxContext();
+
+        if (context.getLocal(TRANSACTIONAL_METHOD_KEY) == null) {
+            // This is the parent method, responsible for commit, rollback or cancelation of the transaction
+
+            /*
+             * Mark the current context to be @Transactional
+             * This is the parent method and will handle commit / rollback
+             * Subsequent nested methods will avoid tx management
+             */
+            LOG.tracef("Setting this method as transactional: %s", method);
+            context.putLocal(TRANSACTIONAL_METHOD_KEY, true);
+
+            return work.get()
+                    .onFailure().call(exception -> {
+                        return rollbackOrCommitBasedOnException(context, annotation, exception);
+                    })
+                    .onCancellation().call(() -> {
+                        return rollbackOnCancel();
+                    })
+                    .call(() -> { // Good path - commit
+                        LOG.tracef("Calling commit from method %s", method);
+                        return invokeBeforeCommitAndCommit(context);
+                    })
+                    .eventually(() -> {
+                        return reactiveResource.afterCommit(context);
+                    }).eventually(() -> {
+                        return closeConnection();
+                    });
+        } else {
+            // Nested methods should just propagate the reactive chain without transaction handling
+            return work.get();
+        }
+    }
+
+    private Uni<Void> invokeBeforeCommitAndCommit(Context context) {
+        return reactiveResource.beforeCommit(context)
+                .onItem().invoke(() -> LOG.tracef("Flushed the session before commit/rollback"))
+                .onItemOrFailure().call((result, exception) -> {
+                    if (exception != null) {
+                        SqlConnection connection = connectionFromContext();
+                        return actualRollback(connection.transaction(), exception).invoke(() -> {
+                            // onItemOrFailure() will still propagate the chain even with an execption
+                            // we need to rethrow it to make sure the reactive chain fails
+                            throw new RuntimeException("Transaction rolled back due to: ", exception);
+                        });
+                    } else {
+                        return commit();
+                    }
+                }).replaceWithVoid();
+    }
+
+    private Uni<?> closeConnection() {
+        SqlConnection connection = connectionFromContext();
+        if (connection == null) {
+            // io/quarkus/hibernate/reactive/transaction/DisableJTATransactionTest.java:38
+            LOG.tracef("Connection doesn't exist, nothing to do here");
+            return Uni.createFrom().nullItem();
+        }
+        LOG.tracef("Closing the connection %s", connection);
+        return toUni(connection.close());
+    }
+
+    SqlConnection connectionFromContext() {
+        return Vertx.currentContext().getLocal(CURRENT_CONNECTION_KEY);
+    }
+
+    // Based on org/hibernate/reactive/pool/impl/SqlClientConnection.java:305
+    Uni<Void> commit() {
+        SqlConnection connection = connectionFromContext();
+        if (connection == null || connection.transaction() == null) {
+            // This might happen if the method is annotated with @Transactional but doesn't flush
+            // i.e. a single persist without an explicit .flush()
+            // We then avoid committing the transaction here, and we rely on Hibernate Reactive
+            // committing the transaction after closing
+            LOG.tracef("Transaction doesn't exist, so won't commit here");
+            return Uni.createFrom().nullItem();
+        }
+
+        return toUni(connection.transaction().commit())
+                .onFailure().invoke(() -> LOG.tracef("Failed to commit transaction: %s", connection))
+                .invoke(() -> LOG.tracef("Transaction committed: %s", connection));
+    }
+
+    private static <T> Uni<T> toUni(Future<T> future) {
+        return Uni.createFrom()
+                .emitter(emitter -> future.onComplete(emitter::complete, emitter::fail));
+    }
+
+    Uni<Void> rollbackOnCancel() {
+        SqlConnection connection = connectionFromContext();
+        Transaction transaction = connection.transaction();
+        return toUni(transaction.rollback())
+                .onFailure().invoke(() -> LOG.tracef("Failed to rollback transaction on cancellation: %s", connection))
+                .invoke(() -> LOG.tracef("Transaction rolled back due to cancellation: %s", transaction));
+    }
+
+    // Based on org/hibernate/reactive/pool/impl/SqlClientConnection.java:314
+    Uni<Void> rollbackOrCommitBasedOnException(Context context, Transactional annotation, Throwable exception) {
+        SqlConnection connection = connectionFromContext();
+
+        for (Class<?> dontRollbackOnClass : annotation.dontRollbackOn()) {
+            if (dontRollbackOnClass.isAssignableFrom(exception.getClass())) {
+                LOG.trace("Avoid rollback due to `dontRollbackOn` on `@Transactional` annotation, committing instead");
+                return invokeBeforeCommitAndCommit(context);
+            }
+        }
+
+        for (Class<?> rollbackOnClass : annotation.rollbackOn()) {
+            if (rollbackOnClass.isAssignableFrom(exception.getClass())) {
+                LOG.tracef(
+                        "Rollback the transaction due to exception class %s included in `rollbackOn` field on `@Transactional` annotation",
+                        exception.getClass());
+                return actualRollback(connection.transaction(), exception);
+            }
+        }
+
+        Rollback rollbackAnnotation = exception.getClass().getAnnotation(Rollback.class);
+        if (rollbackAnnotation != null) {
+            if (rollbackAnnotation.value()) {
+                LOG.tracef("Rollback the transaction as the exception class %s is annotated with `@Rollback` annotation",
+                        exception.getClass());
+                return actualRollback(connection.transaction(), exception);
+            } else {
+                LOG.tracef(
+                        "Do not rollback the transaction as the exception class %s is annotated with `@Rollback(false)` annotation",
+                        exception.getClass());
+                return invokeBeforeCommitAndCommit(context);
+            }
+        }
+
+        // Default behavior: rollback for RuntimeException and Error (unchecked exceptions)
+        // Note: Mutiny wraps checked exceptions in CompletionException, so they appear as RuntimeException here
+        return actualRollback(connection.transaction(), exception);
+    }
+
+    private Uni<Void> actualRollback(Transaction transaction, Throwable exception) {
+        return toUni(transaction.rollback())
+                .onFailure().invoke(() -> LOG.tracef("Failed to rollback transaction: %s", transaction))
+                .invoke(() -> LOG.tracef("Transaction rolled back: %s due to exception %s", transaction, exception));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Uni<Object> proceedUni(InvocationContext context) {
+        try {
+            Object result = context.proceed();
+            if (result instanceof Uni<?> uniResult) {
+                return (Uni<Object>) uniResult;
+            } else {
+                throw new IllegalStateException(
+                        "For reactive methods running on the event loop, @Transactional can only be used if the method returns a `Uni`. Found '"
+                                + result.getClass().getName() + "' instead.");
+            }
+        } catch (Exception e) {
+            return Uni.createFrom().failure(e);
+        }
+    }
+
+    public static boolean reactiveInterceptorShouldRun() {
+        boolean condition = Context.isOnEventLoopThread();
+        LOG.tracef("Transactional interceptor should run: %s", condition);
+        return condition;
+    }
+
+    protected void validateLegacyPanacheAnnotations() {
+        Context context = vertxContext();
+        if (context.getLocal(SESSION_ON_DEMAND_KEY) != null) {
+            throw new UnsupportedOperationException(
+                    "Calling a method annotated with @Transactional from a method annotated with @WithSessionOnDemand is not supported. "
+                            + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "
+                            + "but not both, throughout your whole application.");
+        }
+
+        if (context.getLocal(WITH_TRANSACTION_METHOD_KEY) != null) {
+            throw new UnsupportedOperationException(
+                    "Calling a method annotated with @Transactional from a method annotated with @WithTransaction is not supported. "
+                            + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "
+                            + "but not both, throughout your whole application.");
+        }
+
+        if (context.getLocal(REACTIVE_TRANSACTIONAL_METHOD_KEY) != null) {
+            throw new UnsupportedOperationException(
+                    "Calling a method annotated with @Transactional from a method annotated with @ReactiveTransactional is not supported. "
+                            + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "
+                            + "but not both, throughout your whole application.");
+        }
+    }
+
+    /**
+     *
+     * @return the current vertx duplicated context
+     * @throws IllegalStateException If no vertx context is found or is not a safe context as mandated by the
+     *         {@link VertxContextSafetyToggle}
+     */
+    private static Context vertxContext() {
+        Context context = Vertx.currentContext();
+        if (context != null) {
+            VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG, ERROR_MSG);
+            return context;
+        } else {
+            throw new IllegalStateException("No current Vertx context found");
+        }
+    }
+
+    // Default impl fails .REQUIRED overrides it
+    protected void validateTransactionalType(InvocationContext context) {
+        Transactional transactional = context.getMethod().getAnnotation(Transactional.class);
+        if (transactional != null && transactional.value() != Transactional.TxType.REQUIRED) {
+            throw new UnsupportedOperationException(
+                    "@Transactional on Reactive methods supports only Transactional.TxType.REQUIRED");
+        }
+    }
+
+    /**
+     * <p>
+     * Looking for the {@link Transactional} annotation first on the method,
+     * second on the class.
+     * <p>
+     * Method handles CDI types to cover cases where extensions are used. In
+     * case of EE container uses reflection.
+     *
+     * @param context invocation context of the interceptor
+     * @return instance of {@link Transactional} annotation or null
+     */
+    private Transactional getTransactionalAnnotation(InvocationContext context) {
+        Set<Annotation> bindings = InterceptorBindings.getInterceptorBindings(context);
+        for (Annotation binding : bindings) {
+            if (binding.annotationType() == Transactional.class) {
+                return (Transactional) binding;
+            }
+        }
+        throw new RuntimeException("Cannot find a @Transactional annotation");
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorMandatory.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorMandatory.java
@@ -1,0 +1,18 @@
+package io.quarkus.reactive.transaction;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.Transactional;
+
+@Transactional(Transactional.TxType.MANDATORY)
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
+public class TransactionalInterceptorMandatory extends TransactionalInterceptorBase {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        return doIntercept(ic, null);
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorNever.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorNever.java
@@ -1,0 +1,18 @@
+package io.quarkus.reactive.transaction;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.Transactional;
+
+@Transactional(Transactional.TxType.NEVER)
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
+public class TransactionalInterceptorNever extends TransactionalInterceptorBase {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        return doIntercept(ic, null);
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorNotSupported.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorNotSupported.java
@@ -1,0 +1,18 @@
+package io.quarkus.reactive.transaction;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.Transactional;
+
+@Transactional(Transactional.TxType.NOT_SUPPORTED)
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
+public class TransactionalInterceptorNotSupported extends TransactionalInterceptorBase {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        return doIntercept(ic, null);
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorRequired.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorRequired.java
@@ -1,0 +1,33 @@
+package io.quarkus.reactive.transaction;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.Transactional;
+
+@Transactional(Transactional.TxType.REQUIRED)
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
+public class TransactionalInterceptorRequired extends TransactionalInterceptorBase {
+
+    @Inject
+    Instance<ReactiveResource> databaseActionsStrategy;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        ReactiveResource reactiveResource = this.databaseActionsStrategy.get();
+        if (reactiveResource == null) {
+            throw new UnsupportedOperationException(
+                    "While using @Transactional we need a DatabaseActions Strategy. Something was wrong here");
+        }
+        return doIntercept(context, reactiveResource);
+    }
+
+    @Override
+    protected void validateTransactionalType(InvocationContext context) {
+        // Required is supported
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorRequiresNew.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorRequiresNew.java
@@ -1,0 +1,18 @@
+package io.quarkus.reactive.transaction;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.Transactional;
+
+@Transactional(Transactional.TxType.REQUIRES_NEW)
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
+public class TransactionalInterceptorRequiresNew extends TransactionalInterceptorBase {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        return doIntercept(ic, null);
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorSupports.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorSupports.java
@@ -1,0 +1,18 @@
+package io.quarkus.reactive.transaction;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.Transactional;
+
+@Transactional(Transactional.TxType.SUPPORTS)
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
+public class TransactionalInterceptorSupports extends TransactionalInterceptorBase {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        return doIntercept(ic, null);
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/reactive-transactions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+name: Quarkus - Reactive Transactions
+description: Quarkus - Reactive Transaction manager
+metadata:
+  keywords:
+    - "reactive-transactions"
+    - "hibernate-reactive"
+    - "hibernate"
+    - "reactive"
+    - "database"
+  categories:
+    - "data"
+    - "reactive"
+  status: "preview"

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -78,7 +78,6 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SSE_EVENT_SINK;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.STRING;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SUSPENDED;
-import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.TRANSACTIONAL;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.UNI;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.URI_INFO;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.YEAR;
@@ -947,15 +946,13 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         } else if ((nonBlockingAnnotation != null)) {
             return false;
         }
-        Map.Entry<AnnotationTarget, AnnotationInstance> transactional = getInheritableAnnotation(info, TRANSACTIONAL); //we treat this the same as blocking, as JTA is blocking, but it is lower priority
+
         if (defaultValue == BlockingDefault.BLOCKING) {
             return true;
         } else if (defaultValue == BlockingDefault.RUN_ON_VIRTUAL_THREAD) {
             return false;
         } else if (defaultValue == BlockingDefault.NON_BLOCKING) {
             return false;
-        } else if (transactional != null) {
-            return true;
         }
         return doesMethodHaveBlockingSignature(info);
     }

--- a/integration-tests/grpc-hibernate/src/main/java/com/example/grpc/hibernate/TestService.java
+++ b/integration-tests/grpc-hibernate/src/main/java/com/example/grpc/hibernate/TestService.java
@@ -45,6 +45,7 @@ public class TestService implements Test {
     }
 
     @Override
+    @Blocking
     @Transactional
     public Uni<TestOuterClass.Empty> clear(TestOuterClass.Empty request) {
         contextChecker.newContextId("TestService#clear");

--- a/integration-tests/hibernate-reactive-orm-compatibility/src/test/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveCompatibilityORMTest.java
+++ b/integration-tests/hibernate-reactive-orm-compatibility/src/test/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveCompatibilityORMTest.java
@@ -25,8 +25,20 @@ public class HibernateReactiveCompatibilityORMTest {
 
         RestAssured.given().when()
                 .auth().preemptive().basic("scott", "jb0ss")
+                .get("/tests/reactiveCowPersistTransactional")
+                .then()
+                .body(containsString("\"name\":\"Carolina Reactive Transactional\"}"));
+
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
                 .get("/testsORM/blockingCowPersist")
                 .then()
                 .body(containsString("\"name\":\"Carolina\"}"));
+
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .get("/testsORM/blockingCowPersistReturningUni")
+                .then()
+                .body(containsString("\"name\":\"Carolina returning Uni\"}"));
     }
 }

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jsonb</artifactId>
         </dependency>
         <dependency>
@@ -86,6 +90,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-transactions-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalTestEndpoint.java
@@ -1,0 +1,97 @@
+package io.quarkus.it.hibernate.reactive.postgresql;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+
+@Path("/transactional-tests")
+@Authenticated
+public class HibernateReactiveTransactionalTestEndpoint {
+
+    @Inject
+    Mutiny.Session session;
+
+    @POST
+    @Path("/createPig/{id}")
+    public Uni<GuineaPig> reactiveTransactionalCreatePig(int id) {
+        final GuineaPig expectedPig = new GuineaPig(id, "initialName");
+        return createFindPig(expectedPig);
+    }
+
+    @POST
+    @Path("/updatePig/{pigId}")
+    public Uni<Void> reactiveTransactionalUpdatePig(int pigId, @QueryParam("name") String name) {
+        return updatePig(pigId, name);
+    }
+
+    @GET
+    @Path("/findPig/{pigId}")
+    public Uni<GuineaPig> reactiveTransactionalFindPig(int pigId) {
+        return transactionalFind(pigId);
+    }
+
+    @POST
+    @Path("/updatePigHanging/{pigId}")
+    public Uni<Void> reactiveTransactionalUpdatePigHanging(int pigId, @QueryParam("name") String name) {
+        return updatePigHanging(pigId, name);
+    }
+
+    @POST
+    @Path("/updatePigRollback/{pigId}")
+    public Uni<Void> reactiveTransactionalUpdatePigRollback(int pigId, @QueryParam("name") String name) {
+        return updatePigRollback(pigId, name);
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public Uni<GuineaPig> transactionalFind(int pigId) {
+        return session.find(GuineaPig.class, pigId);
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public Uni<GuineaPig> createFindPig(GuineaPig pig) {
+        return session.persist(pig)
+                .chain(p -> session.find(GuineaPig.class, pig.getId()));
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public Uni<Void> updatePig(int pigId, String newName) {
+        return session.find(GuineaPig.class, pigId)
+                .map(p -> {
+                    p.setName(newName);
+                    return p;
+                })
+                .replaceWithVoid();
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public Uni<Void> updatePigHanging(int pigId, String newName) {
+        return session.find(GuineaPig.class, pigId)
+                .map(p -> {
+                    p.setName(newName);
+                    return p;
+                }).chain(() -> {
+                    // This will make the endpoint never complete
+                    return Uni.createFrom().nothing();
+                })
+                .replaceWithVoid();
+    }
+
+    @Transactional(Transactional.TxType.REQUIRED)
+    public Uni<Void> updatePigRollback(int pigId, String newName) {
+        return session.find(GuineaPig.class, pigId)
+                .map(p -> {
+                    p.setName(newName);
+                    return p;
+                }).chain(() -> {
+                    throw new RuntimeException("Intentional exception to trigger rollback");
+                });
+    }
+}

--- a/integration-tests/hibernate-reactive-postgresql/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/resources/application.properties
@@ -8,3 +8,13 @@ quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.users.scott=jb0ss
 quarkus.security.users.embedded.plain-text=true
 quarkus.security.users.embedded.roles.scott=Admin,admin,Tester,user
+
+
+# Trace @Transactional support
+quarkus.hibernate-orm.log.sql=true
+quarkus.log.min-level=TRACE
+quarkus.log.category."io.quarkus.reactive.transaction.TransactionalInterceptorBase".level=TRACE
+quarkus.log.category."io.quarkus.reactive.transaction.TransactionalContextConnection.TransactionalContextConnection".level=TRACE
+quarkus.log.category."io.quarkus.hibernate.reactive.runtime.customized".level=TRACE
+#quarkus.log.category."org.hibernate.reactive".level=TRACE
+quarkus.log.console.level=TRACE

--- a/integration-tests/hibernate-reactive-postgresql/src/test/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalIntegrationTest.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/test/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalIntegrationTest.java
@@ -1,0 +1,158 @@
+package io.quarkus.it.hibernate.reactive.postgresql;
+
+import static io.restassured.config.HttpClientConfig.*;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Integration tests for @Transactional support with Hibernate Reactive.
+ *
+ * These tests verify that transactional boundaries are properly managed when using
+ * the @Transactional annotation with reactive Hibernate operations.
+ */
+@QuarkusTest
+@TestHTTPEndpoint(HibernateReactiveTransactionalTestEndpoint.class)
+public class HibernateReactiveTransactionalIntegrationTest {
+
+    @Test
+    public void testTransactionalUpdate() {
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .post("/createPig/20")
+                .then()
+                .body("id", equalTo(20))
+                .body("name", equalTo("initialName"));
+
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .post("/updatePig/20?name=updatedName")
+                .then()
+                .statusCode(204);
+
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .get("/findPig/20")
+                .then()
+                .body("id", equalTo(20))
+                .body("name", equalTo("updatedName"));
+    }
+
+    /**
+     * Tests that transaction rollback occurs when the HTTP client cancels a request that is
+     * in the middle of a transactional operation.
+     *
+     * <p>
+     * The endpoint returns Uni.createFrom().nothing() which never completes, causing the client
+     * to timeout and cancel the request. This simulates a real-world scenario where a client
+     * cancels a long-running request. The test verifies that the transaction is properly rolled
+     * back and no changes are persisted.
+     *
+     * <p>
+     * <b>Current Limitations:</b>
+     * <ul>
+     * <li>The timeout must be long enough for the Uni chain to reach the hanging point after
+     * flush(). If the timeout is too short, the cancellation may occur before the transaction
+     * begins, resulting in different behavior (no commit but also no explicit rollback).</li>
+     * <li>Transaction cancellation can only be verified by examining the logs for cancellation
+     * messages. There is currently no programmatic way to assert that cancellation occurred.</li>
+     * <li>This test uses a client-side timeout to trigger cancellation. A more direct approach
+     * using server-side cancellation mechanisms would be preferable but was not achievable
+     * with the current implementation.</li>
+     * </ul>
+     */
+    @Test
+    public void testTransactionalCancellation() throws InterruptedException {
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .post("/createPig/30")
+                .then()
+                .body("id", equalTo(30))
+                .body("name", equalTo("initialName"));
+
+        // Start the hanging update asynchronously
+        CompletableFuture<Void> hangingUpdate = CompletableFuture.runAsync(() -> {
+            try {
+                RestAssured.given()
+                        .config(RestAssured.config()
+                                .httpClient(httpClientConfig()
+                                        // 400ms timeout - long enough for the operation to flush and hang
+                                        .setParam("http.socket.timeout", 400)))
+                        .when()
+                        .auth().preemptive().basic("scott", "jb0ss")
+                        .post("/updatePigHanging/30?name=updatedNameHanging")
+                        .then()
+                        .statusCode(204);
+            } catch (Exception e) {
+                Log.debugf("(expected) failure due to timeout after 400ms");
+            }
+        });
+
+        // Wait for the hanging update to complete
+        hangingUpdate.join();
+
+        // Verify the name was NOT updated (rollback happened)
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .get("/findPig/30")
+                .then()
+                .body("id", equalTo(30))
+                .body("name", equalTo("initialName"));
+    }
+
+    /**
+     * Tests that transaction rollback occurs when an exception is thrown after flush().
+     *
+     * <p>
+     * The test performs a successful update first, then attempts a second update that
+     * throws a RuntimeException after flushing. The test verifies that the second update
+     * is rolled back and the name remains the one set by the first (successful) update.
+     */
+    @Test
+    public void testTransactionalRollback() {
+        // Create the pig
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .post("/createPig/40")
+                .then()
+                .body("id", equalTo(40))
+                .body("name", equalTo("initialName"));
+
+        // First update: should commit successfully
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .post("/updatePig/40?name=firstUpdate")
+                .then()
+                .statusCode(204);
+
+        // Verify the first update was committed
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .get("/findPig/40")
+                .then()
+                .body("id", equalTo(40))
+                .body("name", equalTo("firstUpdate"));
+
+        // Second update: throws an exception after flush, should rollback
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .post("/updatePigRollback/40?name=secondUpdateRolledBack")
+                .then()
+                .statusCode(500);
+
+        // Verify the name is still "firstUpdate" (rollback happened)
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .get("/findPig/40")
+                .then()
+                .body("id", equalTo(40))
+                .body("name", equalTo("firstUpdate"));
+    }
+}

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/ContextEndpoint.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/ContextEndpoint.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Assertions;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.panache.Panache;
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.constraint.Assert;
 
 @Path("/context")
@@ -152,6 +153,7 @@ public class ContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public CompletionStage<String> transactionTest() throws SystemException {
         CompletableFuture<String> ret = all.completedFuture("OK");
 
@@ -177,6 +179,7 @@ public class ContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-tc")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public CompletionStage<String> transactionThreadContextTest() throws SystemException {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
@@ -203,6 +206,7 @@ public class ContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction2")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public CompletionStage<String> transactionTest2() throws SystemException {
         CompletableFuture<String> ret = all.completedFuture("OK");
 
@@ -219,6 +223,7 @@ public class ContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction3")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public CompletionStage<String> transactionTest3() throws SystemException {
         CompletableFuture<String> ret = all
                 .failedFuture(new WebApplicationException(Response.status(Response.Status.CONFLICT).build()));
@@ -234,6 +239,7 @@ public class ContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction4")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public String transactionTest4() throws SystemException {
         // check that the third transaction was not committed
         Assertions.assertEquals(1, ContextEntity.count());
@@ -246,6 +252,7 @@ public class ContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-new")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public CompletionStage<String> transactionNewTest() throws SystemException {
         CompletableFuture<String> ret = all.completedFuture("OK");
 

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import io.quarkus.arc.Arc;
 import io.quarkus.context.test.RequestBean;
 import io.quarkus.hibernate.orm.panache.Panache;
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.constraint.Assert;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -199,6 +200,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-uni")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> contextPropagationWithTxAndUni() throws SystemException {
         SomeEntity.deleteAll();
         Uni<String> ret = Uni.createFrom().item("OK");
@@ -226,6 +228,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-uni-cs")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> contextPropagationWithTxAndUniCreatedFromCS() throws SystemException {
         Uni<String> ret = Uni.createFrom().completionStage(all.completedFuture("OK"));
         SomeOtherEntity entity = new SomeOtherEntity();
@@ -252,6 +255,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-tc-uni")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> transactionPropagationWithThreadContextAndUniCreatedFromCS() throws SystemException {
         CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
         SomeEntity entity = new SomeEntity();
@@ -278,6 +282,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction2-uni")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> transactionTest2() {
         Uni<String> ret = Uni.createFrom().item("OK");
 
@@ -294,6 +299,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction2-uni-cs")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> transactionTest2WithUniCreatedFromCS() {
         Uni<String> ret = Uni.createFrom().completionStage(all.completedFuture("OK"));
 
@@ -310,6 +316,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction3-uni")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> transactionTest3() {
         Uni<String> ret = Uni.createFrom()
                 .failure(new WebApplicationException(Response.status(Response.Status.CONFLICT).build()));
@@ -325,6 +332,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction3-uni-cs")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> transactionTest3WithUniCreatedFromCS() {
         CompletableFuture<String> future = all
                 .failedFuture(new WebApplicationException(Response.status(Response.Status.CONFLICT).build()));
@@ -341,6 +349,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction4")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public String transactionTest4() {
         // check that the third transaction was not committed
         Assertions.assertEquals(1, SomeEntity.count());
@@ -353,6 +362,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction4-cs")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public String transactionTest4CS() {
         // check that the third transaction was not committed
         Assertions.assertEquals(1, SomeOtherEntity.count());
@@ -365,6 +375,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-new-sync")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> newTransactionPropagationSynchronous() throws SystemException {
         Uni<String> ret = Uni.createFrom().item("OK");
         Transaction t1 = Panache.getTransactionManager().getTransaction();
@@ -380,6 +391,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-new-uni")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> newTransactionPropagationWithUni() throws SystemException {
         Person entity = new Person();
         entity.name = "Stef";
@@ -413,6 +425,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-uni-2")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Uni<String> transactionPropagationWithUni() {
         Uni<String> ret = Uni.createFrom().item("OK");
         // now delete both entities
@@ -423,6 +436,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-multi")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Multi<String> transactionPropagationWithMulti() throws SystemException {
         Person entity = new Person();
         entity.name = "Stef";
@@ -456,6 +470,7 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-multi-2")
+    @Blocking // To trigger the Narayana Blocking Interceptor
     public Flow.Publisher<String> transactionPropagationWithMulti2() {
         Multi<String> ret = Multi.createFrom().item("OK");
         // now delete both entities


### PR DESCRIPTION
Introduces a new extension enabling @Transactional annotation support for
Hibernate Reactive. This allows developers to use familiar transaction semantics
with reactive database operations.

Key implementation details:

* New `quarkus-reactive-transactions` extension with dedicated CDI interceptors
* TransactionalContextPool wraps the SQL client pool to lazily open transactions
  based on Vert.x context flags set by the @transactional interceptor
* TransactionalInterceptorBase manages the complete transaction lifecycle
  (begin, commit, rollback) within the reactive Uni pipeline
* TransactionalContextConnection wrapper prevents premature connection closure
  before transaction commit/rollback
* OpenedSessionState refactored from Panache to centrally manage session
  lifecycle and caching (possibly to be reused in Panache as well)
* Validation prevents mixing @transactional with @WithTransaction and
  @WithSessionOnDemand annotations to avoid conflicting transaction semantics
* Disable JTA interceptor execution for methods returning Uni to prevent
  mixups

Limitations:
* Currently supports only Transactional.TxType.REQUIRED, other TxType values
  throw UnsupportedOperationException

Dependencies updated:
* hibernate-orm.version → 7.2.0.CR1
* hibernate-reactive.version → 3.2.0-SNAPSHOT

Fixes #47462
Fixes #47698 

Support @Transactional on Reactive methods as well
Injection of Mutiny.Session as injectable bean

# Migration Guide

* Methods annotated with `@Transactional` are no longer automatically considered `@Blocking` by Quarkus
* Removed forced dispatch to the worker thread when a resource endpoint is annotated with `@Transactional`, now it uses the default behavior: check on the return type (event loop if it returns a `Uni<T>`, otherwise worker thread). If a method is blocking but returns a `Uni<T>`, it requires an explicit `@Blocking` annotation.

