### PR TITLE
Graceful shutdown for named messaging worker pools

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -52,6 +52,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
@@ -258,7 +259,9 @@ public class SmallRyeReactiveMessagingProcessor {
 
     @BuildStep
     @Record(STATIC_INIT)
-    public void build(SmallRyeReactiveMessagingRecorder recorder, RecorderContext recorderContext,
+    public void build(SmallRyeReactiveMessagingRecorder recorder,
+            LaunchModeBuildItem launchMode,
+            RecorderContext recorderContext,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             List<MediatorBuildItem> mediatorMethods,
             List<ConnectorManagedChannelBuildItem> connectorManagedChannels,
@@ -305,6 +308,10 @@ public class SmallRyeReactiveMessagingProcessor {
                     defaultConfig.produce(new RunTimeConfigurationDefaultBuildItem(
                             "smallrye.messaging.worker." + poolName + ".max-concurrency",
                             DEFAULT_VIRTUAL_THREADS_MAX_CONCURRENCY));
+                }
+                if (launchMode.getLaunchMode().isDevOrTest()) {
+                    defaultConfig.produce(new RunTimeConfigurationDefaultBuildItem(
+                            "smallrye.messaging.worker." + poolName + ".shutdown-timeout", "0"));
                 }
                 workerConfigurations.add(new WorkerConfiguration(methodInfo.declaringClass().toString(),
                         methodInfo.name(), poolName, methodInfo.hasAnnotation(RUN_ON_VIRTUAL_THREAD)));

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -15,7 +17,9 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Reception;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
+import jakarta.interceptor.Interceptor;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
@@ -28,6 +32,7 @@ import io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.providers.helpers.Validation;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.WorkerExecutorInternal;
 import io.vertx.mutiny.core.Context;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.WorkerExecutor;
@@ -40,16 +45,15 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
 
     private static final Logger log = Logger.getLogger(WorkerPoolRegistry.class);
 
-    private static final String WORKER_CONFIG_PREFIX = "smallrye.messaging.worker";
-    private static final String WORKER_CONCURRENCY = "max-concurrency";
     public static final String DEFAULT_VIRTUAL_THREAD_WORKER = "<virtual-thread>";
 
     @Inject
     ExecutionHolder executionHolder;
 
-    private final Map<String, Integer> workerConcurrency = new HashMap<>();
+    private final Map<String, WorkerPoolConfig> workerConfig = new HashMap<>();
     private final Map<String, WorkerExecutor> workerExecutors = new ConcurrentHashMap<>();
     private final Set<String> virtualThreadWorkers = initVirtualThreadWorkers();
+    private volatile boolean closed = false;
 
     private static Set<String> initVirtualThreadWorkers() {
         Set<String> set = new ConcurrentHashSet<>();
@@ -58,19 +62,89 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
     }
 
     public void terminate(
-            @Observes(notifyObserver = Reception.IF_EXISTS) @Priority(100) @BeforeDestroyed(ApplicationScoped.class) Object event) {
+            @Observes(notifyObserver = Reception.IF_EXISTS) @Priority(Interceptor.Priority.PLATFORM_BEFORE) @BeforeDestroyed(ApplicationScoped.class) Object event) {
+        log.debug("Terminating messaging worker pools");
         if (!workerExecutors.isEmpty()) {
-            for (WorkerExecutor executor : workerExecutors.values()) {
-                if (Infrastructure.canCallerThreadBeBlocked()) {
-                    executor.closeAndAwait();
-                } else {
+            closed = true;
+            // In most cases this is called from the main thread, so we can block.
+            if (!Infrastructure.canCallerThreadBeBlocked()) {
+                for (WorkerExecutor executor : workerExecutors.values()) {
                     executor.closeAndForget();
                 }
+                return;
+            }
+
+            // Shutdown all worker executors
+            for (Map.Entry<String, WorkerExecutor> entry : workerExecutors.entrySet()) {
+                WorkerExecutor executor = entry.getValue();
+                // Get the underlying Vert.x WorkerPool and shutdown its executor
+                try {
+                    ((WorkerExecutorInternal) executor.getDelegate()).getPool().executor().shutdown();
+                } catch (Exception e) {
+                    log.warnf(e, "Failed to shutdown worker pool %s", entry.getKey());
+                }
+            }
+
+            long start = System.nanoTime();
+            boolean terminated = false;
+            int loop = 1;
+            long elapsed = 0;
+
+            while (!terminated) {
+                terminated = true;
+                for (Map.Entry<String, WorkerExecutor> entry : workerExecutors.entrySet()) {
+                    WorkerExecutor workerExecutor = entry.getValue();
+                    ExecutorService innerExecutor = ((WorkerExecutorInternal) workerExecutor.getDelegate()).getPool()
+                            .executor();
+                    WorkerPoolConfig poolConfig = workerConfig.get(entry.getKey());
+                    long timeout = poolConfig != null ? poolConfig.shutdownTimeout().toNanos()
+                            : TimeUnit.MILLISECONDS.toNanos(DEFAULT_SHUTDOWN_TIMEOUT_MS);
+                    long interval = poolConfig != null ? poolConfig.shutdownCheckInterval().toNanos()
+                            : TimeUnit.MILLISECONDS.toNanos(DEFAULT_SHUTDOWN_CHECK_INTERVAL_MS);
+                    log.debugf("Await termination loop: %d, worker: %s, remaining: %d ns",
+                            Integer.valueOf(loop), entry.getKey(), Long.valueOf(timeout - elapsed));
+                    try {
+                        if (!innerExecutor.awaitTermination(Math.min(timeout - elapsed, interval), TimeUnit.NANOSECONDS)) {
+                            elapsed = System.nanoTime() - start;
+                            if (elapsed >= timeout) {
+                                log.warnf("Worker pool %s did not terminate within timeout, forcing shutdown", entry.getKey());
+                                innerExecutor.shutdownNow();
+                                workerExecutor.closeAndAwait();
+                            } else {
+                                terminated = false; // Still waiting
+                            }
+                        }
+                    } catch (InterruptedException e) {
+                        log.warnf(e,
+                                "Interrupted while waiting for worker pools to terminate, forcing shutdown of all remaining pools");
+                        // Force shutdown all remaining worker pools
+                        for (Map.Entry<String, WorkerExecutor> remaining : workerExecutors.entrySet()) {
+                            try {
+                                WorkerExecutor exec = remaining.getValue();
+                                ExecutorService execService = ((WorkerExecutorInternal) exec.getDelegate()).getPool()
+                                        .executor();
+                                execService.shutdownNow();
+                                exec.closeAndAwait();
+                            } catch (Exception ex) {
+                                log.warnf(ex, "Error forcing shutdown of worker pool %s after interruption",
+                                        remaining.getKey());
+                            }
+                        }
+                        terminated = true; // Exit the loop
+                    } catch (Exception e) {
+                        log.warnf(e, "Error during shutdown of worker pool %s", entry.getKey());
+                    }
+                }
+                loop++;
             }
         }
     }
 
+    @Override
     public <T> Uni<T> executeWork(Context msgContext, Uni<T> uni, String workerName, boolean ordered) {
+        if (closed) {
+            return Uni.createFrom().failure(new RejectedExecutionException("WorkerPoolRegistry is being shut down"));
+        }
         Objects.requireNonNull(uni, "Action to execute not provided");
         if (workerName == null) {
             if (msgContext != null) {
@@ -168,16 +242,17 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
         if (workerExecutors.containsKey(workerName)) {
             return workerExecutors.get(workerName);
         }
-        if (workerConcurrency.containsKey(workerName)) {
+        if (workerConfig.containsKey(workerName)) {
             WorkerExecutor executor = workerExecutors.get(workerName);
             if (executor == null) {
                 synchronized (this) {
                     executor = workerExecutors.get(workerName);
                     if (executor == null) {
+                        WorkerPoolConfig config = workerConfig.get(workerName);
                         executor = executionHolder.vertx().createSharedWorkerExecutor(workerName,
-                                workerConcurrency.get(workerName));
-                        log.info("Created worker pool named " + workerName + " with concurrency of "
-                                + workerConcurrency.get(workerName));
+                                config.maxConcurrency());
+                        log.infof("Created worker pool named %s with concurrency of %d", workerName,
+                                config.maxConcurrency());
                         workerExecutors.put(workerName, executor);
                     }
                 }
@@ -207,14 +282,27 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
                 throw getBlockingError(className, method, "value is blank or null");
             }
 
+            Config config = ConfigProvider.getConfig();
             // Validate @Blocking worker pool has configuration to define concurrency
-            String workerConfigKey = WORKER_CONFIG_PREFIX + "." + poolName + "." + WORKER_CONCURRENCY;
-            Optional<Integer> concurrency = ConfigProvider.getConfig().getOptionalValue(workerConfigKey, Integer.class);
-            if (concurrency.isEmpty()) {
-                throw getBlockingError(className, method, workerConfigKey + " was not defined");
-            }
+            String maxConcurrencyConfigKey = WORKER_CONFIG_PREFIX + "." + poolName + "." + WORKER_CONCURRENCY;
+            String shutdownTimeoutConfigKey = WORKER_CONFIG_PREFIX + "." + poolName + "." + SHUTDOWN_TIMEOUT;
+            String shutdownCheckIntervalConfigKey = WORKER_CONFIG_PREFIX + "." + poolName + "." + SHUTDOWN_CHECK_INTERVAL;
 
-            workerConcurrency.put(poolName, concurrency.get());
+            Optional<Integer> concurrency = config.getOptionalValue(maxConcurrencyConfigKey, Integer.class);
+            if (concurrency.isEmpty()) {
+                throw getBlockingError(className, method, maxConcurrencyConfigKey + " was not defined");
+            }
+            int maxConcurrency = concurrency.get();
+            // Get optional shutdown timeout and check interval configurations
+            int shutdownTimeout = config
+                    .getOptionalValue(shutdownTimeoutConfigKey, Integer.class)
+                    .orElse(DEFAULT_SHUTDOWN_TIMEOUT_MS);
+            int shutdownCheckInterval = config
+                    .getOptionalValue(shutdownCheckIntervalConfigKey, Integer.class)
+                    .orElse(DEFAULT_SHUTDOWN_CHECK_INTERVAL_MS);
+
+            workerConfig.put(poolName,
+                    new WorkerPoolConfig(maxConcurrency, shutdownTimeout, shutdownCheckInterval));
         }
     }
 

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/WorkerPoolConfig.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/WorkerPoolConfig.java
@@ -1,0 +1,11 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.time.Duration;
+
+public record WorkerPoolConfig(Integer maxConcurrency, Duration shutdownTimeout, Duration shutdownCheckInterval) {
+
+    public WorkerPoolConfig(int maxConcurrency, int shutdownTimeoutMs, int shutdownCheckIntervalMs) {
+        this(maxConcurrency, Duration.ofMillis(shutdownTimeoutMs), Duration.ofMillis(shutdownCheckIntervalMs));
+    }
+
+}


### PR DESCRIPTION
Named worker pools created for Messaging are now shut down gracefully with a timeout.

The WorkerPoolRegistry termination event is now called before (lower priority value 0) messaging connector termination (priority value 50), to allow for processed messages during the grace period to be acked.

In dev and test mode, the graceful shutdown is disabled by default by setting the grace period to 0.

Further work is needed to rationalize the config mapping for messaging. WorkerPoolConfig introduced in this PR can be transformed into a config mapping.

- Resolves: #47237