### PR TITLE
Remove duplicated dependency

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6631,8 +6631,8 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.quarkus.junit</groupId>
-                <artifactId>junit-virtual-threads</artifactId>
+                <groupId>io.quarkus.junit5</groupId>
+                <artifactId>junit5-virtual-threads</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <!-- End of Relocations, please put new extensions above this list -->


### PR DESCRIPTION
- Follow up on #51412 
This gets rid of the build warning:
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-bom:pom:999-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.quarkus.junit:junit-virtual-threads:jar -> duplicate declaration of version ${project.version} @ line 6633, column 25
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```
