### PR TITLE
Apply security filters in generated reflection-free Jackson serializers only when security is actually enabled

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -279,7 +279,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 if (fieldSpecs.hasUnknownAnnotation()) {
                     return false;
                 }
-                writeField(classInfo, fieldSpecs, writeFieldBranch(classCreator, serialize, fieldSpecs), ctx);
+                writeField(classInfo, fieldSpecs, writeFieldBranch(classCreator, serialize, fieldSpecs, ctx), ctx);
             }
         }
         return true;
@@ -393,7 +393,8 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         };
     }
 
-    private BytecodeCreator writeFieldBranch(ClassCreator classCreator, MethodCreator serialize, FieldSpecs fieldSpecs) {
+    private BytecodeCreator writeFieldBranch(ClassCreator classCreator, MethodCreator serialize, FieldSpecs fieldSpecs,
+            SerializationContext ctx) {
         String[] rolesAllowed = fieldSpecs.rolesAllowed();
         if (rolesAllowed != null) {
             MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC);
@@ -413,8 +414,8 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                             String[].class.getName()));
 
             MethodDescriptor includeSecureField = MethodDescriptor.ofMethod(JacksonMapperUtil.class, "includeSecureField",
-                    boolean.class, String[].class);
-            ResultHandle included = serialize.invokeStaticMethod(includeSecureField, rolesArrayReader);
+                    boolean.class, SerializerProvider.class, String[].class);
+            ResultHandle included = serialize.invokeStaticMethod(includeSecureField, ctx.serializerProvider, rolesArrayReader);
             return serialize.ifTrue(included).trueBranch();
         }
         return serialize;

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -24,6 +24,10 @@ import io.quarkus.security.identity.SecurityIdentity;
 
 public class JacksonMapperUtil {
 
+    public static boolean includeSecureField(SerializerProvider serializerProvider, String[] rolesAllowed) {
+        return serializerProvider.getConfig().getFilterProvider() == null || includeSecureField(rolesAllowed);
+    }
+
     public static boolean includeSecureField(String[] rolesAllowed) {
         SecurityIdentity securityIdentity = RolesAllowedHolder.SECURITY_IDENTITY;
         if (securityIdentity == null) {
@@ -122,7 +126,7 @@ public class JacksonMapperUtil {
 
     public static void serializePojo(Object value, JsonGenerator generator, SerializerProvider serializerProvider)
             throws IOException {
-        if (value == null || value instanceof Map || value instanceof Iterable) {
+        if (value == null || value instanceof Map) {
             generator.writePOJO(value);
             return;
         }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

