### PR TITLE
Prevent startup failing when having mismatched datasource types

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2334,6 +2334,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-reactive-datasource-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-reactive-db2-client</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -61,6 +61,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator-spi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-datasource-spi</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateDataSourceUtil.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateDataSourceUtil.java
@@ -1,0 +1,29 @@
+package io.quarkus.hibernate.orm.deployment;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
+
+public class HibernateDataSourceUtil {
+    public static <T> Optional<T> findDataSourceWithNameDefault(String persistenceUnitName,
+            List<T> datasSources,
+            Function<T, String> nameExtractor,
+            Function<T, Boolean> defaultExtractor,
+            Optional<String> datasource) {
+        if (datasource.isPresent()) {
+            String dataSourceName = datasource.get();
+            return datasSources.stream()
+                    .filter(i -> dataSourceName.equals(nameExtractor.apply(i)))
+                    .findFirst();
+        } else if (PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
+            return datasSources.stream()
+                    .filter(i -> defaultExtractor.apply(i))
+                    .findFirst();
+        } else {
+            // if it's not the default persistence unit, we mandate an explicit datasource to prevent common errors
+            return Optional.empty();
+        }
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnitBothUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnitBothUnitTest.java
@@ -27,9 +27,10 @@ public class ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnit
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
             ))
-            .withConfigurationResource("application-unittest-both-named.properties")
+            .withConfigurationResource("application-unittest-both-named-different.properties")
 
             // Reactive named datasource
