### PR TITLE
Escape generated JVM property for Surefire correctly when hinting to serialized test app model location

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -122,7 +122,8 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                             Properties properties = mavenProject().getProperties();
                             String argLine = properties.getProperty("argLine", "");
                             properties.setProperty("argLine", argLine +
-                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=" + serializedTestAppModelPath);
+                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=\"" + serializedTestAppModelPath
+                                    + "\"");
                         } catch (IOException e) {
                             getLog().warn("Failed to serialize application model", e);
                         }


### PR DESCRIPTION
* Fixes #51848 

It's trivial but I've marked it as a blocker as I believe it would break too many users. Problem was introduced in #50602 