### PR TITLE
StartupLogCompressor NULL checks

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/StartupLogCompressor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/StartupLogCompressor.java
@@ -69,7 +69,9 @@ public class StartupLogCompressor implements Closeable, BiPredicate<String, Bool
             return;
         }
         QuarkusConsole.removeOutputFilter(this);
-        sl.close();
+        if (sl != null) {
+            sl.close();
+        }
     }
 
     public void closeAndDumpCaptured() {
@@ -77,7 +79,9 @@ public class StartupLogCompressor implements Closeable, BiPredicate<String, Bool
             return;
         }
         QuarkusConsole.removeOutputFilter(this);
-        sl.close();
+        if (sl != null) {
+            sl.close();
+        }
         for (var i : toDump) {
             QuarkusConsole.INSTANCE.write(true, i);
         }
@@ -92,7 +96,9 @@ public class StartupLogCompressor implements Closeable, BiPredicate<String, Bool
         Thread current = Thread.currentThread();
         if (current == this.thread || additionalThreadPredicate.test(current)) {
             toDump.add(s);
-            sl.setMessage(MessageFormat.BLUE + name + MessageFormat.RESET + " " + s.replace("\n", ""));
+            if (sl != null) {
+                sl.setMessage(MessageFormat.BLUE + name + MessageFormat.RESET + " " + s.replace("\n", ""));
+            }
             return false;
         }
         return true;


### PR DESCRIPTION
Discussed on Zulip: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Extension.3A.20StartupLogCompressor.20NPE.20.3F/with/560398910

Mailpit extension user @tmulle reported 

```
Caused by: java.lang.NullPointerException: Cannot invoke "io.quarkus.dev.console.StatusLine.setMessage(String)" because "this.sl" is null
    at io.quarkus.deployment.console.StartupLogCompressor.test(StartupLogCompressor.java:95)
    at io.quarkus.deployment.console.StartupLogCompressor.test(StartupLogCompressor.java:22)
    at io.quarkus.dev.console.QuarkusConsole.shouldWrite(QuarkusConsole.java:199)
    at io.quarkus.deployment.console.AeshConsole.write(AeshConsole.java:418)
    at io.quarkus.deployment.console.StartupLogCompressor.closeAndDumpCaptured(StartupLogCompressor.java:82)
    at io.quarkiverse.mailpit.deployment.MailpitProcessor.startMailpitDevService(MailpitProcessor.java:90)
```