### PR TITLE
Qute debugging support inside Java file

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/JandexElementUriBuilder.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/JandexElementUriBuilder.java
@@ -1,0 +1,53 @@
+package io.quarkus.qute.deployment;
+
+import java.net.URI;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.qute.JavaElementUriBuilder;
+
+/**
+ * Builder for Qute-specific URIs that reference a Jandex Java element
+ * (class, method, or annotation) from a template.
+ * <p>
+ * These URIs have the format:
+ *
+ * <pre>
+ * qute-java://&lt;fully-qualified-class-name&gt;[#method][@annotation]
+ * </pre>
+ *
+ * Examples:
+ * <ul>
+ * <li>Class-level annotation: <code>qute-java://com.acme.Bean@io.quarkus.qute.TemplateContents</code></li>
+ * <li>Method-level annotation: <code>qute-java://com.acme.Bean#process@io.quarkus.qute.TemplateContents</code></li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * This builder is used to construct such URIs in a type-safe way and to provide
+ * utility methods to identify and parse them. It is aligned with
+ * {@link io.quarkus.qute.debug.client.JavaSourceLocationArguments#javaElementUri}.
+ * </p>
+ */
+class JandexElementUriBuilder {
+
+    private JandexElementUriBuilder() {
+
+    }
+
+    public static URI getSource(ClassInfo target, Class<?> annotationClass) {
+        return JavaElementUriBuilder
+                .builder(target.toString())
+                .setAnnotation(annotationClass.getName())
+                .build();
+    }
+
+    public static URI getSource(MethodInfo method, Class<?> annotationClass) {
+        return JavaElementUriBuilder
+                .builder(method.declaringClass().toString())
+                .setMethod(method.name())
+                .setAnnotation(annotationClass.getName())
+                .build();
+    }
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleMethodBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleMethodBuildItem.java
@@ -1,9 +1,13 @@
 package io.quarkus.qute.deployment;
 
+import java.net.URI;
+
 import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.runtime.MessageBundleRecorder.MessageInfo;
 
 /**
  * Represents a message bundle method.
@@ -19,6 +23,7 @@ public final class MessageBundleMethodBuildItem extends MultiBuildItem {
     private final String template;
     private final boolean isDefaultBundle;
     private final boolean hasGeneratedTemplate;
+    private final MessageInfo messageInfo;
 
     MessageBundleMethodBuildItem(String bundleName, String key, String templateId, MethodInfo method, String template,
             boolean isDefaultBundle, boolean hasGeneratedTemplate) {
@@ -29,6 +34,8 @@ public final class MessageBundleMethodBuildItem extends MultiBuildItem {
         this.template = template;
         this.isDefaultBundle = isDefaultBundle;
         this.hasGeneratedTemplate = hasGeneratedTemplate;
+        URI source = hasMethod() ? JandexElementUriBuilder.getSource(method, Message.class) : null;
+        this.messageInfo = new MessageInfo(source != null ? source.toString() : null, template);
     }
 
     public String getBundleName() {
@@ -67,6 +74,10 @@ public final class MessageBundleMethodBuildItem extends MultiBuildItem {
 
     public String getTemplate() {
         return template;
+    }
+
+    public MessageInfo getMessageInfo() {
+        return messageInfo;
     }
 
     /**

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -104,6 +104,7 @@ import io.quarkus.qute.i18n.MessageBundle;
 import io.quarkus.qute.i18n.MessageBundles;
 import io.quarkus.qute.i18n.MessageTemplateLocator;
 import io.quarkus.qute.runtime.MessageBundleRecorder;
+import io.quarkus.qute.runtime.MessageBundleRecorder.MessageInfo;
 import io.quarkus.qute.runtime.QuteConfig;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
 import io.quarkus.runtime.util.StringUtil;
@@ -348,10 +349,10 @@ public class MessageBundleProcessor {
             bundleInterfaces.put(bundle.getName(), localeToInterface);
         }
 
-        Map<String, String> templateIdToContent = messageBundleMethods.stream()
+        Map<String, MessageInfo> templateIdToContent = messageBundleMethods.stream()
                 .filter(MessageBundleMethodBuildItem::isValidatable).collect(
                         Collectors.toMap(MessageBundleMethodBuildItem::getTemplateId,
-                                MessageBundleMethodBuildItem::getTemplate));
+                                MessageBundleMethodBuildItem::getMessageInfo));
 
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(MessageBundleRecorder.BundleContext.class)
                 .scope(BuiltinScope.DEPENDENT.getInfo())

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -129,6 +129,7 @@ import io.quarkus.qute.SectionHelper;
 import io.quarkus.qute.SectionHelperFactory;
 import io.quarkus.qute.SetSectionHelper;
 import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateContents;
 import io.quarkus.qute.TemplateData;
 import io.quarkus.qute.TemplateException;
 import io.quarkus.qute.TemplateExtension;
@@ -2627,6 +2628,7 @@ public class QuteProcessor {
                             .path(getCheckedTemplatePath(index.getIndex(), checkedTemplateAnnotation, fragmentId, target)
                                     + suffix)
                             .extensionInfo(target.toString())
+                            .source(JandexElementUriBuilder.getSource(target, TemplateContents.class))
                             .build());
                     continue;
                 }
@@ -2643,6 +2645,7 @@ public class QuteProcessor {
                             .path(getCheckedTemplatePath(index.getIndex(), checkedTemplateAnnotation, fragmentId,
                                     method.declaringClass(), method) + suffix)
                             .extensionInfo(method.toString())
+                            .source(JandexElementUriBuilder.getSource(method, TemplateContents.class))
                             .build());
                     continue;
                 }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageTemplateLocator.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageTemplateLocator.java
@@ -1,7 +1,5 @@
 package io.quarkus.qute.i18n;
 
-import java.io.Reader;
-import java.io.StringReader;
 import java.util.Optional;
 
 import jakarta.enterprise.inject.Instance;
@@ -9,9 +7,10 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import io.quarkus.arc.WithCaching;
+import io.quarkus.qute.StringTemplateLocation;
 import io.quarkus.qute.TemplateLocator;
-import io.quarkus.qute.Variant;
 import io.quarkus.qute.runtime.MessageBundleRecorder.BundleContext;
+import io.quarkus.qute.runtime.MessageBundleRecorder.MessageInfo;
 
 @Singleton
 public class MessageTemplateLocator implements TemplateLocator {
@@ -28,32 +27,13 @@ public class MessageTemplateLocator implements TemplateLocator {
     @Override
     public Optional<TemplateLocation> locate(String id) {
         if (bundleContext.isResolvable()) {
-            String template = bundleContext.get().getMessageTemplates().get(id);
-            if (template != null) {
-                return Optional.of(new MessageTemplateLocation(template));
+            MessageInfo messageInfo = bundleContext.get().getMessageTemplates().get(id);
+            if (messageInfo != null) {
+                return Optional.of(new StringTemplateLocation(messageInfo.content, Optional.empty(),
+                        Optional.ofNullable(messageInfo.parseSource())));
             }
         }
         return Optional.empty();
-    }
-
-    static final class MessageTemplateLocation implements TemplateLocation {
-
-        private final String content;
-
-        private MessageTemplateLocation(String content) {
-            this.content = content;
-        }
-
-        @Override
-        public Reader read() {
-            return new StringReader(content);
-        }
-
-        @Override
-        public Optional<Variant> getVariant() {
-            return Optional.empty();
-        }
-
     }
 
 }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
@@ -380,7 +380,7 @@ public class EngineProducer {
         LOGGER.debugf("Locate template contents for %s", path);
         TemplateInfo template = templates.get(path);
         if (template != null && template.hasContent()) {
-            return getTemplateLocation(template.content, path);
+            return getTemplateLocation(template, path);
         }
 
         // Try path with suffixes
@@ -391,7 +391,7 @@ public class EngineProducer {
             }
             template = templates.get(pathWithSuffix);
             if (template != null && template.hasContent()) {
-                return getTemplateLocation(template.content, pathWithSuffix);
+                return getTemplateLocation(template, pathWithSuffix);
             }
         }
 
@@ -421,8 +421,11 @@ public class EngineProducer {
         return Optional.empty();
     }
 
-    private Optional<TemplateLocation> getTemplateLocation(String content, String pathWithSuffix) {
-        return Optional.of(new StringTemplateLocation(content, Optional.ofNullable(createVariant(pathWithSuffix))));
+    private Optional<TemplateLocation> getTemplateLocation(TemplateInfo templateInfo, String pathWithSuffix) {
+        String content = templateInfo.content;
+        URI source = templateInfo.parseSource();
+        return Optional.of(new StringTemplateLocation(content, Optional.ofNullable(createVariant(pathWithSuffix)),
+                Optional.ofNullable(source)));
     }
 
     private Optional<TemplateLocation> getTemplateLocation(URL resource, String templatePath, String path) {

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/MessageBundleRecorder.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/MessageBundleRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.qute.runtime;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -8,7 +10,34 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class MessageBundleRecorder {
 
-    public Supplier<Object> createContext(Map<String, String> messageTemplates,
+    public static class MessageInfo {
+
+        public final String source;
+        public final String content;
+
+        public MessageInfo(String source, String content) {
+            this.source = source;
+            this.content = content;
+        }
+
+        public URI parseSource() {
+            if (source != null) {
+                try {
+                    return new URI(source);
+                } catch (URISyntaxException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "MessageInfo [source=" + source + ", content=" + content + "]";
+        }
+    }
+
+    public Supplier<Object> createContext(Map<String, MessageInfo> messageTemplates,
             Map<String, Map<String, Class<?>>> bundleInterfaces) {
         return new Supplier<Object>() {
 
@@ -17,7 +46,7 @@ public class MessageBundleRecorder {
                 return new BundleContext() {
 
                     @Override
-                    public Map<String, String> getMessageTemplates() {
+                    public Map<String, MessageInfo> getMessageTemplates() {
                         return messageTemplates;
                     }
 
@@ -33,7 +62,7 @@ public class MessageBundleRecorder {
     public interface BundleContext {
 
         // message id -> message template
-        Map<String, String> getMessageTemplates();
+        Map<String, MessageInfo> getMessageTemplates();
 
         // bundle name -> (locale -> interface class)
         Map<String, Map<String, Class<?>>> getBundleInterfaces();

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/JavaElementUriBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/JavaElementUriBuilder.java
@@ -1,0 +1,139 @@
+package io.quarkus.qute;
+
+import java.net.URI;
+
+/**
+ * Builder for Qute-specific URIs that reference a Java element
+ * (class, method, or annotation) from a template.
+ * <p>
+ * These URIs have the format:
+ *
+ * <pre>
+ * qute-java://&lt;fully-qualified-class-name&gt;[#method][@annotation]
+ * </pre>
+ *
+ * Examples:
+ * <ul>
+ * <li>Class-level annotation: <code>qute-java://com.acme.Bean@io.quarkus.qute.TemplateContents</code></li>
+ * <li>Method-level annotation: <code>qute-java://com.acme.Bean#process@io.quarkus.qute.TemplateContents</code></li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * This builder is used to construct such URIs in a type-safe way and to provide
+ * utility methods to identify and parse them. It is aligned with
+ * {@link io.quarkus.qute.debug.client.JavaSourceLocationArguments#javaElementUri}.
+ * </p>
+ */
+public class JavaElementUriBuilder {
+
+    /** Scheme used for Qute Java URIs. */
+    public static final String QUTE_JAVA_SCHEME = "qute-java";
+
+    /** Prefix for Qute Java URIs. */
+    public static final String QUTE_JAVA_URI_PREFIX = QUTE_JAVA_SCHEME + "://";
+
+    private final String typeName;
+    private String method;
+    private String annotation;
+
+    private JavaElementUriBuilder(String typeName) {
+        this.typeName = typeName;
+    }
+
+    /**
+     * Returns the fully qualified Java class name for this URI.
+     *
+     * @return the class name
+     */
+    public String getTypeName() {
+        return typeName;
+    }
+
+    /**
+     * Returns the Java method name (nullable if not specified).
+     *
+     * @return the method name or {@code null}
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * Sets the Java method name.
+     *
+     * @param method the method name to set
+     * @return this builder
+     */
+    public JavaElementUriBuilder setMethod(String method) {
+        this.method = method;
+        return this;
+    }
+
+    /**
+     * Returns the fully qualified Java annotation name (nullable if not specified).
+     *
+     * @return the annotation name or {@code null}
+     */
+    public String getAnnotation() {
+        return annotation;
+    }
+
+    /**
+     * Sets the fully qualified Java annotation name.
+     *
+     * @param annotation the annotation name to set
+     * @return this builder
+     */
+    public JavaElementUriBuilder setAnnotation(String annotation) {
+        this.annotation = annotation;
+        return this;
+    }
+
+    /**
+     * Creates a new builder for the given Java class name.
+     *
+     * @param typeName fully qualified Java class name
+     * @return a new {@link JavaElementUriBuilder}
+     */
+    public static JavaElementUriBuilder builder(String typeName) {
+        return new JavaElementUriBuilder(typeName);
+    }
+
+    /**
+     * Builds the Qute Java URI representing the element.
+     *
+     * @return a {@link URI} for the Java element
+     */
+    public URI build() {
+        StringBuilder uri = new StringBuilder(QUTE_JAVA_URI_PREFIX);
+        uri.append(typeName);
+        if (method != null) {
+            uri.append("#").append(method);
+        }
+        if (annotation != null) {
+            uri.append("@").append(annotation);
+        }
+        return URI.create(uri.toString());
+    }
+
+    /**
+     * Returns true if the given URI uses the qute-java scheme.
+     *
+     * @param uri the URI to check
+     * @return {@code true} if this URI is a Qute Java element URI
+     */
+    public static boolean isJavaUri(URI uri) {
+        return uri != null && QUTE_JAVA_SCHEME.equals(uri.getScheme());
+    }
+
+    /**
+     * Returns true if the given string starts with the qute-java URI prefix.
+     *
+     * @param uri the URI string to check
+     * @return {@code true} if this string is a Qute Java element URI
+     */
+    public static boolean isJavaUri(String uri) {
+        return uri != null && uri.startsWith(QUTE_JAVA_URI_PREFIX);
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/StringTemplateLocation.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/StringTemplateLocation.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute;
 
 import java.io.Reader;
+import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -11,14 +12,20 @@ public class StringTemplateLocation implements TemplateLocation {
 
     private final String content;
     private final Optional<Variant> variant;
+    private final Optional<URI> source;
 
     public StringTemplateLocation(String content) {
         this(content, Optional.empty());
     }
 
     public StringTemplateLocation(String content, Optional<Variant> variant) {
+        this(content, variant, Optional.empty());
+    }
+
+    public StringTemplateLocation(String content, Optional<Variant> variant, Optional<URI> source) {
         this.content = Objects.requireNonNull(content);
         this.variant = Objects.requireNonNull(variant);
+        this.source = Objects.requireNonNull(source);
     }
 
     @Override
@@ -29,6 +36,11 @@ public class StringTemplateLocation implements TemplateLocation {
     @Override
     public Optional<Variant> getVariant() {
         return variant;
+    }
+
+    @Override
+    public Optional<URI> getSource() {
+        return source;
     }
 
 }

--- a/independent-projects/qute/debug/README.md
+++ b/independent-projects/qute/debug/README.md
@@ -1,6 +1,6 @@
 # Qute Debugger
 
-Qute Debugger allows you to **debug Qute templates using breakpoints** in any IDE or editor that supports the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/).
+Since Quarkus **3.29**, Qute Debugger allows you to **debug Qute templates using breakpoints** in any IDE or editor that supports the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/).
 
 It works seamlessly with:
 
@@ -138,6 +138,12 @@ Pause only when certain conditions are met.
 
 ![Conditional Breakpoint](./images/ConditionalBreakpoint.png)
 
+### Hover
+
+Hover
+
+![Hover](./images/Hover.png)
+
 ### Expression Evaluation
 
 Evaluate expressions on the fly while debugging templates.
@@ -156,12 +162,6 @@ Inspect the current context and variables in real-time.
 
 ![Variables](./images/Variables.png)
 
-## Feature Summary
+### Degugging in Java file
 
-| Feature                | Supported |
-|------------------------|-----------|
-| Simple Breakpoints     | ✅         |
-| Conditional Breakpoints| ✅         |
-| Expression Evaluation  | ✅         |
-| Code Completion        | ✅         |
-| Variable Inspection    | ✅         |
+Since Quarkus **3.31** ...

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/Debugger.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/Debugger.java
@@ -15,10 +15,12 @@ import org.eclipse.lsp4j.debug.StackTraceResponse;
 import org.eclipse.lsp4j.debug.Thread;
 import org.eclipse.lsp4j.debug.Variable;
 
+import io.quarkus.qute.debug.client.JavaSourceResolver;
+
 /**
  * Qute debugger API.
  */
-public interface Debugger {
+public interface Debugger extends JavaSourceResolver {
 
     /**
      * Returns the current state of the remote debugger for a given thread.

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/adapter/RegisterDebugServerAdapter.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/adapter/RegisterDebugServerAdapter.java
@@ -10,13 +10,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.lsp4j.debug.launch.DSPLauncher;
-import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.jsonrpc.debug.DebugLauncher;
 
 import io.quarkus.qute.Engine;
 import io.quarkus.qute.EngineBuilder.EngineListener;
 import io.quarkus.qute.debug.agent.DebuggeeAgent;
+import io.quarkus.qute.debug.client.QuteDebugProtocolClient;
 import io.quarkus.qute.trace.TemplateEvent;
 import io.quarkus.qute.trace.TraceListener;
 
@@ -279,8 +279,8 @@ public class RegisterDebugServerAdapter implements EngineListener {
             launcherFuture.cancel(true);
         }
 
-        Launcher<IDebugProtocolClient> launcher = DSPLauncher.createServerLauncher(server, client.getInputStream(),
-                client.getOutputStream(), executor, null);
+        Launcher<QuteDebugProtocolClient> launcher = DebugLauncher.createLauncher(server, QuteDebugProtocolClient.class,
+                client.getInputStream(), client.getOutputStream(), executor, null);
 
         var clientProxy = launcher.getRemoteProxy();
         server.connect(clientProxy);

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/frames/RemoteStackFrame.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/frames/RemoteStackFrame.java
@@ -87,11 +87,11 @@ public class RemoteStackFrame extends StackFrame {
         int line = event.getTemplateNode().getOrigin().getLine();
         super.setId(id);
         super.setName(event.getTemplateNode().toString());
-        super.setLine(line);
 
         this.templateId = event.getTemplateNode().getOrigin().getTemplateId();
         super.setSource(
                 sourceTemplateRegistry.getSource(templateId, previousFrame != null ? previousFrame.getSource() : null));
+        super.setLine(line + (getSource() != null ? getSource().getStartLine() : 0));
     }
 
     /** @return the template ID associated with this frame */

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/FileSource.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/FileSource.java
@@ -21,14 +21,18 @@ import java.nio.file.Path;
  */
 public class FileSource extends RemoteSource {
 
+    public FileSource(URI uri, String templateId) {
+        this(uri, templateId, 0);
+    }
+
     /**
      * Creates a new {@link FileSource} for a Qute template located on the local filesystem.
      *
      * @param uri the URI of the template file (must use the {@code file:} scheme)
      * @param templateId the Qute template identifier
      */
-    public FileSource(URI uri, String templateId) {
-        super(uri, templateId);
+    protected FileSource(URI uri, String templateId, int startLine) {
+        super(uri, templateId, startLine);
 
         // Initialize the DAP "path" field so the client can open the file.
         try {

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/JavaFileSource.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/JavaFileSource.java
@@ -1,0 +1,11 @@
+package io.quarkus.qute.debug.agent.source;
+
+import java.net.URI;
+
+public class JavaFileSource extends FileSource {
+
+    public JavaFileSource(URI uri, String templateId, int startLine) {
+        super(uri, templateId, startLine);
+    }
+
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/RemoteSource.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/RemoteSource.java
@@ -35,16 +35,22 @@ public abstract class RemoteSource extends Source {
      */
     private final transient String templateId;
 
+    private final transient int startLine;
+
+    public RemoteSource(URI uri, String templateId) {
+        this(uri, templateId, 0);
+    }
+
     /**
      * Creates a new remote source associated with the given template.
      *
      * @param uri the URI of the template source, or {@code null} if not applicable
      * @param templateId the template ID used by the Qute engine (never {@code null})
      */
-    public RemoteSource(URI uri, String templateId) {
+    public RemoteSource(URI uri, String templateId, int startLine) {
         this.uri = uri;
         this.templateId = templateId;
-
+        this.startLine = startLine;
         // Initialize the DAP "name" field for display purposes in the client.
         // If the URI is known, extract the filename; otherwise, use the templateId.
         super.setName(uri != null ? computeName(uri) : templateId);
@@ -80,6 +86,10 @@ public abstract class RemoteSource extends Source {
      */
     public String getTemplateId() {
         return templateId;
+    }
+
+    public int getStartLine() {
+        return startLine;
     }
 
     /**

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/SourceTemplateRegistry.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/agent/source/SourceTemplateRegistry.java
@@ -10,28 +10,38 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.eclipse.lsp4j.debug.Source;
 
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.JavaElementUriBuilder;
 import io.quarkus.qute.debug.agent.breakpoints.BreakpointsRegistry;
+import io.quarkus.qute.debug.client.JavaSourceLocationArguments;
+import io.quarkus.qute.debug.client.JavaSourceLocationResponse;
+import io.quarkus.qute.debug.client.JavaSourceResolver;
 
 /**
- * Registry responsible for resolving and managing mappings between Qute template IDs
- * and their corresponding {@link RemoteSource} instances.
+ * Registry responsible for resolving and managing mappings between Qute
+ * template IDs and their corresponding {@link RemoteSource} instances.
  * <p>
- * This class plays a key role in the Qute debugger by allowing the Debug Adapter Protocol (DAP)
- * to locate and serve the correct source file for a given template, whether it originates
- * from a local filesystem or a JAR.
+ * This class plays a key role in the Qute debugger by allowing the Debug
+ * Adapter Protocol (DAP) to locate and serve the correct source file for a
+ * given template, whether it originates from a local filesystem or a JAR.
  * </p>
  *
  * <p>
- * The registry maintains a cache of resolved template IDs to avoid redundant lookups
- * and supports flexible base paths and file extensions to locate template files.
+ * The registry maintains a cache of resolved template IDs to avoid redundant
+ * lookups and supports flexible base paths and file extensions to locate
+ * template files.
  * </p>
  */
 public class SourceTemplateRegistry {
+
+    private static final String JAR_SCHEME = "jar";
 
     private final Map<String /* templateId */, RemoteSource> templateIdToSource = new HashMap<>();
 
@@ -41,6 +51,8 @@ public class SourceTemplateRegistry {
 
     private final BreakpointsRegistry breakpointsRegistry;
     private final SourceReferenceRegistry sourceReferenceRegistry;
+
+    private final JavaSourceResolver javaSourceResolver;
 
     /**
      * Creates a registry with default base paths and file extensions.
@@ -63,12 +75,11 @@ public class SourceTemplateRegistry {
      * </ul>
      */
     public SourceTemplateRegistry(BreakpointsRegistry breakpointsRegistry,
-            SourceReferenceRegistry sourceReferenceRegistry,
-            Engine engine) {
-        this(breakpointsRegistry, sourceReferenceRegistry, engine,
+            SourceReferenceRegistry sourceReferenceRegistry, JavaSourceResolver javaFileInfoProvider, Engine engine) {
+        this(breakpointsRegistry, sourceReferenceRegistry, javaFileInfoProvider, engine,
                 List.of("src/main/resources/templates/", "templates/", "content/"),
-                List.of(".qute", ".html", ".qute.html", ".yaml", ".qute.yaml",
-                        ".yml", ".qute.yml", ".txt", ".qute.txt", ".md", ".qute.md"));
+                List.of(".qute", ".html", ".qute.html", ".yaml", ".qute.yaml", ".yml", ".qute.yml", ".txt", ".qute.txt",
+                        ".md", ".qute.md"));
     }
 
     /**
@@ -77,16 +88,17 @@ public class SourceTemplateRegistry {
      * @param breakpointsRegistry registry managing active breakpoints
      * @param sourceReferenceRegistry registry responsible for DAP source references
      * @param engine the Qute template engine instance
-     * @param basePaths list of possible base directories where templates might be located
-     * @param fileExtensions list of supported file extensions for template files
+     * @param basePaths list of possible base directories where
+     *        templates might be located
+     * @param fileExtensions list of supported file extensions for template
+     *        files
      */
     public SourceTemplateRegistry(BreakpointsRegistry breakpointsRegistry,
-            SourceReferenceRegistry sourceReferenceRegistry,
-            Engine engine,
-            List<String> basePaths,
-            List<String> fileExtensions) {
+            SourceReferenceRegistry sourceReferenceRegistry, JavaSourceResolver javaFileInfoProvider, Engine engine,
+            List<String> basePaths, List<String> fileExtensions) {
         this.breakpointsRegistry = breakpointsRegistry;
         this.sourceReferenceRegistry = sourceReferenceRegistry;
+        this.javaSourceResolver = javaFileInfoProvider;
         this.engine = engine;
         this.basePaths = basePaths;
         this.fileExtensions = fileExtensions;
@@ -95,8 +107,8 @@ public class SourceTemplateRegistry {
     /**
      * Attempts to resolve a {@link RemoteSource} for a given Qute template ID.
      * <p>
-     * This method first checks the internal cache. If the source is not yet registered,
-     * it attempts to resolve it from:
+     * This method first checks the internal cache. If the source is not yet
+     * registered, it attempts to resolve it from:
      * <ul>
      * <li>The {@link Engine} via {@link Engine#locate(String)}.</li>
      * <li>Previously known sources (from breakpoints or cached URIs).</li>
@@ -104,8 +116,10 @@ public class SourceTemplateRegistry {
      * </p>
      *
      * @param templateId the Qute template identifier
-     * @param previousSource the previously known source, used to infer relative paths (optional)
-     * @return the resolved {@link RemoteSource}, or {@code null} if none could be found
+     * @param previousSource the previously known source, used to infer relative
+     *        paths (optional)
+     * @return the resolved {@link RemoteSource}, or {@code null} if none could be
+     *         found
      */
     public RemoteSource getSource(String templateId, Source previousSource) {
         RemoteSource source = templateIdToSource.get(templateId);
@@ -115,10 +129,40 @@ public class SourceTemplateRegistry {
 
         URI sourceUri = getSourceUriFromEngine(templateId, this.engine);
         if (sourceUri == null) {
-            sourceUri = getGuessedSourceUri(templateId, previousSource);
+            if (JavaElementUriBuilder.isJavaUri(templateId)) {
+                // Template id defines a qute-java// uri
+                // ex:
+                // qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents
+                sourceUri = URI.create(templateId);
+            } else {
+                sourceUri = getGuessedSourceUri(templateId, previousSource);
+            }
         }
 
         if (sourceUri != null) {
+            if (JavaElementUriBuilder.isJavaUri(sourceUri)) {
+                // ex:
+                // qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents
+                JavaSourceLocationArguments args = parse(sourceUri.toString());
+                try {
+                    JavaSourceLocationResponse response = javaSourceResolver.resolveJavaSource(args).get(2000,
+                            TimeUnit.MILLISECONDS);
+                    if (response != null) {
+                        URI javaSourceUri = URI.create(response.getJavaFileUri());
+                        int startLine = response.getStartLine();
+                        source = new JavaFileSource(javaSourceUri, templateId, startLine);
+                        templateIdToSource.put(templateId, source);
+                        return source;
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    e.printStackTrace();
+                } catch (TimeoutException e) {
+                    e.printStackTrace();
+                }
+                return null;
+            }
             source = createSource(sourceUri, templateId);
             templateIdToSource.put(templateId, source);
             return source;
@@ -127,15 +171,68 @@ public class SourceTemplateRegistry {
         return null;
     }
 
+    private static JavaSourceLocationArguments parse(String javaElementUri) {
+        JavaSourceLocationArguments args = new JavaSourceLocationArguments();
+        args.setJavaElementUri(javaElementUri);
+
+        char[] chars = javaElementUri.toCharArray();
+        int i = JavaElementUriBuilder.QUTE_JAVA_URI_PREFIX.length();
+        int len = chars.length;
+
+        StringBuilder type = new StringBuilder();
+        StringBuilder method = new StringBuilder();
+        StringBuilder annotation = new StringBuilder();
+
+        // 0 = reading type
+        // 1 = reading method (after '#')
+        // 2 = reading annotation (after '@')
+        int mode = 0;
+
+        for (; i < len; i++) {
+            char c = chars[i];
+
+            switch (mode) {
+                case 0: // reading type
+                    if (c == '#') {
+                        mode = 1;
+                    } else if (c == '@') {
+                        mode = 2;
+                    } else {
+                        type.append(c);
+                    }
+                    break;
+
+                case 1: // reading method
+                    if (c == '@') {
+                        mode = 2;
+                    } else {
+                        method.append(c);
+                    }
+                    break;
+
+                case 2: // reading annotation
+                    annotation.append(c);
+                    break;
+            }
+        }
+
+        args.setTypeName(type.length() == 0 ? null : type.toString());
+        args.setMethod(method.length() == 0 ? null : method.toString());
+        args.setAnnotation(annotation.length() == 0 ? null : annotation.toString());
+
+        return args;
+    }
+
     /**
      * Creates a {@link RemoteSource} depending on the URI scheme.
      * <ul>
-     * <li>If the URI scheme is "jar", creates a {@link JarSource} and registers a source reference.</li>
+     * <li>If the URI scheme is "jar", creates a {@link JarSource} and registers a
+     * source reference.</li>
      * <li>Otherwise, creates a {@link FileSource}.</li>
      * </ul>
      */
     private RemoteSource createSource(URI sourceUri, String templateId) {
-        if ("jar".equals(sourceUri.getScheme())) {
+        if (JAR_SCHEME.equals(sourceUri.getScheme())) {
             return new JarSource(sourceUri, templateId, sourceReferenceRegistry);
         }
         return new FileSource(sourceUri, templateId);
@@ -158,8 +255,8 @@ public class SourceTemplateRegistry {
     }
 
     /**
-     * Tries to infer the {@link URI} of a template based on its ID by checking known
-     * source URIs, typical base paths, and possible file extensions.
+     * Tries to infer the {@link URI} of a template based on its ID by checking
+     * known source URIs, typical base paths, and possible file extensions.
      * <p>
      * This method is used as a fallback when the Qute engine cannot resolve a
      * template ID to a physical location.
@@ -167,7 +264,8 @@ public class SourceTemplateRegistry {
      *
      * <ul>
      * <li>Searches in the registered breakpoint URIs and cached RemoteSources.</li>
-     * <li>Supports multiple base paths (e.g. "templates/", "META-INF/resources/").</li>
+     * <li>Supports multiple base paths (e.g. "templates/",
+     * "META-INF/resources/").</li>
      * <li>Supports common file extensions (.html, .qute, .qute.html, etc.).</li>
      * </ul>
      *
@@ -180,9 +278,7 @@ public class SourceTemplateRegistry {
     private URI getGuessedSourceUri(String templateId, Source previousSource) {
 
         Set<URI> knownUris = new HashSet<>(breakpointsRegistry.getSourceUris());
-        knownUris.addAll(templateIdToSource.values().stream()
-                .map(RemoteSource::getUri)
-                .filter(Objects::nonNull)
+        knownUris.addAll(templateIdToSource.values().stream().map(RemoteSource::getUri).filter(Objects::nonNull)
                 .collect(Collectors.toSet()));
 
         if (knownUris.isEmpty()) {
@@ -237,8 +333,8 @@ public class SourceTemplateRegistry {
     }
 
     /**
-     * Converts a {@link Source} object into a normalized {@link URI}.
-     * Supports fallback for Windows paths and relative URIs.
+     * Converts a {@link Source} object into a normalized {@link URI}. Supports
+     * fallback for Windows paths and relative URIs.
      */
     public static URI toUri(Source source) {
         String path = source.getPath();
@@ -257,7 +353,8 @@ public class SourceTemplateRegistry {
     }
 
     /**
-     * Normalizes file URIs (e.g. ensures consistent casing of Windows drive letters).
+     * Normalizes file URIs (e.g. ensures consistent casing of Windows drive
+     * letters).
      */
     private static URI normalize(URI uri) {
         if ("file".equalsIgnoreCase(uri.getScheme())) {

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/EventBasedJavaSourceResolver.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/EventBasedJavaSourceResolver.java
@@ -1,0 +1,73 @@
+package io.quarkus.qute.debug.client;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * JavaSourceResolver implementation for event-based clients (VS Code, etc.).
+ * <p>
+ * When the debugger needs to resolve a Qute template to a Java source, this
+ * resolver sends an event to the client and waits asynchronously for the client
+ * to respond.
+ * </p>
+ */
+public class EventBasedJavaSourceResolver implements JavaSourceResolver {
+
+    private final QuteDebugProtocolClient client;
+
+    /**
+     * Pending requests: maps request ID → CompletableFuture
+     */
+    private final Map<String, CompletableFuture<JavaSourceLocationResponse>> pending = new ConcurrentHashMap<>();
+
+    public EventBasedJavaSourceResolver(QuteDebugProtocolClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Resolves a Java source from a Qute template by sending an event to the
+     * client.
+     * <p>
+     * Returns a CompletableFuture that will be completed when the client responds
+     * via the {@code qute/onJavaSourceResolved} notification.
+     * </p>
+     */
+    @Override
+    public CompletableFuture<JavaSourceLocationResponse> resolveJavaSource(JavaSourceLocationArguments args) {
+        String id = UUID.randomUUID().toString();
+        CompletableFuture<JavaSourceLocationResponse> future = new CompletableFuture<>();
+        pending.put(id, future);
+
+        // Send event to the client
+        JavaSourceLocationEventArguments request = new JavaSourceLocationEventArguments(id, args);
+        client.onResolveJavaSource(request);
+
+        return future;
+    }
+
+    /**
+     * Handles the response from the client when a Java source has been resolved.
+     * <p>
+     * This should be called by the client event handler when it receives the
+     * {@code qute/onJavaSourceResolved} notification.
+     * </p>
+     */
+    public void handleResponse(JavaSourceLocationEventResponse response) {
+        CompletableFuture<JavaSourceLocationResponse> future = pending.remove(response.getId());
+        if (future != null) {
+            future.complete(response.getResponse());
+        }
+    }
+
+    /**
+     * Optionally handles a cancellation from the server side.
+     */
+    public void cancel(String id) {
+        CompletableFuture<JavaSourceLocationResponse> future = pending.remove(id);
+        if (future != null) {
+            future.cancel(true);
+        }
+    }
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationArguments.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationArguments.java
@@ -1,0 +1,116 @@
+package io.quarkus.qute.debug.client;
+
+/**
+ * Arguments describing a Java element referenced from a Qute template.
+ * <p>
+ * Sent by the Debug Adapter via {@link JavaSourceResolver#resolveJavaSource}
+ * to the client in order to locate the corresponding Java source file and position.
+ * </p>
+ *
+ * <h2>Example of a qute-java URI</h2>
+ *
+ * <pre>
+ * qute-java://com.acme.Bean#process@io.quarkus.qute.TemplateContents
+ * </pre>
+ *
+ * <p>
+ * Interpretation:
+ * </p>
+ * <ul>
+ * <li>javaElementUri = "qute-java://com.acme.Bean#process@io.quarkus.qute.TemplateContents"</li>
+ * <li>typeName = "com.acme.Bean"</li>
+ * <li>method = "process" (optional; if null, the annotation is applied on the class)</li>
+ * <li>annotation = "io.quarkus.qute.TemplateContents"</li>
+ * </ul>
+ */
+public class JavaSourceLocationArguments {
+
+    /** The qute-java URI used to locate the Java element from a template. */
+    private String javaElementUri;
+
+    /** Fully qualified Java class, interface name (e.g., "com.acme.Bean"). */
+    private String typeName;
+
+    /**
+     * Java method name.
+     * <p>
+     * Optional: if {@code null}, the annotation is applied to the class itself.
+     * </p>
+     */
+    private String method;
+
+    /** Fully qualified Java annotation name (typically "io.quarkus.qute.TemplateContents"). */
+    private String annotation;
+
+    /**
+     * Returns the qute-java URI used to locate the Java element.
+     *
+     * @return the URI string
+     */
+    public String getJavaElementUri() {
+        return javaElementUri;
+    }
+
+    /**
+     * Sets the qute-java URI used to locate the Java element.
+     *
+     * @param javaElementUri the URI string to set
+     */
+    public void setJavaElementUri(String javaElementUri) {
+        this.javaElementUri = javaElementUri;
+    }
+
+    /**
+     * Returns the fully qualified Java class, interface name.
+     *
+     * @return the class name
+     */
+    public String getTypeName() {
+        return typeName;
+    }
+
+    /**
+     * Sets the fully qualified Java class, interface name.
+     *
+     * @param typeName the class, interface name to set
+     */
+    public void setTypeName(String typeName) {
+        this.typeName = typeName;
+    }
+
+    /**
+     * Returns the Java method name.
+     *
+     * @return the method name, or {@code null} if the annotation applies to the class
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * Sets the Java method name.
+     *
+     * @param method the method name to set, or {@code null} if the annotation applies to the class
+     */
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    /**
+     * Returns the fully qualified Java annotation name.
+     *
+     * @return the annotation name (e.g., "io.quarkus.qute.TemplateContents")
+     */
+    public String getAnnotation() {
+        return annotation;
+    }
+
+    /**
+     * Sets the fully qualified Java annotation name.
+     *
+     * @param annotation the annotation name to set
+     */
+    public void setAnnotation(String annotation) {
+        this.annotation = annotation;
+    }
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationEventArguments.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationEventArguments.java
@@ -1,0 +1,69 @@
+package io.quarkus.qute.debug.client;
+
+import java.util.Objects;
+
+/**
+ * Payload sent by the server to event-based clients (VS Code, etc.) when
+ * requesting the resolution of a Java source corresponding to a Qute template.
+ *
+ * <p>
+ * Contains a unique request ID to match the response and the original
+ * {@link JavaSourceLocationArguments} describing the template location.
+ * </p>
+ */
+public class JavaSourceLocationEventArguments {
+
+    /**
+     * Unique ID of the request. Used to match the response from the client to the
+     * pending CompletableFuture on the server.
+     */
+    private String id;
+
+    /**
+     * Original Java source location arguments parsed from the qute-java:// URI.
+     */
+    private JavaSourceLocationArguments args;
+
+    public JavaSourceLocationEventArguments() {
+    }
+
+    public JavaSourceLocationEventArguments(String id, JavaSourceLocationArguments args) {
+        this.id = id;
+        this.args = args;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public JavaSourceLocationArguments getArgs() {
+        return args;
+    }
+
+    public void setArgs(JavaSourceLocationArguments args) {
+        this.args = args;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof JavaSourceLocationEventArguments that))
+            return false;
+        return Objects.equals(id, that.id) && Objects.equals(args, that.args);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, args);
+    }
+
+    @Override
+    public String toString() {
+        return "JavaSourceLocationRequestArguments{" + "id='" + id + '\'' + ", args=" + args + '}';
+    }
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationEventResponse.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationEventResponse.java
@@ -1,0 +1,41 @@
+package io.quarkus.qute.debug.client;
+
+/**
+ * Event response for a Java source location resolution.
+ * <p>
+ * Sent from an event-based client (VS Code, Eclipse IDE, etc.) back to the server
+ * to complete the pending resolution of a Qute template to a Java source location.
+ * </p>
+ */
+public class JavaSourceLocationEventResponse {
+
+    /** The unique ID matching the original request/event. */
+    private String id;
+
+    /** The resolved Java source location corresponding to the template. */
+    private JavaSourceLocationResponse response;
+
+    public JavaSourceLocationEventResponse() {
+    }
+
+    public JavaSourceLocationEventResponse(String id, JavaSourceLocationResponse response) {
+        this.id = id;
+        this.response = response;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public JavaSourceLocationResponse getResponse() {
+        return response;
+    }
+
+    public void setResponse(JavaSourceLocationResponse response) {
+        this.response = response;
+    }
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationResponse.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceLocationResponse.java
@@ -1,0 +1,82 @@
+package io.quarkus.qute.debug.client;
+
+/**
+ * Response containing the location of a Java method, class, or template content
+ * referenced from a Qute template.
+ * <p>
+ * Typically returned by {@link JavaSourceResolver#resolveJavaSource}.
+ * </p>
+ *
+ * <h2>Example</h2>
+ *
+ * <pre>
+ * qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents
+ * → javaFileUri = "file:///project/src/main/java/org/acme/quarkus/sample/HelloResource.java"
+ * → startLine = 16
+ * </pre>
+ *
+ * <p>
+ * The {@code startLine} represents the line where the template content or the
+ * Java element declaration starts. Lines are 1-based in this API (first line =
+ * 1).
+ * </p>
+ */
+public class JavaSourceLocationResponse {
+
+    /** URI of the Java source file containing the resolved element. */
+    private String javaFileUri;
+
+    /**
+     * Start line of the Java element or template content in the file.
+     * <p>
+     * 1-based index of the line where the element or template content starts.
+     * </p>
+     */
+    private int startLine;
+
+    public JavaSourceLocationResponse() {
+    }
+
+    public JavaSourceLocationResponse(String javaFileUri, int startLine) {
+        setJavaFileUri(javaFileUri);
+        setStartLine(startLine);
+    }
+
+    /**
+     * Returns the URI of the Java source file containing the resolved element.
+     *
+     * @return the file URI
+     */
+    public String getJavaFileUri() {
+        return javaFileUri;
+    }
+
+    /**
+     * Sets the URI of the Java source file containing the resolved element.
+     *
+     * @param javaFileUri the file URI to set
+     */
+    public void setJavaFileUri(String javaFileUri) {
+        this.javaFileUri = javaFileUri;
+    }
+
+    /**
+     * Returns the start line of the Java element or template content in the source
+     * file.
+     *
+     * @return 1-based start line of the element or template content
+     */
+    public int getStartLine() {
+        return startLine;
+    }
+
+    /**
+     * Sets the start line of the Java element or template content in the source
+     * file.
+     *
+     * @param startLine 1-based start line of the element or template content
+     */
+    public void setStartLine(int startLine) {
+        this.startLine = startLine;
+    }
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceResolver.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/JavaSourceResolver.java
@@ -1,0 +1,92 @@
+package io.quarkus.qute.debug.client;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+/**
+ * Resolver for Java source locations referenced from Qute templates.
+ * <p>
+ * Implementations of this interface provide a way to resolve a Qute template reference
+ * (via a {@code qute-java://} URI) to the corresponding Java source file and template position.
+ * </p>
+ *
+ * <p>
+ * This resolver is used by the Debug Adapter Protocol (DAP) **only to support breakpoints**
+ * on Java methods or classes related to Qute templates.
+ * </p>
+ *
+ * <h2>Example with a Qute template in a JAX-RS resource</h2>
+ *
+ * <pre>
+ * package org.acme.quarkus.sample;
+ *
+ * import jakarta.ws.rs.GET;
+ * import jakarta.ws.rs.Path;
+ * import jakarta.ws.rs.QueryParam;
+ * import jakarta.ws.rs.Produces;
+ * import jakarta.ws.rs.core.MediaType;
+ *
+ * import io.quarkus.qute.TemplateContents;
+ * import io.quarkus.qute.TemplateInstance;
+ *
+ * &#64;Path("hello")
+ * public class HelloResource {
+ *
+ *     &#64;TemplateContents("""
+ *             &lt;p&gt;Hello {name ?: "Qute"}&lt;/p&gt;!
+ *             """)
+ *     record Hello(String name) implements TemplateInstance {
+ *     }
+ *
+ *     &#64;GET
+ *     &#64;Produces(MediaType.TEXT_PLAIN)
+ *     public TemplateInstance get(@QueryParam("name") String name) {
+ *         return new Hello(name);
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>
+ * Corresponding {@code qute-java://} URI for the record:
+ * </p>
+ *
+ * <pre>
+ * qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents
+ * </pre>
+ *
+ * <p>
+ * Parsed into {@link JavaSourceLocationArguments}:
+ * </p>
+ * <ul>
+ * <li>unresolvedUri = "qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents"</li>
+ * <li>typeName = "org.acme.quarkus.sample.HelloResource$Hello"</li>
+ * <li>method = null (the annotation is on the record class)</li>
+ * <li>annotation = "io.quarkus.qute.TemplateContents"</li>
+ * </ul>
+ *
+ * <p>
+ * Example resulting {@link JavaSourceLocationResponse}:
+ * </p>
+ * <ul>
+ * <li>javaFileUri = "file:///path/to/project/src/main/java/org/acme/quarkus/sample/HelloResource.java"</li>
+ * <li>startLine = 16 (line of the text block content of the TemplateContents annotation)</li>
+ * </ul>
+ */
+public interface JavaSourceResolver {
+
+    /**
+     * Resolves the Java method or class referenced from a Qute template for the purpose of setting breakpoints.
+     * <p>
+     * The {@link JavaSourceLocationArguments} contains the parsed information from
+     * a {@code qute-java://} URI. The method returns a {@link CompletableFuture} that
+     * completes with a {@link JavaSourceLocationResponse} containing the Java file URI
+     * and the start line of the template content (or the method/class if applicable).
+     * </p>
+     *
+     * @param args the arguments describing the Java element to resolve
+     * @return a future completing with the resolved Java source location
+     */
+    @JsonRequest("qute/resolveJavaSource")
+    CompletableFuture<JavaSourceLocationResponse> resolveJavaSource(JavaSourceLocationArguments args);
+}

--- a/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/QuteDebugProtocolClient.java
+++ b/independent-projects/qute/debug/src/main/java/io/quarkus/qute/debug/client/QuteDebugProtocolClient.java
@@ -1,0 +1,52 @@
+package io.quarkus.qute.debug.client;
+
+import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+
+/**
+ * Combined Debug Protocol client interface for Qute templates.
+ *
+ * <p>
+ * Extends the standard {@link IDebugProtocolClient} to include the
+ * {@link JavaSourceResolver} functionality for resolving Java sources
+ * referenced from Qute templates via {@code qute-java://} URIs.
+ * </p>
+ *
+ * <p>
+ * Event-based clients (like VS Code) can override the notification method
+ * {@link #onResolveJavaSource(JavaSourceLocationEventArguments)}
+ * to asynchronously resolve Java sources for template breakpoints.
+ * </p>
+ *
+ * <p>
+ * Blocking clients (like IntelliJ, Eclipse IDE) can simply implement
+ * {@link JavaSourceResolver} and resolve the source synchronously.
+ * </p>
+ */
+public interface QuteDebugProtocolClient extends IDebugProtocolClient, JavaSourceResolver {
+
+    /**
+     * Event/notification sent by the server to event-based clients (VS Code, etc.)
+     * requesting the resolution of a Java source corresponding to a Qute template.
+     *
+     * <p>
+     * The payload contains a unique request ID and the original
+     * {@link JavaSourceLocationArguments}. The client is expected to
+     * eventually send back a {@code qute/onJavaSourceResolved} notification
+     * with the same ID and the resolved source.
+     * </p>
+     *
+     * <p>
+     * Default implementation is a no-op. Clients that support event-based
+     * resolution should override this method.
+     * </p>
+     *
+     * @param request the event-based request containing ID and source arguments
+     */
+    @JsonNotification("qute/onResolveJavaSource")
+    default void onResolveJavaSource(JavaSourceLocationEventArguments request) {
+        // no-op by default
+        // Event-based clients (VS Code) should override and later send back:
+        // qute/onJavaSourceResolved with the same request ID
+    }
+}

--- a/independent-projects/qute/debug/src/main/java/module-info.java
+++ b/independent-projects/qute/debug/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module io.quarkus.qute.debug {
 
     requires org.eclipse.lsp4j.debug;
     requires org.eclipse.lsp4j.jsonrpc;
+    requires org.eclipse.lsp4j.jsonrpc.debug;
 
     exports io.quarkus.qute.debug;
     exports io.quarkus.qute.debug.adapter;
@@ -15,4 +16,5 @@ module io.quarkus.qute.debug {
     exports io.quarkus.qute.debug.agent.scopes;
     exports io.quarkus.qute.debug.agent.source;
     exports io.quarkus.qute.debug.agent.variables;
+    exports io.quarkus.qute.debug.client;
 }

--- a/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/DAPClient.java
+++ b/independent-projects/qute/debug/src/test/java/io/quarkus/qute/debug/client/DAPClient.java
@@ -39,7 +39,6 @@ import org.eclipse.lsp4j.debug.Thread;
 import org.eclipse.lsp4j.debug.Variable;
 import org.eclipse.lsp4j.debug.VariablesArguments;
 import org.eclipse.lsp4j.debug.launch.DSPLauncher;
-import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
@@ -50,7 +49,7 @@ import io.quarkus.qute.debug.DebuggerListener;
 import io.quarkus.qute.debug.DebuggerState;
 import io.quarkus.qute.debug.client.TransportStreams.SocketTransportStreams;
 
-public class DAPClient implements IDebugProtocolClient, Debugger {
+public class DAPClient implements QuteDebugProtocolClient, Debugger {
 
     private IDebugProtocolServer debugProtocolServer;
     private Future<Void> debugProtocolFuture;
@@ -58,6 +57,7 @@ public class DAPClient implements IDebugProtocolClient, Debugger {
     private final CompletableFuture<Capabilities> capabilitiesFuture = new CompletableFuture<>();
     private final CompletableFuture<Void> initialized = new CompletableFuture<>();
     private boolean enabled;
+    private JavaSourceResolver javaFileInfoProvider;
 
     public CompletableFuture<Void> connectToServer(int port) {
         ServerTrace serverTrace = ServerTrace.getDefaultValue();
@@ -363,4 +363,15 @@ public class DAPClient implements IDebugProtocolClient, Debugger {
         }
     }
 
+    public void setJavaFileInfoProvider(JavaSourceResolver javaFileInfoProvider) {
+        this.javaFileInfoProvider = javaFileInfoProvider;
+    }
+
+    @Override
+    public CompletableFuture<JavaSourceLocationResponse> resolveJavaSource(JavaSourceLocationArguments params) {
+        if (javaFileInfoProvider != null) {
+            return javaFileInfoProvider.resolveJavaSource(params);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
 }


### PR DESCRIPTION
This PR provides the capability to debug Qute template declared in `@TemplateContents`:

<img width="1215" height="388" alt="image" src="https://github.com/user-attachments/assets/016368e0-6104-4b9e-a1ae-819746fb07a7" />

Here a demo for Quarkus LangChain4j in https://github.com/quarkiverse/quarkus-langchain4j/pull/1989

![QuarkusLangchain4jDemo](https://github.com/user-attachments/assets/e2e03882-84cf-4a45-9e7e-3c17b3396f8a)


TODO: explain the Qute Java uri 
