### PR TITLE
Separate SmallryeConfig instance to build the Build Time and Runtime fixed mappings

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
@@ -25,6 +25,10 @@ import io.smallrye.config.common.MapBackedConfigSource;
  */
 public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCustomizer {
 
+    protected static void withSharedBuilder(SmallRyeConfigBuilder builder) {
+        builder.withMappingIgnore("quarkus.**");
+    }
+
     protected static void withDefaultValues(SmallRyeConfigBuilder builder, Map<String, String> values) {
         builder.withDefaultValues(values);
     }
@@ -86,6 +90,10 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected static void withMappingInstance(SmallRyeConfigBuilder builder, ConfigClass configClass, Object instance) {
+        builder.getMappingsBuilder().mappingInstance(configClass, instance);
     }
 
     protected static void withMappingInstance(SmallRyeConfigBuilder builder, ConfigClass mapping) {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
@@ -12,14 +12,15 @@ import io.quarkus.test.QuarkusProdModeTest;
 public class OverrideBuildTimeConfigTest {
     @RegisterExtension
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
-            .setRuntimeProperties(Map.of("quarkus.application.name", "foo"))
+            .setRuntimeProperties(Map.of("quarkus.application.name", "foo", "quarkus.mapping.btrt.optional", "value"))
             .setRun(true);
 
     @Test
     void overrideBuildTimeConfigTest() {
         assertTrue(TEST.getStartupConsoleOutput()
-                .contains(
-                        "- quarkus.application.name is set to 'foo' but it is build time fixed to " +
-                                "'quarkus-integration-test-test-extension-extension-deployment'."));
+                .contains("- quarkus.application.name is set to 'foo' but it is build time fixed to " +
+                        "'quarkus-integration-test-test-extension-extension-deployment'."));
+        assertTrue(TEST.getStartupConsoleOutput()
+                .contains("- quarkus.mapping.btrt.optional is set to 'value' but it is build time fixed to 'null'."));
     }
 }

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingBuildTimeRunTime.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingBuildTimeRunTime.java
@@ -1,6 +1,7 @@
 package io.quarkus.extest.runtime.config;
 
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -23,6 +24,11 @@ public interface TestMappingBuildTimeRunTime {
      * A Map of Map.
      */
     Map<String, Map<String, String>> mapMap();
+
+    /**
+     * An Optional
+     */
+    Optional<String> optional();
 
     interface Group {
         /**


### PR DESCRIPTION
Mappings set as `BUILD_AND_RUN_TIME_FIXED` are now started in their own `SmallRyeConfig` instance, only with access to the `BuildTimeRunTimeFixedConfigSource`.

Previously, these mappings were initialized in the same static `SmallRyeConfig`, which contained the sources available at this stage. Since `BuildTimeRunTimeFixedConfigSource`, recorded all values set during build time at a MAX ordinal, the `BUILD_AND_RUN_TIME_FIXED` could be reconstructed with the same values as build time.

In https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/.E2.9C.94.20Config.20stopped.20reading.20environment.20variables.20in.20v3.2E27/with/558650888, we observed, that there was a flaw in this approach. For `Optional` configurations, which would not record a value, it would be possible to change the value at runtime.

With this PR, the `BuildTimeRunTimeFixedConfigSource` records all names that compose the `BUILD_AND_RUN_TIME_FIXED`, even the ones without a value, and initializes the mappings on its own `SmallRyeConfig` instance, ensuring that there are no other sources in the mix that could influence the result. These instances are then shared with the static and runtime config.

The mechanism for reporting changes between runtime and build time was also adjusted to detect these cases.

Overall, this should also improve performance a bit, since we do fewer lookups to populate the `BUILD_AND_RUN_TIME_FIXED` mappings, since we only have a single source to query, whereas previously we may have had to query the entire config tree to reach the defaults.

- Requires #51259