### PR TITLE
Expose Undertow listener configuration options

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -636,3 +636,36 @@ Route order constants defined in `io.quarkus.vertx.http.runtime.RouteConstants` 
 | `10000` | `ROUTE_ORDER_DEFAULT` | Default route order (i.e. Static Resources, Servlet).
 | `20000` | `ROUTE_ORDER_AFTER_DEFAULT` | Route without priority over the default route (add an offset from this value)
 |===
+
+=== Undertow configuration
+
+The following configuration properties are available when using the Undertow servlet extension.
+
+[cols="3,1,1,5",options="header"]
+|===
+|Configuration property |Type |Default |Description
+
+|`quarkus.undertow.disallowed-methods`
+|list of string
+|`<empty>`
+|A list of HTTP methods that should be rejected with `405 Method Not Allowed`.
+Useful for disabling insecure methods such as `TRACE` or `TRACK`.
+
+Example:
+----
+quarkus.undertow.disallowed-methods=TRACE,TRACK
+----
+
+|`quarkus.undertow.record-request-start-time`
+|boolean
+|false
+|If enabled, Undertow records the request start timestamp.
+Useful for timing, logging and request tracing.
+
+|`quarkus.undertow.max-parameters`
+|int
+|1000
+|Maximum number of allowed HTTP parameters.
+Provides protection against parameter-based DoS attacks.
+
+|===

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/DisallowedMethodsTest.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/DisallowedMethodsTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.undertow.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.http.Method;
+
+public class DisallowedMethodsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClass(DisallowedMethodsTestServlet.class))
+            .withConfigurationResource("application-disallowed-methods.properties");
+
+    @TestHTTPResource("/disallowed")
+    URI testUri;
+
+    @Test
+    public void traceMethodShouldBeBlockedWith405() {
+        given()
+                .when()
+                .request(Method.TRACE, testUri)
+                .then()
+                .statusCode(405);
+    }
+
+    @Test
+    public void getMethodShouldStillWork() {
+        given()
+                .when()
+                .get(testUri)
+                .then()
+                .statusCode(200)
+                .body(equalTo("ok"));
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/DisallowedMethodsTestServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/DisallowedMethodsTestServlet.java
@@ -1,0 +1,17 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = "/disallowed")
+public class DisallowedMethodsTestServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().write("ok");
+    }
+}

--- a/extensions/undertow/deployment/src/test/resources/application-disallowed-methods.properties
+++ b/extensions/undertow/deployment/src/test/resources/application-disallowed-methods.properties
@@ -1,0 +1,1 @@
+quarkus.servlet.disallowed-methods=TRACE

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.undertow.runtime;
 
 import java.util.Optional;
+import java.util.Set;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -34,4 +35,17 @@ public interface ServletRuntimeConfig {
      */
     @WithDefault("1000")
     int maxParameters();
+
+    /**
+     * A list of HTTP methods that are disallowed for servlet requests.
+     * Requests using these methods will be rejected before being processed.
+     */
+    Optional<Set<String>> disallowedMethods();
+
+    /**
+     * Whether to record the request start time for each HTTP request.
+     * Useful for access logs and response time metrics.
+     */
+    @WithDefault("false")
+    boolean recordRequestStartTime();
 }


### PR DESCRIPTION
This PR exposes several Undertow listener configuration options that were previously available in Undertow
but not exposed through Quarkus configuration.

### Added configuration properties

**quarkus.undertow.listener.disallowed-methods**
- List of HTTP methods that should be rejected with `405 Method Not Allowed`
- Useful for disabling unsafe methods such as TRACE or TRACK

**quarkus.undertow.listener.record-request-start-time**
- Enables recording the request start timestamp in Undertow
- Useful for logging, tracing and request timing

**quarkus.undertow.listener.max-parameters**
- Specifies the maximum number of allowed HTTP parameters
- Provides protection against parameter-based DoS attacks

### Motivation

These settings improve security hardening, observability, and request handling consistency.
By exposing them as Quarkus configuration options, applications can now configure Undertow behavior
directly through `application.properties` like other existing Undertow-related settings.

### Documentation

Documentation has been added to: docs/src/main/asciidoc/http-reference.adoc


### Notes

- Default values align with Undertow defaults unless overridden.
- Behavior is fully backward compatible.

---

- Fixes: #51180
