### PR TITLE
Bump OTel to 1.59.0 - Use `HttpSender` and `GrpcSender` from upstream OpenTelemetry API

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -29,8 +29,8 @@
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
         <resteasy.version>6.2.15.Final</resteasy.version>
-        <opentelemetry-instrumentation.version>2.23.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.55.0-->
-        <opentelemetry-semconv.version>1.37.0-alpha</opentelemetry-semconv.version>
+        <opentelemetry-instrumentation.version>2.25.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.59.0-->
+        <opentelemetry-semconv.version>1.40.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.4.0</quarkus-http.version>
         <micrometer.version>1.16.3</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->
         <hdrhistogram.version>2.2.2</hdrhistogram.version><!-- keep in sync with micrometer -->

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -85,6 +85,13 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
             allMetrics.add(new MetricToAssert("jvm.network.io", "Network read/write bytes.", "By", HISTOGRAM));
             allMetrics.add(new MetricToAssert("jvm.network.time", "Network read/write duration.", "s", HISTOGRAM));
         }
+        // Recommended sdk metrics
+        allMetrics.add(new MetricToAssert("otel.sdk.span.live",
+                "The number of created spans with recording=true for which the end operation has not been called yet.",
+                "{span}", LONG_SUM));
+        allMetrics.add(new MetricToAssert("otel.sdk.span.started",
+                "The number of created spans.",
+                "{span}", LONG_SUM));
 
         // Force GC to run
         System.gc();

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -1,6 +1,6 @@
 package io.quarkus.opentelemetry.runtime;
 
-import static io.opentelemetry.sdk.internal.ScopeConfiguratorBuilder.nameEquals;
+import static io.opentelemetry.sdk.common.internal.ScopeConfiguratorBuilder.nameEquals;
 import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
@@ -1,6 +1,6 @@
 package io.quarkus.opentelemetry.runtime.exporter.otlp;
 
