### PR TITLE
[3.20] Unify versions of smallrye-common

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -49,7 +49,7 @@
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.mutiny>2.9.5</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
-        <version.smallrye-common>2.12.0</version.smallrye-common>
+        <version.smallrye-common>2.12.2</version.smallrye-common>
         <!-- test versions -->
         <version.assertj>3.27.3</version.assertj>
         <version.junit5>5.12.2</version.junit5>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -70,7 +70,7 @@
         <plexus-interpolation.version>1.26</plexus-interpolation.version>
         <plexus-sec-dispatcher.version>2.0</plexus-sec-dispatcher.version>
         <plexus-utils.version>3.5.1</plexus-utils.version>
-        <smallrye-common.version>2.12.0</smallrye-common.version>
+        <smallrye-common.version>2.12.2</smallrye-common.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
         <gradle-tooling.version>8.13</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.10</quarkus-fs-util.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -43,7 +43,7 @@
         <version.jandex>3.3.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
-        <version.smallrye-common>2.12.0</version.smallrye-common>
+        <version.smallrye-common>2.12.2</version.smallrye-common>
         <version.smallrye-mutiny>2.9.5</version.smallrye-mutiny>
     </properties>
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,7 +57,7 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>2.9.5</mutiny.version>
-        <smallrye-common.version>2.12.0</smallrye-common.version>
+        <smallrye-common.version>2.12.2</smallrye-common.version>
         <vertx.version>4.5.22</vertx.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>


### PR DESCRIPTION
the application bom contains 2.12.2 but some independent projects are lagging behind

The platform generator seems to have picked 2.12.0: [#dev > &#91;3.20.4&#93; Which smallrye version should be used? @ 💬](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/.5B3.2E20.2E4.5D.20Which.20smallrye.20version.20should.20be.20used.3F/near/560230362)