### PR TITLE
Migrate `io.quarkus.deployment.steps.NativeImageFeatureStep` to Gizmo 2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -1,16 +1,20 @@
 package io.quarkus.deployment.steps;
 
-import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+import static io.quarkus.gizmo2.desc.Descs.MD_Class;
+import static io.quarkus.gizmo2.desc.Descs.MD_Collection;
+import static io.quarkus.gizmo2.desc.Descs.MD_Thread;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
 
-import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeSystemProperties;
 
+import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedNativeImageClassBuildItem;
@@ -20,15 +24,12 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuil
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.gizmo.BranchResult;
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.CatchBlockCreator;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
-import io.quarkus.gizmo.TryBlock;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
 import io.quarkus.runtime.graal.GraalVM;
 
@@ -36,21 +37,25 @@ public class NativeImageFeatureStep {
 
     public static final String GRAAL_FEATURE = "io.quarkus.runner.Feature";
 
-    private static final MethodDescriptor IMAGE_SINGLETONS_LOOKUP = ofMethod(ImageSingletons.class, "lookup", Object.class,
-            Class.class);
-    private static final MethodDescriptor BUILD_TIME_INITIALIZATION = ofMethod(RuntimeClassInitialization.class,
+    private static final MethodDesc BUILD_TIME_INITIALIZATION = MethodDesc.of(RuntimeClassInitialization.class,
             "initializeAtBuildTime", void.class, String[].class);
-    private static final MethodDescriptor REGISTER_RUNTIME_SYSTEM_PROPERTIES = ofMethod(RuntimeSystemProperties.class,
+    private static final MethodDesc REGISTER_RUNTIME_SYSTEM_PROPERTIES = MethodDesc.of(RuntimeSystemProperties.class,
             "register", void.class, String.class, String.class);
-    private static final MethodDescriptor GRAALVM_VERSION_GET_CURRENT = ofMethod(GraalVM.Version.class, "getCurrent",
+    private static final MethodDesc GRAALVM_VERSION_GET_CURRENT = MethodDesc.of(GraalVM.Version.class, "getCurrent",
             GraalVM.Version.class);
-    private static final MethodDescriptor GRAALVM_VERSION_COMPARE_TO = ofMethod(GraalVM.Version.class, "compareTo", int.class,
+    private static final MethodDesc GRAALVM_VERSION_COMPARE_TO = MethodDesc.of(GraalVM.Version.class, "compareTo", int.class,
             int[].class);
-    private static final MethodDescriptor INITIALIZE_CLASSES_AT_RUN_TIME = ofMethod(RuntimeClassInitialization.class,
+    private static final MethodDesc INITIALIZE_CLASSES_AT_RUN_TIME = MethodDesc.of(RuntimeClassInitialization.class,
             "initializeAtRunTime", void.class, Class[].class);
-    private static final MethodDescriptor INITIALIZE_PACKAGES_AT_RUN_TIME = ofMethod(RuntimeClassInitialization.class,
+    private static final MethodDesc INITIALIZE_PACKAGES_AT_RUN_TIME = MethodDesc.of(RuntimeClassInitialization.class,
             "initializeAtRunTime", void.class, String[].class);
-    static final String BEFORE_ANALYSIS_ACCESS = Feature.BeforeAnalysisAccess.class.getName();
+    private static final MethodDesc PRINT_STACK_TRACE = MethodDesc.of(Throwable.class, "printStackTrace", void.class);
+    private static final MethodDesc GET_DECLARED_FIELD = MethodDesc.of(Class.class, "getDeclaredField", Field.class,
+            String.class);
+    private static final MethodDesc REGISTER_AS_UNSAFE_ACCESSED = MethodDesc.of(Feature.BeforeAnalysisAccess.class,
+            "registerAsUnsafeAccessed", void.class, Field.class);
+    private static final MethodDesc GET_CONTEXT_CLASS_LOADER = MethodDesc.of(Thread.class, "getContextClassLoader",
+            ClassLoader.class);
 
     @BuildStep
     void addExportsToNativeImage(BuildProducer<JPMSExportBuildItem> features) {
@@ -70,142 +75,122 @@ public class NativeImageFeatureStep {
             List<UnsafeAccessedFieldBuildItem> unsafeAccessedFields,
             NativeConfig nativeConfig,
             LocalesBuildTimeConfig localesBuildTimeConfig) {
-        ClassCreator file = new ClassCreator(new ClassOutput() {
-            @Override
-            public void write(String s, byte[] bytes) {
-                nativeImageClass.produce(new GeneratedNativeImageClassBuildItem(s, bytes));
-            }
-        }, GRAAL_FEATURE, null,
-                Object.class.getName(), Feature.class.getName());
 
-        // Add getDescription method
-        MethodCreator getDescription = file.getMethodCreator("getDescription", String.class);
-        getDescription.returnValue(getDescription.load("Auto-generated class by Quarkus from the existing extensions"));
+        Gizmo g = Gizmo.create(new GeneratedClassGizmo2Adaptor(
+                item -> nativeImageClass
+                        .produce(new GeneratedNativeImageClassBuildItem(item.binaryName(), item.getClassData())),
+                item -> {
+                },
+                false));
 
-        MethodCreator beforeAn = file.getMethodCreator("beforeAnalysis", "V", BEFORE_ANALYSIS_ACCESS);
-        TryBlock overallCatch = beforeAn.tryBlock();
+        g.class_(GRAAL_FEATURE, cc -> {
+            cc.implements_(Feature.class);
 
-        overallCatch.invokeStaticMethod(BUILD_TIME_INITIALIZATION,
-                overallCatch.marshalAsArray(String.class, overallCatch.load(""))); // empty string means initialize everything
+            cc.defaultConstructor();
 
-        // Set the user.language and user.country system properties to the default locale
-        if (localesBuildTimeConfig.defaultLocale().isPresent()) {
-            overallCatch.invokeStaticMethod(REGISTER_RUNTIME_SYSTEM_PROPERTIES,
-                    overallCatch.load("user.language"),
-                    overallCatch.load(localesBuildTimeConfig.defaultLocale().get().getLanguage()));
-            overallCatch.invokeStaticMethod(REGISTER_RUNTIME_SYSTEM_PROPERTIES,
-                    overallCatch.load("user.country"),
-                    overallCatch.load(localesBuildTimeConfig.defaultLocale().get().getCountry()));
-        } else {
-            ResultHandle graalVMVersion = overallCatch.invokeStaticMethod(GRAALVM_VERSION_GET_CURRENT);
-            BranchResult graalVm24_2Test = overallCatch
-                    .ifGreaterEqualZero(overallCatch.invokeVirtualMethod(GRAALVM_VERSION_COMPARE_TO, graalVMVersion,
-                            overallCatch.marshalAsArray(int.class, overallCatch.load(24), overallCatch.load(2))));
-            /* GraalVM >= 24.2 */
-            try (BytecodeCreator greaterEqual24_2 = graalVm24_2Test.trueBranch()) {
-                greaterEqual24_2.invokeStaticMethod(REGISTER_RUNTIME_SYSTEM_PROPERTIES,
-                        greaterEqual24_2.load("user.language"),
-                        greaterEqual24_2.load("en"));
-                greaterEqual24_2.invokeStaticMethod(REGISTER_RUNTIME_SYSTEM_PROPERTIES,
-                        greaterEqual24_2.load("user.country"),
-                        greaterEqual24_2.load("US"));
-            }
-        }
+            cc.method("getDescription", mc -> {
+                mc.returning(String.class);
+                mc.body(b0 -> b0.return_(Const.of("Auto-generated class by Quarkus from the existing extensions")));
+            });
 
-        if (!runtimeInitializedClassBuildItems.isEmpty() || !runtimeReinitializedClassBuildItems.isEmpty()) {
-            //  Class[] runtimeInitializedClasses()
-            MethodCreator runtimeInitializedClasses = file
-                    .getMethodCreator("runtimeInitializedClasses", Class[].class)
-                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC);
-
-            ResultHandle thisClass = runtimeInitializedClasses.loadClassFromTCCL(GRAAL_FEATURE);
-            ResultHandle cl = runtimeInitializedClasses.invokeVirtualMethod(
-                    ofMethod(Class.class, "getClassLoader", ClassLoader.class),
-                    thisClass);
-            ResultHandle classesArray = runtimeInitializedClasses.newArray(Class.class,
-                    runtimeInitializedClasses
-                            .load(runtimeInitializedClassBuildItems.size() + runtimeReinitializedClassBuildItems.size()));
-            for (int i = 0; i < runtimeInitializedClassBuildItems.size(); i++) {
-                TryBlock tc = runtimeInitializedClasses.tryBlock();
-                ResultHandle clazz = tc.invokeStaticMethod(
-                        ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
-                        tc.load(runtimeInitializedClassBuildItems.get(i).getClassName()), tc.load(false), cl);
-                tc.writeArrayValue(classesArray, i, clazz);
-                CatchBlockCreator cc = tc.addCatch(Throwable.class);
-                cc.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), cc.getCaughtException());
-            }
-            for (int i = 0; i < runtimeReinitializedClassBuildItems.size(); i++) {
-                TryBlock tc = runtimeInitializedClasses.tryBlock();
-                ResultHandle clazz = tc.invokeStaticMethod(
-                        ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
-                        tc.load(runtimeReinitializedClassBuildItems.get(i).getClassName()), tc.load(false), cl);
-                tc.writeArrayValue(classesArray, i, clazz);
-                CatchBlockCreator cc = tc.addCatch(Throwable.class);
-                cc.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), cc.getCaughtException());
-            }
-            runtimeInitializedClasses.returnValue(classesArray);
-
-            ResultHandle classes = overallCatch.invokeStaticMethod(runtimeInitializedClasses.getMethodDescriptor());
-            overallCatch.invokeStaticMethod(INITIALIZE_CLASSES_AT_RUN_TIME, classes);
-        }
-
-        if (!runtimeInitializedPackageBuildItems.isEmpty()) {
-            //  String[] runtimeInitializedPackages()
-            MethodCreator runtimeInitializedPackages = file
-                    .getMethodCreator("runtimeInitializedPackages", String[].class)
-                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC);
-
-            ResultHandle packagesArray = runtimeInitializedPackages.newArray(String.class,
-                    runtimeInitializedPackages.load(runtimeInitializedPackageBuildItems.size()));
-            for (int i = 0; i < runtimeInitializedPackageBuildItems.size(); i++) {
-                TryBlock tc = runtimeInitializedPackages.tryBlock();
-                ResultHandle pkg = tc.load(runtimeInitializedPackageBuildItems.get(i).getPackageName());
-                tc.writeArrayValue(packagesArray, i, pkg);
-                CatchBlockCreator cc = tc.addCatch(Throwable.class);
-                cc.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), cc.getCaughtException());
-            }
-            runtimeInitializedPackages.returnValue(packagesArray);
-
-            ResultHandle packages = overallCatch.invokeStaticMethod(runtimeInitializedPackages.getMethodDescriptor());
-            overallCatch.invokeStaticMethod(INITIALIZE_PACKAGES_AT_RUN_TIME, packages);
-        }
-
-        // Ensure registration of fields being accessed through unsafe is done last to ensure that the class
-        // initialization configuration is done first.  Registering the fields before configuring class initialization
-        // may results in classes being marked for runtime initialization even if not explicitly requested.
-        if (!unsafeAccessedFields.isEmpty()) {
-            ResultHandle beforeAnalysisParam = beforeAn.getMethodParam(0);
-            MethodCreator registerAsUnsafeAccessed = file
-                    .getMethodCreator("registerAsUnsafeAccessed", void.class, Feature.BeforeAnalysisAccess.class)
-                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC);
-            ResultHandle thisClass = registerAsUnsafeAccessed.loadClassFromTCCL(GRAAL_FEATURE);
-            ResultHandle cl = registerAsUnsafeAccessed
-                    .invokeVirtualMethod(ofMethod(Class.class, "getClassLoader", ClassLoader.class), thisClass);
-            for (UnsafeAccessedFieldBuildItem unsafeAccessedField : unsafeAccessedFields) {
-                TryBlock tc = registerAsUnsafeAccessed.tryBlock();
-                ResultHandle declaringClassHandle = tc.invokeStaticMethod(
-                        ofMethod(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class),
-                        tc.load(unsafeAccessedField.getDeclaringClass()), tc.load(false), cl);
-                ResultHandle fieldHandle = tc.invokeVirtualMethod(
-                        ofMethod(Class.class, "getDeclaredField", Field.class, String.class), declaringClassHandle,
-                        tc.load(unsafeAccessedField.getFieldName()));
-                tc.invokeInterfaceMethod(
-                        ofMethod(Feature.BeforeAnalysisAccess.class, "registerAsUnsafeAccessed", void.class, Field.class),
-                        registerAsUnsafeAccessed.getMethodParam(0), fieldHandle);
-                CatchBlockCreator cc = tc.addCatch(Throwable.class);
-                cc.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), cc.getCaughtException());
-            }
-            registerAsUnsafeAccessed.returnVoid();
-            overallCatch.invokeStaticMethod(registerAsUnsafeAccessed.getMethodDescriptor(), beforeAnalysisParam);
-        }
-
-        CatchBlockCreator print = overallCatch.addCatch(Throwable.class);
-        print.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), print.getCaughtException());
-
-        beforeAn.loadClassFromTCCL("io.quarkus.runner.ApplicationImpl");
-        beforeAn.returnValue(null);
-
-        file.close();
+            cc.method("beforeAnalysis", mc -> {
+                ParamVar access = mc.parameter("access", Feature.BeforeAnalysisAccess.class);
+                MethodDesc classForName3 = MethodDesc.of(Class.class, "forName", Class.class, String.class, boolean.class,
+                        ClassLoader.class);
+                mc.body(b0 -> {
+                    b0.try_(t1 -> {
+                        t1.body(b2 -> {
+                            b2.invokeStatic(BUILD_TIME_INITIALIZATION, b2.newArray(String.class, Const.of("")));
+                            LocalVar cl = b2.localVar("cl", b2.invokeVirtual(MD_Class.getClassLoader, Const.of(cc.type())));
+                            if (localesBuildTimeConfig.defaultLocale().isPresent()) {
+                                Locale defaultLocale = localesBuildTimeConfig.defaultLocale().get();
+                                b2.invokeStatic(REGISTER_RUNTIME_SYSTEM_PROPERTIES, Const.of("user.language"),
+                                        Const.of(defaultLocale.getLanguage()));
+                                b2.invokeStatic(REGISTER_RUNTIME_SYSTEM_PROPERTIES, Const.of("user.country"),
+                                        Const.of(defaultLocale.getCountry()));
+                            } else {
+                                LocalVar graalVMVersion = b2.localVar("graalVMVersion",
+                                        b2.invokeStatic(GRAALVM_VERSION_GET_CURRENT));
+                                /* GraalVM >= 24.2 */
+                                b2.if_(b2.gt(
+                                        b2.invokeVirtual(GRAALVM_VERSION_COMPARE_TO,
+                                                graalVMVersion,
+                                                b2.newArray(int.class, Const.of(24), Const.of(2))),
+                                        0), t3 -> {
+                                            t3.invokeStatic(REGISTER_RUNTIME_SYSTEM_PROPERTIES, Const.of("user.language"),
+                                                    Const.of("en"));
+                                            t3.invokeStatic(REGISTER_RUNTIME_SYSTEM_PROPERTIES, Const.of("user.country"),
+                                                    Const.of("US"));
+                                        });
+                            }
+                            if (!runtimeInitializedClassBuildItems.isEmpty()
+                                    || !runtimeReinitializedClassBuildItems.isEmpty()) {
+                                b2.block(b3 -> {
+                                    // use an arraylist so we don't have null entries
+                                    LocalVar classes = b3.localVar("classes", b3.new_(ArrayList.class,
+                                            Const.of(runtimeInitializedClassBuildItems.size()
+                                                    + runtimeReinitializedClassBuildItems.size())));
+                                    Stream.concat(
+                                            runtimeInitializedClassBuildItems.stream()
+                                                    .map(RuntimeInitializedClassBuildItem::getClassName),
+                                            runtimeReinitializedClassBuildItems.stream()
+                                                    .map(RuntimeReinitializedClassBuildItem::getClassName))
+                                            .forEach(name -> b3.try_(t4 -> {
+                                                t4.body(b5 -> b5.invokeInterface(MD_Collection.add, classes,
+                                                        b5.invokeStatic(classForName3, Const.of(name), Const.of(false), cl)));
+                                                t4.catch_(Throwable.class, "t",
+                                                        (b5, t) -> b5.invokeVirtual(PRINT_STACK_TRACE, t));
+                                            }));
+                                    b3.invokeStatic(INITIALIZE_CLASSES_AT_RUN_TIME,
+                                            b3.cast(
+                                                    b3.invokeVirtual(
+                                                            MethodDesc.of(ArrayList.class, "toArray", Object[].class,
+                                                                    Object[].class),
+                                                            classes,
+                                                            b3.newEmptyArray(Class.class,
+                                                                    b3.invokeInterface(MD_Collection.size, classes))),
+                                                    Class[].class));
+                                });
+                            }
+                            if (!runtimeInitializedPackageBuildItems.isEmpty()) {
+                                b2.block(b3 -> {
+                                    b3.invokeStatic(INITIALIZE_PACKAGES_AT_RUN_TIME, b3.newArray(String.class,
+                                            runtimeInitializedPackageBuildItems.stream()
+                                                    .map(RuntimeInitializedPackageBuildItem::getPackageName)
+                                                    .map(Const::of)
+                                                    .toArray(Expr[]::new)));
+                                });
+                            }
+                            // Ensure registration of fields being accessed through unsafe is done last to ensure that the class
+                            // initialization configuration is done first.  Registering the fields before configuring class initialization
+                            // may results in classes being marked for runtime initialization even if not explicitly requested.
+                            if (!unsafeAccessedFields.isEmpty()) {
+                                for (UnsafeAccessedFieldBuildItem unsafeAccessedField : unsafeAccessedFields) {
+                                    b2.try_(t3 -> {
+                                        t3.body(b4 -> {
+                                            LocalVar declaringClass = b4.localVar("declaringClass",
+                                                    b4.invokeStatic(classForName3,
+                                                            Const.of(unsafeAccessedField.getDeclaringClass()), Const.of(false),
+                                                            cl));
+                                            LocalVar declaredField = b4.localVar("declaredField",
+                                                    b4.invokeVirtual(GET_DECLARED_FIELD, declaringClass,
+                                                            Const.of(unsafeAccessedField.getFieldName())));
+                                            b4.invokeInterface(REGISTER_AS_UNSAFE_ACCESSED, access, declaredField);
+                                        });
+                                        t3.catch_(Throwable.class, "t", (b4, t) -> b4.invokeVirtual(PRINT_STACK_TRACE, t));
+                                    });
+                                }
+                            }
+                        });
+                        t1.catch_(Throwable.class, "t", (b2, t) -> b2.invokeVirtual(PRINT_STACK_TRACE, t));
+                    });
+                    // todo: do not use TCCL here (it's incorrect)
+                    Expr tccl = b0.invokeVirtual(GET_CONTEXT_CLASS_LOADER, b0.invokeStatic(MD_Thread.currentThread));
+                    b0.invokeStatic(classForName3, Const.of("io.quarkus.runner.ApplicationImpl"), Const.of(false), tccl);
+                    b0.return_();
+                });
+            });
+        });
     }
 
 }


### PR DESCRIPTION
Fixes #51542.

Future things to consider:

- Fix usage of TCCL at some point
- For massive numbers of classes, move to getting class and package lists from resource files (but see oracle/graal#12453 which would have to be solved first)
