### PR TITLE
QuarkusComponentTest: make sure logging is always initialized

### DIFF
--- a/test-framework/junit5-component/pom.xml
+++ b/test-framework/junit5-component/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>quarkus-test-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-annotation</artifactId>
         </dependency>

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestClassLoader.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestClassLoader.java
@@ -114,6 +114,9 @@ public class QuarkusComponentTestClassLoader extends ClassLoader {
                 || name.startsWith("org.xml.")
                 || name.startsWith("org.junit.")
                 || name.startsWith("org.mockito.")
+                || name.startsWith("org.jboss.logging")
+                || name.startsWith("org.jboss.logmanager")
+                || name.startsWith("org.slf4j")
                 || PARENT_CL_CLASSES.contains(name);
     }
 


### PR DESCRIPTION
- i.e. even when quarkus-junit5 is not present
- also delegate class loading for SLF4J, jboss-logging and jboss-logmanager to the parent CL
- fixes #51117