### PR TITLE
Fix Hibernate ORM logging filters after recent changes

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
@@ -21,11 +21,9 @@ public final class HibernateLogFilterBuildStep {
 
     @BuildStep
     void setupLogFilters(BuildProducer<LogCleanupFilterBuildItem> filters) {
-        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.Version", "HHH000412"));
-        //Disable details about bytecode reflection optimizer:
-        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.cfg.Environment", "HHH000406"));
-        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.jpa.internal.util.LogHelper", "HHH000204"));
-        filters.produce(new LogCleanupFilterBuildItem("SQL dialect", "HHH000400"));
+        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.core", "HHH000001"));
+        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.jpa", "HHH008540"));
+        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.statistics", "HHH000400"));
         filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.beans", "HHH10005002", "HHH10005004"));
         // Silence incubating settings warnings as we will use some for compatibility
         filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.incubating",

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
@@ -13,10 +13,9 @@ import org.graalvm.nativeimage.hosted.Feature;
 public class DisableLoggingFeature implements Feature {
 
     private static final String[] CATEGORIES = {
-            "org.hibernate.Version",
-            "org.hibernate.annotations.common.Version",
-            "SQL dialect",
-            "org.hibernate.cfg.Environment",
+            "org.hibernate.orm.core",
+            "org.hibernate.statistics",
+            "org.hibernate.orm.jpa",
             "org.hibernate.orm.connections.pooling"
     };
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

The recent upgrade to Hibernate 7.2 brought some changes to logging categories / messages we need to account for in our filters. Took the opportunity to also cleanup some old logs that have been gone for a while.

* Fixes #51683

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

