### PR TITLE
Record every configuration marked as build time fixed

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -239,15 +239,10 @@ public final class BuildTimeConfigurationReader {
                         }
                     });
 
-            // Set all defaults from build time runtime mappings as recorded build time runtime values
+            // Records all build time runtime fixed values from the recording config, which includes defaults
             for (ConfigClass buildTimeRunTimeMapping : buildTimeRunTimeMappings) {
                 for (Entry<String, String> entry : buildTimeRunTimeMapping.getProperties().entrySet()) {
-                    buildTimeRunTimeValues.put(entry.getKey(),
-                            ConfigValue.builder()
-                                    .withName(entry.getKey())
-                                    .withValue(entry.getValue())
-                                    .withConfigSourceOrdinal(-Integer.MAX_VALUE)
-                                    .build());
+                    buildTimeRunTimeValues.put(entry.getKey(), runtimeConfig.getConfigValue(entry.getKey()));
                 }
             }
 

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigSource.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigSource.java
@@ -1,0 +1,17 @@
+package io.quarkus.extest;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.smallrye.config.common.MapBackedConfigSource;
+
+public class OverrideBuildTimeConfigSource extends MapBackedConfigSource {
+    public OverrideBuildTimeConfigSource() {
+        super("OverrideBuildTimeConfigSource", Map.of("quarkus.mapping.btrt.unlisted", "value"));
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return Set.of();
+    }
+}

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
@@ -1,9 +1,11 @@
 package io.quarkus.extest;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -12,7 +14,13 @@ import io.quarkus.test.QuarkusProdModeTest;
 public class OverrideBuildTimeConfigTest {
     @RegisterExtension
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
-            .setRuntimeProperties(Map.of("quarkus.application.name", "foo", "quarkus.mapping.btrt.optional", "value"))
+            .withApplicationRoot(jar -> jar
+                    .addClass(OverrideBuildTimeConfigSource.class)
+                    .addAsServiceProvider(ConfigSource.class, OverrideBuildTimeConfigSource.class))
+            .setRuntimeProperties(Map.of(
+                    "quarkus.application.name", "foo",
+                    "quarkus.mapping.btrt.optional", "value",
+                    "quarkus.mapping.btrt.unlisted", "value"))
             .setRun(true);
 
     @Test
@@ -22,5 +30,7 @@ public class OverrideBuildTimeConfigTest {
                         "'quarkus-integration-test-test-extension-extension-deployment'."));
         assertTrue(TEST.getStartupConsoleOutput()
                 .contains("- quarkus.mapping.btrt.optional is set to 'value' but it is build time fixed to 'null'."));
+        assertFalse(TEST.getStartupConsoleOutput()
+                .contains("- quarkus.mapping.btrt.unlisted is set to 'value' but it is build time fixed to 'null'."));
     }
 }

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingBuildTimeRunTime.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingBuildTimeRunTime.java
@@ -30,6 +30,11 @@ public interface TestMappingBuildTimeRunTime {
      */
     Optional<String> optional();
 
+    /**
+     * Unlisted
+     */
+    Optional<String> unlisted();
+
     interface Group {
         /**
          * A Group value.


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/51248, we improved the recording of build time fixed configuration, but the recording of non-default values was relying on the list of property names returned by `Config` and `ConfigSource`s.

If a `ConfigSource` reported values, but not the list of names, it could cause a false positive warning of overriding a build time fixed configuration, observed in https://github.com/keycloak/keycloak/issues/44599.

Since we know the list of build time configuration names, we now record it using our list instead of relying on the list reported by `Config`.