### PR TITLE
Update Smallrye Config to 3.15.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <microprofile-lra.version>2.0.1</microprofile-lra.version>
         <microprofile-openapi.version>4.1.1</microprofile-openapi.version>
         <smallrye-common.version>2.14.0</smallrye-common.version>
-        <smallrye-config.version>3.14.1</smallrye-config.version>
+        <smallrye-config.version>3.15.0</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.2.3</smallrye-open-api.version>
         <smallrye-graphql.version>2.16.0</smallrye-graphql.version>

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -27,7 +27,6 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.ImageMode;
 import io.smallrye.config.ConfigValue;
-import io.smallrye.config.DefaultValuesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.common.utils.StringUtil;
 
@@ -70,7 +69,7 @@ public final class ConfigDiagnostic {
         for (Map.Entry<String, String> entry : deprecatedProperties.entrySet()) {
             String propertyName = entry.getKey();
             ConfigValue configValue = config.getConfigValue(propertyName);
-            if (configValue.getValue() != null && !DefaultValuesConfigSource.NAME.equals(configValue.getConfigSourceName())) {
+            if (configValue.getValue() != null && !configValue.isDefault()) {
                 ConfigDiagnostic.deprecated(propertyName, entry.getValue());
             }
         }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
@@ -28,7 +28,6 @@ import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.smallrye.config.ConfigValue;
-import io.smallrye.config.DefaultValuesConfigSource;
 import io.smallrye.config.Expressions;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
@@ -132,7 +131,7 @@ public final class EffectiveConfig {
                     // system properties to Gradle workers and, we loose the ability to determine if it was set by
                     // the user to evaluate deprecated configuration
                     if (configValue.getValue() != null && (!defaultNames.contains(configValue.getName())
-                            || !DefaultValuesConfigSource.NAME.equals(configValue.getConfigSourceName()))) {
+                            || !configValue.isDefault())) {
                         properties.put(propertyName, configValue.getValue());
                     }
                 }
@@ -156,7 +155,7 @@ public final class EffectiveConfig {
                         // system properties to Gradle workers and, we loose the ability to determine if it was set by
                         // the user to evaluate deprecated configuration
                         if (configValue.getValue() != null && (!defaultNames.contains(configValue.getName())
-                                || !DefaultValuesConfigSource.NAME.equals(configValue.getConfigSourceName()))) {
+                                || !configValue.isDefault())) {
                             properties.put(propertyName, configValue.getValue());
                         }
                     }

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 plugin-publish = "2.0.0"
 
 kotlin = "2.3.0"
