### PR TITLE
Revise project metadata for Vert.x Utils

### DIFF
--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -13,7 +13,8 @@
 
     <groupId>io.quarkus.vertx.utils</groupId>
     <artifactId>quarkus-vertx-utils</artifactId>
-    <name>Ancillary classes for making third party frameworks to run on top of Vert.x</name>
+    <name>Quarkus - Vert.x Utils</name>
+    <description>Ancillary classes for making third party frameworks to run on top of Vert.x</description>
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>


### PR DESCRIPTION
- Set project name to "Quarkus - Vert.x Utils" in the POM file
- Actual name should be the description
