### PR TITLE
Update conditional logic for JUnit dependencies

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/deployment/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/deployment/pom.tpl.qute.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            {#if quarkus.bom.version == null || quarkus.bom.version.compareVersionTo("3.30.999") > 0}
+            {#if quarkus.version == null || quarkus.version.compareVersionTo("3.30.999") > 0}
             <artifactId>quarkus-junit-internal</artifactId>
             {#else}
             <artifactId>quarkus-junit5-internal</artifactId>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/deployment/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/deployment/pom.tpl.qute.xml
@@ -29,7 +29,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            {#if quarkus.bom.version == null || quarkus.bom.version.compareVersionTo("3.30.999") > 0}
             <artifactId>quarkus-junit-internal</artifactId>
+            {#else}
+            <artifactId>quarkus-junit5-internal</artifactId>
+            {/if}
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
@@ -38,7 +38,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            {#if quarkus.bom.version == null || quarkus.bom.version.compareVersionTo("3.30.999") > 0}
+            {#if quarkus.version == null || quarkus.version.compareVersionTo("3.30.999") > 0}
             <artifactId>quarkus-junit</artifactId>
             {#else}
             <artifactId>quarkus-junit5</artifactId>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
@@ -38,7 +38,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            {#if quarkus.bom.version == null || quarkus.bom.version.compareVersionTo("3.30.999") > 0}
             <artifactId>quarkus-junit</artifactId>
+            {#else}
+            <artifactId>quarkus-junit5</artifactId>
+            {/if}
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -103,7 +103,7 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            {#if quarkus.platform.version.compareVersionTo("3.30.999") > 0}
+            {#if quarkus.version == null || quarkus.version.compareVersionTo("3.30.999") > 0}
             <artifactId>quarkus-junit</artifactId>
             {#else}
             <artifactId>quarkus-junit5</artifactId>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_integration-tests_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_integration-tests_pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit</artifactId>
+            <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Add conditional logic to support compatibility with different Quarkus BOM versions in template POM files.
- Introduce dynamic selection of `quarkus-junit` or `quarkus-junit5` dependencies based on version comparison logic.
- Follow-up from https://github.com/quarkusio/quarkus/pull/51563
