### PR TITLE
Remove Otel from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -167,8 +167,6 @@ updates:
       - dependency-name: com.google.errorprone:*
       - dependency-name: com.google.http-client:*
       - dependency-name: io.dekorate:servicebinding-annotations
-      - dependency-name: io.opentelemetry:*
-      - dependency-name: io.opentelemetry.*:*
       - dependency-name: org.aesh:readline
       - dependency-name: org.checkerframework:checker-qual
       - dependency-name: org.jboss.metadata:jboss-metadata-web


### PR DESCRIPTION
We always update this manually. 
Even when build is ok, we need to update and release SR Reactive Messaging to keep versions in sync.
