### PR TITLE
Also populate Panache's "entityToPersistenceUnit" maps with subclasses of those mentioned in repositories

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -114,7 +114,12 @@ public final class PanacheHibernateResourceProcessor {
                 continue;
             List<org.jboss.jandex.Type> typeParameters = JandexUtil
                     .resolveTypeParameters(classInfo.name(), DOTNAME_PANACHE_REPOSITORY_BASE, index.getIndex());
-            panacheEntities.add(typeParameters.get(0).name().toString());
+            var entityTypeName = typeParameters.get(0).name();
+            panacheEntities.add(entityTypeName.toString());
+            // Also add subclasses, so that they get resolved to a persistence unit.
+            for (var subclass : index.getIndex().getAllKnownSubclasses(entityTypeName)) {
+                panacheEntities.add(subclass.name().toString());
+            }
             transformers.produce(new BytecodeTransformerBuildItem(classInfo.name().toString(), daoEnhancer));
         }
 

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/RepositoryAndCustomSuperclassTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/RepositoryAndCustomSuperclassTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.hibernate.orm.panache.deployment.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.TestTransaction;
+
+public class RepositoryAndCustomSuperclassTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyCustomEntitySuperclass.class, MyConcreteEntity.class, MyRepository.class));
+
+    @Inject
+    MyRepository repository;
+
+    @Test
+    @TestTransaction
+    public void smokeTest() {
+        assertThat(repository.count()).isEqualTo(0);
+        repository.persist(new MyConcreteEntity());
+        assertThat(repository.count()).isEqualTo(1);
+    }
+
+    @Entity(name = "Concrete")
+    public static class MyConcreteEntity extends MyCustomEntitySuperclass {
+
+        @Column
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+    }
+
+    @Entity(name = "Super")
+    public abstract static class MyCustomEntitySuperclass {
+
+        @Id
+        @GeneratedValue
+        private Integer id;
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyRepository implements PanacheRepositoryBase<MyCustomEntitySuperclass, Integer> {
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -121,7 +121,12 @@ public final class PanacheHibernateResourceProcessor {
                 continue;
             List<org.jboss.jandex.Type> typeParameters = JandexUtil
                     .resolveTypeParameters(classInfo.name(), DOTNAME_PANACHE_REPOSITORY_BASE, index.getIndex());
-            panacheEntities.add(typeParameters.get(0).name().toString());
+            var entityTypeName = typeParameters.get(0).name();
+            panacheEntities.add(entityTypeName.toString());
+            // Also add subclasses, so that they get resolved to a persistence unit.
+            for (var subclass : index.getIndex().getAllKnownSubclasses(entityTypeName)) {
+                panacheEntities.add(subclass.name().toString());
+            }
             daoClasses.add(classInfo.name().toString());
         }
         for (ClassInfo classInfo : index.getIndex().getAllKnownImplementors(DOTNAME_PANACHE_REPOSITORY)) {

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/RepositoryAndCustomSuperclassTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/RepositoryAndCustomSuperclassTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.hibernate.reactive.panache.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.quarkus.hibernate.reactive.panache.PanacheRepositoryBase;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+
+public class RepositoryAndCustomSuperclassTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyCustomEntitySuperclass.class, MyConcreteEntity.class, MyRepository.class));
+
+    @Inject
+    MyRepository repository;
+
+    @Test
+    @RunOnVertxContext
+    public void smokeTest(UniAsserter asserter) {
+        asserter.assertThat(() -> Panache.withTransaction(() -> repository.count()),
+                count -> assertThat(count).isEqualTo(0));
+        asserter.assertThat(() -> Panache.withTransaction(() -> repository.persist(new MyConcreteEntity()))
+                .chain(() -> Panache.withTransaction(() -> repository.count())),
+                count -> assertThat(count).isEqualTo(1));
+    }
+
+    @Entity(name = "Concrete")
+    public static class MyConcreteEntity extends MyCustomEntitySuperclass {
+
+        @Column
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+    }
+
+    @Entity(name = "Super")
+    public abstract static class MyCustomEntitySuperclass {
+
+        @Id
+        @GeneratedValue
+        private Integer id;
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyRepository implements PanacheRepositoryBase<MyCustomEntitySuperclass, Integer> {
+    }
+}


### PR DESCRIPTION

* Fixes #51176
* Fixes #50955 (probably; @edeandrea could you check? Your reproducer requires an OpenAPI key that I do not have...)

Note this does not change Panache Kotlin modules, because I could not find any code in these modules that would make sure that entity types mentioned exclusively in Panache repositories are correctly considered as Panache entities. I think Kotlin apps probably suffer from a much worse version of #50955. But nobody complained about _that_, so I'll move on to higher priority tasks...