### PR TITLE
Fix early access of Java CI workflow configuration

### DIFF
--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -43,7 +43,7 @@ jobs:
             github.event_name == 'workflow_dispatch'
             && format( '{{ "include": [{{ "version": "{0}", "dist": "{1}" }}] }}',
                 github.event.inputs.jdkVersion, github.event.inputs.jdkDistribution )
-            || '{ "include": [{ "version": 20, "dist": "jdk.java.net" }, { "version": 21, "dist": "jdk.java.net" }] }'
+            || '{ "include": [{ "version": 26, "dist": "jdk.java.net" }] }'
           )
         }}
     if: github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
JDK 20 and 21 are no more available as early access builds. Based on https://jdk.java.net/.
So removing JDK 20 and 21.
Using only JDK 26. This could be discussed and added to the matrix if needed if wanted to test some of the other early access builds (such as Leyden, Loom or Valhalla)

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

