### PR TITLE
Provide fluent API to set up Security JPA identity providers programmatically

### DIFF
--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -600,6 +600,7 @@ The same authorization can be required with the `@PermissionsAllowed(value = { "
 * xref:security-authentication-mechanisms.adoc#mtls-programmatic-set-up[Set up the mutual TLS client authentication programmatically]
 * xref:security-cors.adoc#cors-filter-programmatic-set-up[Configuring the CORS filter programmatically]
 * xref:security-csrf-prevention.adoc#csrf-prevention-programmatic-set-up[Configuring the CSRF prevention programmatically]
+* xref:security-jpa.adoc#programmatic-set-up[Set up Security JPA programmatically]
 
 [[standard-security-annotations]]
 == Authorization using annotations

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -222,6 +222,36 @@ For more information about proactive authentication, see the Quarkus xref:securi
 
 include::{generated-dir}/config/quarkus-security-jpa.adoc[opts=optional, leveloffset=+2]
 
+[[programmatic-set-up]]
+== Set up Security JPA programmatically
+
+If you need to combine authentication mechanisms with different identity providers or persistence units, you can leverage the `io.quarkus.vertx.http.security.HttpSecurity` CDI event.
+For example, if you combine the built-in Basic and the Form-based authentication mechanisms, you can configure different persistence unit for each of mechanism like in the example below:
+
+[source,java]
+----
+package org.acme.http.security;
+
+import static io.quarkus.security.jpa.SecurityJpa.jpa;
+import static io.quarkus.security.jpa.SecurityJpa.jpaTrustedProvider;
+
+import io.quarkus.vertx.http.security.Form;
+import io.quarkus.vertx.http.security.HttpSecurity;
+import jakarta.enterprise.event.Observes;
+
+class HttpSecurityConfiguration {
+
+    void configure(@Observes HttpSecurity httpSecurity) {
+            httpSecurity
+                    .basic(jpa("basic-pu"))   <1>
+                    .mechanism(Form.builder().identityProviders(jpa("form-pu"), jpaTrustedProvider("form-pu")).build());    <2>
+    }
+
+}
+----
+<1> Configure the Basic authentication to store the users information in the `basic-pu` persistence unit.
+<2> Also use the Security JPA identity providers, but this time with the `form-pu` persistence unit.
+
 == References
 
 * xref:security-getting-started-tutorial.adoc[Getting started with Security by using Basic authentication and Jakarta Persistence]

--- a/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/QuarkusSecurityJpaCommonProcessor.java
+++ b/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/QuarkusSecurityJpaCommonProcessor.java
@@ -1,21 +1,29 @@
 package io.quarkus.security.jpa.common.deployment;
 
 import static io.quarkus.security.jpa.common.deployment.JpaSecurityIdentityUtil.getSingleAnnotatedElement;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.gizmo.ClassTransformer;
+import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.security.jpa.Password;
 import io.quarkus.security.jpa.Roles;
 import io.quarkus.security.jpa.UserDefinition;
 import io.quarkus.security.jpa.Username;
+import io.quarkus.security.jpa.common.runtime.JpaIdentityProviderUtil;
 
 class QuarkusSecurityJpaCommonProcessor {
 
@@ -48,4 +56,50 @@ class QuarkusSecurityJpaCommonProcessor {
         }
     }
 
+    /**
+     * This method produces {@link io.quarkus.security.jpa.SecurityJpa} CDI bean producer for either Hibernate ORM
+     * or Hibernate Reactive version of the Quarkus Security JPA.
+     */
+    @BuildStep
+    void registerSecurityJpaImplCdiBean(BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformerProducer,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer,
+            Optional<SecurityJpaProviderInfoBuildItem> securityJpaProviderClassBuildItem) {
+        if (securityJpaProviderClassBuildItem.isPresent()) {
+            var item = securityJpaProviderClassBuildItem.get();
+            additionalBeanProducer.produce(AdditionalBeanBuildItem.unremovableOf(item.securityJpaProviderClass));
+            bytecodeTransformerProducer
+                    .produce(new BytecodeTransformerBuildItem(item.securityJpaProviderClass.getName(), (cls, classVisitor) -> {
+                        var newInstanceUtilMethodDesc = MethodDescriptor.ofMethod(JpaIdentityProviderUtil.class, "newInstance",
+                                Object.class, Class.class);
+                        var classTransformer = new ClassTransformer(cls);
+                        classTransformer.removeMethod("newJpaIdentityProvider", item.jpaIdentityProviderClass);
+                        try (var mc = classTransformer.addMethod("newJpaIdentityProvider", item.jpaIdentityProviderClass)) {
+                            mc.setModifiers(ACC_PRIVATE | ACC_STATIC);
+                            // generates method similar to:
+                            // private static JpaIdentityProvider newJpaIdentityProvider() {
+                            //     return JpaIdentityProviderUtil.newInstance(MyEntity__JpaIdentityProviderImpl.class);
+                            // }
+                            var clazz = mc.loadClassFromTCCL(item.jpaIdentityProviderImplName);
+                            // we don't use "new MyEntity__JpaIdentityProviderImpl()" because the generated class needs TCCL
+                            var newInstance = mc.invokeStaticMethod(newInstanceUtilMethodDesc, clazz);
+                            mc.returnValue(newInstance);
+                        }
+                        classTransformer.removeMethod("newJpaTrustedIdentityProvider", item.jpaTrustedIdentityProviderClass);
+                        try (var mc = classTransformer.addMethod("newJpaTrustedIdentityProvider",
+                                item.jpaTrustedIdentityProviderClass)) {
+                            mc.setModifiers(ACC_PRIVATE | ACC_STATIC);
+                            // generates method similar to:
+                            // private static JpaTrustedIdentityProvider newJpaTrustedIdentityProvider() {
+                            //     return JpaIdentityProviderUtil.newInstance(MyEntity__JpaTrustedIdentityProviderImpl.class);
+                            // }
+                            var clazz = mc.loadClassFromTCCL(item.jpaTrustedIdentityProviderImplName);
+                            // we don't use "new MyEntity__JpaTrustedIdentityProviderImpl()",
+                            // because the generated class needs TCCL
+                            var newInstance = mc.invokeStaticMethod(newInstanceUtilMethodDesc, clazz);
+                            mc.returnValue(newInstance);
+                        }
+                        return classTransformer.applyTo(classVisitor);
+                    }));
+        }
+    }
 }

--- a/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/SecurityJpaProviderInfoBuildItem.java
+++ b/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/SecurityJpaProviderInfoBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.security.jpa.common.deployment;
+
+import java.util.Objects;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Registers {@link io.quarkus.security.jpa.SecurityJpa} CDI bean producer class and generated identity provider names.
+ */
+public final class SecurityJpaProviderInfoBuildItem extends SimpleBuildItem {
+
+    final Class<?> securityJpaProviderClass;
+    final String jpaIdentityProviderImplName;
+    final String jpaTrustedIdentityProviderImplName;
+    final Class<?> jpaIdentityProviderClass;
+    final Class<?> jpaTrustedIdentityProviderClass;
+
+    public SecurityJpaProviderInfoBuildItem(Class<?> securityJpaProviderClass, String jpaIdentityProviderImplName,
+            String jpaTrustedIdentityProviderImplName, Class<?> jpaIdentityProviderClass,
+            Class<?> jpaTrustedIdentityProviderClass) {
+        this.securityJpaProviderClass = Objects.requireNonNull(securityJpaProviderClass);
+        this.jpaIdentityProviderImplName = jpaIdentityProviderImplName;
+        this.jpaTrustedIdentityProviderImplName = jpaTrustedIdentityProviderImplName;
+        this.jpaIdentityProviderClass = jpaIdentityProviderClass;
+        this.jpaTrustedIdentityProviderClass = jpaTrustedIdentityProviderClass;
+    }
+}

--- a/extensions/security-jpa-common/runtime/src/main/java/io/quarkus/security/jpa/SecurityJpa.java
+++ b/extensions/security-jpa-common/runtime/src/main/java/io/quarkus/security/jpa/SecurityJpa.java
@@ -1,0 +1,76 @@
+package io.quarkus.security.jpa;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * A CDI bean used to build Quarkus Security JPA {@link IdentityProvider}s programmatically.
+ * This bean should be used together with the CDI event 'HttpSecurity' when you
+ * want to configure the Basic or Form authentication to use the Quarkus Security {@link IdentityProvider}.
+ */
+@Experimental("This API is currently experimental and might get changed")
+public interface SecurityJpa {
+
+    /**
+     * Creates new {@link IdentityProvider} for the {@link UsernamePasswordAuthenticationRequest} request.
+     *
+     * @param persistenceUnitName persistence unit name or null
+     * @return new {@link IdentityProvider}
+     */
+    IdentityProvider<UsernamePasswordAuthenticationRequest> createJpaIdentityProvider(String persistenceUnitName);
+
+    /**
+     * Creates new {@link IdentityProvider} for the {@link TrustedAuthenticationRequest} request.
+     *
+     * @param persistenceUnitName persistence unit name or null
+     * @return new {@link IdentityProvider}
+     */
+    IdentityProvider<TrustedAuthenticationRequest> createJpaTrustedIdentityProvider(String persistenceUnitName);
+
+    /**
+     * Creates new {@link IdentityProvider} for the {@link UsernamePasswordAuthenticationRequest} request and
+     * the default persistence unit.
+     *
+     * @return new {@link IdentityProvider}
+     */
+    static IdentityProvider<UsernamePasswordAuthenticationRequest> jpa() {
+        return getInstance().createJpaIdentityProvider(null);
+    }
+
+    /**
+     * Creates new {@link IdentityProvider} for the {@link UsernamePasswordAuthenticationRequest} request.
+     *
+     * @param persistenceUnitName persistence unit name
+     * @return new {@link IdentityProvider}
+     */
+    static IdentityProvider<UsernamePasswordAuthenticationRequest> jpa(String persistenceUnitName) {
+        return getInstance().createJpaIdentityProvider(persistenceUnitName);
+    }
+
+    /**
+     * Creates new {@link IdentityProvider} for the {@link TrustedAuthenticationRequest} request and the default
+     * persistence unit.
+     *
+     * @return new {@link IdentityProvider}
+     */
+    static IdentityProvider<TrustedAuthenticationRequest> jpaTrustedProvider() {
+        return getInstance().createJpaTrustedIdentityProvider(null);
+    }
+
+    /**
+     * Creates new {@link IdentityProvider} for the {@link TrustedAuthenticationRequest} request.
+     *
+     * @param persistenceUnitName persistence unit name
+     * @return new {@link IdentityProvider}
+     */
+    static IdentityProvider<TrustedAuthenticationRequest> jpaTrustedProvider(String persistenceUnitName) {
+        return getInstance().createJpaTrustedIdentityProvider(persistenceUnitName);
+    }
+
+    private static SecurityJpa getInstance() {
+        return Arc.requireContainer().select(SecurityJpa.class).get();
+    }
+}

--- a/extensions/security-jpa-common/runtime/src/main/java/io/quarkus/security/jpa/common/runtime/JpaIdentityProviderUtil.java
+++ b/extensions/security-jpa-common/runtime/src/main/java/io/quarkus/security/jpa/common/runtime/JpaIdentityProviderUtil.java
@@ -1,5 +1,6 @@
 package io.quarkus.security.jpa.common.runtime;
 
+import java.lang.reflect.InvocationTargetException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.UUID;
@@ -80,6 +81,15 @@ public class JpaIdentityProviderUtil {
             ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, uuid.toCharArray());
         } else {
             BcryptUtil.bcryptHash(uuid);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T newInstance(Class<T> clazz) {
+        try {
+            return (T) clazz.getConstructors()[0].newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/SecurityJpaReactiveFluentApiTest.java
+++ b/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/SecurityJpaReactiveFluentApiTest.java
@@ -1,0 +1,159 @@
+package io.quarkus.security.jpa.reactive;
+
+import static io.quarkus.security.jpa.SecurityJpa.jpaTrustedProvider;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.jpa.SecurityJpa;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.Form;
+import io.quarkus.vertx.http.security.HttpSecurity;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.smallrye.mutiny.Uni;
+
+class SecurityJpaReactiveFluentApiTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(TestApplication.class, MinimalUserEntity.class, SecurityJpaConfiguration.class,
+                    SingleRoleSecuredResource.class, FailingIdentityProvider.class)
+            .addAsResource("minimal-config/import.sql", "import.sql")
+            .addAsResource(new StringAsset("""
+                    quarkus.datasource.db-kind=postgresql
+                    quarkus.datasource.username=${postgres.reactive.username}
+                    quarkus.datasource.password=${postgres.reactive.password}
+                    quarkus.datasource.reactive=true
+                    quarkus.datasource.reactive.url=${postgres.reactive.url}
+                    quarkus.hibernate-orm.sql-load-script=import.sql
+                    quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+                    """), "application.properties"));
+
+    @Test
+    void testFormBasedAuthentication() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        CookieFilter cookies = new CookieFilter();
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/login"))
+                .cookie("quarkus-redirect-location", containsString("/user-secured"));
+
+        // test with a non-existent user
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "dummy")
+                .formParam("j_password", "dummy")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302);
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "user")
+                .formParam("j_password", "user")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/user-secured"))
+                .cookie("laitnederc-sukrauq", notNullValue());
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    @Test
+    void testBasicAuthentication() {
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "wrong-password")
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .statusCode(401);
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "user")
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    public static class SecurityJpaConfiguration {
+
+        void configure(@Observes HttpSecurity httpSecurity) {
+            var jpa = SecurityJpa.jpa();
+            var form = Form.builder()
+                    .loginPage("login")
+                    .errorPage("error")
+                    .landingPage("landing")
+                    .cookieName("laitnederc-sukrauq")
+                    .newCookieInterval(Duration.ofSeconds(5))
+                    .timeout(Duration.ofSeconds(5))
+                    .encryptionKey("CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT")
+                    .identityProviders(jpa, jpaTrustedProvider())
+                    .build();
+            httpSecurity.mechanism(form).basic(jpa);
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class FailingIdentityProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+        @Override
+        public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+            return UsernamePasswordAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest authenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            throw new IllegalStateException("This provider must never be invoked as we selected the JPA provider");
+        }
+
+        @Override
+        public int priority() {
+            return Integer.MAX_VALUE;
+        }
+    }
+}

--- a/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/SecurityJpaReactiveNamedPersistenceUnitFluentApiTest.java
+++ b/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/SecurityJpaReactiveNamedPersistenceUnitFluentApiTest.java
@@ -1,0 +1,171 @@
+package io.quarkus.security.jpa.reactive;
+
+import static io.quarkus.security.jpa.SecurityJpa.jpa;
+import static io.quarkus.security.jpa.SecurityJpa.jpaTrustedProvider;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.jpa.reactive.other.OtherMinimalUserEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.Form;
+import io.quarkus.vertx.http.security.HttpSecurity;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.smallrye.mutiny.Uni;
+
+class SecurityJpaReactiveNamedPersistenceUnitFluentApiTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(TestApplication.class, OtherMinimalUserEntity.class, SecurityJpaConfiguration.class,
+                    SingleRoleSecuredResource.class, FailingIdentityProvider.class)
+            .addAsResource("minimal-config/import.sql", "import.sql")
+            .addAsResource(new StringAsset("""
+                    quarkus.datasource.named.db-kind=postgresql
+                    quarkus.datasource.named.username=${postgres.reactive.username}
+                    quarkus.datasource.named.password=${postgres.reactive.password}
+                    quarkus.datasource.named.reactive=true
+                    quarkus.datasource.named.reactive.url=${postgres.reactive.url}
+                    quarkus.hibernate-orm.named.packages=io.quarkus.security.jpa.reactive.other
+                    quarkus.hibernate-orm.named.sql-load-script=import.sql
+                    quarkus.hibernate-orm.named.schema-management.strategy=drop-and-create
+                    quarkus.hibernate-orm.named.datasource=named
+                    quarkus.datasource.other-named.db-kind=postgresql
+                    quarkus.datasource.other-named.username=${postgres.reactive.username}
+                    quarkus.datasource.other-named.password=${postgres.reactive.password}
+                    quarkus.datasource.other-named.reactive=true
+                    quarkus.datasource.other-named.reactive.url=${postgres.reactive.url}
+                    quarkus.hibernate-orm.other-named.datasource=other-named
+                    quarkus.hibernate-orm.other-named.packages=io.quarkus.security.jpa.reactive.other
+                    """), "application.properties"));
+
+    @Test
+    void testFormBasedAuthentication() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        CookieFilter cookies = new CookieFilter();
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/login"))
+                .cookie("quarkus-redirect-location", containsString("/jaxrs-secured/user-secured"));
+
+        // test with a non-existent user
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "dummy")
+                .formParam("j_password", "dummy")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302);
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "user")
+                .formParam("j_password", "user")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/jaxrs-secured/user-secured"))
+                .cookie("laitnederc-sukrauq", notNullValue());
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    @Test
+    void testBasicAuthentication() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "wrong-password")
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .statusCode(401);
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "user")
+                .get("/jaxrs-secured/user-secured")
+                .then()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    static class SecurityJpaConfiguration {
+
+        void configure(@Observes HttpSecurity httpSecurity) {
+            var form = Form.builder()
+                    .loginPage("login")
+                    .errorPage("error")
+                    .landingPage("landing")
+                    .cookieName("laitnederc-sukrauq")
+                    .newCookieInterval(Duration.ofSeconds(5))
+                    .timeout(Duration.ofSeconds(5))
+                    .encryptionKey("CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT")
+                    .identityProviders(jpa("named"), jpaTrustedProvider("named"))
+                    .build();
+            httpSecurity
+                    .mechanism(form)
+                    .basic(jpa("other-named"));
+        }
+
+    }
+
+    @ApplicationScoped
+    static class FailingIdentityProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+        @Override
+        public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+            return UsernamePasswordAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest authenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            throw new IllegalStateException("This provider must never be invoked as we selected the JPA provider");
+        }
+
+        @Override
+        public int priority() {
+            return Integer.MAX_VALUE;
+        }
+    }
+}

--- a/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/other/OtherMinimalUserEntity.java
+++ b/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/other/OtherMinimalUserEntity.java
@@ -1,0 +1,33 @@
+package io.quarkus.security.jpa.reactive.other;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import io.quarkus.security.jpa.Password;
+import io.quarkus.security.jpa.PasswordType;
+import io.quarkus.security.jpa.Roles;
+import io.quarkus.security.jpa.UserDefinition;
+import io.quarkus.security.jpa.Username;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class OtherMinimalUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @Roles
+    public String role;
+}

--- a/extensions/security-jpa-reactive/deployment/src/test/resources/minimal-config/import.sql
+++ b/extensions/security-jpa-reactive/deployment/src/test/resources/minimal-config/import.sql
@@ -1,3 +1,4 @@
 INSERT INTO test_user (id, username, password, role) VALUES (1, 'admin', 'admin', 'admin');
 INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','user', 'user');
 INSERT INTO test_user (id, username, password, role) VALUES (3, 'noRoleUser','noRoleUser', '');
+CREATE DATABASE other;

--- a/extensions/security-jpa-reactive/runtime/src/main/java/io/quarkus/security/jpa/reactive/runtime/SecurityJpaReactiveProvider.java
+++ b/extensions/security-jpa-reactive/runtime/src/main/java/io/quarkus/security/jpa/reactive/runtime/SecurityJpaReactiveProvider.java
@@ -1,0 +1,61 @@
+package io.quarkus.security.jpa.reactive.runtime;
+
+import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.jpa.SecurityJpa;
+
+public class SecurityJpaReactiveProvider {
+
+    @Produces
+    SecurityJpa createSecurityJpa(@Any Instance<Mutiny.SessionFactory> sessionFactoryInstance) {
+        return new SecurityJpa() {
+            @Override
+            public IdentityProvider<UsernamePasswordAuthenticationRequest> createJpaIdentityProvider(
+                    String persistenceUnitName) {
+                var jpaIdentityProvider = newJpaIdentityProvider();
+                jpaIdentityProvider.sessionFactory = getSessionFactoryInstance(persistenceUnitName);
+                return jpaIdentityProvider;
+            }
+
+            @Override
+            public IdentityProvider<TrustedAuthenticationRequest> createJpaTrustedIdentityProvider(String persistenceUnitName) {
+                var trustedIdentityProvider = newJpaTrustedIdentityProvider();
+                trustedIdentityProvider.sessionFactory = getSessionFactoryInstance(persistenceUnitName);
+                return trustedIdentityProvider;
+            }
+
+            private Mutiny.SessionFactory getSessionFactoryInstance(String persistenceUnitName) {
+                final Mutiny.SessionFactory sessionFactory;
+                if (persistenceUnitName == null || DEFAULT_PERSISTENCE_UNIT_NAME.equals(persistenceUnitName)) {
+                    if (!sessionFactoryInstance.isResolvable()) {
+                        throw new IllegalArgumentException("Default persistence unit is not available");
+                    }
+                    sessionFactory = sessionFactoryInstance.get();
+                } else {
+                    var namedSessionFactoryInstance = sessionFactoryInstance
+                            .select(new PersistenceUnit.PersistenceUnitLiteral(persistenceUnitName));
+                    if (!namedSessionFactoryInstance.isResolvable()) {
+                        throw new IllegalArgumentException("Unknown persistence unit '%s'".formatted(persistenceUnitName));
+                    }
+                    sessionFactory = namedSessionFactoryInstance.get();
+                }
+                return sessionFactory;
+            }
+        };
+    }
+
+    private static native JpaReactiveIdentityProvider newJpaIdentityProvider();
+
+    private static native JpaReactiveTrustedIdentityProvider newJpaTrustedIdentityProvider();
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SecurityJpaFluentApiTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SecurityJpaFluentApiTest.java
@@ -1,0 +1,161 @@
+package io.quarkus.security.jpa;
+
+import static io.quarkus.security.jpa.SecurityJpa.jpa;
+import static io.quarkus.security.jpa.SecurityJpa.jpaTrustedProvider;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.Form;
+import io.quarkus.vertx.http.security.HttpSecurity;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.smallrye.mutiny.Uni;
+
+class SecurityJpaFluentApiTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(SingleRoleSecuredServlet.class, MinimalUserEntity.class, SecurityJpaConfiguration.class,
+                    FailingIdentityProvider.class)
+            .addAsResource("minimal-config/import.sql", "import.sql")
+            .addAsResource(new StringAsset("""
+                    quarkus.datasource.db-kind=h2
+                    quarkus.datasource.username=sa
+                    quarkus.datasource.password=sa
+                    quarkus.datasource.jdbc.url=jdbc:h2:mem:minimal-config
+                    quarkus.hibernate-orm.sql-load-script=import.sql
+                    quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+                    """), "application.properties"));
+
+    @Test
+    void testFormBasedAuthentication() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        CookieFilter cookies = new CookieFilter();
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/servlet-secured")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/login"))
+                .cookie("quarkus-redirect-location", containsString("/servlet-secured"));
+
+        // test with a non-existent user
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "dummy")
+                .formParam("j_password", "dummy")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302);
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "user")
+                .formParam("j_password", "user")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/servlet-secured"))
+                .cookie("laitnederc-sukrauq", notNullValue());
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/servlet-secured")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    @Test
+    void testBasicAuthentication() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "wrong-password")
+                .get("/servlet-secured")
+                .then()
+                .statusCode(401);
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "user")
+                .get("/servlet-secured")
+                .then()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    static class SecurityJpaConfiguration {
+
+        void configure(@Observes HttpSecurity httpSecurity) {
+            var form = Form.builder()
+                    .loginPage("login")
+                    .errorPage("error")
+                    .landingPage("landing")
+                    .cookieName("laitnederc-sukrauq")
+                    .newCookieInterval(Duration.ofSeconds(5))
+                    .timeout(Duration.ofSeconds(5))
+                    .encryptionKey("CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT")
+                    .identityProviders(jpa(), jpaTrustedProvider())
+                    .build();
+            httpSecurity
+                    .mechanism(form)
+                    .basic(jpa());
+        }
+
+    }
+
+    @ApplicationScoped
+    static class FailingIdentityProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+        @Override
+        public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+            return UsernamePasswordAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest authenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            throw new IllegalStateException("This provider must never be invoked as we selected the JPA provider");
+        }
+
+        @Override
+        public int priority() {
+            return Integer.MAX_VALUE;
+        }
+    }
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SecurityJpaNamedPersistenceUnitFluentApiTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SecurityJpaNamedPersistenceUnitFluentApiTest.java
@@ -1,0 +1,181 @@
+package io.quarkus.security.jpa;
+
+import static io.quarkus.security.jpa.SecurityJpa.jpa;
+import static io.quarkus.security.jpa.SecurityJpa.jpaTrustedProvider;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.jpa.other.OtherMinimalUserEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.Form;
+import io.quarkus.vertx.http.security.HttpSecurity;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.smallrye.mutiny.Uni;
+
+class SecurityJpaNamedPersistenceUnitFluentApiTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(SingleRoleSecuredServlet.class, OtherMinimalUserEntity.class, SecurityJpaConfiguration.class,
+                    FailingIdentityProvider.class)
+            .addAsResource("minimal-config/import.sql", "import.sql")
+            .addAsResource("minimal-config/import-one-user.sql", "import-one-user.sql")
+            .addAsResource(new StringAsset("""
+                    quarkus.datasource.named.db-kind=h2
+                    quarkus.datasource.named.username=sa
+                    quarkus.datasource.named.password=sa
+                    quarkus.datasource.named.jdbc.url=jdbc:h2:mem:minimal-config-1
+                    quarkus.hibernate-orm.named.sql-load-script=import.sql
+                    quarkus.hibernate-orm.named.schema-management.strategy=drop-and-create
+                    quarkus.hibernate-orm.named.packages=io.quarkus.security.jpa.other
+                    quarkus.hibernate-orm.named.datasource=named
+                    quarkus.datasource.other-named.db-kind=h2
+                    quarkus.datasource.other-named.username=sa
+                    quarkus.datasource.other-named.password=sa
+                    quarkus.datasource.other-named.jdbc.url=jdbc:h2:mem:minimal-config-2
+                    quarkus.hibernate-orm.other-named.sql-load-script=import-one-user.sql
+                    quarkus.hibernate-orm.other-named.schema-management.strategy=drop-and-create
+                    quarkus.hibernate-orm.other-named.packages=io.quarkus.security.jpa.other
+                    quarkus.hibernate-orm.other-named.datasource=other-named
+                    """), "application.properties"));
+
+    @Test
+    void testFormBasedAuthentication() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        CookieFilter cookies = new CookieFilter();
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/servlet-secured")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/login"))
+                .cookie("quarkus-redirect-location", containsString("/servlet-secured"));
+
+        // test with a non-existent user
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "dummy")
+                .formParam("j_password", "dummy")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302);
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "user")
+                .formParam("j_password", "user")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/servlet-secured"))
+                .cookie("laitnederc-sukrauq", notNullValue());
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/servlet-secured")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    @Test
+    void testBasicAuthentication() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "wrong-password")
+                .get("/servlet-secured")
+                .then()
+                .statusCode(401);
+        // these are correct credentials for persistence unit 'named', but not for the persistence unit 'other-named'
+        // and the credentials worked for the form-authentication in the other test method of this class
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "user")
+                .get("/servlet-secured")
+                .then()
+                .statusCode(401);
+        // now use correct credentials for persistence unit 'other-named'
+        RestAssured
+                .given()
+                .auth().preemptive().basic("robin", "robin")
+                .get("/servlet-secured")
+                .then()
+                .statusCode(200)
+                .body(equalTo("A secured message"));
+    }
+
+    static class SecurityJpaConfiguration {
+
+        void configure(@Observes HttpSecurity httpSecurity) {
+            var form = Form.builder()
+                    .loginPage("login")
+                    .errorPage("error")
+                    .landingPage("landing")
+                    .cookieName("laitnederc-sukrauq")
+                    .newCookieInterval(Duration.ofSeconds(5))
+                    .timeout(Duration.ofSeconds(5))
+                    .encryptionKey("CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT")
+                    .identityProviders(jpa("named"), jpaTrustedProvider("named"))
+                    .build();
+            httpSecurity
+                    .mechanism(form)
+                    .basic(jpa("other-named"));
+        }
+
+    }
+
+    @ApplicationScoped
+    static class FailingIdentityProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+        @Override
+        public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+            return UsernamePasswordAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest authenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            throw new IllegalStateException("This provider must never be invoked as we selected the JPA provider");
+        }
+
+        @Override
+        public int priority() {
+            return Integer.MAX_VALUE;
+        }
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/other/OtherMinimalUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/other/OtherMinimalUserEntity.java
@@ -1,0 +1,33 @@
+package io.quarkus.security.jpa.other;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import io.quarkus.security.jpa.Password;
+import io.quarkus.security.jpa.PasswordType;
+import io.quarkus.security.jpa.Roles;
+import io.quarkus.security.jpa.UserDefinition;
+import io.quarkus.security.jpa.Username;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class OtherMinimalUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @Roles
+    public String role;
+}

--- a/extensions/security-jpa/deployment/src/test/resources/minimal-config/import-one-user.sql
+++ b/extensions/security-jpa/deployment/src/test/resources/minimal-config/import-one-user.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_user (id, username, password, role) VALUES (1, 'robin', 'robin', 'user');

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/SecurityJpaProvider.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/SecurityJpaProvider.java
@@ -1,0 +1,61 @@
+package io.quarkus.security.jpa.runtime;
+
+import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+
+import org.hibernate.SessionFactory;
+
+import io.quarkus.hibernate.orm.PersistenceUnit.PersistenceUnitLiteral;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.jpa.SecurityJpa;
+
+public class SecurityJpaProvider {
+
+    @Produces
+    SecurityJpa createSecurityJpa(@Any Instance<SessionFactory> sessionFactoryInstance) {
+        return new SecurityJpa() {
+            @Override
+            public IdentityProvider<UsernamePasswordAuthenticationRequest> createJpaIdentityProvider(
+                    String persistenceUnitName) {
+                var jpaIdentityProvider = newJpaIdentityProvider();
+                jpaIdentityProvider.sessionFactory = getSessionFactoryInstance(persistenceUnitName);
+                return jpaIdentityProvider;
+            }
+
+            @Override
+            public IdentityProvider<TrustedAuthenticationRequest> createJpaTrustedIdentityProvider(String persistenceUnitName) {
+                var trustedIdentityProvider = newJpaTrustedIdentityProvider();
+                trustedIdentityProvider.sessionFactory = getSessionFactoryInstance(persistenceUnitName);
+                return trustedIdentityProvider;
+            }
+
+            private SessionFactory getSessionFactoryInstance(String persistenceUnitName) {
+                final SessionFactory sessionFactory;
+                if (persistenceUnitName == null || DEFAULT_PERSISTENCE_UNIT_NAME.equals(persistenceUnitName)) {
+                    if (!sessionFactoryInstance.isResolvable()) {
+                        throw new IllegalArgumentException("Default persistence unit is not available");
+                    }
+                    sessionFactory = sessionFactoryInstance.get();
+                } else {
+                    var namedSessionFactoryInstance = sessionFactoryInstance
+                            .select(new PersistenceUnitLiteral(persistenceUnitName));
+                    if (!namedSessionFactoryInstance.isResolvable()) {
+                        throw new IllegalArgumentException("Unknown persistence unit '%s'".formatted(persistenceUnitName));
+                    }
+                    sessionFactory = namedSessionFactoryInstance.get();
+                }
+                return sessionFactory;
+            }
+        };
+    }
+
+    private static native JpaIdentityProvider newJpaIdentityProvider();
+
+    private static native JpaTrustedIdentityProvider newJpaTrustedIdentityProvider();
+
+}

--- a/extensions/security/deployment/pom.xml
+++ b/extensions/security/deployment/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>bcprov-jdk18on</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -144,6 +144,7 @@ import io.quarkus.security.spi.ClassSecurityCheckStorageBuildItem;
 import io.quarkus.security.spi.ClassSecurityCheckStorageBuildItem.ClassStorageBuilder;
 import io.quarkus.security.spi.CurrentIdentityAssociationClassBuildItem;
 import io.quarkus.security.spi.DefaultSecurityCheckBuildItem;
+import io.quarkus.security.spi.IdentityProviderManagerBuilderBuildItem;
 import io.quarkus.security.spi.PermissionsAllowedMetaAnnotationBuildItem;
 import io.quarkus.security.spi.RegisterClassSecurityCheckBuildItem;
 import io.quarkus.security.spi.RolesAllowedConfigExpResolverBuildItem;
@@ -1355,6 +1356,12 @@ public class SecurityProcessor {
                     new ValidationErrorBuildItem(new RuntimeException("Annotation '%s' cannot be used on following methods: %s"
                             .formatted(RunAsUser.class.getName(), notAllowedTargets))));
         }
+    }
+
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep
+    IdentityProviderManagerBuilderBuildItem createIdentityProviderManagerBuilder(SecurityCheckRecorder recorder) {
+        return new IdentityProviderManagerBuilderBuildItem(recorder.createIdentityProviderManagerBuilder());
     }
 
     private static String toString(MethodInfo mi) {

--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityHandlerConstants.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityHandlerConstants.java
@@ -1,6 +1,5 @@
 package io.quarkus.security.spi.runtime;
 
-import jakarta.annotation.Priority;
 import jakarta.interceptor.Interceptor;
 
 public class SecurityHandlerConstants {

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/IdentityProviderManagerCreator.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/IdentityProviderManagerCreator.java
@@ -34,8 +34,14 @@ public class IdentityProviderManagerCreator {
 
     @Produces
     @ApplicationScoped
-    public IdentityProviderManager ipm(Instance<IdentityProvider<?>> identityProviders,
+    IdentityProviderManager ipm(Instance<IdentityProvider<?>> identityProviders,
             Instance<SecurityIdentityAugmentor> augmentors, BlockingSecurityExecutor blockingExecutor) {
+        return createIdentityProviderManager(identityProviders, augmentors, blockingExecutor);
+    }
+
+    static QuarkusIdentityProviderManagerImpl createIdentityProviderManager(
+            Iterable<IdentityProvider<?>> identityProviders, Iterable<SecurityIdentityAugmentor> augmentors,
+            BlockingSecurityExecutor blockingExecutor) {
         boolean customAnon = false;
         QuarkusIdentityProviderManagerImpl.Builder builder = QuarkusIdentityProviderManagerImpl.builder();
         for (var i : identityProviders) {
@@ -53,5 +59,4 @@ public class IdentityProviderManagerCreator {
         builder.setBlockingExecutor(blockingExecutor);
         return builder.build();
     }
-
 }

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/IdentityProviderManagerBuilderBuildItem.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/IdentityProviderManagerBuilderBuildItem.java
@@ -1,0 +1,26 @@
+package io.quarkus.security.spi;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+
+/**
+ * Provides a way for core extensions to build their own {@link IdentityProviderManager}.
+ * Given identity providers must not be null or empty.
+ */
+public final class IdentityProviderManagerBuilderBuildItem extends SimpleBuildItem {
+
+    private final Function<Collection<IdentityProvider<?>>, IdentityProviderManager> builder;
+
+    public IdentityProviderManagerBuilderBuildItem(Function<Collection<IdentityProvider<?>>, IdentityProviderManager> builder) {
+        this.builder = Objects.requireNonNull(builder);
+    }
+
+    public Function<Collection<IdentityProvider<?>>, IdentityProviderManager> getBuilder() {
+        return builder;
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.security;
 
 import static io.quarkus.security.spi.runtime.SecurityEventHelper.fire;
 import static io.quarkus.vertx.http.runtime.security.FormAuthenticationEvent.createLoginEvent;
+import static io.quarkus.vertx.http.runtime.security.HttpSecurityImpl.createMechanism;
 import static io.quarkus.vertx.http.runtime.security.RoutingContextAwareSecurityIdentity.addRoutingCtxToIdentityIfMissing;
 
 import java.net.URI;
@@ -12,6 +13,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -29,6 +31,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.arc.Arc;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.credential.PasswordCredential;
+import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
@@ -402,6 +405,15 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
         cookie.setMaxAge(0);
         cookie.setPath(cookiePath);
         routingContext.response().addCookie(cookie);
+    }
+
+    public static HttpAuthenticationMechanism of(FormAuthConfig runtimeForm, Optional<String> encKey,
+            IdentityProvider<TrustedAuthenticationRequest> trustedIdentityProvider,
+            IdentityProvider<UsernamePasswordAuthenticationRequest> usernamePasswordIdentityProvider) {
+        Objects.requireNonNull(trustedIdentityProvider);
+        Objects.requireNonNull(usernamePasswordIdentityProvider);
+        var formBasedMechanism = new FormAuthenticationMechanism(runtimeForm, encKey);
+        return createMechanism(formBasedMechanism, List.of(trustedIdentityProvider, usernamePasswordIdentityProvider));
     }
 
     private static String startWithSlash(String page) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -39,6 +40,8 @@ import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationException;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.AuthenticationRedirectException;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
 import io.quarkus.security.spi.runtime.MethodDescription;
@@ -186,10 +189,13 @@ public class HttpSecurityRecorder {
         };
     }
 
-    public RuntimeValue<CORSConfig> prepareHttpSecurityConfiguration(ShutdownContext shutdownContext) {
+    public RuntimeValue<CORSConfig> prepareHttpSecurityConfiguration(ShutdownContext shutdownContext,
+            Function<Collection<IdentityProvider<?>>, IdentityProviderManager> identityProviderManagerBuilder) {
+        HttpSecurityImpl.setIdentityProviderManagerBuilder(identityProviderManagerBuilder);
         // this is done so that we prepare and validate HTTP Security config before the first incoming request
         var config = HttpSecurityConfiguration.get(httpConfig.getValue(), httpBuildTimeConfig);
         shutdownContext.addShutdownTask(HttpSecurityConfiguration::clear);
+        shutdownContext.addShutdownTask(HttpSecurityImpl::clearIdentityProviderManagerBuilder);
         return new RuntimeValue<>(config.getCorsConfig());
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/HttpSecurity.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/HttpSecurity.java
@@ -7,7 +7,9 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
+import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.cors.CORSConfig;
@@ -143,6 +145,14 @@ public interface HttpSecurity {
      * @return HttpSecurity
      */
     HttpSecurity basic(String authenticationRealm);
+
+    /**
+     * Registers the Basic authentication mechanism in addition to all other global authentication mechanisms.
+     *
+     * @param identityProvider such as the Quarkus Security JPA provider; must not be null
+     * @return HttpSecurity
+     */
+    HttpSecurity basic(IdentityProvider<UsernamePasswordAuthenticationRequest> identityProvider);
 
     /**
      * Registers the mutual TLS client authentication mechanism in addition to all other global authentication mechanisms.


### PR DESCRIPTION
- portion of https://github.com/quarkusio/quarkus/issues/16728
- allows to configure persistence unit for JPA programmatically
- adds support for named persistence units for Security JPA Reactive