### PR TITLE
Remove unneeded vertx-http, upgrade LGTM image

### DIFF
--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
@@ -4,7 +4,7 @@ public final class ContainerConstants {
 
     // Images
 
-    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.11.17";
+    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.12.0";
 
     // Ports
 

--- a/extensions/observability-devservices/deployment/pom.xml
+++ b/extensions/observability-devservices/deployment/pom.xml
@@ -31,10 +31,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devui-deployment-spi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/observability-devservices/runtime/pom.xml
+++ b/extensions/observability-devservices/runtime/pom.xml
@@ -21,10 +21,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Looks like we (really) don't need this dependency, which causes problems here

Fixes #51045