### PR TITLE
Use `quarkus.shutdown.timeout` in Vert.x shutdown

### DIFF
--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -38,7 +38,7 @@ public class VertxCoreProducerTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        recorder = new VertxCoreRecorder(new RuntimeValue<>(), new RuntimeValue<>());
+        recorder = new VertxCoreRecorder(new RuntimeValue<>(), new RuntimeValue<>(), new RuntimeValue<>());
     }
 
     @AfterEach


### PR DESCRIPTION
Relates to: https://github.com/quarkusio/quarkus/issues/51227#issuecomment-3595593935