### PR TITLE
Upgrade the default maximum datasource size to 50

### DIFF
--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DevServicesH2DatasourceTestCase.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DevServicesH2DatasourceTestCase.java
@@ -43,7 +43,7 @@ public class DevServicesH2DatasourceTestCase {
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:h2:"));
         assertEquals(DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME,
                 configuration.connectionFactoryConfiguration().principal().getName());
-        assertEquals(20, configuration.maxSize());
+        assertEquals(50, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(ExceptionSorter.emptyExceptionSorter().getClass());
 
         try (Connection connection = dataSource.getConnection()) {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/MultipleDevServicesDataSourcesConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/MultipleDevServicesDataSourcesConfigTest.java
@@ -42,13 +42,13 @@ public class MultipleDevServicesDataSourcesConfigTest {
         testDataSource(DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME, defaultDataSource,
                 "jdbc:h2:tcp://localhost:" + extractPort(defaultDataSource) + "/mem:"
                         + DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME + ";DB_CLOSE_DELAY=-1",
-                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 20);
+                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 50);
         testDataSource("users", dataSource1,
                 "jdbc:h2:tcp://localhost:" + extractPort(dataSource1) + "/mem:users;DB_CLOSE_DELAY=-1",
-                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 20);
+                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 50);
         testDataSource("inventory", dataSource2,
                 "jdbc:h2:tcp://localhost:" + extractPort(dataSource2) + "/mem:inventory;DB_CLOSE_DELAY=-1",
-                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 20);
+                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 50);
     }
 
     public int extractPort(AgroalDataSource ds) {

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -39,7 +39,7 @@ public interface DataSourceJdbcRuntimeConfig {
     /**
      * The datasource pool maximum size
      */
-    @WithDefault("20")
+    @WithDefault("50")
     int maxSize();
 
     /**

--- a/extensions/jdbc/jdbc-db2/deployment/src/test/java/io/quarkus/jdbc/db2/deployment/DevServicesDB2DatasourceTestCase.java
+++ b/extensions/jdbc/jdbc-db2/deployment/src/test/java/io/quarkus/jdbc/db2/deployment/DevServicesDB2DatasourceTestCase.java
@@ -42,7 +42,7 @@ public class DevServicesDB2DatasourceTestCase {
         AgroalConnectionPoolConfiguration configuration = dataSource.getConfiguration().connectionPoolConfiguration();
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:db2:"));
         assertEquals("quarkus", configuration.connectionFactoryConfiguration().principal().getName());
-        assertEquals(20, configuration.maxSize());
+        assertEquals(50, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(DB2ExceptionSorter.class);
 
         try (Connection connection = dataSource.getConnection()) {

--- a/extensions/jdbc/jdbc-mariadb/deployment/src/test/java/io/quarkus/jdbc/mariadb/deployment/DevServicesMariaDBDatasourceTestCase.java
+++ b/extensions/jdbc/jdbc-mariadb/deployment/src/test/java/io/quarkus/jdbc/mariadb/deployment/DevServicesMariaDBDatasourceTestCase.java
@@ -49,7 +49,7 @@ public class DevServicesMariaDBDatasourceTestCase {
         }
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:mariadb:"));
         assertEquals("quarkus", configuration.connectionFactoryConfiguration().principal().getName());
-        assertEquals(20, configuration.maxSize());
+        assertEquals(50, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(MySQLExceptionSorter.class);
 
         try (Connection connection = dataSource.getConnection()) {

--- a/extensions/jdbc/jdbc-mssql/deployment/src/test/java/io/quarkus/jdbc/mssql/deployment/DevServicesMsSQLDatasourceTestCase.java
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/test/java/io/quarkus/jdbc/mssql/deployment/DevServicesMsSQLDatasourceTestCase.java
@@ -42,7 +42,7 @@ public class DevServicesMsSQLDatasourceTestCase {
         AgroalConnectionPoolConfiguration configuration = dataSource.getConfiguration().connectionPoolConfiguration();
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:sqlserver:"));
         assertEquals("sa", configuration.connectionFactoryConfiguration().principal().getName());
-        assertEquals(20, configuration.maxSize());
+        assertEquals(50, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(MSSQLExceptionSorter.class);
 
         try (Connection connection = dataSource.getConnection()) {

--- a/extensions/jdbc/jdbc-mysql/deployment/src/test/java/io/quarkus/jdbc/mysql/deployment/DevServicesMySQLDatasourceTestCase.java
+++ b/extensions/jdbc/jdbc-mysql/deployment/src/test/java/io/quarkus/jdbc/mysql/deployment/DevServicesMySQLDatasourceTestCase.java
@@ -49,7 +49,7 @@ public class DevServicesMySQLDatasourceTestCase {
         }
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:mysql:"));
         assertEquals("quarkus", configuration.connectionFactoryConfiguration().principal().getName());
-        assertEquals(20, configuration.maxSize());
+        assertEquals(50, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(MySQLExceptionSorter.class);
 
         try (Connection connection = dataSource.getConnection()) {

--- a/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/DevServicesOracleDatasourceTestCase.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/DevServicesOracleDatasourceTestCase.java
@@ -49,7 +49,7 @@ public class DevServicesOracleDatasourceTestCase {
         }
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:oracle:"));
         assertEquals("quarkus", configuration.connectionFactoryConfiguration().principal().getName());
-        assertEquals(20, configuration.maxSize());
+        assertEquals(50, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(OracleExceptionSorter.class);
 
         try (Connection connection = dataSource.getConnection()) {

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceTestCase.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceTestCase.java
@@ -49,7 +49,7 @@ public class DevServicesPostgresqlDatasourceTestCase {
         }
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:postgresql:"));
         assertEquals("quarkus", configuration.connectionFactoryConfiguration().principal().getName());
-        assertEquals(20, configuration.maxSize());
+        assertEquals(50, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(PostgreSQLExceptionSorter.class);
 
         try (Connection connection = dataSource.getConnection()) {


### PR DESCRIPTION
A proposal to improve default config a little towards more modern standards.
To be discussed:
 - [#dev > jdbc.max-size : adapt to the times?](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/jdbc.2Emax-size.20.3A.20adapt.20to.20the.20times.3F/with/558745885)

