### PR TITLE
Keep track of generated and transformed classes to avoid lookups

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
@@ -112,7 +112,6 @@ public class SerializedApplication {
             }
             String mainClass = in.readUTF();
             ResourceDirectoryTracker resourceDirectoryTracker = new ResourceDirectoryTracker();
-            Set<String> parentFirstPackages = new HashSet<>();
             int numPaths = in.readUnsignedShort();
             ClassLoadingResource[] allClassLoadingResources = new ClassLoadingResource[numPaths];
             ClassLoadingResource generatedBytecodeClassLoadingResource = null;
@@ -161,18 +160,20 @@ public class SerializedApplication {
                 }
             }
             int packages = in.readUnsignedShort();
+            Set<String> parentFirstPackages = new HashSet<>((int) Math.ceil(packages / 0.75f));
             for (int i = 0; i < packages; ++i) {
                 parentFirstPackages.add(in.readUTF());
             }
-            Set<String> nonExistentResources = new HashSet<>();
             int nonExistentResourcesSize = in.readUnsignedShort();
+            Set<String> nonExistentResources = new HashSet<>((int) Math.ceil(nonExistentResourcesSize / 0.75f));
             for (int i = 0; i < nonExistentResourcesSize; i++) {
                 nonExistentResources.add(in.readUTF());
             }
             // this map is populated correctly because the JarResource entries are added to allClassLoadingResources
             // in the same order as the classpath was written during the writing of the index
-            Map<String, ClassLoadingResource[]> directlyIndexedResourcesIndexMap = new HashMap<>();
             int directlyIndexedSize = in.readUnsignedShort();
+            Map<String, ClassLoadingResource[]> directlyIndexedResourcesIndexMap = new HashMap<>(
+                    (int) Math.ceil(directlyIndexedSize / 0.75f));
             for (int i = 0; i < directlyIndexedSize; i++) {
                 String resource = in.readUTF();
                 int indexesSize = in.readUnsignedShort();

--- a/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/RunnerClassLoaderTest.java
+++ b/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/RunnerClassLoaderTest.java
@@ -38,7 +38,9 @@ public class RunnerClassLoaderTest {
 
         RunnerClassLoader runnerClassLoader = new RunnerClassLoader(ClassLoader.getSystemClassLoader(), resourceDirectoryMap,
                 Collections.emptySet(), Collections.emptySet(),
-                Collections.emptyList(), Collections.emptyMap());
+                Collections.emptyList(), Collections.emptyMap(),
+                null, Collections.emptySet(),
+                null, Collections.emptySet());
 
         // Put the RunnerClassLoader in a postBootPhase thus enabling the jars cache
         runnerClassLoader.resetInternalCaches();
@@ -110,7 +112,9 @@ public class RunnerClassLoaderTest {
 
         RunnerClassLoader runnerClassLoader = new RunnerClassLoader(ClassLoader.getSystemClassLoader(), resourceDirectoryMap,
                 Collections.emptySet(), Collections.emptySet(),
-                Collections.emptyList(), Collections.emptyMap());
+                Collections.emptyList(), Collections.emptyMap(),
+                null, Collections.emptySet(),
+                null, Collections.emptySet());
 
         assertThat(runnerClassLoader.findResource("org").toString()).endsWith("/org");
         assertThat(runnerClassLoader.findResource("org/").toString()).endsWith("/org/");


### PR DESCRIPTION
It happens quite often that a given directory has a couple of
generated/transformed classes and in this case we hit the
generated/transformed-bytecode jars for each lookup in this directory,
even for the regular case of the class being in the "standard" jars.

Keeping track of generated and transformed classes allows to avoid this
additional work with minimal added cost.

In my testing, it dropped 10 ms from the startup time, going from 367 to
353ms for a simple Quarkus REST app.

There's also an additional commit for a tiny improvement.
