### PR TITLE
Docs: First Extension Asciidoc fix

### DIFF
--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -561,8 +561,7 @@ Thanks to basic concepts, you will describe the items to produce/consume and the
 
 The `io.quarkus.builder.item.BuildItem` concept represents object instances you will produce or consume (and at some point convert into bytecode) thanks to methods annotated with `@io.quarkus.deployment.annotations.BuildStep` which describe your extension's deployment tasks.
 
-NOTE:: See xref:all-builditems.adoc[the complete list of BuildItem implementations in core] for more information
-
+NOTE: See xref:all-builditems.adoc[the complete list of BuildItem implementations in core] for more information.
 
 Go back to the generated `org.acme.greeting.extension.deployment.GreetingExtensionProcessor` class.
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

While reading the docs I stumbled across this asciidoc formatting issue. (some styles on screenshots did not apply)

WAS:
<img width="1036" height="417" alt="image" src="https://github.com/user-attachments/assets/9e2862f7-cc0b-499f-80b2-f6b748b41e92" />

WILL BE:
<img width="861" height="345" alt="image" src="https://github.com/user-attachments/assets/13827915-e551-43c6-9ab2-73c22f4de2d1" />

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

