### PR TITLE
Encrypt OIDC tokens for custom TokenStateManager implementations

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -604,14 +604,14 @@ Currently, only a `Cache-Control` `no-store` directive that prohibits caching th
 After the authorization code flow is finished, ID token, access token, and refresh token must be retained to support the user session.
 
 By defaut, Quarkus OIDC stores all three tokens in an encrypted session cookie, making Quarkus OIDC stateless.
-Quarkus OIDC also provides the stateful xref:security-oidc-code-flow-authentication.adoc#db-token-state-manager[Database TokenStateManager] to store tokens in your database of choice and the xref:security-oidc-code-flow-authentication.adoc#redis-token-state-manager[Redis TokenStateManager] to store them in the Redis cache. Users can also register custom `quarkus.oidc.TokenStateManager` to store these tokens as required.
+Quarkus OIDC also provides the stateful xref:security-oidc-code-flow-authentication.adoc#db-token-state-manager[Database TokenStateManager] to store tokens in your database of choice and the xref:security-oidc-code-flow-authentication.adoc#redis-token-state-manager[Redis TokenStateManager] to store them in the Redis cache. Users can also register custom `io.quarkus.oidc.TokenStateManager` to store these tokens as required.
 
 .Default TokenStateManager
 [options="header"]
 |====
 |Property | Default |Description
 
-|quarkus.oidc.token-state-manager.encryption-required |true| Encrypt session cookie by default
+|quarkus.oidc.token-state-manager.encryption-required |true| Encrypt session cookie by default, also see the note below
 |quarkus.oidc.token-state-manager.encryption-secret || Encryption secret, with falling back to the client secret and finally a generated secret key
 |quarkus.oidc.token-state-manager.encryption-algorithm |A256GCMKW| Encryption algorithm
 |quarkus.oidc.token-state-manager.split-tokens |false| Cookie per token
@@ -631,6 +631,15 @@ The encrypted session cookie with up to three tokens may exceed a 4096 bytes coo
 For example, you can do `quarkus.oidc.token-state-manager.strategy=id-refresh-tokens` which means that your application is not intending to use an access token directly or propagate it to downstream services, all it wants is to use ID token to interact with the user and keep refreshing the session.
 
 If your application does not need to use access tokens but only interact with the authenticated user who must always re-authenticate when the session expires, consider `quarkus.oidc.token-state-manager.strategy=idtoken` - which retains ID token only, ignoring both access and refresh tokens.
+
+[NOTE]
+====
+`quarkus.oidc.token-state-manager.encryption-required` and two other related properties, `quarkus.oidc.token-state-manager.encryption-secret` and `quarkus.oidc.token-state-manager.encryption-algorithm`, are also effective when custom `io.quarkus.oidc.TokenStateManager` is used, including xref:security-oidc-code-flow-authentication.adoc#db-token-state-manager[Database TokenStateManager] and xref:security-oidc-code-flow-authentication.adoc#redis-token-state-manager[Redis TokenStateManager]. 
+
+Given that `quarkus.oidc.token-state-manager.encryption-required` is set to `true` by default, a custom `io.quarkus.oidc.TokenStateManager` implementation must encrypt tokens before storing them by default. However, it does not have to encrypt tokens itself, they will be encrypted by the time it is asked to store them.
+
+A custom `io.quarkus.oidc.TokenStateManager` implementation that does not want tokens encrypted by default can disable it with `quarkus.oidc.token-state-manager.encryption-required=false`.
+====
 
 [[logout-properties]]
 == Logout
