### PR TITLE
Remove long deprecated method from  `IgnoreJsonDeserializeClassBuildItem`

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/IgnoreJsonDeserializeClassBuildItem.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/IgnoreJsonDeserializeClassBuildItem.java
@@ -22,11 +22,6 @@ public final class IgnoreJsonDeserializeClassBuildItem extends MultiBuildItem {
         this.dotNames = dotNames;
     }
 
-    @Deprecated(forRemoval = true)
-    public DotName getDotName() {
-        return dotNames.size() > 0 ? dotNames.get(0) : null;
-    }
-
     public List<DotName> getDotNames() {
         return dotNames;
     }


### PR DESCRIPTION
The method was deprecated in 2022