### PR TITLE
Update Base64 encoded credentials

### DIFF
--- a/docs/src/main/asciidoc/security-basic-authentication.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication.adoc
@@ -23,7 +23,7 @@ An HTTP user agent, like a web browser, uses an `Authorization` header to provid
 The header is specified as `Authorization: Basic <credentials>`, where credentials are the Base64 encoding of the user ID and password, joined by a colon.
 
 .Example:
-If the user name is `Alice` and the password is `secret`, the HTTP authorization header would be `Authorization: Basic QWxjZTpzZWNyZXQ=`, where `QWxjZTpzZWNyZXQ=` is a Base64 encoded representation of the `Alice:secret` string.
+If the user name is `Alice` and the password is `secret`, the HTTP authorization header would be `Authorization: Basic QWxpY2U6c2VjcmV0`, where `QWxpY2U6c2VjcmV0` is a Base64 encoded representation of the `Alice:secret` string.
 
 
 The Basic authentication mechanism does not provide confidentiality protection for the transmitted credentials.


### PR DESCRIPTION
Previous value was encoded with a typo (`Alce` instead of `Alice`):

```
$ echo -n "Alce:secret" | base64
QWxjZTpzZWNyZXQ=
$ echo -n "Alice:secret" | base64
QWxpY2U6c2VjcmV0
```