### PR TITLE
Move SmallRye GraphQL configuration from build time runtime fixed to runtime

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
@@ -2,7 +2,6 @@ package io.quarkus.smallrye.graphql.runtime;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -10,7 +9,6 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
-import io.smallrye.graphql.spi.config.LogPayloadOption;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 @ConfigMapping(prefix = "quarkus.smallrye-graphql")
@@ -62,36 +60,11 @@ public interface SmallRyeGraphQLConfig {
     Optional<Boolean> nonBlockingEnabled();
 
     /**
-     * Enable GET Requests. Allow queries via HTTP GET.
-     */
-    @WithName("http.get.enabled")
-    Optional<Boolean> httpGetEnabled();
-
-    /**
-     * Enable Query parameter on POST Requests. Allow POST request to override or supply values in a query parameter.
-     */
-    @WithName("http.post.queryparameters.enabled")
-    Optional<Boolean> httpPostQueryParametersEnabled();
-
-    /**
      * Change the type naming strategy.
      * All possible strategies are: default, merge-inner-class, full
      */
     @WithDefault("Default")
     String autoNameStrategy();
-
-    /**
-     * List of extension fields that should be included in the error response.
-     * By default, none will be included. Examples of valid values include
-     * [exception,classification,code,description,validationErrorType,queryPath]
-     */
-    Optional<List<String>> errorExtensionFields();
-
-    /**
-     * The default error message that will be used for hidden exception messages.
-     * Defaults to "Server Error"
-     */
-    Optional<String> defaultErrorMessage();
 
     /**
      * Print the data fetcher exception to the log file. Default `true` in dev and test mode, default `false` in prod.
@@ -105,81 +78,10 @@ public interface SmallRyeGraphQLConfig {
     boolean schemaAvailable();
 
     /**
-     * Include the Scalar definitions in the schema.
-     */
-    @WithDefault("false")
-    boolean schemaIncludeScalars();
-
-    /**
-     * Include the schema internal definition in the schema.
-     */
-    @WithDefault("false")
-    boolean schemaIncludeSchemaDefinition();
-
-    /**
-     * Include Directives in the schema.
-     */
-    @WithDefault("false")
-    boolean schemaIncludeDirectives();
-
-    /**
-     * Include Introspection Types in the schema.
-     */
-    @WithDefault("false")
-    boolean schemaIncludeIntrospectionTypes();
-
-    /**
-     * Log the payload (and optionally variables) to System out.
-     */
-    @WithDefault("off")
-    LogPayloadOption logPayload();
-
-    /**
-     * Exceptions that should be unwrapped (class names).
-     */
-    Optional<List<String>> unwrapExceptions();
-
-    /**
      * Subprotocols that should be supported by the server for graphql-over-websocket use cases.
      * Allowed subprotocols are "graphql-ws" and "graphql-transport-ws". By default, both are enabled.
      */
     Optional<List<String>> websocketSubprotocols();
-
-    /**
-     * Set to true if ignored chars should be captured as AST nodes. Default to false
-     */
-    Optional<Boolean> parserCaptureIgnoredChars();
-
-    /**
-     * Set to true if `graphql.language.Comment`s should be captured as AST nodes
-     */
-    Optional<Boolean> parserCaptureLineComments();
-
-    /**
-     * Set to true true if `graphql.language.SourceLocation`s should be captured as AST nodes. Default to true
-     */
-    Optional<Boolean> parserCaptureSourceLocation();
-
-    /**
-     * The maximum number of raw tokens the parser will accept, after which an exception will be thrown. Default to 15000
-     */
-    OptionalInt parserMaxTokens();
-
-    /**
-     * The maximum number of raw whitespace tokens the parser will accept, after which an exception will be thrown. Default to
-     * 200000
-     */
-    OptionalInt parserMaxWhitespaceTokens();
-
-    /**
-     * Abort a query if the total number of data fields queried exceeds the defined limit. Default to no limit
-     */
-    OptionalInt instrumentationQueryComplexity();
-
-    /**
-     * Abort a query if the total depth of the query exceeds the defined limit. Default to no limit
-     */
-    OptionalInt instrumentationQueryDepth();
 
     /**
      * SmallRye GraphQL UI configuration

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
@@ -2,12 +2,14 @@ package io.quarkus.smallrye.graphql.runtime;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import io.smallrye.graphql.spi.config.LogPayloadOption;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigMapping(prefix = "quarkus.smallrye-graphql")
@@ -48,6 +50,11 @@ public interface SmallRyeGraphQLRuntimeConfig {
     Optional<Boolean> excludeNullFieldsInResponses();
 
     /**
+     * Exceptions that should be unwrapped (class names).
+     */
+    Optional<List<String>> unwrapExceptions();
+
+    /**
      * List of Runtime Exceptions class names that should show the error message.
      * By default, Runtime Exception messages will be hidden and a generic `Server Error` message will be returned.
      */
@@ -58,4 +65,95 @@ public interface SmallRyeGraphQLRuntimeConfig {
      * By default, Checked Exception messages will show the exception message.
      */
     Optional<List<String>> hideCheckedExceptionMessage();
+
+    /**
+     * The default error message that will be used for hidden exception messages.
+     * Defaults to "Server Error"
+     */
+    Optional<String> defaultErrorMessage();
+
+    /**
+     * List of extension fields that should be included in the error response.
+     * By default, none will be included. Examples of valid values include
+     * [exception,classification,code,description,validationErrorType,queryPath]
+     */
+    Optional<List<String>> errorExtensionFields();
+
+    /**
+     * Enable GET Requests. Allow queries via HTTP GET.
+     */
+    @WithName("http.get.enabled")
+    Optional<Boolean> httpGetEnabled();
+
+    /**
+     * Enable Query parameter on POST Requests. Allow POST request to override or supply values in a query parameter.
+     */
+    @WithName("http.post.queryparameters.enabled")
+    Optional<Boolean> httpPostQueryParametersEnabled();
+
+    /**
+     * Include the Scalar definitions in the schema.
+     */
+    @WithDefault("false")
+    boolean schemaIncludeScalars();
+
+    /**
+     * Include the schema internal definition in the schema.
+     */
+    @WithDefault("false")
+    boolean schemaIncludeSchemaDefinition();
+
+    /**
+     * Include Directives in the schema.
+     */
+    @WithDefault("false")
+    boolean schemaIncludeDirectives();
+
+    /**
+     * Include Introspection Types in the schema.
+     */
+    @WithDefault("false")
+    boolean schemaIncludeIntrospectionTypes();
+
+    /**
+     * Log the payload (and optionally variables) to System out.
+     */
+    @WithDefault("off")
+    LogPayloadOption logPayload();
+
+    /**
+     * Set to true if ignored chars should be captured as AST nodes. Default to false
+     */
+    Optional<Boolean> parserCaptureIgnoredChars();
+
+    /**
+     * Set to true if `graphql.language.Comment`s should be captured as AST nodes
+     */
+    Optional<Boolean> parserCaptureLineComments();
+
+    /**
+     * Set to true true if `graphql.language.SourceLocation`s should be captured as AST nodes. Default to true
+     */
+    Optional<Boolean> parserCaptureSourceLocation();
+
+    /**
+     * The maximum number of raw tokens the parser will accept, after which an exception will be thrown. Default to 15000
+     */
+    OptionalInt parserMaxTokens();
+
+    /**
+     * The maximum number of raw whitespace tokens the parser will accept, after which an exception will be thrown. Default to
+     * 200000
+     */
+    OptionalInt parserMaxWhitespaceTokens();
+
+    /**
+     * Abort a query if the total number of data fields queried exceeds the defined limit. Default to no limit
+     */
+    OptionalInt instrumentationQueryComplexity();
+
+    /**
+     * Abort a query if the total depth of the query exceeds the defined limit. Default to no limit
+     */
+    OptionalInt instrumentationQueryDepth();
 }


### PR DESCRIPTION
Moves all configuration from Graph QL referenced in https://github.com/smallrye/smallrye-graphql/blob/d4698d7a098c2a880bdd1954f5f487bd17783d04/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/MicroProfileConfig.java to runtime.

Configuration lookups to this class always happen at runtime, but many of the configurations were marked `BUILD_AND_RUN_TIME_FIXED`.

In reality, this worked because `SmallRyeGraphQLConfig` was only declaring the configuration, and they were not being used at build time, and due to an issue with `Optional` mappings, the values could be overridden even if fixed.

With https://github.com/quarkusio/quarkus/pull/51248, this became an issue from this side.

Because the configurations were not being used during the build, it should be safe to move this to the runtime mapping.