### PR TITLE
Filter specific interface package hierarchy (for reflection)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -360,7 +360,8 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         private static final List<String> DEFAULT_IGNORED_PACKAGES = Arrays.asList("java.", "io.reactivex.",
                 "org.reactivestreams.", "org.slf4j.", "jakarta.", "jakarta.json.",
                 "javax.net.ssl.", "javax.xml.", "javax.management.", "reactor.core.",
-                "com.fasterxml.jackson.databind.", "io.vertx.core.json.", "kotlin.");
+                "com.fasterxml.jackson.databind.", "io.vertx.core.json.", "kotlin.",
+                "javax.sql.", "javax.naming.");
         // if this gets more complicated we will need to move to some tree like structure
         static final Set<String> ALLOWED_FROM_IGNORED_PACKAGES = new HashSet<>(
                 Arrays.asList("java.math.BigDecimal", "java.math.BigInteger"));


### PR DESCRIPTION
The interfaces in javax.naming package are widely implemented across the ecosystem. Registering all implementations of those interfaces for reflection is too much and can actually fail a native build see #51503 where it fails a quickstart. Skip the hierarchical reflection registration for those types to:

1. Reduce the number of classes registered for reflection
2. Reduce the risk of introducing more native build failures

**Testing:**
- [x] Mandrel 23.1 (JDK 21-based) build and run on quarkus with the patch: https://github.com/graalvm/mandrel/actions/runs/20172399899
- [x] Mandrel 25.0 (JDK 25-based) build and run on quarkus with the patch (and `--future-defaults=all`) turned on: https://github.com/graalvm/mandrel/actions/runs/20172317371
- [x] GraalVM CE build of graal/master (LabsJDK-25-based) build and run on quarkus with the patch: https://github.com/graalvm/mandrel/actions/runs/20172192646

Closes: #51503