### PR TITLE
Remove redundant jakarta classifier from org.infinispan:infinispan-core

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5835,7 +5835,6 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-core</artifactId>
                 <version>${infinispan.version}</version>
-                <classifier>jakarta</classifier>
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>


### PR DESCRIPTION
I'm doing exploratory work upgrading Camel to Infinispan 16.x.

I noticed in Camel Quarkus that `infinispan-core` is misaligned. It seems to be due to `quarkus-bom` using a non-existent `jakarta` classifer for `org.infinispan:infinispan-core`. Hence removing it to restore alignment.