### PR TITLE
Make podman version detection pattern to be case-insensitive

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
@@ -20,7 +20,7 @@ public final class ContainerRuntimeUtil {
     private static final Logger log = Logger.getLogger(ContainerRuntimeUtil.class);
     private static final String CONTAINER_EXECUTABLE = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
             .getOptionalValue("quarkus.native.container-runtime", String.class).orElse(null);
-    private static final Pattern PODMAN_PATTERN = Pattern.compile("^podman(?:\\.exe)? version.*", Pattern.DOTALL);
+    private static final Pattern PODMAN_PATTERN = Pattern.compile("^podman(?i:\\.exe)? version.*", Pattern.DOTALL);
 
     /**
      * Static variable is not used because the class gets loaded by different classloaders at


### PR DESCRIPTION
- Fixes #51085
- Related https://github.com/smallrye/smallrye-common/pull/503

Currently, `ProcessUtil.pathOfCommand(Path.of("podman"))` returns `C:\Program Files\RedHat\Podman\podman.EXE` instead of `C:\Program Files\RedHat\Podman\podman.exe`. This PR modifies the pattern to be case-insensitive for the `exe` part.

