### PR TITLE
Avoid non-actionable warnings during Native Image build on Mandrel for JDK 25

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -746,6 +746,7 @@ public class NativeImageBuildStep {
                     }
                 }
 
+                nativeImageArgs.add("--enable-native-access=ALL-UNNAMED");//Avoid such warnings, as we're working to resolve them in JVM mode first.
                 nativeImageArgs.add("-J-Dfile.encoding=" + nativeConfig.fileEncoding());
 
                 if (enableSslNative) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/JVMUnsafeWarningsControl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/JVMUnsafeWarningsControl.java
@@ -11,9 +11,8 @@ public final class JVMUnsafeWarningsControl {
      * users with it.
      */
     public static void disableUnsafeRelatedWarnings() {
-        //No need for this in native image
         //No need for this in JVMs earlier than 24
-        if (ImageMode.current().isNativeImage() || Runtime.version().feature() < 24) {
+        if (Runtime.version().feature() < 24) {
             return;
         }
         try {

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/JVMChecksFeature.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/JVMChecksFeature.java
@@ -11,9 +11,11 @@ import io.quarkus.runtime.JVMUnsafeWarningsControl;
  */
 public class JVMChecksFeature implements Feature {
 
+    //Use isInConfiguration as it's the earliest callback we can use
     @Override
-    public void duringSetup(Feature.DuringSetupAccess access) {
+    public boolean isInConfiguration(IsInConfigurationAccess access) {
         JVMUnsafeWarningsControl.disableUnsafeRelatedWarnings();
+        return true;
     }
 
 }


### PR DESCRIPTION
* Fixes #51697
