### PR TITLE
Use dev services instead of docker-maven-plugin for Postgresql

### DIFF
--- a/integration-tests/jpa-postgresql-withxml/pom.xml
+++ b/integration-tests/jpa-postgresql-withxml/pom.xml
@@ -13,10 +13,6 @@
     <name>Quarkus - Integration Tests - JPA - PostgreSQL with XML</name>
     <description>Module that contains JPA related tests running with the PostgreSQL database</description>
 
-    <properties>
-        <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -157,86 +153,6 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-postgresql</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${postgres.image}</name>
-                                    <alias>postgresql</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
-                                            and that's the truth the second time only.
-                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
-                                            See also how the condition is configured in testcontainers:
-                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
-                                            <time>20000</time>
-                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all postgres images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-quarkus.datasource.username=hibernate_orm_test
-quarkus.datasource.password=hibernate_orm_test
-quarkus.datasource.jdbc.url=${postgres.url}
 quarkus.datasource.jdbc.max-size=8
 
 quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql.defaultpu

--- a/integration-tests/jpa-postgresql/README.md
+++ b/integration-tests/jpa-postgresql/README.md
@@ -4,7 +4,7 @@
 
 By default, the tests of this module are disabled.
 
-To run the tests in a standard JVM with PostgreSQL started as a Docker container, you can run the following command:
+To run the tests in a standard JVM with PostgreSQL started as a Dev Service, you can run the following command:
 
 ```
 mvn clean install -Dtest-containers -Dstart-containers
@@ -16,12 +16,12 @@ Additionally, you can generate a native image and run the tests for this native 
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
-If you don't want to run PostgreSQL as a Docker container, you can start your own PostgreSQL server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
+If you don't want to run PostgreSQL as a Dev Service, you can start your own PostgreSQL server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 
 ```
-mvn clean install -Dtest-containers
+mvn clean install -Dtest-containers -Dquarkus.datasource.jdbc.url=jdbc:postgresql://...
 ```
 
-If you have specific requirements, you can define a specific connection URL with `-Dpostgres.url=jdbc:postgresql://...`.
+If you have specific requirements, you can also define a specific connection URL with `-Dquarkus.datasource.jdbc.url=jdbc:postgresql://...`.

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -13,10 +13,6 @@
     <name>Quarkus - Integration Tests - JPA - PostgreSQL</name>
     <description>Module that contains JPA related tests running with the PostgreSQL database</description>
 
-    <properties>
-        <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -45,6 +41,23 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+    <!--  Until we have testcontainers 2, which has https://github.com/testcontainers/testcontainers-java/issues/970, add back JUnit 4 so testcontainers doesn't break everything :( -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
@@ -167,86 +180,6 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-postgresql</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${postgres.image}</name>
-                                    <alias>postgresql</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
-                                             and that's the truth the second time only.
-                                             See https://github.com/fabric8io/docker-maven-plugin/issues/628
-                                             See also how the condition is configured in testcontainers:
-                                             https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
-                                            <time>20000</time>
-                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all postgres images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/jpa-postgresql/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-quarkus.datasource.username=hibernate_orm_test
-quarkus.datasource.password=hibernate_orm_test
-quarkus.datasource.jdbc.url=${postgres.url}
 quarkus.datasource.jdbc.max-size=8
 
 quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql.defaultpu

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/ConfigOverrideTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/ConfigOverrideTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.jpa.postgresql;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+/* Exercises OverrideJdbcUrlBuildTimeConfigSource, which cannot coexist with dev services. */
+@TestProfile(ConfigOverrideTest.Profile.class)
+@QuarkusTest
+public class ConfigOverrideTest {
+
+    @Test
+    public void base() {
+        RestAssured.when().get("/jpa/testfunctionality/base").then().body(is("OK"));
+    }
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            // Disable dev services so we know we're connecting to the right database
+            return Map.of("quarkus.devservices.enabled", "false");
+        }
+
+        @Override
+        public String getConfigProfile() {
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            return Collections.singletonList(new TestResourceEntry(PostgresTestResourceLifecycleManager.class));
+        }
+    }
+}

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/PostgresTestResourceLifecycleManager.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/PostgresTestResourceLifecycleManager.java
@@ -1,0 +1,35 @@
+package io.quarkus.it.jpa.postgresql;
+
+import java.util.Map;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class PostgresTestResourceLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+    private static PostgreSQLContainer<?> postgres;
+
+    @SuppressWarnings("resource")
+    @Override
+    public Map<String, String> start() {
+        postgres = new PostgreSQLContainer<>("postgres:14") // the exact value doesn't really matter here
+                .withDatabaseName("testdb")
+                .withUsername("test")
+                .withPassword("test");
+
+        postgres.start();
+
+        return Map.of("quarkus.datasource.jdbc.url", postgres.getJdbcUrl(), "quarkus.datasource.username", "test",
+                "quarkus.datasource.password", "test");
+    }
+
+    @Override
+    public void stop() {
+
+        if (postgres != null) {
+            postgres.stop();
+        }
+    }
+
+}

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -545,14 +545,6 @@
                     <name>test-containers</name>
                 </property>
             </activation>
