### PR TITLE
Fix typos across multiple modules and rename ReponseInfoTest

### DIFF
--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/http/rest/reactive/ReactiveServerFilters.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/http/rest/reactive/ReactiveServerFilters.java
@@ -34,7 +34,7 @@ public class ReactiveServerFilters {
 
     /**
      * This will execute regardless of a processing failure or not.
-     * If there was a failure, we need to check if the start event was not commited
+     * If there was a failure, we need to check if the start event was not committed
      * (which happens when request was not matched to any resource method) and if so, commit it.
      */
     @ServerResponseFilter

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
@@ -14,7 +14,7 @@ public class ApplyOpenshiftRouteConfigurator extends Configurator<OpenshiftConfi
 
     @Override
     public void visit(OpenshiftConfigFluent config) {
-        // The route needs to be configured wether it's exposed or not.
+        // The route needs to be configured whether it's exposed or not.
         // This is needed to support user provided routes.
         var routeBuilder = config.editOrNewRoute();
         routeBuilder.withExpose(routeConfig.expose());

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -208,13 +208,13 @@ public class KubernetesDeployer {
             Optional<GenericKubernetesResource> conflictingResource = findConflictingResource(client, deploymentTarget,
                     list.getItems());
             if (conflictingResource.isPresent()) {
-                String messsage = "Skipping deployment of " + deploymentTarget.getDeploymentResourceKind() + " "
+                String message = "Skipping deployment of " + deploymentTarget.getDeploymentResourceKind() + " "
                         + conflictingResource.get().getMetadata().getName() + " because a "
                         + conflictingResource.get().getKind() + " with the same name exists.";
-                log.warn(messsage);
+                log.warn(message);
                 log.warn("This may occur when switching deployment targets, or when the default deployment target is changed.");
                 log.warn("Please remove conflicting resource and try again.");
-                throw new IllegalStateException(messsage);
+                throw new IllegalStateException(message);
             }
 
             list.getItems().stream().filter(distinctByResourceKey()).forEach(i -> {

--- a/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-opentelemetry.json
+++ b/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-opentelemetry.json
@@ -2328,7 +2328,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "commited",
+          "legendFormat": "committed",
           "metric": "",
           "refId": "B",
           "step": 1800
@@ -2477,7 +2477,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "commited",
+          "legendFormat": "committed",
           "metric": "",
           "refId": "B",
           "step": 1800

--- a/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-otlp.json
+++ b/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-otlp.json
@@ -2234,7 +2234,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "commited",
+          "legendFormat": "committed",
           "metric": "",
           "refId": "B",
           "step": 1800
@@ -2372,7 +2372,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "commited",
+          "legendFormat": "committed",
           "metric": "",
           "refId": "B",
           "step": 1800

--- a/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-prometheus.json
+++ b/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-prometheus.json
@@ -2845,7 +2845,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "commited",
+              "legendFormat": "committed",
               "metric": "",
               "refId": "B",
               "step": 1800
@@ -3007,7 +3007,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "commited",
+              "legendFormat": "committed",
               "metric": "",
               "refId": "B",
               "step": 1800

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
@@ -198,7 +198,7 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
                 OidcEndpoint.Type.CLIENT_REGISTRATION);
         if (resp.statusCode() == 200 || resp.statusCode() == 201) {
             JsonObject json = buffer.toJsonObject();
-            LOG.debugf("Client has been succesfully registered: %s", json.toString());
+            LOG.debugf("Client has been successfully registered: %s", json.toString());
 
             String registrationClientUri = (String) json.remove(OidcConstants.REGISTRATION_CLIENT_URI);
             String registrationToken = (String) json.remove(OidcConstants.REGISTRATION_ACCESS_TOKEN);

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
@@ -191,7 +191,7 @@ public class RegisteredClientImpl implements RegisteredClient {
                 OidcEndpoint.Type.REGISTERED_CLIENT);
         if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
             io.vertx.core.json.JsonObject json = buffer.toJsonObject();
-            LOG.debugf("Client metadata has been succesfully updated: %s", json.toString());
+            LOG.debugf("Client metadata has been successfully updated: %s", json.toString());
 
             String newRegistrationClientUri = (String) json.remove(OidcConstants.REGISTRATION_CLIENT_URI);
             String newRegistrationToken = (String) json.remove(OidcConstants.REGISTRATION_ACCESS_TOKEN);
@@ -212,7 +212,7 @@ public class RegisteredClientImpl implements RegisteredClient {
         Buffer buffer = OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters,
                 OidcEndpoint.Type.REGISTERED_CLIENT);
         if (resp.statusCode() == 200) {
-            LOG.debug("Client has been succesfully deleted");
+            LOG.debug("Client has been successfully deleted");
             return Uni.createFrom().voidItem();
         } else {
             String errorMessage = buffer.toString();

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -154,7 +154,7 @@ public class MessageBundleProcessor {
                             name = MessageBundle.DEFAULT_NAME;
                         } else {
                             // The name starts with the DEFAULT_NAME followed by an underscore, followed by simple names of all
-                            // declaring classes in the hierarchy seperated by underscores
+                            // declaring classes in the hierarchy separated by underscores
                             List<String> names = new ArrayList<>();
                             names.add(DotNames.simpleName(bundleClass));
                             DotName enclosingName = bundleClass.enclosingClass();

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -556,7 +556,7 @@ public class QuteProcessor {
         }
         String name = getTargetName(target);
         if (checkedFragment) {
-            // the name is the part before the last occurence of a dollar sign
+            // the name is the part before the last occurrence of a dollar sign
             name = name.substring(0, name.lastIndexOf('$'));
         }
         return defaultedName(defaultName, name);
@@ -570,7 +570,7 @@ public class QuteProcessor {
             return null;
         }
         String name = getTargetName(target);
-        // the id is the part after the last occurence of a dollar sign
+        // the id is the part after the last occurrence of a dollar sign
         int idx = name.lastIndexOf('$');
         if (idx == -1 || idx == name.length()) {
             return null;
@@ -2142,7 +2142,7 @@ public class QuteProcessor {
             // with priorities of application globals that are regenerated during each hot reload
             // Therefore, the initial priority is increased by the number of all globals ever found
             // For example, if there are three globals [A, B, C] (A and C are non-application classes)
-            // The intial priority during the first hot reload will be "-1000 + 3 = 997"
+            // The initial priority during the first hot reload will be "-1000 + 3 = 997"
             // If a global D is added afterwards, the initial priority during the subsequent hot reload will be "-1000 + 4 = 996"
             // If the global D is removed, the initial priority will still remain "-1000 + 4 = 996"
             // This way we can be sure that the priorities assigned to A and C will never conflict with priorities of B and D or any other application global class

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ListCommands.java
@@ -313,7 +313,7 @@ public interface ListCommands<K, V> extends RedisCommands {
      * Requires Redis 1.0.0
      *
      * @param key the key
-     * @param count the number of occurence to remove, following the given rules:
+     * @param count the number of occurrence to remove, following the given rules:
      *        if count > 0: Remove elements equal to element moving from head to tail.
      *        if count < 0: Remove elements equal to element moving from tail to head.
      *        if count = 0: Remove all elements equal to element.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveListCommands.java
@@ -313,7 +313,7 @@ public interface ReactiveListCommands<K, V> extends ReactiveRedisCommands {
      * Requires Redis 1.0.0
      *
      * @param key the key
-     * @param count the number of occurence to remove, following the given rules:
+     * @param count the number of occurrence to remove, following the given rules:
      *        if count > 0: Remove elements equal to element moving from head to tail.
      *        if count < 0: Remove elements equal to element moving from tail to head.
      *        if count = 0: Remove all elements equal to element.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveTransactionalListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveTransactionalListCommands.java
@@ -321,7 +321,7 @@ public interface ReactiveTransactionalListCommands<K, V> extends ReactiveTransac
      * Requires Redis 1.0.0
      *
      * @param key the key
-     * @param count the number of occurence to remove, following the given rules:
+     * @param count the number of occurrence to remove, following the given rules:
      *        if count > 0: Remove elements equal to element moving from head to tail.
      *        if count < 0: Remove elements equal to element moving from tail to head.
      *        if count = 0: Remove all elements equal to element.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/TransactionalListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/TransactionalListCommands.java
@@ -276,7 +276,7 @@ public interface TransactionalListCommands<K, V> extends TransactionalRedisComma
      * Requires Redis 1.0.0
      *
      * @param key the key
-     * @param count the number of occurence to remove, following the given rules:
+     * @param count the number of occurrence to remove, following the given rules:
      *        if count > 0: Remove elements equal to element moving from head to tail.
      *        if count < 0: Remove elements equal to element moving from tail to head.
      *        if count = 0: Remove all elements equal to element.

--- a/extensions/smallrye-graphql/runtime-dev/src/main/java/io/quarkus/smallrye/graphql/runtime/dev/GraphQLJsonRpcService.java
+++ b/extensions/smallrye-graphql/runtime-dev/src/main/java/io/quarkus/smallrye/graphql/runtime/dev/GraphQLJsonRpcService.java
@@ -62,7 +62,7 @@ public class GraphQLJsonRpcService {
             var response = stub.doOperation(someparam);
             ```
 
-            Your reponse should only contain one field called `code` that contains a value with only the {{language}} code, nothing else, no explanation, and do not put the code in backticks.
+            Your response should only contain one field called `code` that contains a value with only the {{language}} code, nothing else, no explanation, and do not put the code in backticks.
             The {{language}} code must run and be valid.
 
             Example response: `{code: 'package foo.bar; // more code here'}`

--- a/extensions/smallrye-openapi/runtime-dev/src/main/java/io/quarkus/smallrye/openapi/runtime/dev/OpenApiJsonRpcService.java
+++ b/extensions/smallrye-openapi/runtime-dev/src/main/java/io/quarkus/smallrye/openapi/runtime/dev/OpenApiJsonRpcService.java
@@ -58,7 +58,7 @@ public class OpenApiJsonRpcService {
             ```
 
             Don't use ResourceNameHereClient as the name for the generated code (it's just an example). Derive a sensible name from the schema provided.
-            Your reponse should only contain one field called `code` that contains a value with only the {{language}} code, nothing else, no explanation, and do not put the code in backticks.
+            Your response should only contain one field called `code` that contains a value with only the {{language}} code, nothing else, no explanation, and do not put the code in backticks.
             The {{language}} code must run and be valid.
 
             Example response: `{code: 'package foo.bar; // more code here'}`

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/CertificateRecorder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/CertificateRecorder.java
@@ -46,7 +46,7 @@ public class CertificateRecorder implements TlsConfigurationRegistry {
      * Verify that each certificate file exists and that the key store and trust store are correctly configured.
      * When aliases are set, aliases are validated.
      *
-     * @param providerBucketNames the bucket names from {@link Identifier @Identifer} annotations on any
+     * @param providerBucketNames the bucket names from {@link Identifier @Identifier} annotations on any
      *        {@link KeyStoreProvider} or {@link TrustStoreProvider} beans
      * @param vertx the Vert.x instance
      */

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/CheckedTemplate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/CheckedTemplate.java
@@ -69,8 +69,8 @@ import java.lang.annotation.Target;
  * denotes a fragment of a type-safe template.
  * It's possible to ignore the fragments and effectively disable this feature via {@link CheckedTemplate#ignoreFragments()}.
  * <p>
- * The name of the fragment is derived from the annotated element name. The part before the last occurence of a dollar sign
- * {@code $} is the method name of the related type-safe template. The part after the last occurence of a dollar sign is the
+ * The name of the fragment is derived from the annotated element name. The part before the last occurrence of a dollar sign
+ * {@code $} is the method name of the related type-safe template. The part after the last occurrence of a dollar sign is the
  * fragment identifier - the strategy defined by the relevant {@link CheckedTemplate#defaultName()} is used.
  * <p>
  * Parameters of the annotated element are validated. The required names and types are derived from the relevant fragment

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/FragmentNamespaceResolver.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/FragmentNamespaceResolver.java
@@ -51,7 +51,7 @@ public class FragmentNamespaceResolver implements NamespaceResolver, EngineListe
         Template template = null;
         int idx = id.lastIndexOf('$');
         if (idx != -1) {
-            // the part before the last occurence of a dollar sign is the template identifier
+            // the part before the last occurrence of a dollar sign is the template identifier
             String templateId = id.substring(0, idx);
             Engine e = engine;
             if (e == null) {
@@ -61,7 +61,7 @@ public class FragmentNamespaceResolver implements NamespaceResolver, EngineListe
             if (template == null) {
                 throw new TemplateException("Template not found: " + templateId);
             }
-            // the part after the last occurence of a dollar sign is the fragment identifier
+            // the part after the last occurrence of a dollar sign is the fragment identifier
             id = id.substring(idx + 1);
         } else {
             template = context.resolutionContext().getTemplate();

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/IncludeSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/IncludeSectionHelper.java
@@ -480,7 +480,7 @@ public class IncludeSectionHelper implements SectionHelper {
             }
             int idx = templateId.lastIndexOf('$');
             if (idx != -1) {
-                // the part after the last occurence of a dollar sign is the fragment identifier
+                // the part after the last occurrence of a dollar sign is the fragment identifier
                 String fragmentId = templateId.substring(idx + 1, templateId.length());
                 if (FragmentSectionHelper.Factory.FRAGMENT_PATTERN.matcher(fragmentId).matches()) {
                     return fragmentId;

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/ResponseInfoTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/ResponseInfoTest.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * @tpChapter Integration tests
  * @tpSince RESTEasy 3.0.16
  */
-@DisplayName("Reponse Info Test")
-public class ReponseInfoTest {
+@DisplayName("Response Info Test")
+public class ResponseInfoTest {
 
     static Client client;
 
@@ -46,7 +46,7 @@ public class ReponseInfoTest {
                 @Override
                 public JavaArchive get() {
                     JavaArchive war = ShrinkWrap.create(JavaArchive.class);
-                    war.addClasses(PortProviderUtil.class, ReponseInfoTest.class);
+                    war.addClasses(PortProviderUtil.class, ResponseInfoTest.class);
                     // Use of PortProviderUtil in the deployment
                     war.addClasses(ResponseInfoResource.class);
                     return war;
@@ -54,7 +54,7 @@ public class ReponseInfoTest {
             });
 
     private void basicTest(String path) {
-        WebTarget base = client.target(PortProviderUtil.generateURL(path, ReponseInfoTest.class.getSimpleName()));
+        WebTarget base = client.target(PortProviderUtil.generateURL(path, ResponseInfoTest.class.getSimpleName()));
         Response response = base.request().get();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(true, response.readEntity(boolean.class));

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManager.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManager.java
@@ -138,7 +138,7 @@ public class PluginManager {
      * Removes a {@link Plugin} by name.
      * The catalog from which the plugin will be removed is selected
      * based on where the plugin is found. If plugin is found in both catalogs
-     * the project catalog is prefered.
+     * the project catalog is preferred.
      *
      * @param name The name of the plugin to remove.
      * @return The removed plugin wrapped in Optional, empty if no plugin was removed.
@@ -151,7 +151,7 @@ public class PluginManager {
      * Removes a {@link Plugin} by name.
      * The catalog from which the plugin will be removed is selected
      * based on where the plugin is found. If plugin is found in both catalogs
-     * the project catalog is prefered.
+     * the project catalog is preferred.
      *
      * @param name The name of the plugin to remove.
      * @param userCatalog Flag to only use the user catalog.
@@ -188,7 +188,7 @@ public class PluginManager {
      * Removes a {@link Plugin} by name.
      * The catalog from which the plugin will be removed is selected
      * based on where the plugin is found. If plugin is found in both catalogs
-     * the project catalog is prefered.
+     * the project catalog is preferred.
      *
      * @param plugin The plugin to remove
      * @return The removed plugin wrapped in Optional, empty if no plugin was removed.
@@ -201,7 +201,7 @@ public class PluginManager {
      * Removes a {@link Plugin} by name.
      * The catalog from which the plugin will be removed is selected
      * based on where the plugin is found. If plugin is found in both catalogs
-     * the project catalog is prefered.
+     * the project catalog is preferred.
      *
      * @param plugin The plugin to remove
      * @param userCatalog Flag to only use the user catalog.

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
@@ -225,7 +225,7 @@ public class QuarkusCodestartTest implements BeforeAllCallback, AfterAllCallback
      * <br>
      * <br>
      *
-     * Very usefull to check if a file contains a specific String:
+     * Very useful to check if a file contains a specific String:
      * <br>
      * Example:<br>
      * codestartTest.assertThatGeneratedFile(JAVA, "README.md").satisfies(checkContains("./mvnw quarkus:dev

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -425,7 +425,7 @@ public class QuarkusComponentTestExtension
             try {
                 Arc.shutdown();
             } catch (Exception e) {
-                LOG.error("An error occured during ArC shutdown: " + e);
+                LOG.error("An error occurred during ArC shutdown: " + e);
             }
             MockBeanCreator.clear();
             ConfigBeanCreator.clear();


### PR DESCRIPTION
### Summary
While reviewing the codebase, I identified and corrected spelling errors across several extensions (Kubernetes, Redis, Qute, OIDC) and independent projects

### Changes
- Class Rename: Renamed `ReponseInfoTest` to `ResponseInfoTest` in `independent-projects/resteasy-reactive` to fix a typo in the class name
- Log Messages: Fixed "succesfully" -> "successfully" in `OidcClientRegistrationImpl` and `RegisteredClientImpl` to improve log searchability
- Javadocs & Comments: Corrected various typos ("teh", "accross", "seperated") in `ImageBuilder`, `WebSocket`, etc
- Resources: Fixed typos in Grafana dashboard JSON files

### Verification
- these changes are primarily documentation, log messages, and a test class rename
- verified that the file rename was correctly handled via Git (`git status` showed `renamed:`)

### Checklist
- [x] I have read the [contributing guide](https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md)
- [x] I have analyzed the best way to implement the fix
- [x] I have tested the changes (verified file status and spelling)
