### PR TITLE
Config relocation mp.messaging -> quarkus.messaging relocation/fallback

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -54,6 +54,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ClassCreator;
@@ -78,6 +79,7 @@ import io.quarkus.smallrye.reactivemessaging.runtime.HealthCenterFilter;
 import io.quarkus.smallrye.reactivemessaging.runtime.HealthCenterInterceptor;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusMediatorConfiguration;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusWorkerPoolRegistry;
+import io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfigBuilderCustomizer;
 import io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration;
 import io.quarkus.smallrye.reactivemessaging.runtime.RequestScopedDecorator;
 import io.quarkus.smallrye.reactivemessaging.runtime.SmallRyeReactiveMessagingLifecycle;
@@ -544,6 +546,13 @@ public class SmallRyeReactiveMessagingProcessor {
                             "io.quarkus.smallrye.reactivemessaging.runtime.kotlin.ApplicationCoroutineScope")
                     .setUnremovable().build());
         }
+    }
+
+    @BuildStep
+    void configCustomizer(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        // Config mapping between SmallRye / MP and Quarkus
+        serviceProvider.produce(ServiceProviderBuildItem
+                .allProvidersFromClassPath(ReactiveMessagingConfigBuilderCustomizer.class.getName()));
     }
 
     private void ensureKotlinCoroutinesEnabled(CoroutineConfigurationBuildItem coroutineConfigurationBuildItem,

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
@@ -81,7 +81,7 @@ public class WiringHelper {
      */
     static Optional<String> getManagingConnector(ChannelDirection direction, String channel) {
         return ConfigProvider.getConfig().getOptionalValue(
-                "mp.messaging." + direction.name().toLowerCase() + "." + normalizeChannelName(channel) + ".connector",
+                "quarkus.messaging." + direction.name().toLowerCase() + "." + normalizeChannelName(channel) + ".connector",
                 String.class);
     }
 
@@ -95,7 +95,8 @@ public class WiringHelper {
     static boolean isChannelEnabled(ChannelDirection direction, String channel) {
         return ConfigProvider.getConfig()
                 .getOptionalValue(
-                        "mp.messaging." + direction.name().toLowerCase() + "." + normalizeChannelName(channel) + ".enabled",
+                        "quarkus.messaging." + direction.name().toLowerCase() + "." + normalizeChannelName(channel)
+                                + ".enabled",
                         Boolean.class)
                 .orElse(true);
     }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigBuilderCustomizer.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigBuilderCustomizer.java
@@ -1,0 +1,46 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.function.Function;
+
+import io.smallrye.config.FallbackConfigSourceInterceptor;
+import io.smallrye.config.RelocateConfigSourceInterceptor;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+public class ReactiveMessagingConfigBuilderCustomizer implements SmallRyeConfigBuilderCustomizer {
+
+    @Override
+    public void configBuilder(SmallRyeConfigBuilder builder) {
+        builder.withInterceptors(new FallbackConfigSourceInterceptor(new Fallback()));
+        builder.withInterceptors(new RelocateConfigSourceInterceptor(new Relocate()));
+    }
+
+    private static final String REACTIVE_MESSAGING_PREFIX = "quarkus.messaging.";
+    private static final String MP_MESSAGING_PREFIX = "mp.messaging.";
+    private static final String INCOMING = "incoming.";
+    private static final String OUTGOING = "outgoing.";
+
+    private record Fallback() implements Function<String, String> {
+        @Override
+        public String apply(String name) {
+            if (name.startsWith(REACTIVE_MESSAGING_PREFIX)
+                    && (name.regionMatches(18, INCOMING, 0, 9) || name.regionMatches(18, OUTGOING, 0, 9))) {
+                // replaces quarkus with mp
+                return "mp" + name.substring(7);
+            }
+            return name;
+        }
+    }
+
+    private record Relocate() implements Function<String, String> {
+        @Override
+        public String apply(String name) {
+            if (name.startsWith(MP_MESSAGING_PREFIX)
+                    && (name.regionMatches(13, INCOMING, 0, 9) || name.regionMatches(13, OUTGOING, 0, 9))) {
+                // replaces mp with quarkus
+                return "quarkus" + name.substring(2);
+            }
+            return name;
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingRuntimeConfig.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingRuntimeConfig.java
@@ -1,12 +1,16 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocIgnore;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigMapping(prefix = "quarkus.messaging")
@@ -17,4 +21,46 @@ public interface ReactiveMessagingRuntimeConfig {
      */
     @WithName("connector-context-propagation")
     Optional<List<String>> connectorContextPropagation();
+
+    /**
+     * Used internally only. Users use <code>mp.messaging</code>.
+     */
+    @ConfigDocIgnore
+    Map<String, Incoming> incoming();
+
+    /**
+     * Used internally only. Users use <code>mp.messaging</code>.
+     */
+    @ConfigDocIgnore
+    Map<String, Outgoing> outgoing();
+
+    interface ChannelDirection {
+        /**
+         * Used internally only. Users use <code>mp.messaging</code>.
+         */
+        @ConfigDocIgnore
+        Optional<String> connector();
+
+        /**
+         * Used internally only. Users use <code>mp.messaging</code>.
+         */
+        @ConfigDocIgnore
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * Used internally only.
+         */
+        @ConfigDocIgnore
+        @WithParentName
+        Map<String, String> channelConfig();
+    }
+
+    interface Incoming extends ChannelDirection {
+
+    }
+
+    interface Outgoing extends ChannelDirection {
+
+    }
 }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfigBuilderCustomizer


### PR DESCRIPTION
#50800 introduced build-time config mapping for messaging channel configurations: `quarkus.messaging.[incoming|outgoing].[channel].connector` and `quarkus.messaging.[incoming|outgoing].[channel].enabled`, including config relocation/fallback for `mp.messaging` -> `quarkus.messaging` on those config properties.

While these config properties are read at build-time, they are ultimately a part of the runtime config.
So we had to revert that in #51309. 

This PR introduces the runtime config mapping for all properties `quarkus.messaging.[incoming|outgoing] and config relocations for `mp.messaging` -> `quarkus.messaging` for all properties.

@radcortez 