### PR TITLE
Prefer Micrometer Metrics on Fault Tolerance

### DIFF
--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -179,16 +179,19 @@ public class SmallRyeFaultToleranceProcessor {
                         Enablement.class);
 
         int metricsProviders = 0;
-        if (metricsCapability.isPresent() && metricsCapability.get().metricsSupported(MetricsFactory.MP_METRICS)) {
-            builder.addBeanClass("io.smallrye.faulttolerance.metrics.MicroProfileMetricsProvider");
-            metricsProviders++;
-        } else if (metricsCapability.isPresent() && metricsCapability.get().metricsSupported(MetricsFactory.MICROMETER)) {
+        if (metricsCapability.isPresent() && metricsCapability.get().metricsSupported(MetricsFactory.MICROMETER)) {
+            // Priority to Micrometer. We should avoid having OTel + Micrometer on.
             builder.addBeanClass("io.smallrye.faulttolerance.metrics.MicrometerProvider");
             metricsProviders++;
-        }
-        if (openTelemetrySdk.map(OpenTelemetrySdkBuildItem::isMetricsBuildTimeEnabled).orElse(false)) {
-            builder.addBeanClass("io.smallrye.faulttolerance.metrics.OpenTelemetryProvider");
-            metricsProviders++;
+        } else {
+            if (metricsCapability.isPresent() && metricsCapability.get().metricsSupported(MetricsFactory.MP_METRICS)) {
+                builder.addBeanClass("io.smallrye.faulttolerance.metrics.MicroProfileMetricsProvider");
+                metricsProviders++;
+            }
+            if (openTelemetrySdk.map(OpenTelemetrySdkBuildItem::isMetricsBuildTimeEnabled).orElse(false)) {
+                builder.addBeanClass("io.smallrye.faulttolerance.metrics.OpenTelemetryProvider");
+                metricsProviders++;
+            }
         }
 
         if (metricsProviders == 0) {


### PR DESCRIPTION
Fix for the behavior reported by this user: [#users > Open telemetry fault tolerance recording double metrics](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Open.20telemetry.20fault.20tolerance.20recording.20double.20metrics/with/557945296)

When using the `quarkus-micrometer-opentelemetry` extension we actively suppress particular OTel instrumentations to make sure we don't duplicate metrics. 

The idea of the PR is to disable OTel metrics if Micrometer metrics are present. 

`CompoundMetricsProvider` is not needed.