### PR TITLE
Build time fixed override warning false positives with expressions

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -419,6 +419,7 @@ public class ConfigGenerationBuildStep {
             values.add(ConfigValue.builder()
                     .withName(value.getName())
                     .withValue(value.getValue())
+                    .withRawValue(value.getRawValue())
                     .withConfigSourceOrdinal(value.getConfigSourceOrdinal())
                     .build());
         }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -45,7 +45,7 @@ public class ConfigRecorder {
             // - compare the actual config values, if different there is a mismatch
             if (currentValue.getConfigSourcePosition() > 0
                     && currentValue.getSourceOrdinal() >= buildTimeRuntimeValue.getSourceOrdinal()
-                    && !Objects.equals(buildTimeRuntimeValue.getValue(), currentValue.getValue())) {
+                    && !Objects.equals(buildTimeRuntimeValue.getRawValue(), currentValue.getRawValue())) {
                 mismatches.add(
                         " - " + propertyName + " is set to '" + currentValue.getValue()
                                 + "' but it is build time fixed to '"

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
@@ -32,5 +32,7 @@ public class OverrideBuildTimeConfigTest {
                 .contains("- quarkus.mapping.btrt.optional is set to 'value' but it is build time fixed to 'null'."));
         assertFalse(TEST.getStartupConsoleOutput()
                 .contains("- quarkus.mapping.btrt.unlisted is set to 'value' but it is build time fixed to 'null'."));
+        assertFalse(TEST.getStartupConsoleOutput()
+                .contains("- quarkus.mapping.btrt.expanded is set to 'null'"));
     }
 }

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingBuildTimeRunTime.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingBuildTimeRunTime.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigMapping(prefix = "quarkus.mapping.btrt")
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
@@ -34,6 +35,12 @@ public interface TestMappingBuildTimeRunTime {
      * Unlisted
      */
     Optional<String> unlisted();
+
+    /**
+     * Expanded
+     */
+    @WithDefault("${quarkus.application.version")
+    String expanded();
 
     interface Group {
         /**


### PR DESCRIPTION
The check for build time fixed override warning, wasn't checking for recorded values coming from expressions `${}`.

- Fixes #51711