### PR TITLE
Netty: do not set io.netty.tryReflectionSetAccessible for native image

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOnJava24ProcessorExtension.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOnJava24ProcessorExtension.java
@@ -2,7 +2,6 @@ package io.quarkus.netty.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 
 /**
  * As Java 24 locks down access to sun.misc.Unsafe, Netty needs to adapt to this
@@ -17,11 +16,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuil
  * setting such an option.
  */
 public class NettyOnJava24ProcessorExtension {
-
-    @BuildStep
-    public NativeImageSystemPropertyBuildItem jdk24CleanersViaSetAccessible() {
-        return new NativeImageSystemPropertyBuildItem("io.netty.tryReflectionSetAccessible", "true");
-    }
 
     @BuildStep
     ModuleOpenBuildItem openModules() {


### PR DESCRIPTION
I understand from comments on #51667 that this should be the culprit, but I didn't test it.

* Fixes #51667

@Karm or @jerboaa could confirm & review please?

Sorry for having set that flag, it's not necessary and I shouldn't have included that in my previous PR.