### PR TITLE
Rename `io.quarkus.junit:junit-virtual-threads` to `io.quarkus:quarkus-junit-virtual-threads`

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3644,8 +3644,8 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.quarkus.junit</groupId>
-                <artifactId>junit-virtual-threads</artifactId>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-junit-virtual-threads</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -6631,8 +6631,8 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.quarkus.junit5</groupId>
-                <artifactId>junit5-virtual-threads</artifactId>
+                <groupId>io.quarkus.junit</groupId>
+                <artifactId>junit-virtual-threads</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <!-- End of Relocations, please put new extensions above this list -->

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -499,8 +499,8 @@ To enable this detection:
 [source, xml]
 ----
 <dependency>
-    <groupId>io.quarkus.junit</groupId>
-    <artifactId>junit-virtual-threads</artifactId>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-junit-virtual-threads</artifactId>
     <scope>test</scope>
 </dependency>
 ----

--- a/independent-projects/junit-virtual-threads/pom.xml
+++ b/independent-projects/junit-virtual-threads/pom.xml
@@ -11,8 +11,8 @@
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
-    <groupId>io.quarkus.junit</groupId>
-    <artifactId>junit-virtual-threads</artifactId>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-junit-virtual-threads</artifactId>
 
     <name>Quarkus - JUnit Extension - Virtual Threads</name>
     <description>Module that allows detecting virtual threads pinning</description>

--- a/integration-tests/virtual-threads/amqp-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/amqp-virtual-threads/pom.xml
@@ -33,8 +33,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/graphql-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/pom.xml
@@ -29,8 +29,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/grpc-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/grpc-virtual-threads/pom.xml
@@ -33,8 +33,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
@@ -57,8 +57,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/kafka-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/kafka-virtual-threads/pom.xml
@@ -32,8 +32,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/mailer-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/mailer-virtual-threads/pom.xml
@@ -33,8 +33,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/metrics-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/metrics-virtual-threads/pom.xml
@@ -41,8 +41,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/quartz-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/quartz-virtual-threads/pom.xml
@@ -33,8 +33,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/reactive-routes-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/reactive-routes-virtual-threads/pom.xml
@@ -29,8 +29,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/redis-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/redis-virtual-threads/pom.xml
@@ -37,8 +37,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/rest-client-reactive-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/rest-client-reactive-virtual-threads/pom.xml
@@ -33,8 +33,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/pom.xml
@@ -29,8 +29,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/scheduler-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/scheduler-virtual-threads/pom.xml
@@ -33,8 +33,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/security-webauthn-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/security-webauthn-virtual-threads/pom.xml
@@ -38,8 +38,8 @@
             <artifactId>quarkus-test-security-webauthn</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/vertx-event-bus-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/vertx-event-bus-virtual-threads/pom.xml
@@ -29,8 +29,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/virtual-threads/virtual-threads-disabled/pom.xml
+++ b/integration-tests/virtual-threads/virtual-threads-disabled/pom.xml
@@ -29,8 +29,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/relocations/junit5-virtual-threads/pom.xml
+++ b/relocations/junit5-virtual-threads/pom.xml
@@ -14,8 +14,8 @@
 
     <distributionManagement>
         <relocation>
-            <groupId>io.quarkus.junit</groupId>
-            <artifactId>junit-virtual-threads</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-virtual-threads</artifactId>
             <version>${project.version}</version>
             <message>Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31 for more information.</message>
         </relocation>


### PR DESCRIPTION
Rename artifact to be consistent with the other artifacts