### PR TITLE
Make token expiration configurable for OIDC Dev Services

### DIFF
--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesConfig.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.devservices.oidc;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -8,6 +9,7 @@ import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 /**
  * OpenID Connect Dev Services configuration.
@@ -21,6 +23,18 @@ public interface OidcDevServicesConfig {
      */
     @ConfigDocDefault("Enabled when Docker and Podman are not available")
     Optional<Boolean> enabled();
+
+    /**
+     * Relative duration the access token will expire in.
+     */
+    @WithDefault("5M")
+    Duration accessTokenExpiresIn();
+
+    /**
+     * Relative duration the ID token will expire in.
+     */
+    @WithDefault("5M")
+    Duration idTokenExpiresIn();
 
     /**
      * A map of roles for OIDC identity provider users.

--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
@@ -11,7 +11,6 @@ import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,6 +71,8 @@ public class OidcDevServicesProcessor {
     private static volatile String applicationType;
     private static volatile Map<String, String> configProperties;
     private static volatile Map<String, List<String>> userToDefaultRoles;
+    private static volatile Long accessTokenExpiresIn;
+    private static volatile Long idTokenExpiresIn;
     private static volatile Runnable closeDevServiceTask;
 
     @BuildStep
@@ -84,6 +85,8 @@ public class OidcDevServicesProcessor {
         }
 
         userToDefaultRoles = devServicesConfig.roles();
+        accessTokenExpiresIn = devServicesConfig.accessTokenExpiresIn().toSeconds();
+        idTokenExpiresIn = devServicesConfig.idTokenExpiresIn().toSeconds();
         if (closeDevServiceTask == null) {
             LOG.info("Starting Dev Services for OIDC");
             Vertx vertx = Vertx.vertx();
@@ -571,10 +574,10 @@ public class OidcDevServicesProcessor {
                 {
                   "access_token":"%s",
                   "token_type":"Bearer",
-                  "expires_in":3600,
+                  "expires_in":%d,
                   "refresh_token":"%s"
                 }
-                """.formatted(accessToken, refreshToken);
+                """.formatted(accessToken, accessTokenExpiresIn, refreshToken);
         rc.response()
                 .putHeader("Content-Type", "application/json")
                 .putHeader("Cache-Control", "no-store")
@@ -592,9 +595,9 @@ public class OidcDevServicesProcessor {
                 {
                       "access_token": "%s",
                       "token_type": "Bearer",
-                      "expires_in": 3600
+                      "expires_in": %d
                 }
-                """.formatted(accessToken);
+                """.formatted(accessToken, accessTokenExpiresIn);
         rc.response()
                 .putHeader("Content-Type", "application/json")
                 .putHeader("Cache-Control", "no-store")
@@ -669,9 +672,9 @@ public class OidcDevServicesProcessor {
                    "access_token": "%s",
                    "token_type": "Bearer",
                    "refresh_token": "%s",
-                   "expires_in": 3600
+                   "expires_in": %d
                 }
-                """.formatted(accessToken, refreshToken);
+                """.formatted(accessToken, refreshToken, accessTokenExpiresIn);
         rc.response()
                 .putHeader("Content-Type", "application/json")
                 .putHeader("Cache-Control", "no-store")
@@ -689,8 +692,8 @@ public class OidcDevServicesProcessor {
      * {
      * "token_type":"Bearer",
      * "scope":"openid email profile",
-     * "expires_in":3600,
-     * "ext_expires_in":3600,
+     * "expires_in":EXPIRES_IN,
+     * "ext_expires_in":EXPIRES_IN,
      * "access_token":TOKEN,
      * "id_token":JWT
      * }
@@ -734,13 +737,14 @@ public class OidcDevServicesProcessor {
                 {
                  "token_type":"Bearer",
                  "scope":"openid email profile",
-                 "expires_in":3600,
-                 "ext_expires_in":3600,
+                 "expires_in":%d,
+                 "ext_expires_in":%d,
                  "access_token":"%s",
                  "id_token":"%s",
                  "refresh_token": "%s"
                  }
-                """.formatted(accessToken, idToken, userAndRoles.encode());
+                """.formatted(accessTokenExpiresIn, accessTokenExpiresIn, accessToken, idToken,
+                userAndRoles.encode());
         rc.response()
                 .putHeader("Content-Type", "application/json")
                 .putHeader("Cache-Control", "no-store")
@@ -761,7 +765,7 @@ public class OidcDevServicesProcessor {
 
     private static String createIdToken(String user, Set<String> roles, String clientId) {
         return Jwt.claims()
-                .expiresIn(Duration.ofHours(1))
+                .expiresIn(idTokenExpiresIn)
                 .issuedAt(Instant.now())
                 .issuer(baseURI)
                 .audience(clientId)
@@ -778,7 +782,7 @@ public class OidcDevServicesProcessor {
 
     private static String createAccessToken(String user, Set<String> roles, Set<String> scope) {
         return Jwt.claims()
-                .expiresIn(Duration.ofHours(1))
+                .expiresIn(accessTokenExpiresIn)
                 .issuedAt(Instant.now())
                 .issuer(baseURI)
                 .subject(user)

--- a/integration-tests/oidc-dev-services/pom.xml
+++ b/integration-tests/oidc-dev-services/pom.xml
@@ -103,6 +103,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>

--- a/integration-tests/oidc-dev-services/pom.xml
+++ b/integration-tests/oidc-dev-services/pom.xml
@@ -103,7 +103,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>

--- a/integration-tests/oidc-dev-services/src/main/java/io/quarkus/it/oidc/dev/services/SecuredResource.java
+++ b/integration-tests/oidc-dev-services/src/main/java/io/quarkus/it/oidc/dev/services/SecuredResource.java
@@ -23,6 +23,9 @@ public class SecuredResource {
     JsonWebToken idToken;
 
     @Inject
+    JsonWebToken accessToken;
+
+    @Inject
     UserInfo userInfo;
 
     @Inject
@@ -45,6 +48,13 @@ public class SecuredResource {
     @Path("user-only")
     public String getUserOnly() {
         return userInfo.getPreferredUserName() + " " + securityIdentity.getRoles() + " " + userInfo.getName();
+    }
+
+    @RolesAllowed("user")
+    @GET
+    @Path("expires-in")
+    public String getExpiresIn() {
+        return String.valueOf(accessToken.getExpirationTime() - accessToken.getIssuedAtTime());
     }
 
     @GET

--- a/integration-tests/oidc-dev-services/src/test/java/io/quarkus/it/oidc/dev/services/BearerAuthenticationOidcDevServicesTest.java
+++ b/integration-tests/oidc-dev-services/src/test/java/io/quarkus/it/oidc/dev/services/BearerAuthenticationOidcDevServicesTest.java
@@ -91,6 +91,16 @@ public class BearerAuthenticationOidcDevServicesTest {
                 .body(Matchers.containsString(" Bob"));
     }
 
+    @Test
+    void testTokenExpiration() {
+        RestAssured.given()
+                .auth().oauth2(getAccessToken("bob"))
+                .get("/secured/expires-in")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is(String.valueOf(5 * 60L))); // The default token expiration is 5 minutes
+    }
+
     private String getAccessToken(String user) {
         return oidcTestClient.getAccessToken(user, user);
     }


### PR DESCRIPTION
This PR makes the expiration of the returned tokens by OIDC Dev Services configurable.

This should make it easier to debug token refresh and expiring tokens locally with OIDC Dev Services. Currently this is already possible with Keycloak Dev Services (the default token expiration is also 5 mins there), but using OIDC Dev Services locally is a lot nicer for most use cases.

Related to https://github.com/quarkusio/quarkus/issues/51332 & https://github.com/quarkusio/quarkus/pull/51344