### PR TITLE
Allow to set default value for config options with AsciiDoc attributes

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -115,6 +115,7 @@
         <amqp.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.25</amqp.image>
         <apicurio-registry.image>quay.io/apicurio/apicurio-registry-mem:2.6.13.Final</apicurio-registry.image>
         <narayana-lra.image>quay.io/jbosstm/lra-coordinator:latest</narayana-lra.image>
+        <rabbitmq.image>rabbitmq:3.12-management</rabbitmq.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -114,6 +114,7 @@
         <!-- TODO switch to apache/activemq-artemis to match the artemis version-->
         <amqp.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.25</amqp.image>
         <apicurio-registry.image>quay.io/apicurio/apicurio-registry-mem:2.6.13.Final</apicurio-registry.image>
+        <narayana-lra.image>quay.io/jbosstm/lra-coordinator:latest</narayana-lra.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -115,9 +115,9 @@
         <amqp.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.25</amqp.image>
         <apicurio-registry.image>quay.io/apicurio/apicurio-registry-mem:2.6.13.Final</apicurio-registry.image>
         <narayana-lra.image>quay.io/jbosstm/lra-coordinator:latest</narayana-lra.image>
-        <rabbitmq.image>rabbitmq:3.12-management</rabbitmq.image>
-        <pulsar.image>apachepulsar/pulsar:3.2.4</pulsar.image>
-        <redis.image>redis:7</redis.image>
+        <rabbitmq.image>docker.io/rabbitmq:3.12-management</rabbitmq.image>
+        <pulsar.image>docker.io/apachepulsar/pulsar:3.2.4</pulsar.image>
+        <redis.image>docker.io/redis:7</redis.image>
         <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
 
         <!-- Code Coverage Properties-->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -117,6 +117,7 @@
         <narayana-lra.image>quay.io/jbosstm/lra-coordinator:latest</narayana-lra.image>
         <rabbitmq.image>rabbitmq:3.12-management</rabbitmq.image>
         <pulsar.image>apachepulsar/pulsar:3.2.4</pulsar.image>
+        <redis.image>redis:7</redis.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -118,6 +118,7 @@
         <rabbitmq.image>rabbitmq:3.12-management</rabbitmq.image>
         <pulsar.image>apachepulsar/pulsar:3.2.4</pulsar.image>
         <redis.image>redis:7</redis.image>
+        <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -110,6 +110,10 @@
         <!-- Artemis test dependencies -->
         <artemis.version>2.44.0</artemis.version>
 
+        <!-- Dev Services Images -->
+        <!-- TODO switch to apache/activemq-artemis to match the artemis version-->
+        <amqp.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.25</amqp.image>
+
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -113,6 +113,7 @@
         <!-- Dev Services Images -->
         <!-- TODO switch to apache/activemq-artemis to match the artemis version-->
         <amqp.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.25</amqp.image>
+        <apicurio-registry.image>quay.io/apicurio/apicurio-registry-mem:2.6.13.Final</apicurio-registry.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -116,6 +116,7 @@
         <apicurio-registry.image>quay.io/apicurio/apicurio-registry-mem:2.6.13.Final</apicurio-registry.image>
         <narayana-lra.image>quay.io/jbosstm/lra-coordinator:latest</narayana-lra.image>
         <rabbitmq.image>rabbitmq:3.12-management</rabbitmq.image>
+        <pulsar.image>apachepulsar/pulsar:3.2.4</pulsar.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -85,13 +85,13 @@
         <junit-pioneer.version>2.2.0</junit-pioneer.version>
 
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
-        <postgres.image>docker.io/postgres:17</postgres.image>
-        <mariadb.image>docker.io/mariadb:10.11</mariadb.image>
+        <postgres.image>docker.io/library/postgres:17</postgres.image>
+        <mariadb.image>docker.io/library/mariadb:10.11</mariadb.image>
         <db2.image>icr.io/db2_community/db2:12.1.0.0</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>
-        <mysql.image>docker.io/mysql:8.4</mysql.image>
+        <mysql.image>docker.io/library/mysql:8.4</mysql.image>
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
-        <mongo.image>docker.io/mongo:7.0</mongo.image>
+        <mongo.image>docker.io/library/mongo:7.0</mongo.image>
 
         <!-- Align various dependencies that are not really part of the bom-->
         <junit4.version>4.13.2</junit4.version>
@@ -115,9 +115,9 @@
         <amqp.image>quay.io/artemiscloud/activemq-artemis-broker:1.0.25</amqp.image>
         <apicurio-registry.image>quay.io/apicurio/apicurio-registry-mem:2.6.13.Final</apicurio-registry.image>
         <narayana-lra.image>quay.io/jbosstm/lra-coordinator:latest</narayana-lra.image>
-        <rabbitmq.image>docker.io/rabbitmq:3.12-management</rabbitmq.image>
+        <rabbitmq.image>docker.io/library/rabbitmq:3.12-management</rabbitmq.image>
         <pulsar.image>docker.io/apachepulsar/pulsar:3.2.4</pulsar.image>
