### PR TITLE
Generate enum description for lists and optional lists in Quarkus config documentation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -258,7 +258,7 @@ public interface NativeConfig {
      * <ul>
      * <li><code>jfr</code> for JDK flight recorder support</li>
      * <li><code>jvmstat</code> for JVMStat support</li>
-     * <li><code>heapdump</code> for heampdump support</li>
+     * <li><code>heapdump</code> for heapdump support</li>
      * <li><code>jmxclient</code> for JMX client support (experimental)</li>
      * <li><code>jmxserver</code> for JMX server support (experimental)</li>
      * <li><code>nmt</code> for native memory tracking support</li>
@@ -510,13 +510,37 @@ public interface NativeConfig {
     }
 
     enum MonitoringOption {
+        /**
+         * Heapdump support.
+         */
         HEAPDUMP,
+        /**
+         * JVMStat support.
+         */
         JVMSTAT,
+        /**
+         * JDK flight recorder support.
+         */
         JFR,
+        /**
+         * JMX server support (experimental).
+         */
         JMXSERVER,
+        /**
+         * JMX client support (experimental).
+         */
         JMXCLIENT,
+        /**
+         * Native memory tracking support.
+         */
         NMT,
+        /**
+         * All monitoring features.
+         */
         ALL,
+        /**
+         * Explicitly turns off all monitoring features.
+         */
         NONE
     }
 

--- a/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/AbstractFormatter.java
+++ b/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/AbstractFormatter.java
@@ -95,7 +95,8 @@ abstract class AbstractFormatter implements Formatter {
             if (enableEnumTooltips) {
                 typeContent = configProperty.getEnumAcceptedValues().values().entrySet().stream()
                         .map(e -> {
-                            Optional<JavadocElement> javadocElement = javadocRepository.getElement(configProperty.getType(),
+                            String enumQualifiedName = configProperty.getEnumAcceptedValues().qualifiedName();
+                            Optional<JavadocElement> javadocElement = javadocRepository.getElement(enumQualifiedName,
                                     e.getKey());
                             if (javadocElement.isEmpty()) {
                                 return "`" + e.getValue().configValue() + "`";


### PR DESCRIPTION
* closes https://github.com/quarkusio/quarkus/issues/51787
* changes in the `core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java` allowed me to test this PR, but I think it is also an improvement, so I kept it...

I have tested it and saw that newly there is a tooltip in the generated config file:

```
mvavrik@fedora:~/sources/quarkus/docs$ cat ./target/quarkus-generated-doc/config/quarkus-core_quarkus.native.adoc | grep "off all monitoring"
 - `none` for explicitly turning off all monitoring features
a|list of tooltip:heapdump[Heapdump support.], tooltip:jvmstat[JVMStat support.], tooltip:jfr[JDK flight recorder support.], tooltip:jmxserver[JMX server support (experimental).], tooltip:jmxclient[JMX client support (experimental).], tooltip:nmt[Native memory tracking support.], tooltip:all[All monitoring features.], tooltip:none[Explicitly turns off all monitoring features.]
```