### PR TITLE
Run standard security interceptors before CDI interceptors handling transactions

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/StandardSecurityCheckInterceptor.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/StandardSecurityCheckInterceptor.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.runtime;
 
 import static io.quarkus.resteasy.runtime.EagerSecurityFilter.SKIP_DEFAULT_CHECK;
 import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.EXECUTED;
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY;
 import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_HANDLER;
 
 import java.lang.reflect.Method;
@@ -58,7 +59,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @RolesAllowed("")
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class RolesAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -68,7 +69,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermissionsAllowed("")
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class PermissionsAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -78,7 +79,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermitAll
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class PermitAllInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -88,7 +89,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @Authenticated
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class AuthenticatedInterceptor extends StandardSecurityCheckInterceptor {
 
     }

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
@@ -1,6 +1,7 @@
 package io.quarkus.resteasy.reactive.server.runtime;
 
 import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.EXECUTED;
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY;
 import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_HANDLER;
 
 import java.lang.reflect.Method;
@@ -57,7 +58,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @RolesAllowed("")
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class RolesAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -67,7 +68,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermissionsAllowed("")
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class PermissionsAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -77,7 +78,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermitAll
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class PermitAllInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -87,7 +88,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @Authenticated
-    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
+    @Priority(PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY)
     public static final class AuthenticatedInterceptor extends StandardSecurityCheckInterceptor {
 
     }

--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityHandlerConstants.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityHandlerConstants.java
@@ -1,5 +1,8 @@
 package io.quarkus.security.spi.runtime;
 
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
+
 public class SecurityHandlerConstants {
 
     /**
@@ -12,4 +15,14 @@ public class SecurityHandlerConstants {
      * `executed` means the check has already been done.
      */
     public static final String EXECUTED = "executed";
+
+    /**
+     * Interceptor priority for standard security interceptors.
+     */
+    public static final int SECURITY_INTERCEPTOR_PRIORITY = Interceptor.Priority.PLATFORM_BEFORE + 150;
+
+    /**
+     * Priority for interceptors propagating information indicating that a security check has been performed.
+     */
+    public static final int PREVENT_REPEATED_CHECKS_INTERCEPTOR_PRIORITY = SECURITY_INTERCEPTOR_PRIORITY - 10;
 }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/AuthenticatedInterceptor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/AuthenticatedInterceptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.runtime.interceptor;
 
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_INTERCEPTOR_PRIORITY;
+
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
@@ -14,7 +16,7 @@ import io.quarkus.security.spi.runtime.AuthorizationController;
  */
 @Interceptor
 @Authenticated