-        <redis.image>docker.io/redis:7</redis.image>
+        <redis.image>docker.io/library/redis:7</redis.image>
         <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
 
         <!-- Code Coverage Properties-->

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigProperty.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigProperty.java
@@ -13,6 +13,7 @@ public class DiscoveryConfigProperty {
     private final SourceElementType sourceElementType;
     private final String defaultValue;
     private final String defaultValueForDoc;
+    private final boolean escapeDefaultValueForDoc;
     private final Deprecation deprecation;
     private final String mapKey;
     private final boolean unnamedMapKey;
@@ -24,8 +25,8 @@ public class DiscoveryConfigProperty {
 
     public DiscoveryConfigProperty(String path, String sourceType, String sourceElementName,
             SourceElementType sourceElementType,
-            String defaultValue,
-            String defaultValueForDoc, Deprecation deprecation, String mapKey, boolean unnamedMapKey,
+            String defaultValue, String defaultValueForDoc, boolean escapeDefaultValueForDoc,
+            Deprecation deprecation, String mapKey, boolean unnamedMapKey,
             ResolvedType type, boolean converted, boolean enforceHyphenateEnumValue,
             boolean section, boolean sectionGenerated) {
         this.path = path;
@@ -34,6 +35,7 @@ public class DiscoveryConfigProperty {
         this.sourceElementType = sourceElementType;
         this.defaultValue = defaultValue;
         this.defaultValueForDoc = defaultValueForDoc;
+        this.escapeDefaultValueForDoc = escapeDefaultValueForDoc;
         this.deprecation = deprecation;
         this.mapKey = mapKey;
         this.unnamedMapKey = unnamedMapKey;
@@ -66,6 +68,10 @@ public class DiscoveryConfigProperty {
 
     public String getDefaultValueForDoc() {
         return defaultValueForDoc;
+    }
+
+    public boolean isEscapeDefaultValueForDoc() {
+        return escapeDefaultValueForDoc;
     }
 
     public Deprecation getDeprecation() {
@@ -150,6 +156,7 @@ public class DiscoveryConfigProperty {
         private final ResolvedType type;
         private String defaultValue;
         private String defaultValueForDoc;
+        private boolean escapeDefaultValueForDoc = true;
         private Deprecation deprecation;
         private String mapKey;
         private boolean unnamedMapKey = false;
@@ -177,6 +184,11 @@ public class DiscoveryConfigProperty {
 
         public Builder defaultValueForDoc(String defaultValueForDoc) {
             this.defaultValueForDoc = defaultValueForDoc;
+            return this;
+        }
+
+        public Builder escapeDefaultValueForDoc(boolean escapeDefaultValueForDoc) {
+            this.escapeDefaultValueForDoc = escapeDefaultValueForDoc;
             return this;
         }
 
@@ -220,7 +232,7 @@ public class DiscoveryConfigProperty {
             }
 
             return new DiscoveryConfigProperty(name, sourceType, sourceElementName, sourceElementType, defaultValue,
-                    defaultValueForDoc,
+                    defaultValueForDoc, escapeDefaultValueForDoc,
                     deprecation, mapKey, unnamedMapKey, type, converted, enforceHyphenateEnumValue, section, sectionGenerated);
         }
     }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigProperty.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigProperty.java
@@ -27,6 +27,7 @@ public final class ConfigProperty extends AbstractConfigItem {
     private final EnumAcceptedValues enumAcceptedValues;
 
     private final String defaultValue;
+    private final boolean escapeDefaultValue;
 
     private final String javadocSiteLink;
 
@@ -35,7 +36,7 @@ public final class ConfigProperty extends AbstractConfigItem {
             boolean list, boolean optional, boolean secret,
             String mapKey, boolean unnamedMapKey, boolean withinMap, boolean converted, @JsonProperty("enum") boolean isEnum,
             EnumAcceptedValues enumAcceptedValues,
-            String defaultValue, String javadocSiteLink,
+            String defaultValue, boolean escapeDefaultValue, String javadocSiteLink,
             Deprecation deprecation) {
         super(sourceType, sourceElementName, sourceElementType, path, type, deprecation);
         this.phase = phase;
@@ -52,6 +53,7 @@ public final class ConfigProperty extends AbstractConfigItem {
         this.isEnum = isEnum;
         this.enumAcceptedValues = enumAcceptedValues;
         this.defaultValue = defaultValue;
+        this.escapeDefaultValue = escapeDefaultValue;
         this.javadocSiteLink = javadocSiteLink;
     }
 
@@ -119,6 +121,10 @@ public final class ConfigProperty extends AbstractConfigItem {
 
     public String getDefaultValue() {
         return defaultValue;
+    }
+
+    public boolean isEscapeDefaultValue() {
+        return escapeDefaultValue;
     }
 
     public String getJavadocSiteLink() {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
@@ -213,7 +213,7 @@ public class ConfigResolver {
                     discoveryConfigProperty.isUnnamedMapKey(), context.isWithinMap(),
                     discoveryConfigProperty.isConverted(),
                     discoveryConfigProperty.getType().isEnum(),
-                    enumAcceptedValues, defaultValue,
+                    enumAcceptedValues, defaultValue, discoveryConfigProperty.isEscapeDefaultValueForDoc(),
                     JavadocUtil.getJavadocSiteLink(typeBinaryName),
                     deprecation);
             context.getItemCollection().addItem(configProperty);

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigMappingListener.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigMappingListener.java
@@ -152,8 +152,12 @@ public class ConfigMappingListener implements ConfigAnnotationListener {
 
         AnnotationMirror configDocDefaultAnnotation = methodAnnotations.get(Types.ANNOTATION_CONFIG_DOC_DEFAULT);
         if (configDocDefaultAnnotation != null) {
-            builder.defaultValueForDoc(
-                    configDocDefaultAnnotation.getElementValues().values().iterator().next().getValue().toString());
+            String value = (String) utils.element().getAnnotationValues(configDocDefaultAnnotation).get("value");
+            builder.defaultValueForDoc(value);
+            Boolean escape = (Boolean) utils.element().getAnnotationValues(configDocDefaultAnnotation).get("escape");
+            if (escape != null) {
+                builder.escapeDefaultValueForDoc(escape);
+            }
         }
 
         if (resolvedType.isMap()) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigDocDefault.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigDocDefault.java
@@ -22,4 +22,6 @@ import io.smallrye.config.ConfigMapping;
 public @interface ConfigDocDefault {
 
     String value();
+
+    boolean escape() default true;
 }

--- a/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/AbstractFormatter.java
+++ b/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/AbstractFormatter.java
@@ -252,7 +252,11 @@ abstract class AbstractFormatter implements Formatter {
             }
         }
 
-        return escapeDefaultValue(defaultValue);
+        if (configProperty.isEscapeDefaultValue()) {
+            return escapeDefaultValue(defaultValue);
+        } else {
+            return defaultValue;
+        }
     }
 
     private static String trimFinalDot(String javadoc) {

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -20,6 +20,7 @@
 :kibana-image: ${kibana.image}
 :keycloak-image: ${keycloak.docker.image}
 :amqp-image: ${amqp.image}
+:apicurio-registry-image: ${apicurio-registry.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -23,6 +23,7 @@
 :apicurio-registry-image: ${apicurio-registry.image}
 :narayana-lra-image: ${narayana-lra.image}
 :mongo-image: ${mongo.image}
+:rabbitmq-image: ${rabbitmq.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -18,7 +18,7 @@
 :infinispan-protostream-version: ${infinispan.protostream.version}
 :logstash-image: ${logstash.image}
 :kibana-image: ${kibana.image}
-:keycloak-docker-image: ${keycloak.docker.image}
+:keycloak-image: ${keycloak.docker.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -24,6 +24,7 @@
 :narayana-lra-image: ${narayana-lra.image}
 :mongo-image: ${mongo.image}
 :rabbitmq-image: ${rabbitmq.image}
+:pulsar-image: ${pulsar.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -22,6 +22,7 @@
 :amqp-image: ${amqp.image}
 :apicurio-registry-image: ${apicurio-registry.image}
 :narayana-lra-image: ${narayana-lra.image}
+:mongo-image: ${mongo.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -19,6 +19,7 @@
 :logstash-image: ${logstash.image}
 :kibana-image: ${kibana.image}
 :keycloak-image: ${keycloak.docker.image}
+:amqp-image: ${amqp.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -11,6 +11,11 @@
 :mandrel-flavor: ${mandrel.image-tag-for-documentation}
 :surefire-version: ${version.surefire.plugin}
 :gradle-version: ${gradle-wrapper.version}
+:db2-image: ${db2.image}
+:mariadb-image: ${mariadb.image}
+:mssql-image: ${mssql.image}
+:oracle-image: ${oracle.image}
+:postgres-image: ${postgres.image}
 :elasticsearch-version: ${elasticsearch-server.version}
 :elasticsearch-image: ${elasticsearch.image}
 :opensearch-image: ${opensearch.image}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -25,6 +25,7 @@
 :mongo-image: ${mongo.image}
 :rabbitmq-image: ${rabbitmq.image}
 :pulsar-image: ${pulsar.image}
+:redis-image: ${redis.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -21,6 +21,7 @@
 :keycloak-image: ${keycloak.docker.image}
 :amqp-image: ${amqp.image}
 :apicurio-registry-image: ${apicurio-registry.image}
+:narayana-lra-image: ${narayana-lra.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -26,6 +26,7 @@
 :rabbitmq-image: ${rabbitmq.image}
 :pulsar-image: ${pulsar.image}
 :redis-image: ${redis.image}
+:infinispan-image: ${infinispan.image}
 :jandex-version: ${jandex.version}
 :jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}

--- a/docs/src/main/asciidoc/amqp-dev-services.adoc
+++ b/docs/src/main/asciidoc/amqp-dev-services.adoc
@@ -50,9 +50,9 @@ You can set the port by configuring the `quarkus.amqp.devservices.port` property
 Dev Services for AMQP uses https://quay.io/repository/artemiscloud/activemq-artemis-broker[activemq-artemis-broker] images.
 You can configure the image and version using the `quarkus.amqp.devservices.image-name` property:
 
-[source, properties]
+[source, properties, subs=attributes+]
 ----
-quarkus.amqp.devservices.image-name=quay.io/artemiscloud/activemq-artemis-broker:latest
+quarkus.amqp.devservices.image-name={amqp-image}
 ----
 
 IMPORTANT: The configured image must be _compatible_ with the `activemq-artemis-broker` one.
@@ -65,12 +65,12 @@ The ports 5672 and 8161 (web console) are exposed.
 Dev Services for AMQP supports xref:compose-dev-services.adoc[Compose Dev Services].
 It relies on a `compose-devservices.yml`, such as:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 name: <application name>
 services:
   artemis:
-    image: quay.io/artemiscloud/activemq-artemis-broker:1.0.28
+    image: {amqp-image}
     ports:
       - "5672"
       - "8161"

--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -366,14 +366,14 @@ Open `http://localhost:8080/quotes.html` in your browser and request some quotes
 When not running in dev or test mode, you will need to start your AMQP broker.
 You can follow the instructions from the https://activemq.apache.org/components/artemis/documentation/latest/using-server.html[Apache ActiveMQ Artemis website] or create a `docker-compose.yaml` file with the following content:
 
-[source, yaml]
+[source, yaml ,subs=attributes+]
 ----
 version: '2'
 
 services:
 
   artemis:
-    image: quay.io/artemiscloud/activemq-artemis-broker:1.0.25
+    image: {amqp-image}
     ports:
       - "8161:8161"
       - "61616:61616"

--- a/docs/src/main/asciidoc/apicurio-registry-dev-services.adoc
+++ b/docs/src/main/asciidoc/apicurio-registry-dev-services.adoc
@@ -75,9 +75,9 @@ Note that the Kafka channels in SmallRye Reactive messaging are automatically co
 Dev Services for Apicurio Registry uses `apicurio/apicurio-registry-mem` images.
 You can select any 2.x version from https://hub.docker.com/r/apicurio/apicurio-registry-mem:
 
-[source, properties]
+[source,properties,subs=attributes+]
 ----
-quarkus.apicurio-registry.devservices.image-name=apicurio/apicurio-registry-mem:latest-snapshot
+quarkus.apicurio-registry.devservices.image-name={apicurio-registry-image}
 ----
 
 [[Compose]]
@@ -86,12 +86,12 @@ quarkus.apicurio-registry.devservices.image-name=apicurio/apicurio-registry-mem:
 The Apicurio Dev Services supports xref:compose-dev-services.adoc[Compose Dev Services].
 It relies on a `compose-devservices.yml`, such as:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 name: <application name>
 services:
   apicurio:
-    image: apicurio/apicurio-registry-mem:2.4.2.Final
+    image: {apicurio-registry-image}
     ports:
       - "8080"
 ----

--- a/docs/src/main/asciidoc/compose-dev-services.adoc
+++ b/docs/src/main/asciidoc/compose-dev-services.adoc
@@ -56,11 +56,11 @@ Let's see how to use Compose Dev Services with examples ranging from simple to m
 In a Quarkus project already configured to use the `quarkus-jdbc-postgresql` extension,
 you can create a `compose-devservices.yml` file in the root of the project and define a custom service using Compose:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 services:
   db:
-    image: postgres:17
+    image: {postgres-image}
     healthcheck:
       test: pg_isready -U myuser -d mydb
       interval: 5s
@@ -84,11 +84,11 @@ and the application datasource will be configured by extracting connection infor
 
 For more complex scenarios, you can define custom networks and service dependencies:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 services:
   db:
-    image: postgres:17
+    image: {postgres-image}
     ports:
       - '5432'
     environment:
@@ -101,7 +101,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
 
   cache:
-    image: redis:7
+    image: {redis-image}
     command: redis-server --save 60 1 --loglevel warning
     ports:
       - '6379'
@@ -111,7 +111,7 @@ services:
       - db
 
   message-broker:
-    image: rabbitmq:3-management
+    image: {rabbitmq-image}
     ports:
       - '5672'
       - '15672'
@@ -294,11 +294,11 @@ quarkus.compose.devservices.files=src/main/docker/base-compose.yml,src/main/dock
 With profiles, Compose files can define a set of active profiles so that started services are adjusted for various usages and environments.
 You can specify the profiles to activate by setting the `quarkus.compose.devservices.profiles` property in the `application.properties` file:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 services:
   db:
-    image: postgres:17
+    image: {postgres-image}
     profiles:
       - dev
       - local
@@ -319,11 +319,11 @@ services:
 
 You can configure Compose Dev Services to not discover specific services by adding the `io.quarkus.devservices.compose.ignore` label to the service in your Compose file:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 services:
   db:
-    image: postgres:17
+    image: {postgres-image}
     labels:
       io.quarkus.devservices.compose.ignore: true
     ports:
@@ -345,11 +345,11 @@ Compose Dev Services provides several ways to ensure services are ready before y
 Compose Dev Services respects the health checks defined in your Compose file.
 It's recommended to configure health checks for your services to ensure they are ready before your application tries to use them:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 services:
   db:
-    image: postgres:17
+    image: {postgres-image}
     healthcheck:
       test: pg_isready -U myuser -d mydb
       interval: 5s
@@ -419,11 +419,11 @@ This property sets the maximum time to wait for all Dev Services to start. The d
 Compose Dev Services starts services in the order they are defined in the Compose file.
 If you need to start services in a specific order, you can use the `depends_on` attribute:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 services:
   db:
-    image: postgres:17
+    image: {postgres-image}
     ports:
       - '5432'
     environment:
@@ -444,11 +444,11 @@ services:
 Compose Dev Services automatically exposes the configuration of discovered services to your application.
 For example, when a database service is discovered with the following compose service description:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 services:
   db:
-    image: mysql:17
+    image: {mysql-image}
     ports:
       - '9906:3306'
     labels:

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -55,9 +55,10 @@ By default, Quarkus uses the default image for the current version of Testcontai
 An example file is shown below:
 
 .src/main/resources/container-license-acceptance.txt
+[source,subs=attributes+]
 ----
-ibmcom/db2:11.5.0.0a
-mcr.microsoft.com/mssql/server:2022-latest
+{db2-image}
+{mssql-image}
 ----
 
 === Capturing Logs
@@ -249,14 +250,14 @@ psql -h localhost -p <random port> -U quarkus
 
 The random port can be found with `docker ps`
 
-[source, bash]
+[source, bash, subs=attributes+]
 ----
 docker ps
 
 # returns something like this:
 
 CONTAINER ID   IMAGE           [..]    PORTS                                         [..]
-b826e3a168c4   postgres:14.2   [..]    0.0.0.0:49174->5432/tcp, :::49174->5432/tcp   [..] <1>
+b826e3a168c4   {postgres-image}   [..]    0.0.0.0:49174->5432/tcp, :::49174->5432/tcp   [..] <1>
 ----
 <1> The random port is `49174`.
 
@@ -283,10 +284,10 @@ docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Labels}}\t{{.Ports}}
 
 An example output using Dev Services for PostgreSQL is the following:
 
-[source, bash]
+[source, bash, subs=attributes+]
 ----
 CONTAINER ID   IMAGE          LABELS                                                                        PORTS
-a7034c91a392   postgres:14    org.testcontainers.sessionId=xyz,datasource=default,org.testcontainers=true   0.0.0.0:49154->5432/tcp, :::49154->5432/tcp
+a7034c91a392   {postgres-image}     org.testcontainers.sessionId=xyz,datasource=default,org.testcontainers=true   0.0.0.0:49154->5432/tcp, :::49154->5432/tcp
 ----
 
 In the labels tab, we see that Quarkus added the datasource label, which can be very useful in differentiating containers when multiple
@@ -299,12 +300,12 @@ Dev Services have been started.
 The Database Dev Services supports xref:compose-dev-services.adoc[Compose Dev Services].
 It relies on a `compose-devservices.yml`, such as:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 name: <application name>
 services:
   postgresql:
-    image: docker.io/postgres:17
+    image: {postgres-image}
     ports:
       - "5432"
     environment:
@@ -312,7 +313,7 @@ services:
       POSTGRES_PASSWORD: quarkus
       POSTGRES_DB: quarkus
   oracle:
-    image: docker.io/gvenzl/oracle-free:23-slim-faststart
+    image: {oracle-image}
     ports:
       - "1521"
     environment:
@@ -323,7 +324,7 @@ services:
     labels:
       io.quarkus.devservices.compose.wait_for.logs: .*DATABASE IS READY TO USE.*
   mssql:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: {mssql-image}
     ports:
       - "1433"
     environment:

--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -225,8 +225,9 @@ If you like, use your container tool to see what containers are running.
 For example, if you're using Docker, run `docker ps`, and for podman, run `podman ps`.
 You should see something like the following:
 
+[source,bash,subs=attributes+]
 ----
-ff88dcedd899  docker.io/library/postgres:14  postgres -c fsync...  20 minutes ago  Up 20 minutes  0.0.0.0:34789->5432/tcp  nostalgic_bassi
+ff88dcedd899  {postgres-image}  postgres -c fsync...  20 minutes ago  Up 20 minutes  0.0.0.0:34789->5432/tcp  nostalgic_bassi
 ----
 
 Stop Quarkus and run `docker ps` again.

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -300,12 +300,12 @@ To run the application, don’t forget to start a database and provide the confi
 
 For example, you can use Docker to run your database:
 
-[source, bash]
+[source, bash, subs=attributes+]
 ----
 docker run -it --rm=true \
     --name postgres-quarkus -e POSTGRES_USER=quarkus \
     -e POSTGRES_PASSWORD=quarkus -e POSTGRES_DB=fruits \
-    -p 5432:5432 postgres:14.1
+    -p 5432:5432 {postgres-image}
 ----
 
 Then, launch the application using:

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1392,7 +1392,7 @@ The Testcontainers library usually return connection strings without respecting 
 
 The following example illustrates the use with PostgreSQL, but the approach is applicable to all containers.
 
-[source,java]
+[source,java,subs=attributes+]
 ----
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -1417,7 +1417,7 @@ public class CustomResource implements QuarkusTestResourceLifecycleManager, DevS
     @Override
     public Map<String, String> start() {
         // start a container making sure to call withNetworkMode() with the value of containerNetworkId if present
-        container = new PostgreSQLContainer<>("postgres:latest").withLogConsumer(outputFrame -> {});
+        container = new PostgreSQLContainer<>("{postgres-image}").withLogConsumer(outputFrame -> {});
 
         // apply the network to the container
         containerNetworkId.ifPresent(container::withNetworkMode);

--- a/docs/src/main/asciidoc/infinispan-client.adoc
+++ b/docs/src/main/asciidoc/infinispan-client.adoc
@@ -283,9 +283,9 @@ However, in production, you will run your own Infinispan (or Red Hat Data Grid).
 
 Let's start an Infinispan server on the port 11222 using:
 
-[source, shell]
+[source, shell, subs=attributes+]
 ----
-docker run -it -p 11222:11222 -e USER="admin" -e PASS="password" quay.io/infinispan/server:latest
+docker run -it -p 11222:11222 -e USER="admin" -e PASS="password" {infinispan-image}
 ----
 
 Then, open the `src/main/resources/application.properties` file and add:

--- a/docs/src/main/asciidoc/infinispan-dev-services.adoc
+++ b/docs/src/main/asciidoc/infinispan-dev-services.adoc
@@ -209,12 +209,12 @@ You can disable the sharing with `quarkus.infinispan-client.devservices.shared=f
 Dev Services for Infinispan supports xref:compose-dev-services.adoc[Compose Dev Services].
 It relies on a `compose-devservices.yml`, such as:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 name: test-project
 services:
   infinispan:
-    image: quay.io/infinispan/server:15.0.18.Final
+    image: {infinispan-image}
     ports:
       - '11222'
     environment:

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -81,9 +81,9 @@ implementation("org.amqphub.quarkus:quarkus-qpid-jms")
 Then, we need an AMQP broker. In this case we will use an Apache ActiveMQ Artemis server.
 You can follow the instructions from the https://activemq.apache.org/components/artemis/[Apache Artemis website] or start a broker via docker using the https://artemiscloud.io/[ArtemisCloud] container image:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run -it --rm -p 8161:8161 -p 61616:61616 -p 5672:5672 -e AMQ_USER=quarkus -e AMQ_PASSWORD=quarkus quay.io/artemiscloud/activemq-artemis-broker:1.0.25
+docker run -it --rm -p 8161:8161 -p 61616:61616 -p 5672:5672 -e AMQ_USER=quarkus -e AMQ_PASSWORD=quarkus {amqp-image}
 ----
 
 === The price producer

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -317,7 +317,7 @@ You can ignore the `docker-compose` instructions here, as well as the Apicurio R
 
 Create a `docker-compose.yaml` file at the root of the project with the following content:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 services:
 
@@ -333,7 +333,7 @@ services:
       LOG_DIR: "/tmp/logs"
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:2.6.13.Final
+    image: {apicurio-registry-image}
     ports:
       - 8081:8080
     depends_on:

--- a/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
@@ -345,7 +345,7 @@ You can ignore the `docker-compose` instructions here, as well as the Apicurio R
 
 Create a `docker-compose.yaml` file at the root of the project with the following content:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 services:
 
@@ -361,7 +361,7 @@ services:
       LOG_DIR: "/tmp/logs"
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:2.6.13.Final
+    image: {apicurio-registry-image}
     ports:
       - 8081:8080
     depends_on:

--- a/docs/src/main/asciidoc/lra-dev-services.adoc
+++ b/docs/src/main/asciidoc/lra-dev-services.adoc
@@ -77,12 +77,12 @@ images at https://quay.io/repository/jbosstm/lra-coordinator?tab=tags.
 The LRA Dev Services supports xref:compose-dev-services.adoc[Compose Dev Services].
 It relies on a `compose-devservices.yml`, such as:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 name: <application name>
 services:
-  mongo:
-    image: quay.io/jbosstm/lra-coordinator:7.2.2.Final-3.24.4
+  narayana-lra:
+    image: {narayana-lra-image}
     ports:
       - "8080"
 ----

--- a/docs/src/main/asciidoc/mongodb-dev-services.adoc
+++ b/docs/src/main/asciidoc/mongodb-dev-services.adoc
@@ -4,6 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for MongoDB
+include::_attributes.adoc[]
 
 Quarkus supports a feature called Dev Services that allows you to create various datasources without any config. In the case of MongoDB this support extends to the default MongoDB connection.
 What that means practically, is that if you have not configured `quarkus.mongodb.connection-string` nor `quarkus.mongodb.hosts`, Quarkus will automatically start a MongoDB container when
@@ -35,12 +36,12 @@ You can disable the sharing with `quarkus.mongodb.devservices.shared=false`.
 The MongoDB Dev Services supports xref:compose-dev-services.adoc[Compose Dev Services].
 It relies on a `compose-devservices.yml`, such as:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 name: <application name>
 services:
   mongo:
-    image: docker.io/mongo:7.0
+    image: {mongo-image}
     ports:
       - "27017"
 ----

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -372,9 +372,9 @@ startup time if the Mongo Client is inactive. Alternatively, Mongo Clients may a
 As by default, `MongoClient` is configured to access a local MongoDB database on port 27017 (the default MongoDB port), if you have a local running database on this port, there is nothing more to do before being able to test it!
 
 If you want to use Docker to run a MongoDB database, you can use the following command to launch one:
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run -ti --rm -p 27017:27017 mongo:4.4
+docker run -ti --rm -p 27017:27017 {mongo-image}
 ----
 
 [NOTE]

--- a/docs/src/main/asciidoc/pulsar-getting-started.adoc
+++ b/docs/src/main/asciidoc/pulsar-getting-started.adoc
@@ -398,14 +398,14 @@ Open `http://localhost:8080/quotes.html` in your browser and request some quotes
 When not running in dev or test mode, you will need to start your Pulsar broker.
 You can follow the instructions from the https://pulsar.apache.org/docs/3.0.x/getting-started-docker/[Run a standalone Pulsar cluster in Docker] or create a `docker-compose.yaml` file with the following content:
 
-[source, yaml]
+[source, yaml ,subs=attributes+]
 ----
 version: '3.8'
 
 services:
 
   pulsar:
-    image: apachepulsar/pulsar:3.2.4
+    image: {pulsar-image}
     command: [
       "sh", "-c",
       "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone -nfw -nss"

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -319,7 +319,7 @@ http {
 
 In the root directory, create a `docker-compose.yml` file with the following content:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 version: '3'
 
@@ -337,7 +337,7 @@ services:
       - postgres
 
   nginx: <2>
-    image: nginx:1.17.6
+    image: nginx:latest
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
@@ -347,8 +347,8 @@ services:
     networks:
       - tasks-network
 
-  postgres: <3>
-    image: postgres:14.1
+  db: <3>
+    image: {postgres-image}
     container_name: quarkus_test
     environment:
       - POSTGRES_USER=quarkus_test

--- a/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
@@ -50,9 +50,9 @@ You can set the port by configuring the `quarkus.rabbitmq.devservices.port` prop
 Dev Services for RabbitMQ uses official images available at https://hub.docker.com/_/rabbitmq.
 You can configure the image and version with the `quarkus.rabbitmq.devservices.image-name` property:
 
-[source, properties]
+[source, properties, subs=attributes+]
 ----
-quarkus.rabbitmq.devservices.image-name=rabbitmq:latest
+quarkus.rabbitmq.devservices.image-name={rabbitmq-image}
 ----
 
 == Access the management UI

--- a/docs/src/main/asciidoc/rabbitmq.adoc
+++ b/docs/src/main/asciidoc/rabbitmq.adoc
@@ -419,14 +419,14 @@ Open `http://localhost:8080/quotes.html` in your browser and request some quotes
 When not running in dev or test mode, you will need to start your RabbitMQ broker.
 You can follow the instructions from the https://hub.docker.com/_/rabbitmq[RabbitMQ Docker website] or create a `docker-compose.yaml` file with the following content:
 
-[source, yaml]
+[source, yaml, subs=attributes+]
 ----
 version: '2'
 
 services:
 
   rabbit:
-    image: rabbitmq:3.12-management
+    image: {rabbitmq-image}
     ports:
       - "5672:5672"
     networks:

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -81,9 +81,9 @@ If you start the application in dev mode, Quarkus provides you with a https://qu
 
 You might also start a database up front:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
+docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 {postgres-image}
 ----
 ====
 

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -479,9 +479,9 @@ However, in production, you will run your own Redis (or used a Cloud offering).
 
 Let's start a Redis server on the port 6379 using:
 
-[source, shell]
+[source, shell, subs=attributes+]
 ----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name redis_quarkus_test -p 6379:6379 redis:5.0.6
+docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name redis_quarkus_test -p 6379:6379 {redis-image}
 ----
 
 Then, open the `src/main/resources/application.properties` file and add:

--- a/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
@@ -308,7 +308,7 @@ You can configure it to use plain text or custom passwords.
 * For custom iterations: `BcryptUtil.bcryptHash(password, iterationCount)` where higher iterations (12-14) provide more security but slower performance.
 ====
 
-- For more information about configuring passwords and roles, see xref:configure-the-application[Configure the application]. 
+- For more information about configuring passwords and roles, see xref:configure-the-application[Configure the application].
 - For more information on hashing passwords and available options, see xref:security-jpa.adoc#password-storage-and-hashing[Password storage and hashing].
 
 [NOTE]
@@ -534,11 +534,11 @@ Then, compile and run your application in either JVM or native mode.
 
 === Start the PostgreSQL server
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
 docker run --rm=true --name security-getting-started -e POSTGRES_USER=quarkus \
            -e POSTGRES_PASSWORD=quarkus -e POSTGRES_DB=quarkus \
-           -p 5432:5432 postgres:17
+           -p 5432:5432 {postgres-image}
 ----
 
 === Compile and run the application

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -316,7 +316,7 @@ docker run --name keycloak \
   -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
   -p 8543:8443 \
   -v "$(pwd)"/config/keycloak-keystore.jks:/etc/keycloak-keystore.jks \
-  {keycloak-docker-image} \
+  {keycloak-image} \
   start --hostname-strict=false --https-key-store-file=/etc/keycloak-keystore.jks <1>
 ----
 <1> For Keycloak keystore, use the `keycloak-keystore.jks` file located at https://github.com/quarkusio/quarkus-quickstarts/blob/main/security-keycloak-authorization-quickstart/config/keycloak-keystore.jks[quarkus-quickstarts/security-keycloak-authorization-quickstart/config].

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -233,7 +233,7 @@ For more information, see the <<bearer-token-tutorial-keycloak-dev-mode>> sectio
 ====
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-docker-image} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-image} start-dev
 ----
 ====
 . You can access your Keycloak server at http://localhost:8180[localhost:8180].

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -198,7 +198,7 @@ To start a Keycloak server, use Docker and run the following command:
 
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-docker-image} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-image} start-dev
 ----
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -502,7 +502,7 @@ To start a Keycloak Server, you can use Docker and just run the following comman
 
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-docker-image} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-image} start-dev
 ----
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -247,7 +247,7 @@ For more information, see xref:security-oidc-bearer-token-authentication.adoc#be
 [[keycloak-initialization]]
 === Keycloak initialization
 
-The `{keycloak-docker-image}` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+The `{keycloak-image}` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
 `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name.
 For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
 Be aware that a Quarkus-based Keycloak distribution is only available starting from Keycloak `20.0.0`.

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -343,7 +343,7 @@ To start a Keycloak server, you can use Docker and run the following command:
 
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-docker-image} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 {keycloak-image} start-dev
 ----
 
 Access your Keycloak server at http://localhost:8180[localhost:8180].

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -139,9 +139,9 @@ This configuration assumes that PostgreSQL will be running locally.
 
 A very easy way to accomplish that is by using the following Docker command:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
+docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 {postgres-image}
 ----
 
 If you plan on using a different setup, please change your `application.properties` accordingly.

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -158,9 +158,9 @@ This configuration assumes that PostgreSQL will be running locally.
 
 A very easy way to accomplish that is by using the following Docker command:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
+docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 {postgres-image}
 ----
 
 If you plan on using a different setup, please change your `application.properties` accordingly.

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -26,17 +26,17 @@ public interface DevServicesBuildTimeConfig {
 
     /**
      * The container image name for container-based Dev Service providers.
-     * <p>
+     *
      * This has no effect if the provider is not a container-based database, such as H2 or Derby.
-     * <p>
+     *
      * Defaults depend on the configured `datasource`:
-     * <p>
-     * * DB2: {db2-image}
-     * * MariaDB: {mariadb-image}
-     * * Microsoft SQL Server: {mssql-image}
-     * * MySQL: {mysql-image}
-     * * Oracle Express Edition: {oracle-image}
-     * * PostgreSQL: {postgres-image}
+     *
+     * * DB2: `{db2-image}`
+     * * MariaDB: `{mariadb-image}`
+     * * Microsoft SQL Server: `{mssql-image}`
+     * * MySQL: `{mysql-image}`
+     * * Oracle Express Edition: `{oracle-image}`
+     * * PostgreSQL: `{postgres-image}`
      *
      * @asciidoclet
      */

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -28,6 +28,17 @@ public interface DevServicesBuildTimeConfig {
      * The container image name for container-based Dev Service providers.
      * <p>
      * This has no effect if the provider is not a container-based database, such as H2 or Derby.
+     * <p>
+     * Defaults depend on the configured `datasource`:
+     * <p>
+     * * DB2: {db2-image}
+     * * MariaDB: {mariadb-image}
+     * * Microsoft SQL Server: {mssql-image}
+     * * MySQL: {mysql-image}
+     * * Oracle Express Edition: {oracle-image}
+     * * PostgreSQL: {postgres-image}
+     *
+     * @asciidoclet
      */
     Optional<@WithConverter(TrimmedStringConverter.class) String> imageName();
 

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.configuration.MemorySize;
@@ -40,6 +41,7 @@ public interface KeycloakDevServicesConfig {
      * ends with `-legacy`.
      * Override with `quarkus.keycloak.devservices.keycloak-x-image`.
      */
+    @ConfigDocDefault(value = "`{keycloak-image}`", escape = false)
     Optional<String> imageName();
 
     /**

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
@@ -58,8 +58,8 @@ public interface ElasticsearchCommonBuildTimeConfig {
          *
          * Defaults depend on the configured `distribution`:
          *
-         * * For the `elastic` distribution: {elasticsearch-image}
-         * * For the `opensearch` distribution: {opensearch-image}
+         * * For the `elastic` distribution: `{elasticsearch-image}`
+         * * For the `opensearch` distribution: `{opensearch-image}`
          *
          * @asciidoclet
          */

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -1,9 +1,9 @@
 package io.quarkus.infinispan.client.deployment.devservices;
 
+import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 import static org.infinispan.server.test.core.InfinispanContainer.DEFAULT_USERNAME;
-import static org.infinispan.server.test.core.InfinispanContainer.IMAGE_BASENAME;
 
 import java.io.Closeable;
 import java.time.Duration;
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 
 import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
-import org.infinispan.commons.util.Version;
 import org.infinispan.server.test.core.InfinispanContainer;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.BindMode;
@@ -240,7 +239,8 @@ public class InfinispanDevServiceProcessor {
                 .map(containerAddress -> getRunningDevService(clientName, containerAddress.getId(), null,
                         containerAddress.getUrl(), DEFAULT_USERNAME, DEFAULT_PASSWORD, properties)) // TODO can this be always right ?
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
-                        List.of(devServicesConfig.imageName().orElse(IMAGE_BASENAME), "infinispan", "datagrid"),
+                        List.of(devServicesConfig.imageName().orElseGet(() -> getDefaultImageNameFor("infinispan")),
+                                "infinispan", "datagrid"),
                         DEFAULT_INFINISPAN_PORT, launchMode, useSharedNetwork)
                         .map(address -> getRunningDevService(clientName, address, properties)))
                 .orElseGet(infinispanServerSupplier);
@@ -290,7 +290,7 @@ public class InfinispanDevServiceProcessor {
 
         public QuarkusInfinispanContainer(String clientName, InfinispanDevServicesConfig config,
                 LaunchMode launchMode, String defaultNetworkId, boolean useSharedNetwork) {
-            super(config.imageName().orElse(IMAGE_BASENAME + ":" + Version.getUnbrandedVersion()));
+            super(config.imageName().orElseGet(() -> getDefaultImageNameFor("infinispan")));
             this.fixedExposedPort = config.port();
             this.useSharedNetwork = useSharedNetwork;
             if (launchMode == DEVELOPMENT) {

--- a/extensions/infinispan-client/deployment/src/main/resources/infinispan-devservice.properties
+++ b/extensions/infinispan-client/deployment/src/main/resources/infinispan-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${infinispan.image}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanDevServicesConfig.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanDevServicesConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -70,6 +71,7 @@ public interface InfinispanDevServicesConfig {
      * The image to use.
      * Note that only official Infinispan images are supported.
      */
+    @ConfigDocDefault(value = "`{infinispan-image}`", escape = false)
     Optional<String> imageName();
 
     /**

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesBuildTimeConfig.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.mongodb.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -22,6 +23,7 @@ public interface DevServicesBuildTimeConfig {
     /**
      * The container image name to use, for container based DevServices providers.
      */
+    @ConfigDocDefault(value = "`{mongo-image}`", escape = false)
     Optional<String> imageName();
 
     /**

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/DevServicesLRAProcessor.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/DevServicesLRAProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.narayana.lra.deployment.devservice;
 
+import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 
 import java.util.List;
@@ -63,7 +64,7 @@ public class DevServicesLRAProcessor {
         return lraCoordinatorContainerLocator
                 .locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
                 .or(() -> ComposeLocator.locateContainer(compose,
-                        List.of(config.imageName(), "lra-coordinator"),
+                        List.of(config.imageName().orElseGet(() -> getDefaultImageNameFor("narayana-lra")), "lra-coordinator"),
                         LRA_COORDINATOR_CONTAINER_PORT, launchMode.getLaunchMode(), useSharedNetwork))
                 .map(containerAddress -> DevServicesResultBuildItem.discovered()
                         .feature(Feature.NARAYANA_LRA)
@@ -97,7 +98,8 @@ public class DevServicesLRAProcessor {
 
     private Startable createContainer(DevServicesComposeProjectBuildItem compose,
             LRACoordinatorDevServicesBuildTimeConfig config, boolean useSharedNetwork, LaunchModeBuildItem launchMode) {
-        return new LRACoordinatorContainer(DockerImageName.parse(config.imageName()),
+        return new LRACoordinatorContainer(
+                DockerImageName.parse(config.imageName().orElseGet(() -> getDefaultImageNameFor("narayana-lra"))),
                 config.port().orElse(0),
                 compose.getDefaultNetworkId(),
                 useSharedNetwork)

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/LRACoordinatorDevServicesBuildTimeConfig.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/LRACoordinatorDevServicesBuildTimeConfig.java
@@ -1,8 +1,10 @@
 package io.quarkus.narayana.lra.deployment.devservice;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.smallrye.config.WithDefault;
 
@@ -26,8 +28,8 @@ public interface LRACoordinatorDevServicesBuildTimeConfig {
     /**
      * Optional override of the LRA coordinator container image to use.
      */
-    @WithDefault("quay.io/jbosstm/lra-coordinator:7.2.2.Final-3.25.0")
-    String imageName();
+    @ConfigDocDefault(value = "`{narayana-lra-image}`", escape = false)
+    Optional<String> imageName();
 
     /**
      * Indicates if the LRA coordinator managed by Quarkus Dev Services is shared.

--- a/extensions/narayana-lra/deployment/src/main/resources/narayana-lra-devservice.properties
+++ b/extensions/narayana-lra/deployment/src/main/resources/narayana-lra-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${narayana-lra.image}

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -26,6 +27,7 @@ public interface DevServicesConfig {
      * If you want to use Redis Stack modules (bloom, graph, search...), use:
      * {@code redis/redis-stack:latest}.
      */
+    @ConfigDocDefault(value = "`{redis-image}`", escape = false)
     Optional<String> imageName();
 
     /**

--- a/extensions/redis-client/deployment/src/main/resources/redis-devservice.properties
+++ b/extensions/redis-client/deployment/src/main/resources/redis-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${redis.image}

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryBuildTimeConfig.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryBuildTimeConfig.java
@@ -4,11 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigPhase;
-import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.annotations.*;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
@@ -47,8 +43,8 @@ public interface ApicurioRegistryBuildTimeConfig {
          * Note that only Apicurio Registry 2.x images are supported.
          * Specifically, the image repository must end with {@code apicurio/apicurio-registry-mem}.
          */
-        @WithDefault("quay.io/apicurio/apicurio-registry-mem:2.4.2.Final")
-        String imageName();
+        @ConfigDocDefault(value = "`{apicurio-registry-image}`", escape = false)
+        Optional<String> imageName();
 
         /**
          * Indicates if the Apicurio Registry instance managed by Quarkus Dev Services is shared.

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.apicurio.registry.devservice;
 
+import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 
@@ -234,7 +235,7 @@ public class DevServicesApicurioRegistryProcessor {
 
         public ApicurioRegistryDevServiceCfg(ApicurioRegistryDevServicesBuildTimeConfig config) {
             this.devServicesEnabled = config.enabled().orElse(true);
-            this.imageName = config.imageName();
+            this.imageName = config.imageName().orElseGet(() -> getDefaultImageNameFor("apicurio-registry"));
             this.fixedExposedPort = config.port().orElse(0);
             this.shared = config.shared();
             this.serviceName = config.serviceName();

--- a/extensions/schema-registry/devservice/deployment/src/main/resources/apicurio-registry-devservice.properties
+++ b/extensions/schema-registry/devservice/deployment/src/main/resources/apicurio-registry-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${apicurio-registry.image}

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.reactivemessaging.amqp.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -34,8 +35,8 @@ public interface AmqpDevServicesBuildTimeConfig {
      * page</a>
      * to find the available versions.
      */
-    @WithDefault("quay.io/artemiscloud/activemq-artemis-broker:1.0.25")
-    String imageName();
+    @ConfigDocDefault(value = "`{amqp-image}`", escape = false)
+    Optional<String> imageName();
 
     /**
      * The value of the {@code AMQ_EXTRA_ARGS} environment variable to pass to the container.

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.amqp.deployment;
 
+import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 
@@ -291,7 +292,7 @@ public class AmqpDevServicesProcessor {
 
         public AmqpDevServiceCfg(AmqpDevServicesBuildTimeConfig devServicesConfig) {
             this.devServicesEnabled = devServicesConfig.enabled().orElse(true);
-            this.imageName = devServicesConfig.imageName();
+            this.imageName = devServicesConfig.imageName().orElseGet(() -> getDefaultImageNameFor("amqp"));
             this.fixedExposedPort = devServicesConfig.port().orElse(0);
             this.extra = devServicesConfig.extraArgs();
             this.shared = devServicesConfig.shared();

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/resources/amqp-devservice.properties
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/resources/amqp-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${amqp.image}

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.reactivemessaging.pulsar.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -33,8 +34,8 @@ public interface PulsarDevServicesBuildTimeConfig {
      * Check https://hub.docker.com/r/apachepulsar/pulsar to find the available versions.
      */
     // Alpine-based images starting from 3.3.0 fail to start on aarch64: https://github.com/apache/pulsar/issues/23306
-    @WithDefault("apachepulsar/pulsar:3.2.4")
-    String imageName();
+    @ConfigDocDefault(value = "`{pulsar-image}`", escape = false)
+    Optional<String> imageName();
 
     /**
      * Indicates if the Pulsar broker managed by Quarkus Dev Services is shared.

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.pulsar.deployment;
 
+import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 
@@ -276,7 +277,7 @@ public class PulsarDevServicesProcessor {
 
         public PulsarDevServiceCfg(PulsarDevServicesBuildTimeConfig devServicesConfig) {
             this.devServicesEnabled = devServicesConfig.enabled().orElse(true);
-            this.imageName = devServicesConfig.imageName();
+            this.imageName = devServicesConfig.imageName().orElseGet(() -> getDefaultImageNameFor("pulsar"));
             this.fixedExposedPort = devServicesConfig.port().orElse(0);
             this.shared = devServicesConfig.shared();
             this.serviceName = devServicesConfig.serviceName();

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/resources/pulsar-devservice.properties
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/resources/pulsar-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${pulsar.image}

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -140,8 +141,8 @@ public interface RabbitMQDevServicesBuildTimeConfig {
      * Note that only official RabbitMQ images are supported.
      * Specifically, the image repository must end with {@code rabbitmq}.
      */
-    @WithDefault("rabbitmq:3.12-management")
-    String imageName();
+    @ConfigDocDefault(value = "`{rabbitmq-image}`", escape = false)
+    Optional<String> imageName();
 
     /**
      * Indicates if the RabbitMQ broker managed by Quarkus Dev Services is shared.

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment;
 
+import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 
@@ -371,7 +372,7 @@ public class RabbitMQDevServicesProcessor {
 
         public RabbitMQDevServiceCfg(RabbitMQDevServicesBuildTimeConfig devServicesConfig) {
             this.devServicesEnabled = devServicesConfig.enabled().orElse(true);
-            this.imageName = devServicesConfig.imageName();
+            this.imageName = devServicesConfig.imageName().orElseGet(() -> getDefaultImageNameFor("rabbitmq"));
             this.fixedExposedPort = devServicesConfig.port().orElse(0);
             this.fixedExposedHttpPort = devServicesConfig.httpPort().orElse(0);
             this.shared = devServicesConfig.shared();

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/resources/rabbitmq-devservice.properties
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/resources/rabbitmq-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${rabbitmq.image}

--- a/integration-tests/kafka-avro-apicurio2/src/main/resources/application.properties
+++ b/integration-tests/kafka-avro-apicurio2/src/main/resources/application.properties
@@ -5,4 +5,4 @@ quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 # enable health check
 quarkus.kafka.health.enabled=true
 
-quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.4.2.Final
+quarkus.apicurio-registry.devservices.image-name=${apicurio-registry.image}

--- a/integration-tests/kafka-json-schema-apicurio2/src/main/resources/application.properties
+++ b/integration-tests/kafka-json-schema-apicurio2/src/main/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.native.resources.includes=json-schema.json
 # enable health check
 quarkus.kafka.health.enabled=true
 
-quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.4.2.Final
+quarkus.apicurio-registry.devservices.image-name=${apicurio-registry.image}

--- a/integration-tests/opentelemetry-jdbc-instrumentation/README.md
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/README.md
@@ -25,7 +25,7 @@ You can also run tests with a specific database image, just set the following pa
 For example to run tests with the latest PostgreSQL database image, you can run the following command:
 
 ```
-mvn verify -Dtest-containers -Dstart-containers -Dpostgres.image=docker.io/postgres:latest
+mvn verify -Dtest-containers -Dstart-containers -Dpostgres.image=docker.io/library/postgres:latest
 ```
 
 Unfortunately booting DB2 is slow and needs to set a generous timeout, therefore the DB2 test is disabled by default.

--- a/integration-tests/virtual-threads/jms-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/jms-virtual-threads/src/main/resources/application.properties
@@ -5,4 +5,4 @@ mp.messaging.outgoing.prices-out.destination=prices
 smallrye.messaging.worker.<virtual-thread>.max-concurrency=5
 
 quarkus.artemis.devservices.enabled=true
-quarkus.artemis.devservices.image-name=quay.io/artemiscloud/activemq-artemis-broker:1.0.25
+quarkus.artemis.devservices.image-name=${amqp.image}


### PR DESCRIPTION
Make it possible to use AsciiDoc attributes directly in the `ConfigDocDefault` annotation. This is especially useful to pass Maven properties as AsciiDoc attributes to the config properties as a default value for the documentation.

For example, we now define the `keycloak.docker.image` in a central place, however we lost the default value in the documentation. With this change we can also use AsciiDoc attributes as default value again for the documentation.

This should cover the initial idea from @gsmet, see https://github.com/quarkusio/quarkus/pull/51024#issuecomment-3532565804

Locally this rendered the default value again for the Keycloak Docker image

<img width="1091" height="260" alt="image" src="https://github.com/user-attachments/assets/aeeff2d1-7cb9-494f-8c91-b768328f65dc" />

[DEV SERVICES OVERVIEW](https://quarkus.io/guides/dev-services)

- [x] [Compose Dev Services](https://quarkus.io/guides/compose-dev-services) -> updated most examples ✅ 
- [x] [AMQP](https://quarkus.io/guides/dev-services#amqp) -> done ✅ 
- [x] [Apicurio Registry](https://quarkus.io/guides/dev-services#apicurio-registry) -> done ✅ 
- [x] [Databases](https://quarkus.io/guides/dev-services#databases) -> took the same approach as the different Elasticsearch distributions with `@asciidoclet` ✅ 
- [ ] ~~[Kafka](https://quarkus.io/guides/dev-services#kafka) -> version centrally set in the extension itself for each provider~~
- [x] [Keycloak](https://quarkus.io/guides/dev-services#keycloak) -> done ✅ 
- [ ] ~~[Kubernetes](https://quarkus.io/guides/dev-services#kubernetes) -> N/A - different flavours, so did not change anything here~~
- [x] [LRA](https://quarkus.io/guides/dev-services#lra) -> done ✅ 
- [x] [MongoDB](https://quarkus.io/guides/dev-services#mongodb) -> done ✅ 
- [x] [RabbitMQ](https://quarkus.io/guides/dev-services#rabbitmq) -> done ✅ 
- [x] [Pulsar](https://quarkus.io/guides/dev-services#pulsar) -> done ✅ 
- [x] [Redis](https://quarkus.io/guides/dev-services#redis) -> done ✅ 
- [ ] ~~[Vault](https://quarkus.io/guides/dev-services#vault) -> N/A - Quarkiverse~~
- [x] [Infinispan](https://quarkus.io/guides/dev-services#infinispan) -> done ✅ 
- [x] [Elasticsearch](https://quarkus.io/guides/dev-services#elasticsearch) -> multiple distributions possible, default image per distribution already listed in the JavaDoc with `@asciidoclet` ✅ 
- [ ] ~~[Observability](https://quarkus.io/guides/dev-services#observability) -> version centrally set in the extension itself~~