### PR TITLE
Quarkus REST: do not scan static fields in parameter containers

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/BeanParamRecordTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/BeanParamRecordTest.java
@@ -61,6 +61,8 @@ public class BeanParamRecordTest {
             OtherBeanParam obp,
             // record contains record (implicit @BeanParam)
             OtherBeanParamRecord obpr) {
+        private static String X = null;
+        public final static String Y = null;
     }
 
     public static class OtherBeanParam {

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -386,6 +386,10 @@ public class ServerEndpointIndexer
         // records do not have field injection, we use their constructor, so field rules do not apply
         boolean applyFieldRules = !currentClassInfo.isRecord();
         for (FieldInfo field : currentClassInfo.fields()) {
+            // We don't do any injection in static fields
+            if (Modifier.isStatic(field.flags())) {
+                continue;
+            }
             Map<DotName, AnnotationInstance> annotations = new HashMap<>();
             for (AnnotationInstance i : field.annotations()) {
                 annotations.put(i.name(), i);


### PR DESCRIPTION
We don't support that, and they create false positives

Fixes #51546
