### PR TITLE
Remove deprecated `quarkus.http.auth.form.redirect-after-login` configuration property

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthNoRedirectAfterLoginTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthNoRedirectAfterLoginTestCase.java
@@ -26,8 +26,7 @@ public class FormAuthNoRedirectAfterLoginTestCase {
             "quarkus.http.auth.form.enabled=true\n" +
             "quarkus.http.auth.form.login-page=login\n" +
             "quarkus.http.auth.form.error-page=error\n" +
-            "quarkus.http.auth.form.landing-page=landing\n" +
-            "quarkus.http.auth.form.redirect-after-login=false\n" +
+            "quarkus.http.auth.form.landing-page=\n" +
             "quarkus.http.auth.policy.r1.roles-allowed=a d m i n\n" +
             "quarkus.http.auth.permission.roles1.paths=/admin\n" +
             "quarkus.http.auth.permission.roles1.policy=r1\n";
@@ -57,7 +56,7 @@ public class FormAuthNoRedirectAfterLoginTestCase {
      * we do POST with valid credentials.
      * Server should provide a response with quarkus-credential cookie
      * and a redirect to the previously attempted /admin page.
-     * Note the redirect takes place despite having quarkus.http.auth.form.redirect-after-login=false
+     * Note the redirect takes place despite having 'quarkus.http.auth.form.landing-page='
      * because there is some previous location to redirect to.
      *
      * Last but not least, client accesses the protected /admin resource again,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -84,18 +84,6 @@ public interface FormAuthConfig {
     Optional<Set<@WithConverter(TrimmedStringConverter.class) String>> landingPageQueryParams();
 
     /**
-     * Option to disable redirect to landingPage if there is no saved page to redirect back to. Form Auth POST is followed
-     * by redirect to landingPage by default.
-     *
-     * @deprecated redirect to landingPage can be disabled by removing default landing page
-     *             (via `quarkus.http.auth.form.landing-page=`). Quarkus will ignore this configuration property
-     *             if there is no landing page.
-     */
-    @WithDefault("true")
-    @Deprecated(forRemoval = true, since = "2.16")
-    boolean redirectAfterLogin();
-
-    /**
      * Option to control the name of the cookie used to redirect the user back
      * to the location they want to access.
      */

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -103,7 +103,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
         this.locationCookie = runtimeForm.locationCookie();
         this.cookiePath = runtimeForm.cookiePath().orElse(null);
         this.cookieDomain = runtimeForm.cookieDomain().orElse(null);
-        this.redirectToLandingPage = landingPage != null && runtimeForm.redirectAfterLogin();
+        this.redirectToLandingPage = landingPage != null;
         this.redirectToLoginPage = loginPage != null;
         this.redirectToErrorPage = errorPage != null;
         this.cookieSameSite = CookieSameSite.valueOf(runtimeForm.cookieSameSite().name());

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/Form.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/Form.java
@@ -48,7 +48,6 @@ public interface Form {
         private String passwordParameter;
         private Optional<String> errorPage;
         private Optional<String> landingPage;
-        private boolean redirectAfterLogin;
         private String locationCookie;
         private Duration timeout;
         private Duration newCookieInterval;
@@ -75,7 +74,6 @@ public interface Form {
             this.passwordParameter = formAuthConfig.passwordParameter();
             this.errorPage = formAuthConfig.errorPage();
             this.landingPage = formAuthConfig.landingPage();
-            this.redirectAfterLogin = formAuthConfig.redirectAfterLogin();
             this.locationCookie = formAuthConfig.locationCookie();
             this.timeout = formAuthConfig.timeout();
             this.newCookieInterval = formAuthConfig.newCookieInterval();
@@ -349,7 +347,7 @@ public interface Form {
 
         private FormAuthConfig createFormConfig() {
             record FormConfigImpl(Optional<String> loginPage, String usernameParameter, String passwordParameter,
-                    Optional<String> errorPage, Optional<String> landingPage, boolean redirectAfterLogin,
+                    Optional<String> errorPage, Optional<String> landingPage,
                     String locationCookie, Duration timeout, Duration newCookieInterval, String cookieName,
                     Optional<String> cookiePath, Optional<String> cookieDomain, boolean httpOnlyCookie,
                     CookieSameSite cookieSameSite, Optional<Duration> cookieMaxAge, String postLocation,
@@ -357,7 +355,7 @@ public interface Form {
                     Optional<Set<String>> loginPageQueryParams) implements FormAuthConfig {
             }
             return new FormConfigImpl(loginPage, usernameParameter, passwordParameter, errorPage,
-                    landingPage, redirectAfterLogin, locationCookie, timeout, newCookieInterval, cookieName, cookiePath,
+                    landingPage, locationCookie, timeout, newCookieInterval, cookieName, cookiePath,
                     cookieDomain, httpOnlyCookie, cookieSameSite, cookieMaxAge, postLocation, landingPageQueryParams,
                     errorPageQueryParams, loginPageQueryParams);
         }


### PR DESCRIPTION
Removes the `quarkus.http.auth.form.redirect-after-login` configuration property. It has been deprecated since Quarkus 2.16 and users get warnings when they start application with deprecated configuration properties. For that reason, I think there has been enough time and users would mention they need to migrate. We can keep it around if someone feels more time is desirable.