### PR TITLE
Add configurable timeout for blocking mailer

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/BlockingMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/BlockingMailerImpl.java
@@ -1,5 +1,7 @@
 package io.quarkus.mailer.runtime;
 
+import java.time.Duration;
+
 import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.Mailer;
 import io.quarkus.mailer.reactive.ReactiveMailer;
@@ -10,13 +12,21 @@ import io.quarkus.mailer.reactive.ReactiveMailer;
 public class BlockingMailerImpl implements Mailer {
 
     private final ReactiveMailer mailer;
+    private final Duration timeout;
 
-    BlockingMailerImpl(ReactiveMailer mailer) {
+    BlockingMailerImpl(ReactiveMailer mailer, Duration timeout) {
         this.mailer = mailer;
+        this.timeout = timeout;
     }
 
     @Override
     public void send(Mail... mails) {
-        mailer.send(mails).await().indefinitely();
+        if (timeout == null || timeout.isZero()) {
+            // Backward compatibility: if timeout is 0 or null, wait indefinitely
+            mailer.send(mails).await().indefinitely();
+        } else {
+            // Use the configured timeout
+            mailer.send(mails).await().atMost(timeout);
+        }
     }
 }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -261,4 +261,17 @@ public interface MailerRuntimeConfig {
      */
     @WithDefault("false")
     boolean logInvalidRecipients();
+
+    /**
+     * Sets the timeout duration for blocking mailer operations.
+     * When using the blocking mailer ({@link io.quarkus.mailer.Mailer} interface), this timeout determines how long to wait
+     * for the mail to be sent before throwing a {@link java.util.concurrent.TimeoutException}.
+     * <p>
+     * This prevents indefinite thread blocking when SMTP servers are misconfigured or unreachable.
+     * A value of 0 means no timeout (wait indefinitely) - which is not recommended.
+     * <p>
+     * Default is 60 seconds.
+     */
+    @WithDefault("PT60S")
+    Duration timeout();
 }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
@@ -54,6 +54,7 @@ public class Mailers {
     private final Map<String, io.vertx.mutiny.ext.mail.MailClient> mutinyClients;
     private final Map<String, MockMailboxImpl> mockMailboxes;
     private final Map<String, MutinyMailerImpl> mutinyMailers;
+    private final MailersRuntimeConfig mailersRuntimeConfig;
 
     public Mailers(Vertx vertx, io.vertx.mutiny.core.Vertx mutinyVertx, MailersRuntimeConfig mailersRuntimeConfig,
             LaunchMode launchMode, MailerSupport mailerSupport, TlsConfigurationRegistry tlsRegistry,
@@ -111,6 +112,7 @@ public class Mailers {
         this.mutinyClients = Collections.unmodifiableMap(localMutinyClients);
         this.mockMailboxes = Collections.unmodifiableMap(localMockMailboxes);
         this.mutinyMailers = Collections.unmodifiableMap(localMutinyMailers);
+        this.mailersRuntimeConfig = mailersRuntimeConfig;
     }
 
     public MailClient mailClientFromName(String name) {
@@ -122,7 +124,8 @@ public class Mailers {
     }
 
     public Mailer mailerFromName(String name) {
-        return new BlockingMailerImpl(reactiveMailerFromName(name));
+        MailerRuntimeConfig config = mailersRuntimeConfig.mailers().get(name);
+        return new BlockingMailerImpl(reactiveMailerFromName(name), config.timeout());
     }
 
     public ReactiveMailer reactiveMailerFromName(String name) {

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/BlockingMailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/BlockingMailerImplTest.java
@@ -1,0 +1,126 @@
+package io.quarkus.mailer.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.Mailer;
+import io.quarkus.mailer.reactive.ReactiveMailer;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.Vertx;
+
+class BlockingMailerImplTest {
+
+    private Vertx vertx;
+
+    @BeforeEach
+    void setup() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (vertx != null) {
+            vertx.close().await().indefinitely();
+        }
+    }
+
+    @Test
+    void testTimeoutThrowsException() {
+        ReactiveMailer slowMailer = new ReactiveMailer() {
+            @Override
+            public Uni<Void> send(Mail... mails) {
+                return Uni.createFrom().emitter(emitter -> {
+                    // Never complete - simulates hanging connection
+                });
+            }
+        };
+        Mailer blockingMailer = new BlockingMailerImpl(slowMailer, Duration.ofSeconds(1));
+        Mail mail = Mail.withText("test@example.com", "Subject", "Body");
+
+        assertThatThrownBy(() -> blockingMailer.send(mail))
+                .isInstanceOf(io.smallrye.mutiny.TimeoutException.class);
+    }
+
+    @Test
+    void testTimeoutZeroWaitsIndefinitely() throws InterruptedException {
+        ReactiveMailer delayedMailer = new ReactiveMailer() {
+            @Override
+            public Uni<Void> send(Mail... mails) {
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofMillis(500));
+            }
+        };
+        Mailer blockingMailer = new BlockingMailerImpl(delayedMailer, Duration.ZERO);
+        Mail mail = Mail.withText("test@example.com", "Subject", "Body");
+
+        // Should complete successfully even though it takes 500ms
+        // because zero timeout means wait indefinitely
+        long startTime = System.currentTimeMillis();
+        blockingMailer.send(mail);
+        long duration = System.currentTimeMillis() - startTime;
+
+        assertThat(duration).isGreaterThanOrEqualTo(500);
+    }
+
+    @Test
+    void testTimeoutNullWaitsIndefinitely() {
+        ReactiveMailer delayedMailer = new ReactiveMailer() {
+            @Override
+            public Uni<Void> send(Mail... mails) {
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofMillis(500));
+            }
+        };
+        Mailer blockingMailer = new BlockingMailerImpl(delayedMailer, null);
+        Mail mail = Mail.withText("test@example.com", "Subject", "Body");
+
+        // Should complete successfully even though it takes 500ms
+        // because null timeout means wait indefinitely
+        long startTime = System.currentTimeMillis();
+        blockingMailer.send(mail);
+        long duration = System.currentTimeMillis() - startTime;
+
+        assertThat(duration).isGreaterThanOrEqualTo(500);
+    }
+
+    @Test
+    void testSuccessfulSendWithinTimeout() {
+        ReactiveMailer fastMailer = new ReactiveMailer() {
+            @Override
+            public Uni<Void> send(Mail... mails) {
+                return Uni.createFrom().voidItem();
+            }
+        };
+        Mailer blockingMailer = new BlockingMailerImpl(fastMailer, Duration.ofSeconds(10));
+        Mail mail = Mail.withText("test@example.com", "Subject", "Body");
+
+        long startTime = System.currentTimeMillis();
+        assertThatCode(() -> blockingMailer.send(mail)).doesNotThrowAnyException();
+        long duration = System.currentTimeMillis() - startTime;
+        assertThat(duration).isLessThan(1000);
+    }
+
+    @Test
+    void testExceptionPropagation() {
+        ReactiveMailer failingMailer = new ReactiveMailer() {
+            @Override
+            public Uni<Void> send(Mail... mails) {
+                return Uni.createFrom().failure(new RuntimeException("SMTP error"));
+            }
+        };
+        Mailer blockingMailer = new BlockingMailerImpl(failingMailer, Duration.ofSeconds(10));
+        Mail mail = Mail.withText("test@example.com", "Subject", "Body");
+
+        assertThatThrownBy(() -> blockingMailer.send(mail))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("SMTP error");
+    }
+}

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
@@ -313,6 +313,11 @@ public class FakeSmtpTestBase {
             return false;
         }
 
+        @Override
+        public Duration timeout() {
+            return Duration.ofSeconds(60);
+        }
+
     }
 
 }


### PR DESCRIPTION
### Problem
The blocking mailer (`BlockingMailerImpl`) uses` await().indefinitely()` which can cause threads to block indefinitely when SMTP servers are misconfigured or unreachable (e.g., firewall issues, unresponsive postfix servers). This indefinite blocking leads to several critical side effects:

- SQL transaction warnings (connections held open for extended periods)
- Kafka consumer rebalancing after 5 minutes of apparent inactivity

### Solution
This PR introduces a configurable timeout for blocking mailer operations through a new` quarkus.mailer.timeout` configuration property. Instead of waiting indefinitely, the mailer will now throw a `TimeoutException `after the configured duration, preventing thread starvation and allowing applications to handle failures gracefully.

### Configuration Examples

```
# Use default 60 second timeout
# quarkus.mailer.timeout=60s

# Set a shorter timeout for faster failure detection
quarkus.mailer.timeout=10s

# Revert to old behavior (wait indefinitely) - not recommended
quarkus.mailer.timeout=0s

# Named mailer configuration
quarkus.mailer.my-mailer.timeout=30s
```

Fixes #51042 

