### PR TITLE
Break build cycle between gRPC and JFR extensions

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -115,9 +115,13 @@ public class GrpcClientProcessor {
     }
 
     @BuildStep
+    FeatureBuildItem grpcClientFeature() {
+        return new FeatureBuildItem(GRPC_CLIENT);
+    }
+
+    @BuildStep
     void discoverInjectedClients(BeanDiscoveryFinishedBuildItem beanDiscovery,
             BuildProducer<GrpcClientBuildItem> clients,
-            BuildProducer<FeatureBuildItem> features,
             CombinedIndexBuildItem index) {
 
         Map<String, GrpcClientBuildItem> items = new HashMap<>();
@@ -217,7 +221,7 @@ public class GrpcClientProcessor {
                 clients.produce(item);
                 LOGGER.debugf("Detected client associated with the '%s' configuration prefix", item.getClientName());
             }
-            features.produce(new FeatureBuildItem(GRPC_CLIENT));
+
         }
     }
 

--- a/integration-tests/opentelemetry-grpc/pom.xml
+++ b/integration-tests/opentelemetry-grpc/pom.xml
@@ -26,6 +26,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jfr</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
@@ -100,6 +105,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jfr-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
There is no reason to conditionally register a `FeatureBuildItem`. All other extensions do this unconditionally, so
let's do in gRPC as well and easily break the
build cycle

- Fixes: #51485