### PR TITLE
Recover when OIDC Client authentication server is not available on the application startup

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/DeferredOidcClient.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/DeferredOidcClient.java
@@ -1,0 +1,83 @@
+package io.quarkus.oidc.client.runtime;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.Tokens;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * {@link OidcClient} that wraps a lazily initialized OIDC client whose OIDC metadata discovery failed on the application
+ * startup.
+ * If the discovery fails when any of the wrapped {@link OidcClient} methods is invoked, we return a {@link Uni} failure.
+ */
+final class DeferredOidcClient implements OidcClient {
+
+    private static final Logger LOG = Logger.getLogger(DeferredOidcClient.class);
+    private final Uni<OidcClient> deferredOidcClient;
+    private final String oidcClientId;
+    private volatile OidcClient resolvedOidcClient;
+
+    DeferredOidcClient(Uni<OidcClient> deferredOidcClient, String oidcClientId) {
+        this.deferredOidcClient = deferredOidcClient;
+        this.resolvedOidcClient = null;
+        this.oidcClientId = oidcClientId;
+    }
+
+    @Override
+    public Uni<Tokens> getTokens() {
+        return runWithOidcClient(OidcClient::getTokens);
+    }
+
+    @Override
+    public Uni<Tokens> getTokens(Map<String, String> additionalGrantParameters) {
+        return runWithOidcClient(oidcClient -> oidcClient.getTokens(additionalGrantParameters));
+    }
+
+    @Override
+    public Uni<Tokens> refreshTokens(String refreshToken) {
+        return runWithOidcClient(oidcClient -> oidcClient.refreshTokens(refreshToken));
+    }
+
+    @Override
+    public Uni<Tokens> refreshTokens(String refreshToken, Map<String, String> additionalGrantParameters) {
+        return runWithOidcClient(oidcClient -> oidcClient.refreshTokens(refreshToken, additionalGrantParameters));
+    }
+
+    @Override
+    public Uni<Boolean> revokeAccessToken(String accessToken) {
+        return runWithOidcClient(oidcClient -> oidcClient.revokeAccessToken(accessToken));
+    }
+
+    @Override
+    public Uni<Boolean> revokeAccessToken(String accessToken, Map<String, String> additionalParameters) {
+        return runWithOidcClient(oidcClient -> oidcClient.revokeAccessToken(accessToken, additionalParameters));
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (resolvedOidcClient != null) {
+            resolvedOidcClient.close();
+        }
+    }
+
+    OidcClient getResolvedOidcClient() {
+        return resolvedOidcClient;
+    }
+
+    private <T> Uni<T> runWithOidcClient(Function<OidcClient, Uni<T>> action) {
+        if (resolvedOidcClient != null) {
+            return action.apply(resolvedOidcClient);
+        }
+
+        return deferredOidcClient.flatMap(oidcClient -> {
+            DeferredOidcClient.this.resolvedOidcClient = oidcClient;
+            LOG.debugf("OIDC client '%s' metadata discovery succeeded", oidcClientId);
+            return action.apply(oidcClient);
+        });
+    }
+}

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -151,3 +151,10 @@ quarkus.oidc-client.disabled-client.auth-server-url=${keycloak.url}
 quarkus.oidc-client.disabled-client.client-id=quarkus-app
 quarkus.oidc-client.disabled-client.client-enabled=false
 quarkus.oidc-client.disabled-client.client-name=Disabled client
+# client pointing to unknown server
+quarkus.oidc-client.not-ready-client.auth-server-url=http://localhost:1/auth/realms/discovery/
+quarkus.oidc-client.not-ready-client.client-id=quarkus-app
+quarkus.oidc-client.not-ready-client.grant.type=password
+quarkus.oidc-client.not-ready-client.grant-options.password.username=alice
+quarkus.oidc-client.not-ready-client.grant-options.password.password=alice
+quarkus.oidc-client.not-ready-client.client-name=Client with status not ready

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -345,6 +345,7 @@ public class OidcClientTest {
         assertEquals("OK", data.getString("Client with enabled discovery"));
         assertEquals("Error", data.getString("Client with error status"));
         assertEquals("Disabled", data.getString("Disabled client"));
+        assertEquals("Not Ready", data.getString("Client with status not ready"));
     }
 
     private void checkLog() {


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/39293
* If the OIDC Client authentication server is not available on startup, we re-try when the OIDC client is actually used

