### PR TITLE
Upgrade to Gizmo 2.0.0.CR1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <!-- GraalVM sdk 23.1.2 has a minimum JDK requirement of 17+ at runtime -->
         <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.9.0</gizmo.version>
-        <gizmo2.version>2.0.0.Beta10</gizmo2.version>
+        <gizmo2.version>2.0.0.CR1</gizmo2.version>
         <jackson-bom.version>2.20.1</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -46,7 +46,7 @@
         <!-- main versions -->
         <version.gizmo>1.9.0</version.gizmo>
         <version.jandex>3.5.3</version.jandex>
-        <version.gizmo2>2.0.0.Beta10</version.gizmo2>
+        <version.gizmo2>2.0.0.CR1</version.gizmo2>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.mutiny>3.1.0</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>

--- a/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
+++ b/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
@@ -112,6 +112,8 @@
                 <exclude>org.graalvm.nativeimage:svm</exclude>
                 <!-- moved to com.mysql:mysql-connector-j -->
                 <exclude>mysql:mysql-connector-java</exclude>
+                <!-- Use the SmallRye classfile API instead -->
+                <exclude>io.github.dmlloyd:jdk-classfile-backport</exclude>
             </excludes>
             <includes>
                 <!-- this is for REST Assured -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -41,7 +41,7 @@
         <version.junit>5.13.4</version.junit>
         <version.assertj>3.27.6</version.assertj>
         <version.jandex>3.5.3</version.jandex>
-        <version.gizmo2>2.0.0.Beta10</version.gizmo2>
+        <version.gizmo2>2.0.0.CR1</version.gizmo2>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.smallrye-common>2.14.0</version.smallrye-common>
         <version.smallrye-mutiny>3.1.0</version.smallrye-mutiny>


### PR DESCRIPTION
The change includes a change to the classfile API, and an enforcer rule to prevent two versions from being present.
