### PR TITLE
Bump Keycloak version to 26.4.7

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -97,7 +97,7 @@
         <junit4.version>4.13.2</junit4.version>
 
         <!-- The image to use for tests that run Keycloak -->
-        <keycloak.server.version>26.4.5</keycloak.server.version>
+        <keycloak.server.version>26.4.7</keycloak.server.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.server.version}</keycloak.docker.image>
 
         <unboundid-ldap.version>7.0.3</unboundid-ldap.version>


### PR DESCRIPTION
Bump Keycloak version to 26.4.7.

@wjglerum, we can now update a single property only thanks to your earlier optimizations :-), with 26.5.0 - it will be two properties only (keycloak client from `26.0.7` to `26.0.8`, etc)