### PR TITLE
Docs fix: Minor corrections to OpenShift guide based on downstream QE feedback

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -67,6 +67,15 @@ To build and deploy your applications as a container image that runs inside your
 This extension also generates {openshift} resources such as image streams, build configuration, deployment, and service definitions.
 If your application includes the `quarkus-smallrye-health` extension, {openshift} can access the health endpoint and verify the startup, liveness, and readiness of your application.
 
+[IMPORTANT]
+====
+From {project-name} 3.8, the `DeploymentConfig` object, deprecated in OpenShift, is also deprecated in {project-name}.
+`Deployment` is the default and preferred deployment kind for the `quarkus-openshift` extension.
+If you redeploy applications that you deployed before by using `DeploymentConfig`, by default, those applications use `Deployment` but do not remove the previous `DeploymentConfig`.
+This leads to a deployment of both new and old applications, so, you must remove the old `DeploymentConfig` manually.
+However, if you want to continue to use `DeploymentConfig`, it is still possible to do so by explicitly setting `quarkus.openshift.deployment-kind` to `DeploymentConfig`.
+====
+
 .Prerequisites
 
 * You have a Quarkus Maven project.

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -58,7 +58,7 @@ The following table outlines the build strategies that {project-name} supports:
 == Bootstrapping the project
 
 First, you need a new project that contains the OpenShift extension.
-Then, before you build and deploy our application, you must log into an OpenShift cluster.
+Then, before you build and deploy your application, you must log into an OpenShift cluster.
 
 === Adding the OpenShift extension
 
@@ -66,15 +66,6 @@ To build and deploy your applications as a container image that runs inside your
 
 This extension also generates {openshift} resources such as image streams, build configuration, deployment, and service definitions.
 If your application includes the `quarkus-smallrye-health` extension, {openshift} can access the health endpoint and verify the startup, liveness, and readiness of your application.
-
-[IMPORTANT]
-====
-From {project-name} 3.8, the `DeploymentConfig` object, deprecated in OpenShift, is also deprecated in {project-name}.
-`Deployment` is the default and preferred deployment kind for the `quarkus-openshift` extension.
-If you redeploy applications that you deployed before by using `DeploymentConfig`, by default, those applications use `Deployment` but do not remove the previous `DeploymentConfig`.
-This leads to a deployment of both new and old applications, so, you must remove the old `DeploymentConfig` manually.
-However, if you want to continue to use `DeploymentConfig`, it is still possible to do so by explicitly setting `quarkus.openshift.deployment-kind` to `DeploymentConfig`.
-====
 
 .Prerequisites
 
@@ -104,7 +95,7 @@ However, if you want to continue to use `DeploymentConfig`, it is still possible
 +
 [source,bash,subs="+quotes,attributes+"]
 ----
-quarkus extension add 'quarkus-openshift'
+quarkus extension add quarkus-openshift
 ----
 
 == Logging in to an {openshift} cluster


### PR DESCRIPTION
This PR covers correction and minor edits to the Deploy to OpenShift guide based on QE feedback downstream for the products docs for RH and IBM Build of Quarkus 3.27.0

See: https://issues.redhat.com/browse/QUARKUS-6790 
