### PR TITLE
Allow discovering devservice containers in tests

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -74,7 +74,7 @@ public class ContainerLocator {
     }
 
     public Optional<ContainerAddress> locateContainer(String serviceName, boolean shared, LaunchMode launchMode) {
-        if (shared && launchMode == LaunchMode.DEVELOPMENT) {
+        if (shared && launchMode.isDevServicesSupported()) {
             return lookup(serviceName)
                     .flatMap(container -> getMappedPort(container, port).stream()
                             .flatMap(containerPort -> Optional.ofNullable(containerPort.getPublicPort())

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
@@ -3,6 +3,9 @@ package io.quarkus.it.hibernate.search.orm.elasticsearch.devservices;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -24,6 +27,14 @@ public class HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest {
             // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
             // In this test, we do NOT set quarkus.hibernate-search-orm.elasticsearch.hosts.
             return "someotherprofile";
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> config = new HashMap<>();
+            // Use a different service name so that we won't try to "discover" the default dev service started already somewhere
+            config.put("quarkus.elasticsearch.devservices.service-name", "elasticsearch-devservices-91");
+            return config;
         }
     }
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesTest.java
@@ -30,6 +30,8 @@ public class HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesT
         public Map<String, String> getConfigOverrides() {
             Map<String, String> config = new HashMap<>();
             config.put("quarkus.elasticsearch.devservices.enabled", "true");
+            // Use a different service name so that we won't try to "discover" the default dev service started already somewhere
+            config.put("quarkus.elasticsearch.devservices.service-name", "elasticsearch-devservices-91-mixed-test");
             config.put("quarkus.hibernate-search-orm.elasticsearch.version", "9.1");
             return config;
         }

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
@@ -24,6 +24,8 @@ public class HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "quarkus.elasticsearch.devservices.enabled", "true",
+                    // Use a different service name so that we won't try to start this test with the "default" service version != 2.12
+                    "quarkus.elasticsearch.devservices.service-name", "opensearch-devservices",
                     // This needs to be different from the default image, or the test makes no sense.
                     "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.12.0",
                     // This needs to match the version used just above,

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest.java
@@ -3,6 +3,9 @@ package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -25,6 +28,14 @@ public class HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest {
             // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
             // In this test, we do NOT set quarkus.hibernate-search-orm.elasticsearch.hosts.
             return "someotherprofile";
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> config = new HashMap<>();
+            // Use a different service name so that we won't try to "discover" the default dev service started already somewhere
+            config.put("quarkus.elasticsearch.devservices.service-name", "opensearch-devservices-3");
+            return config;
         }
     }
 


### PR DESCRIPTION
Hey 🙂 👋🏻 

I was looking into a failing test in https://github.com/quarkusio/quarkus/pull/51422 and notice that we don't allow to even make an attempt to locate a container when running the tests. Everything seems fine as long as random ports are used for the started services. But .... Elasticseach devservice allows specifying a port that the service should map to, e.g.:

```properties
quarkus.elasticsearch.devservices.port=19205
```
This is still fine for as long as you don't combine that with a `QuarkusTestProfile` in your tests.
when profile is in play, we end up executing the Elasticsearch devservice processor multiple times from different classloaders, and as a result we try to start a container with a port that's already used by another one, and since we don't allow discovering it within tests, we end up failing the build...

If the testcontainer reuse is enabled on your build machine (`testcontainers.reuse.enable=true`) then even though we still have the same problem  ^ testcontainer internals find the container for us when we "start a new one", since the "hash" for the requested container is the same -- we request exactly the same one.

And 🙂 ... we already do it here:

https://github.com/quarkusio/quarkus/blob/c915015a870b820094f6c14c174ac5ee1178d97d/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ComposeLocator.java#L26

so with this it should be a bit more consistent ?

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

