### PR TITLE
Improve TLS protocol warning to skip default secure configuration

### DIFF
--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -134,6 +134,12 @@ public class VertxCertificateHolder implements TlsConfiguration {
 
     boolean warnIfOldProtocols(Set<String> protocols, String name) {
         var list = protocols.stream().map(String::toLowerCase).map(String::trim).toList();
+
+        // Quick check to skip the warning if only the default protocol is used.
+        if (list.size() == 1 && list.get(0).equalsIgnoreCase(TlsBucketConfig.DEFAULT_TLS_PROTOCOLS)) {
+            return false;
+        }
+
         boolean warned = false;
 
         // Check for SSL protocols
@@ -153,7 +159,7 @@ public class VertxCertificateHolder implements TlsConfiguration {
         // Check if TLSv1.3 or higher is enabled.
         boolean isUsingModernTlsVersion = false;
         for (String p : list) {
-            if (IsRecentOrFutureTLSVersion(p)) {
+            if (isRecentOrFutureTLSVersion(p)) {
                 isUsingModernTlsVersion = true;
                 break;
             }
@@ -174,7 +180,7 @@ public class VertxCertificateHolder implements TlsConfiguration {
      * @param protocol the protocol string (already lowercased and trimmed)
      * @return true if the protocol is TLSv1.3 or higher
      */
-    private boolean IsRecentOrFutureTLSVersion(String protocol) {
+    private boolean isRecentOrFutureTLSVersion(String protocol) {
         if (!protocol.startsWith("tlsv")) {
             return false;
         }

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsBucketConfig.java
@@ -13,6 +13,8 @@ import io.smallrye.config.WithDefault;
 @ConfigGroup
 public interface TlsBucketConfig {
 
+    public static final String DEFAULT_TLS_PROTOCOLS = "TLSv1.3";
+
     /**
      * The key store configuration.
      * Key stores are used to store private keys and their associated X.509 certificate chains.
@@ -48,7 +50,7 @@ public interface TlsBucketConfig {
      * You must at least have one protocol.
      * <p>
      */
-    @WithDefault("TLSv1.3")
+    @WithDefault(DEFAULT_TLS_PROTOCOLS)
     Set<String> protocols();
 
     /**

--- a/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
+++ b/extensions/tls-registry/runtime/src/test/java/io/quarkus/tls/runtime/VertxCertificateHolderTest.java
@@ -78,6 +78,12 @@ class VertxCertificateHolderTest {
     }
 
     @Test
+    void testDefault() {
+        assertFalse(holder.warnIfOldProtocols(Set.of(TlsBucketConfig.DEFAULT_TLS_PROTOCOLS), "test"));
+        assertFalse(holder.warnIfOldProtocols(Set.of(TlsBucketConfig.DEFAULT_TLS_PROTOCOLS.toLowerCase()), "test"));
+    }
+
+    @Test
     void testWarnIfOldProtocols_withSSL() {
         assertTrue(holder.warnIfOldProtocols(Set.of("SSLv3"), "test"));
         assertTrue(holder.warnIfOldProtocols(Set.of("SSLv2", "TLSv1.3"), "test"));


### PR DESCRIPTION
This is a follow up of the TLS checks ](https://github.com/quarkusio/quarkus/pull/51336) to speed up the checks if the default configuration is used.