### PR TITLE
Fix a scope double-encoding issue in KeycloakTestClient

### DIFF
--- a/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/OidcMtlsEndpoint.java
+++ b/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/OidcMtlsEndpoint.java
@@ -54,6 +54,7 @@ public class OidcMtlsEndpoint {
         return "Identities: " + cred.getSubjectX500Principal().getName().split(",")[0] + ", "
                 + accessToken.getName() + "; "
                 + "Client: " + accessToken.getClaim("azp") + "; "
+                + "Scope: " + accessToken.getClaim("scope") + "; "
                 + "JWT cert thumbprint: " + isJwtTokenThumbprintAvailable() + ", "
                 + "introspection cert thumbprint: " + isIntrospectionThumbprintAvailable();
     }

--- a/integration-tests/oidc-mtls/src/main/resources/quarkus-realm.json
+++ b/integration-tests/oidc-mtls/src/main/resources/quarkus-realm.json
@@ -589,7 +589,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     },
     {
@@ -643,7 +643,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     },
     {
@@ -683,7 +683,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     },
     {
@@ -786,7 +786,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     },
     {
@@ -896,7 +896,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     },
     {
@@ -937,7 +937,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     },
     {
@@ -976,7 +976,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     },
     {
@@ -1040,7 +1040,7 @@
         "address",
         "phone",
         "offline_access",
-        "microprofile-jwt"
+        "microprofile:jwt"
       ]
     }
   ],
@@ -1249,7 +1249,7 @@
     },
     {
       "id": "55621a1e-cd6b-45a7-9f06-a678e0801b9c",
-      "name": "microprofile-jwt",
+      "name": "microprofile:jwt",
       "description": "Microprofile - JWT built-in scope",
       "protocol": "openid-connect",
       "attributes": {
@@ -1604,7 +1604,7 @@
   "defaultOptionalClientScopes": [
     "address",
     "phone",
-    "microprofile-jwt",
+    "microprofile:jwt",
     "offline_access"
   ],
   "browserSecurityHeaders": {

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
@@ -6,8 +6,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -286,7 +284,7 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
             requestSpec = requestSpec.param("client_secret", clientSecret);
         }
         if (scopes != null && !scopes.isEmpty()) {
-            requestSpec = requestSpec.param("scope", urlEncode(String.join(" ", scopes)));
+            requestSpec = requestSpec.param("scope", String.join(" ", scopes));
         }
         return requestSpec.when().post(authServerUrl + "/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class);
@@ -300,7 +298,7 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
             requestSpec = requestSpec.param("client_secret", clientSecret);
         }
         if (scopes != null && !scopes.isEmpty()) {
-            requestSpec = requestSpec.param("scope", urlEncode(String.join(" ", scopes)));
+            requestSpec = requestSpec.param("scope", String.join(" ", scopes));
         }
         return requestSpec.when().post(authServerUrl + "/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class).getToken();
@@ -429,14 +427,6 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
     @Override
     public void setIntegrationTestContext(DevServicesContext context) {
         this.testContext = context;
-    }
-
-    private static String urlEncode(String value) {
-        try {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
     }
 
     private RequestSpecification getSpec() {


### PR DESCRIPTION
Fixes #51824.

RestAssured URL encodes form param values itself, so there is no need to URL encode a form param `scope` in `KeycloakTestClient`