### PR TITLE
Enable reflection-free Jackson serializers by default

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonOptimizationConfig.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonOptimizationConfig.java
@@ -17,7 +17,7 @@ public interface JacksonOptimizationConfig {
     /**
      * Enable build time generation of reflection-free Jackson serializers.
      */
-    @WithDefault("false")
+    @WithDefault("true")
     boolean enableReflectionFreeSerializers();
 
     class IsReflectionFreeSerializersEnabled implements BooleanSupplier {


### PR DESCRIPTION
Users can always turn it off via `quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false` 