### PR TITLE
Default TLS protocol to TLSv1.3 and warn when not enabled

### DIFF
--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.KeyManager;
@@ -14,6 +15,8 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
@@ -25,6 +28,8 @@ import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.TrustOptions;
 
 public class VertxCertificateHolder implements TlsConfiguration {
+
+    private static final Logger LOGGER = Logger.getLogger(VertxCertificateHolder.class.getName());
 
     private final TlsBucketConfig config;
     private final List<Buffer> crls;
@@ -114,6 +119,8 @@ public class VertxCertificateHolder implements TlsConfiguration {
         options.setSslHandshakeTimeout(config().handshakeTimeout().toSeconds());
         options.setEnabledSecureTransportProtocols(config().protocols());
 
+        warnIfOldProtocols(options.getEnabledSecureTransportProtocols(), name);
+
         for (Buffer buffer : crls) {
             options.addCrlValue(buffer);
         }
@@ -123,6 +130,80 @@ public class VertxCertificateHolder implements TlsConfiguration {
         }
 
         return options;
+    }
+
+    boolean warnIfOldProtocols(Set<String> protocols, String name) {
+        var list = protocols.stream().map(String::toLowerCase).map(String::trim).toList();
+        boolean warned = false;
+
+        // Check for SSL protocols
+        if (list.stream().anyMatch(p -> p.startsWith("ssl"))) {
+            LOGGER.warnf("Insecure SSL protocol is enabled in TLS bucket '%s'." +
+                    " It is strongly recommended to disable SSL protocols (SSLv2, SSLv3), and use at least TLSv1.3.", name);
+            warned = true;
+        }
+
+        // Check for old TLS protocols (TLSv1.0, TLSv1.1)
+        if (list.contains("tlsv1") || list.contains("tlsv1.1")) {
+            LOGGER.warnf("Insecure TLS protocol TLSv1.0 or TLSv1.1 is enabled in TLS bucket '%s'." +
+                    " It is strongly recommended to disable TLSv1.0 and TLSv1.1, and use at least TLSv1.3.", name);
+            warned = true;
+        }
+
+        // Check if TLSv1.3 or higher is enabled.
+        boolean isUsingModernTlsVersion = false;
+        for (String p : list) {
+            if (IsRecentOrFutureTLSVersion(p)) {
+                isUsingModernTlsVersion = true;
+                break;
+            }
+        }
+
+        if (!isUsingModernTlsVersion) {
+            LOGGER.warnf("TLSv1.3 or higher protocol is not enabled in TLS bucket '%s'." +
+                    " It is *strongly* recommended to enable TLSv1.3 or higher.", name);
+            warned = true;
+        }
+
+        return warned;
+    }
+
+    /**
+     * Checks if a protocol string represents TLS 1.3 or higher.
+     *
+     * @param protocol the protocol string (already lowercased and trimmed)
+     * @return true if the protocol is TLSv1.3 or higher
+     */
+    private boolean IsRecentOrFutureTLSVersion(String protocol) {
+        if (!protocol.startsWith("tlsv")) {
+            return false;
+        }
+
+        String afterTlsv = protocol.substring(4); // Skip "tlsv"
+        if (afterTlsv.isEmpty()) {
+            return false;
+        }
+
+        char majorChar = afterTlsv.charAt(0);
+
+        // Check for TLSv1.x
+        if (afterTlsv.startsWith("1.")) {
+            String minorVersion = afterTlsv.substring(2); // Everything after "1."
+            if (minorVersion.isEmpty()) {
+                return false;
+            }
+
+            // Single digit 3-9
+            if (minorVersion.length() == 1) {
+                char minorChar = minorVersion.charAt(0);
+                return minorChar >= '3' && minorChar <= '9'; // TLSv1.3 to TLSv1.9
+            } else {
+                return true; // Multi-digit (TLSv1.10, TLSv1.11, etc.)
+            }
+        }
+
+        // TLSv2.x, TLSv3.x, etc.
+        return majorChar >= '2' && majorChar <= '9'; // Future-proof for TLSv2, TLSv3, etc, if they ever come.
     }
 
     @Override

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
@@ -40,16 +40,15 @@ public interface TlsBucketConfig {
     /**
      * Sets the ordered list of enabled TLS protocols.
      * <p>
-     * If not set, it defaults to {@code "TLSv1.3, TLSv1.2"}.
+     * If not set, it defaults to {@code "TLSv1.3"}.
      * The following list of protocols are supported: {@code TLSv1, TLSv1.1, TLSv1.2, TLSv1.3}.
-     * To only enable {@code TLSv1.3}, set the value to {@code to "TLSv1.3"}.
+     * To enable {@code TLSv1.3} and {@code TLSv1.2}, set the value to {@code to "TLSv1.3, TLSv1.2"}.
      * <p>
      * Note that setting an empty list, and enabling TLS is invalid.
      * You must at least have one protocol.
      * <p>
-     * Also, setting this replaces the default list of protocols.
      */
-    @WithDefault("TLSv1.3,TLSv1.2")
+    @WithDefault("TLSv1.3")
     Set<String> protocols();
 
     /**

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -1,0 +1,141 @@
+package io.quarkus.tls.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.tls.runtime.config.KeyStoreConfig;
+import io.quarkus.tls.runtime.config.TlsBucketConfig;
+import io.quarkus.tls.runtime.config.TrustStoreConfig;
+
+class VertxCertificateHolderTest {
+
+    private VertxCertificateHolder holder;
+
+    @BeforeEach
+    void setUp() {
+        // Create a minimal test config with only the required methods implemented
+        TlsBucketConfig config = new TlsBucketConfig() {
+            @Override
+            public Optional<KeyStoreConfig> keyStore() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<TrustStoreConfig> trustStore() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<List<String>> cipherSuites() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Set<String> protocols() {
+                return Set.of();
+            }
+
+            @Override
+            public Optional<List<Path>> certificateRevocationList() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean trustAll() {
+                return false;
+            }
+
+            @Override
+            public Optional<String> hostnameVerificationAlgorithm() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean alpn() {
+                return false;
+            }
+
+            @Override
+            public Duration handshakeTimeout() {
+                return Duration.ofSeconds(10);
+            }
+
+            @Override
+            public Optional<Duration> reloadPeriod() {
+                return Optional.empty();
+            }
+        };
+        holder = new VertxCertificateHolder(null, "test", config, null, null);
+    }
+
+    @Test
+    void testWarnIfOldProtocols_withSSL() {
+        assertTrue(holder.warnIfOldProtocols(Set.of("SSLv3"), "test"));
+        assertTrue(holder.warnIfOldProtocols(Set.of("SSLv2", "TLSv1.3"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_withOldTLS() {
+        assertTrue(holder.warnIfOldProtocols(Set.of("TLSv1"), "test"));
+        assertTrue(holder.warnIfOldProtocols(Set.of("TLSv1.1"), "test"));
+        assertTrue(holder.warnIfOldProtocols(Set.of("TLSv1", "TLSv1.1"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_withTLSv12Only() {
+        assertTrue(holder.warnIfOldProtocols(Set.of("TLSv1.2"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_withTLSv13() {
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSv1.3"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_withTLSv12AndTLSv13() {
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSv1.2", "TLSv1.3"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_futureTLSVersions() {
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSv1.4"), "test"));
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSv1.5"), "test"));
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSv1.10"), "test"));
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSv2.0"), "test"));
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSv3.0"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_mixedOldAndModern() {
+        assertTrue(holder.warnIfOldProtocols(Set.of("TLSv1.1", "TLSv1.3"), "test"));
+        assertTrue(holder.warnIfOldProtocols(Set.of("SSLv3", "TLSv1.3"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_caseInsensitive() {
+        assertFalse(holder.warnIfOldProtocols(Set.of("tlsv1.3"), "test"));
+        assertFalse(holder.warnIfOldProtocols(Set.of("TLSV1.3"), "test"));
+        assertTrue(holder.warnIfOldProtocols(Set.of("sslv3"), "test"));
+        assertTrue(holder.warnIfOldProtocols(Set.of("TLSV1"), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_withWhitespace() {
+        assertFalse(holder.warnIfOldProtocols(Set.of(" TLSv1.3 "), "test"));
+        assertTrue(holder.warnIfOldProtocols(Set.of(" TLSv1.2 "), "test"));
+    }
+
+    @Test
+    void testWarnIfOldProtocols_emptySet() {
+        assertTrue(holder.warnIfOldProtocols(Set.of(), "test"));
+    }
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/TlsProtocolVersionDefaultTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/TlsProtocolVersionDefaultTestCase.java
@@ -20,7 +20,7 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 @QuarkusTest
 public class TlsProtocolVersionDefaultTestCase {
 
-    @TestHTTPResource(value = "/hello", ssl = true)
+    @TestHTTPResource(value = "/hello", tls = true)
     String url;
 
     @Inject
@@ -55,7 +55,7 @@ public class TlsProtocolVersionDefaultTestCase {
 
     @Test
     void testWithWebClientRequestingTls12() {
-        // The Web client is requesting TLS 1.2, the server is exposing 1.2 and 1.3 - all good
+        // The Web client is requesting TLS 1.2, the server is exposing 1.3 - KO
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
                 .setEnabledSecureTransportProtocols(Set.of("TLSv1.2"))
                 .setKeyStoreOptions(
@@ -63,8 +63,8 @@ public class TlsProtocolVersionDefaultTestCase {
                 .setTrustStoreOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
-        var resp = client.getAbs(url).sendAndAwait();
-        Assertions.assertEquals(200, resp.statusCode());
+        Throwable exception = Assertions.assertThrows(CompletionException.class, () -> client.getAbs(url).sendAndAwait());
+        Assertions.assertTrue(exception.getCause() instanceof SSLHandshakeException);
     }
 
     @Test


### PR DESCRIPTION
**BREAKING CHANGE:** Changes the default TLS protocol from "TLSv1.3,TLSv1.2" to just "TLSv1.3". Applications requiring TLSv1.2 support must now explicitly configure it using the `protocols` property (set to TLSv1.3, TLSv1.2)

Adds a warning log when TLSv1.3 is not enabled in a TLS bucket configuration.
