### PR TITLE
Allow generation of Java 25 based projects

### DIFF
--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -438,6 +438,22 @@ public class CliProjectGradleTest {
                 "Java 21 should be used when specified. Found:\n" + buildGradleContent);
     }
 
+    @Test
+    public void testCreateArgJava25() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle",
+                "-e", "-B", "--verbose",
+                "--java", "25");
+
+        // We don't need to retest this, just need to make sure all the arguments were passed through
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+
+        Path buildGradle = project.resolve("build.gradle");
+        String buildGradleContent = CliDriver.readFileAsString(buildGradle);
+
+        Assertions.assertTrue(buildGradleContent.contains("sourceCompatibility = JavaVersion.VERSION_25"),
+                "Java 25 should be used when specified. Found:\n" + buildGradleContent);
+    }
+
     String validateBasicGradleGroovyIdentifiers(Path project, String group, String artifact, String version) throws Exception {
         Path buildGradle = project.resolve("build.gradle");
         Assertions.assertTrue(buildGradle.toFile().exists(),

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
@@ -197,6 +197,21 @@ public class CliProjectJBangTest {
                 "Generated source should contain //JAVA 21. Found:\n" + source);
     }
 
+    @Test
+    public void testCreateArgJava25() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang",
+                "-e", "-B", "--verbose",
+                "--java", "25");
+
+        // We don't need to retest this, just need to make sure all the arguments were passed through
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+
+        Path javaMain = validateJBangSourcePackage(project, ""); // no package name
+        String source = CliDriver.readFileAsString(javaMain);
+        Assertions.assertTrue(source.contains("//JAVA 25"),
+                "Generated source should contain //JAVA 25. Found:\n" + source);
+    }
+
     void validateBasicIdentifiers(Path project, String group, String artifact, String version) throws Exception {
         Assertions.assertTrue(project.resolve("README.md").toFile().exists(),
                 "README.md should exist: " + project.resolve("README.md").toAbsolutePath().toString());

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -390,6 +390,22 @@ public class CliProjectMavenTest {
     }
 
     @Test
+    public void testCreateArgJava25() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app",
+                "-e", "-B", "--verbose",
+                "--java", "25");
+
+        // We don't need to retest this, just need to make sure all the arguments were passed through
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+
+        Path pom = project.resolve("pom.xml");
+        String pomContent = CliDriver.readFileAsString(pom);
+
+        Assertions.assertTrue(pomContent.contains("maven.compiler.release>25<"),
+                "Java 25 should be used when specified. Found:\n" + pomContent);
+    }
+
+    @Test
     public void testCreateNameDescription() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--name", "My name", "--description",
                 "My description");


### PR DESCRIPTION
This was primarily fixed by #51677 as we were having overlapping work, sending now rebased just to add the relevant tests.

* Fixes #51836 
