### PR TITLE
Fix access to push event attributes in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -257,9 +257,9 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'push' && github.repository != 'quarkusio/quarkus'
         with:
           path: ~/.m2/.develocity/build-cache
-          key: develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number || github.event.push.ref }}-${{ github.event.pull_request.head.sha || github.event.push.head }}
+          key: develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number || github.event.ref }}-${{ github.event.pull_request.head.sha || github.event.head }}
           restore-keys: |
-            develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number || github.event.push.ref }}-
+            develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number || github.event.ref }}-
       - name: Verify native-tests.json
         run: ./.github/verify-tests-json.sh native-tests.json integration-tests/
       - name: Verify virtual-threads-tests.json
@@ -512,9 +512,9 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'push' && github.repository != 'quarkusio/quarkus'
         with:
           path: ~/.m2/.develocity/build-cache
-          key: develocity-cache-${{matrix.java.name}}-${{ github.event.pull_request.number || github.event.push.ref }}-${{ github.event.pull_request.head.sha || github.event.push.head }}
+          key: develocity-cache-${{matrix.java.name}}-${{ github.event.pull_request.number || github.event.ref }}-${{ github.event.pull_request.head.sha || github.event.head }}
           restore-keys: |
-            develocity-cache-${{matrix.java.name}}-${{ github.event.pull_request.number || github.event.push.ref }}-
+            develocity-cache-${{matrix.java.name}}-${{ github.event.pull_request.number || github.event.ref }}-
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/setup-maven@v1.4
         with:


### PR DESCRIPTION
The '.push' prefix was a mistake on my part...

Follows up on #51315 

Hopefully this run will show that it works better now (see step "Cache Develocity local cache"): https://github.com/yrodiere/quarkus/actions/runs/19832435959/job/56821778738