### PR TITLE
Improvements on observability docs

### DIFF
--- a/docs/src/main/asciidoc/observability.adoc
+++ b/docs/src/main/asciidoc/observability.adoc
@@ -128,7 +128,7 @@ The xref:jfr.adoc[`quarkus-jfr`] extension can generate observability related ev
 
 === Metrics
 
-Quarkus has been using Micrometer to collect metrics from the application for a long time. Almost all the out-of-the-box metrics instrumentation in Quarkus are implemented with Micrometer.
+Quarkus has been using Micrometer to collect metrics from the application for a long time. Almost all the out-of-the-box metrics instrumentation in Quarkus are implemented with the xref:telemetry-micrometer.adoc[Micrometer] extension.
 
 More recently, OpenTelemetry Metrics has become available in the xref:opentelemetry.adoc[`quarkus-opentelemetry`] extension, but it's disabled by default because metrics semantic conventions are not stable yet.
 

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -21,6 +21,7 @@ include::{includes}/observability-include.adoc[]
 [NOTE]
 ====
 - OpenTelemetry Metrics is considered _tech preview_ and is disabled by default.
+- Automatic metrics instrumentation in Quarkus is handled by xref:telemetry-micrometer.adoc[Micrometer] and the xref:telemetry-micrometer-to-opentelemetry.adoc[quarkus-micrometer-opentelemetry] extension bridges those metrics into OpenTelemetry.
 - The xref:opentelemetry.adoc[OpenTelemetry Guide] is available with signal independent information about the OpenTelemetry extension.
 - If you search more information about OpenTelemetry Tracing, please refer to the xref:opentelemetry-tracing.adoc[OpenTelemetry Tracing Guide].
 ====

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -33,7 +33,9 @@ This will allow Quarkus based applications to be observable by tools and service
 
 [NOTE]
 ====
-Automatic metrics instrumentation in Quarkus is done by the xref:telemetry-micrometer.adoc[Quarkus Micrometer extension]. We plan to provide, in the future, a bridge for those metrics to be available in OpenTelemetry as well.
+Automatic metrics instrumentation in Quarkus is done by the xref:telemetry-micrometer.adoc[Quarkus Micrometer extension].
+
+The xref:telemetry-micrometer-to-opentelemetry.adoc[quarkus-micrometer-opentelemetry] extension enables the use and export of Micrometer metrics via OpenTelemetry.
 ====
 
 Quarkus supports the OpenTelemetry Autoconfiguration. The configurations match what you can see at

--- a/docs/src/main/asciidoc/telemetry-micrometer.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer.adoc
@@ -34,6 +34,7 @@ Quarkus extensions:
 
 - micrometer
 - micrometer-registry-prometheus
+- micrometer-opentelemetry
 
 link:https://github.com/quarkiverse/quarkus-micrometer-registry[Quarkiverse extensions] (may be incomplete):
 
@@ -126,9 +127,37 @@ implementation("com.acme:custom-micrometer-registry")
 You will then need to specify your own provider to configure and initialize the
 MeterRegistry, as discussed in the next section.
 
+=== Send Micrometer metrics through OpenTelemetry
+
+The xref:telemetry-micrometer-to-opentelemetry.adoc[quarkus-micrometer-opentelemetry] extension allows to use the Micrometer API and all existing automatic instrumentation available in Quarkus while sending all the telemetry with OpenTelemetry.
+
+This is achieved with a Micrometer registry implemented with the OpenTelemetry SDK, allowing integration of Micrometer Metrics, OpenTelemetry Traces and Logs into a unified telemetry output using the OTLP protocol.
+
+If you already have your Quarkus project configured, you can add the `quarkus-micrometer-opentelemetry` extension to your project by running the following command in your project base directory:
+
+:add-extension-extensions: micrometer-opentelemetry
+include::{includes}/devtools/extension-add.adoc[]
+
+This will add the following to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-micrometer-opentelemetry")
+----
+
 === Create a customized MeterRegistry
 
-Use a custom `@Produces` method to create and configure a your own `MeterRegistry` if you need to.
+Use a custom `@Produces` method to create and configure your own `MeterRegistry` if you need to.
 
 The following example customizes the line format used for StatsD:
 


### PR DESCRIPTION
Remove obsolete entries and highlight the `quarkus-micrometer-opentelemetry` extension. 