### PR TITLE
Fix NPE when emitting runtime JFR event from shutdown hook

### DIFF
--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/runtime/JfrRuntimeBean.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/runtime/JfrRuntimeBean.java
@@ -1,5 +1,7 @@
 package io.quarkus.jfr.runtime.internal.runtime;
 
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -22,14 +24,20 @@ public class JfrRuntimeBean {
     @Inject
     ApplicationConfig applicationConfig;
 
-    private final Runnable runtimeEventTask = new RuntimeEventTask();
-    private final Runnable applicationEventTask = new ApplicationEventTask();
-    private final Runnable extensionEventTask = new ExtensionEventTask();
+    private Runnable runtimeEventTask;
+    private Runnable applicationEventTask;
+    private Runnable extensionEventTask;
 
     public void enable() {
         FlightRecorder.register(QuarkusRuntimeEvent.class);
         FlightRecorder.register(QuarkusApplicationEvent.class);
         FlightRecorder.register(ExtensionEvent.class);
+
+        runtimeEventTask = new RuntimeEventTask(quarkusRuntimeInfo.version(), quarkusRuntimeInfo.imageMode(),
+                quarkusRuntimeInfo.profiles());
+        applicationEventTask = new ApplicationEventTask(applicationConfig.name().get(), applicationConfig.version().get());
+        extensionEventTask = new ExtensionEventTask(quarkusRuntimeInfo.features());
+
         FlightRecorder.addPeriodicEvent(QuarkusRuntimeEvent.class, runtimeEventTask);
         FlightRecorder.addPeriodicEvent(QuarkusApplicationEvent.class, applicationEventTask);
         FlightRecorder.addPeriodicEvent(ExtensionEvent.class, extensionEventTask);
@@ -57,34 +65,61 @@ public class JfrRuntimeBean {
     }
 
     class RuntimeEventTask implements Runnable {
+
+        private final String version;
+        private final String imageMode;
+        private final String profiles;
+
+        public RuntimeEventTask(String version, String imageMode, String profiles) {
+            this.version = version;
+            this.imageMode = imageMode;
+            this.profiles = profiles;
+        }
+
         @Override
         public void run() {
             QuarkusRuntimeEvent event = new QuarkusRuntimeEvent();
             if (event.shouldCommit()) {
-                event.setVersion(quarkusRuntimeInfo.version());
-                event.setImageMode(quarkusRuntimeInfo.imageMode());
-                event.setProfiles(quarkusRuntimeInfo.profiles());
+                event.setVersion(version);
+                event.setImageMode(imageMode);
+                event.setProfiles(profiles);
                 event.commit();
             }
         }
     }
 
     class ApplicationEventTask implements Runnable {
+
+        private final String name;
+        private final String version;
+
+        public ApplicationEventTask(String name, String version) {
+            this.name = name;
+            this.version = version;
+        }
+
         @Override
         public void run() {
             QuarkusApplicationEvent event = new QuarkusApplicationEvent();
             if (event.shouldCommit()) {
-                event.setName(applicationConfig.name().get());
-                event.setVersion(applicationConfig.version().get());
+                event.setName(name);
+                event.setVersion(version);
                 event.commit();
             }
         }
     }
 
     class ExtensionEventTask implements Runnable {
+
+        private final List<String> features;
+
+        public ExtensionEventTask(List<String> features) {
+            this.features = features;
+        }
+
         @Override
         public void run() {
-            for (String feature : quarkusRuntimeInfo.features()) {
+            for (String feature : features) {
                 ExtensionEvent event = new ExtensionEvent();
                 if (event.shouldCommit()) {
                     event.setName(feature);


### PR DESCRIPTION
This PR fixes a shutdown-time failure in the Quarkus JFR extension when emitting runtime information.

### Problem
- If the JVM exits before any Quarkus runtime information is recorded into JFR, the extension attempts to write the runtime event from a Java shutdown hook.
- The shutdown hook path currently relies on a Quarkus-managed bean (Arc/CDI). At this point the container may already be tearing down, and Arc state might be no longer available.
- As a result, emitting the event can fail with:
```
[6.026s][warning][jfr,system ] Exception occurred during execution of event quarkus.extension(5056). Error creating synthetic bean [ovaTwVXMMjNA9eHXpMtKozpR4UM]: java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because "io.quarkus.arc.runtime.ArcRecorder.syntheticBeanProviders" is null
```

### Fix
- Instead of accessing Quarkus-managed beans from the shutdown hook, we now capture the required runtime values at registration time (while Arc is still fully available) and pass those values to the shutdown-hook.
- This removes the dependency on CDI/Arc during JVM shutdown and prevents the NPE.