### PR TITLE
Improve error message for recorder constructor

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
@@ -53,7 +53,7 @@ public class ProxyFactory<T> {
         if (!findConstructor(superClass, configuration.isAllowPackagePrivate(), true)) {
             throw new IllegalArgumentException(
                     "A proxy cannot be created for class " + this.superClassName
-                            + " because it does not declare a no-arg constructor");
+                            + " because it does not declare an accessible constructor");
         }
         if (Modifier.isFinal(superClass.getModifiers())) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
We can have args for injection, as long as the constructor is public. I decided to be a bit more blurry so that the message is not obviously wrong.
