### PR TITLE
ArC: materialize the map bean ID -> bean eagerly

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
@@ -275,7 +275,7 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
                     Expr thisAnnType = Const.of(classDescOf(literal.annotationClass));
                     Expr thatAnnType = bc.invokeInterface(MethodDesc.of(Annotation.class, "annotationType", Class.class),
                             other);
-                    bc.return_(bc.objEquals(thisAnnType, thatAnnType));
+                    bc.return_(bc.exprEquals(thisAnnType, thatAnnType));
                     return;
                 }
 
@@ -341,7 +341,7 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
                         // annotation members are never `null`
                         memberValueHash = bc.withObject(value).hashCode_();
                     } else {
-                        memberValueHash = bc.objHashCode(value);
+                        memberValueHash = bc.exprHashCode(value);
                     }
 
                     Expr xor = bc.xor(memberNameHash, memberValueHash);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1355,7 +1355,7 @@ public class BeanGenerator extends AbstractGenerator {
                         msgBuilder.append("\n\t- ").append(matchingIP.getTargetInfo());
                     }
                 }
-                b1.throw_(InactiveBeanException.class, b1.objToString(msg));
+                b1.throw_(InactiveBeanException.class, b1.exprToString(msg));
             });
         }
 
@@ -2034,7 +2034,7 @@ public class BeanGenerator extends AbstractGenerator {
                 // return identifier.equals(((InjectableBean) other).getIdentifier());
                 Expr otherBean = bc.cast(other, InjectableBean.class);
                 Expr otherIdentifier = bc.invokeInterface(MethodDescs.GET_IDENTIFIER, otherBean);
-                bc.return_(bc.objEquals(Const.of(bean.getIdentifier()), otherIdentifier));
+                bc.return_(bc.exprEquals(Const.of(bean.getIdentifier()), otherIdentifier));
             });
         });
     }


### PR DESCRIPTION
Follows up on #51468 where @gsmet noticed (and me and @mkouba confirmed) that `ArcContainer.bean(String)` actually _is_ used fairly often, notably in all constructors of generated `_ClientProxy` classes. Therefore, materializing the map early is beneficial (the more normal scoped beans in the app, the more benefits).