### PR TITLE
Add test for disabling GraphQL over HTTP GET requests and move runtime config to the recorder

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -18,7 +18,6 @@ import java.util.concurrent.SubmissionPublisher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
@@ -473,13 +472,11 @@ public class SmallRyeGraphQLProcessor {
         });
 
         // Queries and Mutations
-        boolean allowGet = getBooleanConfigValue(ConfigKey.ALLOW_GET, false);
-        boolean allowQueryParametersOnPost = getBooleanConfigValue(ConfigKey.ALLOW_POST_WITH_QUERY_PARAMETERS, false);
         boolean allowCompression = httpBuildTimeConfig.enableCompression() && httpBuildTimeConfig.compressMediaTypes()
                 .map(mediaTypes -> mediaTypes.contains(GRAPHQL_MEDIA_TYPE))
                 .orElse(false);
         Handler<RoutingContext> executionHandler = recorder.executionHandler(graphQLInitializedBuildItem.getInitialized(),
-                allowGet, allowQueryParametersOnPost, runBlocking, allowCompression);
+                runBlocking, allowCompression);
 
         HttpRootPathBuildItem.Builder requestBuilder = httpRootPathBuildItem.routeBuilder()
                 .routeFunction(graphQLConfig.rootPath(), recorder.routeFunction(bodyHandlerBuildItem.getHandler()))
@@ -523,10 +520,6 @@ public class SmallRyeGraphQLProcessor {
             return !graphQLConfig.nonBlockingEnabled().get();
         }
         return false;
-    }
-
-    private boolean getBooleanConfigValue(String smallryeKey, boolean defaultValue) {
-        return ConfigProvider.getConfig().getOptionalValue(smallryeKey, boolean.class).orElse(defaultValue);
     }
 
     private String[] getSchemaJavaClasses(Schema schema) {

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLOverHttpDisabledGetTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLOverHttpDisabledGetTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.HttpURLConnection;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GraphQLOverHttpDisabledGetTest extends AbstractGraphQLTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(GraphQLOverHttpApi.class, User.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-graphql.http.get.enabled=false"), "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void shouldNotAllowGet() {
+        given().basePath("graphql")
+                .contentType("application/json")
+                .get()
+                .then().assertThat()
+                .statusCode(HttpURLConnection.HTTP_BAD_METHOD);
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -70,9 +70,11 @@ public class SmallRyeGraphQLRecorder {
         }
     }
 
-    public Handler<RoutingContext> executionHandler(RuntimeValue<Boolean> initialized, boolean allowGet,
-            boolean allowPostWithQueryParameters, boolean runBlocking, boolean allowCompression) {
+    public Handler<RoutingContext> executionHandler(RuntimeValue<Boolean> initialized, boolean runBlocking,
+            boolean allowCompression) {
         if (initialized.getValue()) {
+            boolean allowGet = runtimeConfig.getValue().httpGetEnabled();
+            boolean allowPostWithQueryParameters = runtimeConfig.getValue().httpPostQueryParametersEnabled();
             Handler<RoutingContext> handler = new SmallRyeGraphQLExecutionHandler(allowGet,
                     allowPostWithQueryParameters, runBlocking,
                     getCurrentIdentityAssociation(),

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
@@ -83,13 +83,15 @@ public interface SmallRyeGraphQLRuntimeConfig {
      * Enable GET Requests. Allow queries via HTTP GET.
      */
     @WithName("http.get.enabled")
-    Optional<Boolean> httpGetEnabled();
+    @WithDefault("false")
+    boolean httpGetEnabled();
 
     /**
      * Enable Query parameter on POST Requests. Allow POST request to override or supply values in a query parameter.
      */
     @WithName("http.post.queryparameters.enabled")
-    Optional<Boolean> httpPostQueryParametersEnabled();
+    @WithDefault("false")
+    boolean httpPostQueryParametersEnabled();
 
     /**
      * Include the Scalar definitions in the schema.


### PR DESCRIPTION
- Add test to validate configuration for disabling GraphQL over HTTP GET requests


It also moves the runtime config to the recorder

This should fix the SmallRye GraphQL failures in https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/20015957338 