### PR TITLE
Run quarkus-hibernate-orm-rest-data-panache DevMode tests in a separate Surefire execution

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
@@ -65,6 +65,35 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- These tests seem to leak metaspace memory
+                                 so we run them in a separate, short-lived JVM -->
+                            <excludedGroups>devmode</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>devmode-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- These tests seem to leak metaspace memory
+                                 so we run them in a separate, short-lived JVM -->
+                            <groups>devmode</groups>
+                            <!-- We could consider setting reuseForks=false if we
+                                 really need to run every single test in its own JVM -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractDevModeTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractDevModeTest.java
@@ -4,10 +4,12 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.restassured.response.Response;
 
+@Tag(TestTags.DEVMODE)
 public abstract class AbstractDevModeTest {
 
     @Test

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractHotReloadTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/AbstractHotReloadTest.java
@@ -2,10 +2,12 @@ package io.quarkus.hibernate.orm.rest.data.panache.deployment;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
+@Tag(TestTags.DEVMODE)
 public abstract class AbstractHotReloadTest {
 
     protected abstract QuarkusDevModeTest getTestArchive();

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/TestTags.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/TestTags.java
@@ -1,0 +1,10 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment;
+
+public class TestTags {
+    /**
+     * Tag for tests that use {@link io.quarkus.test.QuarkusDevModeTest},
+     * so that surefire config can run them in a different execution
+     * and keep the metaspace memory leaks there.
+     */
+    public static final String DEVMODE = "devmode";
+}


### PR DESCRIPTION
These tests have been flaky due to OOM: Metaspace lately, see https://ge.quarkus.io/scans/tests?search.timeZoneId=Europe%2FParis&tests.container=io.quarkus.hibernate.orm.rest.data.panache.deployment.build.BuildConditionsWithResourceDisabledTest&tests.test=#

I believe we have the same problem here as in the Hibernate ORM extension: many devmode tests, combined with a metaspace leak when using QuarkusDevModeTest, leading to OOM.

It's possible more investigation is needed, in particular because this OOM is new.
If anyone thinks so, maybe we should create an issue and work on that whenever possible.

In the meantime... this will at least avoid flaky CI.