### PR TITLE
Update OIDC ResourceMetadataHandler to return scopes

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -1310,6 +1310,7 @@ In turn, a client that requested the protected resource metadata can use its pro
 
 |quarkus.oidc.resource-metadata.enabled |false|Enable resource metadata properties
 |quarkus.oidc.resource-metadata.resource ||Resource identifier
+|quarkus.oidc.resource-metadata.scopes ||Supported scopes
 |quarkus.oidc.resource-metadata.authorization-server ||Authorization server URL
 |quarkus.oidc.resource-metadata.force-https-scheme |true|Force that a resource identifier URL has an HTTPS scheme
 |====

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -112,5 +112,6 @@ public final class OidcConstants {
 
     public static final String RESOURCE_METADATA_WELL_KNOWN_PATH = "/.well-known/oauth-protected-resource";
     public static final String RESOURCE_METADATA_RESOURCE = "resource";
+    public static final String RESOURCE_METADATA_SCOPES = "scopes_supported";
     public static final String RESOURCE_METADATA_AUTHORIZATION_SERVERS = "authorization_servers";
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -2759,6 +2759,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
 
         public boolean enabled;
         public Optional<String> resource = Optional.empty();
+        public Optional<Set<String>> scopes = Optional.empty();
         public Optional<String> authorizationServer = Optional.empty();
         public boolean forceHttpsScheme = true;
 
@@ -2770,6 +2771,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         @Override
         public Optional<String> resource() {
             return resource;
+        }
+
+        @Override
+        public Optional<Set<String>> scopes() {
+            return scopes;
         }
 
         @Override
@@ -2785,6 +2791,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         private void addConfigMappingValues(io.quarkus.oidc.runtime.OidcTenantConfig.ResourceMetadata mapping) {
             enabled = mapping.enabled();
             resource = mapping.resource();
+            scopes = mapping.scopes();
             authorizationServer = mapping.authorizationServer();
             forceHttpsScheme = mapping.forceHttpsScheme();
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
@@ -865,13 +865,14 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
      */
     public static final class ResourceMetadataBuilder {
 
-        private record ResourceMetadataImpl(boolean enabled, Optional<String> resource,
+        private record ResourceMetadataImpl(boolean enabled, Optional<String> resource, Optional<Set<String>> scopes,
                 Optional<String> authorizationServer, boolean forceHttpsScheme) implements ResourceMetadata {
         }
 
         private final OidcTenantConfigBuilder builder;
         private boolean enabled;
         private Optional<String> resource;
+        private Optional<Set<String>> scopes;
         private Optional<String> authorizationServer;
         private boolean forceHttpsScheme;
 
@@ -883,6 +884,8 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
             this.builder = Objects.requireNonNull(builder);
             this.enabled = builder.resourceMetadata.enabled();
             this.resource = builder.resourceMetadata.resource();
+            this.scopes = builder.resourceMetadata.scopes().isEmpty() ? Optional.empty()
+                    : Optional.of(Set.copyOf(builder.resourceMetadata.scopes().get()));
             this.authorizationServer = builder.resourceMetadata.authorizationServer();
             this.forceHttpsScheme = builder.resourceMetadata.forceHttpsScheme();
         }
@@ -911,6 +914,23 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
          */
         public ResourceMetadataBuilder resource(String resource) {
             this.resource = Optional.ofNullable(resource);
+            return this;
+        }
+
+        /**
+         * @param scopes {@link ResourceMetadata#scopes()}
+         * @return this builder
+         */
+        public ResourceMetadataBuilder scopes(String scope) {
+            return this.scopes(Set.of(scope));
+        }
+
+        /**
+         * @param scopes {@link ResourceMetadata#scopes()}
+         * @return this builder
+         */
+        public ResourceMetadataBuilder scopes(Set<String> scopes) {
+            this.scopes = Optional.ofNullable(scopes);
             return this;
         }
 
@@ -952,7 +972,7 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
          * @return built ResourceMetadata
          */
         public ResourceMetadata build() {
-            return new ResourceMetadataImpl(enabled, resource, authorizationServer, forceHttpsScheme);
+            return new ResourceMetadataImpl(enabled, resource, scopes, authorizationServer, forceHttpsScheme);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -163,6 +163,11 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         Optional<String> resource();
 
         /**
+         * Supported scopes.
+         */
+        Optional<Set<String>> scopes();
+
+        /**
          * Authorization server URL.
          * 'quarkus.oidc.auth-server-url' property value is reported by default.
          */

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/ResourceMetadataHandler.java
@@ -146,6 +146,14 @@ public class ResourceMetadataHandler implements Handler<RoutingContext> {
             String resourceIdentifier = buildResourceIdentifierUrl(context, resolver, oidcConfig);
             metadata.put(OidcConstants.RESOURCE_METADATA_RESOURCE, resourceIdentifier);
 
+            if (oidcConfig.resourceMetadata().scopes().isPresent()) {
+                JsonArray scopes = new JsonArray();
+                for (String scope : oidcConfig.resourceMetadata().scopes().get()) {
+                    scopes.add(scope);
+                }
+                metadata.put(OidcConstants.RESOURCE_METADATA_SCOPES, scopes);
+            }
+
             JsonArray authorizationServers = new JsonArray();
             authorizationServers.add(0, oidcConfig.resourceMetadata().authorizationServer()
                     .orElse(oidcConfig.authServerUrl().get()));

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -163,6 +163,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         CERTIFICATION_CHAIN_TRUST_STORE_FILE_TYPE,
         RESOURCE_METADATA_ENABLED,
         RESOURCE_METADATA_RESOURCE,
+        RESOURCE_METADATA_SCOPES,
         RESOURCE_METADATA_AUTHORIZATION_SERVER,
         RESOURCE_METADATA_FORCE_HTTPS_SCHEME,
         LOGOUT_PATH,
@@ -620,6 +621,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             @Override
             public Optional<String> resource() {
                 invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA_RESOURCE, true);
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Set<String>> scopes() {
+                invocationsRecorder.put(ConfigMappingMethods.RESOURCE_METADATA_SCOPES, true);
                 return Optional.empty();
             }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -112,6 +112,7 @@ quarkus.oidc.tenant-refresh.token.refresh-expired=true
 quarkus.oidc.tenant-refresh.authentication.remove-redirect-parameters=false
 quarkus.oidc.tenant-refresh.authentication.cache-control=no-store
 quarkus.oidc.tenant-refresh.resource-metadata.enabled=true
+quarkus.oidc.tenant-refresh.resource-metadata.scopes=read,write
 
 quarkus.oidc.tenant-autorefresh.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-autorefresh.client-id=quarkus-app
@@ -151,6 +152,7 @@ quarkus.oidc.tenant-nonce.token-state-manager.encryption-required=false
 quarkus.oidc.tenant-nonce.token.allow-jwt-introspection=false
 quarkus.oidc.tenant-nonce.resource-metadata.enabled=true
 quarkus.oidc.tenant-nonce.resource-metadata.resource=/metadata
+quarkus.oidc.tenant-nonce.resource-metadata.scopes=read
 quarkus.oidc.tenant-nonce.resource-metadata.authorization-server=http://localhost:8080/q/oidc
 
 quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}


### PR DESCRIPTION
This PR updates OIDC `ResourceMetadataHandler` to support returning a `scopes_supported` property.

MCP Authorization spec draft talks about it [here](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-selection-strategy), so that MCP clients do not have to be explicitly configured with scopes that it must request when authorizing a user.

Note that we have `quarkus.oidc.authentication.scopes` - these are used to request authorization code flow access token scopes, typically, for Quarkus REST server to forward that access token to access some other server.

In context of the MCP authorization work, Quarkus REST server accepts `bearer access tokens` sent to it by MCP clients. So we can't really reuse `quarkus.oidc.authentication.scopes` property to request scopes for such bearer tokens.

The other thing is that even though, for ex, Keycloak can support assigning `a` and `b` scopes to tokens, a given Quarkus REST server may only want tokens with the `a` scope.

This is why it makes sense to have a dedicated `quarkus.oidc.resource-metadata.scopes` property IMHO.
The MCP Authorization draft spec [also talks](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-selection-strategy) about considering returning a `WWW-Authenticate` `scope` property - but I'm not doing it just yet, I think supporting returning scopes with the protected resource metadata should be enough at the start,  `WWW-Authenticate` `scope` property may have to be supported independently from the resource metadata.