### PR TITLE
Remove `keycloak-authz-client` dependency from Keycloak Admin RESTEasy client

### DIFF
--- a/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
@@ -71,16 +71,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-authz-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>


### PR DESCRIPTION
I was looking how we support the `keycloak-authz-client` in Quarkus and mentioned that the RESTEasy based Admin client has this dependency, while the REST based Admin client does not. There is no reason for it to be there, it doesn't seem like the extension adapts it to native mode or some other reason that is not immediately obvious.

I think we should remove it as it is not related to this extension nor it is used, but I acknowledge that if some user relies on transitive dependencies and need the authorization client, they will be affected. 

The `quarkus-keycloak-authorization` on the other hand seems to adapt this `keycloak-authz-client` client to native mode and seems like the right extension to use.