### PR TITLE
Extend NativeAgentIT to cover the manual registration of `Carol`

### DIFF
--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/GreetingResourceIT.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/GreetingResourceIT.java
@@ -1,8 +1,29 @@
 package org.acme;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusIntegrationTest
 public class GreetingResourceIT extends GreetingResourceTest {
-    // Execute the same tests but in packaged mode.
+    // Execute the same tests but in packaged mode, plus a native-image specific one.
+
+    @DisabledIfSystemProperty(
+            named = "quarkus.test.integration-test-profile",
+            matches = "test-with-native-agent",
+            disabledReason = "Keep org.acme.Carol unreachable to prevent the agent from detecting the access. This way we ensure that both the manual configuration and the generated one are used by GraalVM."
+    )
+    @Test
+    public void testCarol()
+    {
+        given()
+                .when().get("/hello/Carol")
+                .then()
+                .statusCode(200)
+                .body(is("Hello Carol"));
+    }
+
 }


### PR DESCRIPTION
The tests correctly avoid making `org.acme.Carol` reachable, thus making
it impossible for the native image agent to detect the access and
automatically register the class for reflection. They also correctly
annotate the `org.acme.Carol` class with `@RegisterForReflection`, but
till now there was no test to ensure that the Quarkus generated `Carol`
registration was respected.

The new test ensures this is also checked by only accessing `Carol` when
running the test and not during the native-image agent run.
