### PR TITLE
Require Maven 3.9.0+ for Quarkus projects

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -57,8 +57,8 @@
         <!--
         Supported Maven versions, interpreted as a version range (Also defined in quarkus-enforcer-rules)
          -->
-        <!-- TODO: once we can upgrade the minimum Maven version to use for Quarkus projects, let's use ${maven.min.version} again -->
-        <supported-maven-versions>[3.8.6,)</supported-maven-versions>
+        <!-- This version is more permissive than ${maven.min.version} as we usually have more requirements for the Quarkus build itself than for Quarkus projects -->
+        <supported-maven-versions>[3.9.0,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.9.12</proposed-maven-version>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -40,7 +40,7 @@
         <!--
            Supported Maven versions, interpreted as a version range (Also defined in build-parent)
         -->
-        <supported-maven-versions>[3.6.2,)</supported-maven-versions>
+        <supported-maven-versions>[3.9.0,)</supported-maven-versions>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Maven 3.9.0 has been released on Jan 31st 2023 so it will be two years when we will release 3.31.
I think we can now mandate it.
We are using more and more advanced features of Maven and I think we need to set a reasonable minimum version given we don't test 3.8 at all.

> [!WARNING]
> Created as draft as we need to have a thorough discussion about it.
