### PR TITLE
Fix handling of native-image future-defaults

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
@@ -32,9 +32,7 @@ public enum NativeImageFutureDefault {
                             }
                             break;
                         default:
-                            final NativeImageFutureDefault futureDefaultArg = NativeImageFutureDefault
-                                    .valueOf(futureDefaultString.toUpperCase(Locale.ROOT).replace('-', '_'));
-                            if (futureDefaultArg == this) {
+                            if (futureDefaultString.toUpperCase(Locale.ROOT).replace('-', '_').equals(this.toString())) {
                                 return true;
                             }
                     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefault.java
@@ -14,10 +14,6 @@ public enum NativeImageFutureDefault {
     private static final String FUTURE_DEFAULTS_MARKER = "--future-defaults=";
 
     public boolean isEnabled(NativeConfig nativeConfig) {
-        return isFutureDefault(this, nativeConfig);
-    }
-
-    private static boolean isFutureDefault(NativeImageFutureDefault futureDefault, NativeConfig nativeConfig) {
         final List<String> additionalBuildArgs = NativeConfigUtils.getNativeAdditionalBuildArgs(nativeConfig);
         for (String buildArg : additionalBuildArgs) {
             String trimmedBuildArg = buildArg.trim();
@@ -25,22 +21,22 @@ public enum NativeImageFutureDefault {
                 int index = trimmedBuildArg.indexOf('=');
                 String[] futureDefaultStringArgs = trimmedBuildArg.substring(index + 1).split(",");
                 for (String futureDefaultString : futureDefaultStringArgs) {
-                    if ("all".equals(futureDefaultString)) {
-                        return true;
-                    }
-
-                    if ("run-time-initialize-jdk".equals(futureDefaultString)) {
-                        switch (futureDefault) {
-                            case RUN_TIME_INITIALIZE_SECURITY_PROVIDERS:
-                            case RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS:
+                    switch (futureDefaultString) {
+                        case "all":
+                            return true;
+                        case "run-time-initialize-jdk":
+                            switch (this) {
+                                case RUN_TIME_INITIALIZE_SECURITY_PROVIDERS:
+                                case RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS:
+                                    return true;
+                            }
+                            break;
+                        default:
+                            final NativeImageFutureDefault futureDefaultArg = NativeImageFutureDefault
+                                    .valueOf(futureDefaultString.toUpperCase(Locale.ROOT).replace('-', '_'));
+                            if (futureDefaultArg == this) {
                                 return true;
-                        }
-                    }
-
-                    final NativeImageFutureDefault futureDefaultArg = NativeImageFutureDefault
-                            .valueOf(futureDefaultString.toUpperCase(Locale.ROOT).replace('-', '_'));
-                    if (futureDefaultArg == futureDefault) {
-                        return true;
+                            }
                     }
                 }
             }
@@ -64,7 +60,7 @@ public enum NativeImageFutureDefault {
 
         @Override
         public boolean getAsBoolean() {
-            return isFutureDefault(NativeImageFutureDefault.RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS, nativeConfig);
+            return RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(nativeConfig);
         }
     }
 
@@ -75,7 +71,7 @@ public enum NativeImageFutureDefault {
 
         @Override
         public boolean getAsBoolean() {
-            return isFutureDefault(NativeImageFutureDefault.RUN_TIME_INITIALIZE_SECURITY_PROVIDERS, nativeConfig);
+            return RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(nativeConfig);
         }
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
@@ -9,6 +9,8 @@ import io.quarkus.deployment.util.ContainerRuntimeUtil;
 public class TestNativeConfig implements NativeConfig {
 
     private final NativeConfig.BuilderImageConfig builderImage;
+    private List<String> additionalBuildArgs;
+    private List<String> additionalBuildArgsAppend;
 
     public TestNativeConfig(String builderImage) {
         this(builderImage, ImagePullStrategy.ALWAYS);
@@ -22,6 +24,12 @@ public class TestNativeConfig implements NativeConfig {
         this.builderImage = new TestBuildImageConfig(builderImage, builderImagePull);
     }
 
+    public TestNativeConfig(List<String> additionalBuildArgs, List<String> additionalBuildArgsAppend) {
+        this("dummy", ImagePullStrategy.NEVER);
+        this.additionalBuildArgs = additionalBuildArgs;
+        this.additionalBuildArgsAppend = additionalBuildArgsAppend;
+    }
+
     public boolean enabled() {
         return true;
     }
@@ -32,12 +40,18 @@ public class TestNativeConfig implements NativeConfig {
 
     @Override
     public Optional<List<String>> additionalBuildArgs() {
-        return Optional.empty();
+        if (additionalBuildArgs == null) {
+            return Optional.empty();
+        }
+        return Optional.of(additionalBuildArgs);
     }
 
     @Override
     public Optional<List<String>> additionalBuildArgsAppend() {
-        return Optional.empty();
+        if (additionalBuildArgsAppend == null) {
+            return Optional.empty();
+        }
+        return Optional.of(additionalBuildArgsAppend);
     }
 
     @Override

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefaultTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefaultTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.deployment.pkg.steps;
+
+import static io.quarkus.deployment.pkg.steps.NativeImageFutureDefault.RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS;
+import static io.quarkus.deployment.pkg.steps.NativeImageFutureDefault.RUN_TIME_INITIALIZE_SECURITY_PROVIDERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.deployment.pkg.TestNativeConfig;
+
+class NativeImageFutureDefaultTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "all", "run-time-initialize-jdk",
+            "run-time-initialize-security-providers,run-time-initialize-file-system-providers" })
+    void runtimeInitFSandSecurityProvidersWithFutureDefaultsAll(String param) {
+        List<String> futureDefaultsValue = List.of("--future-defaults=" + param);
+        TestNativeConfig testNativeConfig = new TestNativeConfig(futureDefaultsValue, null);
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+        testNativeConfig = new TestNativeConfig(null, futureDefaultsValue);
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+        testNativeConfig = new TestNativeConfig(futureDefaultsValue, futureDefaultsValue);
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+    }
+
+    @Test
+    void runtimeInitFileSystemProviders() {
+        TestNativeConfig testNativeConfig = new TestNativeConfig(
+                List.of("--future-defaults=run-time-initialize-file-system-providers"), null);
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
+    }
+
+    @Test
+    void runtimeInitSecurityProviders() {
+        TestNativeConfig testNativeConfig = new TestNativeConfig(
+                List.of("--future-defaults=run-time-initialize-security-providers"), null);
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefaultTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageFutureDefaultTest.java
@@ -30,10 +30,12 @@ class NativeImageFutureDefaultTest {
         assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
     }
 
-    @Test
-    void runtimeInitFileSystemProviders() {
+    @ParameterizedTest
+    @ValueSource(strings = { "run-time-initialize-file-system-providers", "run-time-initialize-file-system-providers,other",
+            "other,run-time-initialize-file-system-providers" })
+    void runtimeInitFileSystemProviders(String param) {
         TestNativeConfig testNativeConfig = new TestNativeConfig(
-                List.of("--future-defaults=run-time-initialize-file-system-providers"), null);
+                List.of("--future-defaults=" + param), null);
         assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
         assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
     }
@@ -44,5 +46,20 @@ class NativeImageFutureDefaultTest {
                 List.of("--future-defaults=run-time-initialize-security-providers"), null);
         assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
         assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "complete-reflection-types", "none", "arbitrary-text" })
+    void runtimeInitOfFSandSecurityProvidersWithOtherFutureDefaults(String param) {
+        List<String> futureDefaultsValue = List.of("--future-defaults=" + param);
+        TestNativeConfig testNativeConfig = new TestNativeConfig(futureDefaultsValue, null);
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
+        testNativeConfig = new TestNativeConfig(null, futureDefaultsValue);
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
+        testNativeConfig = new TestNativeConfig(futureDefaultsValue, futureDefaultsValue);
+        assertThat(RUN_TIME_INITIALIZE_SECURITY_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
+        assertThat(RUN_TIME_INITIALIZE_FILE_SYSTEM_PROVIDERS.isEnabled(testNativeConfig)).isFalse();
     }
 }


### PR DESCRIPTION
Related to #51667

- **Add tests for NativeImageFutureDefaults**
- **Refactor NativeImageFutureDefault**
- **Add more tests for NativeImageFutureDefaultTest**
- **Fix handling of `--future-defaults` in native**

Prevents Quarkus from failing when `--future-defaults` contains
`complete-reflection-types` or any other option as we expect more to
come in the future (like `run-time-initialize-resource-bundles`)