### PR TITLE
Update to AsciidoctorJ 3.0.0 and handle more blocks in id collection

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -33,7 +33,7 @@
         <jandex.version>3.5.3</jandex.version>
         <jandex-gradle-plugin.version>2.3.0</jandex-gradle-plugin.version>
 
-        <asciidoctorj.version>2.5.13</asciidoctorj.version>
+        <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <htmlunit.version>4.20.0</htmlunit.version>
         <javaparser-core.version>3.27.1</javaparser-core.version>
         <jdeparser.version>2.0.3.Final</jdeparser.version>

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigItemTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigItemTest.java
@@ -3,9 +3,8 @@ package io.quarkus.annotation.processor.documentation.config.formatter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.Collections;
-
 import org.asciidoctor.Asciidoctor.Factory;
+import org.asciidoctor.Options;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -309,7 +308,7 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         final String asciiDoc = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
-        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        final String actual = Factory.create().convert(asciiDoc, Options.builder().build());
         final String expected = "<div class=\"paragraph\">\n<p>Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch
                 + " " + ch + ch + "</code>, <code>JavaDoc tag " + ch + " " + ch + ch + "</code></p>\n</div>";
         assertEquals(expected, actual);
@@ -323,7 +322,7 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         final String asciiDoc = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format(), true);
-        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        final String actual = Factory.create().convert(asciiDoc, Options.builder().build());
 
         if (ch.equals("]")) {
             ch = "&#93;";
@@ -340,7 +339,7 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         final String asciiDoc = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
-        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        final String actual = Factory.create().convert(asciiDoc, Options.builder().build());
         assertEquals(expected, actual);
     }
 
@@ -354,7 +353,7 @@ public class JavadocToAsciidocTransformerConfigItemTest {
 
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         final String asciiDoc = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
-        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        final String actual = Factory.create().convert(asciiDoc, Options.builder().build());
         assertEquals(expected, actual);
     }
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,8 +23,8 @@
         <mandrel.image-tag-for-documentation>jdk-21</mandrel.image-tag-for-documentation>
 
         <assembly-maven-plugin.version>3.8.0</assembly-maven-plugin.version>
-        <asciidoctor-maven-plugin.version>2.2.5</asciidoctor-maven-plugin.version>
-        <asciidoctorj-pdf.version>1.5.0-beta.8</asciidoctorj-pdf.version>
+        <asciidoctor-maven-plugin.version>3.2.0</asciidoctor-maven-plugin.version>
+        <asciidoctorj-pdf.version>2.3.23</asciidoctorj-pdf.version>
         <asciidoctor.fail-if>WARN</asciidoctor.fail-if>
         <roaster-jdt.version>2.26.0.Final</roaster-jdt.version>
         <maven-model-helper.version>37</maven-model-helper.version>

--- a/docs/src/main/java/io/quarkus/docs/generation/ReferenceIndexGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/ReferenceIndexGenerator.java
@@ -17,14 +17,9 @@ import java.util.stream.Stream;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
-import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.Cell;
-import org.asciidoctor.ast.DescriptionList;
-import org.asciidoctor.ast.DescriptionListEntry;
 import org.asciidoctor.ast.Document;
-import org.asciidoctor.ast.ListItem;
 import org.asciidoctor.ast.Row;
-import org.asciidoctor.ast.Section;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Table;
 
@@ -158,29 +153,25 @@ public class ReferenceIndexGenerator {
 
     private void addBlocks(Index index, String fileName, List<StructuralNode> blocks) {
         for (StructuralNode block : blocks) {
-            if (block instanceof Section || block instanceof Table || block instanceof Block
-                    || block instanceof org.asciidoctor.ast.List || block instanceof ListItem
-                    || block instanceof DescriptionList || block instanceof DescriptionListEntry) {
-                if (block.getId() != null) {
-                    // unfortunately, AsciiDoc already formats the title in the AST
-                    // and I couldn't find a way to get the original one
-                    IndexReference reference = new IndexReference(fileName, block.getId(),
-                            block.getTitle() != null ? block.getTitle().replace("<code>", "`")
-                                    .replace("</code>", "`")
-                                    .replace('\n', ' ')
-                                    .replace("&#8217;", "'")
-                                    .replace("&amp;", "&")
-                                    .replace("&#8230;&#8203;", "...")
-                                    .replace("<em>", "_")
-                                    .replace("</em>", "_")
-                                    .replace("<b>", "*")
-                                    .replace("</b>", "*")
-                                    .replace("<strong>", "*")
-                                    .replace("</strong>", "*")
-                                    .replaceAll("<a.*</a> ", "") : "~~ unknown title ~~");
+            if (block.getId() != null) {
+                // unfortunately, AsciiDoc already formats the title in the AST
+                // and I couldn't find a way to get the original one
+                IndexReference reference = new IndexReference(fileName, block.getId(),
+                        block.getTitle() != null ? block.getTitle().replace("<code>", "`")
+                                .replace("</code>", "`")
+                                .replace('\n', ' ')
+                                .replace("&#8217;", "'")
+                                .replace("&amp;", "&")
+                                .replace("&#8230;&#8203;", "...")
+                                .replace("<em>", "_")
+                                .replace("</em>", "_")
+                                .replace("<b>", "*")
+                                .replace("</b>", "*")
+                                .replace("<strong>", "*")
+                                .replace("</strong>", "*")
+                                .replaceAll("<a.*</a> ", "") : "~~ unknown title ~~");
 
-                    index.add(reference);
-                }
+                index.add(reference);
             }
             // we go into the content of the tables to add references for the configuration properties
             if (block instanceof Table table) {

--- a/docs/src/main/java/io/quarkus/docs/generation/TooltipInlineMacroProcessor.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/TooltipInlineMacroProcessor.java
@@ -1,9 +1,9 @@
 package io.quarkus.docs.generation;
 
-import java.util.HashMap;
 import java.util.Map;
 
-import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -16,9 +16,7 @@ import org.asciidoctor.extension.Name;
 public class TooltipInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
-    public Object process(ContentNode contentNode, String target, Map<String, Object> map) {
-        var attributes = new HashMap<String, Object>();
-        attributes.put("subs", ":normal");
-        return createPhraseNode(contentNode, "quoted", String.format("`%s`", target), attributes);
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        return createPhraseNode(parent, "quoted", String.format("`%s`", target), Map.of("subs", ":normal"));
     }
 }

--- a/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
@@ -144,7 +144,6 @@ public class YamlMetadataGenerator {
 
         Options options = Options.builder()
                 .docType("book")
-                .sourceDir(srcDir.toFile())
                 .baseDir(srcDir.toFile())
                 .safe(SafeMode.UNSAFE)
                 .build();


### PR DESCRIPTION
Note that we can't collect ids for inline elements as the Java AST doesn't expose the inline elements.

