### PR TITLE
Fix OTel MDC context set

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarContextUnwrapper.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/exemplars/OpenTelemetryExemplarContextUnwrapper.java
@@ -17,7 +17,7 @@ public class OpenTelemetryExemplarContextUnwrapper implements OpenTelemetryConte
             return methodReference.apply(parameter);
         }
 
-        Context newContext = QuarkusContextStorage.getContext(requestContext);
+        Context newContext = QuarkusContextStorage.getOtelContext(requestContext);
 
         if (newContext == null) {
             return methodReference.apply(parameter);

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
@@ -6,6 +6,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jboss.logging.Logger;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -13,6 +15,9 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.quarkus.vertx.core.runtime.VertxMDC;
 
 public final class OpenTelemetryUtil {
+
+    private static final Logger logger = Logger.getLogger(OpenTelemetryUtil.class);
+
     public static final String TRACE_ID = "traceId";
     public static final String SPAN_ID = "spanId";
     public static final String SAMPLED = "sampled";
@@ -49,20 +54,27 @@ public final class OpenTelemetryUtil {
     }
 
     /**
-     * Sets MDC data by using the current span from the context.
+     * Sets MDC data by using the current span from the otelContext.
      * <p>
      * This method is in the hot path and was optimized to not use getSpanData()
      *
-     * @param context opentelemetry context
-     * @param vertxContext vertx context
+     * @param otelContext opentelemetry otelContext
+     * @param vertxContext vertx otelContext
      */
-    public static void setMDCData(Context context, io.vertx.core.Context vertxContext) {
-        if (context == null) {
+    public static void setMDCData(Context otelContext, io.vertx.core.Context vertxContext) {
+        if (otelContext == null) {
             return;
         }
 
-        Span span = Span.fromContextOrNull(context);
+        Span span = Span.fromContextOrNull(otelContext);
         if (span != null) {
+            if (logger.isDebugEnabled()) {
+                logger.debugv("Setting span in MDC: {0} with otel data in vertx context: {1}",
+                        getSpanData(otelContext),
+                        getSpanData(QuarkusContextStorage.getOtelContext(vertxContext)));
+            }
+            // clear the object ref to force a new one and prevent crosstalk
+            VertxMDC.INSTANCE.clearVertxMdcFromContext(vertxContext);
             SpanContext spanContext = span.getSpanContext();
             VertxMDC.INSTANCE.put(SPAN_ID, spanContext.getSpanId(), vertxContext);
             VertxMDC.INSTANCE.put(TRACE_ID, spanContext.getTraceId(), vertxContext);
@@ -109,6 +121,11 @@ public final class OpenTelemetryUtil {
      */
     public static void clearMDCData(io.vertx.core.Context vertxContext) {
         VertxMDC vertxMDC = VertxMDC.INSTANCE;
+        if (logger.isDebugEnabled()) {
+            logger.debugv("Removing from MDC the span id: {0}, with otel data in vertx context: {1}",
+                    vertxMDC.get(SPAN_ID, vertxContext),
+                    getSpanData(QuarkusContextStorage.getOtelContext(vertxContext)));
+        }
         vertxMDC.remove(TRACE_ID, vertxContext);
         vertxMDC.remove(SPAN_ID, vertxContext);
         vertxMDC.remove(PARENT_ID, vertxContext);

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/restclient/OpenTelemetryClientFilter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/restclient/OpenTelemetryClientFilter.java
@@ -87,7 +87,7 @@ public class OpenTelemetryClientFilter implements ClientRequestFilter, ClientRes
     @Override
     public void filter(final ClientRequestContext request) {
         io.vertx.core.Context vertxContext = getVertxContext(request);
-        io.opentelemetry.context.Context parentContext = QuarkusContextStorage.getContext(vertxContext);
+        io.opentelemetry.context.Context parentContext = QuarkusContextStorage.getOtelContext(vertxContext);
         if (parentContext == null) {
             parentContext = io.opentelemetry.context.Context.current();
         }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/InstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/InstrumenterVertxTracer.java
@@ -34,7 +34,7 @@ public interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOper
         }
 
         Instrumenter<REQ, RESP> instrumenter = getReceiveRequestInstrumenter();
-        io.opentelemetry.context.Context parentContext = QuarkusContextStorage.getContext(context);
+        io.opentelemetry.context.Context parentContext = QuarkusContextStorage.getOtelContext(context);
         if (parentContext == null) {
             parentContext = io.opentelemetry.context.Context.current();
         }
@@ -89,7 +89,7 @@ public interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOper
         }
 
         Instrumenter<REQ, RESP> instrumenter = getSendRequestInstrumenter();
-        io.opentelemetry.context.Context parentContext = QuarkusContextStorage.getContext(context);
+        io.opentelemetry.context.Context parentContext = QuarkusContextStorage.getOtelContext(context);
         if (parentContext == null) {
             parentContext = io.opentelemetry.context.Context.current();
         }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
@@ -265,7 +265,7 @@ public enum VertxMDC implements MDCProvider {
     }
 
     /**
-     * Clear the current MDC map.
+     * Clear the contents of the current MDC map.
      * Tries to use the current Vert.x Context, if the context is non-existent
      * meaning that it was called out of a Vert.x thread it will fall back to
      * the thread local context map.
@@ -276,11 +276,23 @@ public enum VertxMDC implements MDCProvider {
     }
 
     /**
-     * Clear the current MDC map.
+     * Clears the contents of the current MDC map in the Context.
      * If the informed context is null it falls back to the thread local context map.
      */
     public void clear(Context vertxContext) {
         contextualDataMap(vertxContext).clear();
+    }
+
+    /**
+     * Clears out the object ref from the context to force a new one to be created and prevent thread crosstalk.
+     * Should be used before adding data to the VertxMCD context on a new thread.
+     *
+     * @param vertxContext
+     */
+    public void clearVertxMdcFromContext(Context vertxContext) {
+        if (vertxContext != null) {
+            vertxContext.removeLocal(VertxMDC.class.getName());
+        }
     }
 
     /**


### PR DESCRIPTION
There are 2 fixes here: 
- Make sure we clear the reference for the VertxMDC reference before we add more data there. If we don't do that, that reference will end up being used in multiple threads and be subject to crosstalk.
- When we close the scope, we were restoring previous scopes from spans that were already finished.

Did some refactoring to clarify context objects because we have too many types of contexts. 
Added some debug logs for future debugging. 

- Fixes: https://github.com/quarkusio/quarkus/issues/43134