### PR TITLE
Download all dependencies by default when going offline

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GoOfflineMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GoOfflineMojo.java
@@ -64,10 +64,10 @@ public class GoOfflineMojo extends AbstractMojo {
 
     /**
      * Target launch mode corresponding to {@link io.quarkus.runtime.LaunchMode} for which the dependencies should be resolved.
-     * {@code io.quarkus.runtime.LaunchMode.TEST} is the default, since it includes both {@code provided} and {@code test}
-     * dependency scopes.
+     * {@code all} is the default, since it includes both {@code provided} and {@code test}
+     * dependency scopes and also the dependencies required by dev mode.
      */
-    @Parameter(property = "mode", required = false, defaultValue = "test")
+    @Parameter(property = "mode", required = false, defaultValue = "all")
     String mode;
 
     @Override
@@ -82,7 +82,11 @@ public class GoOfflineMojo extends AbstractMojo {
         final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(resolver);
 
         final Set<String> excludedScopes;
-        if (mode.equalsIgnoreCase("test")) {
+        if (mode.equals("all")) {
+            appModelResolver.setDevMode(true);
+            appModelResolver.setTest(true);
+            excludedScopes = Set.of();
+        } else if (mode.equalsIgnoreCase("test")) {
             appModelResolver.setTest(true);
             excludedScopes = Set.of();
         } else if (mode.equalsIgnoreCase("dev") || mode.equalsIgnoreCase("development")) {


### PR DESCRIPTION
It is sometimes confusing and cumbersome to explicitly call the right mode before going offline. For example if you are about to board a plane you might forget to give the option to also download dependencies for dev mode. (I actually had that last week, but luckily could switch back to a previous minor release)

This PR introduces a new option that downloads dev, test and prod dependencies and makes it the new default. This allows developers to go offline without having to specify the mode explicitly.

Did a quick local tests by building the plugin locally and it now also downloads the Dev UI dependencies, for example:

```
Downloaded from central: https://repo.maven.apache.org/maven2/io/quarkus/quarkus-devui-deployment/3.29.3/quarkus-devui-deployment-3.29.3.jar (194 kB at 3.2 MB/s)
```