### PR TITLE
Missing Jackson dependencies to AWT Packaging integration test

### DIFF
--- a/integration-tests/awt-packaging/pom.xml
+++ b/integration-tests/awt-packaging/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jaxb</artifactId>
         </dependency>
         <dependency>
@@ -51,6 +55,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/51389, I had to change this test a bit to drop the old amazon-lambda-test extension.

The test invokes a REST endpoint and a lambda with an XML payload, but I couldn't make the Mock Lambda Event Server accept XML, so I've changed it to use JSON instead. The test is missing the Jackson dependencies... unsure how it seems to work (the test passed in the CI build), but I've seen it fail as well.