-            <properties>
-                <datasource.db-kind>postgresql</datasource.db-kind>
-                <datasource.url>${postgres.url}</datasource.url>
-                <datasource.username>hibernate_orm_test</datasource.username>
-                <datasource.password>hibernate_orm_test</datasource.password>
-
-                <hibernate-orm.dialect>org.hibernate.dialect.PostgreSQLDialect</hibernate-orm.dialect>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>
@@ -603,88 +595,6 @@
             </properties>
         </profile>
 
-        <profile>
-            <id>docker-postgresql</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <properties>
-                <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${postgres.image}</name>
-                                    <alias>postgresql</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
-                                            and that's the truth the second time only.
-                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
-                                            See also how the condition is configured in testcontainers:
-                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
-                                            <time>20000</time>
-                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all postgres images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/reactive-pg-client/README.md
+++ b/integration-tests/reactive-pg-client/README.md
@@ -4,7 +4,7 @@
 
 By default, the tests of this module are disabled.
 
-To run the tests in a standard JVM with PostgreSQL started as a Docker container, you can run the following command:
+To run the tests in a standard JVM with PostgreSQL started as a Dev Service, you can run the following command:
 
 ```
 mvn clean install -Dtest-containers -Dstart-containers
@@ -16,7 +16,7 @@ Additionally, you can generate a native image and run the tests for this native 
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
-If you don't want to run PostgreSQL as a Docker container, you can start your own PostgreSQL server. It needs to listen on port 5431 and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
+If you don't want to run PostgreSQL as a Dev Service, you can start your own PostgreSQL server. 
 
 You can then run the tests as follows (either with `-Dnative` or not):
 
@@ -24,4 +24,4 @@ You can then run the tests as follows (either with `-Dnative` or not):
 mvn clean install -Dtest-containers
 ```
 
-If you have specific requirements, you can define a specific connection URL with `-Dreactive-postgres.url=vertx-reactive:postgresql://:5431/hibernate_orm_test`.
+You will need to pass in properties with the details of the external service. For example, you can define a specific connection URL with `-Dquarkus.datasource.reactive.url=vertx-reactive:postgresql://:5431/hibernate_orm_test`.

--- a/integration-tests/reactive-pg-client/pom.xml
+++ b/integration-tests/reactive-pg-client/pom.xml
@@ -14,10 +14,6 @@
 
     <name>Quarkus - Integration Tests - Reactive Pg Client</name>
 
