### PR TITLE
Rename new OIDC filter methods to `filter`

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -1537,7 +1537,7 @@ import io.quarkus.oidc.runtime.OidcUtils;
 public class DiscoveryEndpointResponseFilter implements OidcResponseFilter {
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         String contentType = rc.responseHeaders().get("Content-Type"); <2>
         if (contentType.equals("application/json") {
             String tenantId = rc.requestProperties().get(OidcUtils.TENANT_ID_ATTRIBUTE); <3>
@@ -1577,7 +1577,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class CustomOidcRequestFilter implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         requestContext.request().putHeader("custom-header-name", "custom-header-value");
         return Uni.createFrom().voidItem();
     }

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -355,7 +355,7 @@ import io.smallrye.mutiny.Uni;
 @Unremovable
 public class OidcTokenRequestCustomizer implements OidcRequestFilter {
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         OidcConfigurationMetadata metadata = requestContext.contextProperties().get(OidcConfigurationMetadata.class.getName()); <1>
         // Metadata URI is absolute, request URI value is relative
         if (metadata.getTokenUri().endsWith(requestContext.request().uri())) { <2>
@@ -392,7 +392,7 @@ import io.smallrye.mutiny.Uni;
 public class OidcDiscoveryRequestCustomizer implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         requestContext.request().putHeader("Discovery", "OK");
         return Uni.createFrom().voidItem();
     }
@@ -427,7 +427,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class TokenRequestFilter implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext rc) {
+    public Uni<Void> filter(OidcRequestFilterContext rc) {
         // Add more required properties to the token request
         rc.requestBody(Buffer.buffer(rc.requestBody().toString() + "&opaque_token_param=opaque_token_value"));
         return Uni.createFrom().voidItem();
@@ -463,7 +463,7 @@ import io.quarkus.oidc.runtime.OidcUtils;
 public class TokenEndpointResponseFilter implements OidcResponseFilter {
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         String contentType = rc.responseHeaders().get("Content-Type"); <2>
         if (contentType.equals("application/json")
                 && OidcConstants.AUTHORIZATION_CODE.equals(rc.requestProperties().get(OidcConstants.GRANT_TYPE)) <3>
@@ -505,7 +505,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class TokenResponseFilter implements OidcResponseFilter {
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         JsonObject body = rc.responseBody().toJsonObject();
         // JSON `scope` property has multiple values separated by a comma character.
         // It must be replaced with a space character.
@@ -540,7 +540,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class CustomOidcRequestFilter implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         requestContext.request().putHeader("custom-header-name", "custom-header-value");
         return Uni.createFrom().voidItem();
     }

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1288,7 +1288,7 @@ import io.vertx.core.http.HttpMethod;
 public class OidcRequestCustomizer implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         HttpMethod method = requestContext.request().method();
         String uri = requestContext.request().uri();
         if (method == HttpMethod.POST && uri.endsWith("/token") && requestContext.requestBody() != null) {
@@ -1328,7 +1328,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class TokenRequestFilter implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext rc) {
+    public Uni<Void> filter(OidcRequestFilterContext rc) {
         // Add more required properties to the token request
         rc.requestBody(rc.requestBody().toString() + "&opaque_token_param=opaque_token_value"));
         return Uni.createFrom().voidItem();
@@ -1365,7 +1365,7 @@ public class TokenEndpointResponseFilter implements OidcResponseFilter {
     private static final Logger LOG = Logger.getLogger(TokenEndpointResponseFilter.class);
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         String contentType = rc.responseHeaders().get("Content-Type"); <2>
         if (contentType.equals("application/json")
                 && "refresh_token".equals(rc.requestProperties().get(OidcConstants.GRANT_TYPE)) <3>
@@ -1406,7 +1406,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class TokenResponseFilter implements OidcResponseFilter {
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         JsonObject body = rc.responseBody().toJsonObject();
         // JSON `scope` property has multiple values separated by a comma character.
         // It must be replaced with a space character.

--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -532,7 +532,7 @@ public class ClientRegistrationRequestFilter implements OidcRequestFilter {
     private static final Logger LOG = Logger.getLogger(ClientRegistrationRequestFilter.class);
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext rc) {
+    public Uni<Void> filter(OidcRequestFilterContext rc) {
         JsonObject body = rc.requestBody().toJsonObject();
         if ("Default Client".equals(body.getString("client_name"))) { <2>
             LOG.debug("'Default Client' registration request");
@@ -571,7 +571,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class ClientRegistrationReRequestFilter implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext rc) {
+    public Uni<Void> filter(OidcRequestFilterContext rc) {
         // Update the client name
         JsonObject body = rc.requestBody().toJsonObject();
         if ("Dynamic Tenant Client".equals(body.getString("client_name"))) {
@@ -612,7 +612,7 @@ public class ClientRegistrationResponseFilter implements OidcResponseFilter {
     private static final Logger LOG = Logger.getLogger(ClientRegistrationResponseFilter.class);
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         String contentType = rc.responseHeaders().get("Content-Type"); <2>
         JsonObject body = rc.responseBody().toJsonObject();
         if (contentType.startsWith("application/json")
@@ -652,7 +652,7 @@ public class RegisteredClientResponseFilter implements OidcResponseFilter {
     private static final Logger LOG = Logger.getLogger(RegisteredClientResponseFilter.class);
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         String contentType = rc.responseHeaders().get("Content-Type"); <2>
         if (contentType.startsWith("application/json")
                 && "Default Client Updated".equals(rc.responseBody().toJsonObject().getString("client_name"))) { <3>
@@ -693,7 +693,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class ClientRegistrationResponseFilter implements OidcResponseFilter {
 
     @Override
-    public Uni<Void> filterResponse(OidcResponseContext rc) {
+    public Uni<Void> filter(OidcResponseFilterContext rc) {
         // Update the client name
         JsonObject body = rc.responseBody().toJsonObject();
         if ("Registered Dynamic Tenant Client".equals(body.getString("client_name"))) {

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -1006,7 +1006,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class CustomOidcRequestFilter implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         requestContext.request().putHeader("custom-header-name", "custom-header-value");
         return Uni.createFrom().voidItem();
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestFilter.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestFilter.java
@@ -44,6 +44,13 @@ public interface OidcRequestFilter {
             requestBody = buffer;
             contextProperties.put(OidcRequestContextProperties.REQUEST_BODY, buffer);
         }
+    }
+
+    class OidcRequestFilterContext extends OidcRequestContext {
+        public OidcRequestFilterContext(HttpRequest<Buffer> request, Buffer requestBody,
+                OidcRequestContextProperties contextProperties) {
+            super(request, requestBody, contextProperties);
+        }
 
         public final Uni<Void> runBlocking(Runnable runnable) {
             return OidcCommonUtils.runBlocking(runnable);
@@ -55,7 +62,7 @@ public interface OidcRequestFilter {
      *
      * @param requestContext the request context which provides access to the HTTP request headers and body, as well as context
      *        properties.
-     * @deprecated use the {@link #filterRequest(OidcRequestContext)} method instead
+     * @deprecated use the {@link #filter(OidcRequestContext)} method instead
      */
     @Deprecated(since = "3.31", forRemoval = true)
     default void filter(OidcRequestContext requestContext) {
@@ -64,15 +71,15 @@ public interface OidcRequestFilter {
 
     /**
      * Filter OIDC request asynchronously.
-     * Blocking tasks can be run with the {@link OidcRequestContext#runBlocking(Runnable)} method.
+     * Blocking tasks can be run with the {@link OidcRequestFilterContext#runBlocking(Runnable)} method.
      *
      * @param requestContext the request context which provides access to the HTTP request headers and body, as well
      *        as context properties.
      * @return {@link Uni}; must not be null
      */
-    default Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    default Uni<Void> filter(OidcRequestFilterContext requestContext) {
         return Uni.createFrom().item(() -> {
-            filter(requestContext);
+            filter((OidcRequestContext) requestContext);
             return null;
         });
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcResponseFilter.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcResponseFilter.java
@@ -49,6 +49,13 @@ public interface OidcResponseFilter {
             responseBody = buffer;
             requestProperties.put(OidcRequestContextProperties.RESPONSE_BODY, buffer);
         }
+    }
+
+    class OidcResponseFilterContext extends OidcResponseContext {
+        public OidcResponseFilterContext(OidcRequestContextProperties requestProperties, int statusCode,
+                MultiMap responseHeaders, Buffer responseBody) {
+            super(requestProperties, statusCode, responseHeaders, responseBody);
+        }
 
         public final Uni<Void> runBlocking(Runnable runnable) {
             return OidcCommonUtils.runBlocking(runnable);
@@ -59,7 +66,7 @@ public interface OidcResponseFilter {
      * Filter OIDC responses.
      *
      * @param responseContext the response context which provides access to the HTTP response status code, headers and body.
-     * @deprecated use the {@link #filterResponse(OidcResponseContext)} method instead
+     * @deprecated use the {@link #filter(OidcResponseContext)} method instead
      */
     @Deprecated(since = "3.31", forRemoval = true)
     default void filter(OidcResponseContext responseContext) {
@@ -68,14 +75,14 @@ public interface OidcResponseFilter {
 
     /**
      * Filter OIDC responses asynchronously.
-     * Blocking tasks can be run with the {@link OidcResponseContext#runBlocking(Runnable)} method.
+     * Blocking tasks can be run with the {@link OidcResponseFilterContext#runBlocking(Runnable)} method.
      *
      * @param responseContext the response context which provides access to the HTTP response status code, headers and body.
      * @return {@link Uni}
      */
-    default Uni<Void> filterResponse(OidcResponseContext responseContext) {
+    default Uni<Void> filter(OidcResponseFilterContext responseContext) {
         return Uni.createFrom().item(() -> {
-            filter(responseContext);
+            filter((OidcResponseContext) responseContext);
             return null;
         });
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -43,7 +43,7 @@ import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
-import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
+import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestFilterContext;
 import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport.TlsConfigSupport;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig;
@@ -617,7 +617,7 @@ public class OidcCommonUtils {
         if (!responseFilters.isEmpty()) {
             var matchingResponseFilters = getMatchingOidcResponseFilters(responseFilters, type);
             if (!matchingResponseFilters.isEmpty()) {
-                var context = new OidcResponseFilter.OidcResponseContext(requestProps, resp.statusCode(), resp.headers(),
+                var context = new OidcResponseFilter.OidcResponseFilterContext(requestProps, resp.statusCode(), resp.headers(),
                         responseBody);
                 return applyResponseFilters(matchingResponseFilters, 0, context)
                         .replaceWith(() -> getResponseBuffer(requestProps, responseBody));
@@ -627,12 +627,12 @@ public class OidcCommonUtils {
     }
 
     private static Uni<Void> applyResponseFilters(List<OidcResponseFilter> responseFilters, int index,
-            OidcResponseFilter.OidcResponseContext context) {
+            OidcResponseFilter.OidcResponseFilterContext context) {
         if (responseFilters.size() == index) {
             return Uni.createFrom().voidItem();
         }
 
-        return responseFilters.get(index).filterResponse(context)
+        return responseFilters.get(index).filter(context)
                 .chain(() -> applyResponseFilters(responseFilters, index + 1, context));
     }
 
@@ -731,7 +731,7 @@ public class OidcCommonUtils {
     private static Uni<Void> applyRequestFilters(Map<Type, List<OidcRequestFilter>> requestFilters,
             Type type, HttpRequest<Buffer> request, OidcRequestContextProperties requestProps, Buffer body) {
         if (!requestFilters.isEmpty()) {
-            var context = new OidcRequestContext(request, body, requestProps);
+            var context = new OidcRequestFilterContext(request, body, requestProps);
             var matchingRequestFilters = getMatchingOidcRequestFilters(requestFilters, type);
             if (!matchingRequestFilters.isEmpty()) {
                 return applyRequestFilters(matchingRequestFilters, 0, context);
@@ -741,12 +741,12 @@ public class OidcCommonUtils {
     }
 
     private static Uni<Void> applyRequestFilters(List<OidcRequestFilter> requestFilters, int index,
-            OidcRequestContext context) {
+            OidcRequestFilterContext context) {
         if (requestFilters.size() == index) {
             return Uni.createFrom().voidItem();
         }
 
-        return requestFilters.get(index).filterRequest(context)
+        return requestFilters.get(index).filter(context)
                 .chain(() -> applyRequestFilters(requestFilters, index + 1, context));
     }
 

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestResponseCustomizer.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestResponseCustomizer.java
@@ -18,7 +18,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 public class OidcRequestResponseCustomizer implements OidcRequestFilter, OidcResponseFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         return requestContext.runBlocking(() -> {
             var request = requestContext.request();
             String uri = request.uri();

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcJwksRequestCustomizer.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcJwksRequestCustomizer.java
@@ -15,7 +15,7 @@ import io.smallrye.mutiny.Uni;
 public class OidcJwksRequestCustomizer implements OidcRequestFilter {
 
     @Override
-    public Uni<Void> filterRequest(OidcRequestContext requestContext) {
+    public Uni<Void> filter(OidcRequestFilterContext requestContext) {
         return requestContext.runBlocking(() -> {
             var contextProps = requestContext.contextProperties();
             OidcConfigurationMetadata metadata = contextProps.get(OidcConfigurationMetadata.class.getName());


### PR DESCRIPTION
This PR uses the original idea from @michalvavrik in one of the earlier iterations of #51744 to keep new `OidcRequestFilter` and `OidcResponseFilter` named as `filter` as opposed to rather unusual `filterRequest` and `filterResponse` that I was insisting on in #51744, by introducing light weight request and response context extensions that also have `#runBlocking`.

It is all still on `main` only so no breaking changes are introduced with this PR.