+            .overrideConfigKey("quarkus.datasource.\"named-datasource-reactive\".jdbc", "false")
             .overrideConfigKey("quarkus.datasource.\"named-datasource-reactive\".reactive", "true")
             .overrideConfigKey("quarkus.datasource.\"named-datasource-reactive\".db-kind", POSTGRES_KIND)
             .overrideConfigKey("quarkus.datasource.\"named-datasource-reactive\".username", USERNAME_PWD)

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatibilityNamedReactiveDefaultBlockingUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatibilityNamedReactiveDefaultBlockingUnitTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.hibernate.reactive.compatibility;
+
+import java.util.List;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.reactive.entities.Hero;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+
+public class ORMReactiveCompatibilityNamedReactiveDefaultBlockingUnitTest extends CompatibilityUnitTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Hero.class)
+                    .addAsResource("complexMultilineImports.sql", "import.sql"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
+            ))
+            .withConfigurationResource("application-unittest-both-named-reactive-and-default-blocking.properties")
+            // If we want the named PU to be reactive only we need to explicitly disable the blocking the JDBC data source
+            .overrideConfigKey("quarkus.datasource.\"named-datasource\".jdbc", "false")
+            .overrideConfigKey("quarkus.datasource.\"named-datasource\".reactive", "true")
+            .overrideConfigKey("quarkus.hibernate-orm.\"named-pu\".schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
+            .overrideConfigKey("quarkus.hibernate-orm.\"named-pu\".datasource", "named-datasource")
+            .overrideConfigKey("quarkus.hibernate-orm.\"named-pu\".packages", "io.quarkus.hibernate.reactive.entities")
+            .overrideConfigKey("quarkus.datasource.\"named-datasource\".db-kind", POSTGRES_KIND)
+            .overrideConfigKey("quarkus.datasource.\"named-datasource\".username", USERNAME_PWD)
+            .overrideConfigKey("quarkus.datasource.\"named-datasource\".password", USERNAME_PWD)
+
+            // In this test we want the default PU as blocking only, so we need to disable reactive on the datasource.
+            // JDBC is enabled by default.
+            .overrideConfigKey("quarkus.datasource.reactive", "false")
+            // In this case packages for the default PU should be explicit as well
+            .overrideConfigKey("quarkus.hibernate-orm.packages", "io.quarkus.hibernate.reactive.entities")
+            .overrideConfigKey("quarkus.datasource.username", USERNAME_PWD)
+            .overrideConfigKey("quarkus.datasource.password", USERNAME_PWD)
+            .overrideConfigKey("quarkus.datasource.db-kind", POSTGRES_KIND)
+            .overrideConfigKey("quarkus.log.category.\"io.quarkus.hibernate\".level", "DEBUG");
+
+    @PersistenceUnit("named-pu")
+    Mutiny.SessionFactory namedMutinySessionFactory;
+
+    @Test
+    @RunOnVertxContext
+    public void test(UniAsserter uniAsserter) {
+        testReactiveWorks(namedMutinySessionFactory, uniAsserter);
+    }
+
+    @Test
+    public void testBlocking() {
+        testBlockingWorks();
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigDefaultPUDatasourceMissingTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/datasource/ConfigDefaultPUDatasourceMissingTest.java
@@ -2,31 +2,22 @@ package io.quarkus.hibernate.reactive.config.datasource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.builder.Version;
 import io.quarkus.hibernate.reactive.config.MyEntity;
-import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class ConfigDefaultPUDatasourceMissingTest {
 
-    // To get exactly this error message, two different JDBC drivers needs to be included, otherwise the error message will be different
-    // https://github.com/quarkusio/quarkus/issues/47036
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClass(MyEntity.class))
             .overrideConfigKey("quarkus.hibernate-orm.datasource", "ds-1")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "drop-and-create")
-            .setForcedDependencies(List.of(
-                    Dependency.of("io.quarkus", "quarkus-reactive-pg-client", Version.getVersion()),
-                    Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))
             .assertException(t -> assertThat(t)
                     .isInstanceOf(ConfigurationException.class)
                     .hasMessageContainingAll(

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-different.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-different.properties
@@ -1,0 +1,2 @@
+quarkus.datasource."named-datasource-reactive".reactive.url=${postgres.reactive.url}
+quarkus.datasource."named-datasource-blocking".jdbc.url=${postgres.blocking.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-reactive-and-default-blocking.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-reactive-and-default-blocking.properties
@@ -1,0 +1,2 @@
+quarkus.datasource.jdbc.url=${postgres.blocking.url}
+quarkus.datasource."named-datasource".reactive.url=${postgres.reactive.url}

--- a/extensions/reactive-datasource/deployment/pom.xml
+++ b/extensions/reactive-datasource/deployment/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-datasource-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-datasource</artifactId>
         </dependency>
 

--- a/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceProcessor.java
+++ b/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceProcessor.java
@@ -97,17 +97,32 @@ class ReactiveDataSourceProcessor {
     @BuildStep
     void produceReactiveDataSourceBuildItem(
             List<AggregatedDataSourceBuildTimeConfigBuildItem> aggregatedBuildTimeConfigBuildItems,
-            BuildProducer<ReactiveDataSourceBuildItem> dataSource) {
+            BuildProducer<io.quarkus.reactive.datasource.spi.ReactiveDataSourceBuildItem> dataSource) {
         if (aggregatedBuildTimeConfigBuildItems.isEmpty()) {
             // No datasource has been configured so bail out
             return;
         }
 
         for (AggregatedDataSourceBuildTimeConfigBuildItem aggregatedBuildTimeConfigBuildItem : aggregatedBuildTimeConfigBuildItems) {
-            dataSource.produce(new ReactiveDataSourceBuildItem(aggregatedBuildTimeConfigBuildItem.getName(),
+            dataSource.produce(new io.quarkus.reactive.datasource.spi.ReactiveDataSourceBuildItem(
+                    aggregatedBuildTimeConfigBuildItem.getName(),
                     aggregatedBuildTimeConfigBuildItem.getDbKind(),
                     aggregatedBuildTimeConfigBuildItem.isDefault(),
                     aggregatedBuildTimeConfigBuildItem.getDataSourceConfig().dbVersion()));
+        }
+    }
+
+    @BuildStep
+    void convertSPIReactiveDataSourceToDeprecatedOne(
+            List<io.quarkus.reactive.datasource.spi.ReactiveDataSourceBuildItem> dataSource,
+            BuildProducer<ReactiveDataSourceBuildItem> reactiveDataSource) {
+
+        for (io.quarkus.reactive.datasource.spi.ReactiveDataSourceBuildItem newDataSourceBuildItem : dataSource) {
+            reactiveDataSource.produce(new ReactiveDataSourceBuildItem(
+                    newDataSourceBuildItem.getName(),
+                    newDataSourceBuildItem.getDbKind(),
+                    newDataSourceBuildItem.isDefault(),
+                    newDataSourceBuildItem.getVersion()));
         }
     }
 }

--- a/extensions/reactive-datasource/pom.xml
+++ b/extensions/reactive-datasource/pom.xml
@@ -16,5 +16,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>spi</module>
     </modules>
 </project>

--- a/extensions/reactive-datasource/spi/pom.xml
+++ b/extensions/reactive-datasource/spi/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-reactive-datasource-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-reactive-datasource-spi</artifactId>
+    <name>Quarkus - Reactive Datasource - SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/reactive-datasource/spi/src/main/java/io/quarkus/reactive/datasource/spi/ReactiveDataSourceBuildItem.java
+++ b/extensions/reactive-datasource/spi/src/main/java/io/quarkus/reactive/datasource/spi/ReactiveDataSourceBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.datasource.deployment;
+package io.quarkus.reactive.datasource.spi;
 
 import java.util.Optional;
 
@@ -10,10 +10,7 @@ import io.quarkus.builder.item.MultiBuildItem;
  * If you inject this build item when recording runtime init template calls, you are guaranteed the Pool configuration
  * has been injected. Pools are created witihin their own extensions
  * Similar to VertxPoolBuildItem, but doesn't include the Pool itself, only the name.
- *
- * Deprecated: use io/quarkus/reactive/datasource/spi/ReactiveDataSourceBuildItem.java instead
  */
-@Deprecated
 public final class ReactiveDataSourceBuildItem extends MultiBuildItem {
 
     private final String name;


### PR DESCRIPTION
Prevent startup failing when having mismatched datasource types between Hibernate ORM (blocking) and Hibernate Reactive by validating datasource configuration at build time.

- Blocking persistence units are not created when only reactive datasources are configured
- Reactive persistence units are not created when only blocking datasources are configured
- Clear error messages are provided when datasources are missing

- Created HibernateDataSourceUtil with shared datasource lookup logic
- Extracted ReactiveDataSourceBuildItem to new `quarkus-reactive-datasource-spi` module to enable reactive data source checking in the Hibernate ORM extension
- Refactored HibernateOrmProcessor and HibernateReactiveProcessor to validate datasource types and don't create the PU when there's no appropriate DS
- Fail correctly when using a single extension but the datasource name is mismatched
- Fixed ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnitBothUnitTest which was incorrectly passing due to dev services
- Added new test cases for mixed datasource scenarios

* Fixes #50634 
* Fixes #47036

