### PR TITLE
Introduce property to ensure embedded jar name is artifactId.type

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -161,6 +161,27 @@ public interface PackageConfig {
         boolean addRunnerSuffix();
 
         /**
+         * Indicates a list of dependency for which the jar will use artifactId.type filename scheme
+         * Each dependency needs to be expressed in the following format:
+         * <p>
+         * {@code groupId:artifactId[:[classifier][:[type]]]}
+         * <p>
+         * With the classifier and type being optional (note that the brackets ({@code []}) denote optionality and are
+         * not a part of the syntax specification).
+         * The group ID and artifact ID must be present and non-empty.
+         * <p>
+         * If the type is missing, the artifact is assumed to be of type {@code jar}.
+         * <p>
+         * This parameter is optional; if absent, jar names will use groupId.artifactId[-version][-classifier].type scheme
+         *
+         * Note that using this parameter is not recommended and only be used for specific corner cases when the jar name is
+         * enforced.
+         *
+         */
+        @WithDefault("com.sap.conn.jco:sapjco3::jar,com.sap.conn.idoc:sapidoc3::jar")
+        Optional<Set<GACT>> forceUseArtifactIdOnlyAsName();
+
+        /**
          * AppCDS archive sub-configuration.
          * This configuration only applies to certain JAR types.
          */

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/FastJarQuarkusIntegrationTestIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/FastJarQuarkusIntegrationTestIT.java
@@ -1,15 +1,27 @@
 package io.quarkus.maven.it;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
 import java.io.IOException;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Test;
 
 @DisableForNative
-public class FastJarQuarkusIntegrationTestIT extends QuarkusITBase {
+class FastJarQuarkusIntegrationTestIT extends QuarkusITBase {
 
     @Test
-    public void testFastJar() throws MavenInvocationException, IOException {
+    void testFastJar() throws MavenInvocationException, IOException {
         doTest("qit-fast-jar", "fastjar");
+    }
+
+    @Test
+    void testFastJarWithForceUseArtifactIdOnlyAsName() throws MavenInvocationException, IOException {
+        File testDir = doTest("qit-fast-jar-forceUseArtifactId", "fastjar",
+                "-Dquarkus.package.jar.force-use-artifact-id-only-as-name=io.quarkus:quarkus-reactive-routes");
+        System.out.println(testDir);
+        File forceNamedFile = new File(testDir, "target/quarkus-app/lib/main/quarkus-reactive-routes.jar");
+        assertThat(forceNamedFile).exists();
     }
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusITBase.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusITBase.java
@@ -17,13 +17,14 @@ import io.quarkus.maven.it.verifier.RunningInvoker;
 // meant to test that @QuarkusIntegrationTest can properly launch jars
 abstract class QuarkusITBase extends MojoTestBase {
 
-    void doTest(String projectName, String profile) throws MavenInvocationException, IOException {
+    File doTest(String projectName, String profile, String additionalBuildParameter)
+            throws MavenInvocationException, IOException {
         File testDir = initProject("projects/reactive-routes", "projects/" + projectName);
         RunningInvoker packageInvocation = new RunningInvoker(testDir, false);
 
         MavenProcessInvocationResult packageInvocationResult = packageInvocation
                 .execute(Arrays.asList("package", "-B",
-                        "-D" + profile), Collections.emptyMap());
+                        "-D" + profile, additionalBuildParameter), Collections.emptyMap());
 
         await().atMost(3, TimeUnit.MINUTES)
                 .until(() -> packageInvocationResult.getProcess() != null && !packageInvocationResult.getProcess().isAlive());
@@ -39,5 +40,10 @@ abstract class QuarkusITBase extends MojoTestBase {
                 .until(() -> integrationTestsInvocationResult.getProcess() != null
                         && !integrationTestsInvocationResult.getProcess().isAlive());
         assertThat(integrationTestsInvocation.log()).containsIgnoringCase("BUILD SUCCESS");
+        return testDir;
+    }
+
+    File doTest(String projectName, String profile) throws MavenInvocationException, IOException {
+        return doTest(projectName, profile, "");
     }
 }


### PR DESCRIPTION
by default, it is used for sapjco3 and sapidoc3 which requires to have jar having the exact naming scheme sapjco3.jar and sapidoc3.jar starting with version 3.1.12 and 3.1.4 respectively.

fixes #51224

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

