### PR TITLE
Load Shedding: use `RoutingContext` instead of `HttpServerRequest`

### DIFF
--- a/docs/src/main/asciidoc/load-shedding-reference.adoc
+++ b/docs/src/main/asciidoc/load-shedding-reference.adoc
@@ -15,6 +15,9 @@ include::_attributes.adoc[]
 include::{includes}/extension-status.adoc[]
 
 Load shedding is the practice of detecting service overload and rejecting requests.
+By rejecting requests when overloaded, load shedding keeps the application alive.
+With priority load shedding, the application even keeps working, albeit in a degraded state: only a fraction of requests is handled, others are rejected early.
+You should consider using it if your application runs in a dynamic environment with a real risk of getting overloaded and is not fronted by another service that sheds load already.
 
 In Quarkus, the `quarkus-load-shedding` extension provides a load shedding mechanism.
 
@@ -37,7 +40,21 @@ To use the load shedding extension, you need to add the `io.quarkus:quarkus-load
 implementation("io.quarkus:quarkus-load-shedding")
 ----
 
-No configuration is required, though the possible configuration options are described below.
+When added, load shedding is enabled.
+It can be disabled by setting `quarkus.load-shedding.enabled` to `false`.
+
+There are 2 variants of load shedding: pure and priority-based.
+Pure load shedding rejects all requests when overload is detected.
+Priority load shedding only rejects a fraction of requests even if overload is detected, based on application-defined criteria.
+By default, priority load shedding is enabled.
+It can be disabled by setting `quarkus.load-shedding.priority.enabled` to `false.`
+
+There are 2 ways of customizing priority load shedding:
+
+* By implementing `io.quarkus.load.shedding.RequestPrioritizer`, the application can decide which requests can be rejected early on and which requests can only be rejected when there's no other choice.
+* By implementing `io.quarkus.load.shedding.RequestClassifier`, the application can classify requests into cohorts which are rejected independently.
+
+Other configuration options are described below, although they should typically be left untouched.
 
 == The load shedding algorithm
 
@@ -50,24 +67,26 @@ The load shedding algorithm has 2 parts:
 
 To detect whether the current service is overloaded, an adaptation of TCP Vegas is used.
 
-The algorithm starts with 100 allowed concurrent requests.
-For each request, it compares the number of current requests with the allowed limit and if the limit is exceeded, an overload situation is signalled.
+This algorithm starts with a configurable limit of in-flight requests, by default 100.
+If the current number of concurrent in-flight requests reaches the limit, overload situation is signalled.
 
-If the limit is not exceeded, or if priority load shedding determines that the request should not be rejected (see below), the request is allowed.
-When it finishes, its duration is compared with the lowest duration seen so far to estimate a queue size.
-If the queue size is lower than _alpha_, the current limit is increased, but only up to a given maximum, by default 1000.
-If the queue size is greater than _beta_, the current limit is decreased.
-Otherwise, the current limit is kept intact.
+That is not very interesting, but the algorithm dynamically adjusts the limit based on the size of the request queue.
+If the queue is short, more requests can be handled and the limit increases; if the queue is long, fewer requests can be handled and the limit decreases.
+The limit cannot be increased indefinitely; there's a configurable maximum, by default 1000.
 
-Alpha and beta are computed by multiplying the configurable constants with a base 10 logarithm of the current limit.
-
-After some number of requests, which can be modified by configuring the _probe_ factor, the lowest duration seen is reset to the last seen duration of a request.
+There's no actual queue of requests that we could monitor, though, so the algorithm estimates the current length of a request queue based on previously seen response times.
+The longer recent requests take, compared to the recent lowest response time, the longer the queue is supposed to be.
 
 === Priority load shedding
 
 If an overload situation is signalled, priority load shedding is invoked.
 
-By default, priority load shedding is enabled, which means a request is only rejected if the current CPU load is high enough.
+If priority load shedding is disabled, there's nothing to do and all requests are rejected immediately.
+However, by default, priority load shedding is enabled, which means a request is only rejected if the current CPU load is high enough.
+
+NOTE: Priority load shedding is currently always based on CPU load.
+Other mechanisms are possible (such as network utilization), but currently not implemented.
+
 To determine whether a request should be rejected, 2 attributes are considered:
 
 * request priority
@@ -75,11 +94,12 @@ To determine whether a request should be rejected, 2 attributes are considered:
 
 There are 5 statically defined priorities and 128 cohorts, which amounts to 640 request groups in total.
 
-After both priority and cohort are assigned to a request, a request group number is computed: `group = priority * num_cohorts + cohort`.
-Then, the group number is compared to a simple cubic function of current CPU load, where `load` is a number between 0 and 1: `num_groups * (1 - load^3)`.
-If the group number is higher, the request is rejected, otherwise it is allowed even in an overload situation.
+After both priority and cohort are assigned to a request, a request group number is computed.
+The group number is smaller for higher priority requests and higher for lower priority requests.
+If the group number is higher that the current CPU load, the request is rejected, otherwise it is allowed even in an overload situation.
 
-If priority load shedding is disabled, all requests are rejected in an overload situation.
+NOTE: The group number is actually not compared to the CPU load directly; instead, it is compared to a function of CPU load.
+The function is `(1 - load^3) * 640`, where `load` is the CPU load as a number between 0.0 and 1.0, and 640 is a number of requests group as mentioned above.
 
 ==== Customizing request priority
 
@@ -130,6 +150,7 @@ Netflix Technology Blog:
 
 * https://netflixtechblog.medium.com/performance-under-load-3e6fa9a60581[Performance Under Load]
 * https://netflixtechblog.com/keeping-netflix-reliable-using-prioritized-load-shedding-6cc827b02f94[Keeping Netflix Reliable Using Prioritized Load Shedding]
+* https://netflixtechblog.com/enhancing-netflix-reliability-with-service-level-prioritized-load-shedding-e735e6ce8f7d[Enhancing Netflix Reliability with Service-Level Prioritized Load Shedding]
 
 Uber Engineering Blog:
 
@@ -148,3 +169,8 @@ Google Cloud Blog:
 CodeReliant Blog:
 
 * https://www.codereliant.io/load-shedding/[Load Shedding for High Traffic Systems]
+
+TCP Vegas:
+
+* https://www.geeksforgeeks.org/computer-networks/basic-concept-of-tcp-vegas/[Basic concept of TCP-Vegas]
+* TCP Congestion Control: A Systems Approach, https://tcpcc.systemsapproach.org/avoidance.html[Chapter 5: Avoidance-Based Algorithms]

--- a/extensions/load-shedding/deployment/src/test/java/io/quarkus/load/shedding/ManagementRequestPrioritizerTest.java
+++ b/extensions/load-shedding/deployment/src/test/java/io/quarkus/load/shedding/ManagementRequestPrioritizerTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.load.shedding;
+
+import static io.restassured.RestAssured.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.load.shedding.runtime.ManagementRequestPrioritizer;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.ext.web.Router;
+
+public class ManagementRequestPrioritizerTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(RouterInit.class));
+
+    @Test
+    public void test() {
+        String result = when().get("/").then().extract().body().asString();
+        assertEquals("false|false|/", result);
+
+        result = when().get("/q/health").then().extract().body().asString();
+        assertEquals("false|true|/q/health", result);
+
+        result = when().get("/q/../other").then().extract().body().asString();
+        assertEquals("false|false|/other", result);
+    }
+
+    @Singleton
+    public static class RouterInit {
+        public void init(@Observes Router router, ManagementRequestPrioritizer prioritizer) {
+            // before `io.quarkus.load.shedding.runtime.HttpLoadShedding`
+            router.route().order(-1_000_000_001).handler(ctx -> {
+                ctx.end(prioritizer.appliesTo(ctx.request()) // never, wrong type
+                        + "|" + prioritizer.appliesTo(ctx) // only if the request targets non-app endpoint
+                        + "|" + ctx.normalizedPath());
+            });
+        }
+    }
+}

--- a/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/RequestClassifier.java
+++ b/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/RequestClassifier.java
@@ -10,6 +10,8 @@ package io.quarkus.load.shedding;
  * rules must be followed. That is, if multiple implementations are provided with different
  * {@link jakarta.annotation.Priority} values, only the implementations with the highest
  * priority are retained.
+ * <p>
+ * For HTTP requests, the type of the request ({@code R}) is {@link io.vertx.ext.web.RoutingContext}.
  *
  * @param <R> type of the request
  */

--- a/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/RequestPrioritizer.java
+++ b/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/RequestPrioritizer.java
@@ -13,6 +13,8 @@ package io.quarkus.load.shedding;
  * rules must be followed. That is, if multiple implementations are provided with different
  * {@link jakarta.annotation.Priority} values, only the implementations with the highest
  * priority are retained.
+ * <p>
+ * For HTTP requests, the type of the request ({@code R}) is {@link io.vertx.ext.web.RoutingContext}.
  *
  * @param <R> type of the request
  */

--- a/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/HttpLoadShedding.java
+++ b/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/HttpLoadShedding.java
@@ -21,7 +21,7 @@ public class HttpLoadShedding {
         }
 
         router.route().order(-1_000_000_000).handler(ctx -> {
-            if (detector.isOverloaded() && priority.shedLoad(ctx.request())) {
+            if (detector.isOverloaded() && priority.shedLoad(ctx)) {
                 HttpServerResponse response = ctx.response();
                 response.setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code());
                 response.headers().add(HttpHeaderNames.CONNECTION, "close");

--- a/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/HttpRequestClassifier.java
+++ b/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/HttpRequestClassifier.java
@@ -3,19 +3,19 @@ package io.quarkus.load.shedding.runtime;
 import jakarta.inject.Singleton;
 
 import io.quarkus.load.shedding.RequestClassifier;
-import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
 
 @Singleton
-public class HttpRequestClassifier implements RequestClassifier<HttpServerRequest> {
+public class HttpRequestClassifier implements RequestClassifier<RoutingContext> {
     @Override
     public boolean appliesTo(Object request) {
-        return request instanceof HttpServerRequest;
+        return request instanceof RoutingContext;
     }
 
     @Override
-    public int cohort(HttpServerRequest request) {
+    public int cohort(RoutingContext request) {
         int hour = (int) (System.currentTimeMillis() >> 22); // roughly 1 hour
-        String host = request.remoteAddress().hostAddress();
+        String host = request.request().remoteAddress().hostAddress();
         if (host == null) {
             host = "";
         }

--- a/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/ManagementRequestPrioritizer.java
+++ b/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/ManagementRequestPrioritizer.java
@@ -7,10 +7,10 @@ import io.quarkus.load.shedding.RequestPrioritizer;
 import io.quarkus.load.shedding.RequestPriority;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
-import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
 
 @Singleton
-public class ManagementRequestPrioritizer implements RequestPrioritizer<HttpServerRequest> {
+public class ManagementRequestPrioritizer implements RequestPrioritizer<RoutingContext> {
     private final String managementPath;
 
     @Inject
@@ -34,14 +34,14 @@ public class ManagementRequestPrioritizer implements RequestPrioritizer<HttpServ
 
     @Override
     public boolean appliesTo(Object request) {
-        if (managementPath != null && request instanceof HttpServerRequest httpRequest) {
-            return httpRequest.path().startsWith(managementPath);
+        if (managementPath != null && request instanceof RoutingContext ctx) {
+            return ctx.normalizedPath().startsWith(managementPath);
         }
         return false;
     }
 
     @Override
-    public RequestPriority priority(HttpServerRequest request) {
+    public RequestPriority priority(RoutingContext request) {
         return RequestPriority.CRITICAL;
     }
 }


### PR DESCRIPTION
This is because `RoutingContext`, unlike `HttpServerRequest`, has a method `normalizedPath()`, which we need to use in `ManagementRequestPrioritizer`. Previously, we used `HttpServerRequest.path()`, which returns the path unmodified, so the request prioritizer considers `/q/../something` as pertaining to the non-application endpoint, even though it is not. `RoutingContext.normalizedPath()` returns `/something` in this case, as expected.

Further, this commit somewhat improves the load shedding documentation.

Follows up on #51289
Fixes #41835