### PR TITLE
Add inline configuration support to QuarkusUnitTest and remove obsolete test config files (#51206)

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultBothUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultBothUnitTest.java
@@ -24,7 +24,6 @@ public class ORMReactiveCompatbilityDefaultBothUnitTest extends CompatibilityUni
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
             ))
-            .withConfigurationResource("application-unittest-both.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.datasource.reactive", "true")
             .overrideConfigKey("quarkus.datasource.db-kind", POSTGRES_KIND)

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultOnlyBlockingUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultOnlyBlockingUnitTest.java
@@ -21,7 +21,6 @@ public class ORMReactiveCompatbilityDefaultOnlyBlockingUnitTest extends Compatib
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
             ))
-            .withConfigurationResource("application-unittest-onlyblocking.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.datasource.reactive", "false")
             .overrideConfigKey("quarkus.datasource.db-kind", POSTGRES_KIND)

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultOnlyReactiveDisabledBlockingSessionUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultOnlyReactiveDisabledBlockingSessionUnitTest.java
@@ -23,7 +23,6 @@ public class ORMReactiveCompatbilityDefaultOnlyReactiveDisabledBlockingSessionUn
                     .addAsResource("complexMultilineImports.sql", "import.sql"))
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion())))
-            .withConfigurationResource("application-unittest-onlyreactive.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.hibernate-orm.blocking", "false")
             .overrideConfigKey("quarkus.datasource.reactive", "true")

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultOnlyReactiveUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDefaultOnlyReactiveUnitTest.java
@@ -16,7 +16,6 @@ public class ORMReactiveCompatbilityDefaultOnlyReactiveUnitTest extends Compatib
             .withApplicationRoot((jar) -> jar
                     .addClasses(Hero.class)
                     .addAsResource("complexMultilineImports.sql", "import.sql"))
-            .withConfigurationResource("application-unittest-onlyreactive.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.datasource.reactive", "true")
             .overrideConfigKey("quarkus.datasource.db-kind", POSTGRES_KIND)

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnitBothUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnitBothUnitTest.java
@@ -27,8 +27,6 @@ public class ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnit
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
             ))
-            .withConfigurationResource("application-unittest-both-named-different.properties")
-
             // Reactive named datasource
             .overrideConfigKey("quarkus.datasource.\"named-datasource-reactive\".jdbc", "false")
             .overrideConfigKey("quarkus.datasource.\"named-datasource-reactive\".reactive", "true")
@@ -42,6 +40,7 @@ public class ORMReactiveCompatbilityDifferentNamedDataSourceNamedPersistenceUnit
             .overrideConfigKey("quarkus.hibernate-orm.\"named-pu-reactive\".packages", "io.quarkus.hibernate.reactive.entities")
 
             // Blocking named datasource
+            .overrideConfigKey("quarkus.datasource.\"named-datasource-blocking\".jdbc", "true")
             .overrideConfigKey("quarkus.datasource.\"named-datasource-blocking\".reactive", "false")
             .overrideConfigKey("quarkus.datasource.\"named-datasource-blocking\".db-kind", POSTGRES_KIND)
             .overrideConfigKey("quarkus.datasource.\"named-datasource-blocking\".username", USERNAME_PWD)

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceBothUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceBothUnitTest.java
@@ -22,7 +22,6 @@ public class ORMReactiveCompatbilityNamedDataSourceBothUnitTest extends Compatib
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
             ))
-            .withConfigurationResource("application-unittest-both-named.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.hibernate-orm.datasource", "named-datasource")
             .overrideConfigKey("quarkus.datasource.\"named-datasource\".reactive", "true")

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceNamedPersistenceUnitBothUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceNamedPersistenceUnitBothUnitTest.java
@@ -27,7 +27,6 @@ public class ORMReactiveCompatbilityNamedDataSourceNamedPersistenceUnitBothUnitT
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
             ))
