### PR TITLE
QuarkusComponentTest: remove duplicate unsatisfied injection points

### DIFF
--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/ComponentContainer.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/ComponentContainer.java
@@ -59,6 +59,7 @@ import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.jboss.logging.Logger;
@@ -355,6 +356,19 @@ class ComponentContainer {
                         }
                         unsatisfiedInjectionPoints
                                 .add(new TypeAndQualifiers(Types.jandexType(param.getParameterizedType()), requiredQualifiers));
+                    }
+
+                    // We need to remove duplicate unsatisfied injection points
+                    // More specifically, injection points with the the same required type
+                    // and the same qualifiers (with non-binding members ignored)
+                    if (!unsatisfiedInjectionPoints.isEmpty()) {
+                        Map<DotName, Set<String>> qualifierToNonbindingMembers = findQualifierToNonbindingMembers(
+                                beanDeployment);
+                        if (!qualifierToNonbindingMembers.isEmpty()) {
+                            findDuplicateInjectionPoints(beanDeployment, unsatisfiedInjectionPoints,
+                                    qualifierToNonbindingMembers)
+                                    .forEach(unsatisfiedInjectionPoints::remove);
+                        }
                     }
 
                     for (TypeAndQualifiers unsatisfied : unsatisfiedInjectionPoints) {
@@ -889,6 +903,94 @@ class ComponentContainer {
     private static Set<Annotation> findBindings(Method method, Set<String> bindings) {
         return Arrays.stream(method.getAnnotations()).filter(a -> bindings.contains(a.annotationType().getName()))
                 .collect(Collectors.toSet());
+    }
+
+    private static Map<DotName, Set<String>> findQualifierToNonbindingMembers(BeanDeployment beanDeployment) {
+        Map<DotName, Set<String>> ret = new HashMap<>();
+        for (ClassInfo qualifier : beanDeployment.getQualifiers()) {
+            Set<String> nonbinding = new HashSet<>();
+            for (MethodInfo m : qualifier.methods()) {
+                if (m.hasAnnotation(DotNames.NONBINDING)) {
+                    nonbinding.add(m.name());
+                }
+            }
+            nonbinding.addAll(beanDeployment.getQualifierNonbindingMembers(qualifier.name()));
+            if (!nonbinding.isEmpty()) {
+                ret.put(qualifier.name(), nonbinding);
+            }
+        }
+        return ret;
+    }
+
+    private static List<TypeAndQualifiers> findDuplicateInjectionPoints(BeanDeployment beanDeployment,
+            Set<TypeAndQualifiers> unsatisfiedInjectionPoints, Map<DotName, Set<String>> qualifierToNonbindingMembers) {
+        List<TypeAndQualifiers> ret = new ArrayList<>();
+
+        for (List<TypeAndQualifiers> groupByType : unsatisfiedInjectionPoints.stream()
+                .collect(Collectors.groupingBy(ip -> ip.type)).values()) {
+
+            if (groupByType.size() > 1) {
+                for (List<TypeAndQualifiers> groupByNumberOfQualifiers : groupByType.stream()
+                        .collect(Collectors.groupingBy(tq -> tq.qualifiers.size())).values()) {
+
+                    if (groupByNumberOfQualifiers.size() > 1) {
+                        for (Entry<Set<DotName>, List<TypeAndQualifiers>> e : groupByNumberOfQualifiers.stream()
+                                .collect(Collectors.groupingBy(tq -> {
+                                    return tq.qualifiers.stream().map(AnnotationInstance::name).collect(Collectors.toSet());
+                                })).entrySet()) {
+
+                            List<TypeAndQualifiers> byQualiferNames = e.getValue();
+                            if (byQualiferNames.size() > 1) {
+                                Set<DotName> qualifiers = e.getKey();
+                                boolean nonbinding = false;
+                                for (DotName q : qualifiers) {
+                                    if (qualifierToNonbindingMembers.containsKey(q)) {
+                                        nonbinding = true;
+                                        break;
+                                    }
+                                }
+                                if (nonbinding) {
+                                    // At least two unsatisfied injection points with
+                                    // - the same required type
+                                    // - the same qualifier annotations
+                                    // - where at least one qualifier has a @Nonbinding member
+                                    for (List<TypeAndQualifiers> maybeDuplicit : byQualiferNames.stream()
+                                            .collect(Collectors.groupingBy(
+                                                    tq -> new MatchingQualifiers(tq, qualifierToNonbindingMembers)))
+                                            .values()) {
+                                        if (maybeDuplicit.size() > 1) {
+                                            maybeDuplicit.subList(1, maybeDuplicit.size()).forEach(ret::add);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    record MatchingQualifier(DotName name, Set<AnnotationValue> values) {
+
+        public MatchingQualifier(AnnotationInstance annotation, Map<DotName, Set<String>> qualifierToNonbindingMembers) {
+            this(annotation.name(),
+                    annotation.values().stream()
+                            .filter(v -> !qualifierToNonbindingMembers.get(annotation.name()).contains(v.name()))
+                            .collect(Collectors.toSet()));
+        }
+
+    }
+
+    record MatchingQualifiers(Set<MatchingQualifier> qualifiers) {
+
+        public MatchingQualifiers(TypeAndQualifiers typeAndQualifiers, Map<DotName, Set<String>> qualifierToNonbindingMembers) {
+            this(typeAndQualifiers.qualifiers.stream()
+                    .map(q -> new MatchingQualifier(q, qualifierToNonbindingMembers))
+                    .collect(Collectors.toSet()));
+        }
+
     }
 
     @SuppressWarnings("unchecked")

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/unsatisfied/UnsatisfiedDependencyClassHierarchyTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/unsatisfied/UnsatisfiedDependencyClassHierarchyTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.test.component.unsatisfied;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class UnsatisfiedDependencyClassHierarchyTest {
+
+    @Inject
+    Consumer consumer;
+
+    @InjectMock
+    Foo fooMock;
+
+    @InjectMock
+    Bar barMock;
+
+    @Test
+    public void testAutoMocks() {
+        Mockito.when(fooMock.val()).thenReturn("fooMock");
+        Mockito.when(barMock.val()).thenReturn("barMock");
+        assertEquals("fooMock", consumer.foo.val());
+        assertEquals("barMock", consumer.bar.val());
+    }
+
+    @Singleton
+    public static class Consumer {
+
+        @Inject
+        Foo foo; // -> register mock synthetic bean for bean types [Foo] and default qualifiers
+
+        @Inject
+        Bar bar; // -> register mock synthetic bean for bean types [Bar] and default qualifiers
+
+    }
+
+    public static class Foo {
+
+        String val() {
+            return "foo";
+        }
+
+    }
+
+    public static class Bar extends Foo {
+
+        @Override
+        String val() {
+            return super.val() + "bar";
+        }
+
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/unsatisfied/UnsatisfiedDependencyNonbindingQualifierMemberTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/unsatisfied/UnsatisfiedDependencyNonbindingQualifierMemberTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.test.component.unsatisfied;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Retention;
+
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Inject;
+import jakarta.inject.Qualifier;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class UnsatisfiedDependencyNonbindingQualifierMemberTest {
+
+    @Inject
+    FooConsumer consumer;
+
+    @InjectMock
+    @FooQualifier("ignored")
+    Foo mock; // this mock is used for both FooConsumer#alpha nad FooConsumer#bravo
+
+    @Test
+    public void testAutoMocks() {
+        Mockito.when(mock.val()).thenReturn("dummy");
+        assertEquals("dummydummy", consumer.ping());
+    }
+
+    @Singleton
+    public static class FooConsumer {
+
+        @FooQualifier("alpha")
+        Foo alpha;
+
+        @FooQualifier("bravo")
+        Foo bravo;
+
+        public String ping() {
+            return alpha.val() + bravo.val();
+        }
+
+    }
+
+    public static class Foo {
+
+        String val() {
+            return "foo";
+        }
+
+    }
+
+    @Qualifier
+    @Retention(RUNTIME)
+    public @interface FooQualifier {
+
+        @Nonbinding
+        String value();
+    }
+
+}


### PR DESCRIPTION
- these duplicates can appear if a qualifier with non-binding member is used
- fixes #51378