### PR TITLE
Include NATIVE_IMAGE_OPTIONS when looking for future defaults

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/NativeConfigUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/NativeConfigUtils.java
@@ -1,10 +1,12 @@
-package io.quarkus.deployment.pkg;
+package io.quarkus.deployment.configuration;
+
+import io.quarkus.deployment.pkg.NativeConfig;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public final class NativeConfigs {
+public final class NativeConfigUtils {
     public static List<String> getNativeAdditionalBuildArgs(NativeConfig nativeConfig) {
         List<String> additionalBuildArgs = new ArrayList<>();
         nativeConfig.additionalBuildArgs().map(additionalBuildArgs::addAll);
@@ -21,6 +23,6 @@ public final class NativeConfigs {
         return additionalBuildArgs;
     }
 
-    private NativeConfigs() {
+    private NativeConfigUtils() {
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/NativeConfigUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/NativeConfigUtils.java
@@ -1,10 +1,10 @@
 package io.quarkus.deployment.configuration;
 
-import io.quarkus.deployment.pkg.NativeConfig;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import io.quarkus.deployment.pkg.NativeConfig;
 
 public final class NativeConfigUtils {
     public static List<String> getNativeAdditionalBuildArgs(NativeConfig nativeConfig) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfigs.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfigs.java
@@ -1,0 +1,26 @@
+package io.quarkus.deployment.pkg;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class NativeConfigs {
+    public static List<String> getNativeAdditionalBuildArgs(NativeConfig nativeConfig) {
+        List<String> additionalBuildArgs = new ArrayList<>();
+        nativeConfig.additionalBuildArgs().map(additionalBuildArgs::addAll);
+        nativeConfig.additionalBuildArgsAppend().map(additionalBuildArgs::addAll);
+
+        final String nativeImageOptions = System.getenv().get("NATIVE_IMAGE_OPTIONS");
+        if (nativeImageOptions != null) {
+            // Native image options are space separated,
+            // it follows same format as JAVA_TOOL_OPTIONS.
+            final String[] options = nativeImageOptions.split("\\s+");
+            additionalBuildArgs.addAll(Arrays.asList(options));
+        }
+
+        return additionalBuildArgs;
+    }
+
+    private NativeConfigs() {
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -39,7 +39,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeMinimalJavaVersionBuild
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.pkg.NativeConfigs;
+import io.quarkus.deployment.configuration.NativeConfigUtils;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
@@ -1031,7 +1031,7 @@ public class NativeImageBuildStep {
             }
 
             private void handleAdditionalProperties(List<String> command) {
-                final List<String> additionalBuildArgs = NativeConfigs.getNativeAdditionalBuildArgs(nativeConfig);
+                final List<String> additionalBuildArgs = NativeConfigUtils.getNativeAdditionalBuildArgs(nativeConfig);
                 for (String buildArg : additionalBuildArgs) {
                     String trimmedBuildArg = buildArg.trim();
                     if (trimmedBuildArg.contains(TRUST_STORE_SYSTEM_PROPERTY_MARKER) && containerBuild) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -38,8 +38,8 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuil
 import io.quarkus.deployment.builditem.nativeimage.NativeMinimalJavaVersionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem;
-import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.configuration.NativeConfigUtils;
+import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -39,6 +39,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeMinimalJavaVersionBuild
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.pkg.NativeConfigs;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
@@ -1030,40 +1031,33 @@ public class NativeImageBuildStep {
             }
 
             private void handleAdditionalProperties(List<String> command) {
-                Optional<List<String>>[] additionalBuildArgs = new Optional[] { nativeConfig.additionalBuildArgs(),
-                        nativeConfig.additionalBuildArgsAppend() };
-                for (Optional<List<String>> args : additionalBuildArgs) {
-                    if (args.isEmpty()) {
-                        continue;
-                    }
-                    List<String> strings = args.get();
-                    for (String buildArg : strings) {
-                        String trimmedBuildArg = buildArg.trim();
-                        if (trimmedBuildArg.contains(TRUST_STORE_SYSTEM_PROPERTY_MARKER) && containerBuild) {
-                            /*
-                             * When the native binary is being built with a docker container, because a volume is created,
-                             * we need to copy the trustStore file into the output directory (which is the root of volume)
-                             * and change the value of 'javax.net.ssl.trustStore' property to point to this value
-                             *
-                             * TODO: we might want to introduce a dedicated property in order to overcome this ugliness
-                             */
-                            int index = trimmedBuildArg.indexOf(TRUST_STORE_SYSTEM_PROPERTY_MARKER);
-                            if (trimmedBuildArg.length() > index + 2) {
-                                String configuredTrustStorePath = trimmedBuildArg
-                                        .substring(index + TRUST_STORE_SYSTEM_PROPERTY_MARKER.length());
-                                try {
-                                    IoUtils.copy(Paths.get(configuredTrustStorePath),
-                                            outputDir.resolve(MOVED_TRUST_STORE_NAME));
-                                    command.add(trimmedBuildArg.substring(0, index) + TRUST_STORE_SYSTEM_PROPERTY_MARKER
-                                            + CONTAINER_BUILD_VOLUME_PATH + "/" + MOVED_TRUST_STORE_NAME);
-                                } catch (IOException e) {
-                                    throw new UncheckedIOException("Unable to copy trustStore file '" + configuredTrustStorePath
-                                            + "' to volume root directory '" + outputDir.toAbsolutePath() + "'", e);
-                                }
+                final List<String> additionalBuildArgs = NativeConfigs.getNativeAdditionalBuildArgs(nativeConfig);
+                for (String buildArg : additionalBuildArgs) {
+                    String trimmedBuildArg = buildArg.trim();
+                    if (trimmedBuildArg.contains(TRUST_STORE_SYSTEM_PROPERTY_MARKER) && containerBuild) {
+                        /*
+                         * When the native binary is being built with a docker container, because a volume is created,
+                         * we need to copy the trustStore file into the output directory (which is the root of volume)
+                         * and change the value of 'javax.net.ssl.trustStore' property to point to this value
+                         *
+                         * TODO: we might want to introduce a dedicated property in order to overcome this ugliness
+                         */
+                        int index = trimmedBuildArg.indexOf(TRUST_STORE_SYSTEM_PROPERTY_MARKER);
+                        if (trimmedBuildArg.length() > index + 2) {
+                            String configuredTrustStorePath = trimmedBuildArg
+                                    .substring(index + TRUST_STORE_SYSTEM_PROPERTY_MARKER.length());
+                            try {
+                                IoUtils.copy(Paths.get(configuredTrustStorePath),
+                                        outputDir.resolve(MOVED_TRUST_STORE_NAME));
+                                command.add(trimmedBuildArg.substring(0, index) + TRUST_STORE_SYSTEM_PROPERTY_MARKER
+                                        + CONTAINER_BUILD_VOLUME_PATH + "/" + MOVED_TRUST_STORE_NAME);
+                            } catch (IOException e) {
+                                throw new UncheckedIOException("Unable to copy trustStore file '" + configuredTrustStorePath
+                                        + "' to volume root directory '" + outputDir.toAbsolutePath() + "'", e);
                             }
-                        } else {
-                            command.add(trimmedBuildArg);
                         }
+                    } else {
+                        command.add(trimmedBuildArg);
                     }
                 }
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
@@ -2,10 +2,10 @@ package io.quarkus.deployment.pkg.steps;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
 import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.pkg.NativeConfigs;
 
 public enum NativeImageFutureDefault {
     COMPLETE_REFLECTION_TYPES,
@@ -19,37 +19,29 @@ public enum NativeImageFutureDefault {
     }
 
     private static boolean isFutureDefault(NativeImageFutureDefault futureDefault, NativeConfig nativeConfig) {
-        Optional<List<String>>[] additionalBuildArgs = new Optional[] { nativeConfig.additionalBuildArgs(),
-                nativeConfig.additionalBuildArgsAppend() };
+        final List<String> additionalBuildArgs = NativeConfigs.getNativeAdditionalBuildArgs(nativeConfig);
+        for (String buildArg : additionalBuildArgs) {
+            String trimmedBuildArg = buildArg.trim();
+            if (trimmedBuildArg.contains(FUTURE_DEFAULTS_MARKER)) {
+                int index = trimmedBuildArg.indexOf('=');
+                String[] futureDefaultStringArgs = trimmedBuildArg.substring(index + 1).split(",");
+                for (String futureDefaultString : futureDefaultStringArgs) {
+                    if ("all".equals(futureDefaultString)) {
+                        return true;
+                    }
 
-        for (Optional<List<String>> args : additionalBuildArgs) {
-            if (args.isEmpty()) {
-                continue;
-            }
-            List<String> strings = args.get();
-            for (String buildArg : strings) {
-                String trimmedBuildArg = buildArg.trim();
-                if (trimmedBuildArg.contains(FUTURE_DEFAULTS_MARKER)) {
-                    int index = trimmedBuildArg.indexOf('=');
-                    String[] futureDefaultStringArgs = trimmedBuildArg.substring(index + 1).split(",");
-                    for (String futureDefaultString : futureDefaultStringArgs) {
-                        if ("all".equals(futureDefaultString)) {
-                            return true;
+                    if ("run-time-initialize-jdk".equals(futureDefaultString)) {
+                        switch (futureDefault) {
+                            case RUN_TIME_INITIALIZE_SECURITY_PROVIDERS:
+                            case RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS:
+                                return true;
                         }
+                    }
 
-                        if ("run-time-initialize-jdk".equals(futureDefaultString)) {
-                            switch (futureDefault) {
-                                case RUN_TIME_INITIALIZE_SECURITY_PROVIDERS:
-                                case RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS:
-                                    return true;
-                            }
-                        }
-
-                        final NativeImageFutureDefault futureDefaultArg = NativeImageFutureDefault
-                                .valueOf(futureDefaultString.toUpperCase(Locale.ROOT).replace('-', '_'));
-                        if (futureDefaultArg == futureDefault) {
-                            return true;
-                        }
+                    final NativeImageFutureDefault futureDefaultArg = NativeImageFutureDefault
+                            .valueOf(futureDefaultString.toUpperCase(Locale.ROOT).replace('-', '_'));
+                    if (futureDefaultArg == futureDefault) {
+                        return true;
                     }
                 }
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 import java.util.function.BooleanSupplier;
 
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.pkg.NativeConfigs;
+import io.quarkus.deployment.configuration.NativeConfigUtils;
 
 public enum NativeImageFutureDefault {
     COMPLETE_REFLECTION_TYPES,
@@ -19,7 +19,7 @@ public enum NativeImageFutureDefault {
     }
 
     private static boolean isFutureDefault(NativeImageFutureDefault futureDefault, NativeConfig nativeConfig) {
-        final List<String> additionalBuildArgs = NativeConfigs.getNativeAdditionalBuildArgs(nativeConfig);
+        final List<String> additionalBuildArgs = NativeConfigUtils.getNativeAdditionalBuildArgs(nativeConfig);
         for (String buildArg : additionalBuildArgs) {
             String trimmedBuildArg = buildArg.trim();
             if (trimmedBuildArg.contains(FUTURE_DEFAULTS_MARKER)) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.BooleanSupplier;
 
-import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.configuration.NativeConfigUtils;
+import io.quarkus.deployment.pkg.NativeConfig;
 
 public enum NativeImageFutureDefault {
     COMPLETE_REFLECTION_TYPES,


### PR DESCRIPTION
Fixes #51359.

Include `NATIVE_IMAGE_OPTIONS` environment values into set of native additional build arguments that are checked for future defaults settings. I've also refactored other existing use cases that look for specific native build arguments.

`NATIVE_IMAGE_OPTIONS` follows same format as `JAVA_TOOL_OPTIONS`, whose values are space separated.