### PR TITLE
Create separate `HttpTestConfig` for `quarkus.http.test-timeout`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/HttpTestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/HttpTestConfig.java
@@ -1,0 +1,22 @@
+package io.quarkus.deployment.dev.testing;
+
+import java.time.Duration;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * HTTP-related testing configuration.
+ */
+@ConfigMapping(prefix = "quarkus.http")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface HttpTestConfig {
+
+    /**
+     * The REST Assured client timeout for testing.
+     */
+    @WithDefault("30s")
+    Duration testTimeout();
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
@@ -1,6 +1,5 @@
 package io.quarkus.vertx.http.runtime;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -68,12 +67,6 @@ public interface VertxHttpBuildTimeConfig {
      */
     @WithDefault("q")
     String nonApplicationRootPath();
-
-    /**
-     * The REST Assured client timeout for testing.
-     */
-    @WithDefault("30s")
-    Duration testTimeout();
 
     /**
      * If enabled then the response body is compressed if the {@code Content-Type} header is set and the value is a compressed


### PR DESCRIPTION
Instead of moving the property to TestConfig which would result in the property path being `quarkus.test.http.test-timeout`, create a separate ConfigMapping for `quarkus.http` prefix.

- Fixes: #51061
- Supercedes: #51131