### PR TITLE
Set expiresIn to one hour for OIDC Dev Services

### DIFF
--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
@@ -761,7 +761,7 @@ public class OidcDevServicesProcessor {
 
     private static String createIdToken(String user, Set<String> roles, String clientId) {
         return Jwt.claims()
-                .expiresIn(Duration.ofDays(1))
+                .expiresIn(Duration.ofHours(1))
                 .issuedAt(Instant.now())
                 .issuer(baseURI)
                 .audience(clientId)
@@ -778,7 +778,7 @@ public class OidcDevServicesProcessor {
 
     private static String createAccessToken(String user, Set<String> roles, Set<String> scope) {
         return Jwt.claims()
-                .expiresIn(Duration.ofDays(1))
+                .expiresIn(Duration.ofHours(1))
                 .issuedAt(Instant.now())
                 .issuer(baseURI)
                 .subject(user)


### PR DESCRIPTION
To match with the `expires_in` that we manually set for the token response for OIDC Dev Services. This should make debugging the property `quarkus.oidc.authentication.session-age-extension` a bit easier, as you now get a token that's valid for a day.

We can probably also make this configurable, as that would be useful if you want to test locally what happens if your token expires. Will add that in a next commit.

Follow up of https://github.com/quarkusio/quarkus/issues/51332