-            .withConfigurationResource("application-unittest-both-named.properties")
             .overrideConfigKey("quarkus.hibernate-orm.\"named-pu\".schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.hibernate-orm.\"named-pu\".datasource", "named-datasource")
             .overrideConfigKey("quarkus.hibernate-orm.\"named-pu\".packages", "io.quarkus.hibernate.reactive.entities")

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceReactiveUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityNamedDataSourceReactiveUnitTest.java
@@ -21,7 +21,6 @@ public class ORMReactiveCompatbilityNamedDataSourceReactiveUnitTest extends Comp
             .withApplicationRoot((jar) -> jar
                     .addClasses(Hero.class)
                     .addAsResource("complexMultilineImports.sql", "import.sql"))
-            .withConfigurationResource("application-unittest-onlyreactive-named.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.hibernate-orm.datasource", "named-datasource")
             .overrideConfigKey("quarkus.datasource.\"named-datasource\".reactive", "true")

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityOnlyReactiveJDBCDisabledUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatbilityOnlyReactiveJDBCDisabledUnitTest.java
@@ -23,7 +23,6 @@ public class ORMReactiveCompatbilityOnlyReactiveJDBCDisabledUnitTest extends Com
                     .addAsResource("complexMultilineImports.sql", "import.sql"))
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion())))
-            .withConfigurationResource("application-unittest-onlyreactive.properties")
             .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.datasource.jdbc", "false")
             .overrideConfigKey("quarkus.datasource.reactive", "true")

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatibilityNamedReactiveDefaultBlockingUnitTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/ORMReactiveCompatibilityNamedReactiveDefaultBlockingUnitTest.java
@@ -24,7 +24,6 @@ public class ORMReactiveCompatibilityNamedReactiveDefaultBlockingUnitTest extend
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-jdbc-postgresql-deployment", Version.getVersion()) // this triggers Agroal
             ))
-            .withConfigurationResource("application-unittest-both-named-reactive-and-default-blocking.properties")
             // If we want the named PU to be reactive only we need to explicitly disable the blocking the JDBC data source
             .overrideConfigKey("quarkus.datasource.\"named-datasource\".jdbc", "false")
             .overrideConfigKey("quarkus.datasource.\"named-datasource\".reactive", "true")
@@ -40,6 +39,7 @@ public class ORMReactiveCompatibilityNamedReactiveDefaultBlockingUnitTest extend
             .overrideConfigKey("quarkus.datasource.reactive", "false")
             // In this case packages for the default PU should be explicit as well
             .overrideConfigKey("quarkus.hibernate-orm.packages", "io.quarkus.hibernate.reactive.entities")
