### PR TITLE
Fully disable Develocity capture of resource usage

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -4,3 +4,4 @@
 -Daether.remoteRepositoryFilter.prefixes.basedir=${session.rootDirectory}/.mvn/rrf/
 -Daether.remoteRepositoryFilter.groupId=true
 -Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/
+-Ddevelocity.scan.captureResourceUsage=false


### PR DESCRIPTION
This has proven to cause many issues so let's disable it entirely at the Maven level.