### PR TITLE
Update Vert.x version to 4.5.22 in vertx-utils

### DIFF
--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.21</vertx.version>
+        <vertx.version>4.5.22</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Closes #51136 

Follows-up on 0c96108

This `vertx.version` property was the only one not updated in the last bump