### PR TITLE
Unconditionally enable complete reflection type changes in quarkus

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -28,7 +28,6 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.deployment.util.ReflectUtil;
 import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
 import io.smallrye.config.ConfigMapping;
@@ -140,9 +139,7 @@ public class ConfigMappingUtils {
             additionalConstrainedClasses.produce(AdditionalConstrainedClassBuildItem.of(mappingMetadata.getClassName(),
                     classBytes));
             ReflectiveClassBuildItem.Builder reflection = ReflectiveClassBuildItem.builder(mappingMetadata.getClassName());
-            if (NativeImageFutureDefault.COMPLETE_REFLECTION_TYPES.isEnabled(nativeConfig)) {
-                reflection.methods();
-            }
+            reflection.methods();
             reflectiveClasses.produce(reflection
                     .reason(ConfigMappingUtils.class.getName())
                     .build());

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -38,7 +38,6 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.deployment.util.JandexUtil;
 
 public class ReflectiveHierarchyStep {
@@ -238,13 +237,11 @@ public class ReflectiveHierarchyStep {
                 info.superName(), initialName,
                 processedReflectiveHierarchies,
                 unindexedClasses, reflectiveClass, visits));
-        if (NativeImageFutureDefault.COMPLETE_REFLECTION_TYPES.isEnabled(nativeConfig)) {
-            for (Type interfaceType : info.interfaceTypes()) {
-                visits.addLast(() -> addReflectiveHierarchy(nativeConfig, combinedIndexBuildItem, capabilities,
-                        reflectiveHierarchyBuildItem,
-                        source, interfaceType, processedReflectiveHierarchies, unindexedClasses,
-                        reflectiveClass, visits));
-            }
+        for (Type interfaceType : info.interfaceTypes()) {
+            visits.addLast(() -> addReflectiveHierarchy(nativeConfig, combinedIndexBuildItem, capabilities,
+                    reflectiveHierarchyBuildItem,
+                    source, interfaceType, processedReflectiveHierarchies, unindexedClasses,
+                    reflectiveClass, visits));
         }
         for (FieldInfo field : info.fields()) {
             if (reflectiveHierarchyBuildItem.getIgnoreFieldPredicate().test(field) ||

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -26,7 +26,6 @@ import io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageRunnerBuildItem;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabledBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.pkg.steps.NoopNativeImageBuildRunner;
 import io.quarkus.runtime.graal.GraalVM;
@@ -302,15 +301,11 @@ class AwtProcessor {
                 "java.awt",
                 "javax.imageio",
                 "sun.awt",
+                "sun.datatransfer",
                 "sun.font",
                 "sun.java2d")
                 .map(RuntimeInitializedPackageBuildItem::new)
                 .forEach(runtimeInitilizedPackages::produce);
         //@formatter:on
-    }
-
-    @BuildStep(onlyIf = NativeImageFutureDefault.CompleteReflectionTypes.class)
-    RuntimeInitializedPackageBuildItem runtimeInitializedClassesForCompleteReflectionTypes() {
-        return new RuntimeInitializedPackageBuildItem("sun.datatransfer");
     }
 }


### PR DESCRIPTION
The graal master branch made complete reflection types default. See:
https://github.com/oracle/graal/pull/12521

The impact of it has been assessed in this issue:
https://github.com/oracle/graal/issues/7753

By unconditionally enabling complete reflection types we enable quarkus testing on graal master. The impact for quarkus seems to be similar (or smaller, see attached charts) as reported in the upstream issue.

- Closes: #51271
- Closes: #51392
- Closes: #51393