### PR TITLE
Add a configuration to serve a local directory with a static handler

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -62,6 +62,44 @@ public class StaticResources {
 }
 ----
 
+=== Local filesystem static resources
+
+NOTE: Serving static resources from a local filesystem directory is enabled
+when `quarkus.http.static-dir.path` is set.
+The `quarkus.http.static-dir.enabled` property can be used to explicitly
+disable this feature.
+
+Quarkus can serve static files from a local filesystem directory, outside of the application JAR and Java resources.
+This is configured via the `quarkus.http.static-dir.*` properties.
+
+To expose the contents of a `static/` directory:
+
+[source,properties]
+----
+quarkus.http.static-dir.path=static
+----
+
+By default, static files are exposed under the `/static` endpoint.
+
+With this configuration, a file located at `static/picture.jpg` will be available at:
+`http://localhost:8080/static/picture.jpg`.
+
+To change the default endpoint:
+[source,properties]
+----
+quarkus.http.static-dir.endpoint=/
+----
+
+With this configuration, a file located at `static/picture.jpg` will be available at:
+`http://localhost:8080/picture.jpg`.
+
+The `quarkus.http.static-dir.endpoint` value must not contain `*` or `..`, and it will be normalized
+to avoid trailing slashes.
+Similarly, `quarkus.http.static-dir.path` must be a relative path without `..`.
+Quarkus validates these values at build time.
+
+This feature can be used in both development and production environments.
+
 === HTTP Compression
 
 The response body of a static resource is not compressed by default.

