### PR TITLE
Increate LRA TCK waitForCallbacks timeout

### DIFF
--- a/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
+++ b/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
@@ -47,7 +47,7 @@ public class NarayanaLRARecovery implements LRARecoveryService {
     private static final Logger log = Logger.getLogger(NarayanaLRARecovery.class);
     private static final long WAIT_CALLBACK_TIMEOUT = initWaitForCallbackTimeout();
     private static final String WAIT_CALLBACK_TIMEOUT_PROPERTY = "lra.tck.callback.timeout";
-    private static final int DEFAULT_CALLBACK_TIMEOUT = 10000;
+    private static final int DEFAULT_CALLBACK_TIMEOUT = 30000;
 
     private Client client = ClientBuilder.newClient();
 


### PR DESCRIPTION
The CI seems to be even slower than thought. We have now a shortcut that doesn't wait the full timeout all the time, so maybe we can try to increate the timeout even a little bit more.