### PR TITLE
ArC: fix `InterceptionProxy` generation for `void` methods

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -381,8 +381,7 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
      * <p>
      * The class of the provider type is scanned for interceptor binding annotations.
      * <p>
-     * This method may only be called once. If called multiple times, the last call wins and
-     * the previous calls are lost.
+     * This method may only be called once. Subsequent calls throw an exception.
      *
      * @return self
      */
@@ -400,8 +399,7 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
      * of the provider type are ignored; instead, the {@code bindingsSource} class is scanned
      * for interceptor binding annotations as defined in {@link io.quarkus.arc.BindingsSource}.
      * <p>
-     * This method may only be called once. If called multiple times, the last call wins and
-     * the previous calls are lost.
+     * This method may only be called once. Subsequent calls throw an exception.
      *
      * @param bindingsSource the bindings source class, may be {@code null}
      * @return self
@@ -420,8 +418,7 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
      * of the provider type are ignored; instead, the {@code bindingsSource} class is scanned
      * for interceptor binding annotations as defined in {@link io.quarkus.arc.BindingsSource}.
      * <p>
-     * This method may only be called once. If called multiple times, the last call wins and
-     * the previous calls are lost.
+     * This method may only be called once. Subsequent calls throw an exception.
      *
      * @param bindingsSource the bindings source class, may be {@code null}
      * @return self

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptionProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptionProxyGenerator.java
@@ -398,7 +398,7 @@ public class InterceptionProxyGenerator extends AbstractGenerator {
                             Expr superResult = method.declaringClass().isInterface()
                                     ? lbc.invokeInterface(methodDesc, target, superArgs)
                                     : lbc.invokeVirtual(methodDesc, target, superArgs);
-                            lbc.return_(superResult);
+                            lbc.return_(superResult.isVoid() ? Const.ofNull(Object.class) : superResult);
                         });
                     });
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithVoidInterceptedMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithVoidInterceptedMethodTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.arc.test.interceptors.producer;
+
+import static io.smallrye.common.constraint.Assert.assertFalse;
+import static io.smallrye.common.constraint.Assert.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InterceptionProxy;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ProducerWithVoidInterceptedMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBinding.class, MyInterceptor.class, MyProducer.class);
+
+    @Test
+    public void test() {
+        assertFalse(MyNonbean.invoked);
+        assertFalse(MyInterceptor.invoked);
+        MyNonbean nonbean = Arc.container().instance(MyNonbean.class).get();
+        nonbean.hello();
+        assertTrue(MyNonbean.invoked);
+        assertTrue(MyInterceptor.invoked);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+    @InterceptorBinding
+    @interface MyBinding {
+    }
+
+    @MyBinding
+    @Priority(1)
+    @Interceptor
+    static class MyInterceptor {
+        static boolean invoked = false;
+
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            invoked = true;
+            return ctx.proceed();
+        }
+    }
+
+    static class MyNonbean {
+        static boolean invoked = false;
+
+        @MyBinding
+        void hello() {
+            invoked = true;
+        }
+    }
+
+    @Dependent
+    static class MyProducer {
+        @Produces
+        MyNonbean produce(InterceptionProxy<MyNonbean> proxy) {
+            return proxy.create(new MyNonbean());
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/synthbean/SynthBeanWithVoidInterceptedMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/synthbean/SynthBeanWithVoidInterceptedMethodTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.arc.test.interceptors.synthbean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.InterceptionProxy;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SynthBeanWithVoidInterceptedMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyBinding.class, MyInterceptor.class)
+            .beanRegistrars(new BeanRegistrar() {
+                @Override
+                public void register(RegistrationContext context) {
+                    context.configure(MyNonbean.class)
+                            .types(MyNonbean.class)
+                            .injectInterceptionProxy(MyNonbean.class)
+                            .creator(MyNonbeanCreator.class)
+                            .done();
+                }
+            })
+            .build();
+
+    static class MyNonbeanCreator implements BeanCreator<MyNonbean> {
+        @Override
+        public MyNonbean create(SyntheticCreationalContext<MyNonbean> context) {
+            InterceptionProxy<MyNonbean> proxy = context.getInterceptionProxy();
+            return proxy.create(new MyNonbean());
+        }
+    }
+
+    @Test
+    public void test() {
+        assertFalse(MyNonbean.invoked);
+        assertFalse(MyInterceptor.invoked);
+        MyNonbean nonbean = Arc.container().instance(MyNonbean.class).get();
+        nonbean.hello();
+        assertTrue(MyNonbean.invoked);
+        assertTrue(MyInterceptor.invoked);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+    @InterceptorBinding
+    @interface MyBinding {
+    }
+
+    @MyBinding
+    @Priority(1)
+    @Interceptor
+    static class MyInterceptor {
+        static boolean invoked = false;
+
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            invoked = true;
+            return ctx.proceed();
+        }
+    }
+
+    static class MyNonbean {
+        static boolean invoked = false;
+
+        @MyBinding
+        void hello() {
+            invoked = true;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a build-time failure in Arc when generating InterceptionProxy metadata for intercepted methods that return void.
With the Gizmo2-based implementation, createInitMetadataMethod() always returns the result of the underlying super call. For void methods this leads to IllegalArgumentException: Cannot box void during bytecode generation.
The fix special-cases void return types: we invoke the underlying method without capturing a result and return null from the forwarding BiFunction.
A regression test is included to cover interception proxy generation for a void method and ensure the build no longer fails.

### Notes:
No behavioral changes for non-void return types.
This only affects build-time generated proxies/metadata.