-    <properties>
-        <reactive-postgres.url>vertx-reactive:postgresql://:5431/hibernate_orm_test</reactive-postgres.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -150,86 +146,6 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-postgresql</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${postgres.image}</name>
-                                    <alias>postgresql</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
-                                            and that's the truth the second time only.
-                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
-                                            See also how the condition is configured in testcontainers:
-                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
-                                            <time>20000</time>
-                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all postgres images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/reactive-pg-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-pg-client/src/main/resources/application.properties
@@ -1,4 +1,0 @@
-quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=hibernate_orm_test
-quarkus.datasource.password=hibernate_orm_test
-quarkus.datasource.reactive.url=${reactive-postgres.url}

--- a/integration-tests/reactive-pg-client/src/test/resources/application-tl.properties
+++ b/integration-tests/reactive-pg-client/src/test/resources/application-tl.properties
@@ -1,6 +1,3 @@
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=hibernate_orm_test
-quarkus.datasource.password=hibernate_orm_test
-quarkus.datasource.reactive.url=${reactive-postgres.url}
 quarkus.datasource.reactive.thread-local=true
 quarkus.log.category."io.quarkus.reactive.datasource".level=DEBUG

--- a/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
+++ b/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <keycloak.url>http://localhost:8180</keycloak.url>
-        <reactive-postgres.url>vertx-reactive:postgresql://:5431/oidc_db_token_state_manager_test</reactive-postgres.url>
     </properties>
 
     <dependencies>
@@ -208,84 +207,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-keycloak</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${postgres.image}</name>
-                                    <alias>postgresql-db</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>oidc_db_token_state_manager_test_user</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>oidc_db_token_state_manager_test_pwd</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>oidc_db_token_state_manager_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
-                                            and that's the truth the second time only.
-                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
-                                            See also how the condition is configured in testcontainers:
-                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
-                                            <time>20000</time>
-                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/main/resources/application.properties
@@ -10,9 +10,4 @@ quarkus.oidc.application-type=web-app
 quarkus.keycloak.devservices.create-realm=false
 quarkus.keycloak.devservices.port=8180
 
-quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=oidc_db_token_state_manager_test_user
-quarkus.datasource.password=oidc_db_token_state_manager_test_pwd
-quarkus.datasource.reactive.url=${reactive-postgres.url}
-
 quarkus.log.category."org.htmlunit.css".level=FATAL


### PR DESCRIPTION
Partial resolution of https://github.com/quarkusio/quarkus/issues/44124.

As with https://github.com/quarkusio/quarkus/pull/51059, I left the `extensions/*` project using an independently-managed container, since the test exercises `application.properties` a lot. 

I'm marking this as a draft, because I had a failure I can't explain. I'm hoping @radcortez and @yrodiere might be able to help. I don't know if it's a bug, or if I'm asking the test to do something that's not supported. The `jpa-postgresql` project fails with 

```
Caused by: io.quarkus.arc.InactiveBeanException: Bean is not active: SYNTHETIC bean [class=io.agroal.api.AgroalDataSource, id=83v3mgZs1bc75ou7lAXNtJCAcLA]
Reason: Datasource '<default>' was deactivated automatically because its URL is not set. To activate the datasource, set configuration property 'quarkus.datasource.jdbc.url'. Refer to https://quarkus.io/guides/datasource for guidance.
```

The reason seems to be related to the config override, `OverrideJdbcUrlBuildTimeConfigSource`, which sets a `quarkus.datasource.jdbc.url`, to reproduce https://github.com/quarkusio/quarkus/issues/16123. If I disable that override by deleting `src/test/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource`, the test all passes. With the override, I'd expect a connection failure, because `quarkus.datasource.jdbc.url` would disable the dev service, and there's nothing listening at the hardcoded endpoint. But instead I get an error saying the `quarkus.datasource.jdbc.url` property isn't set. It's like the dev service processor sees it as set, so doesn't start anything, but the `AgroalRecorder` sees it as not set. Maybe that's expected because of when the reading and writing of the config happens, but it makes me wonder if the test is testing what it's supposed to be testing. As far as I can tell, the override was just setting the same value as was set in `application.properties` already.

