### PR TITLE
Fix application.properties not loaded in standalone generate-code goal

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -1,5 +1,6 @@
 package io.quarkus.maven;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -14,7 +15,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import io.quarkus.bootstrap.app.AdditionalDependency;
 import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.util.BootstrapUtils;
@@ -80,7 +83,7 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
         CuratedApplication curatedApplication = null;
         QuarkusClassLoader deploymentClassLoader = null;
         try {
-            curatedApplication = bootstrapApplication(launchMode);
+            curatedApplication = bootstrapApplication(launchMode, this::addResourcesDirToBootstrap);
             deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
@@ -138,6 +141,13 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
             }
         }
         return builder.build();
+    }
+
+    private void addResourcesDirToBootstrap(QuarkusBootstrap.Builder builder) {
+        File resourcesDir = new File(mavenProject().getBasedir(), "src/main/resources");
+        if (resourcesDir.exists()) {
+            builder.addAdditionalApplicationArchive(new AdditionalDependency(resourcesDir.toPath(), false, false));
+        }
     }
 
     private Path generatedSourcesDir(boolean test) {

--- a/integration-tests/grpc-google-common-protos/pom.xml
+++ b/integration-tests/grpc-google-common-protos/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-google-common-protos</artifactId>
+    <name>Quarkus - Integration Tests - gRPC Google Common Protos</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>proto-google-common-protos</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/grpc-google-common-protos/src/main/proto/my_message.proto
+++ b/integration-tests/grpc-google-common-protos/src/main/proto/my_message.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package my.message;
+
+import "google/type/decimal.proto";
+
+option java_package = "io.quarkus.grpc.google.common.protos";
+option java_multiple_files = true;
+
+message MyMessage {
+  google.type.Decimal decimal = 1;
+}

--- a/integration-tests/grpc-google-common-protos/src/main/resources/application.properties
+++ b/integration-tests/grpc-google-common-protos/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.generate-code.grpc.scan-for-imports=com.google.api.grpc:proto-google-common-protos
+

--- a/integration-tests/grpc-google-common-protos/src/test/java/io/quarkus/grpc/google/common/protos/GoogleCommonProtosTest.java
+++ b/integration-tests/grpc-google-common-protos/src/test/java/io/quarkus/grpc/google/common/protos/GoogleCommonProtosTest.java
@@ -1,0 +1,14 @@
+package io.quarkus.grpc.google.common.protos;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class GoogleCommonProtosTest {
+
+    @Test
+    public void test() {
+        // Just verify that the application starts and the code generation worked
+    }
+}


### PR DESCRIPTION
## Problem
When running `mvn quarkus:generate-code` as a standalone goal (without a prior build), the` application.properties` file from `src/main/resources` is not loaded. This occurs because `src/main/resources` is only added to the classpath during the `process-resources` phase, which doesn't run when invoking the goal standalone.

This causes configuration properties (e.g., `quarkus.generate-code.grpc.scan-for-imports`) to be ignored, resulting in build failures when proto files import types from dependencies.

**Example failure:**
`[ERROR] google/type/decimal.proto: File not found. [ERROR] "google.type.Decimal" is not defined.`

## Solution
Modified https://github.com/quarkusio/quarkus/blob/3ba284725e835dc306f1e4b982c5676e8bdd8e7f/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java#L83 to explicitly add `src/main/resources` to the bootstrap classpath when bootstrapping the application. This ensures configuration is loaded correctly even when running the goal standalone.

## Testing
- Created integration test module `integration-tests/grpc-google-common-protos`
- Verified `mvn clean quarkus:generate-code` fails without the fix
- Verified `mvn clean quarkus:generate-code` succeeds with the fix

Fixes #50380

