### PR TITLE
Reduce type registrations when using `ReflectiveHierarchyBuildItem`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -25,6 +25,7 @@ import io.quarkus.builder.item.MultiBuildItem;
  *
  * <ul>
  * <li>Superclasses</li>
+ * <li>Interfaces</li>
  * <li>Component types of collections</li>
  * <li>Types used in bean properties (if method reflection is enabled)</li>
  * <li>Field types (if field reflection is enabled)</li>

--- a/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
+++ b/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
@@ -54,30 +54,31 @@ class QuarkusSecurityWebAuthnProcessor {
 
     @BuildStep
     public void registerJacksonTypes(BuildProducer<ReflectiveHierarchyBuildItem> reflection) {
+        String source = QuarkusSecurityWebAuthnProcessor.class.getSimpleName();
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(AuthenticatorAssertionResponse.class).build());
+                ReflectiveHierarchyBuildItem.builder(AuthenticatorAssertionResponse.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(AuthenticatorAttestationResponse.class).build());
-        reflection.produce(ReflectiveHierarchyBuildItem.builder(AuthenticationRequest.class).build());
-        reflection.produce(ReflectiveHierarchyBuildItem.builder(RegistrationRequest.class).build());
+                ReflectiveHierarchyBuildItem.builder(AuthenticatorAttestationResponse.class).source(source).build());
+        reflection.produce(ReflectiveHierarchyBuildItem.builder(AuthenticationRequest.class).source(source).build());
+        reflection.produce(ReflectiveHierarchyBuildItem.builder(RegistrationRequest.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialCreationOptions.class).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialCreationOptions.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialRequestOptions.class).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialRequestOptions.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialRpEntity.class).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialRpEntity.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialUserEntity.class).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialUserEntity.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialParameters.class).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialParameters.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialType.class).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialType.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredential.class).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredential.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(AttestationObject.class).build());
+                ReflectiveHierarchyBuildItem.builder(AttestationObject.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(CollectedClientData.class).build());
+                ReflectiveHierarchyBuildItem.builder(CollectedClientData.class).source(source).build());
     }
 
     @BuildStep

--- a/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
+++ b/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
@@ -8,17 +8,18 @@ import jakarta.inject.Singleton;
 import org.jboss.jandex.DotName;
 
 import com.webauthn4j.data.AuthenticationRequest;
-import com.webauthn4j.data.AuthenticatorAssertionResponse;
-import com.webauthn4j.data.AuthenticatorAttestationResponse;
+import com.webauthn4j.data.AuthenticatorResponse;
 import com.webauthn4j.data.PublicKeyCredential;
 import com.webauthn4j.data.PublicKeyCredentialCreationOptions;
+import com.webauthn4j.data.PublicKeyCredentialEntity;
 import com.webauthn4j.data.PublicKeyCredentialParameters;
 import com.webauthn4j.data.PublicKeyCredentialRequestOptions;
-import com.webauthn4j.data.PublicKeyCredentialRpEntity;
 import com.webauthn4j.data.PublicKeyCredentialType;
-import com.webauthn4j.data.PublicKeyCredentialUserEntity;
 import com.webauthn4j.data.RegistrationRequest;
 import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.attestation.authenticator.COSEKey;
+import com.webauthn4j.data.attestation.authenticator.Curve;
+import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import com.webauthn4j.data.client.CollectedClientData;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -56,9 +57,7 @@ class QuarkusSecurityWebAuthnProcessor {
     public void registerJacksonTypes(BuildProducer<ReflectiveHierarchyBuildItem> reflection) {
         String source = QuarkusSecurityWebAuthnProcessor.class.getSimpleName();
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(AuthenticatorAssertionResponse.class).source(source).build());
-        reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(AuthenticatorAttestationResponse.class).source(source).build());
+                ReflectiveHierarchyBuildItem.builder(AuthenticatorResponse.class).source(source).build());
         reflection.produce(ReflectiveHierarchyBuildItem.builder(AuthenticationRequest.class).source(source).build());
         reflection.produce(ReflectiveHierarchyBuildItem.builder(RegistrationRequest.class).source(source).build());
         reflection.produce(
@@ -66,9 +65,7 @@ class QuarkusSecurityWebAuthnProcessor {
         reflection.produce(
                 ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialRequestOptions.class).source(source).build());
         reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialRpEntity.class).source(source).build());
