### PR TITLE
Fix missing mysql image attribute

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -14,6 +14,7 @@
 :db2-image: ${db2.image}
 :mariadb-image: ${mariadb.image}
 :mssql-image: ${mssql.image}
+:mysql-image: ${mysql.image}
 :oracle-image: ${oracle.image}
 :postgres-image: ${postgres.image}
 :elasticsearch-version: ${elasticsearch-server.version}


### PR DESCRIPTION
Forgot to add it here https://github.com/quarkusio/quarkus/pull/51098

<img width="954" height="427" alt="image" src="https://github.com/user-attachments/assets/0e61c76f-933c-4527-8292-58e4e425e79f" />