### PR TITLE
Use correct name for `org.graalvm.sdk:nativebridge` dependency

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -236,7 +236,7 @@
                         <runnerParentFirstArtifact>org.graalvm.sdk:jniutils</runnerParentFirstArtifact>
                         <runnerParentFirstArtifact>org.graalvm.sdk:word</runnerParentFirstArtifact>
                         <runnerParentFirstArtifact>org.graalvm.sdk:collections</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.graalvm.sdk:native-bridge</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.graalvm.sdk:nativebridge</runnerParentFirstArtifact>
                         <!-- /support for GraalVM js -->
                         <runnerParentFirstArtifact>io.quarkus:quarkus-bootstrap-runner</runnerParentFirstArtifact>
                         <runnerParentFirstArtifact>io.quarkus:quarkus-classloader-commons</runnerParentFirstArtifact>


### PR DESCRIPTION
The dependency can be found here:
https://central.sonatype.com/artifact/org.graalvm.sdk/nativebridge

Follow-up to https://github.com/quarkusio/quarkus/pull/50288