### PR TITLE
Disable hibernate-orm-panache-kotlin build on IBM Semeru

### DIFF
--- a/extensions/panache/hibernate-orm-panache-kotlin/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/pom.xml
@@ -13,8 +13,23 @@
     <artifactId>quarkus-hibernate-orm-panache-kotlin-parent</artifactId>
     <name>Quarkus - Hibernate ORM with Panache and Kotlin</name>
     <packaging>pom</packaging>
-    <modules>
-        <module>deployment</module>
-        <module>runtime</module>
-    </modules>
+    <profiles>
+        <profile>
+            <!-- Kapt has been failing on Semeru for obscure reasons, it's not ideal disabling these modules entirely
+            but it seems the build could work without it, and it's better than having very regular failures...
+            That also means we can't release with Semeru...
+            -->
+            <id>skip-modules-on-semeru</id>
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>!IBM Corporation</value>
+                </property>
+            </activation>
+            <modules>
+                <module>deployment</module>
+                <module>runtime</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
We have weird errors in Kapt:

```
2025-12-22T17:36:03.0923968Z [INFO] --- kotlin:2.3.0:kapt (kapt) @ quarkus-hibernate-orm-panache-kotlin ---
2025-12-22T17:36:04.0420693Z [INFO] Options for KOTLIN DAEMON: CompilationOptions(compilerMode=NON_INCREMENTAL_COMPILER, targetPlatform=JVM, reportCategories=[0, 3], reportSeverity=2, requestedCompilationResults=[], kotlinScriptExtensions=null)
2025-12-22T17:36:20.4560462Z [ERROR] Internal Kotlin compilation error
2025-12-22T17:36:20.4561525Z java.rmi.UnmarshalException: Error unmarshaling return header; nested exception is: 
2025-12-22T17:36:20.4561978Z 	java.io.EOFException
2025-12-22T17:36:20.4564427Z     at sun.rmi.transport.StreamRemoteCall.executeCall (StreamRemoteCall.java:255)
2025-12-22T17:36:20.4565113Z     at sun.rmi.server.UnicastRef.invoke (UnicastRef.java:166)
2025-12-22T17:36:20.4565578Z     at java.rmi.server.RemoteObjectInvocationHandler.invokeRemoteMethod (RemoteObjectInvocationHandler.java:215)
2025-12-22T17:36:20.4566138Z     at java.rmi.server.RemoteObjectInvocationHandler.invoke (RemoteObjectInvocationHandler.java:160)
2025-12-22T17:36:20.4567493Z     at jdk.proxy196.$Proxy903.compile (Unknown Source)
2025-12-22T17:36:20.4568413Z     at org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmCompilationOperationImpl.compileWithDaemon (JvmCompilationOperationImpl.kt:227)
2025-12-22T17:36:20.4569639Z     at org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmCompilationOperationImpl.execute (JvmCompilationOperationImpl.kt:103)
2025-12-22T17:36:20.4571275Z     at org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmCompilationOperationImpl.execute (JvmCompilationOperationImpl.kt:62)
2025-12-22T17:36:20.4572578Z     at org.jetbrains.kotlin.buildtools.internal.KotlinToolchainsImpl$BuildSessionImpl.executeOperation$lambda$1 (KotlinToolchainsImpl.kt:70)

[...]

2025-12-22T17:36:20.4605574Z Caused by: java.io.EOFException
2025-12-22T17:36:20.4605854Z     at java.io.DataInputStream.readUnsignedByte (DataInputStream.java:297)
2025-12-22T17:36:20.4606184Z     at java.io.DataInputStream.readByte (DataInputStream.java:275)
2025-12-22T17:36:20.4606535Z     at sun.rmi.transport.StreamRemoteCall.executeCall (StreamRemoteCall.java:241)
2025-12-22T17:36:20.4607009Z     at sun.rmi.server.UnicastRef.invoke (UnicastRef.java:166)
2025-12-22T17:36:20.4607459Z     at java.rmi.server.RemoteObjectInvocationHandler.invokeRemoteMethod (RemoteObjectInvocationHandler.java:215)
2025-12-22T17:36:20.4607996Z     at java.rmi.server.RemoteObjectInvocationHandler.invoke (RemoteObjectInvocationHandler.java:160)
2025-12-22T17:36:20.4608424Z     at jdk.proxy196.$Proxy903.compile (Unknown Source)
2025-12-22T17:36:20.4608961Z     at org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmCompilationOperationImpl.compileWithDaemon (JvmCompilationOperationImpl.kt:227)
2025-12-22T17:36:20.4609730Z     at org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmCompilationOperationImpl.execute (JvmCompilationOperationImpl.kt:103)
2025-12-22T17:36:20.4610445Z     at org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmCompilationOperationImpl.execute (JvmCompilationOperationImpl.kt:62)
2025-12-22T17:36:20.4611144Z     at org.jetbrains.kotlin.buildtools.internal.KotlinToolchainsImpl$BuildSessionImpl.executeOperation$lambda$1 (KotlinToolchainsImpl.kt:70)
2025-12-22T17:36:20.4611809Z     at org.jetbrains.kotlin.buildtools.internal.KotlinToolchainsImpl$BuildSessionImpl.executeOperation (KotlinToolchainsImpl.kt:74)
2025-12-22T17:36:20.4612396Z     at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execCompiler (K2JVMCompileMojo.java:373)
2025-12-22T17:36:20.4612870Z     at org.jetbrains.kotlin.maven.kapt.KaptJVMCompilerMojo.execCompiler (KaptJVMCompilerMojo.java:154)
2025-12-22T17:36:20.4613385Z     at org.jetbrains.kotlin.maven.kapt.KaptJVMCompilerMojo.execCompiler (KaptJVMCompilerMojo.java:46)
2025-12-22T17:36:20.4613881Z     at org.jetbrains.kotlin.maven.KotlinCompileMojoBase.execute (KotlinCompileMojoBase.java:191)
2025-12-22T17:36:20.4614354Z     at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execute (K2JVMCompileMojo.java:257)
2025-12-22T17:36:20.4614812Z     at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
```

and it seems the build is working without these two modules (CI will tell us more...).

Note that we may never use IBM Semeru to do a release or these two modules will be missing...