@@ -1231,7 +1240,7 @@ You can register a `quarkus.oidc.UserInfoCache` provider to support a custom `Us
 === TokenStateManager
 
 As discussed in the <<token-state-manager>> section above, Quarkus OIDC already provides stateless (default) and stateful options for storing  authorization code flow tokens.
-You can also provide your own custom `quarkus.oidc.TokenStateManager` implementation.
+You can also provide your own custom `io.quarkus.oidc.TokenStateManager` implementation.
 
 === Request, response and redirect filters
 

--- a/extensions/oidc-db-token-state-manager/deployment/src/main/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerProcessor.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/main/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerProcessor.java
@@ -151,9 +151,9 @@ public class OidcDbTokenStateManagerProcessor {
             case REACTIVE_DB2_CLIENT:
                 createTableDdl = "CREATE TABLE oidc_db_token_state_manager ("
                         + "id VARCHAR(100) NOT NULL PRIMARY KEY, "
-                        + "id_token VARCHAR(4000), "
-                        + "access_token VARCHAR(4000), "
-                        + "refresh_token VARCHAR(4000), "
+                        + "id_token VARCHAR(5000), "
+                        + "access_token VARCHAR(5000), "
+                        + "refresh_token VARCHAR(5000), "
                         + "access_token_expires_in BIGINT, "
                         + "access_token_scope VARCHAR(100), "
                         + "expires_in BIGINT NOT NULL)";
@@ -162,9 +162,9 @@ public class OidcDbTokenStateManagerProcessor {
             case REACTIVE_ORACLE_CLIENT:
                 createTableDdl = "CREATE TABLE IF NOT EXISTS oidc_db_token_state_manager ("
                         + "id VARCHAR2(100), "
-                        + "id_token VARCHAR2(4000), "
-                        + "access_token VARCHAR2(4000), "
-                        + "refresh_token VARCHAR2(4000), "
+                        + "id_token VARCHAR2(5000), "
+                        + "access_token VARCHAR2(5000), "
+                        + "refresh_token VARCHAR2(5000), "
                         + "access_token_expires_in NUMBER, "
                         + "access_token_scope VARCHAR2(100), "
                         + "expires_in NUMBER NOT NULL, "

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
@@ -75,6 +75,7 @@ public abstract class AbstractDbTokenStateManagerTest {
                     textPage.getContent());
 
             assertTokenStateCount(1);
+            assertTokensAreEncryptedInDB();
 
             webClient.getOptions().setRedirectEnabled(false);
             WebResponse webResponse = webClient
@@ -95,6 +96,22 @@ public abstract class AbstractDbTokenStateManagerTest {
                 .then()
                 .statusCode(200)
                 .body(Matchers.is(tokenStateCount.toString()));
+    }
+
+    protected void assertTokensAreEncryptedInDB() {
+        String expectedTokenEncryptionStatus = """
+                id token encrypted: %1$s, access token encrypted: %1$s, refresh token encrypted: %1$s
+                """.formatted(tokenEncryptionStatus()).trim();
+        RestAssured
+                .given()
+                .get("public/db-state-manager-tokens")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is(expectedTokenEncryptionStatus));
+    }
+
+    protected boolean tokenEncryptionStatus() {
+        return true;
     }
 
     protected static WebClient createWebClient() {

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/HibernateOrmPgDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/HibernateOrmPgDbTokenStateManagerTest.java
@@ -68,6 +68,11 @@ public class HibernateOrmPgDbTokenStateManagerTest extends AbstractDbTokenStateM
         }
     }
 
+    @Override
+    protected boolean tokenEncryptionStatus() {
+        return false;
+    }
+
     @Test
     public void testExpiredTokenDeletion() {
         assertTokenStateCount(0);

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/PublicResource.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/PublicResource.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
+import io.quarkus.oidc.runtime.OidcUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.Row;
@@ -36,6 +37,32 @@ public class PublicResource {
                             }
                         }
                         return 0L;
+                    }
+                })
+                .toCompletionStage());
+    }
+
+    @Path("/db-state-manager-tokens")
+    @GET
+    public Uni<String> getDbStateManagerTokens() {
+        return Uni.createFrom().completionStage(pool
+                .query("SELECT id_token, access_token, refresh_token FROM oidc_db_token_state_manager")
+                .execute()
+                .map(new Function<RowSet<Row>, String>() {
+                    @Override
+                    public String apply(RowSet<Row> rows) {
+                        if (rows != null) {
+                            var iterator = rows.iterator();
+                            if (iterator.hasNext()) {
+                                Row row = iterator.next();
+                                return """
+                                        id token encrypted: %b, access token encrypted: %b, refresh token encrypted: %b
+                                        """.formatted(OidcUtils.isEncryptedToken(row.getString(0)),
+                                        OidcUtils.isEncryptedToken(row.getString(1)),
+                                        OidcUtils.isEncryptedToken(row.getString(2))).trim();
+                            }
+                        }
+                        return "";
                     }
                 })
                 .toCompletionStage());

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/resources/hibernate-orm-application.properties
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/resources/hibernate-orm-application.properties
@@ -5,3 +5,6 @@ quarkus.log.category."org.htmlunit.javascript.host.css.CSSStyleSheet".level=FATA
 quarkus.log.category."org.htmlunit.css".level=FATAL
 quarkus.oidc.db-token-state-manager.delete-expired-delay=3
 quarkus.oidc.db-token-state-manager.create-database-table-if-not-exists=false
+quarkus.hibernate-orm.log.sql=true
+
+quarkus.oidc.token-state-manager.encryption-required=false

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -254,7 +254,7 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
     CodeGrant codeGrant();
 
     /**
-     * Default token state manager configuration
+     * Token state manager configuration
      */
     @ConfigDocSection
     TokenStateManager tokenStateManager();
@@ -524,13 +524,16 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         boolean splitTokens();
 
         /**
-         * Mandates that the Default TokenStateManager encrypt the session cookie that stores the tokens.
+         * Mandates that the TokenStateManager stores tokens in the encrypted form.
+         * Default TokenStateManager encrypts a session cookie that keeps the tokens.
+         * Custom TokenStateManager do not have to encrypt tokens, they will already be encrypted
+         * by the time it is asked to store tokens.
          */
         @WithDefault("true")
         boolean encryptionRequired();
 
         /**
-         * The secret used by the Default TokenStateManager to encrypt the session cookie
+         * The secret used by the TokenStateManager to encrypt the session cookie
          * storing the tokens when {@link #encryptionRequired} property is enabled.
          * <p>
          * If this secret is not set, the client secret configured with
@@ -539,7 +542,8 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
          * checked.
          * The secret is auto-generated every time an application starts if it remains uninitialized after checking all of these
          * properties.
-         * Generated secret can not decrypt the session cookie encrypted before the restart, therefore a user re-authentication
+         * Generated secret can not decrypt the session cookie or token encrypted before the restart, therefore a user
+         * re-authentication
          * will be required.
          * <p>
          * The length of the secret used to encrypt the tokens should be at least 32 characters long.
@@ -569,7 +573,7 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         }
 
         /**
-         * Session cookie key encryption algorithm
+         * Session cookie or token key encryption algorithm
          */
         @WithDefault("A256GCMKW")
         EncryptionAlgorithm encryptionAlgorithm();


### PR DESCRIPTION
Fixes #51083.

This PR ensure that by default, tokens are encrypted by default irrespective of whether it is a `default` `TokenStateManager` or a custom one.

It lets the default one to continue encrypting tokens itself, because it encrypts the session cookie that holds all tokens, with a few tests proving it.

DB `TokenStateManager`, which is a custom `TokenStateManager`, is tested to prove it has tokens encrypted by default but also that users retain an option to avoid encrypting them. I run most of DB tests including the optional ones, `Db2DB` was the only one I could not run as the image download takes ages and probably hangs...

I did not update Redis `TokenStateManager` tests because it is just another custom `TokenStateManager`.