-@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+@Priority(SECURITY_INTERCEPTOR_PRIORITY)
 public class AuthenticatedInterceptor {
 
     @Inject

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/DenyAllInterceptor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/DenyAllInterceptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.runtime.interceptor;
 
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_INTERCEPTOR_PRIORITY;
+
 import jakarta.annotation.Priority;
 import jakarta.annotation.security.DenyAll;
 import jakarta.inject.Inject;
@@ -15,7 +17,7 @@ import io.quarkus.security.spi.runtime.AuthorizationController;
  */
 @Interceptor
 @DenyAll
-@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+@Priority(SECURITY_INTERCEPTOR_PRIORITY)
 public class DenyAllInterceptor {
 
     @Inject

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/PermissionsAllowedInterceptor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/PermissionsAllowedInterceptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.runtime.interceptor;
 
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_INTERCEPTOR_PRIORITY;
+
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
@@ -11,7 +13,7 @@ import io.quarkus.security.spi.runtime.AuthorizationController;
 
 @Interceptor
 @PermissionsAllowed("")
-@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+@Priority(SECURITY_INTERCEPTOR_PRIORITY)
 public class PermissionsAllowedInterceptor {
 
     @Inject

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/PermitAllInterceptor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/PermitAllInterceptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.runtime.interceptor;
 
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_INTERCEPTOR_PRIORITY;
+
 import jakarta.annotation.Priority;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
@@ -14,7 +16,7 @@ import io.quarkus.security.spi.runtime.AuthorizationController;
  */
 @Interceptor
 @PermitAll
-@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+@Priority(SECURITY_INTERCEPTOR_PRIORITY)
 public class PermitAllInterceptor {
 
     @Inject

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/RolesAllowedInterceptor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/RolesAllowedInterceptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.runtime.interceptor;
 
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_INTERCEPTOR_PRIORITY;
+
 import jakarta.annotation.Priority;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
@@ -14,7 +16,7 @@ import io.quarkus.security.spi.runtime.AuthorizationController;
  */
 @Interceptor
 @RolesAllowed("")
-@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+@Priority(SECURITY_INTERCEPTOR_PRIORITY)
 public class RolesAllowedInterceptor {
 
     @Inject

--- a/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/CustomInterceptor.java
+++ b/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/CustomInterceptor.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.security.webauthn;
+
+import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.EXECUTED;
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_HANDLER;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+
+import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.hibernate.reactive.panache.common.runtime.SessionOperations;
+
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 190)
+@CustomInterceptorBinding
+@Interceptor
+public class CustomInterceptor {
+
+    public static volatile boolean sessionNotStarted = false;
+    public static volatile boolean securityCheckRun = false;
+
+    @AroundInvoke
+    public Object aroundInvoke(ArcInvocationContext context) throws Exception {
+        var currentSession = SessionOperations.getCurrentSession(DEFAULT_PERSISTENCE_UNIT_NAME);
+        sessionNotStarted = currentSession == null;
+        securityCheckRun = EXECUTED.equals(context.getContextData().get(SECURITY_HANDLER));
+        return context.proceed();
+    }
+
+}

--- a/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/CustomInterceptorBinding.java
+++ b/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/CustomInterceptorBinding.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.security.webauthn;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Documented
+@Retention(RUNTIME)
+@Target({ METHOD, TYPE })
+public @interface CustomInterceptorBinding {
+}

--- a/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/UserResource.java
+++ b/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/UserResource.java
@@ -1,18 +1,32 @@
 package io.quarkus.it.security.webauthn;
 
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
 
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.smallrye.mutiny.Uni;
+
 @Path("/api/users")
 public class UserResource {
+
+    @Inject
+    UserService userService;
 
     @GET
     @RolesAllowed("user")
     @Path("/me")
     public String me(@Context SecurityContext securityContext) {
         return securityContext.getUserPrincipal().getName();
+    }
+
+    @GET
+    @Path("/{name}")
+    public Uni<Long> findUserIdByName(@RestPath String name) {
+        return userService.findUserIdByName(name);
     }
 }

--- a/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/UserService.java
+++ b/integration-tests/security-webauthn/src/main/java/io/quarkus/it/security/webauthn/UserService.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.security.webauthn;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+class UserService {
+
+    @CustomInterceptorBinding
+    @WithTransaction
+    @Authenticated
+    Uni<Long> findUserIdByName(String username) {
+        return User.findByUsername(username).map(u -> u.id);
+    }
+
+}

--- a/integration-tests/security-webauthn/src/test/java/io/quarkus/it/security/webauthn/test/SecurityInterceptorsPriorityTest.java
+++ b/integration-tests/security-webauthn/src/test/java/io/quarkus/it/security/webauthn/test/SecurityInterceptorsPriorityTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.it.security.webauthn.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.security.webauthn.CustomInterceptor;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.webauthn.WebAuthnEndpointHelper;
+import io.quarkus.test.security.webauthn.WebAuthnHardware;
+import io.restassured.RestAssured;
+import io.restassured.filter.Filter;
+import io.restassured.filter.cookie.CookieFilter;
+import io.vertx.core.json.JsonObject;
+
+@QuarkusTest
+class SecurityInterceptorsPriorityTest {
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    void testSecurityChecksRunsBeforeTransactions() {
+        Filter cookieFilter = new CookieFilter();
+        registerUser("Roman", cookieFilter);
+
+        CustomInterceptor.securityCheckRun = false;
+        CustomInterceptor.sessionNotStarted = false;
+
+        long id = Long.parseLong(RestAssured.given()
+                .filter(cookieFilter)
+                .pathParam("name", "Roman")
+                .get("/api/users/{name}")
+                .then()
+                .statusCode(200)
+                .extract().asString());
+
+        assertTrue(CustomInterceptor.securityCheckRun);
+        assertTrue(CustomInterceptor.sessionNotStarted);
+
+        // check we received response from database
+        assertTrue(id >= 1);
+    }
+
+    private void registerUser(String username, Filter cookieFilter) {
+        String challenge = WebAuthnEndpointHelper.obtainRegistrationChallenge(username, cookieFilter);
+        WebAuthnHardware token = new WebAuthnHardware(url);
+        JsonObject registrationJson = token.makeRegistrationJson(challenge);
+        WebAuthnEndpointHelper.invokeRegistration(username, registrationJson, cookieFilter);
+    }
+
+}


### PR DESCRIPTION
If authorization is not enforced on endpoints, but later on CDI beans, we should run security checks sooner to avoid starting transaction with the `@Transactional` annotation if access was denied. If security checks require active transactions, which can only be a case for the `@PermissionsAllowed` annotation or identity providers/augmentors in lazy authentication, then they need to use `@Transactional` on CDI beans that require it (like a permission checker method, identity provider etc.). There could be edge cases where users don't do that, in which case they will be affected by this PR.