### PR TITLE
Fix typos in kubernetes-config documentation

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-config.adoc
+++ b/docs/src/main/asciidoc/kubernetes-config.adoc
@@ -56,9 +56,9 @@ as the running application. If they are to be found in a different namespace, th
 
 The properties obtained from the ConfigMaps and Secrets have a higher priority than (i.e. they override) any properties of the same name that are found in `application.properties` (or the YAML equivalents), but they have lower priority than properties set via Environment Variables or Java System Properties.
 
-Furthermore, when multiple ConfigMaps (or Secrets) are used, ConfigMaps (or Secrets) defined later in the list have a higher priority that ConfigMaps defined earlier in the list.
+Furthermore, when multiple ConfigMaps (or Secrets) are used, ConfigMaps (or Secrets) defined later in the list have a higher priority than ConfigMaps (or Secrets) defined earlier in the list.
 
-Finally, when both ConfigMaps and Secrets are used, the latter always a higher priority than the former.
+Finally, when both ConfigMaps and Secrets are used, the latter always has a higher priority than the former.
 
 === Kubernetes Permissions
 


### PR DESCRIPTION
Fix a few minor typos in the kubernetes-config documentation I noticed while reading through it.

