### PR TITLE
Correct error message so that parameter matches text

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -182,7 +182,7 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
             } else if (isEclipse) {
                 // Tracked by https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2257; fixed in Eclipse 4.37
                 log.error(
-                        "Could not read configuration while evaluating whether to run a test. This is a known issue when running tests in the Eclipse IDE. To work around the problem, edit the run configuration and add `-uniqueId [engine:junit-jupiter]/[class:"
+                        "Could not read configuration while evaluating whether to run a test. This is a known issue when running tests in older versions of the Eclipse IDE. Please upgrade to at least version 2025-09. Alternatively, to work around the problem, edit the run configuration and add `-uniqueId [engine:junit-jupiter]/[class:"
                                 + context.getRequiredTestClass().getName()
                                 + "]` in the program arguments. Running the whole package, or running individual test methods, will also work without any extra configuration.");
             } else {
@@ -201,7 +201,7 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
                                     + context.getRequiredTestClass().getName()
                                     + "]` in the program arguments. "
                             : "Internal error: Test class was loaded with an unexpected classloader ("
-                                    + TestConfig.class.getClassLoader() + ") or the thread context classloader ("
+                                    + context.getRequiredTestClass().getClassLoader() + ") or the thread context classloader ("
                                     + Thread.currentThread().getContextClassLoader() + ") was incorrect.";
             throw new IllegalStateException(message, e);
         } finally {


### PR DESCRIPTION
I'm working on a fix for #51269, but it's going to be pretty complicated, and might even need a surefire update if we can't work around recent changes to that plugin. 

In the interim, I noticed that the parameter in our error message doesn't actually match the text, so we should fix that. 

We can also give more useful solutions in the Eclipse path, so I've done that.