### PR TITLE
Log how OIDC session age is calculated

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1452,7 +1452,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         }
 
         @Override
-        public Duration sessionAgeExtension() {
+        public Optional<Duration> sessionAgeExtension() {
             return sessionAgeExtension;
         }
 
@@ -1747,7 +1747,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
          * the session has expired.
          * This property is ignored if the `token.refresh-expired` property has not been enabled.
          */
-        public Duration sessionAgeExtension = Duration.ofMinutes(5);
+        public Optional<Duration> sessionAgeExtension = Optional.empty();
 
         /**
          * State cookie age in minutes.
@@ -1959,12 +1959,12 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             this.verifyAccessToken = verifyAccessToken;
         }
 
-        public Duration getSessionAgeExtension() {
+        public Optional<Duration> getSessionAgeExtension() {
             return sessionAgeExtension;
         }
 
         public void setSessionAgeExtension(Duration sessionAgeExtension) {
-            this.sessionAgeExtension = sessionAgeExtension;
+            this.sessionAgeExtension = Optional.of(sessionAgeExtension);
         }
 
         public Optional<String> getCookiePathHeader() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Base64.Encoder;
 import java.util.List;
@@ -1064,16 +1065,29 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                             LOG.error(error);
                             throw new AuthenticationCompletionException(error);
                         }
-                        long maxAge = idTokenJson.getLong("exp") - idTokenJson.getLong("iat");
-                        LOG.debugf("ID token is valid for %d seconds", maxAge);
+                        long idTokenAge = idTokenJson.getLong("exp") - idTokenJson.getLong("iat");
+                        LOG.debugf("Session age is initialized with ID token age of %d seconds", idTokenAge);
+                        long sessionAge = idTokenAge;
                         if (configContext.oidcConfig().token().lifespanGrace().isPresent()) {
-                            maxAge += configContext.oidcConfig().token().lifespanGrace().getAsInt();
+                            int lifespanGrace = configContext.oidcConfig().token().lifespanGrace().getAsInt();
+                            LOG.debugf("Adding token lifespan grace of %d seconds to the session age", lifespanGrace);
+                            sessionAge += lifespanGrace;
                         }
-                        if (configContext.oidcConfig().token().refreshExpired() && tokens.getRefreshToken() != null) {
-                            maxAge += configContext.oidcConfig().authentication().sessionAgeExtension().getSeconds();
+                        if (configContext.oidcConfig().token().refreshExpired()) {
+                            if (tokens.getRefreshToken() != null) {
+                                long sessionAgeExtension = configContext.oidcConfig().authentication().sessionAgeExtension()
+                                        .orElse(Duration.ofMinutes(5)).getSeconds();
+                                LOG.debugf("Extending the session age with %d seconds", sessionAgeExtension);
+                                sessionAge += sessionAgeExtension;
+                            } else {
+                                LOG.debug("Session age can not be extended becase a refresh token is not available");
+                            }
                         }
-                        final long sessionMaxAge = maxAge;
-                        context.put(SESSION_MAX_AGE_PARAM, maxAge);
+                        if (sessionAge != idTokenAge) {
+                            LOG.debugf("Final session age is %d seconds", sessionAge);
+                        }
+                        final long sessionMaxAge = sessionAge;
+                        context.put(SESSION_MAX_AGE_PARAM, sessionAge);
                         context.put(TenantConfigContext.class.getName(), configContext);
                         // Just in case, remove the stale Back-Channel Logout data if the previous session was not terminated correctly
                         resolver.getBackChannelLogoutTokens().remove(configContext.oidcConfig().tenantId().get());

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -917,10 +917,11 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
          * the user is redirected to the OIDC provider to re-authenticate once the session has expired.
          * If this property is set to a nonzero value, then the expired ID token can be refreshed before
          * the session has expired.
-         * This property is ignored if the `token.refresh-expired` property has not been enabled.
+         * This property is effective only if the `token.refresh-expired` property is enabled and a refresh token is available.
+         * It is set to 5 minutes by default.
          */
-        @WithDefault("5M")
-        Duration sessionAgeExtension();
+        @ConfigDocDefault("5M")
+        Optional<Duration> sessionAgeExtension();
 
         /**
          * State cookie age in minutes.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
@@ -291,6 +291,11 @@ final class TenantContextFactory {
             if (oidcConfig.token().refreshTokenTimeSkew().isPresent()) {
                 oidcConfig.token.setRefreshExpired(true);
             }
+            if (oidcConfig.authentication().sessionAgeExtension().isPresent()
+                    && !oidcConfig.token().refreshExpired()) {
+                LOG.warn(
+                        "Session age extension will not be effective because 'quarkus.oidc.token.refresh-expired=true' is not set");
+            }
         }
 
         if (oidcConfig.tokenStateManager()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
@@ -30,7 +30,7 @@ public final class AuthenticationConfigBuilder {
             boolean cookieForceSecure, Optional<String> cookieSuffix, String cookiePath, Optional<String> cookiePathHeader,
             Optional<String> cookieDomain, CookieSameSite cookieSameSite, Optional<Set<CacheControl>> cacheControl,
             boolean allowMultipleCodeFlows, boolean failOnMissingStateParam, boolean failOnUnresolvedKid,
-            Optional<Boolean> userInfoRequired, Duration sessionAgeExtension,
+            Optional<Boolean> userInfoRequired, Optional<Duration> sessionAgeExtension,
             Duration stateCookieAge, boolean javaScriptAutoRedirect, Optional<Boolean> idTokenRequired,
             Optional<Duration> internalIdTokenLifespan, Optional<Boolean> pkceRequired, Optional<String> pkceSecret,
             Optional<String> stateSecret) implements Authentication {
@@ -62,7 +62,7 @@ public final class AuthenticationConfigBuilder {
     private boolean failOnMissingStateParam;
     private boolean failOnUnresolvedKid;
     private Optional<Boolean> userInfoRequired;
-    private Duration sessionAgeExtension;
+    private Optional<Duration> sessionAgeExtension;
     private Duration stateCookieAge;
     private boolean javaScriptAutoRedirect;
     private Optional<Boolean> idTokenRequired;
@@ -465,7 +465,7 @@ public final class AuthenticationConfigBuilder {
      * @return this builder
      */
     public AuthenticationConfigBuilder sessionAgeExtension(Duration sessionAgeExtension) {
-        this.sessionAgeExtension = Objects.requireNonNull(sessionAgeExtension);
+        this.sessionAgeExtension = Optional.of(Objects.requireNonNull(sessionAgeExtension));
         return this;
     }
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
@@ -153,7 +153,7 @@ public class OidcTenantConfigBuilderTest {
         assertTrue(authentication.allowMultipleCodeFlows());
         assertFalse(authentication.failOnMissingStateParam());
         assertTrue(authentication.userInfoRequired().isEmpty());
-        assertEquals(5, authentication.sessionAgeExtension().toMinutes());
+        assertTrue(authentication.sessionAgeExtension().isEmpty());
         assertEquals(5, authentication.stateCookieAge().toMinutes());
         assertTrue(authentication.javaScriptAutoRedirect());
         assertTrue(authentication.idTokenRequired().isEmpty());
@@ -552,7 +552,7 @@ public class OidcTenantConfigBuilderTest {
         assertFalse(authentication.allowMultipleCodeFlows());
         assertTrue(authentication.failOnMissingStateParam());
         assertTrue(authentication.userInfoRequired().orElseThrow());
-        assertEquals(77, authentication.sessionAgeExtension().toMinutes());
+        assertEquals(77, authentication.sessionAgeExtension().get().toMinutes());
         assertEquals(88, authentication.stateCookieAge().toMinutes());
         assertFalse(authentication.javaScriptAutoRedirect());
         assertFalse(authentication.idTokenRequired().orElseThrow());
@@ -1288,7 +1288,7 @@ public class OidcTenantConfigBuilderTest {
         assertFalse(builtFirst.allowMultipleCodeFlows());
         assertTrue(builtFirst.failOnMissingStateParam());
         assertTrue(builtFirst.userInfoRequired().orElseThrow());
-        assertEquals(77, builtFirst.sessionAgeExtension().toMinutes());
+        assertEquals(77, builtFirst.sessionAgeExtension().get().toMinutes());
         assertEquals(88, builtFirst.stateCookieAge().toMinutes());
         assertFalse(builtFirst.javaScriptAutoRedirect());
         assertFalse(builtFirst.idTokenRequired().orElseThrow());
@@ -1338,7 +1338,7 @@ public class OidcTenantConfigBuilderTest {
         assertFalse(builtSecond.allowMultipleCodeFlows());
         assertTrue(builtSecond.failOnMissingStateParam());
         assertTrue(builtSecond.userInfoRequired().orElseThrow());
-        assertEquals(77, builtSecond.sessionAgeExtension().toMinutes());
+        assertEquals(77, builtSecond.sessionAgeExtension().get().toMinutes());
         assertEquals(88, builtSecond.stateCookieAge().toMinutes());
         assertFalse(builtSecond.javaScriptAutoRedirect());
         assertFalse(builtSecond.idTokenRequired().orElseThrow());

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -791,7 +791,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             }
 
             @Override
-            public Duration sessionAgeExtension() {
+            public Optional<Duration> sessionAgeExtension() {
                 invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_SESSION_AGE_EXTENSION, true);
                 return null;
             }


### PR DESCRIPTION
Fixes #51332.

This PR attempts to make it clearer how the session age is calculated, tries to highlight it set to the ID token age initially but can be extended.

It also warns if a user has configured the session age extension but did not allow to have tokens refreshed, for this warning to work I had to make the session age extension property optional to detect it was set by a user