### PR TITLE
Cache Maven Repo in forks

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -233,7 +233,7 @@ jobs:
           java-version: 17
       - name: Restore Maven Repository
         uses: actions/cache/restore@v5
-        if: github.event_name != 'push' || github.repository != 'quarkusio/quarkus' || github.actor == 'dependabot[bot]'
+        if: github.event_name != 'push' || github.actor == 'dependabot[bot]'
         with:
           path: ~/.m2/repository
           key: ${{ needs.configure.outputs.m2-cache-key }}
@@ -242,7 +242,7 @@ jobs:
             ${{ needs.configure.outputs.m2-monthly-cache-key }}-
       - name: Cache Maven Repository on push
         uses: actions/cache@v5
-        if: github.event_name == 'push' && github.repository == 'quarkusio/quarkus' && github.actor != 'dependabot[bot]'
+        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
         with:
           path: ~/.m2/repository
           key: ${{ needs.configure.outputs.m2-cache-key }}


### PR DESCRIPTION
It doesn't make sense to restore the cache in forks if we never populate it. Even if forks could make use of the upstream repo's cache (which I doubt), they don't use the same cache keys, so that wouldn't work.

Also, it seems we already take care of:
1. Skipping main in forks, so synchronizing `main` in forks shouldn't unnecessarily populate the cache.
2. Using "fork" in the cache key instead of a branch name, so we should end up sharing the cache between all branches in the fork -- which seems like a reasonable compromise between performance and space usage.