### PR TITLE
Try to improve `SimpleSchedulerRunAsUserTest` results by adding build order as we have seen failed attemps to resolve Quarkus Security artifact

### DIFF
--- a/extensions/quartz/deployment/pom.xml
+++ b/extensions/quartz/deployment/pom.xml
@@ -45,6 +45,14 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <!-- QuartzSchedulerRunAsUserTest needs Quarkus Security dependency -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-deployment</artifactId>
+            <optional>true</optional>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/security/QuartzSchedulerRunAsUserTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/security/QuartzSchedulerRunAsUserTest.java
@@ -20,6 +20,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.scheduler.Scheduled;
 import io.quarkus.security.Authenticated;
@@ -39,7 +40,7 @@ class QuartzSchedulerRunAsUserTest {
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClasses(Scheduler.class, SecuredBean.class, StaticScheduler.class))
-            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-security")));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-security", Version.getVersion())));
 
     @Inject
     Scheduler scheduler;

--- a/extensions/scheduler/deployment/pom.xml
+++ b/extensions/scheduler/deployment/pom.xml
@@ -77,6 +77,14 @@
           <artifactId>awaitility</artifactId>
           <scope>test</scope>
       </dependency>
+      <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+      <!-- SimpleSchedulerRunAsUserTest needs Quarkus Security dependency -->
+      <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-security-deployment</artifactId>
+          <optional>true</optional>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
     <build>

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/security/SimpleSchedulerRunAsUserTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/security/SimpleSchedulerRunAsUserTest.java
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.scheduler.Scheduled;
 import io.quarkus.security.Authenticated;
@@ -38,7 +39,7 @@ class SimpleSchedulerRunAsUserTest {
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClasses(Scheduler.class, SecuredBean.class, StaticScheduler.class))
-            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-security")));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-security", Version.getVersion())));
 
     @Inject
     Scheduler scheduler;


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/51823 PR CI I have seen following flakiness, which I am trying to solve experimentally. I don't know if this will help.

```
2026-01-07T01:12:50.9676450Z [ERROR] io.quarkus.scheduler.test.security.SimpleSchedulerRunAsUserTest -- Time elapsed: 1.528 s <<< ERROR!
2026-01-07T01:12:50.9710612Z java.lang.RuntimeException: io.quarkus.bootstrap.BootstrapException: Failed to create the application model for io.quarkus:quarkus-scheduler-deployment::jar:999-SNAPSHOTnull
2026-01-07T01:12:50.9712783Z 	at io.quarkus.test.QuarkusUnitTest.beforeAll(QuarkusUnitTest.java:753)
2026-01-07T01:12:50.9714180Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
2026-01-07T01:12:50.9715607Z Caused by: io.quarkus.bootstrap.BootstrapException: Failed to create the application model for io.quarkus:quarkus-scheduler-deployment::jar:999-SNAPSHOTnull
2026-01-07T01:12:50.9717997Z 	at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModelForWorkspace(BootstrapAppModelFactory.java:270)
2026-01-07T01:12:50.9719669Z 	at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModel(BootstrapAppModelFactory.java:212)
2026-01-07T01:12:50.9720937Z 	at io.quarkus.bootstrap.app.QuarkusBootstrap.bootstrap(QuarkusBootstrap.java:138)
2026-01-07T01:12:50.9722054Z 	at io.quarkus.test.QuarkusUnitTest.beforeAll(QuarkusUnitTest.java:694)
2026-01-07T01:12:50.9723021Z 	... 1 more
2026-01-07T01:12:50.9724162Z Caused by: java.lang.RuntimeException: The following errors were encountered while processing Quarkus application dependencies:
2026-01-07T01:12:50.9751801Z 1) Failed to resolve artifact io.quarkus:quarkus-security:jar:
2026-01-07T01:12:50.9753211Z   at io.quarkus.bootstrap.resolver.maven.ApplicationDependencyResolver.resolve(ApplicationDependencyResolver.java:885)
2026-01-07T01:12:50.9755671Z   ...
2026-01-07T01:12:50.9757123Z 	at io.quarkus.bootstrap.resolver.maven.FailAtCompletionErrorHandler.throwFailureReport(FailAtCompletionErrorHandler.java:62)
2026-01-07T01:12:50.9759806Z 	at io.quarkus.bootstrap.resolver.maven.FailAtCompletionErrorHandler.allTasksFinished(FailAtCompletionErrorHandler.java:29)
2026-01-07T01:12:50.9761648Z 	at io.quarkus.bootstrap.resolver.maven.NonBlockingModelResolutionTaskRunner.waitForCompletion(NonBlockingModelResolutionTaskRunner.java:48)
2026-01-07T01:12:50.9763675Z 	at io.quarkus.bootstrap.resolver.maven.ApplicationDependencyResolver.visitRuntimeDeps(ApplicationDependencyResolver.java:485)
2026-01-07T01:12:50.9765184Z 	at io.quarkus.bootstrap.resolver.maven.ApplicationDependencyResolver.processRuntimeDeps(ApplicationDependencyResolver.java:474)
2026-01-07T01:12:50.9766418Z 	at io.quarkus.bootstrap.resolver.maven.ApplicationDependencyResolver.resolve(ApplicationDependencyResolver.java:206)
2026-01-07T01:12:50.9767588Z 	at io.quarkus.bootstrap.resolver.BootstrapAppModelResolver.buildAppModel(BootstrapAppModelResolver.java:408)
2026-01-07T01:12:50.9768489Z 	at io.quarkus.bootstrap.resolver.BootstrapAppModelResolver.doResolveModel(BootstrapAppModelResolver.java:340)
2026-01-07T01:12:50.9769490Z 	at io.quarkus.bootstrap.resolver.BootstrapAppModelResolver.resolveManagedModel(BootstrapAppModelResolver.java:238)
2026-01-07T01:12:50.9770554Z 	at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModelForWorkspace(BootstrapAppModelFactory.java:259)
2026-01-07T01:12:50.9771215Z 	... 4 more
```
