### PR TITLE
Set project models when initializing BootstrapMavenContext in DevMojo

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -77,11 +77,10 @@ public class QuarkusBootstrapProvider implements Closeable {
         return ArtifactKey.ga(project.getGroupId(), project.getArtifactId());
     }
 
-    static void setProjectModels(QuarkusBootstrapMojo mojo, BootstrapMavenContextConfig<?> config) {
-        final List<MavenProject> allProjects = mojo.mavenSession().getAllProjects();
+    static void setProjectModels(BootstrapMavenContextConfig<?> config, List<MavenProject> allProjects, Set<File> reloadPoms) {
         if (allProjects != null) {
             for (MavenProject mp : allProjects) {
-                if (mojo.reloadPoms.contains(mp.getFile())) {
+                if (reloadPoms.contains(mp.getFile())) {
                     continue;
                 }
                 final Model model = getRawModel(mp);
@@ -235,7 +234,7 @@ public class QuarkusBootstrapProvider implements Closeable {
                             .setRemoteRepositories(mojo.remoteRepositories())
                             .setEffectiveModelBuilder(BootstrapMavenContextConfig
                                     .getEffectiveModelBuilderProperty(mojo.mavenProject().getProperties()));
-                    setProjectModels(mojo, config);
+                    setProjectModels(config, mojo.mavenSession().getAllProjects(), mojo.reloadPoms);
                     var resolver = workspaceProvider.createArtifactResolver(config);
                     final LocalProject currentProject = resolver.getMavenContext().getCurrentProject();
                     if (currentProject != null && workspaceId == 0) {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -525,7 +525,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         shutdownTheApp();
 
         runAndCheck("-f", alternatePomName);
-        devModeClient.getHttpResponse("/q/openapi").contains("hello");
+        assertThat(devModeClient.getHttpResponse("/q/openapi")).contains("hello");
     }
 
     @Test

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic/pom.xml
@@ -79,6 +79,7 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>\${quarkus-plugin.version}</version>
+        <extensions>true</extensions>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This is to properly support projects configured with Maven plugins and/or extensions manipulating POM files.

FYI @gsmet 