### PR TITLE
Switch to the docs.hibernate.org for all Hibernate projects docs

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -67,11 +67,11 @@
 :quickstarts-blob-url: ${quickstarts-base-url}/blob/main
 :quickstarts-tree-url: ${quickstarts-base-url}/tree/main
 // .
-:hibernate-orm-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/userguide/html_single/Hibernate_User_Guide.html
-:hibernate-orm-javadocs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/javadocs/
-:hibernate-orm-dialect-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/dialect/dialect.html
-:hibernate-search-docs-url: https://docs.jboss.org/hibernate/search/{hibernate-search-version-major-minor}/reference/en-US/html_single/
-:hibernate-validator-docs-url: https://docs.jboss.org/hibernate/validator/{hibernate-validator-version-major-minor}/reference/en-US/html_single/
+:hibernate-orm-docs-url: https://docs.hibernate.org/orm/{hibernate-orm-version-major-minor}/userguide/html_single/
+:hibernate-orm-javadocs-url: https://docs.hibernate.org/orm/{hibernate-orm-version-major-minor}/javadocs/
+:hibernate-orm-dialect-docs-url: https://docs.hibernate.org/orm/{hibernate-orm-version-major-minor}/dialect/dialect.html
+:hibernate-search-docs-url: https://docs.hibernate.org/search/{hibernate-search-version-major-minor}/reference/en-US/html_single/
+:hibernate-validator-docs-url: https://docs.hibernate.org/validator/{hibernate-validator-version-major-minor}/reference/en-US/html_single/
 :jakarta-persistence-spec-url: https://jakarta.ee/specifications/persistence/{jakarta-persistence-version-major-minor}/jakarta-persistence-spec-{jakarta-persistence-version-major-minor}#a6072
 // .
 :amazon-services-guide: https://docs.quarkiverse.io/quarkus-amazon-services/dev/index.html

--- a/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
@@ -863,9 +863,9 @@ and such loading must be implemented explicitly.
 You can refer to Hibernate Search's reference documentation for more information about configuring loading:
 
 * To load entities from an external datasource in order to reindex them,
-see https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#mapping-entitydefinition-loading-mass[Mass loading strategy].
+see https://docs.hibernate.org/stable/search/reference/en-US/html_single/#mapping-entitydefinition-loading-mass[Mass loading strategy].
 * To load entities from an external datasource when returning search hits,
