### PR TITLE
Compute bean raw types in a Set/HashSet before materializing them

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -26,7 +27,6 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -116,7 +116,7 @@ public class ArcContainerImpl implements ArcContainer {
         id = String.valueOf(ID_GENERATOR.incrementAndGet());
         running = new AtomicBoolean(true);
         List<InjectableBean<?>> beans = new ArrayList<>();
-        Map<String, List<InjectableBean<?>>> beansByRawType = new HashMap<>();
+        Map<String, Set<InjectableBean<?>>> beansByRawType = new HashMap<>();
         List<Supplier<Collection<RemovedBean>>> removedBeans = new ArrayList<>();
         List<InjectableInterceptor<?>> interceptors = new ArrayList<>();
         List<InjectableDecorator<?>> decorators = new ArrayList<>();
@@ -179,16 +179,8 @@ public class ArcContainerImpl implements ArcContainer {
         instance = InstanceImpl.forGlobalEntrypoint(Object.class, Collections.emptySet());
 
         this.beans = List.copyOf(beans);
-        this.beansByRawType = Map.copyOf(beansByRawType);
-        // Trim the size of the non-singleton lists
-        this.beansByRawType.forEach(new BiConsumer<String, List<InjectableBean<?>>>() {
-            @Override
-            public void accept(String key, List<InjectableBean<?>> val) {
-                if (val.size() > 1) {
-                    ((ArrayList<InjectableBean<?>>) val).trimToSize();
-                }
-            }
-        });
+        this.beansByRawType = beansByRawType.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Entry::getKey, e -> List.copyOf(e.getValue())));
 
         this.interceptors = List.copyOf(interceptors);
         this.decorators = List.copyOf(decorators);
@@ -245,7 +237,7 @@ public class ArcContainerImpl implements ArcContainer {
         this.contexts = contextsBuilder.build();
     }
 
-    static void precomputeBeanRawTypes(Map<String, List<InjectableBean<?>>> map, InjectableBean<?> bean) {
+    static void precomputeBeanRawTypes(Map<String, Set<InjectableBean<?>>> map, InjectableBean<?> bean) {
         for (Type type : bean.getTypes()) {
             if (Object.class.equals(type)) {
                 continue;
@@ -256,18 +248,19 @@ public class ArcContainerImpl implements ArcContainer {
             }
             rawType = Types.boxedClass(rawType);
             String key = rawType.getName();
-            List<InjectableBean<?>> match = map.get(key);
+            Set<InjectableBean<?>> match = map.get(key);
             if (match == null) {
                 // very often a singleton list will be used
-                map.put(key, List.of(bean));
+                map.put(key, Set.of(bean));
             } else {
-                // we don't expect large lists so this should be fine performance wise
                 if (match.contains(bean)) {
                     continue;
                 }
                 if (match.size() == 1) {
-                    List<InjectableBean<?>> newMatch = new ArrayList<>();
-                    newMatch.add(match.get(0));
+                    // a set of 2 elements is also a relatively common case
+                    map.put(key, Set.of(match.iterator().next(), bean));
+                } else if (match.size() == 2) {
+                    Set<InjectableBean<?>> newMatch = new HashSet<>(match);
                     newMatch.add(bean);
                     map.put(key, newMatch);
                 } else {
@@ -536,7 +529,7 @@ public class ArcContainerImpl implements ArcContainer {
         return notifier.isEmpty() ? null : notifier;
     }
 
-    private static void addBuiltInBeans(List<InjectableBean<?>> beans, Map<String, List<InjectableBean<?>>> beansByRawType) {
+    private static void addBuiltInBeans(List<InjectableBean<?>> beans, Map<String, Set<InjectableBean<?>>> beansByRawType) {
         // BeanManager, Event<?>, Instance<?>, InjectionPoint
         BeanManagerBean beanManagerBean = new BeanManagerBean();
         beans.add(beanManagerBean);


### PR DESCRIPTION
It allows to avoid performing very badly when we have lots of beans of the same type, for instance when you have a lot of Panache repositories for various entities.

We materialize things with Lists in the end, and they might be a bit more optimized than before for small non-singleton lists.

The downside is that we have a bit more allocations but from my testing, it wasn't affecting startup times.

Fixes #51468

We went from (see elements on the left side):

<img width="3337" height="1074" alt="Screenshot From 2025-12-09 15-35-23" src="https://github.com/user-attachments/assets/64ba713a-a447-4493-8733-8af0f3a15795" />

to

<img width="3337" height="1074" alt="Screenshot From 2025-12-09 15-35-28" src="https://github.com/user-attachments/assets/d553aaa9-90c8-4ad7-b4b1-f2f705e19621" />

The rest of the ArC container initialization is mostly class loading.

