### PR TITLE
Add missing imports to Decorator example

### DIFF
--- a/docs/src/main/asciidoc/cdi.adoc
+++ b/docs/src/main/asciidoc/cdi.adoc
@@ -443,6 +443,8 @@ import jakarta.decorator.Delegate;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Decorated;
+import jakarta.enterprise.inject.spi.Bean;
 
 public interface Account {
    void withdraw(BigDecimal amount);


### PR DESCRIPTION
Add missing imports for import jakarta.enterprise.inject.Decorated and jakarta.enterprise.inject.spi.Bean for consistency.