### PR TITLE
OIDC Client GraphQL: do not renew access token on every call

### DIFF
--- a/extensions/oidc-client-graphql/deployment/pom.xml
+++ b/extensions/oidc-client-graphql/deployment/pom.xml
@@ -46,17 +46,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-keycloak-server</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-deployment</artifactId>
             <scope>test</scope>
         </dependency>
@@ -119,10 +108,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
-                                <keycloak.use.https>false</keycloak.use.https>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/extensions/oidc-client-graphql/deployment/src/main/java/io/quarkus/oidc/client/graphql/OidcGraphQLClientIntegrationProcessor.java
+++ b/extensions/oidc-client-graphql/deployment/src/main/java/io/quarkus/oidc/client/graphql/OidcGraphQLClientIntegrationProcessor.java
@@ -1,33 +1,50 @@
 package io.quarkus.oidc.client.graphql;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+import static io.quarkus.oidc.client.runtime.OidcClientsConfig.DEFAULT_CLIENT_KEY;
 
+import java.lang.constant.ClassDesc;
 import java.util.HashMap;
 import java.util.Map;
+
+import jakarta.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 
+import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmo2Adaptor;
+import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.gizmo2.ClassOutput;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.oidc.client.graphql.runtime.AbstractGraphQLTokenProvider;
 import io.quarkus.oidc.client.graphql.runtime.OidcClientGraphQLConfig;
 import io.quarkus.oidc.client.graphql.runtime.OidcGraphQLClientIntegrationRecorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.graphql.client.deployment.GraphQLClientConfigInitializedBuildItem;
 
