### PR TITLE
Support building jars in parallel for uberjars

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
@@ -14,6 +14,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -52,6 +53,7 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
     protected final List<GeneratedClassBuildItem> generatedClasses;
     protected final List<GeneratedResourceBuildItem> generatedResources;
     protected final Set<ArtifactKey> removedArtifactKeys;
+    protected final ExecutorService executorService;
     protected final ResolvedJVMRequirements jvmRequirements;
 
     public AbstractJarBuilder(CurateOutcomeBuildItem curateOutcome,
@@ -64,6 +66,7 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
             List<GeneratedClassBuildItem> generatedClasses,
             List<GeneratedResourceBuildItem> generatedResources,
             Set<ArtifactKey> removedArtifactKeys,
+            ExecutorService executorService,
             ResolvedJVMRequirements jvmRequirements) {
         this.curateOutcome = curateOutcome;
         this.outputTarget = outputTarget;
@@ -75,7 +78,9 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
         this.generatedClasses = generatedClasses;
         this.generatedResources = generatedResources;
         this.removedArtifactKeys = removedArtifactKeys;
+        this.executorService = executorService;
         this.jvmRequirements = jvmRequirements;
+
         checkConsistency(generatedClasses);
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -17,8 +17,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 
-import org.jboss.logging.Logger;
-
 import io.quarkus.builder.item.BuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
@@ -36,10 +34,6 @@ import io.quarkus.maven.dependency.ResolvedDependency;
 
 public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends AbstractJarBuilder<T> {
 
-    private static final Logger LOG = Logger.getLogger(AbstractLegacyThinJarBuilder.class);
-
-    private final ExecutorService executorService;
-
     public AbstractLegacyThinJarBuilder(CurateOutcomeBuildItem curateOutcome,
             OutputTargetBuildItem outputTarget,
             ApplicationInfoBuildItem applicationInfo,
@@ -53,9 +47,7 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
             ExecutorService executorService,
             ResolvedJVMRequirements jvmRequirements) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys, jvmRequirements);
-
-        this.executorService = executorService;
+                generatedClasses, generatedResources, removedArtifactKeys, executorService, jvmRequirements);
     }
 
     public abstract T build() throws IOException;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ArchiveCreator.java
@@ -48,6 +48,10 @@ public interface ArchiveCreator extends AutoCloseable {
         addFile(bytes, target, UNKNOWN_SOURCE);
     }
 
+    boolean isMultiVersion();
+
+    void makeMultiVersion() throws IOException;
+
     @Override
     void close();
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
@@ -70,7 +70,6 @@ public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
     private final List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives;
     private final Set<ArtifactKey> parentFirstArtifactKeys;
-    private final ExecutorService executorService;
 
     public FastJarBuilder(CurateOutcomeBuildItem curateOutcome,
             OutputTargetBuildItem outputTarget,
@@ -87,10 +86,9 @@ public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             ExecutorService executorService,
             ResolvedJVMRequirements jvmRequirements) {
         super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys, jvmRequirements);
+                generatedClasses, generatedResources, removedArtifactKeys, executorService, jvmRequirements);
         this.additionalApplicationArchives = additionalApplicationArchives;
         this.parentFirstArtifactKeys = parentFirstArtifactKeys;
-        this.executorService = executorService;
     }
 
     public JarBuildItem build() throws IOException {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
@@ -22,7 +22,6 @@ import io.quarkus.fs.util.ZipUtils;
 
 class ZipFileSystemArchiveCreator implements ArchiveCreator {
 
-    private static final Path MANIFEST = Path.of("META-INF", "MANIFEST.MF");
     // we probably don't need the Windows entry but let's be safe
     private static final Set<String> MANIFESTS = Set.of("META-INF/MANIFEST.MF", "META-INF\\MANIFEST.MF");
 
@@ -124,16 +123,12 @@ class ZipFileSystemArchiveCreator implements ArchiveCreator {
         addFile(joinWithNewlines(bytes), target, source);
     }
 
-    /**
-     * Note: this method may only be used for Uberjars, for which we might need to amend the manifest at the end of the build.
-     */
+    @Override
     public boolean isMultiVersion() {
         return Files.isDirectory(zipFileSystem.getPath("META-INF", "versions"));
     }
 
-    /**
-     * Note: this method may only be used for Uberjars, for which we might need to amend the manifest at the end of the build.
-     */
+    @Override
     public void makeMultiVersion() throws IOException {
         final Path manifestPath = zipFileSystem.getPath("META-INF", "MANIFEST.MF");
         final Manifest manifest = new Manifest();

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -131,6 +131,7 @@ public class JarResultBuildStep {
                     removedArtifactKeys,
                     uberJarMergedResourceBuildItems,
                     uberJarIgnoredResourceBuildItems,
+                    buildExecutor,
                     jvmRequirements).build();
             case LEGACY_JAR -> new LegacyThinJarBuilder(curateOutcomeBuildItem,
                     outputTargetBuildItem,


### PR DESCRIPTION
There's one drawback: we need to keep all the jars open until the uberjar has been fully written but I think we can live with it.

And we can revert if people start complaining, or provide an option.

This is a follow-up of https://github.com/quarkusio/quarkus/pull/49585 .