-import static io.opentelemetry.sdk.internal.StandardComponentId.ExporterType.OTLP_GRPC_METRIC_EXPORTER;
+import static io.opentelemetry.sdk.common.internal.StandardComponentId.ExporterType.OTLP_GRPC_METRIC_EXPORTER;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.HTTP_PROTOBUF;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig.DEFAULT_GRPC_BASE_URI;
@@ -22,14 +22,11 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.ExporterBuilderUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.http.HttpExporter;
-import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
-import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
-import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
-import io.opentelemetry.sdk.internal.ComponentId;
-import io.opentelemetry.sdk.internal.StandardComponentId;
+import io.opentelemetry.sdk.common.internal.ComponentId;
+import io.opentelemetry.sdk.common.internal.StandardComponentId;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -166,7 +163,7 @@ public class OTelExporterRecorder {
 
                 OtlpExporterTracesConfig tracesConfig = exporterRuntimeConfig.traces();
 
-                return new VertxGrpcSpanExporter(new GrpcExporter<TraceRequestMarshaler>(
+                return new VertxGrpcSpanExporter(new GrpcExporter(
                         new VertxGrpcSender(
                                 baseUri,
                                 VertxGrpcSender.GRPC_TRACE_SERVICE_NAME,
@@ -178,7 +175,7 @@ public class OTelExporterRecorder {
                         InternalTelemetryVersion.LATEST,
                         ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_GRPC_SPAN_EXPORTER), // use the same as OTel does
                         MeterProvider::noop,
-                        baseUri.toASCIIString()));
+                        baseUri));
             }
 
             private SpanExporter createHttpSpanExporter(OtlpExporterRuntimeConfig exporterRuntimeConfig, Vertx vertx,
@@ -189,7 +186,7 @@ public class OTelExporterRecorder {
 
                 boolean exportAsJson = false; //TODO: this will be enhanced in the future
 
-                return new VertxHttpSpanExporter(new HttpExporter<TraceRequestMarshaler>(
+                return new VertxHttpSpanExporter(new HttpExporter(
                         ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
                         new VertxHttpSender(
                                 baseUri,
@@ -202,7 +199,8 @@ public class OTelExporterRecorder {
                                 vertx),
                         MeterProvider::noop,
                         InternalTelemetryVersion.LATEST,
-                        baseUri.toASCIIString()));
+                        baseUri,
+                        false));
             }
         };
     }
@@ -233,7 +231,7 @@ public class OTelExporterRecorder {
                     String protocol = metricsConfig.protocol().get();
                     if (GRPC.equals(protocol)) {
                         metricExporter = new VertxGrpcMetricExporter(
-                                new GrpcExporter<MetricsRequestMarshaler>(
+                                new GrpcExporter(
                                         new VertxGrpcSender(
                                                 baseUri,
                                                 VertxGrpcSender.GRPC_METRIC_SERVICE_NAME,
@@ -245,13 +243,13 @@ public class OTelExporterRecorder {
                                         InternalTelemetryVersion.LATEST,
                                         ComponentId.generateLazy(OTLP_GRPC_METRIC_EXPORTER), // use the same as OTel does
                                         MeterProvider::noop,
-                                        baseUri.toASCIIString()),
+                                        baseUri),
                                 aggregationTemporalityResolver(metricsConfig),
                                 aggregationResolver(metricsConfig));
                     } else if (HTTP_PROTOBUF.equals(protocol)) {
                         boolean exportAsJson = false; //TODO: this will be enhanced in the future
                         metricExporter = new VertxHttpMetricsExporter(
-                                new HttpExporter<MetricsRequestMarshaler>(
+                                new HttpExporter(
                                         ComponentId.generateLazy(
                                                 StandardComponentId.ExporterType.OTLP_HTTP_METRIC_EXPORTER),
                                         new VertxHttpSender(
@@ -265,7 +263,8 @@ public class OTelExporterRecorder {
                                                 vertx.get()),
                                         MeterProvider::noop,
                                         InternalTelemetryVersion.LATEST,
-                                        baseUri.toASCIIString()),
+                                        baseUri,
+                                        false),
                                 aggregationTemporalityResolver(metricsConfig),
                                 aggregationResolver(metricsConfig));
                     } else {
@@ -307,7 +306,7 @@ public class OTelExporterRecorder {
                     String protocol = logsConfig.protocol().get();
                     if (GRPC.equals(protocol)) {
                         logRecordExporter = new VertxGrpcLogRecordExporter(
-                                new GrpcExporter<LogsRequestMarshaler>(
+                                new GrpcExporter(
                                         new VertxGrpcSender(
                                                 baseUri,
                                                 VertxGrpcSender.GRPC_LOG_SERVICE_NAME,
@@ -320,11 +319,11 @@ public class OTelExporterRecorder {
                                         ComponentId.generateLazy(
                                                 StandardComponentId.ExporterType.OTLP_GRPC_LOG_EXPORTER), // use the same as OTel does
                                         MeterProvider::noop,
-                                        baseUri.toASCIIString()));
+                                        baseUri));
                     } else if (HTTP_PROTOBUF.equals(protocol)) {
                         boolean exportAsJson = false; //TODO: this will be enhanced in the future
                         logRecordExporter = new VertxHttpLogRecordExporter(
-                                new HttpExporter<LogsRequestMarshaler>(
+                                new HttpExporter(
                                         ComponentId.generateLazy(
                                                 StandardComponentId.ExporterType.OTLP_HTTP_LOG_EXPORTER),
                                         new VertxHttpSender(
@@ -338,7 +337,8 @@ public class OTelExporterRecorder {
                                                 vertx.get()),
                                         MeterProvider::noop,
                                         InternalTelemetryVersion.LATEST,
-                                        baseUri.toASCIIString()));
+                                        baseUri,
+                                        false));
                     } else {
                         throw new IllegalArgumentException(String.format("Unsupported OTLP protocol %s specified. " +
                                 "Please check `quarkus.otel.exporter.otlp.logs.protocol` property", protocol));

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxGrpcLogRecordExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxGrpcLogRecordExporter.java
@@ -9,9 +9,9 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 
 public class VertxGrpcLogRecordExporter implements LogRecordExporter {
-    private final GrpcExporter<LogsRequestMarshaler> delegate;
+    private final GrpcExporter delegate;
 
-    public VertxGrpcLogRecordExporter(GrpcExporter<LogsRequestMarshaler> delegate) {
+    public VertxGrpcLogRecordExporter(GrpcExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxHttpLogRecordExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxHttpLogRecordExporter.java
@@ -9,9 +9,9 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 
 public class VertxHttpLogRecordExporter implements LogRecordExporter {
-    private final HttpExporter<LogsRequestMarshaler> delegate;
+    private final HttpExporter delegate;
 
-    public VertxHttpLogRecordExporter(HttpExporter<LogsRequestMarshaler> delegate) {
+    public VertxHttpLogRecordExporter(HttpExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxGrpcMetricExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxGrpcMetricExporter.java
@@ -16,11 +16,11 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
 public class VertxGrpcMetricExporter implements MetricExporter {
 
-    private final GrpcExporter<MetricsRequestMarshaler> delegate;
+    private final GrpcExporter delegate;
     private final AggregationTemporalitySelector aggregationTemporalitySelector;
     private final DefaultAggregationSelector defaultAggregationSelector;
 
-    public VertxGrpcMetricExporter(GrpcExporter<MetricsRequestMarshaler> grpcExporter,
+    public VertxGrpcMetricExporter(GrpcExporter grpcExporter,
             AggregationTemporalitySelector aggregationTemporalitySelector,
             DefaultAggregationSelector defaultAggregationSelector) {
         this.delegate = grpcExporter;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxHttpMetricsExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxHttpMetricsExporter.java
@@ -16,11 +16,11 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
 public class VertxHttpMetricsExporter implements MetricExporter {
 
-    private final HttpExporter<MetricsRequestMarshaler> delegate;
+    private final HttpExporter delegate;
     private final AggregationTemporalitySelector aggregationTemporalitySelector;
     private final DefaultAggregationSelector defaultAggregationSelector;
 
-    public VertxHttpMetricsExporter(HttpExporter<MetricsRequestMarshaler> delegate,
+    public VertxHttpMetricsExporter(HttpExporter delegate,
             AggregationTemporalitySelector aggregationTemporalitySelector,
             DefaultAggregationSelector defaultAggregationSelector) {
         this.delegate = delegate;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
@@ -17,16 +17,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
-import io.opentelemetry.exporter.internal.grpc.GrpcResponse;
-import io.opentelemetry.exporter.internal.grpc.GrpcSender;
-import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import io.opentelemetry.sdk.common.export.GrpcResponse;
+import io.opentelemetry.sdk.common.export.GrpcSender;
+import io.opentelemetry.sdk.common.export.GrpcStatusCode;
+import io.opentelemetry.sdk.common.export.MessageWriter;
+import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
 import io.quarkus.opentelemetry.runtime.exporter.otlp.OTelExporterUtil;
 import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
@@ -89,15 +92,17 @@ public final class VertxGrpcSender implements GrpcSender {
     }
 
     @Override
-    public void send(Marshaler request, Consumer onSuccess, Consumer onError) {
+    public void send(MessageWriter messageWriter,
+            Consumer<GrpcResponse> onResponse,
+            Consumer<Throwable> onError) {
         if (isShutdown.get()) {
             return;
         }
 
-        final String marshalerType = request.getClass().getSimpleName();
+        final String marshalerType = messageWriter.getClass().getSimpleName();
         var onSuccessHandler = new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled,
-                request,
-                loggedUnimplemented, logger, marshalerType, onSuccess, onError, 1, grpcEndpointPath,
+                messageWriter,
+                loggedUnimplemented, logger, marshalerType, onResponse, onError, 1, grpcEndpointPath,
                 isShutdown::get, exportTimeout);
 
         initiateSend(client, server, MAX_ATTEMPTS, onSuccessHandler, exportTimeout, new Consumer<>() {
@@ -196,11 +201,11 @@ public final class VertxGrpcSender implements GrpcSender {
         private final Map<String, String> headers;
         private final boolean compressionEnabled;
 
-        private final Marshaler marshaler;
+        private final MessageWriter messageWriter;
         private final AtomicBoolean loggedUnimplemented;
         private final ThrottlingLogger logger;
         private final String type;
-        private final Consumer<GrpcResponse> onSuccess;
+        private final Consumer<GrpcResponse> onResponse;
         private final Consumer<Throwable> onError;
         private final String grpcEndpointPath;
 
@@ -212,11 +217,11 @@ public final class VertxGrpcSender implements GrpcSender {
                 SocketAddress server,
                 Map<String, String> headers,
                 boolean compressionEnabled,
-                Marshaler marshaler,
+                MessageWriter messageWriter,
                 AtomicBoolean loggedUnimplemented,
                 ThrottlingLogger logger,
                 String type,
-                Consumer<GrpcResponse> onSuccess,
+                Consumer<GrpcResponse> onResponse,
                 Consumer<Throwable> onError,
                 int attemptNumber,
                 String grpcEndpointPath,
@@ -227,11 +232,11 @@ public final class VertxGrpcSender implements GrpcSender {
             this.grpcEndpointPath = grpcEndpointPath;
             this.headers = headers;
             this.compressionEnabled = compressionEnabled;
-            this.marshaler = marshaler;
+            this.messageWriter = messageWriter;
             this.loggedUnimplemented = loggedUnimplemented;
             this.logger = logger;
             this.type = type;
-            this.onSuccess = onSuccess;
+            this.onResponse = onResponse;
             this.onError = onError;
             this.attemptNumber = attemptNumber;
             this.isShutdown = isShutdown;
@@ -256,10 +261,10 @@ public final class VertxGrpcSender implements GrpcSender {
             }
 
             try {
-                int messageSize = marshaler.getBinarySerializedSize();
+                int messageSize = messageWriter.getContentLength();
                 Buffer buffer = Buffer.buffer(messageSize);
                 var os = new BufferOutputStream(buffer);
-                marshaler.writeBinaryTo(os);
+                messageWriter.writeMessage(os);
                 request.send(buffer).onSuccess(new Handler<>() {
                     @Override
                     public void handle(GrpcClientResponse<Buffer, Buffer> response) {
@@ -292,7 +297,44 @@ public final class VertxGrpcSender implements GrpcSender {
                             public void handle(Void ignored) {
                                 GrpcStatus status = getStatus(response);
                                 if (status == GrpcStatus.OK) {
-                                    onSuccess.accept(GrpcResponse.create(status.code, status.toString()));
+                                    // onResponse.accept(GrpcResponse.create(status.code, status.toString()));
+                                    onResponse.accept(new GrpcResponse() {
+                                        @Override
+                                        public GrpcStatusCode getStatusCode() {
+                                            return GrpcStatusCode.fromValue(status.code);
+                                        }
+
+                                        @Override
+                                        public String getStatusDescription() {
+                                            return status.name();
+                                        }
+
+                                        @Override
+                                        public byte[] getResponseMessage() {
+                                            if (response == null) {
+                                                return null;
+                                            }
+                                            Promise<String> promise = Promise.promise();
+                                            StringBuilder sb = new StringBuilder();
+                                            response.handler(msg -> {
+                                                sb.append(msg.toString());
+                                            });
+                                            response.endHandler(v -> {
+                                                // Done reading stream
+                                                promise.complete(sb.toString());
+                                            });
+                                            response.exceptionHandler(promise::fail);
+                                            String result = promise.future()
+                                                    .timeout(exportTimeout.toMillis(), MILLISECONDS)
+                                                    .recover(throwable -> Future.succeededFuture(
+                                                            "Response error: " + throwable.getMessage()))
+                                                    .result();
+                                            if (result == null || result.isEmpty()) {
+                                                return null;
+                                            }
+                                            return result.getBytes(StandardCharsets.UTF_8);
+                                        }
+                                    });
                                 } else {
                                     handleError(status, response);
                                 }
@@ -448,8 +490,8 @@ public final class VertxGrpcSender implements GrpcSender {
         }
 
         public ClientRequestOnSuccessHandler newAttempt() {
-            return new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled, marshaler,
-                    loggedUnimplemented, logger, type, onSuccess, onError, attemptNumber + 1,
+            return new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled, messageWriter,
+                    loggedUnimplemented, logger, type, onResponse, onError, attemptNumber + 1,
                     grpcEndpointPath, isShutdown, exportTimeout);
         }
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -18,10 +18,11 @@ import java.util.zip.GZIPOutputStream;
 
 import org.jboss.logging.Logger;
 
-import io.opentelemetry.exporter.internal.http.HttpSender;
-import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import io.opentelemetry.sdk.common.export.HttpResponse;
+import io.opentelemetry.sdk.common.export.HttpSender;
+import io.opentelemetry.sdk.common.export.MessageWriter;
+import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
 import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
@@ -107,24 +108,23 @@ public final class VertxHttpSender implements HttpSender {
     }
 
     @Override
-    public void send(Marshaler marshaler,
-            int contentLength,
-            Consumer<Response> onHttpResponseRead,
+    public void send(MessageWriter requestBodyWriter,
+            Consumer<HttpResponse> onHttpResponseRead,
             Consumer<Throwable> onError) {
         if (isShutdown.get()) {
             return;
         }
 
-        String marshalerType = marshaler.getClass().getSimpleName();
+        String writerType = requestBodyWriter.getClass().getSimpleName();
         String requestURI = basePath + signalPath;
         var clientRequestSuccessHandler = new ClientRequestSuccessHandler(client, requestURI, headers, compressionEnabled,
                 contentType,
-                contentLength, onHttpResponseRead,
-                onError, marshaler, 1, isShutdown::get);
+                onHttpResponseRead,
+                onError, requestBodyWriter, 1, isShutdown::get);
         initiateSend(client, requestURI, MAX_ATTEMPTS, clientRequestSuccessHandler, new Consumer<>() {
             @Override
             public void accept(Throwable throwable) {
-                failOnClientRequest(marshalerType, throwable, onError);
+                failOnClientRequest(writerType, throwable, onError);
             }
         });
     }
@@ -214,10 +214,9 @@ public final class VertxHttpSender implements HttpSender {
         private final Map<String, String> headers;
         private final boolean compressionEnabled;
         private final String contentType;
-        private final int contentLength;
-        private final Consumer<Response> onHttpResponseRead;
+        private final Consumer<HttpResponse> onHttpResponseRead;
         private final Consumer<Throwable> onError;
-        private final Marshaler marshaler;
+        private final MessageWriter requestBodyWriter;
 
         private final int attemptNumber;
         private final Supplier<Boolean> isShutdown;
@@ -226,10 +225,9 @@ public final class VertxHttpSender implements HttpSender {
                 String requestURI, Map<String, String> headers,
                 boolean compressionEnabled,
                 String contentType,
-                int contentLength,
-                Consumer<Response> onHttpResponseRead,
+                Consumer<HttpResponse> onHttpResponseRead,
                 Consumer<Throwable> onError,
-                Marshaler marshaler,
+                MessageWriter requestBodyWriter,
                 int attemptNumber,
                 Supplier<Boolean> isShutdown) {
             this.client = client;
@@ -237,10 +235,9 @@ public final class VertxHttpSender implements HttpSender {
             this.headers = headers;
             this.compressionEnabled = compressionEnabled;
             this.contentType = contentType;
-            this.contentLength = contentLength;
             this.onHttpResponseRead = onHttpResponseRead;
             this.onError = onError;
-            this.marshaler = marshaler;
+            this.requestBodyWriter = requestBodyWriter;
             this.attemptNumber = attemptNumber;
             this.isShutdown = isShutdown;
         }
@@ -268,19 +265,19 @@ public final class VertxHttpSender implements HttpSender {
                                             return;
                                         }
                                     }
-                                    onHttpResponseRead.accept(new Response() {
+                                    onHttpResponseRead.accept(new HttpResponse() {
                                         @Override
-                                        public int statusCode() {
+                                        public int getStatusCode() {
                                             return clientResponse.statusCode();
                                         }
 
                                         @Override
-                                        public String statusMessage() {
+                                        public String getStatusMessage() {
                                             return clientResponse.statusMessage();
                                         }
 
                                         @Override
-                                        public byte[] responseBody() {
+                                        public byte[] getResponseBody() {
                                             return bodyResult.result().getBytes();
                                         }
                                     });
@@ -312,18 +309,18 @@ public final class VertxHttpSender implements HttpSender {
             })
                     .putHeader("Content-Type", contentType);
 
-            Buffer buffer = Buffer.buffer(contentLength);
+            Buffer buffer = Buffer.buffer(requestBodyWriter.getContentLength());
             OutputStream os = new BufferOutputStream(buffer);
             if (compressionEnabled) {
                 clientRequest.putHeader("Content-Encoding", "gzip");
                 try (var gzos = new GZIPOutputStream(os)) {
-                    marshaler.writeBinaryTo(gzos);
+                    requestBodyWriter.writeMessage(gzos);
                 } catch (IOException e) {
                     throw new IllegalStateException(e);
                 }
             } else {
                 try {
-                    marshaler.writeBinaryTo(os);
+                    requestBodyWriter.writeMessage(os);
                 } catch (IOException e) {
                     throw new IllegalStateException(e);
                 }
@@ -340,8 +337,8 @@ public final class VertxHttpSender implements HttpSender {
 
         public ClientRequestSuccessHandler newAttempt() {
             return new ClientRequestSuccessHandler(client, requestURI, headers, compressionEnabled,
-                    contentType, contentLength, onHttpResponseRead,
-                    onError, marshaler, attemptNumber + 1, isShutdown);
+                    contentType, onHttpResponseRead,
+                    onError, requestBodyWriter, attemptNumber + 1, isShutdown);
         }
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxGrpcSpanExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxGrpcSpanExporter.java
@@ -10,9 +10,9 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public final class VertxGrpcSpanExporter implements SpanExporter {
 
-    private final GrpcExporter<TraceRequestMarshaler> delegate;
+    private final GrpcExporter delegate;
 
-    public VertxGrpcSpanExporter(GrpcExporter<TraceRequestMarshaler> delegate) {
+    public VertxGrpcSpanExporter(GrpcExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxHttpSpanExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxHttpSpanExporter.java
@@ -10,9 +10,9 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public final class VertxHttpSpanExporter implements SpanExporter {
 
-    private final HttpExporter<TraceRequestMarshaler> delegate;
+    private final HttpExporter delegate;
 
-    public VertxHttpSpanExporter(HttpExporter<TraceRequestMarshaler> delegate) {
+    public VertxHttpSpanExporter(HttpExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/RandomSupplier.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/RandomSupplier.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "io.opentelemetry.sdk.internal.RandomSupplier")
+@TargetClass(className = "io.opentelemetry.sdk.common.internal.RandomSupplier")
 final class RandomSupplier {
 
     @Substitute

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcAttributesGetter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcAttributesGetter.java
@@ -1,8 +1,9 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.grpc;
 
+import io.grpc.Status;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcAttributesGetter;
 
-enum GrpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
+enum GrpcAttributesGetter implements RpcAttributesGetter<GrpcRequest, Status> {
     INSTANCE;
 
     @Override
@@ -15,8 +16,20 @@ enum GrpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
         return grpcRequest.getMethodDescriptor().getServiceName();
     }
 
+    /**
+     * Marked as Deprecated upstream
+     *
+     * @param grpcRequest
+     * @return
+     */
+    @Deprecated
     @Override
     public String getMethod(final GrpcRequest grpcRequest) {
+        return grpcRequest.getMethodDescriptor().getBareMethodName();
+    }
+
+    @Override
+    public String getRpcMethod(final GrpcRequest grpcRequest) {
         return grpcRequest.getMethodDescriptor().getBareMethodName();
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
@@ -181,7 +181,7 @@ public class RedisClientInstrumenterVertxTracer implements
         }
 
         @Override
-        public String getDbSystem(final CommandTrace commandTrace) {
+        public String getDbSystemName(final CommandTrace commandTrace) {
             return REDIS;
         }
 
@@ -194,7 +194,7 @@ public class RedisClientInstrumenterVertxTracer implements
 
         @Override
         public String getDbNamespace(CommandTrace commandTrace) {
-            return null;
+            return commandTrace.dbIndex();
         }
 
         // kept for compatibility reasons

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
@@ -152,7 +152,7 @@ public class SqlClientInstrumenterVertxTracer implements
         }
 
         @Override
-        public String getDbSystem(final QueryTrace queryTrace) {
+        public String getDbSystemName(final QueryTrace queryTrace) {
             return queryTrace.system();
         }
 

--- a/integration-tests/opentelemetry-redis-instrumentation/src/test/java/io/quarkus/it/opentelemetry/QuarkusOpenTelemetryRedisTest.java
+++ b/integration-tests/opentelemetry-redis-instrumentation/src/test/java/io/quarkus/it/opentelemetry/QuarkusOpenTelemetryRedisTest.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.opentelemetry;
 
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
@@ -60,8 +60,8 @@ class QuarkusOpenTelemetryRedisTest {
     @Test
     public void syncValidOperation() {
         String path = String.format("redis/sync/%s", getKey(SYNC_KEY));
-        String getCommand = Command.GET.toString();
-        String setCommand = Command.SET.toString();
+        String getCommand = Command.GET.toString() + " 0";
+        String setCommand = Command.SET.toString() + " 0";
 
         RestAssured.given()
                 .body(SYNC_VALUE)
@@ -91,7 +91,7 @@ class QuarkusOpenTelemetryRedisTest {
 
         // SET
         assertEquals(setCommand, setSpan.get("name"));
-        assertEquals(setCommand, setAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("set", setAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, setAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", setAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -101,7 +101,7 @@ class QuarkusOpenTelemetryRedisTest {
         assertEquals(16379, setAttributes.get(NETWORK_LOCAL_PORT.getKey()));
         // GET
         assertEquals(getCommand, getSpan.get("name"));
-        assertEquals(getCommand, getAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("get", getAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, getAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", setAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -127,7 +127,7 @@ class QuarkusOpenTelemetryRedisTest {
         Map<String, Object> event = ((List<Map<String, Object>>) span.get("events")).get(0);
         Map<String, Object> exception = (Map<String, Object>) event.get("exception");
 
-        assertEquals("bazinga", span.get("name"));
+        assertEquals("bazinga 0", span.get("name"));
         assertEquals("ERROR", status.get("statusCode"));
         assertEquals("exception", event.get("name"));
 
@@ -142,8 +142,8 @@ class QuarkusOpenTelemetryRedisTest {
     @Test
     public void reactiveValidOperation() {
         String path = String.format("redis/reactive/%s", getKey(REACTIVE_KEY));
-        String getCommand = Command.GET.toString();
-        String setCommand = Command.SET.toString();
+        String getCommand = Command.GET.toString() + " 0";
+        String setCommand = Command.SET.toString() + " 0";
 
         RestAssured.given()
                 .body(REACTIVE_VALUE)
@@ -173,7 +173,7 @@ class QuarkusOpenTelemetryRedisTest {
 
         // SET
         assertEquals(setCommand, setSpan.get("name"));
-        assertEquals(setCommand, setAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("set", setAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, setAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", setAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -183,7 +183,7 @@ class QuarkusOpenTelemetryRedisTest {
         assertEquals(16379, setAttributes.get(NETWORK_LOCAL_PORT.getKey()));
         // GET
         assertEquals(getCommand, getSpan.get("name"));
-        assertEquals(getCommand, getAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("get", getAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, getAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", getAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -209,7 +209,7 @@ class QuarkusOpenTelemetryRedisTest {
         Map<String, Object> event = ((List<Map<String, Object>>) span.get("events")).get(0);
         Map<String, Object> exception = (Map<String, Object>) event.get("exception");
 
-        assertEquals("bazinga", span.get("name"));
+        assertEquals("bazinga 0", span.get("name"));
         assertEquals("ERROR", status.get("statusCode"));
         assertEquals("exception", event.get("name"));
 


### PR DESCRIPTION
Use HttpSender and GrpcSender from upstream OpenTelemetry API implemented here: https://github.com/open-telemetry/opentelemetry-java/pull/7782

The API has become public in release of OTel SDK 1.59 and we implement the transition with this PR.

This PR includes upgrade to:
OTel SDK -> 1.59
OTel Instrumentation -> 2.25.0-alpha
Semantic conventions -> 1.40.0-alpha

**Breaking Changes:**
- REDIS span name now follows recommended name format: {db.operation.name} {target}. See: https://opentelemetry.io/docs/specs/semconv/db/database-spans/#name

New features:
- "otel.sdk.span.live" metric: The number of created spans with recording=true for which the end operation has not been called yet.
- "otel.sdk.span.started": Counter for the number of created spans.