### PR TITLE
Log OTel scope inconsistencies only on debug mode

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
@@ -3,6 +3,8 @@ package io.quarkus.opentelemetry.runtime;
 import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
 import static io.smallrye.common.vertx.VertxContext.isDuplicatedContext;
 
+import java.util.Map;
+
 import org.jboss.logging.Logger;
 
 import io.opentelemetry.api.trace.Span;
@@ -83,10 +85,14 @@ public enum QuarkusContextStorage implements ContextStorage {
                     log.debugv("Closing Otel context: {0}", OpenTelemetryUtil.getSpanData(otelToAttach));
                 }
 
-                if (otelBefore != otelToAttach) {
-                    log.info("Context in storage not the expected context, Scope.close was not called correctly. Details:" +
-                            " OTel context otelBefore: " + OpenTelemetryUtil.getSpanData(otelBefore) +
-                            ". OTel context otelToAttach: " + OpenTelemetryUtil.getSpanData(otelToAttach));
+                if (otelBefore != otelToAttach && log.isDebugEnabled()) {
+                    Map<String, String> spanDataBefore = OpenTelemetryUtil.getSpanData(otelBefore);
+                    if (spanDataBefore != null && !spanDataBefore.isEmpty()) {
+                        log.debug(
+                                "Context in storage not the expected context, Scope.close was not called correctly. Details:" +
+                                        " OTel context otelBefore: " + spanDataBefore +
+                                        ". OTel context otelToAttach: " + OpenTelemetryUtil.getSpanData(otelToAttach));
+                    }
                 }
 
                 if (otelBeforeAttach == null) {


### PR DESCRIPTION
Performance tests have revealed that we can log this line when the original context was empty. 
This can spam the logs and we are reducing the log level while investigation is ongoing. 
Sadly for debugging, the problem doesn't happen locally neither in dev mode or prod, just in the perf lab.
