### PR TITLE
Bump to Mutiny 3.1.0 and Mutiny Vert.x bindings 3.21.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.20.4</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.21.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.31.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
@@ -137,7 +137,7 @@
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <mutiny.version>3.0.3</mutiny.version>
+        <mutiny.version>3.1.0</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka3.version>4.0.1</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -48,7 +48,7 @@
         <version.jandex>3.5.3</version.jandex>
         <version.gizmo2>2.0.0.Beta10</version.gizmo2>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
-        <version.mutiny>3.0.3</version.mutiny>
+        <version.mutiny>3.1.0</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.14.0</version.smallrye-common>
         <!-- test versions -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -44,7 +44,7 @@
         <version.gizmo2>2.0.0.Beta10</version.gizmo2>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.smallrye-common>2.14.0</version.smallrye-common>
-        <version.smallrye-mutiny>3.0.3</version.smallrye-mutiny>
+        <version.smallrye-mutiny>3.1.0</version.smallrye-mutiny>
         <version.lsp4j>0.24.0</version.lsp4j>
     </properties>
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -55,8 +55,8 @@
         <gizmo.version>1.9.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <mutiny.version>3.0.3</mutiny.version>
-        <smallrye-mutiny-vertx-core.version>3.20.4</smallrye-mutiny-vertx-core.version>
+        <mutiny.version>3.1.0</mutiny.version>
+        <smallrye-mutiny-vertx-core.version>3.21.1</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.14.0</smallrye-common.version>
         <vertx.version>4.5.22</vertx.version>
         <rest-assured.version>5.5.6</rest-assured.version>


### PR DESCRIPTION
There is no need for these changes to be back-ported.

