### PR TITLE
Remove extraneous semicolon in LGTM codestart

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/lgtm-codestart/java/src/test/java/org/acme/SimpleTest.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/lgtm-codestart/java/src/test/java/org/acme/SimpleTest.java
@@ -1,6 +1,6 @@
 package org.acme;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;

--- a/integration-tests/devtools/src/test/resources/__snapshots__/LgtmCodestartTest/testContent/src_test_java_ilove_quark_us_SimpleTest.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/LgtmCodestartTest/testContent/src_test_java_ilove_quark_us_SimpleTest.java
@@ -1,6 +1,6 @@
 package ilove.quark.us;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;


### PR DESCRIPTION
Removes extraneous semicolons in LGTM codestart.

* Fixes #51345