### PR TITLE
Update Maven template to support compatibility with multiple Quarkus platform versions

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -103,7 +103,11 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            {#if quarkus.platform.version.compareVersionTo("3.30.999") > 0}
             <artifactId>quarkus-junit</artifactId>
+            {#else}
+            <artifactId>quarkus-junit5</artifactId>
+            {/if}
             <scope>test</scope>
         </dependency>
         {#each test-dependencies}


### PR DESCRIPTION
Introduce logic to dynamically select `quarkus-junit` or `quarkus-junit5` based on Quarkus platform version.

- Follow up from #51412 