--- a/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/GeneratedStaticResourceBuildItem.java
+++ b/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/GeneratedStaticResourceBuildItem.java
@@ -70,7 +70,7 @@ public final class GeneratedStaticResourceBuildItem extends MultiBuildItem {
 
     public boolean isFile() {
         return file != null;
-    };
+    }
 
     public byte[] getContent() {
         return this.content;

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HttpStaticDirTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HttpStaticDirTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HttpStaticDirTest {
+
+    private static final String PUBLIC_RESOURCES_DIR = "src/test/resources/public-resources";
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.http.static-dir.enabled", "true")
+            .overrideConfigKey("quarkus.http.static-dir.endpoint", "/public-resources")
+            .overrideConfigKey("quarkus.http.static-dir.path", PUBLIC_RESOURCES_DIR);
+
+    @Test
+    public void shouldServeHttpStaticDir() {
+        given()
+                .when().get("/public-resources/test.txt")
+                .then()
+                .statusCode(200)
+                .body(equalTo("hello-static"));
+    }
+
+    @Test
+    public void shouldReturn404ForMissingResource() {
+        given()
+                .when().get("/public-resources/does-not-exist.txt")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void shouldServeSubdirectoryResources() {
+        given()
+                .when().get("/public-resources/subdir/test.txt")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void shouldReturn404ForTraversal() {
+        given()
+                .when().get("/public-resources/../test.txt")
+                .then()
+                .statusCode(404);
+
+        given()
+                .when().get("/public-resources/../../etc/passwd")
+                .then()
+                .statusCode(404);
+
+        given()
+                .when().get("/public-resources/%2e%2e/test.txt")
+                .then()
+                .statusCode(404);
+
+        // Returns 200 because Vert.x normalizes the path. The ../public-resources/ segment
+        // collapses to the same directory, so the resolved path remains under /public-resources.
+        given()
+                .when().get("/public-resources/../public-resources/test.txt")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/resources/conf/quarkus.http.static-dir.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/quarkus.http.static-dir.properties
@@ -1,0 +1,3 @@
+quarkus.http.static-dir.enabled=true
+quarkus.http.static-dir.endpoint=/public-resources
+quarkus.http.static-dir.path=src/test/resources/public-resources

--- a/extensions/vertx-http/deployment/src/test/resources/public-resources/subdir/test.txt
+++ b/extensions/vertx-http/deployment/src/test/resources/public-resources/subdir/test.txt
@@ -1,0 +1,1 @@
+hello from subdir

--- a/extensions/vertx-http/deployment/src/test/resources/public-resources/test.txt
+++ b/extensions/vertx-http/deployment/src/test/resources/public-resources/test.txt
@@ -1,0 +1,1 @@
+hello-static

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpStaticDirConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpStaticDirConfig.java
@@ -1,0 +1,123 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface HttpStaticDirConfig {
+
+    /**
+     * Allows explicitly disabling static directory serving (e.g. for CI or DevOps use cases).
+     * <p>
+     * Defaults to {@code true}. Note that this property does not enable static directory serving
+     * by itself. The feature is enabled only when {@code quarkus.http.static-dir.path} is set.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * The base endpoint under which the local directory is exposed.
+     * <p>
+     * e.g. {@code /static} with hello.txt will be served at <code>/static/hello.txt</code>.
+     */
+    @WithDefault("static")
+    String endpoint();
+
+    /**
+     * The local directory from which static files will be served,
+     * relative to the application's working directory.
+     * <p>
+     * For example, if set to {@code static} and the directory contains
+     * {@code picture.jpg}, it will be available at the configured
+     * {@code quarkus.http.static-dir.endpoint}/picture.jpg.
+     */
+    Optional<String> path();
+
+    /**
+     * Normalizes and validates the local path from which files are served.
+     *
+     * @return a normalized directory string
+     * @throws IllegalArgumentException if the directory contains {@code ..}
+     */
+    default String normalizedPath() {
+
+        Optional<String> path = path();
+        if (path.isEmpty()) {
+            return null;
+        }
+
+        String d = path.get().trim();
+
+        if (d.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.path must not be empty or blank");
+        }
+
+        if (d.contains("..")) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.path must not contain '..': " + d);
+        }
+
+        Path p = Path.of(d);
+
+        if (p.getNameCount() == 0 || ".".equals(d)) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.path must not resolve to the project root directory (e.g. '.', './'): " + d);
+        }
+
+        if (p.isAbsolute()) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.path must be relative, but was: " + d);
+        }
+
+        return d;
+    }
+
+    /**
+     * Normalizes the configured path for serving endpoint.
+     *
+     * @return a normalized, safe base path for static resources
+     * @throws IllegalArgumentException if the path contains {@code *} or {@code ..}
+     */
+    default String normalizedEndpoint() {
+        String p = endpoint().trim();
+
+        if (p.contains("*")) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.endpoint must not contain '*': " + p);
+        }
+
+        if (p.contains("..")) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.endpoint must not contain '..': " + p);
+        }
+
+        if (p.indexOf(' ') >= 0) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.endpoint must not contain spaces: " + p);
+        }
+
+        if (p.contains("\\")) {
+            throw new IllegalArgumentException(
+                    "quarkus.http.static-dir.endpoint must use '/' as separator: " + p);
+        }
+
+        if (p.isEmpty()) {
+            return "/";
+        }
+
+        if (!p.startsWith("/")) {
+            p = "/" + p;
+        }
+
+        while (p.endsWith("/") && p.length() > 1) {
+            p = p.substring(0, p.length() - 1);
+        }
+
+        return p;
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
@@ -115,4 +115,11 @@ public interface VertxHttpBuildTimeConfig {
      * The compression level used when compression support is enabled.
      */
     OptionalInt compressionLevel();
+
+    /**
+     * Configure Quarkus to serve static files from a local filesystem directory (outside of Java resources)
+     *
+     */
+    @WithName("static-dir")
+    Optional<HttpStaticDirConfig> httpStaticDirConfig();
 }


### PR DESCRIPTION
### Summary
This PR introduces support for serving static files from a local directory, 
configurable via `quarkus.http.static-dir.*`.

### New configuration
`quarkus.http.static-dir.path=static`

### Tests
Added `LocalStaticResourcesTest` which verifies:
- Serving an existing file
- Returning 404 when missing
