### PR TITLE
Fix LRA TCK optimization for manually TCK-managed tests

### DIFF
--- a/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
+++ b/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
@@ -65,7 +65,14 @@ public class NarayanaLRARecovery implements LRARecoveryService {
             await().atMost(Duration.ofMillis(WAIT_CALLBACK_TIMEOUT)).catchUncaughtExceptions()
                     .until(() -> {
                         try {
-                            client.target(lraId).request().get();
+                            WebTarget target;
+                            try {
+                                target = client.target(lraId);
+                            } catch (Exception | Error e) {
+                                // Some TCK tests don't start Quarkus application, so we can't create REST request
+                                return false;
+                            }
+                            target.request().get();
                         } catch (NotFoundException notFoundException) {
                             // LRA not found means it has been finished
                             return true;
@@ -73,7 +80,7 @@ public class NarayanaLRARecovery implements LRARecoveryService {
                         return false;
                     });
         } catch (ConditionTimeoutException e) {
-            log.warn("waitForCallbacks timeout: " + e.getMessage());
+            log.warn("waitForCallbacks timeout (OK, optimization): " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
Unfortunatelly, the optimization caused another flaky. The LRA TCK is really bad in this regard. I'm trying to rewrite the LRA TCK to use Quarkus REST but there are some missing piecies. This should fix the issue for now.

https://ge.quarkus.io/scans/tests?search.timeZoneId=Europe%2FPrague&tests.container=org.eclipse.microprofile.lra.tck.TckTests&tests.test=mixedMultiLevelNestedActivity