### PR TITLE
Implement Kibana/OpenSearch Dashboards dev services 

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -76,6 +76,7 @@
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>9.1.5</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
+        <kibana.server.version>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.server.version>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -76,7 +76,6 @@
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>9.1.5</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
-        <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -76,12 +76,13 @@
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>9.1.5</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
-        <kibana.server.version>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.server.version>
+        <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
         <opensearch-server.version>3.1.0</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
+        <opensearch-dashboards.image>docker.io/opensearchproject/opensearch-dashboards:${opensearch-server.version}</opensearch-dashboards.image>
         <opensearch.protocol>http</opensearch.protocol>
         <junit-pioneer.version>2.3.0</junit-pioneer.version>
 

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -1,14 +1,11 @@
 package io.quarkus.elasticsearch.restclient.common.deployment;
 
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
-import static io.quarkus.elasticsearch.restclient.common.deployment.DevServicesElasticsearchProcessor.DEV_SERVICE_LABEL;
-import static io.quarkus.elasticsearch.restclient.common.deployment.DevServicesElasticsearchProcessor.ELASTICSEARCH_PORT;
-import static io.quarkus.elasticsearch.restclient.common.deployment.DevServicesElasticsearchProcessor.NEW_DEV_SERVICE_LABEL;
-import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_ELASTICSEARCH;
-import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_OPENSEARCH;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_LABEL;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.ELASTICSEARCH_PORT;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.NEW_DEV_SERVICE_LABEL;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.buildPropertiesMap;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.getElasticsearchHosts;
-import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.loadProperties;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.resolveDistribution;
 
 import java.time.Duration;
@@ -56,12 +53,12 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 public class DevServicesElasticsearchDashboardsProcessor {
     private static final Logger log = Logger.getLogger(DevServicesElasticsearchDashboardsProcessor.class);
     static final int DASHBOARD_PORT = 5601;
+    private static final String DEV_SERVICE_KIBANA = "elasticsearch-kibana";
     private static final String DEV_SERVICE_DASHBOARDS = "opensearch-dashboards";
     private static final ContainerLocator elasticsearchContainerLocator = locateContainerWithLabels(ELASTICSEARCH_PORT,
             DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);
     private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT,
             DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);
-    private static final String DEV_SERVICE_KIBANA = "kibana";
     private static final int LOCATE_BACKEND_MAX_RETRIES = 5;
     private static final int LOCATE_BACKEND_INITIAL_WAIT_MILLIS = 5000;
     static volatile RunningDevService devDashboardService;
