### PR TITLE
Allow to keep JWT audience trailing slash

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -261,6 +261,7 @@ https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[Stand
 
 |quarkus.oidc.credentials.jwt.token-key-id ||The token key id (`kid`) header value
 |quarkus.oidc.credentials.jwt.audience |OIDC token endpoint address|Audience (`aud`) claim value
+|quarkus.oidc.credentials.jwt.keep-audience-trailing-slash |false|Whether to keep a trailing slash in the audience value
 |quarkus.oidc.credentials.jwt.issuer |OIDC client id|Issuer (`iss`) claim value
 |quarkus.oidc.credentials.jwt.subject |OIDC client id|Subject (`sub`) cliam value
 |quarkus.oidc.credentials.jwt.lifespan |10 seconds|Lifespan added to the `issued at` (`iat`) claim value to calculate the expiry (`exp`) claim value
@@ -269,6 +270,7 @@ https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[Stand
 
 `quarkus.oidc.credentials.jwt.token-key-id` can be used to set a key identifier (`kid`) header value to help the OIDC provider with fidning a token verification key.
 All other properties listed in the table above can be used to customize JWT claim values.
+
 
 ==== JWT Bearer
 

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
@@ -91,6 +91,7 @@ final class OidcClientConfigImpl implements OidcClientConfig {
         CREDENTIALS_JWT_LIFESPAN,
         CREDENTIALS_JWT_ASSERTION,
         CREDENTIALS_JWT_AUDIENCE,
+        CREDENTIALS_JWT_KEEP_AUDIENCE_TRAILING_SLASH,
         CREDENTIALS_JWT_TOKEN_ID,
         JWT_BEARER_TOKEN_PATH,
         REFRESH_INTERVAL
@@ -263,6 +264,12 @@ final class OidcClientConfigImpl implements OidcClientConfig {
                     public Optional<String> audience() {
                         invocationsRecorder.put(ConfigMappingMethods.CREDENTIALS_JWT_AUDIENCE, true);
                         return Optional.empty();
+                    }
+
+                    @Override
+                    public boolean keepAudienceTrailingSlash() {
+                        invocationsRecorder.put(ConfigMappingMethods.CREDENTIALS_JWT_KEEP_AUDIENCE_TRAILING_SLASH, true);
+                        return false;
                     }
 
                     @Override

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -331,6 +331,11 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
             }
 
             @Override
+            public boolean keepAudienceTrailingSlash() {
+                return keepAudienceTrailingSlash;
+            }
+
+            @Override
             public Optional<String> tokenKeyId() {
                 return tokenKeyId;
             }
@@ -433,6 +438,11 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
              * By default, the audience is set to the address of the OpenId Connect Provider's token endpoint.
              */
             public Optional<String> audience = Optional.empty();
+
+            /**
+             * Whether to keep a trailing slash `/` in the {@link #audience()} value.
+             */
+            public boolean keepAudienceTrailingSlash = false;
 
             /**
              * The key identifier of the signing key added as a JWT `kid` header.
@@ -575,6 +585,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
                 keyId = mapping.keyId();
                 keyPassword = mapping.keyPassword();
                 audience = mapping.audience();
+                keepAudienceTrailingSlash = mapping.keepAudienceTrailingSlash();
                 tokenKeyId = mapping.tokenKeyId();
                 issuer = mapping.issuer();
                 subject = mapping.subject();

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -246,6 +246,10 @@ public class OidcCommonUtils {
         return removeLastPathSeparator(oidcConfig.authServerUrl().get());
     }
 
+    private static String removeAudienceTrailingSlash(Credentials.Jwt jwtConfig, String value) {
+        return !jwtConfig.keepAudienceTrailingSlash() ? removeLastPathSeparator(value) : value;
+    }
+
     private static String removeLastPathSeparator(String value) {
         return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
     }
@@ -436,7 +440,8 @@ public class OidcCommonUtils {
                 .issuer(oidcConfig.credentials().jwt().issuer().orElse(oidcConfig.clientId().get()))
                 .subject(oidcConfig.credentials().jwt().subject().orElse(oidcConfig.clientId().get()))
                 .audience(oidcConfig.credentials().jwt().audience().isPresent()
-                        ? removeLastPathSeparator(oidcConfig.credentials().jwt().audience().get())
+                        ? removeAudienceTrailingSlash(oidcConfig.credentials().jwt(),
+                                oidcConfig.credentials().jwt().audience().get())
                         : tokenRequestUri)
                 .expiresIn(oidcConfig.credentials().jwt().lifespan()).jws();
         if (oidcConfig.credentials().jwt().tokenKeyId().isPresent()) {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
@@ -210,6 +210,12 @@ public interface OidcClientCommonConfig extends OidcCommonConfig {
             Optional<String> audience();
 
             /**
+             * Whether to keep a trailing slash `/` in the {@link #audience()} value.
+             */
+            @WithDefault("false")
+            boolean keepAudienceTrailingSlash();
+
+            /**
              * The key identifier of the signing key added as a JWT `kid` header.
              */
             Optional<String> tokenKeyId();

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfigBuilder.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfigBuilder.java
@@ -484,8 +484,9 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
 
         private record JwtImpl(Source source, Optional<String> secret, Provider secretProvider, Optional<String> key,
                 Optional<String> keyFile, Optional<String> keyStoreFile, Optional<String> keyStorePassword,
-                Optional<String> keyId, Optional<String> keyPassword, Optional<String> audience, Optional<String> tokenKeyId,
-                Optional<String> issuer, Optional<String> subject, Map<String, String> claims,
+                Optional<String> keyId, Optional<String> keyPassword, Optional<String> audience,
+                boolean keepAudienceTrailingSlash,
+                Optional<String> tokenKeyId, Optional<String> issuer, Optional<String> subject, Map<String, String> claims,
                 Optional<String> signatureAlgorithm, int lifespan, boolean assertion,
                 Optional<Path> tokenPath) implements Jwt {
 
@@ -503,6 +504,7 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
         private Optional<String> keyId;
         private Optional<String> keyPassword;
         private Optional<String> audience;
+        private boolean keepAudienceTrailingSlash;
         private Optional<String> tokenKeyId;
         private Optional<String> issuer;
         private Optional<String> subject;
@@ -523,6 +525,7 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
             this.keyId = Optional.empty();
             this.keyPassword = Optional.empty();
             this.audience = Optional.empty();
+            this.keepAudienceTrailingSlash = false;
             this.tokenKeyId = Optional.empty();
             this.issuer = Optional.empty();
             this.subject = Optional.empty();
@@ -548,6 +551,7 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
             this.keyId = jwt.keyId();
             this.keyPassword = jwt.keyPassword();
             this.audience = jwt.audience();
+            this.keepAudienceTrailingSlash = jwt.keepAudienceTrailingSlash();
             this.tokenKeyId = jwt.tokenKeyId();
             this.issuer = jwt.issuer();
             this.subject = jwt.subject();
@@ -667,6 +671,23 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
         }
 
         /**
+         * @param keepAudienceTrailingSlash {@link Jwt#keepAudienceTrailingSlash()}
+         * @return this builder
+         */
+        public JwtBuilder<T> keepAudienceTrailingSlash() {
+            return keepAudienceTrailingSlash(true);
+        }
+
+        /**
+         * @param keepAudienceTrailingSlash {@link Jwt#keepAudienceTrailingSlash()}
+         * @return this builder
+         */
+        public JwtBuilder<T> keepAudienceTrailingSlash(boolean keepAudienceTrailingSlash) {
+            this.keepAudienceTrailingSlash = keepAudienceTrailingSlash;
+            return this;
+        }
+
+        /**
          * @param tokenKeyId {@link Jwt#tokenKeyId()}
          * @return this builder
          */
@@ -768,7 +789,8 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
          */
         public Jwt build() {
             return new JwtImpl(source, secret, secretProvider, key, keyFile, keyStoreFile, keyStorePassword, keyId, keyPassword,
-                    audience, tokenKeyId, issuer, subject, Map.copyOf(claims), signatureAlgorithm, lifespan, assertion,
+                    audience, keepAudienceTrailingSlash, tokenKeyId, issuer, subject, Map.copyOf(claims), signatureAlgorithm,
+                    lifespan, assertion,
                     tokenPath);
         }
     }

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfigBuilderTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfigBuilderTest.java
@@ -42,6 +42,7 @@ public class OidcClientCommonConfigBuilderTest {
         assertTrue(jwt.keyId().isEmpty());
         assertTrue(jwt.keyPassword().isEmpty());
         assertTrue(jwt.audience().isEmpty());
+        assertFalse(jwt.keepAudienceTrailingSlash());
         assertTrue(jwt.tokenKeyId().isEmpty());
         assertTrue(jwt.issuer().isEmpty());
         assertTrue(jwt.subject().isEmpty());

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -86,6 +86,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         CREDENTIALS_JWT_LIFESPAN,
         CREDENTIALS_JWT_ASSERTION,
         CREDENTIALS_JWT_AUDIENCE,
+        CREDENTIALS_JWT_KEEP_AUDIENCE_TRAILING_SLASH,
         CREDENTIALS_JWT_TOKEN_ID,
         PROVIDER,
         JWKS,
@@ -1119,6 +1120,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
                     public Optional<String> audience() {
                         invocationsRecorder.put(ConfigMappingMethods.CREDENTIALS_JWT_AUDIENCE, true);
                         return Optional.empty();
+                    }
+
+                    @Override
+                    public boolean keepAudienceTrailingSlash() {
+                        invocationsRecorder.put(ConfigMappingMethods.CREDENTIALS_JWT_KEEP_AUDIENCE_TRAILING_SLASH, true);
+                        return false;
                     }
 
                     @Override


### PR DESCRIPTION
Fixes #51133.

I did a mistake 4 years ago in https://github.com/quarkusio/quarkus/commit/4a42b44360929793d0cc91976ad4db6b5c10ce7b where the audience property had its trailing slash, if present, removed in `OidcCommonUtils#signJwtWithKey`, because this is what was necessary to get the Keycloak test passing (Keycloak realm endpoint URL is used as an audience by default), but it is really in `application.properties` where the users should deal with having the trailing slash present or not.

There is also `quarkus.credentials.jwt.audience` property that can always be used to customize it.
