### PR TITLE
Set Keycloak client web origins in the dev service

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -889,7 +889,6 @@ public class KeycloakDevServicesProcessor {
         ClientRepresentation client = new ClientRepresentation();
 
         client.setClientId(clientId);
-        client.setRedirectUris(List.of("*"));
         client.setPublicClient(false);
         client.setSecret(oidcClientSecret);
         client.setDirectAccessGrantsEnabled(true);
@@ -897,6 +896,7 @@ public class KeycloakDevServicesProcessor {
         client.setImplicitFlowEnabled(true);
         client.setEnabled(true);
         client.setRedirectUris(List.of("*"));
+        client.setWebOrigins(List.of("*"));
         client.setDefaultClientScopes(List.of("microprofile-jwt", "basic"));
 
         return client;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

When the default Keycloak client is created in the dev service, weborigins is not set breaking SwaggerUI integration. This MR sets weborigins to `*` by default.  A duplicated `client.setRedirectUris(List.of("*"));` was also removed. 

Fixes #51251

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