+            .overrideConfigKey("quarkus.hibernate-orm.database.generation", SCHEMA_MANAGEMENT_STRATEGY)
             .overrideConfigKey("quarkus.datasource.username", USERNAME_PWD)
             .overrideConfigKey("quarkus.datasource.password", USERNAME_PWD)
             .overrideConfigKey("quarkus.datasource.db-kind", POSTGRES_KIND)

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-postgres-reactive-url-only.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-postgres-reactive-url-only.properties
@@ -1,4 +1,0 @@
-# This is not mapped to a Quarkus configuration property directly.
-# It's only a way to inject Maven-provided URLs into tests,
-# which will refer to this property in other properties.
-postgres.reactive.url=${postgres.reactive.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-different.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-different.properties
@@ -1,2 +1,0 @@
-quarkus.datasource."named-datasource-reactive".reactive.url=${postgres.reactive.url}
-quarkus.datasource."named-datasource-blocking".jdbc.url=${postgres.blocking.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-reactive-and-default-blocking.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named-reactive-and-default-blocking.properties
@@ -1,2 +1,0 @@
-quarkus.datasource.jdbc.url=${postgres.blocking.url}
-quarkus.datasource."named-datasource".reactive.url=${postgres.reactive.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both-named.properties
@@ -1,2 +1,0 @@
-quarkus.datasource."named-datasource".reactive.url=${postgres.reactive.url}
-quarkus.datasource."named-datasource".jdbc.url=${postgres.blocking.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-both.properties
@@ -1,2 +1,0 @@
-quarkus.datasource.reactive.url=${postgres.reactive.url}
-quarkus.datasource.jdbc.url=${postgres.blocking.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyblocking.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyblocking.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.jdbc.url=${postgres.blocking.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyreactive-named.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyreactive-named.properties
@@ -1,1 +1,0 @@
-quarkus.datasource."named-datasource".reactive.url=${postgres.reactive.url}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyreactive.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-unittest-onlyreactive.properties
@@ -1,1 +1,0 @@
-quarkus.datasource.reactive.url=${postgres.reactive.url}

--- a/independent-projects/vertx-utils/src/main/java/io/quarkus/vertx/utils/VertxOutputStream.java
+++ b/independent-projects/vertx-utils/src/main/java/io/quarkus/vertx/utils/VertxOutputStream.java
@@ -5,13 +5,13 @@ import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.util.Optional;
 
-import io.vertx.core.Context;
 import org.jboss.logging.Logger;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponse;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -24,6 +24,7 @@ import java.util.ServiceLoader;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -903,6 +904,54 @@ public class QuarkusUnitTest
      */
     public QuarkusUnitTest withConfigurationResource(String resourceName) {
         this.configResourceName = Objects.requireNonNull(resourceName);
+        return this;
+    }
+
+    /**
+     * Adds build-time configuration properties using a text block.
+     *
+     * @param configBlock text block containing {@code key=value} configuration entries
+     */
+    public QuarkusUnitTest withConfiguration(String configBlock) {
+        applyConfigurationBlock(configBlock, this::overrideConfigKey);
+        return this;
+    }
+
+    /**
+     * Adds runtime configuration properties using a text block.
+     *
+     * @param configBlock text block containing {@code key=value} configuration entries
+     */
+    public QuarkusUnitTest withRuntimeConfiguration(String configBlock) {
+        applyConfigurationBlock(configBlock, this::overrideRuntimeConfigKey);
+        return this;
+    }
+
+    /**
+     * Parses a configuration text block and applies the given action for each {@code key=value} entry.
+     *
+     * @param configBlock the configuration text block to parse
+     * @param keyValueConsumer action applied to each parsed key/value pair
+     * @return this instance for fluent chaining
+     */
+    private QuarkusUnitTest applyConfigurationBlock(String configBlock, BiConsumer<String, String> keyValueConsumer) {
+        Objects.requireNonNull(configBlock, "Configuration text block must not be null");
+        Objects.requireNonNull(keyValueConsumer, "Key/value consumer must not be null");
+
+        configBlock.lines()
+                .map(String::trim)
+                .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                .forEach(line -> {
+                    int idx = line.indexOf('=');
+                    if (idx <= 0) {
+                        throw new IllegalArgumentException(
+                                "Invalid configuration line: '" + line + "'. Expected format 'key=value'");
+                    }
+                    String key = line.substring(0, idx).trim();
+                    String value = line.substring(idx + 1).trim();
+                    keyValueConsumer.accept(key, value);
+                });
+
         return this;
     }
 

--- a/test-framework/junit-internal/src/test/java/io/quarkus/test/QuarkusUnitTestWithConfigurationTest.java
+++ b/test-framework/junit-internal/src/test/java/io/quarkus/test/QuarkusUnitTestWithConfigurationTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for QuarkusUnitTest.withConfiguration(String),
+ * without starting Quarkus or CDI.
+ */
+final class QuarkusUnitTestWithConfigurationTest {
+
+    static final class TestableConfigUnit extends QuarkusUnitTest {
+
+        private final Map<String, String> configMap = new LinkedHashMap<>();
+
+        @Override
+        public QuarkusUnitTest overrideConfigKey(String key, String value) {
+            configMap.put(key, value);
+            return this;
+        }
+
+        Map<String, String> getConfig() {
+            return configMap;
+        }
+    }
+
+    @Test
+    void parsesConfigurationCorrectly() {
+        TestableConfigUnit testUnit = new TestableConfigUnit();
+
+        testUnit.withConfiguration("""
+                        quarkus.datasource.db-kind=postgresql
+                        quarkus.datasource.username=testuser
+                        quarkus.datasource.password=secret
+                """);
+
+        Map<String, String> expected = Map.of(
+                "quarkus.datasource.db-kind", "postgresql",
+                "quarkus.datasource.username", "testuser",
+                "quarkus.datasource.password", "secret");
+
+        assertEquals(expected, testUnit.getConfig());
+    }
+
+    @Test
+    void ignoresBlankLinesAndComments() {
+        TestableConfigUnit testUnit = new TestableConfigUnit();
+
+        testUnit.withConfiguration("""
+                        # comment
+
+                        my.key = value
+
+                        # another comment
+                        other.key= foo
+                """);
+
+        Map<String, String> expected = Map.of(
+                "my.key", "value",
+                "other.key", "foo");
+
+        assertEquals(expected, testUnit.getConfig());
+    }
+}

--- a/test-framework/junit-internal/src/test/java/io/quarkus/test/QuarkusUnitTestWithRuntimeConfigurationTest.java
+++ b/test-framework/junit-internal/src/test/java/io/quarkus/test/QuarkusUnitTestWithRuntimeConfigurationTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for QuarkusUnitTest.withRuntimeConfiguration(String),
+ * without starting Quarkus or CDI.
+ */
+final class QuarkusUnitTestWithRuntimeConfigurationTest {
+
+    /**
+     * Test double that captures calls to overrideRuntimeConfigKey.
+     */
+    static final class TestableQuarkusUnitTest extends QuarkusUnitTest {
+
+        private final Map<String, String> runtimeConfig = new LinkedHashMap<>();
+
+        @Override
+        public QuarkusUnitTest overrideRuntimeConfigKey(String key, String value) {
+            runtimeConfig.put(key, value);
+            return this;
+        }
+
+        Map<String, String> getRuntimeConfig() {
+            return runtimeConfig;
+        }
+    }
+
+    @Test
+    void parsesValidConfigBlock() {
+        TestableQuarkusUnitTest testUnit = new TestableQuarkusUnitTest();
+
+        testUnit.withRuntimeConfiguration("""
+                test.inline.runtime=value
+                quarkus.log.category.test.category.level=DEBUG
+                """);
+
+        Map<String, String> expected = Map.of(
+                "test.inline.runtime", "value",
+                "quarkus.log.category.test.category.level", "DEBUG");
+
+        assertEquals(expected, testUnit.getRuntimeConfig());
+    }
+
+    @Test
+    void ignoresBlankAndCommentLines() {
+        TestableQuarkusUnitTest testUnit = new TestableQuarkusUnitTest();
+
+        testUnit.withRuntimeConfiguration("""
+                # comment
+
+                test.key1=foo
+
+                # comment
+                test.key2 = bar
+                """);
+
+        Map<String, String> expected = Map.of(
+                "test.key1", "foo",
+                "test.key2", "bar");
+
+        assertEquals(expected, testUnit.getRuntimeConfig());
+    }
+}


### PR DESCRIPTION
Add inline configuration support to QuarkusUnitTest and remove obsolete test config files (#51206)

This commit introduces a new API method `withConfiguration(String)` that enables
inline configuration for QuarkusUnitTest using Java text blocks. The method
parses `key=value` properties and forwards them to `overrideConfigKey(...)`,
eliminating the need for external `.properties` files or multiple configuration
calls in test code.

As part of this enhancement and in relation to issue #51206, obsolete test configuration
resources such as `application-unittest-onlyreactive*.properties` were removed,
since Dev Services now provide datasource URLs automatically and these files were
no longer required.

A new test `QuarkusUnitTestWithConfigurationTest` verifies that inline configuration
is correctly applied and propagated to the MicroProfile Config runtime.

- Closes: https://github.com/quarkusio/quarkus/issues/51206
