### PR TITLE
Fix missing renaming of junit5-internal dependency

### DIFF
--- a/integration-tests/hibernate-orm-panache-data/pom.xml
+++ b/integration-tests/hibernate-orm-panache-data/pom.xml
@@ -38,7 +38,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/hibernate-orm-panache-data/pom.xml
+++ b/integration-tests/hibernate-orm-panache-data/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Follows up on #51412 + #50987 , which were merged in parallel and (I think) broke the world.

cc @gsmet @geoand @sberyozkin @michalvavrik .

