### PR TITLE
Add skipGet on CachedResult annotation

### DIFF
--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CachedResultsProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CachedResultsProcessor.java
@@ -120,6 +120,7 @@ public class CachedResultsProcessor {
                     if (config.exclude() != null) {
                         ac.add("exclude", config.exclude());
                     }
+                    ac.add("skipGet", config.skipGet());
                 });
                 // Add @CachedResultsDiff
                 // The diff may be an empty string if no additional qualifiers are used
@@ -188,7 +189,7 @@ public class CachedResultsProcessor {
                                     ac.add("lockTimeout", config.lockTimeout());
                                 if (config.keyGenerator() != null)
                                     ac.add("keyGenerator", classDescOf(config.keyGenerator()));
-
+                                ac.add("skipGet", config.skipGet());
                             });
                         }
 
@@ -319,6 +320,7 @@ public class CachedResultsProcessor {
         Long lockTimeout = null;
         Type type;
         String exclude = null;
+        boolean skipGet = false;
 
         AnnotationValue cacheNameValue = annotation.value("cacheName");
         if (cacheNameValue != null)
@@ -335,6 +337,10 @@ public class CachedResultsProcessor {
         AnnotationValue excludeValue = annotation.value("exclude");
         if (excludeValue != null)
             exclude = excludeValue.asString();
+
+        AnnotationValue skipGetValue = annotation.value("skipGet");
+        if (skipGetValue != null)
+            skipGet = skipGetValue.asBoolean();
 
         if (annotation.target().kind() == Kind.FIELD) {
             type = annotation.target().asField().type();
@@ -362,11 +368,11 @@ public class CachedResultsProcessor {
                         a -> !a.name().equals(CACHED_RESULTS)
                                 && !a.name().equals(INJECT))
                         .toList(),
-                exclude);
+                exclude, skipGet);
     }
 
     record CachedResultsInjectConfig(String cacheName, Long lockTimeout, DotName keyGenerator, ClassInfo injectedClazz,
-            Collection<AnnotationInstance> annotations, String exclude) {
+            Collection<AnnotationInstance> annotations, String exclude, boolean skipGet) {
 
     }
 

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptionContextTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptionContextTest.java
@@ -51,6 +51,11 @@ public class CacheInterceptionContextTest {
                 public Class<? extends CacheKeyGenerator> keyGenerator() {
                     return UndefinedCacheKeyGenerator.class;
                 }
+
+                @Override
+                public boolean skipGet() {
+                    return false;
+                }
             });
         });
         assertThrows(UnsupportedOperationException.class, () -> {

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CachedResultsTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CachedResultsTest.java
@@ -72,6 +72,10 @@ public class CachedResultsTest {
     @CachedResults
     EmbeddingModel model7;
 
+    @Inject
+    @CachedResults(cacheName = "model8", skipGet = true)
+    EmbeddingModel model8;
+
     @CachedResults
     AnotherModel anotherModel1;
 
@@ -133,6 +137,9 @@ public class CachedResultsTest {
         // test additional qualifiers
         assertEquals(model7.ping(), model7.ping());
         assertEquals(model7.pong(), model7.pong());
+
+        // test skipGet: "baz" method return random value, so with skipGet=true, returned values must be different.
+        assertNotEquals(model8.baz("hello"), model8.baz("hello"));
 
         // injected class has a no-args constructor
         assertEquals(anotherModel1.foo(111), anotherModel1.foo(111));

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SkipGetCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SkipGetCacheTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.UUID;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests cache <b>skipGet</b> option.
+ */
+public class SkipGetCacheTest {
+
+    private static final long KEY_1 = 123L;
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withApplicationRoot(jar -> jar.addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        String value1 = cachedService.cachedMethodWithSkipGet(KEY_1, new Object());
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method invoked and result put into the cache.
+        // Verified by: different object reference between STEPS 1 and 2 results.
+        String value2 = cachedService.cachedMethodWithSkipGet(KEY_1, new Object());
+        assertNotEquals(value1, value2);
+
+        // STEP 3
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method not invoked and result taken from the cache.
+        // Verified by: same object reference between STEPS 2 and 3 results, but not STEP 1
+        String value3 = cachedService.cachedMethodWithoutSkipGet(KEY_1);
+        assertNotEquals(value1, value3);
+        assertEquals(value2, value3);
+    }
+
+    @Dependent
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME, skipGet = true)
+        public String cachedMethodWithSkipGet(@CacheKey long key, Object notPartOfTheKey) {
+            return UUID.randomUUID().toString();
+        }
+
+        @CacheResult(cacheName = CACHE_NAME, skipGet = false)
+        public String cachedMethodWithoutSkipGet(@CacheKey long key) {
+            return UUID.randomUUID().toString();
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SpecializedCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SpecializedCacheTest.java
@@ -87,6 +87,11 @@ public class SpecializedCacheTest {
         }
 
         @Override
+        public <K, V> Uni<Void> put(final K key, final V value) {
+            throw new UnsupportedOperationException("This method is not tested here");
+        }
+
+        @Override
         public <T extends Cache> T as(Class<T> cacheType) {
             throw new UnsupportedOperationException("This method is not tested here");
         }

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/UniSkipGetCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/UniSkipGetCacheTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.UUID;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Tests cache <b>skipGet</b> option.
+ */
+public class UniSkipGetCacheTest {
+
+    private static final long KEY_1 = 123L;
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withApplicationRoot(jar -> jar.addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        String value1 = cachedService.cachedMethodWithSkipGet(KEY_1, new Object()).await().indefinitely();
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method invoked and result put into the cache.
+        // Verified by: different object reference between STEPS 1 and 2 results.
+        String value2 = cachedService.cachedMethodWithSkipGet(KEY_1, new Object()).await().indefinitely();
+        assertNotEquals(value1, value2);
+
+        // STEP 3
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method not invoked and result taken from the cache.
+        // Verified by: same object reference between STEPS 2 and 3 results, but not STEP 1
+        String value3 = cachedService.cachedMethodWithoutSkipGet(KEY_1).await().indefinitely();
+        assertNotEquals(value1, value3);
+        assertEquals(value2, value3);
+    }
+
+    @Dependent
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME, skipGet = true)
+        public Uni<String> cachedMethodWithSkipGet(@CacheKey long key, Object notPartOfTheKey) {
+            return Uni.createFrom().item(UUID.randomUUID().toString());
+        }
+
+        @CacheResult(cacheName = CACHE_NAME, skipGet = false)
+        public Uni<String> cachedMethodWithoutSkipGet(@CacheKey long key) {
+            return Uni.createFrom().item(UUID.randomUUID().toString());
+        }
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/Cache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/Cache.java
@@ -83,6 +83,20 @@ public interface Cache {
     Uni<Void> invalidateIf(Predicate<Object> predicate);
 
     /**
+     * Put a value in the cache.
+     *
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @param key the key
+     * @param value the value
+     * @return a Uni emitting {@code null} when the operation completes
+     * @throws NullPointerException if the key is {@code null}
+     * @throws CacheException if an exception is thrown during a cache value computation
+     */
+    @CheckReturnValue
+    <K, V> Uni<Void> put(K key, V value);
+
+    /**
      * Returns this cache as an instance of the provided type if possible.
      *
      * @return cache instance of the provided type

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheResult.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheResult.java
@@ -68,4 +68,11 @@ public @interface CacheResult {
      */
     @Nonbinding
     Class<? extends CacheKeyGenerator> keyGenerator() default UndefinedCacheKeyGenerator.class;
+
+    /**
+     * If set to true the cached value (if exists) will not be used.
+     * The method will always be executed and have their returned value placed in the cache.
+     */
+    @Nonbinding
+    boolean skipGet() default false;
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CachedResults.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CachedResults.java
@@ -66,4 +66,9 @@ public @interface CachedResults {
      */
     String exclude() default "";
 
+    /**
+     * If set to true the cached value (if exists) will not be used.
+     * The method will always be executed and have their returned value placed in the cache.
+     */
+    boolean skipGet() default false;
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
@@ -53,75 +53,13 @@ public class CacheResultInterceptor extends CacheInterceptor {
         try {
             ReturnType returnType = determineReturnType(invocationContext.getMethod().getReturnType());
             if (returnType != ReturnType.NonAsync) {
-                Uni<Object> cacheValue = cache.getAsync(key, new Function<Object, Uni<Object>>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public Uni<Object> apply(Object key) {
-                        try {
-                            return (Uni<Object>) asyncInvocationResultToUni(invocationContext.proceed(), returnType);
-                        } catch (CacheException e) {
-                            throw e;
-                        } catch (Exception e) {
-                            throw new CacheException(e);
-                        }
-                    }
-                }).onFailure().call(new Function<>() {
-                    @Override
-                    public Uni<?> apply(Throwable throwable) {
-                        return cache.invalidate(key).replaceWith(throwable);
-                    }
-                });
-
-                if (binding.lockTimeout() <= 0) {
-                    return createAsyncResult(cacheValue, returnType);
-                }
-                // IMPORTANT: The item/failure are emitted on the captured context.
-                cacheValue = cacheValue.ifNoItem().after(Duration.ofMillis(binding.lockTimeout()))
-                        .recoverWithUni(new Supplier<Uni<?>>() {
-                            @Override
-                            public Uni<?> get() {
-                                try {
-                                    return asyncInvocationResultToUni(invocationContext.proceed(), returnType);
-                                } catch (CacheException e) {
-                                    throw e;
-                                } catch (Exception e) {
-                                    throw new CacheException(e);
-                                }
-                            }
-                        });
-                return createAsyncResult(cacheValue, returnType);
+                return binding.skipGet()
+                        ? computeAlwaysAsync(invocationContext, binding, returnType, cache, key)
+                        : computeIfAbsentAsync(invocationContext, binding, returnType, cache, key);
             } else {
-                Uni<Object> cacheValue = cache.get(key, new Function<Object, Object>() {
-                    @Override
-                    public Object apply(Object k) {
-                        try {
-                            LOGGER.debugf("Adding entry with key [%s] into cache [%s]",
-                                    key, binding.cacheName());
-                            return invocationContext.proceed();
-                        } catch (CacheException e) {
-                            throw e;
-                        } catch (Throwable e) {
-                            throw new CacheException(e);
-                        }
-                    }
-                });
-                Object value;
-                if (binding.lockTimeout() <= 0) {
-                    value = cacheValue.await().indefinitely();
-                } else {
-                    try {
-                        /*
-                         * If the current thread started the cache value computation, then the computation is already finished
-                         * since
-                         * it was done synchronously and the following call will never time out.
-                         */
-                        value = cacheValue.await().atMost(Duration.ofMillis(binding.lockTimeout()));
-                    } catch (TimeoutException e) {
-                        // TODO: Add statistics here to monitor the timeout.
-                        return invocationContext.proceed();
-                    }
-                }
-                return value;
+                return binding.skipGet()
+                        ? computeAlways(invocationContext, binding, cache, key)
+                        : computeIfAbsent(invocationContext, binding, cache, key);
             }
 
         } catch (CacheException e) {
@@ -133,4 +71,137 @@ public class CacheResultInterceptor extends CacheInterceptor {
         }
     }
 
+    private Object computeAlwaysAsync(final InvocationContext invocationContext,
+            final CacheResult binding,
+            final ReturnType returnType,
+            final AbstractCache cache,
+            final Object key) throws Exception {
+
+        Uni<Object> cacheValue = asyncInvocationResultToUni(invocationContext.proceed(), returnType)
+                .chain(freshValue -> {
+                    if (freshValue != null) {
+                        Uni<Object> cacheUni = cache.put(key, freshValue)
+                                .onItemOrFailure()
+                                .transformToUni((v, t) -> Uni.createFrom().item(freshValue));
+
+                        if (binding.lockTimeout() <= 0) {
+                            return cacheUni;
+                        }
+
+                        return cacheUni.ifNoItem().after(Duration.ofMillis(binding.lockTimeout()))
+                                .recoverWithItem(() -> freshValue);
+                    }
+
+                    return Uni.createFrom().nullItem();
+                });
+
+        return createAsyncResult(cacheValue, returnType);
+    }
+
+    private Object computeAlways(final InvocationContext invocationContext,
+            final CacheResult binding,
+            final AbstractCache cache,
+            final Object key) throws Exception {
+
+        Object value = invocationContext.proceed();
+
+        if (value != null) {
+            try {
+                Uni<Void> cacheSetUni = cache.put(key, value);
+
+                if (binding.lockTimeout() <= 0) {
+                    cacheSetUni.await().indefinitely();
+                } else {
+                    cacheSetUni.await().atMost(Duration.ofMillis(binding.lockTimeout()));
+                }
+            } catch (TimeoutException ignore) {
+                // TODO: Add statistics here to monitor the timeout.
+            }
+        }
+
+        return value;
+    }
+
+    private Object computeIfAbsentAsync(final InvocationContext invocationContext,
+            final CacheResult binding,
+            final ReturnType returnType,
+            final AbstractCache cache,
+            final Object key) {
+
+        Uni<Object> cacheValue = cache.getAsync(key, new Function<Object, Uni<Object>>() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public Uni<Object> apply(Object key) {
+                try {
+                    return (Uni<Object>) asyncInvocationResultToUni(invocationContext.proceed(), returnType);
+                } catch (CacheException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new CacheException(e);
+                }
+            }
+        }).onFailure().call(new Function<>() {
+            @Override
+            public Uni<?> apply(Throwable throwable) {
+                return cache.invalidate(key).replaceWith(throwable);
+            }
+        });
+
+        if (binding.lockTimeout() <= 0) {
+            return createAsyncResult(cacheValue, returnType);
+        }
+        // IMPORTANT: The item/failure are emitted on the captured context.
+        cacheValue = cacheValue.ifNoItem().after(Duration.ofMillis(binding.lockTimeout()))
+                .recoverWithUni(new Supplier<Uni<?>>() {
+                    @Override
+                    public Uni<?> get() {
+                        try {
+                            return asyncInvocationResultToUni(invocationContext.proceed(), returnType);
+                        } catch (CacheException e) {
+                            throw e;
+                        } catch (Exception e) {
+                            throw new CacheException(e);
+                        }
+                    }
+                });
+        return createAsyncResult(cacheValue, returnType);
+    }
+
+    private Object computeIfAbsent(final InvocationContext invocationContext,
+            final CacheResult binding,
+            final AbstractCache cache,
+            final Object key) throws Exception {
+
+        Uni<Object> cacheValue = cache.get(key, new Function<Object, Object>() {
+            @Override
+            public Object apply(Object k) {
+                try {
+                    LOGGER.debugf("Adding entry with key [%s] into cache [%s]",
+                            key, binding.cacheName());
+                    return invocationContext.proceed();
+                } catch (CacheException e) {
+                    throw e;
+                } catch (Throwable e) {
+                    throw new CacheException(e);
+                }
+            }
+        });
+        Object value;
+        if (binding.lockTimeout() <= 0) {
+            value = cacheValue.await().indefinitely();
+        } else {
+            try {
+                /*
+                 * If the current thread started the cache value computation, then the computation is already finished
+                 * since
+                 * it was done synchronously and the following call will never time out.
+                 */
+                value = cacheValue.await().atMost(Duration.ofMillis(binding.lockTimeout()));
+            } catch (TimeoutException e) {
+                // TODO: Add statistics here to monitor the timeout.
+                return invocationContext.proceed();
+            }
+        }
+        return value;
+    }
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -281,6 +281,18 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
     }
 
     @Override
+    public <K, V> Uni<Void> put(final K key, final V value) {
+
+        return Uni.createFrom().item(new Supplier<>() {
+            @Override
+            public Void get() {
+                cache.synchronous().put(key, value);
+                return null;
+            }
+        });
+    }
+
+    @Override
     public Set<Object> keySet() {
         return Set.copyOf(cache.asMap().keySet());
     }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
@@ -50,4 +50,9 @@ public class NoOpCache extends AbstractCache {
         return Uni.createFrom().voidItem();
     }
 
+    @Override
+    public <K, V> Uni<Void> put(final K key, final V value) {
+        return Uni.createFrom().voidItem();
+    }
+
 }

--- a/extensions/infinispan-cache/deployment/src/test/java/io/quarkus/cache/infinispan/InfinispanCacheTest.java
+++ b/extensions/infinispan-cache/deployment/src/test/java/io/quarkus/cache/infinispan/InfinispanCacheTest.java
@@ -351,6 +351,17 @@ public class InfinispanCacheTest {
         return new InfinispanCacheImpl(info, remoteCache);
     }
 
+    @Test
+    public void testPut() {
+        Cache cache = getCache();
+        String id = generateId();
+        awaitUni(cache.put(id, "value"));
+        assertThat(remoteCache.size()).isOne();
+        assertThat(remoteCache.get(id)).isEqualTo("value");
+        awaitUni(cache.invalidate(id));
+        assertThat(remoteCache.size()).isZero();
+    }
+
     private static <T> T awaitUni(Uni<T> uni) {
         return uni.await().atMost(Duration.ofSeconds(10));
     }

--- a/extensions/infinispan-cache/runtime/src/main/java/io/quarkus/cache/infinispan/runtime/InfinispanCacheImpl.java
+++ b/extensions/infinispan-cache/runtime/src/main/java/io/quarkus/cache/infinispan/runtime/InfinispanCacheImpl.java
@@ -298,6 +298,13 @@ public class InfinispanCacheImpl extends AbstractCache implements Cache {
     }
 
     @Override
+    public <K, V> Uni<Void> put(final K key, final V value) {
+
+        return Uni.createFrom().completionStage(
+                CompletableFuture.runAsync(() -> remoteCache.put(key, value)));
+    }
+
+    @Override
     public <T extends Cache> T as(Class<T> type) {
         if (type.getTypeName().equals(InfinispanCacheImpl.class.getTypeName())) {
             return (T) this;

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCache.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCache.java
@@ -80,17 +80,6 @@ public interface RedisCache extends Cache {
      * Put a value in the cache.
      *
      * @param key the key
-     * @param value the value
-     * @param <K> the type of key
-     * @param <V> the type of value
-     * @return a Uni emitting {@code null} when the operation completes
-     */
-    <K, V> Uni<Void> put(K key, V value);
-
-    /**
-     * Put a value in the cache.
-     *
-     * @param key the key
      * @param supplier supplier of the value
      * @param <K> the type of key
      * @param <V> the type of value


### PR DESCRIPTION
- Add "skipGet" on `CacheResult` annotation
- Add "skipGet" on `CacheResults` annotation
- Add method "put" on `Cache` interface
- Remove method "put" from `RedisCache` interface (who extends `Cache` interface / same definition)
- Implement "put" methods
- Rewrite `CacheResultInterceptor`
- Update `CacheResultsProcessor`

Fixes: #51531


**EDIT 2025-12-29:** Rebase (no conflicts)
**EDIT 2026-01-11:** Rebase (no conflicts)

