### PR TITLE
Make sure we don't accept unannotated parameters for records

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/EmptyBeanParamRecordTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/EmptyBeanParamRecordTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.server.test.beanparam;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EmptyBeanParamRecordTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> {
+                return ShrinkWrap.create(JavaArchive.class)
+                        .addClasses(EmptyBeanParam.class, Resource.class);
+            }).assertException(x -> {
+                x.printStackTrace();
+                Assertions.assertEquals(
+                        "Body parameters (or non-annotated fields) are not allowed for records. Make sure to annotate your record components with @Rest* or @*Param or that they can be injected as context objects.",
+                        x.getMessage());
+            });
+
+    @Test
+    void empty() {
+        Assertions.fail();
+    }
+
+    public record EmptyBeanParam(String something, Integer other) {
+    }
+
+    @Path("/")
+    public static class Resource {
+
+        @Path("/record")
+        @GET
+        public String beanParamRecord(@BeanParam EmptyBeanParam param) {
+            return "OK";
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/ReallyEmptyBeanParamRecordTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/ReallyEmptyBeanParamRecordTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.resteasy.reactive.server.test.beanparam;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ReallyEmptyBeanParamRecordTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> {
+                return ShrinkWrap.create(JavaArchive.class)
+                        .addClasses(EmptyBeanParam.class, Resource.class);
+            }).assertException(x -> {
+                x.printStackTrace();
+                Assertions.assertEquals(
+                        "No annotations found on fields at 'io.quarkus.resteasy.reactive.server.test.beanparam.ReallyEmptyBeanParamRecordTest$EmptyBeanParam'. Annotations like `@QueryParam` should be used in fields, not in methods.",
+                        x.getMessage());
+            });
+
+    @Test
+    void empty() {
+        Assertions.fail();
+    }
+
+    // This one does not even have body params
+    public record EmptyBeanParam() {
+    }
+
+    @Path("/")
+    public static class Resource {
+
+        @Path("/record")
+        @GET
+        public String beanParamRecord(@BeanParam EmptyBeanParam param) {
+            return "OK";
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -395,6 +395,10 @@ public class ServerEndpointIndexer
                     annotations, field.type(), "%s", new Object[] { field }, applyFieldRules, hasRuntimeConverters,
                     // We don't support annotation-less path params in injectable beans: only annotations
                     Collections.emptySet(), field.name(), EMPTY_STRING_ARRAY, new HashMap<>());
+            if (currentClassInfo.isRecord() && result.getType() == ParameterType.BODY) {
+                throw new DeploymentException(
+                        "Body parameters (or non-annotated fields) are not allowed for records. Make sure to annotate your record components with @Rest* or @*Param or that they can be injected as context objects.");
+            }
             if ((result.getType() != null) && (result.getType() != ParameterType.BEAN)) {
                 //BODY means no annotation, so for fields not injectable
                 fieldExtractors.put(field, result);


### PR DESCRIPTION
This does not apply to implicit record bean params, because they are not treated as implicit bean params if they do not contain any annotated field.

- Fixes: #51431