### PR TITLE
[3.20] Update Hibernate ORM to 6.6.40 / Hibernate Search to 7.2.5 / Bytebuddy to 1.17.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <rest-assured.version>5.5.1</rest-assured.version>
         <hibernate-orm.version>6.6.40.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
-        <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
+        <bytebuddy.version>1.17.5</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>2.4.11.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.3.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,13 +71,13 @@
         <jacoco.version>0.8.12</jacoco.version>
         <kubernetes-client.version>7.2.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.1</rest-assured.version>
-        <hibernate-orm.version>6.6.39.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>6.6.40.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>2.4.11.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.3.Final</hibernate-validator.version>
-        <hibernate-search.version>7.2.4.Final</hibernate-search.version>
+        <hibernate-search.version>7.2.5.Final</hibernate-search.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.69.1</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->


### PR DESCRIPTION
Hey 👋🏻 🙂 

opening this PR since for this ORM update a byte-buddy update is also required. It's a bit unusual as it bumps a dependency from 1.15 to 1.17 but that was done to make Hibernate ORM 6.6 work on JDK 25 ([#hibernate-orm-dev > JDK 25 in 6.6](https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/JDK.2025.20in.206.2E6/with/564212340))

* Supersedes https://github.com/quarkusio/quarkus/pull/51703

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

