### PR TITLE
Reintroduce MongoClientBeanUtil#isDefault() for a few versions

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientBeanUtil.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientBeanUtil.java
@@ -11,6 +11,11 @@ public final class MongoClientBeanUtil {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated(forRemoval = true, since = "3.31")
+    public static boolean isDefault(String clientName) {
+        return MongoConfig.isDefaultClient(clientName);
+    }
+
     public static String namedQualifier(String clientName, boolean isReactive) {
         if (MongoConfig.isDefaultClient(clientName)) {
             throw new IllegalArgumentException("The default client should not have a named qualifier");


### PR DESCRIPTION
Apparently, some external extensions are using it and there's no reason being so brutal.