### PR TITLE
Documentation - Fix ending of ifdef/ifndef

### DIFF
--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/memorySizeNote.qute.adoc
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/memorySizeNote.qute.adoc
@@ -7,4 +7,4 @@ A size configuration option recognizes strings in this format (shown as a regula
 
 If no suffix is given, assume bytes.
 ====
-ifndef::no-memory-size-note[]
+endif::no-memory-size-note[]

--- a/docs/src/main/asciidoc/_includes/extension-status.adoc
+++ b/docs/src/main/asciidoc/_includes/extension-status.adoc
@@ -22,4 +22,4 @@ endif::[]
 
 For a full list of possible statuses, check our https://quarkus.io/faq/#what-are-the-extension-statuses[FAQ entry].
 ====
-endif::[]
+endif::extension-status[]


### PR DESCRIPTION
This is causing warnings in the website after an Asciidoc update.