-public class OidcGraphQLClientIntegrationProcessor {
+class OidcGraphQLClientIntegrationProcessor {
 
     private static final DotName GRAPHQL_CLIENT_API = DotName
             .createSimple("io.smallrye.graphql.client.typesafe.api.GraphQLClientApi");
 
     private static final String OIDC_CLIENT_FILTER = "io.quarkus.oidc.client.filter.OidcClientFilter";
+
+    private static final String TOKEN_PROVIDER_CLASS = AbstractGraphQLTokenProvider.class.getName();
 
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> featureProducer) {
@@ -35,26 +52,12 @@ public class OidcGraphQLClientIntegrationProcessor {
     }
 
     @BuildStep
-    @Record(RUNTIME_INIT)
-    void initialize(BeanContainerBuildItem containerBuildItem,
-            OidcGraphQLClientIntegrationRecorder recorder,
-            OidcClientGraphQLConfig config,
-            BeanArchiveIndexBuildItem index,
-            GraphQLClientConfigInitializedBuildItem configInitialized) {
-        Map<String, String> configKeysToOidcClients = new HashMap<>();
-        for (AnnotationInstance annotation : index.getIndex().getAnnotations(GRAPHQL_CLIENT_API)) {
-            ClassInfo clazz = annotation.target().asClass();
-            AnnotationInstance oidcClient = clazz.annotation(OIDC_CLIENT_FILTER);
-            if (oidcClient != null) {
-                String oidcClientName = oidcClient.valueWithDefault(index.getIndex(), "value").asString();
-                AnnotationValue configKeyValue = annotation.value("configKey");
-                String configKey = configKeyValue != null ? configKeyValue.asString() : null;
-                String actualConfigKey = (configKey != null && !configKey.equals("")) ? configKey : clazz.name().toString();
-                if (oidcClientName != null && !oidcClientName.isEmpty()) {
-                    configKeysToOidcClients.put(actualConfigKey, oidcClientName);
-                }
-            }
-        }
+    GraphQLTokenProducerInfo collectGraphQLTokenProducerInfo(OidcClientGraphQLConfig config,
+            CombinedIndexBuildItem combinedIndex) {
+        var configKeysToOidcClientsFromIndex = getConfigKeysToOidcClientsFromIndex(combinedIndex.getIndex(), false);
+
+        // named OIDC clients
+        var configKeysToOidcClients = new HashMap<>(configKeysToOidcClientsFromIndex);
         config.additionalOidcClients().forEach((graphQlClient, oidcClient) -> {
             var previousOidcClient = configKeysToOidcClients.put(graphQlClient, oidcClient.clientName());
             if (previousOidcClient != null && !previousOidcClient.equals(oidcClient.clientName())) {
@@ -66,6 +69,129 @@ public class OidcGraphQLClientIntegrationProcessor {
                         oidcClient.clientName()));
             }
         });
-        recorder.enhanceGraphQLClientConfigurationWithOidc(configKeysToOidcClients, config.clientName().orElse(null));
+
+        Map<String, String> oidcClientToTokenProducerBeanName = new HashMap<>();
+        configKeysToOidcClients.values().forEach(oidcClient -> oidcClientToTokenProducerBeanName
+                .putIfAbsent(oidcClient, generatedBeanClassName(oidcClient)));
+
+        // default OIDC client used when the GraphQL client doesn't have explicitly assigned another client
+        config.clientName().ifPresentOrElse(defaultOidcClientName -> oidcClientToTokenProducerBeanName
+                .putIfAbsent(defaultOidcClientName, generatedBeanClassName(defaultOidcClientName)),
+                () -> oidcClientToTokenProducerBeanName.put(DEFAULT_CLIENT_KEY, generatedBeanClassName(DEFAULT_CLIENT_KEY)));
+
+        return new GraphQLTokenProducerInfo(oidcClientToTokenProducerBeanName, configKeysToOidcClientsFromIndex);
+    }
+
+    /**
+     * For each OIDC client required by GraphQL clients, we generate a token producer like this:
+     *
+     * <pre>
+     * {
+     *     &#64;code
+     *     &#64;Singleton
+     *     @Unremovable
+     *     public class AbstractGraphQLTokenProvider_OidcClient1 extends AbstractGraphQLTokenProvider {
+     *         public AbstractGraphQLTokenProvider_OidcClient1() {
+     *             super("OidcClient1");
+     *         }
+     *     }
+     * }
+     * </pre>
+     */
+    @BuildStep
+    void generateGraphQLTokenProducers(GraphQLTokenProducerInfo graphQLTokenProducerInfo,
+            BuildProducer<GeneratedBeanBuildItem> generatedBeanProducer) {
+        graphQLTokenProducerInfo.oidcClientToTokenProducerBeanName.forEach((oidcClientName, generatedClassName) -> {
+            ClassOutput classOutput = new GeneratedBeanGizmo2Adaptor(generatedBeanProducer);
+            Gizmo gizmo = Gizmo.create(classOutput).withDebugInfo(false).withParameters(false);
+            gizmo.class_(generatedClassName, cc -> {
+                cc.public_();
+                cc.addAnnotation(Singleton.class);
+                cc.addAnnotation(Unremovable.class);
+                var tokenProviderClassDesc = ClassDesc.of(TOKEN_PROVIDER_CLASS);
+                cc.extends_(tokenProviderClassDesc);
+                cc.constructor(ctorCreator -> {
+                    ctorCreator.public_();
+                    ctorCreator
+                            .body(bc -> {
+                                bc.invokeSpecial(ConstructorDesc.of(tokenProviderClassDesc, String.class), cc.this_(),
+                                        Const.of(oidcClientName));
+                                bc.return_();
+                            });
+                });
+            });
+        });
+    }
+
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    void initialize(BeanContainerBuildItem containerBuildItem,
+            OidcGraphQLClientIntegrationRecorder recorder,
+            OidcClientGraphQLConfig config,
+            BeanArchiveIndexBuildItem index,
+            GraphQLTokenProducerInfo graphQLTokenProducerInfo,
+            GraphQLClientConfigInitializedBuildItem configInitialized) {
+        Map<String, String> configKeysToOidcClients = getConfigKeysToOidcClientsFromIndex(index.getIndex(), true);
+        configKeysToOidcClients.forEach((graphQLConfigKey, oidcClient) -> {
+            if (!graphQLTokenProducerInfo.configKeysToOidcClientsFromCombinedIndex.containsValue(oidcClient)) {
+                // ATM GraphQL extension processor relies on the combined index as well, this validation is in place
+                // so that we don't miss future changes
+                throw new IllegalStateException("GraphQL client with config key '%s' wasn't present in the combined index,"
+                        + " therefore Quarkus didn't generate required OIDC token provider");
+            }
+        });
+        config.additionalOidcClients()
+                .forEach((graphQlClient, oidcClient) -> configKeysToOidcClients.put(graphQlClient, oidcClient.clientName()));
+
+        recorder.enhanceGraphQLClientConfigurationWithOidc(configKeysToOidcClients, config.clientName().orElse(null),
+                graphQLTokenProducerInfo.oidcClientToTokenProducerBeanName);
+    }
+
+    private static Map<String, String> getConfigKeysToOidcClientsFromIndex(IndexView index, boolean withDefault) {
+        Map<String, String> configKeysToOidcClients = new HashMap<>();
+        for (AnnotationInstance annotation : index.getAnnotations(GRAPHQL_CLIENT_API)) {
+            ClassInfo clazz = annotation.target().asClass();
+            AnnotationInstance oidcClient = clazz.annotation(OIDC_CLIENT_FILTER);
+            if (oidcClient != null) {
+
+                final String oidcClientName;
+                if (withDefault) {
+                    oidcClientName = oidcClient.valueWithDefault(index, "value").asString();
+                } else {
+                    // combined index doesn't contain this annotation, and we don't really need it as if default really
+                    // changed, the build time validation will start failing
+                    var annotationValue = oidcClient.value("value");
+                    oidcClientName = annotationValue == null ? null : annotationValue.asString();
+                }
+
+                AnnotationValue configKeyValue = annotation.value("configKey");
+                String configKey = configKeyValue != null ? configKeyValue.asString() : null;
+                String actualConfigKey = (configKey != null && !configKey.equals("")) ? configKey : clazz.name().toString();
+                if (oidcClientName != null && !oidcClientName.isEmpty()) {
+                    configKeysToOidcClients.put(actualConfigKey, oidcClientName);
+                }
+            }
+        }
+        return configKeysToOidcClients;
+    }
+
+    private static String generatedBeanClassName(String oidcClient) {
+        return TOKEN_PROVIDER_CLASS + "_" + sanitizeOidcClientName(oidcClient);
+    }
+
+    private static String sanitizeOidcClientName(String oidcClientName) {
+        return oidcClientName.replaceAll("\\W+", "");
+    }
+
+    private static final class GraphQLTokenProducerInfo extends SimpleBuildItem {
+
+        private final Map<String, String> oidcClientToTokenProducerBeanName;
+        private final Map<String, String> configKeysToOidcClientsFromCombinedIndex;
+
+        private GraphQLTokenProducerInfo(Map<String, String> oidcClientToTokenProducerBeanName,
+                Map<String, String> configKeysToOidcClientsFromCombinedIndex) {
+            this.oidcClientToTokenProducerBeanName = Map.copyOf(oidcClientToTokenProducerBeanName);
+            this.configKeysToOidcClientsFromCombinedIndex = Map.copyOf(configKeysToOidcClientsFromCombinedIndex);
+        }
     }
 }

--- a/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/AnnotationTypesafeGraphQLClient.java
+++ b/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/AnnotationTypesafeGraphQLClient.java
@@ -12,4 +12,6 @@ public interface AnnotationTypesafeGraphQLClient {
     @Query
     String principalName();
 
+    @Query
+    String accessToken();
 }

--- a/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientResource.java
+++ b/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientResource.java
@@ -30,6 +30,12 @@ public class GraphQLClientResource {
         return defaultTypesafeClient.principalName();
     }
 
+    @GET
+    @Path("/access-token")
+    public String getAccessToken() {
+        return annotationTypesafeClient.accessToken();
+    }
+
     @Inject
     @GraphQLClient("default-dynamic")
     DynamicGraphQLClient dynamicClient;

--- a/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientUsingOidcClientTest.java
+++ b/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientUsingOidcClientTest.java
@@ -1,16 +1,15 @@
 package io.quarkus.oidc.client.graphql;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
 public class GraphQLClientUsingOidcClientTest {
 
     private static final Class<?>[] testClasses = {
@@ -73,4 +72,18 @@ public class GraphQLClientUsingOidcClientTest {
                 .body(equalTo("admin"));
     }
 
+    @Test
+    void testTokenNotRenewedOnEveryCall() {
+        String accessToken1 = getAccessTokenUsedByGraphQLClient();
+        String accessToken2 = getAccessTokenUsedByGraphQLClient();
+        assertEquals(accessToken1, accessToken2, "Expected that GraphQL client will reuse the same access token");
+    }
+
+    private static String getAccessTokenUsedByGraphQLClient() {
+        return RestAssured.when().get("/oidc-graphql-client/access-token")
+                .then()
+                .statusCode(200)
+                .body(Matchers.notNullValue())
+                .extract().asString();
+    }
 }

--- a/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/ProtectedResource.java
+++ b/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/ProtectedResource.java
@@ -7,7 +7,9 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 
+import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
 
 @GraphQLApi
 @Authenticated
@@ -16,8 +18,16 @@ public class ProtectedResource {
     @Inject
     Principal principal;
 
+    @Inject
+    SecurityIdentity securityIdentity;
+
     @Query
     public String principalName() {
         return principal.getName();
+    }
+
+    @Query
+    public String accessToken() {
+        return securityIdentity.getCredential(AccessTokenCredential.class).getToken();
     }
 }

--- a/extensions/oidc-client-graphql/deployment/src/test/resources/application.properties
+++ b/extensions/oidc-client-graphql/deployment/src/test/resources/application.properties
@@ -1,35 +1,31 @@
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
-quarkus.oidc.client-id=quarkus-service-app
-quarkus.oidc.credentials.secret=secret
+quarkus.keycloak.devservices.users.alice=alice
+quarkus.keycloak.devservices.users.jdoe=jdoe
+quarkus.keycloak.devservices.users.admin=admin
 
-quarkus.oidc-client.annotation.auth-server-url=${quarkus.oidc.auth-server-url}
-quarkus.oidc-client.annotation.client-id=${quarkus.oidc.client-id}
-quarkus.oidc-client.annotation.credentials.client-secret.value=${quarkus.oidc.credentials.secret}
-quarkus.oidc-client.annotation.credentials.client-secret.method=POST
+quarkus.oidc-client.annotation.auth-server-url=${quarkus.oidc-client.auth-server-url}
+quarkus.oidc-client.annotation.client-id=${quarkus.oidc-client.client-id}
+quarkus.oidc-client.annotation.credentials.secret=${quarkus.oidc-client.credentials.secret}
 quarkus.oidc-client.annotation.grant.type=password
 quarkus.oidc-client.annotation.grant-options.password.username=jdoe
 quarkus.oidc-client.annotation.grant-options.password.password=jdoe
 
-quarkus.oidc-client.doe.auth-server-url=${quarkus.oidc-client.annotation.auth-server-url}
-quarkus.oidc-client.doe.client-id=${quarkus.oidc-client.annotation.client-id}
-quarkus.oidc-client.doe.credentials.client-secret.value=${quarkus.oidc-client.annotation.credentials.client-secret.value}
-quarkus.oidc-client.doe.credentials.client-secret.method=${quarkus.oidc-client.annotation.credentials.client-secret.method}
-quarkus.oidc-client.doe.grant.type=${quarkus.oidc-client.annotation.grant.type}
-quarkus.oidc-client.doe.grant-options.password.username=${quarkus.oidc-client.annotation.grant-options.password.username}
-quarkus.oidc-client.doe.grant-options.password.password=${quarkus.oidc-client.annotation.grant-options.password.password}
+quarkus.oidc-client.doe.auth-server-url=${quarkus.oidc-client.auth-server-url}
+quarkus.oidc-client.doe.client-id=${quarkus.oidc-client.client-id}
+quarkus.oidc-client.doe.credentials.secret=${quarkus.oidc-client.credentials.secret}
+quarkus.oidc-client.doe.grant.type=password
+quarkus.oidc-client.doe.grant-options.password.username=jdoe
+quarkus.oidc-client.doe.grant-options.password.password=jdoe
 
-quarkus.oidc-client.admin.auth-server-url=${quarkus.oidc-client.annotation.auth-server-url}
-quarkus.oidc-client.admin.client-id=${quarkus.oidc-client.annotation.client-id}
-quarkus.oidc-client.admin.credentials.client-secret.value=${quarkus.oidc-client.annotation.credentials.client-secret.value}
-quarkus.oidc-client.admin.credentials.client-secret.method=${quarkus.oidc-client.annotation.credentials.client-secret.method}
-quarkus.oidc-client.admin.grant.type=${quarkus.oidc-client.annotation.grant.type}
+quarkus.oidc-client.admin.auth-server-url=${quarkus.oidc-client.auth-server-url}
+quarkus.oidc-client.admin.client-id=${quarkus.oidc-client.client-id}
+quarkus.oidc-client.admin.credentials.secret=${quarkus.oidc-client.credentials.secret}
+quarkus.oidc-client.admin.grant.type=password
 quarkus.oidc-client.admin.grant-options.password.username=admin
 quarkus.oidc-client.admin.grant-options.password.password=admin
 
-quarkus.oidc-client.configured-default.auth-server-url=${quarkus.oidc.auth-server-url}
-quarkus.oidc-client.configured-default.client-id=${quarkus.oidc.client-id}
-quarkus.oidc-client.configured-default.credentials.client-secret.value=${quarkus.oidc.credentials.secret}
-quarkus.oidc-client.configured-default.credentials.client-secret.method=POST
+quarkus.oidc-client.configured-default.auth-server-url=${quarkus.oidc-client.auth-server-url}
+quarkus.oidc-client.configured-default.client-id=${quarkus.oidc-client.client-id}
+quarkus.oidc-client.configured-default.credentials.secret=${quarkus.oidc-client.credentials.secret}
 quarkus.oidc-client.configured-default.grant.type=password
 quarkus.oidc-client.configured-default.grant-options.password.username=alice
 quarkus.oidc-client.configured-default.grant-options.password.password=alice

--- a/extensions/oidc-client-graphql/runtime/src/main/java/io/quarkus/oidc/client/graphql/runtime/AbstractGraphQLTokenProvider.java
+++ b/extensions/oidc-client-graphql/runtime/src/main/java/io/quarkus/oidc/client/graphql/runtime/AbstractGraphQLTokenProvider.java
@@ -1,0 +1,31 @@
+package io.quarkus.oidc.client.graphql.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.oidc.client.Tokens;
+import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Abstract token provider parent extended by generated provider beans.
+ */
+public abstract class AbstractGraphQLTokenProvider extends AbstractTokensProducer {
+
+    private final String oidcClientId;
+
+    protected AbstractGraphQLTokenProvider(String oidcClientId) {
+        this.oidcClientId = oidcClientId;
+    }
+
+    final Uni<String> getAccessToken() {
+        return Uni.createFrom()
+                .deferred(this::getTokens)
+                .map(Tokens::getAccessToken)
+                .map(token -> "Bearer " + token);
+    }
+
+    @Override
+    protected Optional<String> clientId() {
+        return Optional.of(oidcClientId);
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/quarkusio/quarkus/issues/47875

This PR creates OIDC Client token producer for each OIDC client used by GraphQL clients, thanks to that:

- we don't renew access token on every call
- we newly respect OIDC Client configuration like:
  - `quarkus.oidc-client.early-tokens-acquisition`
  - `quarkus.oidc-client.refresh-interval`

I have also migrated OIDC GraphQL Client tests from the Keycloak Test Resource to the Keycloak Dev Service because the test resource has access token lifespan 3 seconds https://github.com/quarkusio/quarkus/blob/e177b4be9e35304d9c840611af2a8abccb795127/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestResourceLifecycleManager.java#L72. That is not exactly ideal for testing of access token refresh and the dev service has much more reasonable lifespan (600 s) https://github.com/quarkusio/quarkus/blob/e177b4be9e35304d9c840611af2a8abccb795127/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java#L860. I think it is preferrable to use the dev service anyway.
