### PR TITLE
Change ArtifactLauncher.start to return the listening address

### DIFF
--- a/integration-tests/awt-packaging/src/test/java/io/quarkus/it/jaxb/AwtJaxbTest.java
+++ b/integration-tests/awt-packaging/src/test/java/io/quarkus/it/jaxb/AwtJaxbTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.jaxb;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +31,7 @@ class AwtJaxbTest {
                 .then()
                 .statusCode(200)
                 // The height in pixels of the book's cover image.
-                .body(equalTo("\"10\""));
+                .body(containsString("10"));
     }
 
     /**
@@ -47,6 +47,6 @@ class AwtJaxbTest {
                 .post()
                 .then()
                 .statusCode(200)
-                .body(equalTo("\"10\""));
+                .body(containsString("10"));
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
 
@@ -12,13 +13,11 @@ public interface ArtifactLauncher<T extends ArtifactLauncher.InitContext> extend
 
     void init(T t);
 
-    void start() throws IOException;
+    Optional<ListeningAddress> start() throws IOException;
 
     LaunchResult runToCompletion(String[] args);
 
     void includeAsSysProps(Map<String, String> systemProps);
-
-    boolean listensOnSsl();
 
     interface InitContext {
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -1,7 +1,6 @@
 package io.quarkus.test.common;
 
 import static io.quarkus.test.common.LauncherUtil.createStartedFunction;
-import static io.quarkus.test.common.LauncherUtil.updateConfigForPort;
 import static io.quarkus.test.common.LauncherUtil.waitForCapturedListeningData;
 import static io.quarkus.test.common.LauncherUtil.waitForStartedFunction;
 
@@ -15,13 +14,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.logging.LogRuntimeConfig;
-import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.smallrye.config.SmallRyeConfig;
 
 public class DefaultJarLauncher implements JarArtifactLauncher {
@@ -55,7 +54,6 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     private final Map<String, String> systemProps = new HashMap<>();
     private Process quarkusProcess;
 
-    private boolean isSsl;
     private Path logFile;
 
     @Override
@@ -70,21 +68,20 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         this.generateAotFile = initContext.generateAotFile();
     }
 
-    public void start() throws IOException {
+    @Override
+    public Optional<ListeningAddress> start() throws IOException {
         start(new String[0], true);
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
         LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
                 .getConfigMapping(LogRuntimeConfig.class);
         logFile = logRuntimeConfig.file().path().toPath();
         if (startedFunction != null) {
-            IntegrationTestStartedNotifier.Result result = waitForStartedFunction(startedFunction, quarkusProcess,
-                    waitTimeSeconds, logFile);
-            isSsl = result.isSsl();
+            waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logFile);
+            return Optional.empty();
         } else {
             ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(),
                     waitTimeSeconds);
-            updateConfigForPort(result.getPort());
-            isSsl = result.isSsl();
+            return Optional.of(result);
         }
     }
 
@@ -110,7 +107,6 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
         logFile = logRuntimeConfig.file().path().toPath();
-        System.setProperty("test.url", TestHTTPResourceManager.getUri());
 
         List<String> args = new ArrayList<>();
         args.add(determineJavaPath());
@@ -123,10 +119,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         if (HTTP_PRESENT) {
             args.add("-Dquarkus.http.port=" + httpPort);
             args.add("-Dquarkus.http.ssl-port=" + httpsPort);
-            // this won't be correct when using the random port but it's really only used by us for the rest client
-            // tests
-            // in the main module, since those tests hit the application itself
-            args.add("-Dtest.url=" + TestHTTPResourceManager.getUri());
+            args.add("-Dtest.url=" + LauncherUtil.generateTestUrl());
         }
         args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath());
         args.add("-Dquarkus.log.file.enabled=true");
@@ -178,11 +171,6 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
 
         // just assume 'java' is on the system path
         return "java";
-    }
-
-    @Override
-    public boolean listensOnSsl() {
-        return isSsl;
     }
 
     @Override

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RunCommandLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RunCommandLauncher.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -110,7 +111,7 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
     }
 
     @Override
-    public void start() throws IOException {
+    public Optional<ListeningAddress> start() throws IOException {
         System.setProperty("test.url", TestHTTPResourceManager.getUri());
 
         Path logFile = logFilePath;
@@ -161,10 +162,8 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
             LauncherUtil.destroyProcess(quarkusProcess, true);
             throw new RuntimeException("Unable to start target quarkus application " + this.waitTimeSeconds + "s");
         }
-    }
 
-    public boolean listensOnSsl() {
-        return false;
+        return Optional.empty();
     }
 
     public void includeAsSysProps(Map<String, String> systemProps) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
@@ -2,6 +2,7 @@ package io.quarkus.test.common;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A launcher that simply sets the {@code quarkus.http.host} property based on the value {@code quarkus.http.test-host}
@@ -10,13 +11,13 @@ import java.util.Map;
  */
 @SuppressWarnings("rawtypes")
 public class TestHostLauncher implements ArtifactLauncher {
-
     private String previousHost;
 
     @Override
-    public void start() throws IOException {
+    public Optional<ListeningAddress> start() throws IOException {
         // set 'quarkus.http.host' to ensure that RestAssured targets the proper host
         previousHost = System.setProperty("quarkus.http.host", System.getProperty("quarkus.http.test-host"));
+        return Optional.empty();
     }
 
     @Override
@@ -24,11 +25,6 @@ public class TestHostLauncher implements ArtifactLauncher {
         if (previousHost != null) {
             System.setProperty("quarkus.http.host", previousHost);
         }
-    }
-
-    @Override
-    public boolean listensOnSsl() {
-        return Boolean.parseBoolean(System.getProperty("quarkus.http.test-ssl-enabled", "false"));
     }
 
     @Override

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestExtensionState.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestExtensionState.java
@@ -3,9 +3,11 @@ package io.quarkus.test.junit;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
+import io.quarkus.test.common.ListeningAddress;
 import io.quarkus.test.common.TestResourceManager;
 import io.smallrye.config.SmallRyeConfig;
 
@@ -13,9 +15,9 @@ public class IntegrationTestExtensionState extends QuarkusTestExtensionState {
 
     private final Map<String, String> sysPropRestore;
 
-    public IntegrationTestExtensionState(TestResourceManager testResourceManager, Closeable resource,
-            Runnable clearCallbacks, Map<String, String> sysPropRestore) {
-        super(testResourceManager, resource, clearCallbacks);
+    public IntegrationTestExtensionState(TestResourceManager testResourceManager, Closeable resource, Runnable clearCallbacks,
+            Optional<ListeningAddress> listeningAddress, Map<String, String> sysPropRestore) {
+        super(testResourceManager, resource, clearCallbacks, listeningAddress);
         this.sysPropRestore = sysPropRestore;
     }
 

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/TestProfileAndProperties.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/TestProfileAndProperties.java
@@ -1,13 +1,35 @@
 package io.quarkus.test.junit;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 final class TestProfileAndProperties {
-    final QuarkusTestProfile testProfile;
-    final Map<String, String> properties;
+    private final QuarkusTestProfile testProfile;
+    private final Map<String, String> properties;
 
-    public TestProfileAndProperties(QuarkusTestProfile testProfile, Map<String, String> properties) {
+    TestProfileAndProperties(QuarkusTestProfile testProfile, Map<String, String> properties) {
         this.testProfile = testProfile;
-        this.properties = properties;
+        this.properties = properties != null ? properties : Collections.emptyMap();
+    }
+
+    public Optional<QuarkusTestProfile> testProfile() {
+        return Optional.ofNullable(testProfile);
+    }
+
+    Map<String, String> properties() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    Optional<String> configProfile() {
+        return testProfile().map(QuarkusTestProfile::getConfigProfile);
+    }
+
+    boolean isDisabledGlobalTestResources() {
+        return testProfile().map(QuarkusTestProfile::disableGlobalTestResources).orElse(false);
+    }
+
+    Optional<String> testProfileClassName() {
+        return testProfile().map(testProfile -> testProfile.getClass().getName());
     }
 }


### PR DESCRIPTION
Calling `ArtifactLauncher.start` to start Quarkus now returns an `Optional<ListeningAddress>`, which was already available when starting the process internally. The `ListeningAddress` is then registered with the test `Context`, which allows us to avoid using System properties to propagate the running port.

This also means that it removes the ability to query `quarkus.http.port` and `quarkus.http.test-port` from the test itself using `Config` to get the real port (in case of using a random port for integration tests). From our tests, I don't see us doing that, but that doesn't mean users out there aren't. We could probably add a JUnit `ParameterResolver` to support injection of the `ListeningAddress`, but I'm not sure if this would be the final API we want to expose, since I think it would be interesting to have a unified API for both test and regular runtime. The real port is still registered with `RESTAssured`, so that is a way to get it if required. Again, this only applies to tests running outside Quarkus. 

Also, `io.quarkus.test.junit.QuarkusTestProfile#getConfigOverrides`, which was being set in `SystemProperties`, was moved to set the properties directly into the runner arguments, and set directly into the `CuratedApplication` when we require DevServices. This also means that properties set by `io.quarkus.test.junit.QuarkusTestProfile#getConfigOverrides` can no longer be retrieved by `ConfigProvider.getConfig` in integration-tests. Unsure if this is something that users use, but I'm thinking that we need to ban the usage of `ConfigProvider.getConfig`, and offer it as a test parameter, so we can create local instances to each test.

If this becomes a big issue, we can temporarily register the ports with System properties again. Hopefully, it shouldn't be required if we can do all the related work in a single release. This relates to:
- https://github.com/quarkusio/quarkus/pull/51209
- https://github.com/quarkusio/quarkus/discussions/46915

Splitting this into smaller PRs to make it easier to review and track.