### PR TITLE
Tidy switch of Oracle tests to dev services

### DIFF
--- a/integration-tests/hibernate-reactive-oracle/pom.xml
+++ b/integration-tests/hibernate-reactive-oracle/pom.xml
@@ -166,35 +166,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>docker-oracle</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!-- Disabled pending fix of #33094 -->
         <profile>
             <id>podman</id>

--- a/integration-tests/jpa-oracle/README.md
+++ b/integration-tests/jpa-oracle/README.md
@@ -3,7 +3,7 @@
 ## Running the tests
 
 
-To run the tests in a standard JVM with an Oracle database started as a Docker container, you can run the following command:
+To run the tests in a standard JVM with an Oracle database started as a Dev Service, you can run the following command:
 
 ```
 mvn verify -Dtest-containers -Dstart-containers
@@ -17,7 +17,7 @@ mvn verify -Dtest-containers -Dstart-containers -Dnative
 
 Alternatively you can connect to your own Oracle database.
 Reconfigure the connection URL with `-Doracledb.url=jdbc:Oracle://...`;
-Authentication parameters might need to be changed in the Quarkus configuration file `application.properties`.
+Authentication parameters might need to be added in the Quarkus configuration file `application.properties`.
 
 ### Starting Oracle via docker
 
@@ -25,5 +25,5 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23-slim-faststart
 ```
 
-This will start a local instance with the configuration matching the parameters used by the integration tests of this module.
+This will start a local instance. Update `application.properties` with the new configuration.
 

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -174,35 +174,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile>
-            <id>docker-oracle</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/reactive-oracle-client/README.md
+++ b/integration-tests/reactive-oracle-client/README.md
@@ -1,10 +1,10 @@
 # Reactive Oracle example
 
+
 ## Running the tests
 
-By default, the tests of this module are disabled.
 
-To run the tests in a standard JVM with an Oracle database started as a Docker container, you can run the following command:
+To run the tests in a standard JVM with an Oracle database started as a Dev Service, you can run the following command:
 
 ```
 mvn verify -Dtest-containers -Dstart-containers
@@ -18,7 +18,7 @@ mvn verify -Dtest-containers -Dstart-containers -Dnative
 
 Alternatively you can connect to your own Oracle database.
 Reconfigure the connection URL with `-Dreactive-oracledb.url=jdbc:oracle:thin:...`;
-Authentication parameters might need to be changed in the Quarkus configuration file `application.properties`.
+Authentication parameters might need to be added in the Quarkus configuration file `application.properties`.
 
 ### Starting Oracle via docker
 
@@ -26,4 +26,4 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23-slim-faststart
 ```
 
-This will start a local instance with the configuration matching the parameters used by the integration tests of this module.
+This will start a local instance. Update `application.properties` with the new configuration.

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -140,34 +140,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>docker-oracle</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Ah, there's nothing like having a PR merged and moving on the next task to help you spot all the problems with the PR. :)

This is a follow-on to https://github.com/quarkusio/quarkus/pull/51059. I realised I needed to update the readmes now that dev services are being used. I also noticed that while the `start-containers` maven profile has content, the content is only an invocation of `.github/docker-prune`, which is a no-op everywhere but windows CI. https://github.com/quarkusio/quarkus/pull/35458 disabled it because it was causing more problems than it was fixing. 

Adding @famod and @geoand for review, since they added the original scripts. I *think* we don't need to do a docker prune if we're using testcontainers, even on Windows, but they may have scars that say otherwise. :) 