### PR TITLE
QuarkusComponentTest: add support for JaCoCo code coverage

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -866,8 +866,15 @@ public class ArcProcessor {
         }
 
         @Override
-        public void accept(BytecodeTransformer t) {
-            bytecodeTransformer.produce(new BytecodeTransformerBuildItem(t.getClassToTransform(), t.getVisitorFunction()));
+        public void accept(BytecodeTransformer transformer) {
+            if (transformer.getVisitorFunction() != null) {
+                bytecodeTransformer.produce(
+                        new BytecodeTransformerBuildItem(transformer.getClassToTransform(), transformer.getVisitorFunction()));
+            } else if (transformer.getInputTransformer() != null) {
+                bytecodeTransformer.produce(new BytecodeTransformerBuildItem.Builder()
+                        .setClassToTransform(transformer.getClassToTransform())
+                        .setInputTransformer(transformer.getInputTransformer()).build());
+            }
         }
     }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BytecodeTransformer.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BytecodeTransformer.java
@@ -6,13 +6,26 @@ import org.objectweb.asm.ClassVisitor;
 
 public class BytecodeTransformer {
 
+    public static BytecodeTransformer forInputTransformer(String classToTransform,
+            BiFunction<String, byte[], byte[]> inputTransformer) {
+        return new BytecodeTransformer(classToTransform, null, inputTransformer);
+    }
+
     private final String classToTransform;
     private final BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction;
+    private final BiFunction<String, byte[], byte[]> inputTransformer;
 
     public BytecodeTransformer(String classToTransform,
             BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction) {
+        this(classToTransform, visitorFunction, null);
+    }
+
+    private BytecodeTransformer(String classToTransform, BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction,
+            BiFunction<String, byte[], byte[]> inputTransformer) {
+        super();
         this.classToTransform = classToTransform;
         this.visitorFunction = visitorFunction;
+        this.inputTransformer = inputTransformer;
     }
 
     public String getClassToTransform() {
@@ -22,4 +35,9 @@ public class BytecodeTransformer {
     public BiFunction<String, ClassVisitor, ClassVisitor> getVisitorFunction() {
         return visitorFunction;
     }
+
+    public BiFunction<String, byte[], byte[]> getInputTransformer() {
+        return inputTransformer;
+    }
+
 }

--- a/test-framework/jacoco/runtime/pom.xml
+++ b/test-framework/jacoco/runtime/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-component</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoQuarkusComponentTestCallbacks.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoQuarkusComponentTestCallbacks.java
@@ -1,0 +1,50 @@
+package io.quarkus.jacoco.runtime;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.function.BiFunction;
+
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.processor.BytecodeTransformer;
+import io.quarkus.test.component.QuarkusComponentTestCallbacks;
+import io.quarkus.test.component.QuarkusComponentTestClassLoader;
+
+public class JacocoQuarkusComponentTestCallbacks implements QuarkusComponentTestCallbacks {
+
+    private static final Logger LOG = Logger.getLogger(JacocoQuarkusComponentTestCallbacks.class);
+
+    @Override
+    public void beforeBuild(BeforeBuildContext beforeBuild) {
+        // Instrument all classes loaded by QuarkusComponentTestClassLoader
+        Collection<ClassInfo> toTransform = beforeBuild.getImmutableBeanArchiveIndex()
+                .getKnownClasses()
+                .stream()
+                .filter(c -> !QuarkusComponentTestClassLoader.mustDelegateToParent(c.name().toString()))
+                .toList();
+        Instrumenter instrumenter = new Instrumenter(new OfflineInstrumentationAccessGenerator());
+        for (ClassInfo clazz : toTransform) {
+            beforeBuild.addBytecodeTransformer(
+                    BytecodeTransformer.forInputTransformer(clazz.name().toString(), new BiFunction<String, byte[], byte[]>() {
+                        @Override
+                        public byte[] apply(String className, byte[] bytes) {
+                            try {
+                                byte[] enhanced = instrumenter.instrument(bytes, className);
+                                if (enhanced == null) {
+                                    return bytes;
+                                }
+                                return enhanced;
+                            } catch (IOException e) {
+                                LOG.warnf(e,
+                                        "Unable to instrument class %s with JaCoCo, keeping the original class",
+                                        className);
+                                return bytes;
+                            }
+                        }
+                    }));
+        }
+    }
+}

--- a/test-framework/jacoco/runtime/src/main/resources/META-INF/services/io.quarkus.test.component.QuarkusComponentTestCallbacks
+++ b/test-framework/jacoco/runtime/src/main/resources/META-INF/services/io.quarkus.test.component.QuarkusComponentTestCallbacks
@@ -1,0 +1,1 @@
+io.quarkus.jacoco.runtime.JacocoQuarkusComponentTestCallbacks

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestClassLoader.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestClassLoader.java
@@ -103,7 +103,7 @@ public class QuarkusComponentTestClassLoader extends ClassLoader {
         return new Bytecode(bytecode);
     }
 
-    private static boolean mustDelegateToParent(String name) {
+    public static boolean mustDelegateToParent(String name) {
         return name.startsWith("java.")
                 || name.startsWith("jdk.")
                 || name.startsWith("javax.")
@@ -117,6 +117,7 @@ public class QuarkusComponentTestClassLoader extends ClassLoader {
                 || name.startsWith("org.jboss.logging")
                 || name.startsWith("org.jboss.logmanager")
                 || name.startsWith("org.slf4j")
+                || name.startsWith("org.jacoco")
                 || PARENT_CL_CLASSES.contains(name);
     }
 


### PR DESCRIPTION
- JacocoQuarkusComponentTestCallbacks registers bytecode transformers to instrument all classes loaded by QuarkusComponentTestClassLoader
- see also https://github.com/quarkusio/quarkus/discussions/51020