### PR TITLE
Bump quarkus-security version to 2.3.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -175,7 +175,7 @@
         <quarkus-spring-boot-api.version>3.4</quarkus-spring-boot-api.version>
         <mockito.version>5.21.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
-        <quarkus-security.version>2.2.1</quarkus-security.version>
+        <quarkus-security.version>2.3.2</quarkus-security.version>
         <keycloak-client.version>26.0.7</keycloak-client.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>
         <checker-qual.version>3.52.1</checker-qual.version>

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/SecurityContextFilter.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/SecurityContextFilter.java
@@ -47,6 +47,7 @@ public class SecurityContextFilter implements ContainerRequestFilter {
             return;
         }
         Set<Credential> oldCredentials = old.getCredentials();
+        Set<Permission> oldPermissions = old.getPermissions();
         Map<String, Object> oldAttributes = old.getAttributes();
         SecurityIdentity newIdentity = new SecurityIdentity() {
             @Override
@@ -83,6 +84,11 @@ public class SecurityContextFilter implements ContainerRequestFilter {
             @Override
             public Set<Credential> getCredentials() {
                 return oldCredentials;
+            }
+
+            @Override
+            public Set<Permission> getPermissions() {
+                return oldPermissions;
             }
 
             @Override

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
@@ -58,6 +58,7 @@ public class SecurityContextOverrideHandler implements ServerRestHandler {
                 @Override
                 public SecurityIdentity apply(SecurityIdentity old) {
                     Set<Credential> oldCredentials = old.getCredentials();
+                    Set<Permission> oldPermissions = old.getPermissions();
                     Map<String, Object> oldAttributes = old.getAttributes();
                     SecurityIdentity newIdentity = new SecurityIdentity() {
                         @Override
@@ -95,6 +96,11 @@ public class SecurityContextOverrideHandler implements ServerRestHandler {
                         @Override
                         public Set<Credential> getCredentials() {
                             return oldCredentials;
+                        }
+
+                        @Override
+                        public Set<Permission> getPermissions() {
+                            return oldPermissions;
                         }
 
                         @SuppressWarnings("unchecked")

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/AnonymousIdentityProvider.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/AnonymousIdentityProvider.java
@@ -54,6 +54,11 @@ public class AnonymousIdentityProvider implements IdentityProvider<AnonymousAuth
         }
 
         @Override
+        public Set<Permission> getPermissions() {
+            return Collections.emptySet();
+        }
+
+        @Override
         public <T> T getAttribute(String name) {
             return null;
         }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusPermissionSecurityIdentityAugmentor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusPermissionSecurityIdentityAugmentor.java
@@ -128,6 +128,11 @@ public final class QuarkusPermissionSecurityIdentityAugmentor implements Securit
             return delegate.getCredentials();
         }
 
+        @Override
+        public Set<Permission> getPermissions() {
+            return delegate.getPermissions();
+        }
+
         @SuppressWarnings("unchecked")
         @Override
         public <T> T getAttribute(String s) {

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusSecurityIdentity.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusSecurityIdentity.java
@@ -23,6 +23,7 @@ public class QuarkusSecurityIdentity implements SecurityIdentity {
     private final Set<String> roles;
     private final Set<Credential> credentials;
     private final Map<String, Object> attributes;
+    private final Set<Permission> permissions;
     private final List<Function<Permission, Uni<Boolean>>> permissionCheckers;
     private final boolean anonymous;
 
@@ -31,6 +32,7 @@ public class QuarkusSecurityIdentity implements SecurityIdentity {
         this.roles = Collections.unmodifiableSet(builder.roles);
         this.credentials = Collections.unmodifiableSet(builder.credentials);
         this.attributes = Collections.unmodifiableMap(builder.attributes);
+        this.permissions = Collections.unmodifiableSet(builder.permissions);
         this.permissionCheckers = Collections.unmodifiableList(builder.permissionCheckers);
         this.anonymous = builder.anonymous;
     }
@@ -78,6 +80,11 @@ public class QuarkusSecurityIdentity implements SecurityIdentity {
     @Override
     public Map<String, Object> getAttributes() {
         return attributes;
+    }
+
+    @Override
+    public Set<Permission> getPermissions() {
+        return permissions;
     }
 
     @Override
@@ -341,5 +348,4 @@ public class QuarkusSecurityIdentity implements SecurityIdentity {
 
         }
     }
-
 }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityProxy.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityProxy.java
@@ -61,6 +61,11 @@ public class SecurityIdentityProxy implements SecurityIdentity {
     }
 
     @Override
+    public Set<Permission> getPermissions() {
+        return association.getIdentity().getPermissions();
+    }
+
+    @Override
     public Uni<Boolean> checkPermission(Permission permission) {
         return association.getDeferredIdentity()
                 .flatMap(new Function<>() {

--- a/extensions/security/runtime/src/test/java/io/quarkus/security/runtime/QuarkusSecurityIdentityTest.java
+++ b/extensions/security/runtime/src/test/java/io/quarkus/security/runtime/QuarkusSecurityIdentityTest.java
@@ -32,6 +32,9 @@ public class QuarkusSecurityIdentityTest {
 
         assertTrue(identity.checkPermissionBlocking(new StringPermission("read")));
         assertFalse(identity.checkPermissionBlocking(new StringPermission("write")));
+        assertTrue(identity.getPermissions().contains(new StringPermission("read")));
+        assertEquals(1, identity.getPermissions().size());
+
     }
 
     @Test
@@ -56,6 +59,9 @@ public class QuarkusSecurityIdentityTest {
         assertTrue(identity.checkPermissionBlocking(new StringPermission("read")));
         assertTrue(identity.checkPermissionBlocking(new StringPermission("write")));
         assertFalse(identity.checkPermissionBlocking(new StringPermission("comment")));
+        assertTrue(identity.getPermissions().contains(new StringPermission("read")));
+        assertTrue(identity.getPermissions().contains(new StringPermission("write")));
+        assertEquals(2, identity.getPermissions().size());
     }
 
     @Test
@@ -93,6 +99,9 @@ public class QuarkusSecurityIdentityTest {
         assertTrue(identity.checkPermissionBlocking(new StringPermission("read")));
         assertTrue(identity.checkPermissionBlocking(new StringPermission("write")));
         assertFalse(identity.checkPermissionBlocking(new StringPermission("comment")));
+        assertTrue(identity.getPermissions().contains(new StringPermission("read")));
+        assertTrue(identity.getPermissions().contains(new StringPermission("write")));
+        assertEquals(2, identity.getPermissions().size());
     }
 
     @Test
@@ -219,6 +228,11 @@ public class QuarkusSecurityIdentityTest {
 
         @Override
         public Set<Credential> getCredentials() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<Permission> getPermissions() {
             return Collections.emptySet();
         }
 

--- a/extensions/security/test-utils/src/main/java/io/quarkus/security/test/utils/IdentityMock.java
+++ b/extensions/security/test-utils/src/main/java/io/quarkus/security/test/utils/IdentityMock.java
@@ -76,6 +76,11 @@ public class IdentityMock implements SecurityIdentity {
     }
 
     @Override
+    public Set<Permission> getPermissions() {
+        return permissions;
+    }
+
+    @Override
     public <T extends Credential> T getCredential(Class<T> aClass) {
         return null;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/RolesMapping.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/RolesMapping.java
@@ -127,6 +127,11 @@ public class RolesMapping implements Function<SecurityIdentity, SecurityIdentity
             }
 
             @Override
+            public Set<Permission> getPermissions() {
+                return securityIdentity.getPermissions();
+            }
+
+            @Override
             public Uni<Boolean> checkPermission(Permission requiredPermission) {
                 if (addPerms) {
                     for (Permission possessedPermission : permissions) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/RoutingContextAwareSecurityIdentity.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/RoutingContextAwareSecurityIdentity.java
@@ -59,6 +59,11 @@ final class RoutingContextAwareSecurityIdentity implements SecurityIdentity {
         return delegate.getCredentials();
     }
 
+    @Override
+    public Set<Permission> getPermissions() {
+        return delegate.getPermissions();
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getAttribute(String s) {

--- a/test-framework/security/src/test/java/io/quarkus/test/security/callback/AbstractSecurityCallbackTest.java
+++ b/test-framework/security/src/test/java/io/quarkus/test/security/callback/AbstractSecurityCallbackTest.java
@@ -60,6 +60,11 @@ abstract public class AbstractSecurityCallbackTest {
         }
 
         @Override
+        public Set<Permission> getPermissions() {
+            return Collections.emptySet();
+        }
+
+        @Override
         public <T> T getAttribute(String name) {
             return null;
         }


### PR DESCRIPTION
Bump quarkus-security version to 2.3.2, new method is added returning a list of resolved permissions, so a lot of internal classes have been updated