@@ -300,11 +297,10 @@ public class DevServicesElasticsearchDashboardsProcessor {
 
     static DockerImageName resolveDashboardImageName(ElasticsearchDevServicesBuildTimeConfig config,
             Distribution resolvedDistribution) {
-        return DockerImageName.parse(config.dashboard().imageName().orElseGet(() -> loadProperties(
+        return DockerImageName.parse(config.imageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor(
                 Distribution.ELASTIC.equals(resolvedDistribution)
-                        ? DEV_SERVICE_ELASTICSEARCH
-                        : DEV_SERVICE_OPENSEARCH)
-                .getProperty("default.dashboard.image")));
+                        ? DEV_SERVICE_KIBANA
+                        : DEV_SERVICE_DASHBOARDS)));
     }
 
     private void shutdownElasticsearchDashboards() {

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -55,8 +55,6 @@ public class DevServicesElasticsearchDashboardsProcessor {
     static final int DASHBOARD_PORT = 5601;
     private static final String DEV_SERVICE_KIBANA = "elasticsearch-kibana";
     private static final String DEV_SERVICE_DASHBOARDS = "opensearch-dashboards";
-    private static final ContainerLocator elasticsearchContainerLocator = locateContainerWithLabels(ELASTICSEARCH_PORT,
-            DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);
     private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT,
             DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);
     private static final int LOCATE_BACKEND_MAX_RETRIES = 5;

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -47,7 +47,7 @@ import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommon
 import io.quarkus.runtime.configuration.ConfigUtils;
 
 /**
- * Starts an Elasticsearch server as dev service if needed.
+ * Starts an Elasticsearch Kibana/OpenSearch Dashboards as dev service if needed.
  */
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public class DevServicesElasticsearchDashboardsProcessor {

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -57,8 +57,6 @@ public class DevServicesElasticsearchDashboardsProcessor {
     private static final String DEV_SERVICE_DASHBOARDS = "opensearch-dashboards";
     private static final String DEV_SERVICE_LABEL = "io.quarkus.devservice.elasticsearch.dashboards";
     private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT, DEV_SERVICE_LABEL);
-    private static final int LOCATE_BACKEND_MAX_RETRIES = 5;
-    private static final int LOCATE_BACKEND_INITIAL_WAIT_MILLIS = 5000;
     static volatile RunningDevService devDashboardService;
     static volatile ElasticsearchCommonBuildTimeConfig cfg;
     static volatile boolean first = true;

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -55,8 +55,8 @@ public class DevServicesElasticsearchDashboardsProcessor {
     static final int DASHBOARD_PORT = 5601;
     private static final String DEV_SERVICE_KIBANA = "elasticsearch-kibana";
     private static final String DEV_SERVICE_DASHBOARDS = "opensearch-dashboards";
-    private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT,
-            DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);
+    private static final String DEV_SERVICE_LABEL = "io.quarkus.devservice.elasticsearch.dashboards";
+    private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT, DEV_SERVICE_LABEL);
     private static final int LOCATE_BACKEND_MAX_RETRIES = 5;
     private static final int LOCATE_BACKEND_INITIAL_WAIT_MILLIS = 5000;
     static volatile RunningDevService devDashboardService;

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -23,7 +23,8 @@ import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public class DevServicesElasticsearchDashboardsProcessor {
 
-    static volatile DevservicesElasticsearchDashboardProcessorStrategy strategy = DevservicesElasticsearchDashboardProcessorStrategy.dashboards();
+    static volatile DevservicesElasticsearchDashboardProcessorStrategy strategy = DevservicesElasticsearchDashboardProcessorStrategy
+            .dashboards();
 
     @BuildStep
     public DevServicesResultBuildItem startElasticsearchDevService(

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -72,16 +72,14 @@ public class DevServicesElasticsearchDashboardsProcessor {
             CuratedApplicationShutdownBuildItem closeBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
             List<DevservicesElasticsearchConnectionBuildItem> elasticsearchConnectionBuildItems,
-            DevServicesConfig devServicesConfig,
-            List<DevservicesElasticsearchBuildItem> devservicesElasticsearchBuildItems) throws BuildException {
+            DevServicesConfig devServicesConfig) throws BuildException {
 
-        if (devservicesElasticsearchBuildItems.isEmpty()) {
+        if (elasticsearchConnectionBuildItems.isEmpty()) {
             // safety belt in case a module depends on this one without producing the build item
             return null;
         }
 
-        DevservicesElasticsearchBuildItemsConfiguration buildItemsConfig = new DevservicesElasticsearchBuildItemsConfiguration(
-                devservicesElasticsearchBuildItems);
+        // TODO: group the `elasticsearchConnectionBuildItems` so that we know what distributions to start and what hosts to pass to each.
 
         if (devDashboardService != null) {
             boolean shouldShutdownTheServer = !configuration.equals(cfg);

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -23,7 +23,7 @@ import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public class DevServicesElasticsearchDashboardsProcessor {
 
-    static volatile DevservicesElasticsearchProcessorStrategy strategy = DevservicesElasticsearchProcessorStrategy.dashboards();
+    static volatile DevservicesElasticsearchDashboardProcessorStrategy strategy = DevservicesElasticsearchDashboardProcessorStrategy.dashboards();
 
     @BuildStep
     public DevServicesResultBuildItem startElasticsearchDevService(

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchDashboardsProcessor.java
@@ -1,0 +1,322 @@
+package io.quarkus.elasticsearch.restclient.common.deployment;
+
+import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevServicesElasticsearchProcessor.DEV_SERVICE_LABEL;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevServicesElasticsearchProcessor.ELASTICSEARCH_PORT;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevServicesElasticsearchProcessor.NEW_DEV_SERVICE_LABEL;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_ELASTICSEARCH;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_OPENSEARCH;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.buildPropertiesMap;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.getElasticsearchHosts;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.loadProperties;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.resolveDistribution;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.IsDevServicesSupportedByLaunchMode;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.builditem.DockerStatusBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ComposeLocator;
+import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.Labels;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig.Distribution;
+import io.quarkus.runtime.configuration.ConfigUtils;
+
+/**
+ * Starts an Elasticsearch server as dev service if needed.
+ */
+@BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
+public class DevServicesElasticsearchDashboardsProcessor {
+    private static final Logger log = Logger.getLogger(DevServicesElasticsearchDashboardsProcessor.class);
+    static final int DASHBOARD_PORT = 5601;
+    private static final String DEV_SERVICE_DASHBOARDS = "opensearch-dashboards";
+    private static final ContainerLocator elasticsearchContainerLocator = locateContainerWithLabels(ELASTICSEARCH_PORT,
+            DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);
+    private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT,
+            DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);
+    private static final String DEV_SERVICE_KIBANA = "kibana";
+    private static final int LOCATE_BACKEND_MAX_RETRIES = 5;
+    private static final int LOCATE_BACKEND_INITIAL_WAIT_MILLIS = 5000;
+    static volatile RunningDevService devDashboardService;
+    static volatile ElasticsearchCommonBuildTimeConfig cfg;
+    static volatile boolean first = true;
+
+    @BuildStep
+    public DevServicesResultBuildItem startElasticsearchDevService(
+            DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            LaunchModeBuildItem launchMode,
+            ElasticsearchCommonBuildTimeConfig configuration,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
+            CuratedApplicationShutdownBuildItem closeBuildItem,
+            LoggingSetupBuildItem loggingSetupBuildItem,
+            DevServicesConfig devServicesConfig,
+            List<DevservicesElasticsearchBuildItem> devservicesElasticsearchBuildItems) throws BuildException {
+
+        if (devservicesElasticsearchBuildItems.isEmpty()) {
+            // safety belt in case a module depends on this one without producing the build item
+            return null;
+        }
+
+        DevservicesElasticsearchBuildItemsConfiguration buildItemsConfig = new DevservicesElasticsearchBuildItemsConfiguration(
+                devservicesElasticsearchBuildItems);
+
+        if (devDashboardService != null) {
+            boolean shouldShutdownTheServer = !configuration.equals(cfg);
+            if (!shouldShutdownTheServer) {
+                return devDashboardService.toBuildItem();
+            }
+            shutdownElasticsearchDashboards();
+            cfg = null;
+        }
+
+        StartupLogCompressor compressor = new StartupLogCompressor(
+                (launchMode.isTest() ? "(test) " : "") + "Dev Services for Elasticsearch Dashboards starting:",
+                consoleInstalledBuildItem, loggingSetupBuildItem);
+        try {
+            boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                    devServicesSharedNetworkBuildItem);
+
+            devDashboardService = startDashboardDevServices(dockerStatusBuildItem, composeProjectBuildItem,
+                    configuration.devservices(),
+                    buildItemsConfig, launchMode, useSharedNetwork, devServicesConfig.timeout());
+            if (devDashboardService == null) {
+                compressor.closeAndDumpCaptured();
+            } else {
+                compressor.close();
+            }
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw new RuntimeException(t);
+        }
+
+        if (devDashboardService == null) {
+            return null;
+        }
+
+        // Configure the watch dog
+        if (first) {
+            first = false;
+            Runnable closeTask = () -> {
+                if (devDashboardService != null) {
+                    shutdownElasticsearchDashboards();
+                }
+                first = true;
+                devDashboardService = null;
+                cfg = null;
+            };
+            closeBuildItem.addCloseTask(closeTask, true);
+        }
+        cfg = configuration;
+
+        if (devDashboardService.isOwner()) {
+            log.infof(
+                    "Dev Services for Elasticsearch Dashboards started. You can open th ui in your Browser at %s",
+                    getElasticsearchHosts(buildItemsConfig, devDashboardService));
+        }
+        return devDashboardService.toBuildItem();
+    }
+
+    private RunningDevService startDashboardDevServices(
+            DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            ElasticsearchDevServicesBuildTimeConfig config,
+            DevservicesElasticsearchBuildItemsConfiguration buildItemConfig,
+            LaunchModeBuildItem launchMode, boolean useSharedNetwork, Optional<Duration> timeout) throws BuildException {
+        if (!config.enabled().orElse(true)) {
+            // explicitly disabled
+            log.debug("Not starting Dashboard DevServices for Elasticsearch, as it has been disabled in the config.");
+            return null;
+        }
+
+        if (!config.dashboard().enabled()) {
+            // Kibana explicitly disabled
+            log.debug("Not starting Kibana Dev Service, as it has been disabled in the config.");
+            return null;
+        }
+
+        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
+            log.warn("Docker is not working, cannot start the Kibana/OpenSearch dashboards dev service.");
+            return null;
+        }
+
+        Distribution resolvedDistribution = resolveDistribution(config, buildItemConfig);
+        DockerImageName resolvedImageName = resolveDashboardImageName(config, resolvedDistribution);
+
+        Set<String> opensearchHosts;
+        if (buildItemConfig.hostsConfigProperties.stream().anyMatch(ConfigUtils::isPropertyNonEmpty)) {
+            log.error("elasticsearch hosts config property found, using it");
+            opensearchHosts = buildItemConfig.hostsConfigProperties.stream().filter(ConfigUtils::isPropertyNonEmpty)
+                    .flatMap(property -> ConfigProvider.getConfig().getValues(property, String.class).stream())
+                    .map(host -> "http://" + host.replace("localhost", "host.docker.internal"))
+                    .collect(Collectors.toSet());
+        } else {
+            Optional<ContainerAddress> maybeContainerAddressSearchBackend = Optional.empty();
+            log.info("no elasticsearch hosts config property found, waiting for the elasticsearch container to be started");
+            for (int i = 0; i < LOCATE_BACKEND_MAX_RETRIES; i++) {
+                maybeContainerAddressSearchBackend = elasticsearchContainerLocator.locateContainer(
+                        config.serviceName(),
+                        config.shared(),
+                        launchMode.getLaunchMode())
+                        .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
+                                List.of(resolvedImageName.getUnversionedPart(), "elasticsearch", "opensearch"),
+                                ELASTICSEARCH_PORT,
+                                launchMode.getLaunchMode(), useSharedNetwork));
+                if (maybeContainerAddressSearchBackend.isPresent()) {
+                    break;
+                }
+                try {
+                    Thread.sleep((long) (LOCATE_BACKEND_INITIAL_WAIT_MILLIS * Math.pow(2, i)));
+                    log.infof("waiting for the elasticsearch container to be started, attempt %d of %d", i + 1,
+                            LOCATE_BACKEND_MAX_RETRIES);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            opensearchHosts = maybeContainerAddressSearchBackend.map(containerAddress -> Set
+                    .of(("http://" + containerAddress.getHost() + ":" + containerAddress.getPort())
+                            .replace("localhost", "host.docker.internal")))
+                    .orElseGet(() -> Set.of());
+        }
+
+        final Optional<ContainerAddress> maybeContainerAddress = dashboardContainerLocator.locateContainer(
+                config.serviceName(),
+                config.shared(),
+                launchMode.getLaunchMode())
+                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
+                        List.of(resolvedImageName.getUnversionedPart(), "kibana", "opensearch-dashboards"),
+                        DASHBOARD_PORT,
+                        launchMode.getLaunchMode(), useSharedNetwork));
+
+        // Starting the server
+        final Supplier<RunningDevService> defaultDashboardsSupplier = () -> {
+
+            String defaultNetworkId = composeProjectBuildItem.getDefaultNetworkId();
+            CreatedContainer createdContainer = resolvedDistribution.equals(Distribution.ELASTIC)
+                    ? createKibanaContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork, launchMode,
+                            composeProjectBuildItem, opensearchHosts)
+                    : createDashboardsContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork, launchMode,
+                            composeProjectBuildItem, opensearchHosts);
+            GenericContainer<?> container = createdContainer.genericContainer();
+            if (config.serviceName() != null) {
+                container.withLabel(DEV_SERVICE_LABEL, config.serviceName());
+                container.withLabel(Labels.QUARKUS_DEV_SERVICE, config.serviceName());
+            }
+            if (config.dashboard().port().isPresent()) {
+                container.setPortBindings(List.of(config.dashboard().port().get() + ":" + DASHBOARD_PORT));
+            }
+            timeout.ifPresent(container::withStartupTimeout);
+            container.withEnv(config.dashboard().containerEnv());
+            container.withReuse(config.reuse());
+            container.start();
+
+            var httpHost = createdContainer.hostName + ":"
+                    + (useSharedNetwork ? DASHBOARD_PORT : container.getMappedPort(DASHBOARD_PORT));
+            return new RunningDevService(Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
+                    container.getContainerId(),
+                    new ContainerShutdownCloseable(container, "Kibana"),
+                    buildPropertiesMap(buildItemConfig, httpHost));
+        };
+
+        return maybeContainerAddress
+                .map(containerAddress -> new RunningDevService(
+                        Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
+                        containerAddress.getId(),
+                        null,
+                        buildPropertiesMap(buildItemConfig, containerAddress.getUrl())))
+                .orElseGet(defaultDashboardsSupplier);
+    }
+
+    private CreatedContainer createKibanaContainer(ElasticsearchDevServicesBuildTimeConfig config,
+            DockerImageName resolvedImageName, String defaultNetworkId, boolean useSharedNetwork,
+            LaunchModeBuildItem launchMode, DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            Set<String> elasticsearchHosts) {
+        //Create Generic Kibana container
+        GenericContainer<?> container = new GenericContainer<>(
+                resolvedImageName.asCompatibleSubstituteFor("docker.elastic.co/kibana/kibana"));
+
+        String kibanaHostName = ConfigureUtil.configureNetwork(container, defaultNetworkId, useSharedNetwork,
+                DEV_SERVICE_KIBANA);
+        container.setExposedPorts(List.of(DASHBOARD_PORT));
+        if (!elasticsearchHosts.isEmpty()) {
+            container.addEnv("ELASTICSEARCH_HOSTS",
+                    "[" + elasticsearchHosts.stream().map(url -> "\"" + url + "\"").collect(Collectors.joining(",")) + "]");
+        }
+        config.dashboard().nodeOpts().ifPresent(nodeOpts -> container.addEnv("NODE_OPTIONS", nodeOpts));
+        return new CreatedContainer(container, kibanaHostName);
+    }
+
+    private CreatedContainer createDashboardsContainer(ElasticsearchDevServicesBuildTimeConfig config,
+            DockerImageName resolvedImageName, String defaultNetworkId, boolean useSharedNetwork,
+            LaunchModeBuildItem launchMode, DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            Set<String> opensearchHosts) {
+        //Create Generic Kibana container
+        GenericContainer<?> container = new GenericContainer<>(
+                resolvedImageName.asCompatibleSubstituteFor("opensearchproject/opensearch-dashboards"));
+
+        String kibanaHostName = ConfigureUtil.configureNetwork(container, defaultNetworkId, useSharedNetwork,
+                DEV_SERVICE_DASHBOARDS);
+        container.setExposedPorts(List.of(DASHBOARD_PORT));
+        if (!opensearchHosts.isEmpty()) {
+            container.addEnv("OPENSEARCH_HOSTS",
+                    "[" + opensearchHosts.stream().map(url -> "\"" + url + "\"").collect(Collectors.joining(",")) + "]");
+        }
+
+        config.dashboard().nodeOpts().ifPresent(nodeOpts -> container.addEnv("NODE_OPTIONS", nodeOpts));
+        container.addEnv("DISABLE_SECURITY_DASHBOARDS_PLUGIN", "true");
+        return new CreatedContainer(container, kibanaHostName);
+    }
+
+    private record CreatedContainer(GenericContainer<?> genericContainer, String hostName) {
+    }
+
+    static DockerImageName resolveDashboardImageName(ElasticsearchDevServicesBuildTimeConfig config,
+            Distribution resolvedDistribution) {
+        return DockerImageName.parse(config.dashboard().imageName().orElseGet(() -> loadProperties(
+                Distribution.ELASTIC.equals(resolvedDistribution)
+                        ? DEV_SERVICE_ELASTICSEARCH
+                        : DEV_SERVICE_OPENSEARCH)
+                .getProperty("default.dashboard.image")));
+    }
+
+    private void shutdownElasticsearchDashboards() {
+        if (devDashboardService != null) {
+            try {
+                devDashboardService.close();
+            } catch (Throwable e) {
+                log.error("Failed to stop the Dashboards", e);
+            } finally {
+                devDashboardService = null;
+            }
+        }
+    }
+
+}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchKibanaProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchKibanaProcessor.java
@@ -17,13 +17,10 @@ import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 
-/**
- * Starts an Elasticsearch Kibana/OpenSearch Dashboards as dev service if needed.
- */
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
-public class DevServicesElasticsearchDashboardsProcessor {
+public class DevServicesElasticsearchKibanaProcessor {
 
-    static volatile DevservicesElasticsearchProcessorStrategy strategy = DevservicesElasticsearchProcessorStrategy.dashboards();
+    static volatile DevservicesElasticsearchProcessorStrategy strategy = DevservicesElasticsearchProcessorStrategy.kibana();
 
     @BuildStep
     public DevServicesResultBuildItem startElasticsearchDevService(
@@ -43,5 +40,4 @@ public class DevServicesElasticsearchDashboardsProcessor {
                 devServicesSharedNetworkBuildItem, consoleInstalledBuildItem, closeBuildItem, loggingSetupBuildItem,
                 elasticsearchConnectionBuildItems, devservicesElasticsearchBuildItems, devServicesConfig);
     }
-
 }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchKibanaProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchKibanaProcessor.java
@@ -20,7 +20,8 @@ import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public class DevServicesElasticsearchKibanaProcessor {
 
-    static volatile DevservicesElasticsearchDashboardProcessorStrategy strategy = DevservicesElasticsearchDashboardProcessorStrategy.kibana();
+    static volatile DevservicesElasticsearchDashboardProcessorStrategy strategy = DevservicesElasticsearchDashboardProcessorStrategy
+            .kibana();
 
     @BuildStep
     public DevServicesResultBuildItem startElasticsearchDevService(

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchKibanaProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchKibanaProcessor.java
@@ -20,7 +20,7 @@ import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public class DevServicesElasticsearchKibanaProcessor {
 
-    static volatile DevservicesElasticsearchProcessorStrategy strategy = DevservicesElasticsearchProcessorStrategy.kibana();
+    static volatile DevservicesElasticsearchDashboardProcessorStrategy strategy = DevservicesElasticsearchDashboardProcessorStrategy.kibana();
 
     @BuildStep
     public DevServicesResultBuildItem startElasticsearchDevService(

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -311,7 +311,7 @@ public class DevServicesElasticsearchProcessor {
                 config.shared(),
                 launchMode.getLaunchMode())
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
-                        List.of(resolvedImageName.getUnversionedPart(), "elasticsearch", "opensearch"),
+                        List.of(resolvedImageName.getUnversionedPart(), "kibana", "opensearch-dashboards"),
                         DASHBOARD_PORT,
                         launchMode.getLaunchMode(), useSharedNetwork));
 

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -316,7 +316,7 @@ public class DevServicesElasticsearchProcessor {
                         launchMode.getLaunchMode(), useSharedNetwork));
 
         // Starting the server
-        final Supplier<RunningDevService> defaultElasticsearchSupplier = () -> {
+        final Supplier<RunningDevService> defaultDashboardsSupplier = () -> {
 
             String defaultNetworkId = composeProjectBuildItem.getDefaultNetworkId();
             CreatedContainer createdContainer = resolvedDistribution.equals(Distribution.ELASTIC)
@@ -352,7 +352,7 @@ public class DevServicesElasticsearchProcessor {
                         containerAddress.getId(),
                         null,
                         buildPropertiesMap(buildItemConfig, containerAddress.getUrl())))
-                .orElseGet(defaultElasticsearchSupplier);
+                .orElseGet(defaultDashboardsSupplier);
     }
 
     private CreatedContainer createElasticsearchContainer(ElasticsearchDevServicesBuildTimeConfig config,

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -184,7 +184,7 @@ public class DevServicesElasticsearchProcessor {
     }
 
     private void shutdownDashboard() {
-        if (devService != null) {
+        if (devDashboardService != null) {
             try {
                 devDashboardService.close();
             } catch (Throwable e) {

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -2,7 +2,10 @@ package io.quarkus.elasticsearch.restclient.common.deployment;
 
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_ELASTICSEARCH;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_LABEL;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.DEV_SERVICE_OPENSEARCH;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.ELASTICSEARCH_PORT;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.NEW_DEV_SERVICE_LABEL;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.buildPropertiesMap;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.getElasticsearchHosts;
 import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.resolveDistribution;
@@ -51,14 +54,6 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 @BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public class DevServicesElasticsearchProcessor {
     private static final Logger log = Logger.getLogger(DevServicesElasticsearchProcessor.class);
-
-    /**
-     * Label to add to shared Dev Service for Elasticsearch running in containers.
-     * This allows other applications to discover the running service and use it instead of starting a new instance.
-     */
-    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-elasticsearch";
-    static final String NEW_DEV_SERVICE_LABEL = "io.quarkus.devservice.elasticsearch";
-    static final int ELASTICSEARCH_PORT = 9200;
 
     private static final ContainerLocator elasticsearchContainerLocator = locateContainerWithLabels(ELASTICSEARCH_PORT,
             DEV_SERVICE_LABEL, NEW_DEV_SERVICE_LABEL);

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -219,7 +219,7 @@ public class DevServicesElasticsearchProcessor {
             var httpHost = createdContainer.hostName + ":"
                     + (useSharedNetwork ? ELASTICSEARCH_PORT : container.getMappedPort(ELASTICSEARCH_PORT));
             connectionBuildItemProducer.produce(new DevservicesElasticsearchConnectionBuildItem(createdContainer.hostName,
-                    container.getMappedPort(ELASTICSEARCH_PORT)));
+                    container.getMappedPort(ELASTICSEARCH_PORT), resolvedDistribution));
             return new RunningDevService(Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
                     container.getContainerId(),
                     new ContainerShutdownCloseable(container, "Elasticsearch"),

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -429,7 +429,7 @@ public class DevServicesElasticsearchProcessor {
             container.addEnv("ELASTICSEARCH_HOSTS",
                     "[" + elasticsearchHosts.stream().map(url -> "\"" + url + "\"").collect(Collectors.joining(",")) + "]");
         }
-        container.addEnv("NODE_OPTIONS", config.dashboard().nodeOpts());
+        config.dashboard().nodeOpts().ifPresent(nodeOpts -> container.addEnv("NODE_OPTIONS", nodeOpts));
         return new CreatedContainer(container, kibanaHostName);
     }
 
@@ -448,7 +448,8 @@ public class DevServicesElasticsearchProcessor {
             container.addEnv("OPENSEARCH_HOSTS",
                     "[" + opensearchHosts.stream().map(url -> "\"" + url + "\"").collect(Collectors.joining(",")) + "]");
         }
-        container.addEnv("NODE_OPTIONS", config.dashboard().nodeOpts());
+
+        config.dashboard().nodeOpts().ifPresent(nodeOpts -> container.addEnv("NODE_OPTIONS", nodeOpts));
         container.addEnv("DISABLE_SECURITY_DASHBOARDS_PLUGIN", "true");
         return new CreatedContainer(container, kibanaHostName);
     }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -299,8 +299,7 @@ public class DevServicesElasticsearchProcessor {
         }
 
         if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
-            log.warnf("Docker isn't working, please configure the Elasticsearch hosts property (%s).",
-                    displayProperties(buildItemConfig.hostsConfigProperties));
+            log.warn("Docker is not working, cannot start the Kibana/OpenSearch dashboards dev service.");
             return null;
         }
 

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -262,6 +262,12 @@ public class DevServicesElasticsearchProcessor {
             return null;
         }
 
+        if (!config.kibana().enabled()) {
+            // Kibana explicitly disabled
+            log.debug("Not starting Kibana Dev Service, as it has been disabled in the config.");
+            return null;
+        }
+
         for (String hostsConfigProperty : buildItemConfig.hostsConfigProperties) {
             // Check if elasticsearch hosts property is set
             if (ConfigUtils.isPropertyNonEmpty(hostsConfigProperty)) {

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchBuildItemsConfiguration.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchBuildItemsConfiguration.java
@@ -1,0 +1,43 @@
+package io.quarkus.elasticsearch.restclient.common.deployment;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig.Distribution;
+
+class DevservicesElasticsearchBuildItemsConfiguration {
+    Set<String> hostsConfigProperties;
+    String version;
+    Distribution distribution;
+
+    DevservicesElasticsearchBuildItemsConfiguration(List<DevservicesElasticsearchBuildItem> buildItems)
+            throws BuildException {
+        hostsConfigProperties = new HashSet<>(buildItems.size());
+
+        // check that all build items agree on the version and distribution to start
+        for (DevservicesElasticsearchBuildItem buildItem : buildItems) {
+            if (version == null) {
+                version = buildItem.getVersion();
+            } else if (buildItem.getVersion() != null && !version.equals(buildItem.getVersion())) {
+                // safety guard but should never occur as only Hibernate Search ORM Elasticsearch configure the version
+                throw new BuildException(
+                        "Multiple extensions request different versions of Elasticsearch for Dev Services.",
+                        Collections.emptyList());
+            }
+
+            if (distribution == null) {
+                distribution = buildItem.getDistribution();
+            } else if (buildItem.getDistribution() != null && !distribution.equals(buildItem.getDistribution())) {
+                // safety guard but should never occur as only Hibernate Search ORM Elasticsearch configure the distribution
+                throw new BuildException(
+                        "Multiple extensions request different distributions of Elasticsearch for Dev Services.",
+                        Collections.emptyList());
+            }
+
+            hostsConfigProperties.add(buildItem.getHostsConfigProperty());
+        }
+    }
+}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchConnectionBuildItem.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchConnectionBuildItem.java
@@ -1,14 +1,17 @@
 package io.quarkus.elasticsearch.restclient.common.deployment;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig.Distribution;
 
 public final class DevservicesElasticsearchConnectionBuildItem extends MultiBuildItem {
     private final String host;
     private final int port;
+    private final Distribution distribution;
 
-    public DevservicesElasticsearchConnectionBuildItem(String host, int port) {
+    public DevservicesElasticsearchConnectionBuildItem(String host, int port, Distribution distribution) {
         this.host = host;
         this.port = port;
+        this.distribution = distribution;
     }
 
     public String getHost() {
@@ -17,5 +20,9 @@ public final class DevservicesElasticsearchConnectionBuildItem extends MultiBuil
 
     public int getPort() {
         return port;
+    }
+
+    public Distribution getDistribution() {
+        return distribution;
     }
 }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchConnectionBuildItem.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchConnectionBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.elasticsearch.restclient.common.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class DevservicesElasticsearchConnectionBuildItem extends MultiBuildItem {
+    private final String host;
+    private final int port;
+
+    public DevservicesElasticsearchConnectionBuildItem(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchDashboardProcessorStrategy.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchDashboardProcessorStrategy.java
@@ -328,7 +328,7 @@ public class DevservicesElasticsearchDashboardProcessorStrategy {
 
     static DockerImageName resolveDashboardImageName(ElasticsearchDevServicesBuildTimeConfig config,
             Distribution resolvedDistribution) {
-        return DockerImageName.parse(config.imageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor(
+        return DockerImageName.parse(config.dashboard().imageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor(
                 Distribution.ELASTIC.equals(resolvedDistribution)
                         ? DEV_SERVICE_KIBANA
                         : DEV_SERVICE_DASHBOARDS)));

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchDashboardProcessorStrategy.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchDashboardProcessorStrategy.java
@@ -59,8 +59,8 @@ enum DistributionStrategy {
     }
 }
 
-public class DevservicesElasticsearchProcessorStrategy {
-    private static final Logger log = Logger.getLogger(DevservicesElasticsearchProcessorStrategy.class);
+public class DevservicesElasticsearchDashboardProcessorStrategy {
+    private static final Logger log = Logger.getLogger(DevservicesElasticsearchDashboardProcessorStrategy.class);
     private static final int DASHBOARD_PORT = 5601;
     private static final String DEV_SERVICE_LABEL = "io.quarkus.devservice.elasticsearch.dashboards";
 
@@ -75,16 +75,16 @@ public class DevservicesElasticsearchProcessorStrategy {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final DistributionStrategy strategy;
 
-    private DevservicesElasticsearchProcessorStrategy(DistributionStrategy strategy) {
+    private DevservicesElasticsearchDashboardProcessorStrategy(DistributionStrategy strategy) {
         this.strategy = strategy;
     }
 
-    static DevservicesElasticsearchProcessorStrategy kibana() {
-        return new DevservicesElasticsearchProcessorStrategy(DistributionStrategy.KIBANA);
+    static DevservicesElasticsearchDashboardProcessorStrategy kibana() {
+        return new DevservicesElasticsearchDashboardProcessorStrategy(DistributionStrategy.KIBANA);
     }
 
-    static DevservicesElasticsearchProcessorStrategy dashboards() {
-        return new DevservicesElasticsearchProcessorStrategy(DistributionStrategy.DASHBOARDS);
+    static DevservicesElasticsearchDashboardProcessorStrategy dashboards() {
+        return new DevservicesElasticsearchDashboardProcessorStrategy(DistributionStrategy.DASHBOARDS);
     }
 
     public DevServicesResultBuildItem startElasticsearchDevService(

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorStrategy.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorStrategy.java
@@ -1,0 +1,405 @@
+package io.quarkus.elasticsearch.restclient.common.deployment;
+
+import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchProcessorUtils.resolveDistribution;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLConnection;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.builditem.DockerStatusBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ComposeLocator;
+import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.Labels;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig.Distribution;
+import io.quarkus.runtime.configuration.ConfigUtils;
+
+enum DistributionStrategy {
+    DASHBOARDS(Distribution.OPENSEARCH),
+    KIBANA(Distribution.ELASTIC);
+
+    private final Distribution distribution;
+
+    private DistributionStrategy(Distribution distribution) {
+        this.distribution = distribution;
+    }
+
+    public Distribution supportedDistribution() {
+        return distribution;
+    }
+}
+
+public class DevservicesElasticsearchProcessorStrategy {
+    private static final Logger log = Logger.getLogger(DevservicesElasticsearchProcessorStrategy.class);
+    private static final int DASHBOARD_PORT = 5601;
+    private static final String DEV_SERVICE_LABEL = "io.quarkus.devservice.elasticsearch.dashboards";
+
+    private static final String DEV_SERVICE_KIBANA = "elasticsearch-kibana";
+    private static final String DEV_SERVICE_DASHBOARDS = "opensearch-dashboards";
+
+    private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT,
+            DEV_SERVICE_LABEL);
+    static volatile RunningDevService devDashboardService;
+    static volatile ElasticsearchCommonBuildTimeConfig cfg;
+    static volatile boolean first = true;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final DistributionStrategy strategy;
+
+    private DevservicesElasticsearchProcessorStrategy(DistributionStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    static DevservicesElasticsearchProcessorStrategy kibana() {
+        return new DevservicesElasticsearchProcessorStrategy(DistributionStrategy.KIBANA);
+    }
+
+    static DevservicesElasticsearchProcessorStrategy dashboards() {
+        return new DevservicesElasticsearchProcessorStrategy(DistributionStrategy.DASHBOARDS);
+    }
+
+    public DevServicesResultBuildItem startElasticsearchDevService(
+            DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            LaunchModeBuildItem launchMode,
+            ElasticsearchCommonBuildTimeConfig configuration,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
+            CuratedApplicationShutdownBuildItem closeBuildItem,
+            LoggingSetupBuildItem loggingSetupBuildItem,
+            List<DevservicesElasticsearchConnectionBuildItem> elasticsearchConnectionBuildItems,
+            List<DevservicesElasticsearchBuildItem> devservicesElasticsearchBuildItems,
+            DevServicesConfig devServicesConfig) throws BuildException {
+
+        if (devservicesElasticsearchBuildItems.isEmpty() && elasticsearchConnectionBuildItems.isEmpty()) {
+            log.info("Skip starting dashboards since no Elasticsearch hosts have been configured");
+            // safety belt in case a module depends on this one without producing the build item
+            return null;
+        }
+        DevservicesElasticsearchBuildItemsConfiguration buildItemsConfig = new DevservicesElasticsearchBuildItemsConfiguration(
+                devservicesElasticsearchBuildItems);
+
+        if (devDashboardService != null) {
+            boolean shouldShutdownTheServer = !configuration.equals(cfg);
+            if (!shouldShutdownTheServer) {
+                return devDashboardService.toBuildItem();
+            }
+            shutdownElasticsearchDashboards();
+            cfg = null;
+        }
+
+        StartupLogCompressor compressor = new StartupLogCompressor(
+                (launchMode.isTest() ? "(test) " : "") + "Dev Services for Elasticsearch Dashboards starting:",
+                consoleInstalledBuildItem, loggingSetupBuildItem);
+        try {
+            boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                    devServicesSharedNetworkBuildItem);
+
+            devDashboardService = startDashboardDevServices(dockerStatusBuildItem, composeProjectBuildItem,
+                    configuration.devservices(),
+                    buildItemsConfig, elasticsearchConnectionBuildItems, launchMode, useSharedNetwork,
+                    devServicesConfig.timeout());
+            if (devDashboardService == null) {
+                compressor.closeAndDumpCaptured();
+            } else {
+                compressor.close();
+            }
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw new RuntimeException(t);
+        }
+
+        if (devDashboardService == null) {
+            return null;
+        }
+
+        // Configure the watch dog
+        if (first) {
+            first = false;
+            Runnable closeTask = () -> {
+                if (devDashboardService != null) {
+                    shutdownElasticsearchDashboards();
+                }
+                first = true;
+                devDashboardService = null;
+                cfg = null;
+            };
+            closeBuildItem.addCloseTask(closeTask, true);
+        }
+        cfg = configuration;
+
+        if (devDashboardService.isOwner()) {
+            log.infof(
+                    "Dev Services for %s started. You can open th ui in your Browser at %s",
+                    strategy.supportedDistribution().name(),
+                    new DashboardDevServicesConfiguration(devDashboardService.getConfig()).hostName);
+        }
+        return devDashboardService.toBuildItem();
+    }
+
+    private RunningDevService startDashboardDevServices(
+            DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            ElasticsearchDevServicesBuildTimeConfig config,
+            DevservicesElasticsearchBuildItemsConfiguration buildItemConfig,
+            List<DevservicesElasticsearchConnectionBuildItem> elasticsearchConnectionBuildItems,
+            LaunchModeBuildItem launchMode, boolean useSharedNetwork, Optional<Duration> timeout) throws BuildException {
+        if (!config.enabled().orElse(true)) {
+            // explicitly disabled
+            log.debug("Not starting Dashboard DevServices for Elasticsearch, as it has been disabled in the config.");
+            return null;
+        }
+
+        if (!config.dashboard().enabled()) {
+            // Kibana explicitly disabled
+            log.debug("Not starting Kibana Dev Service, as it has been disabled in the config.");
+            return null;
+        }
+
+        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
+            log.warn("Docker is not working, cannot start the Kibana/OpenSearch dashboards dev service.");
+            return null;
+        }
+
+        Set<String> backendHosts = determineHosts(buildItemConfig, elasticsearchConnectionBuildItems);
+
+        if (hostsConfigAvailable(buildItemConfig)) {
+            // Filter out all hosts that are not the same distribution as the supported distribution
+            boolean distributionFromConfigSupported = resolveDistribution(config, buildItemConfig)
+                    .equals(strategy.supportedDistribution());
+            //We could pass quarkus.elasticsearch.username and quarkus.elasticsearch.password via DevservicesElasticsearchBuildItem if authentication is required.
+            backendHosts.removeIf(host -> determineDistributionViaApi(host, null, null)
+                    .map(distribution -> !distribution.equals(strategy.supportedDistribution()))
+                    .orElse(!distributionFromConfigSupported));
+        }
+        if (backendHosts.isEmpty()) {
+            log.infof("No hosts found for %s, skip starting the dev service.", strategy.supportedDistribution().name());
+            return null;
+        }
+
+        DockerImageName resolvedImageName = resolveDashboardImageName(config, strategy.supportedDistribution());
+
+        final Optional<ContainerAddress> maybeContainerAddress = dashboardContainerLocator.locateContainer(
+                config.serviceName(),
+                config.shared(),
+                launchMode.getLaunchMode())
+                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
+                        List.of(resolvedImageName.getUnversionedPart(), "kibana", "opensearch-dashboards"),
+                        DASHBOARD_PORT,
+                        launchMode.getLaunchMode(), useSharedNetwork));
+
+        // Starting the server
+        final Supplier<RunningDevService> defaultDashboardsSupplier = () -> {
+
+            String defaultNetworkId = composeProjectBuildItem.getDefaultNetworkId();
+            Set<String> backendHostsLocahostReplaced = backendHosts.stream()
+                    .map(host -> host.replace("localhost", "host.docker.internal")).collect(Collectors.toSet());
+            CreatedContainer createdContainer = strategy.supportedDistribution().equals(Distribution.ELASTIC)
+                    ? createKibanaContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork, launchMode,
+                            composeProjectBuildItem, backendHostsLocahostReplaced)
+                    : createDashboardsContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork, launchMode,
+                            composeProjectBuildItem, backendHostsLocahostReplaced);
+            GenericContainer<?> container = createdContainer.genericContainer();
+            if (config.serviceName() != null) {
+                container.withLabel(DEV_SERVICE_LABEL, config.serviceName());
+                container.withLabel(Labels.QUARKUS_DEV_SERVICE, config.serviceName());
+            }
+            if (config.dashboard().port().isPresent()) {
+                container.setPortBindings(List.of(config.dashboard().port().get() + ":" + DASHBOARD_PORT));
+            }
+            timeout.ifPresent(container::withStartupTimeout);
+            container.withEnv(config.dashboard().containerEnv());
+            container.withReuse(config.reuse());
+            container.start();
+
+            var httpHost = createdContainer.hostName + ":"
+                    + (useSharedNetwork ? DASHBOARD_PORT : container.getMappedPort(DASHBOARD_PORT));
+            return new RunningDevService(Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
+                    container.getContainerId(),
+                    new ContainerShutdownCloseable(container, "Kibana"),
+                    DashboardDevServicesConfiguration.buildPropertiesMap(strategy.supportedDistribution(), httpHost));
+        };
+
+        return maybeContainerAddress
+                .map(containerAddress -> new RunningDevService(
+                        Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
+                        containerAddress.getId(),
+                        null,
+                        DashboardDevServicesConfiguration.buildPropertiesMap(strategy.supportedDistribution(),
+                                containerAddress.getUrl())))
+                .orElseGet(defaultDashboardsSupplier);
+    }
+
+    private Set<String> determineHosts(DevservicesElasticsearchBuildItemsConfiguration buildItemConfig,
+            List<DevservicesElasticsearchConnectionBuildItem> elasticsearchConnectionBuildItems) {
+        Set<String> hosts;
+        if (hostsConfigAvailable(buildItemConfig)) {
+            log.info("elasticsearch hosts config property found, using it");
+            hosts = buildItemConfig.hostsConfigProperties.stream().filter(ConfigUtils::isPropertyNonEmpty)
+                    .flatMap(property -> ConfigProvider.getConfig().getValues(property, String.class).stream())
+                    // We could pass quarkus.elasticsearch.protocol via DevservicesElasticsearchBuildItem if it is not http.
+                    .map(host -> "http://" + host)
+                    .collect(Collectors.toSet());
+        } else {
+            log.info(
+                    "no elasticsearch hosts config property found, using the host of the elasticsearch dev services container to connect");
+            hosts = elasticsearchConnectionBuildItems.stream()
+                    .filter(connection -> strategy.supportedDistribution().equals(connection.getDistribution()))
+                    // We could pass quarkus.elasticsearch.protocol via DevservicesElasticsearchBuildItem if it is not http.
+                    .map(connection -> ("http://" + connection.getHost() + ":" + connection.getPort()))
+                    .collect(Collectors.toSet());
+        }
+        return hosts;
+    }
+
+    private boolean hostsConfigAvailable(DevservicesElasticsearchBuildItemsConfiguration buildItemConfig) {
+        return buildItemConfig.hostsConfigProperties.stream().anyMatch(ConfigUtils::isPropertyNonEmpty);
+    }
+
+    private CreatedContainer createKibanaContainer(ElasticsearchDevServicesBuildTimeConfig config,
+            DockerImageName resolvedImageName, String defaultNetworkId, boolean useSharedNetwork,
+            LaunchModeBuildItem launchMode, DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            Set<String> elasticsearchHosts) {
+        //Create Generic Kibana container
+        GenericContainer<?> container = new GenericContainer<>(
+                resolvedImageName.asCompatibleSubstituteFor("docker.elastic.co/kibana/kibana"));
+
+        String kibanaHostName = ConfigureUtil.configureNetwork(container, defaultNetworkId, useSharedNetwork,
+                DEV_SERVICE_KIBANA);
+        container.setExposedPorts(List.of(DASHBOARD_PORT));
+        if (!elasticsearchHosts.isEmpty()) {
+            container.addEnv("ELASTICSEARCH_HOSTS",
+                    "[" + elasticsearchHosts.stream().map(url -> "\"" + url + "\"").collect(Collectors.joining(",")) + "]");
+        }
+        config.dashboard().nodeOpts().ifPresent(nodeOpts -> container.addEnv("NODE_OPTIONS", nodeOpts));
+        return new CreatedContainer(container, kibanaHostName);
+    }
+
+    private CreatedContainer createDashboardsContainer(ElasticsearchDevServicesBuildTimeConfig config,
+            DockerImageName resolvedImageName, String defaultNetworkId, boolean useSharedNetwork,
+            LaunchModeBuildItem launchMode, DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            Set<String> opensearchHosts) {
+        //Create Generic Kibana container
+        GenericContainer<?> container = new GenericContainer<>(
+                resolvedImageName.asCompatibleSubstituteFor("opensearchproject/opensearch-dashboards"));
+
+        String kibanaHostName = ConfigureUtil.configureNetwork(container, defaultNetworkId, useSharedNetwork,
+                DEV_SERVICE_DASHBOARDS);
+        container.setExposedPorts(List.of(DASHBOARD_PORT));
+        if (!opensearchHosts.isEmpty()) {
+            container.addEnv("OPENSEARCH_HOSTS",
+                    "[" + opensearchHosts.stream().map(url -> "\"" + url + "\"").collect(Collectors.joining(",")) + "]");
+        }
+
+        config.dashboard().nodeOpts().ifPresent(nodeOpts -> container.addEnv("NODE_OPTIONS", nodeOpts));
+        container.addEnv("DISABLE_SECURITY_DASHBOARDS_PLUGIN", "true");
+        return new CreatedContainer(container, kibanaHostName);
+    }
+
+    private record CreatedContainer(GenericContainer<?> genericContainer, String hostName) {
+    }
+
+    static DockerImageName resolveDashboardImageName(ElasticsearchDevServicesBuildTimeConfig config,
+            Distribution resolvedDistribution) {
+        return DockerImageName.parse(config.imageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor(
+                Distribution.ELASTIC.equals(resolvedDistribution)
+                        ? DEV_SERVICE_KIBANA
+                        : DEV_SERVICE_DASHBOARDS)));
+    }
+
+    private void shutdownElasticsearchDashboards() {
+        if (devDashboardService != null) {
+            try {
+                devDashboardService.close();
+            } catch (Throwable e) {
+                log.error("Failed to stop the Dashboards", e);
+            } finally {
+                devDashboardService = null;
+            }
+        }
+    }
+
+    private static class DashboardDevServicesConfiguration {
+        private final Distribution distribution;
+        private final String hostName;
+        private final static String DISTRIBUTION_PROPERTY = "quarkus.elasticsearch.devservices.dashboard.distribution";
+        private final static String HOST_NAME_PROPERTY = "quarkus.elasticsearch.devservices.dashboard.hostName";
+
+        private DashboardDevServicesConfiguration(Distribution distribution, String hostName) {
+            this.distribution = distribution;
+            this.hostName = hostName;
+        }
+
+        private DashboardDevServicesConfiguration(Map<String, String> properties) {
+            this.distribution = Distribution.valueOf(properties.get(DISTRIBUTION_PROPERTY));
+            this.hostName = properties.get(HOST_NAME_PROPERTY);
+        }
+
+        private static Map<String, String> buildPropertiesMap(Distribution distribution, String hostName) {
+            return Map.of(DISTRIBUTION_PROPERTY, distribution.name(), HOST_NAME_PROPERTY, hostName);
+        }
+    }
+
+    public Optional<Distribution> determineDistributionViaApi(String url, String username, String password) {
+        try {
+            log.debugf("Call the API on %s to determine the distribution", url);
+            URLConnection connection = URI.create(url).toURL().openConnection();
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Authorization",
+                    "Basic " + Base64.getEncoder().encodeToString(String.format("%s:%s", username, password).getBytes()));
+            Map<String, Map<String, Object>> nodeInfo = objectMapper.readValue(connection.getInputStream(), Map.class);
+            Map<String, Object> versionInfo = nodeInfo.get("version");
+            if (versionInfo == null) {
+                log.error("No version info found in the response");
+                return Optional.empty();
+            }
+            Object distribution = versionInfo.get("distribution");
+            if (distribution instanceof String) {
+                log.debugf("The distribution is %s", ((String) distribution));
+                try {
+                    return Optional.of(Distribution.valueOf(((String) distribution).toUpperCase()));
+                } catch (IllegalArgumentException e) {
+                    log.errorf("The distribution %s is not supported", ((String) distribution));
+                    return Optional.empty();
+                }
+            } else {
+                // Elastic does not return a distribution, so we assume it is Elastic
+                return Optional.of(Distribution.ELASTIC);
+            }
+        } catch (IOException e) {
+            log.error("Failed to determine the distribution via API", e);
+            return Optional.empty();
+        }
+    }
+
+}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorStrategy.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorStrategy.java
@@ -69,9 +69,9 @@ public class DevservicesElasticsearchProcessorStrategy {
 
     private static final ContainerLocator dashboardContainerLocator = locateContainerWithLabels(DASHBOARD_PORT,
             DEV_SERVICE_LABEL);
-    static volatile RunningDevService devDashboardService;
-    static volatile ElasticsearchCommonBuildTimeConfig cfg;
-    static volatile boolean first = true;
+    volatile RunningDevService devDashboardService;
+    volatile ElasticsearchCommonBuildTimeConfig cfg;
+    volatile boolean first = true;
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final DistributionStrategy strategy;
 
@@ -263,7 +263,7 @@ public class DevservicesElasticsearchProcessorStrategy {
             List<DevservicesElasticsearchConnectionBuildItem> elasticsearchConnectionBuildItems) {
         Set<String> hosts;
         if (hostsConfigAvailable(buildItemConfig)) {
-            log.info("elasticsearch hosts config property found, using it");
+            log.info("Elasticsearch hosts config property found, using it");
             hosts = buildItemConfig.hostsConfigProperties.stream().filter(ConfigUtils::isPropertyNonEmpty)
                     .flatMap(property -> ConfigProvider.getConfig().getValues(property, String.class).stream())
                     // We could pass quarkus.elasticsearch.protocol via DevservicesElasticsearchBuildItem if it is not http.
@@ -271,7 +271,7 @@ public class DevservicesElasticsearchProcessorStrategy {
                     .collect(Collectors.toSet());
         } else {
             log.info(
-                    "no elasticsearch hosts config property found, using the host of the elasticsearch dev services container to connect");
+                    "no Elasticsearch hosts config property found, using the host of the elasticsearch dev services container to connect");
             hosts = elasticsearchConnectionBuildItems.stream()
                     .filter(connection -> strategy.supportedDistribution().equals(connection.getDistribution()))
                     // We could pass quarkus.elasticsearch.protocol via DevservicesElasticsearchBuildItem if it is not http.

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorStrategy.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorStrategy.java
@@ -224,10 +224,10 @@ public class DevservicesElasticsearchProcessorStrategy {
             Set<String> backendHostsLocahostReplaced = backendHosts.stream()
                     .map(host -> host.replace("localhost", "host.docker.internal")).collect(Collectors.toSet());
             CreatedContainer createdContainer = strategy.supportedDistribution().equals(Distribution.ELASTIC)
-                    ? createKibanaContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork, launchMode,
-                            composeProjectBuildItem, backendHostsLocahostReplaced)
-                    : createDashboardsContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork, launchMode,
-                            composeProjectBuildItem, backendHostsLocahostReplaced);
+                    ? createKibanaContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork,
+                            backendHostsLocahostReplaced)
+                    : createDashboardsContainer(config, resolvedImageName, defaultNetworkId, useSharedNetwork,
+                            backendHostsLocahostReplaced);
             GenericContainer<?> container = createdContainer.genericContainer();
             if (config.serviceName() != null) {
                 container.withLabel(DEV_SERVICE_LABEL, config.serviceName());
@@ -287,7 +287,6 @@ public class DevservicesElasticsearchProcessorStrategy {
 
     private CreatedContainer createKibanaContainer(ElasticsearchDevServicesBuildTimeConfig config,
             DockerImageName resolvedImageName, String defaultNetworkId, boolean useSharedNetwork,
-            LaunchModeBuildItem launchMode, DevServicesComposeProjectBuildItem composeProjectBuildItem,
             Set<String> elasticsearchHosts) {
         //Create Generic Kibana container
         GenericContainer<?> container = new GenericContainer<>(
@@ -306,7 +305,6 @@ public class DevservicesElasticsearchProcessorStrategy {
 
     private CreatedContainer createDashboardsContainer(ElasticsearchDevServicesBuildTimeConfig config,
             DockerImageName resolvedImageName, String defaultNetworkId, boolean useSharedNetwork,
-            LaunchModeBuildItem launchMode, DevServicesComposeProjectBuildItem composeProjectBuildItem,
             Set<String> opensearchHosts) {
         //Create Generic Kibana container
         GenericContainer<?> container = new GenericContainer<>(

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorUtils.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorUtils.java
@@ -1,13 +1,9 @@
 package io.quarkus.elasticsearch.restclient.common.deployment;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
 
 import org.testcontainers.utility.DockerImageName;
 
@@ -18,8 +14,15 @@ import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommon
 
 final class DevservicesElasticsearchProcessorUtils {
 
+    /**
+     * Label to add to shared Dev Service for Elasticsearch running in containers.
+     * This allows other applications to discover the running service and use it instead of starting a new instance.
+     */
+    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-elasticsearch";
+    static final String NEW_DEV_SERVICE_LABEL = "io.quarkus.devservice.elasticsearch";
     static final String DEV_SERVICE_ELASTICSEARCH = "elasticsearch";
     static final String DEV_SERVICE_OPENSEARCH = "opensearch";
+    static final int ELASTICSEARCH_PORT = 9200;
     static final Distribution DEFAULT_DISTRIBUTION = Distribution.ELASTIC;
 
     private DevservicesElasticsearchProcessorUtils() {
@@ -29,20 +32,6 @@ final class DevservicesElasticsearchProcessorUtils {
             RunningDevService devService) {
         String hostsConfigProperty = buildItemsConfiguration.hostsConfigProperties.stream().findAny().get();
         return devService.getConfig().get(hostsConfigProperty);
-    }
-
-    static Properties loadProperties(String devserviceName) {
-        var fileName = devserviceName + "-devservice.properties";
-        try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)) {
-            if (in == null) {
-                throw new IllegalArgumentException(fileName + " not found on classpath");
-            }
-            var properties = new Properties();
-            properties.load(in);
-            return properties;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     static Distribution resolveDistribution(ElasticsearchDevServicesBuildTimeConfig config,

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorUtils.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchProcessorUtils.java
@@ -1,0 +1,89 @@
+package io.quarkus.elasticsearch.restclient.common.deployment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig.Distribution;
+
+final class DevservicesElasticsearchProcessorUtils {
+
+    static final String DEV_SERVICE_ELASTICSEARCH = "elasticsearch";
+    static final String DEV_SERVICE_OPENSEARCH = "opensearch";
+    static final Distribution DEFAULT_DISTRIBUTION = Distribution.ELASTIC;
+
+    private DevservicesElasticsearchProcessorUtils() {
+    }
+
+    static String getElasticsearchHosts(DevservicesElasticsearchBuildItemsConfiguration buildItemsConfiguration,
+            RunningDevService devService) {
+        String hostsConfigProperty = buildItemsConfiguration.hostsConfigProperties.stream().findAny().get();
+        return devService.getConfig().get(hostsConfigProperty);
+    }
+
+    static Properties loadProperties(String devserviceName) {
+        var fileName = devserviceName + "-devservice.properties";
+        try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)) {
+            if (in == null) {
+                throw new IllegalArgumentException(fileName + " not found on classpath");
+            }
+            var properties = new Properties();
+            properties.load(in);
+            return properties;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    static Distribution resolveDistribution(ElasticsearchDevServicesBuildTimeConfig config,
+            DevservicesElasticsearchBuildItemsConfiguration buildItemConfig) throws BuildException {
+        // First, let's see if it was explicitly configured:
+        if (config.distribution().isPresent()) {
+            return config.distribution().get();
+        }
+        // Now let's see if we can guess it from the image:
+        if (config.imageName().isPresent()) {
+            String imageNameRepository = DockerImageName.parse(config.imageName().get()).getRepository()
+                    .toLowerCase(Locale.ROOT);
+            if (imageNameRepository.contains(DEV_SERVICE_OPENSEARCH)) {
+                return Distribution.OPENSEARCH;
+            }
+            if (imageNameRepository.contains(DEV_SERVICE_ELASTICSEARCH)) {
+                return Distribution.ELASTIC;
+            }
+            // no luck guessing so let's ask user to be more explicit:
+            throw new BuildException(
+                    "Wasn't able to determine the distribution of the search service based on the provided image name ["
+                            + config.imageName().get()
+                            + "]. Please specify the distribution explicitly.",
+                    Collections.emptyList());
+        }
+        // Otherwise, let's see if the build item has a value available:
+        if (buildItemConfig.distribution != null) {
+            return buildItemConfig.distribution;
+        }
+        // If we didn't get an explicit distribution
+        // and no image name was provided
+        // then elastic is a default distribution:
+        return DEFAULT_DISTRIBUTION;
+    }
+
+    static Map<String, String> buildPropertiesMap(DevservicesElasticsearchBuildItemsConfiguration buildItemConfig,
+            String httpHosts) {
+        Map<String, String> propertiesToSet = new HashMap<>();
+        for (String property : buildItemConfig.hostsConfigProperties) {
+            propertiesToSet.put(property, httpHosts);
+        }
+        return propertiesToSet;
+    }
+}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
@@ -66,6 +66,18 @@ public interface ElasticsearchCommonBuildTimeConfig {
         Optional<String> imageName();
 
         /**
+         * The Elasticsearch container image to use.
+         *
+         * Defaults depend on the configured `distribution`:
+         *
+         * * For the `elastic` distribution: {elasticsearch-image}
+         * * For the `opensearch` distribution: {opensearch-image}
+         *
+         * @asciidoclet
+         */
+        //Optional<String> imageKibanaName();
+
+        /**
          * The value for the ES_JAVA_OPTS env variable.
          *
          * @asciidoclet

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
@@ -186,8 +186,8 @@ public interface ElasticsearchCommonBuildTimeConfig {
              *
              * @asciidoclet
              */
-            @WithDefault(" ")
-            String nodeOpts();
+
+            Optional<String> nodeOpts();
         }
     }
 }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
@@ -66,18 +66,6 @@ public interface ElasticsearchCommonBuildTimeConfig {
         Optional<String> imageName();
 
         /**
-         * The Elasticsearch container image to use.
-         *
-         * Defaults depend on the configured `distribution`:
-         *
-         * * For the `elastic` distribution: {elasticsearch-image}
-         * * For the `opensearch` distribution: {opensearch-image}
-         *
-         * @asciidoclet
-         */
-        //Optional<String> imageKibanaName();
-
-        /**
          * The value for the ES_JAVA_OPTS env variable.
          *
          * @asciidoclet

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
@@ -36,12 +36,6 @@ public interface ElasticsearchCommonBuildTimeConfig {
         Optional<Boolean> enabled();
 
         /**
-         * Kibana configuration for Dev Services.
-         */
-        @ConfigDocSection
-        KibanaDevServicesConfig kibana();
-
-        /**
          * Optional fixed port the dev service will listen to.
          * <p>
          * If not defined, the port will be chosen randomly.
@@ -151,15 +145,21 @@ public interface ElasticsearchCommonBuildTimeConfig {
         @WithDefault("true")
         boolean reuse();
 
+        /**
+         * Kibana configuration for Dev Services.
+         */
+        @ConfigDocSection
+        DashboardDevServicesConfig dashboard();
+
         enum Distribution {
             ELASTIC,
             OPENSEARCH
         }
 
         @ConfigGroup
-        interface KibanaDevServicesConfig {
+        interface DashboardDevServicesConfig {
             /**
-             * Whether the Kibana Dev Service should start with the application in dev mode or tests.
+             * Whether the Dashboard Dev Service should start with the application in dev mode or tests.
              * <p>
              * Kibana Dev Services are disabled by default when Elasticsearch Dev Services are enabled.
              *
@@ -167,6 +167,39 @@ public interface ElasticsearchCommonBuildTimeConfig {
              */
             @WithDefault("false")
             boolean enabled();
+
+            /**
+             * Optional fixed port the dev service will listen to.
+             * <p>
+             * If not defined, the port will be chosen randomly.
+             */
+            Optional<Integer> port();
+
+            /**
+             * The Elasticsearch container image to use.
+             *
+             * Defaults depend on the configured `distribution`:
+             *
+             * * For the `elastic` distribution: {kibana-image}
+             * * For the `opensearch` distribution: {dashboardimage}
+             *
+             * @asciidoclet
+             */
+            Optional<String> imageName();
+
+            /**
+             * Environment variables that are passed to the container.
+             */
+            @ConfigDocMapKey("environment-variable-name")
+            Map<String, String> containerEnv();
+
+            /**
+             * The value for the NODE_OPTIONS env variable.
+             *
+             * @asciidoclet
+             */
+            @WithDefault(" ")
+            String nodeOpts();
         }
     }
 }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
@@ -134,7 +134,7 @@ public interface ElasticsearchCommonBuildTimeConfig {
         boolean reuse();
 
         /**
-         * Kibana configuration for Dev Services.
+         * Dashboards/Kibana configuration for Dev Services.
          */
         @ConfigDocSection
         DashboardDevServicesConfig dashboard();
@@ -149,7 +149,7 @@ public interface ElasticsearchCommonBuildTimeConfig {
             /**
              * Whether the Dashboard Dev Service should start with the application in dev mode or tests.
              * <p>
-             * Kibana Dev Services are disabled by default when Elasticsearch Dev Services are enabled.
+             * Dashboards/Kibana Dev Services are disabled by default when Elasticsearch Dev Services are enabled.
              *
              * @asciidoclet
              */
@@ -164,12 +164,12 @@ public interface ElasticsearchCommonBuildTimeConfig {
             Optional<Integer> port();
 
             /**
-             * The Elasticsearch container image to use.
+             * The Dashboards/Kibana container image to use.
              *
              * Defaults depend on the configured `distribution`:
              *
              * * For the `elastic` distribution: {kibana-image}
-             * * For the `opensearch` distribution: {dashboardimage}
+             * * For the `opensearch` distribution: {opensearch-dashboards-image}
              *
              * @asciidoclet
              */

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchCommonBuildTimeConfig.java
@@ -36,6 +36,12 @@ public interface ElasticsearchCommonBuildTimeConfig {
         Optional<Boolean> enabled();
 
         /**
+         * Kibana configuration for Dev Services.
+         */
+        @ConfigDocSection
+        KibanaDevServicesConfig kibana();
+
+        /**
          * Optional fixed port the dev service will listen to.
          * <p>
          * If not defined, the port will be chosen randomly.
@@ -148,6 +154,19 @@ public interface ElasticsearchCommonBuildTimeConfig {
         enum Distribution {
             ELASTIC,
             OPENSEARCH
+        }
+
+        @ConfigGroup
+        interface KibanaDevServicesConfig {
+            /**
+             * Whether the Kibana Dev Service should start with the application in dev mode or tests.
+             * <p>
+             * Kibana Dev Services are disabled by default when Elasticsearch Dev Services are enabled.
+             *
+             * @asciidoclet
+             */
+            @WithDefault("false")
+            boolean enabled();
         }
     }
 }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
@@ -1,2 +1,1 @@
 default.image=${elasticsearch.image}
-default.dashboard.image=${kibana.image}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
@@ -1,1 +1,2 @@
 default.image=${elasticsearch.image}
+default.kibana.image=${kibana.image}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
@@ -1,2 +1,2 @@
 default.image=${elasticsearch.image}
-default.kibana.image=${kibana.image}
+default.dashboard.image=${kibana.image}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-kibana-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-kibana-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${kibana.image}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-dashboards-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-dashboards-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${opensearch-dashboards.image}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-devservice.properties
@@ -1,2 +1,1 @@
 default.image=${opensearch.image}
-default.dashboard.image=${opensearch-dashboards.image}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-devservice.properties
@@ -1,1 +1,2 @@
 default.image=${opensearch.image}
+default.dashboard.image=${opensearch-dashboards.image}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

This change will add dashboard services to the dev services for extensions/elasticsearch-rest-client and extensions/elasticsearch-java-client. If the distribution is elasticsearch, it will start Kibana as the dashboard. If the distribution is opensearch, it will start OpenSearch-dashboards as the dashboard.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

* Fixes #39582