-        reflection.produce(
-                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialUserEntity.class).source(source).build());
+                ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialEntity.class).source(source).build());
         reflection.produce(
                 ReflectiveHierarchyBuildItem.builder(PublicKeyCredentialParameters.class).source(source).build());
         reflection.produce(
@@ -79,6 +76,12 @@ class QuarkusSecurityWebAuthnProcessor {
                 ReflectiveHierarchyBuildItem.builder(AttestationObject.class).source(source).build());
         reflection.produce(
                 ReflectiveHierarchyBuildItem.builder(CollectedClientData.class).source(source).build());
+        reflection.produce(
+                ReflectiveHierarchyBuildItem.builder(Curve.class).source(source).build());
+        reflection.produce(
+                ReflectiveHierarchyBuildItem.builder(AttestationStatement.class).source(source).build());
+        reflection.produce(
+                ReflectiveHierarchyBuildItem.builder(COSEKey.class).source(source).build());
     }
 
     @BuildStep

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
@@ -225,6 +225,17 @@ public class TestResource {
     }
 
     @GET
+    @Path("/subsubclass")
+    @Produces("application/json")
+    public ParentClass subsubclass() {
+        GrandChildClass grandChild = new GrandChildClass();
+        grandChild.setName("your name");
+        grandChild.setValue("your value");
+        grandChild.setToy("your toy");
+        return grandChild;
+    }
+
+    @GET
     @Path("/implementor")
     @Produces("application/json")
     public MyInterface implementor() {
@@ -486,6 +497,18 @@ public class TestResource {
 
         public void setValue(String value) {
             this.value = value;
+        }
+    }
+
+    public static class GrandChildClass extends ChildClass {
+        private String toy;
+
+        public String getToy() {
+            return toy;
+        }
+
+        public void setToy(String toy) {
+            this.toy = toy;
         }
     }
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
@@ -153,6 +153,14 @@ public class JaxRSTestCase {
     }
 
     @Test
+    public void testSubSubclass() {
+        RestAssured.when().get("/test/subsubclass").then()
+                .body("name", is("your name"),
+                        "value", is("your value"),
+                        "toy", is("your toy"));
+    }
+
+    @Test
     public void testImplementor() {
         RestAssured.when().get("/test/implementor").then()
                 .body("name", is("my name"),


### PR DESCRIPTION
Only registers subclasses and implementors of the class being registered
for reflective hierarchy, skipping subclasses and implementors of
transitively reachable classes and interfaces.

As a result:

1. if a class implements a commonly implemented interface, Quarkus won't
   end up registering all the implementations of this interface as well.

2. if a class is a subclass of a class with many subclasses, Quarkus won't
   end up registering all these subclasses as well.

Relates to https://github.com/quarkusio/quarkus/issues/51503 and
https://github.com/quarkusio/quarkus/pull/51538

## Testing

- :heavy_check_mark: https://github.com/quarkusio/quarkus-quickstarts/tree/main/hibernate-orm-panache-kotlin-quickstart (locally)
- :heavy_check_mark: Mandrel 23.1 (JDK 21-based) build and run on quarkus with the patch: https://github.com/graalvm/mandrel/actions/runs/20306456519
- :heavy_check_mark: Mandrel 25.0 (JDK 25-based) build and run on quarkus with the patch (and --future-defaults=all) turned on: https://github.com/graalvm/mandrel/actions/runs/20306496273
- :heavy_check_mark: GraalVM CE build of graal/master (LabsJDK-25-based) build and run on quarkus with the patch: https://github.com/graalvm/mandrel/actions/runs/20306556680

mandrel-IT failures seem related to https://github.com/Karm/mandrel-integration-tests/issues/382 and not this PR.

cc @jerboaa 