### PR TITLE
Option to allow a registry to configure the client Maven resolver to resolve its platform extension catalogs

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/RegistryCacheRefreshLogger.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/RegistryCacheRefreshLogger.java
@@ -1,0 +1,69 @@
+package io.quarkus.registry.client.maven;
+
+import org.eclipse.aether.transfer.TransferCancelledException;
+import org.eclipse.aether.transfer.TransferEvent;
+import org.eclipse.aether.transfer.TransferListener;
+
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.registry.config.RegistryConfig;
+
+class RegistryCacheRefreshLogger implements TransferListener {
+
+    private final RegistryConfig config;
+    private final MessageWriter log;
+    private final TransferListener delegate;
+    boolean loggedCatalogRefreshMsg;
+
+    public RegistryCacheRefreshLogger(RegistryConfig config, MessageWriter log, TransferListener delegate) {
+        this.config = config;
+        this.log = log;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void transferInitiated(TransferEvent event) throws TransferCancelledException {
+        if (!loggedCatalogRefreshMsg && !event.getResource().getResourceName()
+                .contains(config.getDescriptor().getArtifact().getArtifactId())) {
+            loggedCatalogRefreshMsg = true;
+            log.info("Looking for the newly published extensions in " + config.getId());
+        }
+        if (delegate != null) {
+            delegate.transferInitiated(event);
+        }
+    }
+
+    @Override
+    public void transferStarted(TransferEvent event) throws TransferCancelledException {
+        if (delegate != null) {
+            delegate.transferStarted(event);
+        }
+    }
+
+    @Override
+    public void transferProgressed(TransferEvent event) throws TransferCancelledException {
+        if (delegate != null) {
+            delegate.transferProgressed(event);
+        }
+    }
+
+    @Override
+    public void transferCorrupted(TransferEvent event) throws TransferCancelledException {
+        if (delegate != null) {
+            delegate.transferCorrupted(event);
+        }
+    }
+
+    @Override
+    public void transferSucceeded(TransferEvent event) {
+        if (delegate != null) {
+            delegate.transferSucceeded(event);
+        }
+    }
+
+    @Override
+    public void transferFailed(TransferEvent event) {
+        if (delegate != null) {
+            delegate.transferFailed(event);
+        }
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryMavenRepoConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryMavenRepoConfigImpl.java
@@ -56,10 +56,7 @@ public class RegistryMavenRepoConfigImpl implements RegistryMavenRepoConfig {
 
     @Override
     public String toString() {
-        return "BaseRegistryMavenRepoConfig{" +
-                "id='" + id + '\'' +
-                ", url='" + url + '\'' +
-                '}';
+        return "Maven repo " + id + " " + " " + url;
     }
 
     /**

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryPlatformsConfig.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryPlatformsConfig.java
@@ -17,6 +17,13 @@ public interface RegistryPlatformsConfig extends RegistryArtifactConfig {
      */
     Boolean getExtensionCatalogsIncluded();
 
+    /**
+     * Allows configuring a Maven repository to resolve platform extension catalogs from.
+     *
+     * @return Maven repository configuration or null
+     */
+    RegistryMavenConfig getMaven();
+
     default Mutable mutable() {
         return new RegistryPlatformsConfigImpl.Builder(this);
     }
@@ -30,6 +37,8 @@ public interface RegistryPlatformsConfig extends RegistryArtifactConfig {
         RegistryPlatformsConfig.Mutable setDisabled(boolean disabled);
 
         RegistryPlatformsConfig.Mutable setExtensionCatalogsIncluded(Boolean extensionCatalogsIncluded);
+
+        RegistryPlatformsConfig.Mutable setMaven(RegistryMavenConfig mavenConfig);
 
         /** @return an immutable copy of this config */
         @Override

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryPlatformsConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryPlatformsConfigImpl.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.json.JsonBuilder;
@@ -21,15 +22,22 @@ import io.quarkus.registry.json.JsonBuilder;
 public class RegistryPlatformsConfigImpl extends RegistryArtifactConfigImpl implements RegistryPlatformsConfig {
 
     protected final Boolean extensionCatalogsIncluded;
+    protected final RegistryMavenConfig mavenConfig;
 
     private RegistryPlatformsConfigImpl(Builder builder) {
         super(builder.disabled, builder.artifact);
         this.extensionCatalogsIncluded = builder.extensionCatalogsIncluded;
+        this.mavenConfig = builder.mavenConfig;
     }
 
     @Override
     public Boolean getExtensionCatalogsIncluded() {
         return extensionCatalogsIncluded;
+    }
+
+    @Override
+    public RegistryMavenConfig getMaven() {
+        return mavenConfig;
     }
 
     @Override
@@ -67,6 +75,7 @@ public class RegistryPlatformsConfigImpl extends RegistryArtifactConfigImpl impl
      */
     public static class Builder extends RegistryArtifactConfigImpl.Builder implements RegistryPlatformsConfig.Mutable {
         protected Boolean extensionCatalogsIncluded;
+        protected RegistryMavenConfig mavenConfig;
 
         public Builder() {
         }
@@ -97,6 +106,18 @@ public class RegistryPlatformsConfigImpl extends RegistryArtifactConfigImpl impl
         @Override
         public RegistryPlatformsConfig.Mutable setExtensionCatalogsIncluded(Boolean extensionCatalogsIncluded) {
             this.extensionCatalogsIncluded = extensionCatalogsIncluded;
+            return this;
+        }
+
+        @Override
+        @JsonDeserialize(as = RegistryMavenConfigImpl.Builder.class)
+        public RegistryMavenConfig getMaven() {
+            return mavenConfig;
+        }
+
+        @Override
+        public RegistryPlatformsConfig.Mutable setMaven(RegistryMavenConfig mavenConfig) {
+            this.mavenConfig = mavenConfig;
             return this;
         }
 

--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/DevToolsConfigSerializationTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/DevToolsConfigSerializationTest.java
@@ -350,6 +350,35 @@ public class DevToolsConfigSerializationTest {
     }
 
     @Test
+    void testRegistryClientMavenPlatformExtensionJsonConfig() throws IOException {
+        String configName = "registry-client-platform-extension-maven-config.json";
+        Path expectedFile = baseDir.resolve(configName);
+        Path actualFile = writeDir.resolve(configName);
+
+        RegistryConfig expected = RegistryConfig.builder()
+                .setId("registry.acme.org")
+                .setDescriptor(RegistryDescriptorConfig.builder()
+                        .setArtifact(
+                                ArtifactCoords
+                                        .fromString("registry.quarkus.test:quarkus-registry-descriptor::json:1.0-SNAPSHOT")))
+                .setPlatforms(RegistryPlatformsConfig.builder()
+                        .setArtifact(ArtifactCoords.fromString("registry.quarkus.test:quarkus-platforms::json:1.0-SNAPSHOT"))
+                        .setMaven(RegistryMavenConfig.builder().setRepository(
+                                RegistryMavenRepoConfig.builder().setId("repo-id").setUrl("repo-url"))))
+                .setNonPlatformExtensions(RegistryNonPlatformExtensionsConfig.builder()
+                        .setDisabled(true)
+                        .setArtifact(ArtifactCoords
+                                .fromString("registry.quarkus.test:quarkus-non-platform-extensions::json:1.0-SNAPSHOT")));
+
+        expected.persist(actualFile);
+
+        String expectedContents = Files.readString(expectedFile);
+        String actualContents = Files.readString(actualFile);
+
+        assertThat(actualContents).isEqualTo(expectedContents);
+    }
+
+    @Test
     void testReadJsonRegistryDescriptor() throws IOException {
         String configName = "registry-descriptor-1.0-SNAPSHOT.json";
         Path expectedFile = baseDir.resolve(configName);

--- a/independent-projects/tools/registry-client/src/test/resources/devtools-config/registry-client-platform-extension-maven-config.json
+++ b/independent-projects/tools/registry-client/src/test/resources/devtools-config/registry-client-platform-extension-maven-config.json
@@ -1,0 +1,18 @@
+{
+  "descriptor" : {
+    "artifact" : "registry.quarkus.test:quarkus-registry-descriptor::json:1.0-SNAPSHOT"
+  },
+  "platforms" : {
+    "artifact" : "registry.quarkus.test:quarkus-platforms::json:1.0-SNAPSHOT",
+    "maven" : {
+      "repository" : {
+        "id" : "repo-id",
+        "url" : "repo-url"
+      }
+    }
+  },
+  "non-platform-extensions" : {
+    "disabled" : true,
+    "artifact" : "registry.quarkus.test:quarkus-non-platform-extensions::json:1.0-SNAPSHOT"
+  }
+}


### PR DESCRIPTION
This change allows a registry to provide a Maven repository configuration to the client that should be used to resolve platform extension catalogs.

Currently, unless an extension catalog is available from Maven Central, a user is supposed to enable the corresponding Maven repository, e.g. maven.repository.redhat.com in the `settings.xml` for the project generator to work. With this change this isn't necessary. A registry can provide the necessary Maven repo config in its descriptor artifact to the client.

A YAML equivalent would look like
```
registries:
  - registry.quarkus.redhat.com:
      platforms:
        maven:
          repository:
            id: "redhat"
            url: "https://maven.repository.redhat.com/ga"
```

There is still an issue with codestart artifact resolution that I need to look into.