### PR TITLE
Move `quarkus.http.test-timeout` to `TestConfig`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -12,6 +12,7 @@ import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
 
 /**
@@ -214,6 +215,13 @@ public interface TestConfig {
      * Allowed values are: jar, native
      */
     Optional<String> integrationTestArtifactType();
+
+    /**
+     * The REST Assured client timeout for testing.
+     */
+    @WithDefault("30s")
+    @WithName("http.test-timeout")
+    Duration httpTestTimeout();
 
     interface Profile {
         /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
@@ -1,6 +1,5 @@
 package io.quarkus.vertx.http.runtime;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -68,12 +67,6 @@ public interface VertxHttpBuildTimeConfig {
      */
     @WithDefault("q")
     String nonApplicationRootPath();
-
-    /**
-     * The REST Assured client timeout for testing.
-     */
-    @WithDefault("30s")
-    Duration testTimeout();
 
     /**
      * If enabled then the response body is compressed if the {@code Content-Type} header is set and the value is a compressed


### PR DESCRIPTION
This is done to overcome the false positive that
Quarkus displays when the property is set and
the `quarkus-vertx-http` extension isn't part
of the classpath.

- Closes: #51061