### PR TITLE
Load CLI plugins from a (Maven) project-specific extension catalog instead of the registry-recommended one

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -324,6 +324,13 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
         if (buildTool == null) {
             return () -> null;
         }
+        if (buildTool == BuildTool.MAVEN) {
+            return () -> QuarkusProjectHelper.getQuarkusMavenProject(root, output);
+        }
+        // TODO below is the previous implementation, which basically resolves the latest recommended catalog
+        // instead of the one corresponding to the project configuration.
+        // This is something that's not easy to do for Gradle unless it's done from a Gradle task.
+        // So this functionality should probably move to BuildSystemRunner.
         return () -> {
             try {
                 return registryClient.createQuarkusProject(root, new TargetQuarkusPlatformGroup(), buildTool, output);
@@ -336,7 +343,7 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
     private PluginManager pluginManager(OutputOptionMixin output, Optional<String> testDir, boolean interactiveMode) {
         PluginManagerSettings settings = PluginManagerSettings.defaultSettings()
                 .withInteractivetMode(interactiveMode); // Why not just getting it from output.isClieTest ? Cause args have not been parsed yet.
-        return PluginManager.create(settings, output, Optional.ofNullable(Paths.get(System.getProperty("user.home"))),
+        return PluginManager.create(settings, output, Optional.of(Path.of(System.getProperty("user.home"))),
                 getProjectRoot(testDir), quarkusProject(testDir));
     }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerUtil.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerUtil.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
-import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.registry.catalog.Extension;
 
 public class PluginManagerUtil {
@@ -35,13 +35,13 @@ public class PluginManagerUtil {
     /**
      * Create a {@link Plugin} from the specified location.
      *
-     * @param the location
+     * @param location the location
      * @return the {@link Plugin} that corresponds to the location.
      */
     public Plugin fromLocation(String location) {
         Optional<URL> url = PluginUtil.checkUrl(location);
         Optional<Path> path = PluginUtil.checkPath(location);
-        Optional<GACTV> gactv = PluginUtil.checkGACTV(location);
+        Optional<ArtifactCoords> gactv = PluginUtil.checkArtifactCoords(location);
         String name = getName(gactv, url, path);
         PluginType type = PluginUtil.getType(gactv, url, path);
         return new Plugin(name, type, Optional.of(location), Optional.empty());
@@ -73,7 +73,7 @@ public class PluginManagerUtil {
     public String getName(String location) {
         Optional<URL> url = PluginUtil.checkUrl(location);
         Optional<Path> path = PluginUtil.checkPath(location);
-        Optional<GACTV> gactv = PluginUtil.checkGACTV(location);
+        Optional<ArtifactCoords> gactv = PluginUtil.checkArtifactCoords(location);
         return getName(gactv, url, path);
     }
 
@@ -86,9 +86,9 @@ public class PluginManagerUtil {
      * @param gactv the gactv
      * @return the name.
      */
-    public String getName(Optional<GACTV> gactv, Optional<URL> url, Optional<Path> path) {
+    public String getName(Optional<ArtifactCoords> gactv, Optional<URL> url, Optional<Path> path) {
         String prefix = settings.getPluginPrefix();
-        return gactv.map(GACTV::getArtifactId)
+        return gactv.map(ArtifactCoords::getArtifactId)
                 .or(() -> url.map(URL::getPath).map(s -> s.substring(s.lastIndexOf("/") + 1))
                         .map(s -> s.replaceAll("\\.jar$", "").replaceAll("\\.java$", "")))
                 .or(() -> path.map(Path::getFileName).map(Path::toString)

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginUtil.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginUtil.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
-import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.maven.dependency.ArtifactCoords;
 
 public final class PluginUtil {
 
@@ -36,13 +36,13 @@ public final class PluginUtil {
     /**
      * Get the {@link PluginType} that corresponds the the specified location.
      *
-     * @param the location
+     * @param location the location
      * @return the {@link PluginType} that corresponds to the location.
      */
     public static PluginType getType(String location) {
         Optional<URL> url = checkUrl(location);
         Optional<Path> path = checkPath(location);
-        Optional<GACTV> gactv = checkGACTV(location);
+        Optional<ArtifactCoords> gactv = checkArtifactCoords(location);
         return getType(gactv, url, path);
     }
 
@@ -51,12 +51,12 @@ public final class PluginUtil {
      *
      * @param url the url
      * @param path the path
-     * @param gactv the gactv
+     * @param coords the artifact coordinates
      * @return the {@link PluginType} that corresponds to the location.
      */
-    public static PluginType getType(Optional<GACTV> gactv, Optional<URL> url, Optional<Path> path) {
+    public static PluginType getType(Optional<ArtifactCoords> coords, Optional<URL> url, Optional<Path> path) {
 
-        return gactv.map(i -> PluginType.maven)
+        return coords.map(i -> PluginType.maven)
                 .or(() -> url.map(u -> u.getPath()).or(() -> path.map(Path::toAbsolutePath).map(Path::toString))
                         .filter(f -> f.endsWith(".jar") || f.endsWith(".java")) // java or jar files
                         .map(f -> f.substring(f.lastIndexOf(".") + 1)) // get extension
@@ -84,7 +84,7 @@ public final class PluginUtil {
         if (checkUrl(p.getLocation()).isPresent()) { //We don't want to remove remotely located plugins
             return false;
         }
-        if (checkGACTV(p.getLocation()).isPresent() && p.getType() != PluginType.extension) { //We don't want to remove remotely located plugins
+        if (checkArtifactCoords(p.getLocation()).isPresent() && p.getType() != PluginType.extension) { //We don't want to remove remotely located plugins
             return false;
         }
         if (p.getLocation().map(PluginUtil::isLocalFile).orElse(false)) {
@@ -112,21 +112,21 @@ public final class PluginUtil {
     }
 
     /**
-     * Chekcs if specified {@link String} is a valid {@URL}.
+     * Checks if specified {@link String} is a valid {@link ArtifactCoords}.
      *
      * @param location The string to check
      * @return The {@link URL} wrapped in {@link Optional} if valid, empty otherwise.
      */
-    public static Optional<GACTV> checkGACTV(String location) {
+    public static Optional<ArtifactCoords> checkArtifactCoords(String location) {
         try {
-            return Optional.of(GACTV.fromString(location));
+            return Optional.of(ArtifactCoords.fromString(location));
         } catch (IllegalArgumentException | NullPointerException e) {
             return Optional.empty();
         }
     }
 
-    public static Optional<GACTV> checkGACTV(Optional<String> location) {
-        return location.flatMap(PluginUtil::checkGACTV);
+    public static Optional<ArtifactCoords> checkArtifactCoords(Optional<String> location) {
+        return location.flatMap(PluginUtil::checkArtifactCoords);
     }
 
     /**
@@ -171,7 +171,8 @@ public final class PluginUtil {
      * @return true if location is url or gactv
      */
     public static boolean isRemoteLocation(String location) {
-        return checkUrl(location).isPresent() || checkGACTV(location).isPresent() || checkRemoteCatalog(location).isPresent();
+        return checkUrl(location).isPresent() || checkArtifactCoords(location).isPresent()
+                || checkRemoteCatalog(location).isPresent();
     }
 
     /**

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/QuarkusProjectHelper.java
@@ -55,19 +55,16 @@ public class QuarkusProjectHelper {
                 buildTool = BuildTool.MAVEN;
             }
             if (BuildTool.MAVEN.equals(buildTool)) {
+                cachedProject = getQuarkusMavenProject(projectDir, log);
+            } else {
+                final ExtensionCatalog catalog;
                 try {
-                    return MavenProjectBuildFile.getProject(projectDir, log, null);
-                } catch (RegistryResolutionException e) {
-                    throw new RuntimeException("Failed to initialize the Quarkus Maven extension manager", e);
+                    catalog = resolveExtensionCatalog();
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to resolve the Quarkus extension catalog", e);
                 }
+                cachedProject = getProject(projectDir, catalog, buildTool, JavaVersion.NA, log);
             }
-            final ExtensionCatalog catalog;
-            try {
-                catalog = resolveExtensionCatalog();
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to resolve the Quarkus extension catalog", e);
-            }
-            cachedProject = getProject(projectDir, catalog, buildTool, JavaVersion.NA, log);
         }
 
         return cachedProject;
@@ -118,11 +115,7 @@ public class QuarkusProjectHelper {
 
     public static QuarkusProject getProject(Path projectDir, BuildTool buildTool) {
         if (BuildTool.MAVEN.equals(buildTool)) {
-            try {
-                return MavenProjectBuildFile.getProject(projectDir, messageWriter(), null);
-            } catch (RegistryResolutionException e) {
-                throw new RuntimeException("Failed to initialize the Quarkus Maven extension manager", e);
-            }
+            return getQuarkusMavenProject(projectDir, messageWriter());
         }
         final ExtensionCatalog catalog;
         try {
@@ -132,6 +125,14 @@ public class QuarkusProjectHelper {
         }
 
         return getProject(projectDir, catalog, buildTool, JavaVersion.NA, messageWriter());
+    }
+
+    public static QuarkusProject getQuarkusMavenProject(Path projectDir, MessageWriter log) {
+        try {
+            return MavenProjectBuildFile.getProject(projectDir, log, null);
+        } catch (RegistryResolutionException e) {
+            throw new RuntimeException("Failed to initialize the Quarkus Maven extension manager", e);
+        }
     }
 
     public static QuarkusProject getProject(Path projectDir, ExtensionCatalog catalog, BuildTool buildTool,


### PR DESCRIPTION
This is a Maven-only fix for now. An equivalent fix for Gradle would require calling Gradle, so perhaps this should move to `BuildSystemRunner`.

Fix #51119