### PR TITLE
Fix CDI request context activation race when Quarkus REST and Reactive Routes are used during the same request

### DIFF
--- a/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -47,6 +47,7 @@ import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveSecurityContext;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.RoutingUtils;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.ResponseCommitListener;
@@ -60,6 +61,7 @@ import io.vertx.ext.web.RoutingContext;
 public class ServletRequestContext extends ResteasyReactiveRequestContext
         implements ServerHttpRequest, ServerHttpResponse, ResponseCommitListener {
 
+    private static final String QUARKUS_REST_SERVLET_KEY = "quarkus-rest-servlet";
     private static final LazyValue<Event<SecurityIdentity>> SECURITY_IDENTITY_EVENT = new LazyValue<>(
             ServletRequestContext::createEvent);
     final RoutingContext context;
@@ -136,6 +138,11 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
         if (user != null) {
             fireSecurityIdentity(user.getSecurityIdentity());
         }
+    }
+
+    @Override
+    protected void onPreRequestScopeActivation() {
+        RoutingUtils.assumeCdiRequestContext(context, QUARKUS_REST_SERVLET_KEY);
     }
 
     static void fireSecurityIdentity(SecurityIdentity identity) {

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.quarkus.vertx.http.runtime.RoutingUtils;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
@@ -23,6 +24,7 @@ import io.vertx.ext.web.RoutingContext;
 
 public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactiveRequestContext {
 
+    private static final String QUARKUS_REST_KEY = "quarkus-rest";
     final CurrentIdentityAssociation association;
     boolean userSetup = false;
 
@@ -49,6 +51,11 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
                 association.setIdentity(QuarkusHttpUser.getSecurityIdentity(context, null));
             }
         }
