### PR TITLE
Don't try to download our own artifacts when populating the local Maven repo on CI

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -251,7 +251,7 @@ jobs:
             ${{ needs.configure.outputs.m2-monthly-cache-key }}-
       - name: Populate the .m2 repository (for cache and for shipping to follow-up builds)
         run: |
-          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline -Dgo-offline
+          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline -Dgo-offline -DexcludeReactor=true
       - name: Cache Develocity local cache
         uses: actions/cache@v5
         if: github.event_name == 'pull_request' || github.event_name == 'push' && github.repository != 'quarkusio/quarkus'

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -71,4 +71,4 @@ jobs:
           runs-on: false
       - name: Populate the cache
         run: |
-          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline
+          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline -Dgo-offline -DexcludeReactor=true


### PR DESCRIPTION
Otherwise, if the local repo doesn't include our own artifacts yet, we get this warning:
```
2025-12-17T11:11:39.0820731Z [WARNING] Failed to retrieve plugin descriptor for io.quarkus:quarkus-extension-maven-plugin:999-SNAPSHOT: Plugin io.quarkus:quarkus-extension-maven-plugin:999-SNAPSHOT or one of its dependencies could not be resolved:
2025-12-17T11:11:39.0823166Z Could not find artifact io.quarkus:quarkus-extension-maven-plugin:jar:999-SNAPSHOT
```

Downloading our own artifacts shouldn't be necessary anyway, and could even quite possibly be harmful.

See https://maven.apache.org/plugins/maven-dependency-plugin/go-offline-mojo.html#excludeReactor
