### PR TITLE
Make sure collected managed dependencies do not include duplicates

### DIFF
--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/ManagedReplacedDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/ManagedReplacedDependencyTestCase.java
@@ -45,7 +45,7 @@ public class ManagedReplacedDependencyTestCase extends CollectDependenciesBase {
         install(ext301, false);
 
         // add a dependency on ext3 (no version)
-        root.addDependency(TsArtifact.jar(ext300.getRuntime().getArtifactId(), null));
+        root.addDependency(TsArtifact.jar("ext3", null));
 
         // the dependency management
         addManagedDep(ext103);


### PR DESCRIPTION
Fixes an issue found in Maven 4 RC5 (Maven resolver 2.11) discussed in [#dev > Maven 4 ignoring our BOM?](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Maven.204.20ignoring.20our.20BOM.3F/with/562687141) and https://github.com/quarkiverse/quarkus-logging-json/issues/398

The fix in the resolver https://github.com/apache/maven-resolver/pull/1702