### PR TITLE
Better handling for null or empty authority

### DIFF
--- a/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/rest-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -55,6 +55,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.ext.web.RoutingContext;
 
@@ -86,10 +87,12 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
         exchange.addResponseCommitListener(this);
     }
 
+    @Override
     protected boolean isRequestScopeManagementRequired() {
         return asyncContext != null;
     }
 
+    @Override
     protected void beginAsyncProcessing() {
         asyncContext = request.startAsync();
     }
@@ -132,6 +135,7 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
         }
     }
 
+    @Override
     protected void handleRequestScopeActivation() {
         super.handleRequestScopeActivation();
         QuarkusHttpUser user = (QuarkusHttpUser) context.user();
@@ -157,6 +161,7 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
         return Arc.container().beanManager().getEvent().select(SecurityIdentity.class);
     }
 
+    @Override
     protected SecurityContext createSecurityContext() {
         return new ResteasyReactiveSecurityContext(context);
     }
@@ -248,8 +253,16 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
     }
 
     @Override
-    public String getRequestHost() {
-        return context.request().authority().toString();
+    public String getRequestHostAndPort() {
+        HostAndPort authority = context.request().authority();
+        if (authority == null) {
+            return null;
+        }
+        if (authority.port() >= 0) {
+            return authority.host() + ':' + authority.port();
+        } else {
+            return authority.host();
+        }
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -542,7 +542,7 @@ public abstract class ResteasyReactiveRequestContext
 
     public String getAuthority() {
         if (authority == null) {
-            return serverRequest().getRequestHost();
+            return serverRequest().getRequestHostAndPort();
         }
         return authority;
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/LocationUtil.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/LocationUtil.java
@@ -29,7 +29,11 @@ final class LocationUtil {
             if (!path.startsWith("/")) {
                 path = "/" + path;
             }
-            return new URI(request.getScheme(), request.getAuthority(), null, null, null).resolve(prefix + path);
+            URI uri = new URI(request.getScheme(), request.getAuthority(), "/", null, null);
+            if (prefix.isEmpty() && path.equals("/")) {
+                return uri;
+            }
+            return uri.resolve(prefix + path);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpRequest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpRequest.java
@@ -28,7 +28,15 @@ public interface ServerHttpRequest {
 
     String getRequestScheme();
 
-    String getRequestHost();
+    /**
+     * Use {@link #getRequestHostAndPort()} instead
+     */
+    @Deprecated
+    default String getRequestHost() {
+        return getRequestHostAndPort();
+    }
+
+    String getRequestHostAndPort();
 
     void closeConnection();
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
@@ -50,7 +50,7 @@ public class ResteasyReactiveRequestContextTest {
         };
         Mockito.when(request.getRequestNormalisedPath()).thenReturn("/path;a");
         Mockito.when(request.getRequestScheme()).thenReturn("http");
-        Mockito.when(request.getRequestHost()).thenReturn("host:port");
+        Mockito.when(request.getRequestHostAndPort()).thenReturn("host:port");
 
         context.initPathSegments();
         assertEquals("http://host:port/path", context.getAbsoluteURI());

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/LocationUtilTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/LocationUtilTest.java
@@ -1,0 +1,37 @@
+package org.jboss.resteasy.reactive.server.jaxrs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URISyntaxException;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class LocationUtilTest {
+
+    static ResteasyReactiveRequestContext mockContext(String authority) {
+        var context = Mockito.mock(ResteasyReactiveRequestContext.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(context.getScheme()).thenReturn("https");
+        Mockito.when(context.getAuthority()).thenReturn(authority);
+        Mockito.when(context.getDeployment().getPrefix()).thenReturn("/prefix");
+        return context;
+    }
+
+    @Test
+    public void uriWithEmtpyAuthority() {
+        assertEquals("https:///", LocationUtil.getUri("", mockContext(""), false).toString());
+    }
+
+    @Test
+    public void uriWithRelativeUri() throws URISyntaxException {
+        assertEquals("https://host:999/prefix/a?b",
+                LocationUtil.getUri("a?b", mockContext("host:999"), true).toString());
+    }
+
+    @Test
+    public void uriWithNullAuthority() {
+        assertEquals("https:/", LocationUtil.getUri("", mockContext(null), false).toString());
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImplTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImplTest.java
@@ -7,18 +7,13 @@ import java.net.URI;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
-import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class ResponseBuilderImplTest {
 
     @Test
     public void shouldBuildWithNonAbsoulteLocationAndIPv6Address() {
-        var context = Mockito.mock(ResteasyReactiveRequestContext.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(context.getScheme()).thenReturn("https");
-        Mockito.when(context.getAuthority()).thenReturn("[0:0:0:0:0:0:0:1]");
-        Mockito.when(context.getDeployment().getPrefix()).thenReturn("/prefix");
+        var context = LocationUtilTest.mockContext("[0:0:0:0:0:0:0:1]");
         CurrentRequestManager.set(context);
         var response = ResponseBuilderImpl.ok().location(URI.create("/host")).build();
         assertEquals("https://[0:0:0:0:0:0:0:1]/prefix/host", response.getLocation().toString());

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/RestResponseBuilderImplTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/RestResponseBuilderImplTest.java
@@ -7,18 +7,13 @@ import java.net.URI;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
-import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class RestResponseBuilderImplTest {
 
     @Test
     public void shouldBuildWithNonAbsoulteLocationAndIPv6Address() {
-        var context = Mockito.mock(ResteasyReactiveRequestContext.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(context.getScheme()).thenReturn("https");
-        Mockito.when(context.getAuthority()).thenReturn("[0:0:0:0:0:0:0:1]");
-        Mockito.when(context.getDeployment().getPrefix()).thenReturn("/prefix");
+        var context = LocationUtilTest.mockContext("[0:0:0:0:0:0:0:1]");
         CurrentRequestManager.set(context);
         var response = RestResponseBuilderImpl.ok().location(URI.create("/host")).build();
         assertEquals("https://[0:0:0:0:0:0:0:1]/prefix/host", response.getLocation().toString());

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -53,6 +53,7 @@ import io.vertx.core.buffer.impl.VertxByteBufAllocator;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.impl.Http1xServerResponse;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.ext.web.RoutingContext;
 
@@ -137,6 +138,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
         return ((ConnectionBase) context.request().connection()).channel().eventLoop();
     }
 
+    @Override
     public Executor getContextExecutor() {
         return contextExecutor;
     }
@@ -204,8 +206,16 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     }
 
     @Override
-    public String getRequestHost() {
-        return request.authority().toString();
+    public String getRequestHostAndPort() {
+        HostAndPort authority = request.authority();
+        if (authority == null) {
+            return null;
+        }
+        if (authority.port() >= 0) {
+            return authority.host() + ':' + authority.port();
+        } else {
+            return authority.host();
+        }
     }
 
     @Override


### PR DESCRIPTION
http 1.0 allows for no host header, while http 1.1 allows for an empty one respectively. Several places need updated to account for those cases.

* Fixes #51845

