### PR TITLE
Unconditionally register o.sf.d.u.Streamable for reflection

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -44,7 +44,6 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.hibernate.orm.deployment.IgnorableNonIndexedClasses;
 import io.quarkus.hibernate.orm.deployment.JpaModelPersistenceUnitMappingBuildItem;
@@ -97,12 +96,6 @@ public class SpringDataJPAProcessor {
         return new IgnorableNonIndexedClasses(ignorable);
     }
 
-    @BuildStep(onlyIf = NativeImageFutureDefault.CompleteReflectionTypes.class)
-    void registerReflectionForCompleteReflectionTypes(BuildProducer<ReflectiveClassBuildItem> producer) {
-        producer.produce(ReflectiveClassBuildItem.builder(
-                "org.springframework.data.util.Streamable").methods().build());
-    }
-
     @BuildStep
     void registerReflection(BuildProducer<ReflectiveClassBuildItem> producer) {
         producer.produce(ReflectiveClassBuildItem.builder(
@@ -114,7 +107,8 @@ public class SpringDataJPAProcessor {
                 "org.springframework.data.domain.Sort",
                 "org.springframework.data.domain.Chunk",
                 "org.springframework.data.domain.PageRequest",
-                "org.springframework.data.domain.AbstractPageRequest").methods().build());
+                "org.springframework.data.domain.AbstractPageRequest",
+                "org.springframework.data.util.Streamable").methods().build());
     }
 
     @BuildStep


### PR DESCRIPTION
This reflection configuration is already turned on for native builds (Mandrel/GraalVM 25) with` --future-defaults=all` being turned on. Since a GraalVM master build trips over this issue as well I propose to enable the reflection config unconditionally. 

**Testing:**
- [x] spring-data-jpa native integration test with Mandrel 23.1
- [x] spring-data-jpa native integration test with Mandrel 25.0
- [x] spring-data-jpa native integration test with GraalVM CE build from master branch

Closes: #51403