### PR TITLE
Make container-image.tag optional so it is possible to nullify it

### DIFF
--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
@@ -30,8 +30,8 @@ public interface ContainerImageConfig {
     /**
      * The tag of the container image. If not set defaults to the application version
      */
-    @WithDefault("${quarkus.application.version:latest}")
-    String tag(); //used only by ContainerImageProcessor, use ContainerImageInfoBuildItem instead
+    // keep it Optional as we need the ability to nullify it
+    Optional<String> tag(); //used only by ContainerImageProcessor, use ContainerImageInfoBuildItem instead
 
     /**
      * Additional tags of the container image.

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
@@ -105,7 +105,7 @@ public class ContainerImageProcessor {
                     + group + "' and name '" + effectiveName + "' is invalid");
         }
 
-        String effectiveTag = containerImageConfig.tag();
+        String effectiveTag = containerImageConfig.tag().orElse(app.getVersion());
         if (effectiveTag.equals(UNSET_VALUE)) {
             effectiveTag = DEFAULT_TAG;
         }


### PR DESCRIPTION
This used to work in 3.15.1 and it broke one use case we had in the book - https://github.com/xstefank/quarkus-in-action/blob/main/chapter-11/11_3_4/inventory-service/src/main/resources/application.properties