-see https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#mapping-entitydefinition-loading-selection[Selection loading strategy].
+see https://docs.hibernate.org/stable/search/reference/en-US/html_single/#mapping-entitydefinition-loading-selection[Selection loading strategy].
 
 [NOTE]
 ====

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1226,7 +1226,7 @@ suitable for tips, source code extracts, lists and more:
 ----
 /**
  * Class name of the Hibernate ORM dialect. The complete list of bundled dialects is available in the
- * https://docs.jboss.org/hibernate/stable/orm/javadocs/org/hibernate/dialect/package-summary.html[Hibernate ORM JavaDoc].
+ * https://docs.hibernate.org/stable/orm/javadocs/org/hibernate/dialect/package-summary.html[Hibernate ORM JavaDoc].
  *
  * [NOTE]
  * ====

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -124,13 +124,13 @@ public interface HibernateOrmConfigPersistenceUnit {
 
     /**
      * Class name of a custom
-     * https://docs.jboss.org/hibernate/stable/orm/javadocs/org/hibernate/boot/spi/MetadataBuilderContributor.html[`org.hibernate.boot.spi.MetadataBuilderContributor`]
+     * https://docs.hibernate.org/stable/orm/javadocs/org/hibernate/boot/spi/MetadataBuilderContributor.html[`org.hibernate.boot.spi.MetadataBuilderContributor`]
      * implementation.
      *
      * [NOTE]
      * ====
      * Not all customization options exposed by
-     * https://docs.jboss.org/hibernate/stable/orm/javadocs/org/hibernate/boot/MetadataBuilder.html[`org.hibernate.boot.MetadataBuilder`]
+     * https://docs.hibernate.org/stable/orm/javadocs/org/hibernate/boot/MetadataBuilder.html[`org.hibernate.boot.MetadataBuilder`]
      * will work correctly. Stay clear of options related to classpath scanning in particular.
      *
      * This setting is exposed mainly to allow registration of types, converters and SQL functions.

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -157,7 +157,7 @@ public final class DotNames {
     public static final DotName INSTANT = DotName.createSimple(Instant.class.getName());
     public static final DotName ZONED_DATETIME = DotName.createSimple(ZonedDateTime.class.getName());
 
-    // https://docs.jboss.org/hibernate/stable/orm/userguide/html_single/Hibernate_User_Guide.html#basic
+    // https://docs.hibernate.org/stable/orm/userguide/html_single/#basic
     // Should be in sync with org.hibernate.type.BasicTypeRegistry
     public static final Set<DotName> HIBERNATE_PROVIDED_BASIC_TYPES = new HashSet<>(Arrays.asList(
             STRING, CLASS,

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
@@ -2095,7 +2095,7 @@ public class TestEndpoint {
     @Transactional
     public String testBug26308() {
         testBug26308Query("from Person2 p left join fetch p.address");
-        // This cannot work, see https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html#create-query
+        // This cannot work, see https://docs.hibernate.org/orm/7.0/migration-guide/#create-query
         //testBug26308Query("from Person2 p left join p.address");
         // This must be used instead:
         testBug26308Query("from Person2 this left join this.address");

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
@@ -2341,7 +2341,7 @@ public class TestEndpoint {
     @WithTransaction
     public Uni<String> testBug26308() {
         return testBug26308Query("from Person2 p left join fetch p.address")
-                // This cannot work, see https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html#create-query
+                // This cannot work, see https://docs.hibernate.org/orm/7.0/migration-guide/#create-query
                 //.flatMap(p -> testBug26308Query("from Person2 p left join p.address"))
                 // This must be used instead:
                 .flatMap(p -> testBug26308Query("from Person2 this left join this.address"))

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/search/MyMassLoadingStrategy.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/search/MyMassLoadingStrategy.java
@@ -22,7 +22,7 @@ import io.quarkus.it.hibernate.search.standalone.elasticsearch.search.stub.Datas
 import io.quarkus.it.hibernate.search.standalone.elasticsearch.search.stub.DatastoreCursorStub;
 import io.quarkus.it.hibernate.search.standalone.elasticsearch.search.stub.DatastoreStub;
 
-// See https://docs.jboss.org/hibernate/search/7.1/reference/en-US/html_single/#mapping-entitydefinition-loading-mass
+// See https://docs.hibernate.org/search/7.1/reference/en-US/html_single/#mapping-entitydefinition-loading-mass
 public class MyMassLoadingStrategy<E>
         implements MassLoadingStrategy<E, Long> {
 

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/search/MySelectionLoadingStrategy.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/search/MySelectionLoadingStrategy.java
@@ -16,7 +16,7 @@ import org.hibernate.search.mapper.pojo.standalone.loading.SelectionLoadingStrat
 
 import io.quarkus.it.hibernate.search.standalone.elasticsearch.search.stub.DatastoreConnectionStub;
 
-// See https://docs.jboss.org/hibernate/search/7.1/reference/en-US/html_single/#mapping-entitydefinition-loading-selection
+// See https://docs.hibernate.org/search/7.1/reference/en-US/html_single/#mapping-entitydefinition-loading-selection
 public class MySelectionLoadingStrategy<E>
         implements SelectionLoadingStrategy<E> {
     private final Class<E> rootEntityType;


### PR DESCRIPTION
Since we changed the docs server and don't publish to the old one +  the redirects for the old one are in place ... 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

