### PR TITLE
[3.27] Exclude org.lz4:lz4-java in favor of at.yawk.lz4:lz4-java

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -141,7 +141,7 @@
         <mutiny.version>2.9.5</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka3.version>4.0.0</kafka3.version>
-        <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
+        <lz4.version>1.10.1</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.10.8</snappy.version>
         <strimzi-test-container.version>0.109.2</strimzi-test-container.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
@@ -4612,9 +4612,16 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka3.version}</version>
+                <!-- TODO: remove the exclusion after upgrading to kafka-clients depending on the new lz4-java groupId (at.yawk.lz4) -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.lz4</groupId>
+                        <artifactId>lz4-java</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.lz4</groupId>
+                <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
                 <version>${lz4.version}</version>
             </dependency>

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -52,6 +52,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -101,6 +101,12 @@
             <artifactId>kafka-clients</artifactId>
             <optional>true</optional>
         </dependency>
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>

--- a/extensions/schema-registry/apicurio/avro/deployment/pom.xml
+++ b/extensions/schema-registry/apicurio/avro/deployment/pom.xml
@@ -19,6 +19,12 @@
             <artifactId>quarkus-apicurio-registry-avro</artifactId>
         </dependency>
 
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-apicurio-registry-common-deployment</artifactId>

--- a/extensions/schema-registry/apicurio/avro/runtime/pom.xml
+++ b/extensions/schema-registry/apicurio/avro/runtime/pom.xml
@@ -25,6 +25,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/schema-registry/apicurio/json-schema/deployment/pom.xml
+++ b/extensions/schema-registry/apicurio/json-schema/deployment/pom.xml
@@ -19,6 +19,12 @@
             <artifactId>quarkus-apicurio-registry-json-schema</artifactId>
         </dependency>
 
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-apicurio-registry-common-deployment</artifactId>

--- a/extensions/schema-registry/apicurio/json-schema/runtime/pom.xml
+++ b/extensions/schema-registry/apicurio/json-schema/runtime/pom.xml
@@ -26,6 +26,12 @@
             </exclusions>
         </dependency>
 
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-apicurio-registry-common</artifactId>

--- a/extensions/schema-registry/confluent/json-schema/runtime/pom.xml
+++ b/extensions/schema-registry/confluent/json-schema/runtime/pom.xml
@@ -43,6 +43,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -46,6 +46,11 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
+++ b/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
@@ -110,6 +110,8 @@
                 <!-- svm artifact, shouldn't be used as it's not public API. Use the -->
                 <!-- org.graalvm.sdk:graal-sdk dependency instead -->
                 <exclude>org.graalvm.nativeimage:svm</exclude>
+                <!-- org.lz4:lz4-java is abandoned and has a CVE -->
+                <exclude>org.lz4:lz4-java</exclude>
             </excludes>
             <includes>
                 <!-- this is for REST Assured -->


### PR DESCRIPTION
backport of https://github.com/quarkusio/quarkus/pull/51792 to 3.27