-smallrye-config = "3.14.1"
+smallrye-config = "3.15.0"
 
 junit = "6.0.1"
 assertj = "3.27.6"

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DependenciesProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DependenciesProcessor.java
@@ -91,7 +91,7 @@ public class DependenciesProcessor {
     }
 
     private boolean isEnabled() {
-        SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         var value = config.getConfigValue("quarkus.bootstrap.incubating-model-resolver");
         // if it's not false and if it's false it doesn't come from the default value
         return value == null || !"false".equals(value.getValue()) || value.isDefault();

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DependenciesProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DependenciesProcessor.java
@@ -25,7 +25,7 @@ import io.quarkus.devui.spi.page.Page;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
-import io.smallrye.config.DefaultValuesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
 
 public class DependenciesProcessor {
 
@@ -91,10 +91,10 @@ public class DependenciesProcessor {
     }
 
     private boolean isEnabled() {
-        var value = ConfigProvider.getConfig().getConfigValue("quarkus.bootstrap.incubating-model-resolver");
+        SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
+        var value = config.getConfigValue("quarkus.bootstrap.incubating-model-resolver");
         // if it's not false and if it's false it doesn't come from the default value
-        return value == null || !"false".equals(value.getValue())
-                || DefaultValuesConfigSource.NAME.equals(value.getSourceName());
+        return value == null || !"false".equals(value.getValue()) || value.isDefault();
     }
 
     private void buildTree(ApplicationModel model, Root root, Optional<Set<String>> allGavs, Optional<String> toTarget) {

--- a/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/KubernetesConfigSourceFactory.java
+++ b/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/KubernetesConfigSourceFactory.java
@@ -16,7 +16,6 @@ import io.smallrye.config.ConfigSourceContext.ConfigSourceContextConfigSource;
 import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Converters;
-import io.smallrye.config.DefaultValuesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
@@ -85,7 +84,7 @@ class KubernetesConfigSourceFactory implements ConfigSourceFactory {
 
     private boolean isExplicitlyDisabled(ConfigSourceContext context) {
         ConfigValue configValue = context.getValue("quarkus.kubernetes-config.enabled");
-        if (DefaultValuesConfigSource.NAME.equals(configValue.getConfigSourceName())) {
+        if (configValue.isDefault()) {
             return false;
         }
         if (configValue.getValue() != null) {

--- a/extensions/resteasy-classic/rest-client-config/deployment/src/main/java/io/quarkus/restclient/config/deployment/RestClientsBuildTimeConfigBuildItem.java
+++ b/extensions/resteasy-classic/rest-client-config/deployment/src/main/java/io/quarkus/restclient/config/deployment/RestClientsBuildTimeConfigBuildItem.java
@@ -22,7 +22,6 @@ import io.quarkus.restclient.config.RestClientKeysProvider;
 import io.quarkus.restclient.config.RestClientsBuildTimeConfig;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.config.ConfigValue;
-import io.smallrye.config.DefaultValuesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
@@ -59,8 +58,7 @@ public final class RestClientsBuildTimeConfigBuildItem extends SimpleBuildItem {
                     @Override
                     public String getValue(final String propertyName) {
                         ConfigValue configValue = config.getConfigValue(propertyName);
-                        if (configValue.getValue() != null
-                                && !DefaultValuesConfigSource.NAME.equals(configValue.getConfigSourceName())) {
+                        if (configValue.getValue() != null && !configValue.isDefault()) {
                             return configValue.getValue();
                         }
                         return null;

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingRuntimeConfig.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingRuntimeConfig.java
@@ -53,7 +53,7 @@ public interface ReactiveMessagingRuntimeConfig {
          */
         @ConfigDocIgnore
         @WithParentName
-        Map<String, String> channelConfig();
+        Map<String, Optional<String>> channelConfig();
     }
 
     interface Incoming extends ChannelDirection {


### PR DESCRIPTION
SmallRye Config Release notes:
<br>
<blockquote>
    <h2>3.15.0</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1447">#1447</a> Release 3.15.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1446">#1446</a> Matcher for property names</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1444">#1444</a> Ensure modular access when reflecting</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1442">#1442</a> Bump kotlin.version from 2.2.21 to 2.3.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1441">#1441</a> Bump pymdown-extensions from 10.15 to 10.16.1 in /documentation</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1440">#1440</a> Bump org.ow2.asm:asm from 9.9 to 9.9.1</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1439">#1439</a> Bump actions/upload-artifact from 5 to 6</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1438">#1438</a> Support `Map&lt;String, Optional&lt;String&gt;&gt;` in `@ConfigMapping`</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1437">#1437</a> Add a `isDefault` method to `ConfigValue` to check if the value is a default</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1435">#1435</a> Bump urllib3 from 2.5.0 to 2.6.0 in /documentation</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1434">#1434</a> Provide a way to enable / disable cache of property names when building the config</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1433">#1433</a> Bump io.smallrye:smallrye-parent from 47 to 48</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1432">#1432</a> Bump actions/checkout from 5 to 6</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1431">#1431</a> Bump io.fabric8:docker-maven-plugin from 0.47.0 to 0.48.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1430">#1430</a> Document that when using Map quoted key, they must be use the same quoted format</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1429">#1429</a> Support single underscore to represent ending quote in property name environment variable matching</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1428">#1428</a> Throw IllegalArgumentException when using self-reference types</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1426">#1426</a> Bump io.smallrye.common:smallrye-common-bom from 2.13.9 to 2.14.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1425">#1425</a> docs: remove unexisting converters</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1424">#1424</a> Bump version.smallrye.testing from 2.4.0 to 2.4.1</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1423">#1423</a> Bump io.fabric8:docker-maven-plugin from 0.46.0 to 0.47.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1422">#1422</a> Bump io.sundr:sundr-maven-plugin from 0.230.1 to 0.230.2</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1421">#1421</a> Bump actions/upload-artifact from 4 to 5</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1420">#1420</a> Bump kotlin.version from 2.2.20 to 2.2.21</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1419">#1419</a> Introduce exact methods to get values from String, int and boolean</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1418">#1418</a> Bump io.sundr:sundr-maven-plugin from 0.230.0 to 0.230.1</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1417">#1417</a> Bump io.sundr:sundr-maven-plugin from 0.220.1 to 0.230.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1416">#1416</a> Bump org.ow2.asm:asm from 9.8 to 9.9</li>
    </ul>
</blockquote>
<br>

Quarkus:
- Fixes #51501
- Fixes #51556