### PR TITLE
[3.27] Bump to Vert.x 4.5.23 and Netty 4.1.130.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.19.2</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.21.3</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.28.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
@@ -112,7 +112,7 @@
         <wildfly-elytron.version>2.6.5.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.3.Final</jboss-marshalling.version>
         <jboss-threads.version>3.9.1</jboss-threads.version>
-        <vertx.version>4.5.22</vertx.version>
+        <vertx.version>4.5.23</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -134,7 +134,7 @@
         <infinispan.version>15.0.19.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.2.2</caffeine.version>
-        <netty.version>4.1.128.Final</netty.version>
+        <netty.version>4.1.130.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
@@ -185,7 +185,7 @@
         <error-prone-annotations.version>2.41.0</error-prone-annotations.version>
         <jib-core.version>0.27.3</jib-core.version>
         <google-http-client.version>1.47.1</google-http-client.version>
-        <scram-client.version>2.1</scram-client.version>
+        <scram-client.version>3.2</scram-client.version>
         <picocli.version>4.7.7</picocli.version>
         <google-cloud-functions.version>1.1.4</google-cloud-functions.version>
         <commons-compress.version>1.28.0</commons-compress.version> <!-- Please check with Java Operator SDK / Fabric8 team before updating -->
@@ -5784,7 +5784,7 @@
             <dependency>
                 <!-- Used by the Reactive PG Client -->
                 <groupId>com.ongres.scram</groupId>
-                <artifactId>client</artifactId>
+                <artifactId>scram-client</artifactId>
                 <version>${scram-client.version}</version>
             </dependency>
             <dependency>

--- a/extensions/reactive-pg-client/runtime/pom.xml
+++ b/extensions/reactive-pg-client/runtime/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>com.ongres.scram</groupId>
-            <artifactId>client</artifactId>
+            <artifactId>scram-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -55,9 +55,10 @@
         <gizmo.version>1.9.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <mutiny.version>2.9.5</mutiny.version>
+        <mutiny.version>3.1.0</mutiny.version>
+        <smallrye-mutiny-vertx-core.version>3.21.3</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.13.9</smallrye-common.version>
-        <vertx.version>4.5.22</vertx.version>
+        <vertx.version>4.5.23</vertx.version>
         <rest-assured.version>5.5.6</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.19.2</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.21</vertx.version>
+        <vertx.version>4.5.23</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
These version upgrades address CVE-2025-67735 from Netty, see: https://github.com/netty/netty/security/advisories/GHSA-84h7-rjj3-6jx4

This also bumps the Mutiny Vert.x clients to 3.21.3

I suggest to use this as a basis for backporting to other branches.
This patch includes a Mutiny + Mutiny Vert.x bindings bump, but this comes
with useful additional bug fixes in Mutiny, and provides version alignment
across the Vert.x clients.
