### PR TITLE
Fix scope configuration property in rest-client.adoc

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -489,7 +489,7 @@ public interface ExtensionsService {
 ----
 # Your configuration properties
 quarkus.rest-client.extensions-api.url=https://stage.code.quarkus.io/api
-quarkus.rest-client.extensions-api.scope=jakarta.inject.Singleton
+quarkus.rest-client.extensions-api.scope=jakarta.enterprise.context.ApplicationScoped
 ----
 
 [IMPORTANT]


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

The REST client documentation uses `jakarta.inject.Singleton` as a scope property value. Since Quarkus 3.28.x this should be `jakarta.enterprise.context.ApplicationScoped` or `ApplicationScoped`

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

