### PR TITLE
Remove warning failing to determine the build plugin prefix

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -791,9 +791,7 @@ public class DevMojo extends AbstractMojo {
             var colon = goal.lastIndexOf(':');
             if (colon >= 0) {
                 var plugin = pluginPrefixes.get(goal.substring(0, colon));
-                if (plugin == null) {
-                    getLog().warn("Failed to locate plugin for " + goal);
-                } else {
+                if (plugin != null) {
                     executedPluginGoals.computeIfAbsent(plugin.getId(), k -> new ArrayList<>()).add(goal.substring(colon + 1));
                 }
             }


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/51326