### PR TITLE
Form-based authentication: add 3 new properties to configure which query params should be passed through to the redirect location

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthRedirectQueryParamsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthRedirectQueryParamsTest.java
@@ -1,0 +1,352 @@
+package io.quarkus.vertx.http.security;
+
+import static io.restassured.matcher.RestAssuredMatchers.detailedCookie;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.event.Observes;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.FormAuthConfig.CookieSameSite;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+class FormAuthRedirectQueryParamsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().withApplicationRoot(jar -> jar
+            .addClasses(TestIdentityProvider.class, TestIdentityController.class, TestTrustedIdentityProvider.class,
+                    PathHandler.class, HttpSecurityConfigurator.class, DelegatingMechanism.class)
+            .addAsResource(new StringAsset("""
+                    quarkus.http.auth.form.enabled=true
+                    quarkus.http.auth.form.login-page-query-params=jfwid
+                    quarkus.http.auth.form.landing-page=landing
+                    quarkus.http.auth.form.error-page=error
+                    quarkus.http.auth.form.login-page=login
+                    quarkus.http.auth.form.cookie-same-site=lax
+                    quarkus.http.auth.form.cookie-name=laitnederc-sukrauq
+                    quarkus.http.auth.form.http-only-cookie=true
+                    quarkus.http.auth.form.cookie-max-age=2m
+                    """), "application.properties"));
+
+    @BeforeAll
+    static void setup() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin");
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    void testSingleQueryParamPassed() {
+        Map<String, Set<String>> allQueryParams = Map.of("jfwid", Set.of("1234"));
+        Set<String> passedQueryParams = Set.of("jfwid=1234");
+        Set<String> ignoredQueryParams = Set.of();
+        testLoginPageQueryParams("/admin", allQueryParams, passedQueryParams, ignoredQueryParams, "/login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/error");
+        allQueryParams = Map.of("jfwid", Set.of("1234"), "ignored-1", Set.of("haha"));
+        passedQueryParams = Set.of("jfwid=1234");
+        ignoredQueryParams = Set.of("ignored-1");
+        testLoginPageQueryParams("/admin", allQueryParams, passedQueryParams, ignoredQueryParams, "/login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/error");
+        allQueryParams = Map.of("whatever", Set.of("9"), "jfwid", Set.of("1234"), "ignored-1", Set.of("haha"));
+        passedQueryParams = Set.of("jfwid=1234");
+        ignoredQueryParams = Set.of("ignored-1", "whatever");
+        testLoginPageQueryParams("/admin", allQueryParams, passedQueryParams, ignoredQueryParams, "/login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/error");
+        allQueryParams = Map.of("whatever", Set.of("9"), "unknown", Set.of("1234"), "ignored-1", Set.of("❤"));
+        passedQueryParams = Set.of();
+        ignoredQueryParams = Set.of("ignored-1", "whatever", "unknown");
+        testLoginPageQueryParams("/admin", allQueryParams, passedQueryParams, ignoredQueryParams, "/login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/error");
+        allQueryParams = Map.of();
+        passedQueryParams = Set.of();
+        ignoredQueryParams = Set.of();
+        testLoginPageQueryParams("/admin", allQueryParams, passedQueryParams, ignoredQueryParams, "/login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/error");
+    }
+
+    @Test
+    void testMultipleQueryParamsPassed() {
+        // following parameters are set for all the parameters
+        Map<String, Set<String>> allQueryParams = Map.of("elvis", Set.of("Presley"), "jfwid", Set.of("1234"), "jitka",
+                Set.of("teacher"), "otherid", Set.of("8765"), "mavis", Set.of("staples"));
+        Set<String> passedQueryParams = Set.of("jfwid=1234");
+        Set<String> ignoredQueryParams = Set.of("jitka", "mavis", "elvis");
+        testLoginPageQueryParams("/multiple-params", allQueryParams, passedQueryParams, ignoredQueryParams, "/m-login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-error");
+
+        // the 'login-only' pass-through parameter is only set for the login page
+        allQueryParams = Map.of("elvis", Set.of("Presley"), "login-only", Set.of("8765"), "mavis", Set.of("staples"));
+        passedQueryParams = Set.of("login-only=8765");
+        ignoredQueryParams = Set.of("mavis", "elvis");
+        testLoginPageQueryParams("/multiple-params", allQueryParams, passedQueryParams, ignoredQueryParams, "/m-login");
+        passedQueryParams = Set.of();
+        ignoredQueryParams = Set.of("mavis", "elvis", "login-only");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-error");
+
+        // the 'landing-only' pass-through parameter is only set for the login page
+        allQueryParams = Map.of("elvis", Set.of("Presley"), "landing-only", Set.of("8765"), "mavis", Set.of("staples"));
+        passedQueryParams = Set.of("landing-only=8765");
+        ignoredQueryParams = Set.of("mavis", "elvis");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-landing");
+        passedQueryParams = Set.of();
+        ignoredQueryParams = Set.of("mavis", "elvis", "landing-only");
+        testLoginPageQueryParams("/multiple-params", allQueryParams, passedQueryParams, ignoredQueryParams, "/m-login");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-error");
+
+        // the 'error-only' pass-through parameter is only set for the login page
+        allQueryParams = Map.of("elvis", Set.of("Presley"), "error-only", Set.of("8765"), "mavis", Set.of("staples"));
+        passedQueryParams = Set.of("error-only=8765");
+        ignoredQueryParams = Set.of("mavis", "elvis");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-error");
+        passedQueryParams = Set.of();
+        ignoredQueryParams = Set.of("mavis", "elvis", "error-only");
+        testLoginPageQueryParams("/multiple-params", allQueryParams, passedQueryParams, ignoredQueryParams, "/m-login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-landing");
+    }
+
+    @Test
+    void testMultipleQueryParamValues() {
+        Map<String, Set<String>> allQueryParams = Map.of("elvis", Set.of("Presley"), "jfwid",
+                Set.of("1234", "2345", "3456", "4567"),
+                "jitka", Set.of("teacher"), "otherid", Set.of("8765"), "mavis", Set.of("staples"));
+        Set<String> passedQueryParams = Set.of("jfwid=1234", "jfwid=2345", "jfwid=3456", "jfwid=4567");
+        Set<String> ignoredQueryParams = Set.of("jitka", "mavis", "elvis");
+        testLoginPageQueryParams("/multiple-params", allQueryParams, passedQueryParams, ignoredQueryParams, "/m-login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/m_security_check", "/m-error");
+    }
+
+    @Test
+    void testQueryParamEncoding() {
+        Map<String, Set<String>> allQueryParams = Map.of("jfwid", Set.of("Test%20Case & Check", "a=b&c=d", "/path?q=1"));
+        // we expect that the query param value was encoded, so that we stay safe; the client can decode it if necessary
+        Set<String> passedQueryParams = Set.of("jfwid=Test%2520Case%20%26%20Check", "jfwid=a%3Db%26c%3Dd",
+                "jfwid=%2Fpath%3Fq%3D1");
+        Set<String> ignoredQueryParams = Set.of();
+        testLoginPageQueryParams("/admin", allQueryParams, passedQueryParams, ignoredQueryParams, "/login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/j_security_check", "/error");
+    }
+
+    @Test
+    void testRedirectLocationWithQuery() {
+        Map<String, Set<String>> allQueryParams = Map.of("elvis", Set.of("Presley"), "jfwid",
+                Set.of("1234", "2345", "3456", "4567"),
+                "jitka", Set.of("teacher"), "otherid", Set.of("8765"), "mavis", Set.of("staples"));
+        Set<String> passedQueryParams = Set.of("jfwid=1234", "jfwid=2345", "jfwid=3456", "jfwid=4567");
+        Set<String> ignoredQueryParams = Set.of("jitka", "mavis", "elvis");
+        testLoginPageQueryParams("/redirect-location-with-query", allQueryParams, passedQueryParams, ignoredQueryParams,
+                "/log-me-in?failed=that-is-life");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/q_security_check",
+                "/landing?avalon");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/q_security_check",
+                "/error?what-a-surprise=ack");
+    }
+
+    @Test
+    void testNoQueryParamPassed() {
+        Map<String, Set<String>> allQueryParams = Map.of("jfwid", Set.of("1234"));
+        Set<String> passedQueryParams = Set.of();
+        Set<String> ignoredQueryParams = Set.of("jfwid");
+        testLoginPageQueryParams("/no-params", allQueryParams, passedQueryParams, ignoredQueryParams, "/n-login");
+        testLandingPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/n_security_check", "/n-landing");
+        testErrorPageQueryParams(allQueryParams, passedQueryParams, ignoredQueryParams, "/n_security_check", "/n-error");
+    }
+
+    private static void testErrorPageQueryParams(Map<String, Set<String>> queryParams, Set<String> passedQueryParams,
+            Set<String> ignoredQueryParams, String jSecurityCheckPath, String errorPage) {
+        var passedParamsMatcher = getPassedParamsMatcher(passedQueryParams);
+
+        var request = RestAssured.given();
+        queryParams.forEach(request::queryParam);
+        request
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "admin")
+                .formParam("j_password", "wrong")
+                .post(jSecurityCheckPath)
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString(errorPage))
+                .header("location", passedParamsMatcher)
+                .header("location", getIgnoredParamsMatcher(ignoredQueryParams));
+    }
+
+    private static void testLandingPageQueryParams(Map<String, Set<String>> queryParams, Set<String> passedQueryParams,
+            Set<String> ignoredQueryParams, String jSecurityCheckPath, String landingPage) {
+        var passedParamsMatcher = getPassedParamsMatcher(passedQueryParams);
+
+        var request = RestAssured.given();
+        queryParams.forEach(request::queryParam);
+        request
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "admin")
+                .formParam("j_password", "admin")
+                .post(jSecurityCheckPath)
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString(landingPage))
+                .header("location", passedParamsMatcher)
+                .header("location", getIgnoredParamsMatcher(ignoredQueryParams))
+                .cookie("laitnederc-sukrauq", detailedCookie().value(notNullValue())
+                        .httpOnly(true).sameSite("Lax").maxAge(120));
+    }
+
+    private static void testLoginPageQueryParams(String path, Map<String, Set<String>> queryParams,
+            Set<String> passedQueryParams,
+            Set<String> ignoredQueryParams, String loginPage) {
+        CookieFilter cookies = new CookieFilter();
+        var passedParamsMatcher = getPassedParamsMatcher(passedQueryParams);
+        var request = RestAssured.given();
+        queryParams.forEach(request::queryParam);
+        request
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get(path)
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString(loginPage))
+                .header("location", passedParamsMatcher)
+                .header("location", getIgnoredParamsMatcher(ignoredQueryParams))
+                .cookie("quarkus-redirect-location",
+                        detailedCookie().value(allOf(containsString(path), passedParamsMatcher)).sameSite("Lax"));
+    }
+
+    private static Matcher<String> getIgnoredParamsMatcher(Set<String> ignoredQueryParams) {
+        return ignoredQueryParams.stream().map(Matchers::containsString).map(Matchers::not).reduce(Matchers::allOf)
+                .orElse(Matchers.containsString(""));
+    }
+
+    private static Matcher<String> getPassedParamsMatcher(Set<String> passedQueryParams) {
+        return passedQueryParams.stream().map(Matchers::containsString).reduce(Matchers::allOf)
+                .orElse(Matchers.containsString(""));
+    }
+
+    static class HttpSecurityConfigurator {
+
+        void configureFormAuthentication(@Observes HttpSecurity httpSecurity) {
+            var multipleQueryParams = new DelegatingMechanism(
+                    createFormBuilderBase("m-")
+                            .errorPageQueryParameters("jfwid", "otherid", "error-only")
+                            .landingPageQueryParameters("jfwid", "otherid", "landing-only")
+                            .loginPageQueryParameters("jfwid", "otherid", "login-only")
+                            .postLocation("m_security_check").build(),
+                    "multiple-query-param");
+            var noQueryParams = new DelegatingMechanism(createFormBuilderBase("n-").postLocation("n_security_check")
+                    .loginPageQueryParameters()
+                    .landingPageQueryParameters()
+                    .errorPageQueryParameters()
+                    .build(),
+                    "no-query-param");
+            var redirectLocationWithQuery = new DelegatingMechanism(
+                    createFormBuilderBase("")
+                            .loginPage("log-me-in?failed=that-is-life")
+                            .errorPage("error?what-a-surprise=ack")
+                            .landingPage("landing?avalon")
+                            .errorPageQueryParameters("jfwid", "otherid", "error-only")
+                            .landingPageQueryParameters("jfwid", "otherid", "landing-only")
+                            .loginPageQueryParameters("jfwid", "otherid", "login-only")
+                            .postLocation("q_security_check").build(),
+                    "redirect-location-with-query");
+            httpSecurity
+                    .mechanism(multipleQueryParams)
+                    .mechanism(noQueryParams)
+                    .mechanism(redirectLocationWithQuery)
+                    .path("/admin").form().roles("admin")
+                    .path("/multiple-params").authenticatedWith(multipleQueryParams.name).roles("admin")
+                    .path("/no-params").authenticatedWith(noQueryParams.name).roles("admin")
+                    .path("/redirect-location-with-query").authenticatedWith(redirectLocationWithQuery.name);
+        }
+
+        private static Form.Builder createFormBuilderBase(String prefix) {
+            return Form.builder()
+                    .loginPage(prefix + "login")
+                    .errorPage(prefix + "error")
+                    .landingPage(prefix + "landing")
+                    .timeout(Duration.ofSeconds(2))
+                    .newCookieInterval(Duration.ofSeconds(1))
+                    .cookieName("laitnederc-sukrauq")
+                    .cookieSameSite(CookieSameSite.LAX)
+                    .httpOnlyCookie()
+                    .cookieMaxAge(Duration.ofMinutes(2))
+                    .encryptionKey("CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT");
+        }
+    }
+
+    private static final class DelegatingMechanism implements HttpAuthenticationMechanism {
+
+        private final HttpAuthenticationMechanism delegate;
+        private final String name;
+
+        private DelegatingMechanism(HttpAuthenticationMechanism httpAuthenticationMechanism, String name) {
+            this.delegate = httpAuthenticationMechanism;
+            this.name = name;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return delegate.authenticate(context, identityProviderManager);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return delegate.getChallenge(context);
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return delegate.getCredentialTypes();
+        }
+
+        @Override
+        public Uni<Boolean> sendChallenge(RoutingContext context) {
+            return delegate.sendChallenge(context);
+        }
+
+        @Override
+        public Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
+            return Uni.createFrom()
+                    .item(new HttpCredentialTransport(HttpCredentialTransport.Type.POST, "/j_security_check", name));
+        }
+
+        @Override
+        public int getPriority() {
+            return delegate.getPriority();
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -2,7 +2,10 @@ package io.quarkus.vertx.http.runtime;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 
 /**
@@ -25,6 +28,15 @@ public interface FormAuthConfig {
     Optional<String> loginPage();
 
     /**
+     * List of query parameters that should be passed through when Quarkus redirects requests to the login page.
+     * For example, if a request to the `/secured-path?query_param=1&other_query_param=2` is redirected
+     * on the authentication failure to the login page and this property is set to the `other_query_param`,
+     * then the resulting redirect path will be `/login.html?other_query_param=2`.
+     * By default, no request query parameters are passed through.
+     */
+    Optional<Set<@WithConverter(TrimmedStringConverter.class) String>> loginPageQueryParams();
+
+    /**
      * The username field name.
      */
     @WithDefault("j_username")
@@ -43,11 +55,33 @@ public interface FormAuthConfig {
     Optional<String> errorPage();
 
     /**
+     * List of query parameters that should be passed through when Quarkus redirects requests to the error page.
+     * For example, if the POST request to the `/j_security_check?query_param=1&other_query_param=2` is redirected
+     * on the authentication failure to the error page and this property is set to the `other_query_param`,
+     * then the resulting redirect path will be `/error.html?other_query_param=2`.
+     * By default, only query parameters configured with the `quarkus.http.auth.form.login-page-query-params` property are
+     * passed through.
+     */
+    @WithDefault("${quarkus.http.auth.form.login-page-query-params:}")
+    Optional<Set<@WithConverter(TrimmedStringConverter.class) String>> errorPageQueryParams();
+
+    /**
      * The landing page to redirect to if there is no saved page to redirect back to.
      * Redirect to landing page can be disabled by setting `quarkus.http.auth.form.landing-page=`.
      */
     @WithDefault("/index.html")
     Optional<String> landingPage();
+
+    /**
+     * List of query parameters that should be passed through when Quarkus redirects requests to the landing page.
+     * For example, if the POST request to the `/j_security_check?query_param=1&other_query_param=2` is redirected
+     * on the authentication success to the landing page and this property is set to the `other_query_param`,
+     * then the resulting redirect path will be `/index.html?other_query_param=2`.
+     * By default, only query parameters configured with the `quarkus.http.auth.form.login-page-query-params` property are
+     * passed through.
+     */
+    @WithDefault("${quarkus.http.auth.form.login-page-query-params:}")
+    Optional<Set<@WithConverter(TrimmedStringConverter.class) String>> landingPageQueryParams();
 
     /**
      * Option to disable redirect to landingPage if there is no saved page to redirect back to. Form Auth POST is followed

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/Form.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/Form.java
@@ -3,6 +3,7 @@ package io.quarkus.vertx.http.security;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -58,6 +59,9 @@ public interface Form {
         private FormAuthConfig.CookieSameSite cookieSameSite;
         private Optional<Duration> cookieMaxAge;
         private Optional<String> encryptionKey;
+        private Optional<Set<String>> landingPageQueryParams;
+        private Optional<Set<String>> errorPageQueryParams;
+        private Optional<Set<String>> loginPageQueryParams;
 
         public Builder() {
             this(ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getConfigMapping(VertxHttpConfig.class));
@@ -82,6 +86,9 @@ public interface Form {
             this.cookieSameSite = formAuthConfig.cookieSameSite();
             this.cookieMaxAge = formAuthConfig.cookieMaxAge();
             this.encryptionKey = vertxHttpConfig.encryptionKey();
+            this.landingPageQueryParams = formAuthConfig.landingPageQueryParams();
+            this.errorPageQueryParams = formAuthConfig.errorPageQueryParams();
+            this.loginPageQueryParams = formAuthConfig.loginPageQueryParams();
         }
 
         /**
@@ -106,6 +113,20 @@ public interface Form {
          */
         public Builder loginPage(String loginPage) {
             this.loginPage = Optional.ofNullable(loginPage);
+            return this;
+        }
+
+        /**
+         * Configures query parameters Quarkus passes through when redirecting requests to the login page.
+         *
+         * @param queryParameters query parameters; must not be null
+         * @return Builder
+         * @see FormAuthConfig#loginPageQueryParams()
+         */
+        public Builder loginPageQueryParameters(String... queryParameters) {
+            if (queryParameters != null) {
+                this.loginPageQueryParams = Optional.of(Set.of(queryParameters));
+            }
             return this;
         }
 
@@ -148,6 +169,20 @@ public interface Form {
         }
 
         /**
+         * Configures query parameters Quarkus passes through when redirecting requests to the error page.
+         *
+         * @param queryParameters query parameters; must not be null
+         * @return Builder
+         * @see FormAuthConfig#errorPageQueryParams()
+         */
+        public Builder errorPageQueryParameters(String... queryParameters) {
+            if (queryParameters != null) {
+                this.errorPageQueryParams = Optional.of(Set.of(queryParameters));
+            }
+            return this;
+        }
+
+        /**
          * Configures the landing page to redirect to if there is no saved page to redirect back to.
          *
          * @param landingPage see the 'quarkus.http.auth.form.landing-page' configuration property
@@ -156,6 +191,20 @@ public interface Form {
          */
         public Builder landingPage(String landingPage) {
             this.landingPage = Optional.ofNullable(landingPage);
+            return this;
+        }
+
+        /**
+         * Configures query parameters Quarkus passes through when redirecting requests to the landing page.
+         *
+         * @param queryParameters query parameters; must not be null
+         * @return Builder
+         * @see FormAuthConfig#landingPageQueryParams()
+         */
+        public Builder landingPageQueryParameters(String... queryParameters) {
+            if (queryParameters != null) {
+                this.landingPageQueryParams = Optional.of(Set.of(queryParameters));
+            }
             return this;
         }
 
@@ -303,13 +352,14 @@ public interface Form {
                     Optional<String> errorPage, Optional<String> landingPage, boolean redirectAfterLogin,
                     String locationCookie, Duration timeout, Duration newCookieInterval, String cookieName,
                     Optional<String> cookiePath, Optional<String> cookieDomain, boolean httpOnlyCookie,
-                    CookieSameSite cookieSameSite, Optional<Duration> cookieMaxAge, String postLocation)
-                    implements
-                        FormAuthConfig {
+                    CookieSameSite cookieSameSite, Optional<Duration> cookieMaxAge, String postLocation,
+                    Optional<Set<String>> landingPageQueryParams, Optional<Set<String>> errorPageQueryParams,
+                    Optional<Set<String>> loginPageQueryParams) implements FormAuthConfig {
             }
             return new FormConfigImpl(loginPage, usernameParameter, passwordParameter, errorPage,
                     landingPage, redirectAfterLogin, locationCookie, timeout, newCookieInterval, cookieName, cookiePath,
-                    cookieDomain, httpOnlyCookie, cookieSameSite, cookieMaxAge, postLocation);
+                    cookieDomain, httpOnlyCookie, cookieSameSite, cookieMaxAge, postLocation, landingPageQueryParams,
+                    errorPageQueryParams, loginPageQueryParams);
         }
     }
 }


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/46315
* Before this PR, when form-based authentication mechanism redirected to the login page / landing page / error page configured in app properties, query params from incoming requests were ignored.
* A new whitelist for query parameters is added which specifies query param names that should be added to the redirect location.
