### PR TITLE
Workaround for DB2 Dev Service not starting on Podman

### DIFF
--- a/extensions/jdbc/jdbc-db2/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-db2/deployment/pom.xml
@@ -114,25 +114,5 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Disabled pending fix of #33104 -->
-        <profile>
-            <id>podman</id>
-            <activation>
-                <property>
-                    <name>env.IS_PODMAN</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Fixes #33104, at least in the default case when there are no volume mounts. Which I suppose is good enough?

At the very least, this looks better than simply failing to start with cryptic errors.

* Fixes #33104