+    }
+
+    @Override
+    protected void onPreRequestScopeActivation() {
+        RoutingUtils.assumeCdiRequestContext(context, QUARKUS_REST_KEY);
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -246,6 +246,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
         if (requestScopeActivated) {
             return;
         }
+        onPreRequestScopeActivation();
         if (isRequestScopeManagementRequired()) {
             if (requestContext.isRequestContextActive()) {
                 // req. context is already active, just reuse existing one
@@ -273,6 +274,10 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     }
 
     protected abstract void handleRequestScopeActivation();
+
+    protected void onPreRequestScopeActivation() {
+        // by default do nothing
+    }
 
     /**
      * Restarts handler chain processing on a chain that does not target a specific resource

--- a/integration-tests/openapi/src/main/java/io/quarkus/it/openapi/security/FailureStorage.java
+++ b/integration-tests/openapi/src/main/java/io/quarkus/it/openapi/security/FailureStorage.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.openapi.security;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class FailureStorage {
+
+    private volatile Throwable throwable = null;
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    public void setThrowable(Throwable throwable) {
+        Log.info("Setting throwable value to " + throwable);
+        this.throwable = throwable;
+    }
+}

--- a/integration-tests/openapi/src/main/java/io/quarkus/it/openapi/security/TestSecurityResource.java
+++ b/integration-tests/openapi/src/main/java/io/quarkus/it/openapi/security/TestSecurityResource.java
@@ -1,16 +1,32 @@
 package io.quarkus.it.openapi.security;
 
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.SecurityContext;
 
 import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 @Path("/security")
 public class TestSecurityResource {
+
+    public static final String TEST_HEADER_NAME = "test-security-header";
+    public static final String TEST_HEADER_VALUE = "hush-hush";
+    public static int REQUEST_TIMEOUT = 3;
+
+    @Inject
+    FailureStorage failureStorage;
+
+    @Context
+    HttpHeaders httpHeaders;
 
     @RolesAllowed("admin")
     @GET
@@ -19,11 +35,57 @@ public class TestSecurityResource {
         return securityContext.getUserPrincipal().getName();
     }
 
+    @RolesAllowed("admin")
+    @GET
+    @Path("reactive-routes-with-delayed-response")
+    public String reactiveRoutesWithDelayedResponse(@Context SecurityContext securityContext) throws InterruptedException {
+        Thread.sleep(REQUEST_TIMEOUT);
+        try {
+            // ATM this code is not invoked every single time, it is timing issue
+            // but on my laptop it is invoked 7 times out of 10, therefore, if re-run multiple times,
+            // it sufficiently reproduces our original issue with accessing CDI request context
+            var headerValue = httpHeaders.getHeaderString(TEST_HEADER_NAME);
+
+            // just to do something - check the expected value
+            if (!TEST_HEADER_VALUE.equals(headerValue)) {
+                throw new IllegalStateException(
+                        "Invalid header value, got '%s',but expected '%s' ".formatted(headerValue, TEST_HEADER_VALUE));
+            }
+        } catch (Throwable t) {
+            failureStorage.setThrowable(t);
+        }
+        return securityContext.getUserPrincipal().getName();
+    }
+
+    @Path("throwable")
+    @GET
+    public String getThrowable() {
+        return String.valueOf(failureStorage.getThrowable());
+    }
+
+    @Path("empty-failure-storage")
+    @DELETE
+    public void emptyFailureStorage() {
+        failureStorage.setThrowable(null);
+    }
+
     @RouteFilter(401)
     public void doNothing(RoutingContext routingContext) {
         // here so that the Reactive Routes extension activates CDI request context
         routingContext.response().putHeader("reactive-routes-filter", "true");
         routingContext.next();
+    }
+
+    void addFailureHandler(@Observes Router router) {
+        // this is necessary, because before the fix, the ContextNotActiveException was sometimes
+        // thrown in the CDI interceptors and handled by the QuarkusErrorHandler
+        router.route().order(Integer.MAX_VALUE - 100).failureHandler(new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext routingContext) {
+                failureStorage.setThrowable(routingContext.failure());
+                routingContext.end();
+            }
+        });
     }
 
 }

--- a/integration-tests/openapi/src/test/java/io/quarkus/it/openapi/security/TestSecurityReactiveRoutesTest.java
+++ b/integration-tests/openapi/src/test/java/io/quarkus/it/openapi/security/TestSecurityReactiveRoutesTest.java
@@ -1,13 +1,21 @@
 package io.quarkus.it.openapi.security;
 
+import static io.quarkus.it.openapi.security.TestSecurityResource.TEST_HEADER_NAME;
+import static io.quarkus.it.openapi.security.TestSecurityResource.TEST_HEADER_VALUE;
+import static org.apache.http.params.CoreConnectionPNames.SO_TIMEOUT;
 import static org.hamcrest.Matchers.is;
 
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
 
 @QuarkusTest
 @TestHTTPEndpoint(TestSecurityResource.class)
@@ -21,6 +29,49 @@ public class TestSecurityReactiveRoutesTest {
                 .statusCode(200)
                 .header("reactive-routes-filter", is("true"))
                 .body(is("Martin"));
+    }
+
+    /**
+     * This verifies that CDI request context activated by Reactive Routes is not deactivated/destroyed while
+     * Quarkus REST needs it. Before the fix, there was a racy behavior. Sometimes during the CDI interceptors processing,
+     * sometimes after the socket timeout when resource method was executed, CDI request context was not active.
+     * Depending on the speed of a test executor, you may need to execute this test couple of times in order to reproduce
+     * the original issue.
+     */
+    @TestSecurity(user = "Martin", roles = "admin")
+    @Test
+    public void testCdiRequestActiveAfterTimeout() throws InterruptedException {
+        RestAssured.delete("empty-failure-storage").then().statusCode(204);
+
+        int valueLesserThanDelay = TestSecurityResource.REQUEST_TIMEOUT - 2;
+        // using deprecated constant due to https://github.com/rest-assured/rest-assured/issues/497
+        var config = RestAssured.config()
+                .httpClient(HttpClientConfig.httpClientConfig().setParam(SO_TIMEOUT, valueLesserThanDelay));
+        try {
+            RestAssured.given()
+                    .config(config)
+                    .header(TEST_HEADER_NAME, TEST_HEADER_VALUE)
+                    .get("reactive-routes-with-delayed-response")
+                    .then()
+                    .statusCode(200)
+                    .header("reactive-routes-filter", is("true"))
+                    .body(is("Martin"));
+            Assertions.fail("HTTP request didn't result in a socket timeout exception");
+        } catch (Exception socketTimeoutException) {
+            // yes, this checked exception is thrown even though no method signature declares it
+            if (!(socketTimeoutException instanceof SocketTimeoutException)) {
+                // socket timeout exception is required to verify what happens with the CDI request context after the timeout
+                Assertions.fail("Expected a SocketTimeoutException but got " + socketTimeoutException);
+            }
+        }
+        int timeoutRemainder = TestSecurityResource.REQUEST_TIMEOUT - valueLesserThanDelay + 1;
+        Thread.sleep(Duration.ofSeconds(timeoutRemainder).toMillis());
+        RestAssured.given()
+                .get("throwable")
+                .then()
+                .statusCode(200)
+                .header("reactive-routes-filter", is("true"))
+                .body(is("null"));
     }
 
 }


### PR DESCRIPTION
- closes https://github.com/quarkusio/quarkus/issues/51230