### PR TITLE
Clear some internal state of REST Assured between tests

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationPathHttpRootTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationPathHttpRootTest.java
@@ -26,7 +26,7 @@ public class ApplicationPathHttpRootTest {
 
     @Test
     public void testResources() {
-        // Note that /foo is added automatically by RestAssuredURLManager
+        // Note that /foo is added automatically by RestAssuredStateManager
         RestAssured.when().get("/hello/world").then().body(Matchers.is("hello world"));
         RestAssured.when().get("/world").then().statusCode(404);
     }

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -144,16 +144,6 @@
                     tests (using the 'default-test' execution), and one for the prod mode tests (this 'dev-mode' execution)
                     -->
                     <execution>
-                      <id>default-test</id>
-                      <configuration>
-                        <includes>
-                          <include>**/Test*.java</include>
-                          <include>**/*Test.java</include>
-                          <include>**/*Tests.java</include>
-                        </includes>
-                      </configuration>
-                    </execution>
-                    <execution>
                         <id>dev-mode</id>
                         <phase>test</phase>
                         <goals>
@@ -162,17 +152,6 @@
                         <configuration>
                             <includes>**/*DMT.java</includes>
                         </configuration>
-                    </execution>
-                    <!-- for now, run the TestCase in a separate surefire execution to try and minimize OOME issues -->
-                    <execution>
-                      <id>test-case</id>
-                      <phase>test</phase>
-                      <goals>
-                        <goal>test</goal>
-                      </goals>
-                      <configuration>
-                        <includes>**/*TestCase.java</includes>
-                      </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredStateManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredStateManager.java
@@ -1,0 +1,178 @@
+package io.quarkus.test.common;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.internal.path.json.ConfigurableJsonSlurper;
+import io.restassured.path.json.JsonPath;
+import io.restassured.specification.RequestSpecification;
+
+/**
+ * Utility class that sets the rest assured port to the default test port and meaningful timeouts.
+ * <p>
+ * This class works whether RestAssured is on the classpath or not - if it is not, invoking the methods of the class are
+ * essentially NO-OPs
+ * <p>
+ * TODO: do we actually want this here, or should it be in a different module?
+ */
+public class RestAssuredStateManager {
+
+    private static final int DEFAULT_HTTP_PORT = 8081;
+    private static final int DEFAULT_HTTPS_PORT = 8444;
+
+    private static int oldPort;
+    private static String oldBaseURI;
+    private static String oldBasePath;
+    private static Object oldRestAssuredConfig; // we can't declare the type here as that would prevent this class for being loaded if RestAssured is not present
+    private static Object oldRequestSpecification;
+
+    private static final boolean REST_ASSURED_PRESENT;
+
+    static {
+        boolean present = false;
+        try {
+            Class.forName("io.restassured.RestAssured");
+            present = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        REST_ASSURED_PRESENT = present;
+    }
+
+    private RestAssuredStateManager() {
+
+    }
+
+    private static int getPortFromConfig(int defaultValue, String... keys) {
+        for (String key : keys) {
+            Optional<Integer> port = ConfigProvider.getConfig().getOptionalValue(key, Integer.class);
+            if (port.isPresent())
+                return port.get();
+        }
+        return defaultValue;
+    }
+
+    public static void setURL(boolean useSecureConnection) {
+        setURL(useSecureConnection, null, null);
+    }
+
+    public static void setURL(boolean useSecureConnection, String additionalPath) {
+        setURL(useSecureConnection, null, additionalPath);
+    }
+
+    public static void setURL(boolean useSecureConnection, Integer port) {
+        setURL(useSecureConnection, port, null);
+    }
+
+    public static void setURL(boolean useSecureConnection, Integer port, String additionalPath) {
+        if (!REST_ASSURED_PRESENT) {
+            return;
+        }
+
+        oldPort = RestAssured.port;
+        if (port == null) {
+            port = useSecureConnection ? getPortFromConfig(DEFAULT_HTTPS_PORT, "quarkus.http.test-ssl-port")
+                    : getPortFromConfig(DEFAULT_HTTP_PORT, "quarkus.lambda.mock-event-server.test-port",
+                            "quarkus.http.test-port");
+        }
+        RestAssured.port = port;
+
+        oldBaseURI = RestAssured.baseURI;
+        final String protocol = useSecureConnection ? "https://" : "http://";
+        String host = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class)
+                .orElse("localhost");
+        if (host.equals("0.0.0.0")) {
+            host = "localhost";
+        }
+        RestAssured.baseURI = protocol + host;
+
+        oldBasePath = RestAssured.basePath;
+        Optional<String> basePath = ConfigProvider.getConfig().getOptionalValue("quarkus.http.root-path",
+                String.class);
+        if (basePath.isPresent() || additionalPath != null) {
+            StringBuilder bp = new StringBuilder();
+            if (basePath.isPresent()) {
+                if (basePath.get().startsWith("/")) {
+                    bp.append(basePath.get().substring(1));
+                } else {
+                    bp.append(basePath.get());
+                }
+                if (bp.toString().endsWith("/")) {
+                    bp.setLength(bp.length() - 1);
+                }
+            }
+            if (additionalPath != null) {
+                if (!additionalPath.startsWith("/")) {
+                    bp.append("/");
+                }
+                bp.append(additionalPath);
+                if (bp.toString().endsWith("/")) {
+                    bp.setLength(bp.length() - 1);
+                }
+            }
+            RestAssured.basePath = bp.toString();
+        }
+
+        oldRestAssuredConfig = RestAssured.config();
+
+        Duration timeout = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.http.test-timeout", Duration.class).orElse(Duration.ofSeconds(30));
+        configureTimeouts(timeout);
+
+        oldRequestSpecification = RestAssured.requestSpecification;
+        if (ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.test.rest-assured.enable-logging-on-failure", Boolean.class).orElse(true)) {
+            RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        }
+    }
+
+    private static void configureTimeouts(Duration d) {
+        RestAssured.config = RestAssured.config().httpClient(new HttpClientConfig()
+                .setParam("http.conn-manager.timeout", d.toMillis()) // this needs to be long
+                .setParam("http.connection.timeout", (int) d.toMillis()) // this needs to be int
+                .setParam("http.socket.timeout", (int) d.toMillis())); // same here
+    }
+
+    public static void clearState() {
+        if (!REST_ASSURED_PRESENT) {
+            return;
+        }
+
+        clearURL();
+
+        JsonPath.config = null;
+        // Reset the numberReturnType ThreadLocal in ConfigurableJsonSlurper as it is causing class loader leaks
+        try {
+            java.lang.reflect.Field numberReturnTypeField = ConfigurableJsonSlurper.class.getDeclaredField("numberReturnType");
+            numberReturnTypeField.setAccessible(true);
+            ThreadLocal<?> threadLocal = (ThreadLocal<?>) numberReturnTypeField.get(null);
+            if (threadLocal != null) {
+                threadLocal.remove();
+            }
+        } catch (Exception e) {
+            // Ignore if the field doesn't exist or can't be accessed
+        }
+    }
+
+    /**
+     * @deprecated most probably, you want to call {@link #clearState()}. If it's not the case, please let us know so that we
+     *             can reconsider the deprecation.
+     *             Note: when removing, please move the code to {@link #clearState()}.
+     */
+    @Deprecated(forRemoval = true, since = "3.31")
+    static void clearURL() {
+        if (!REST_ASSURED_PRESENT) {
+            return;
+        }
+
+        RestAssured.port = oldPort;
+        RestAssured.baseURI = oldBaseURI;
+        RestAssured.basePath = oldBasePath;
+        RestAssured.config = (RestAssuredConfig) oldRestAssuredConfig;
+        RestAssured.requestSpecification = (RequestSpecification) oldRequestSpecification;
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
@@ -1,58 +1,10 @@
 package io.quarkus.test.common;
 
-import java.time.Duration;
-import java.util.Optional;
-
-import org.eclipse.microprofile.config.ConfigProvider;
-
-import io.restassured.RestAssured;
-import io.restassured.config.HttpClientConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.specification.RequestSpecification;
-
 /**
- * Utility class that sets the rest assured port to the default test port and meaningful timeouts.
- * <p>
- * This class works whether RestAssured is on the classpath or not - if it is not, invoking the methods of the class are
- * essentially NO-OPs
- * <p>
- * TODO: do we actually want this here, or should it be in a different module?
+ * @deprecated use {@link RestAssuredStateManager} instead
  */
+@Deprecated(forRemoval = true, since = "3.31")
 public class RestAssuredURLManager {
-
-    private static final int DEFAULT_HTTP_PORT = 8081;
-    private static final int DEFAULT_HTTPS_PORT = 8444;
-
-    private static int oldPort;
-    private static String oldBaseURI;
-    private static String oldBasePath;
-    private static Object oldRestAssuredConfig; // we can't declare the type here as that would prevent this class for being loaded if RestAssured is not present
-    private static Object oldRequestSpecification;
-
-    private static final boolean REST_ASSURED_PRESENT;
-
-    static {
-        boolean present = false;
-        try {
-            Class.forName("io.restassured.RestAssured");
-            present = true;
-        } catch (ClassNotFoundException ignored) {
-        }
-        REST_ASSURED_PRESENT = present;
-    }
-
-    private RestAssuredURLManager() {
-
-    }
-
-    private static int getPortFromConfig(int defaultValue, String... keys) {
-        for (String key : keys) {
-            Optional<Integer> port = ConfigProvider.getConfig().getOptionalValue(key, Integer.class);
-            if (port.isPresent())
-                return port.get();
-        }
-        return defaultValue;
-    }
 
     public static void setURL(boolean useSecureConnection) {
         setURL(useSecureConnection, null, null);
@@ -67,83 +19,10 @@ public class RestAssuredURLManager {
     }
 
     public static void setURL(boolean useSecureConnection, Integer port, String additionalPath) {
-        if (!REST_ASSURED_PRESENT) {
-            return;
-        }
-
-        oldPort = RestAssured.port;
-        if (port == null) {
-            port = useSecureConnection ? getPortFromConfig(DEFAULT_HTTPS_PORT, "quarkus.http.test-ssl-port")
-                    : getPortFromConfig(DEFAULT_HTTP_PORT, "quarkus.lambda.mock-event-server.test-port",
-                            "quarkus.http.test-port");
-        }
-        RestAssured.port = port;
-
-        oldBaseURI = RestAssured.baseURI;
-        final String protocol = useSecureConnection ? "https://" : "http://";
-        String host = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class)
-                .orElse("localhost");
-        if (host.equals("0.0.0.0")) {
-            host = "localhost";
-        }
-        RestAssured.baseURI = protocol + host;
-
-        oldBasePath = RestAssured.basePath;
-        Optional<String> basePath = ConfigProvider.getConfig().getOptionalValue("quarkus.http.root-path",
-                String.class);
-        if (basePath.isPresent() || additionalPath != null) {
-            StringBuilder bp = new StringBuilder();
-            if (basePath.isPresent()) {
-                if (basePath.get().startsWith("/")) {
-                    bp.append(basePath.get().substring(1));
-                } else {
-                    bp.append(basePath.get());
-                }
-                if (bp.toString().endsWith("/")) {
-                    bp.setLength(bp.length() - 1);
-                }
-            }
-            if (additionalPath != null) {
-                if (!additionalPath.startsWith("/")) {
-                    bp.append("/");
-                }
-                bp.append(additionalPath);
-                if (bp.toString().endsWith("/")) {
-                    bp.setLength(bp.length() - 1);
-                }
-            }
-            RestAssured.basePath = bp.toString();
-        }
-
-        oldRestAssuredConfig = RestAssured.config();
-
-        Duration timeout = ConfigProvider.getConfig()
-                .getOptionalValue("quarkus.http.test-timeout", Duration.class).orElse(Duration.ofSeconds(30));
-        configureTimeouts(timeout);
-
-        oldRequestSpecification = RestAssured.requestSpecification;
-        if (ConfigProvider.getConfig()
-                .getOptionalValue("quarkus.test.rest-assured.enable-logging-on-failure", Boolean.class).orElse(true)) {
-            RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-        }
-    }
-
-    private static void configureTimeouts(Duration d) {
-        RestAssured.config = RestAssured.config().httpClient(new HttpClientConfig()
-                .setParam("http.conn-manager.timeout", d.toMillis()) // this needs to be long
-                .setParam("http.connection.timeout", (int) d.toMillis()) // this needs to be int
-                .setParam("http.socket.timeout", (int) d.toMillis())); // same here
+        RestAssuredStateManager.setURL(useSecureConnection, port, additionalPath);
     }
 
     public static void clearURL() {
-        if (!REST_ASSURED_PRESENT) {
-            return;
-        }
-
-        RestAssured.port = oldPort;
-        RestAssured.baseURI = oldBaseURI;
-        RestAssured.basePath = oldBasePath;
-        RestAssured.config = (RestAssuredConfig) oldRestAssuredConfig;
-        RestAssured.requestSpecification = (RequestSpecification) oldRequestSpecification;
+        RestAssuredStateManager.clearURL();
     }
 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -57,7 +57,7 @@ import io.quarkus.builder.item.BuildItem;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.common.PathTestHelper;
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredStateManager;
 import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.smallrye.common.process.ProcessUtil;
@@ -642,7 +642,7 @@ public class QuarkusProdModeTest
 
         }
         if (clearRestAssuredURL) {
-            RestAssuredURLManager.clearURL();
+            RestAssuredStateManager.clearState();
             clearRestAssuredURL = false;
         }
     }
@@ -653,12 +653,12 @@ public class QuarkusProdModeTest
                 .orElse(DEFAULT_HTTP_PORT_INT);
 
         // If http port is 0, then we need to set the port to null in order to use the `quarkus.http.test-ssl-port` property
-        // which is done in `RestAssuredURLManager.setURL`.
+        // which is done in `RestAssuredStateManager.setURL`.
         if (httpPort == 0) {
             httpPort = null;
         }
 
-        RestAssuredURLManager.setURL(false, httpPort);
+        RestAssuredStateManager.setURL(false, httpPort);
     }
 
     private void ensureApplicationStartupOrFailure() throws IOException {

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -70,7 +70,7 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.common.GroovyClassValue;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.PropertyTestUtil;
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredStateManager;
 import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
@@ -849,8 +849,8 @@ public class QuarkusUnitTest
     public void afterEach(ExtensionContext context) throws Exception {
         if (runningQuarkusApplication != null) {
             //this kinda sucks, but everything is isolated, so we need to hook into everything via reflection
-            runningQuarkusApplication.getClassLoader().loadClass(RestAssuredURLManager.class.getName())
-                    .getDeclaredMethod("clearURL")
+            runningQuarkusApplication.getClassLoader().loadClass(RestAssuredStateManager.class.getName())
+                    .getDeclaredMethod("clearState")
                     .invoke(null);
         }
     }
@@ -862,7 +862,7 @@ public class QuarkusUnitTest
             return;
         }
         if (runningQuarkusApplication != null) {
-            runningQuarkusApplication.getClassLoader().loadClass(RestAssuredURLManager.class.getName())
+            runningQuarkusApplication.getClassLoader().loadClass(RestAssuredStateManager.class.getName())
                     .getDeclaredMethod("setURL", boolean.class).invoke(null, useSecureConnection);
         } else {
             Optional<Class<?>> testClass = context.getTestClass();

--- a/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestExpectExitTest.java
+++ b/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestExpectExitTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import io.quarkus.runtime.annotations.QuarkusMain;
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredStateManager;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class QuarkusProdModeTestExpectExitTest {
@@ -40,7 +40,7 @@ public class QuarkusProdModeTestExpectExitTest {
         thenAppIsNotRunning();
         thenAppWasNotRestarted();
 
-        try (var urlMgrMock = Mockito.mockStatic(RestAssuredURLManager.class)) {
+        try (var urlMgrMock = Mockito.mockStatic(RestAssuredStateManager.class)) {
             whenStartApp();
             thenAppIsNotRunning();
             thenAppWasRestarted();

--- a/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestTest.java
+++ b/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredStateManager;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class QuarkusProdModeTestTest {
@@ -27,7 +27,7 @@ public class QuarkusProdModeTestTest {
     public void shouldStopAndStartManually() {
         thenAppIsRunning();
 
-        try (var urlMgrMock = Mockito.mockStatic(RestAssuredURLManager.class)) {
+        try (var urlMgrMock = Mockito.mockStatic(RestAssuredStateManager.class)) {
             whenStopApp();
             thenAppIsNotRunning();
 
@@ -37,8 +37,8 @@ public class QuarkusProdModeTestTest {
             whenStopApp(); // stop again to verify in next test method that app was auto-restarted
             thenAppIsNotRunning();
 
-            urlMgrMock.verify(() -> RestAssuredURLManager.setURL(false, 8081));
-            urlMgrMock.verify(RestAssuredURLManager::clearURL, times(2));
+            urlMgrMock.verify(() -> RestAssuredStateManager.setURL(false, 8081));
+            urlMgrMock.verify(RestAssuredStateManager::clearState, times(2));
         }
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -47,7 +47,7 @@ import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DevServicesContext;
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredStateManager;
 import io.quarkus.test.common.RunCommandLauncher;
 import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestHostLauncher;
@@ -90,7 +90,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                 invokeAfterEachCallbacks(createQuarkusTestMethodContext(context));
             }
 
-            RestAssuredURLManager.clearURL();
+            RestAssuredStateManager.clearState();
             TestScopeManager.tearDown(true);
         }
     }
@@ -116,7 +116,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                 invokeBeforeEachCallbacks(createQuarkusTestMethodContext(context));
             }
 
-            RestAssuredURLManager.setURL(ssl, QuarkusTestExtension.getEndpointPath(context, testHttpEndpointProviders));
+            RestAssuredStateManager.setURL(ssl, QuarkusTestExtension.getEndpointPath(context, testHttpEndpointProviders));
             TestScopeManager.setup(true);
         }
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -68,7 +68,7 @@ import io.quarkus.runtime.configuration.DurationConverter;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.TestMethodInvoker;
 import io.quarkus.test.common.GroovyClassValue;
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredStateManager;
 import io.quarkus.test.common.RestorableSystemProperties;
 import io.quarkus.test.common.TestClassIndexer;
 import io.quarkus.test.common.TestResourceManager;
@@ -401,7 +401,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                 if (insecureAllowed.isPresent()) {
                     secure = !insecureAllowed.get().toLowerCase(Locale.ENGLISH).equals("enabled");
                 }
-                runningQuarkusApplication.getClassLoader().loadClass(RestAssuredURLManager.class.getName())
+                runningQuarkusApplication.getClassLoader().loadClass(RestAssuredStateManager.class.getName())
                         .getDeclaredMethod("setURL", boolean.class, String.class).invoke(null, secure, endpointPath);
                 runningQuarkusApplication.getClassLoader().loadClass(TestScopeManager.class.getName())
                         .getDeclaredMethod("setup", boolean.class).invoke(null, false);
@@ -521,8 +521,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             popMockContext();
             Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
             invokeAfterEachCallbacks(tuple.getKey(), tuple.getValue());
-            runningQuarkusApplication.getClassLoader().loadClass(RestAssuredURLManager.class.getName())
-                    .getDeclaredMethod("clearURL").invoke(null);
+            runningQuarkusApplication.getClassLoader().loadClass(RestAssuredStateManager.class.getName())
+                    .getDeclaredMethod("clearState").invoke(null);
             runningQuarkusApplication.getClassLoader().loadClass(TestScopeManager.class.getName())
                     .getDeclaredMethod("tearDown", boolean.class).invoke(null, false);
 


### PR DESCRIPTION
It seems to improve the class loader leaks issues.

Also revert the previous workaround in the hope it won't be useful anymore.

I was able to run the tests locally after this patch but let's see what CI has to say.
