### PR TITLE
Bump rest-assured from 5.5.6 to 6.0.0, load Groovy parent-first

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -220,6 +220,11 @@
 
                         <!-- Make use of byteman frictionless -->
                         <parentFirstArtifact>org.jboss.byteman:byteman</parentFirstArtifact>
+
+                        <!-- Load Groovy parent first to minimize thread/memory leaking. -->
+                        <parentFirstArtifact>org.apache.groovy:groovy</parentFirstArtifact>
+                        <parentFirstArtifact>org.apache.groovy:groovy-json</parentFirstArtifact>
+                        <parentFirstArtifact>org.apache.groovy:groovy-xml</parentFirstArtifact>
                     </parentFirstArtifacts>
                     <runnerParentFirstArtifacts>
                         <runnerParentFirstArtifact>org.graalvm.sdk:nativeimage</runnerParentFirstArtifact>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -59,7 +59,7 @@
         <smallrye-mutiny-vertx-core.version>3.21.5</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.16.0</smallrye-common.version>
         <vertx.version>4.5.25</vertx.version>
-        <rest-assured.version>5.5.6</rest-assured.version>
+        <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.21.1</jackson-bom.version>
         <smallrye-stork.version>2.7.7</smallrye-stork.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
              in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.5.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
-        <rest-assured.version>5.5.6</rest-assured.version>
+        <rest-assured.version>6.0.0</rest-assured.version>
         <hibernate-orm.version>7.2.5.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version> <!-- version controlled by Hibernate ORM's needs -->

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredStateManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredStateManager.java
@@ -8,7 +8,6 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import io.restassured.RestAssured;
 import io.restassured.config.HttpClientConfig;
 import io.restassured.config.RestAssuredConfig;
-import io.restassured.internal.path.json.ConfigurableJsonSlurper;
 import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 
@@ -145,17 +144,6 @@ public class RestAssuredStateManager {
         clearURL();
 
         JsonPath.config = null;
-        // Reset the numberReturnType ThreadLocal in ConfigurableJsonSlurper as it is causing class loader leaks
-        try {
-            java.lang.reflect.Field numberReturnTypeField = ConfigurableJsonSlurper.class.getDeclaredField("numberReturnType");
-            numberReturnTypeField.setAccessible(true);
-            ThreadLocal<?> threadLocal = (ThreadLocal<?>) numberReturnTypeField.get(null);
-            if (threadLocal != null) {
-                threadLocal.remove();
-            }
-        } catch (Exception e) {
-            // Ignore if the field doesn't exist or can't be accessed
-        }
     }
 
     /**


### PR DESCRIPTION
- Upgrade rest-assured from 5.5.6 to 6.0.0. See changelog [here](https://github.com/rest-assured/rest-assured/blob/0b3a0d9f280056a45c47c14b351e5285ed2455ed/changelog.txt#L1-L16).
- Remove work-around to clear ThreadLocal field in rest-assured that is no longer present as of version 6.
- Make Groovy class loading parent-first to prevent leaking of multiple daemon threads started by the Groovy runtime that do not (yet) have a way to be stopped.
- Also upgrades rest-assured for resteasy-reactive (is it wanted here or separately?)

 - Fixes: #50563 

