### PR TITLE
ArC: guard against multiple occurrences of the same decorator

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -603,10 +603,11 @@ public class SubclassGenerator extends AbstractGenerator {
         }
 
         Map<MethodDesc, DecoratorMethod> nextDecorators = bean.getNextDecorators(decorator);
-        List<DecoratorInfo> decoratorParameters = new ArrayList<>();
+        Set<DecoratorInfo> decoratorParametersSet = new HashSet<>();
         for (DecoratorMethod decoratorMethod : nextDecorators.values()) {
-            decoratorParameters.add(decoratorMethod.decorator);
+            decoratorParametersSet.add(decoratorMethod.decorator);
         }
+        List<DecoratorInfo> decoratorParameters = new ArrayList<>(decoratorParametersSet);
         Collections.sort(decoratorParameters);
 
         List<ClassDesc> delegateSubclassCtorParams = new ArrayList<>();
@@ -800,19 +801,19 @@ public class SubclassGenerator extends AbstractGenerator {
         LocalVar cc = subclassCtor.localVar("cc", subclassCtor.invokeStatic(MethodDescs.CREATIONAL_CTX_CHILD, ccParam));
 
         // Create new delegate subclass instance
-        Expr[] params = new Expr[1 + decoratorParameters.size()];
-        params[0] = subclass.this_();
-        int paramIdx = 1;
+        Expr[] args = new Expr[1 + decoratorParameters.size()];
+        args[0] = subclass.this_();
+        int argIndex = 1;
         for (DecoratorInfo decoratorParameter : decoratorParameters) {
             LocalVar decoratorVar = decoratorToLocalVar.get(decoratorParameter.getIdentifier());
             if (decoratorVar == null) {
                 throw new IllegalStateException("Unknown next " + decoratorParameter + " when generating " + generatedName);
             }
-            params[paramIdx] = decoratorVar;
-            paramIdx++;
+            args[argIndex] = decoratorVar;
+            argIndex++;
         }
         Expr delegateSubclassInstance = subclassCtor.new_(ConstructorDesc.of(
-                delegateSubclass, delegateSubclassCtorParams), params);
+                delegateSubclass, delegateSubclassCtorParams), args);
 
         // Set the DecoratorDelegateProvider to satisfy the delegate IP
         LocalVar prev = subclassCtor.localVar("prev", subclassCtor.invokeStatic(

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/SameDecoratorInMultipleNextChainsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/SameDecoratorInMultipleNextChainsTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.arc.test.decorators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+/**
+ * Verifies correct behavior in case the same decorator occurs multiple times
+ * in the {@code BeanInfo.getNextDecorators()} map. The {@code SubclassGenerator}
+ * code generator didn't bother checking, which was fine in Gizmo 1 which didn't
+ * check duplicate fields. Gizmo 2 does check, so the {@code SubclassGenerator}
+ * has to guard against that.
+ */
+public class SameDecoratorInMultipleNextChainsTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyInterface.class, MyClass.class, MyDecorator1.class,
+            MyDecorator2.class);
+
+    @Test
+    public void test() {
+        MyInterface instance = Arc.container().instance(MyInterface.class).get();
+        assertEquals("d1m1 d2m1 A", instance.method1());
+        assertEquals("d1m2 d2m2 B", instance.method2());
+    }
+
+    interface MyInterface {
+        String method1();
+
+        String method2();
+    }
+
+    @ApplicationScoped
+    static class MyClass implements MyInterface {
+        @Override
+        public String method1() {
+            return "A";
+        }
+
+        @Override
+        public String method2() {
+            return "B";
+        }
+    }
+
+    @Priority(10)
+    @Decorator
+    static class MyDecorator1 implements MyInterface {
+        @Inject
+        @Delegate
+        MyInterface resource;
+
+        @Override
+        public String method1() {
+            return "d1m1 " + resource.method1();
+        }
+
+        @Override
+        public String method2() {
+            return "d1m2 " + resource.method2();
+        }
+    }
+
+    @Priority(20)
+    @Decorator
+    static class MyDecorator2 implements MyInterface {
+        @Inject
+        @Delegate
+        MyInterface resource;
+
+        @Override
+        public String method1() {
+            return "d2m1 " + resource.method1();
+        }
+
+        @Override
+        public String method2() {
+            return "d2m2 " + resource.method2();
+        }
+    }
+}


### PR DESCRIPTION
Gizmo 1 didn't bother checking that multiple fields of the same name are added to a class, so `SubclassGenerator` didn't fail in case the same decorator occurred multiple times in the `BeanInfo.getNextDecorators()` map. However, Gizmo 2 does check, so we have to guard against it. The guard is simple: instead of adding decorators to a list directly, we first add them to a set and when that's done, we create a list from that set.

Fixes #51285