### PR TITLE
Avoid VertxHttpRecorder to trigger warnings about sun.misc.Unsafe by initializing Netty constants

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -57,6 +57,7 @@ import io.quarkus.netty.runtime.virtual.VirtualAddress;
 import io.quarkus.netty.runtime.virtual.VirtualChannel;
 import io.quarkus.netty.runtime.virtual.VirtualServerChannel;
 import io.quarkus.runtime.ErrorPageAction;
+import io.quarkus.runtime.JVMChecksRecorder;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.LiveReloadConfig;
 import io.quarkus.runtime.QuarkusBindException;
@@ -130,6 +131,14 @@ import io.vertx.ext.web.handler.CorsHandler;
 
 @Recorder
 public class VertxHttpRecorder {
+
+    //Unfortunately this needs to be triggered in a static block on the very top of this class,
+    //as several static class initializers triggered by this class might cause the warning to be logged
+    //as a side-effect of initializing Netty classes; even a simple AsciiString constant initialization
+    //triggers it.
+    static {
+        JVMChecksRecorder.disableUnsafeRelatedWarnings();
+    }
 
     /**
      * The key that the request start time is stored under


### PR DESCRIPTION

Essentially `VertxHttpRecorder` was bypassing the solution previously implemented in #49979 as it's triggering some class initializations as a side-effect of Netty classes, before the perform the regular bootstrap of Netty.

* Fixes #51371 

This is hard to test - apparently @geoand couldn't reproduce on his machine, but it triggered on mine - and this fixes it.
This doesn't bother me as it's just about avoiding a particular warning to be logged.