### PR TITLE
Make sure application root paths are normalized and absolute when bootstrapping for tests

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/AppMakerHelper.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/AppMakerHelper.java
@@ -139,8 +139,11 @@ public class AppMakerHelper {
             boolean isContinuousTesting) throws IOException, AppModelResolverException, BootstrapException {
         final PathList.Builder rootBuilder = PathList.builder();
         final Consumer<Path> addToBuilderIfConditionMet = path -> {
-            if (path != null && !rootBuilder.contains(path) && Files.exists(path)) {
-                rootBuilder.add(path);
+            if (path != null && Files.exists(path)) {
+                path = path.normalize().toAbsolutePath();
+                if (!rootBuilder.contains(path)) {
+                    rootBuilder.add(path);
+                }
             }
         };
 


### PR DESCRIPTION
There is a suspicion this may fix an issue in a CI build of a project. I couldn't reproduce it locally yet but having this change in a nightly snapshot will help test the effect of it.