### PR TITLE
Infinispan: Add JFR support for remote cache operations

### DIFF
--- a/docs/src/main/asciidoc/jfr.adoc
+++ b/docs/src/main/asciidoc/jfr.adoc
@@ -267,6 +267,54 @@ Extension::
 
   Records information about extensions included in the running Quarkus. This event includes the name of the extensions installed in Quarkus.
 
+=== Infinispan RemoteCache events
+
+When the `infinispan-client` extension is present, Quarkus emits JFR events for methods executed on Infinispan `RemoteCache`.
+There are nine event types, grouped by scope (single-entry, multi-entry, cache-wide) and by type (start, period, end).
+These events help you analyze the latency and behavior of remote cache access in your application.
+
+`quarkus.infinispanSingleEntry`::
+A duration event for a single-entry `RemoteCache` operation
+
+`quarkus.infinispanSingleEntryStart`::
+A point-in-time event emitted when a single-entry `RemoteCache` operation starts (disabled by default)
+
+`quarkus.infinispanSingleEntryEnd`::
+A point-in-time event emitted when a single-entry `RemoteCache` operation completes (disabled by default)
+
+`quarkus.infinispanMultiEntry`::
+A duration event for a multi-entry `RemoteCache` operation, such as `putAll` or `getAll`
+
+`quarkus.infinispanMultiEntryStart`::
+A point-in-time event emitted when a multi-entry `RemoteCache` operation starts (disabled by default)
+
+`quarkus.infinispanMultiEntryEnd`::
+A point-in-time event emitted when a multi-entry `RemoteCache` operation completes (disabled by default)
+
+`quarkus.infinispanCacheWide`::
+A duration event for a cache-wide `RemoteCache` operation, such as `clear` or `size`
+
+`quarkus.infinispanCacheWideStart`::
+A point-in-time event emitted when a cache-wide `RemoteCache` operation starts (disabled by default)
+
+`quarkus.infinispanCacheWideEnd`::
+A point-in-time event emitted when a cache-wide `RemoteCache` operation completes (disabled by default)
+
+All `RemoteCache` events contain:
+
+- Method name
+- Cache name
+- Cluster name
+
+Multi-entry events also contain:
+
+- Entry count
+
+Method name is the invoked `RemoteCache` method (for example, `get`, `put`, or `remove`).
+Cache name is the name of the remote cache.
+Cluster name is the name of the cluster that hosts the remote cache.
+Entry count is the number of keys or entries targeted by the multi-entry operation.
+
 === Native Image
 
 Native executables supports JDK Flight Recorder.
@@ -442,4 +490,4 @@ public class NewInterceptor {
 
 == Configuration Reference
 
-include::{generated-dir}/config/quarkus-jfr.adoc[leveloffset=+1, opts=optional]
+include::{generated-dir}/config/quarkus-jfr-api.adoc[leveloffset=+1, opts=optional]

--- a/extensions/infinispan-client/deployment/pom.xml
+++ b/extensions/infinispan-client/deployment/pom.xml
@@ -77,6 +77,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jfr-deployment-spi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>testcontainers-infinispan</artifactId>
             <exclusions>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -45,6 +45,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jfr-api</artifactId>
+        </dependency>
         <!-- Will allow projects to run annotation processor -->
         <dependency>
             <groupId>org.infinispan.protostream</groupId>

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AbstractCacheOperationInterceptor.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AbstractCacheOperationInterceptor.java
@@ -1,0 +1,91 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+import org.infinispan.client.hotrod.RemoteCache;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.InfinispanEventRecorder;
+import io.quarkus.jfr.api.IdProducer;
+
+public abstract class AbstractCacheOperationInterceptor {
+
+    @Inject
+    IdProducer idProducer;
+
+    @AroundInvoke
+    Object aroundInvoke(InvocationContext context) throws Exception {
+        InfinispanEventRecorder eventRecorder = createEventRecorder(context, idProducer);
+        eventRecorder.createAndCommitStartEvent().createPeriodEvent();
+        return invoke(context, eventRecorder);
+    }
+
+    abstract InfinispanEventRecorder createEventRecorder(InvocationContext context, IdProducer idProducer);
+
+    abstract Object invoke(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception;
+
+    protected InfinispanEventRecorder createSingleEntryEventRecorder(InvocationContext context, IdProducer idProducer) {
+        String traceId = idProducer.getTraceId();
+        String spanId = idProducer.getSpanId();
+        RemoteCache remoteCache = (RemoteCache) context.getTarget();
+        String cacheName = remoteCache.getName();
+        String clusterName = remoteCache.getRemoteCacheContainer().getCurrentClusterName();
+        Method method = context.getMethod();
+        String methodName = method.getName();
+        return InfinispanEventRecorder.createSingleEntryEventRecorder(traceId, spanId, methodName, cacheName, clusterName);
+    }
+
+    protected InfinispanEventRecorder createMultiEntryEventRecorder(InvocationContext context, IdProducer idProducer) {
+        String traceId = idProducer.getTraceId();
+        String spanId = idProducer.getSpanId();
+        RemoteCache remoteCache = (RemoteCache) context.getTarget();
+        String cacheName = remoteCache.getName();
+        String clusterName = remoteCache.getRemoteCacheContainer().getCurrentClusterName();
+        Method method = context.getMethod();
+        String methodName = method.getName();
+        Collection allParams = (Collection) context.getParameters()[0];
+        int size = allParams.size();
+        return InfinispanEventRecorder.createMultiEntryEventRecorder(traceId, spanId, methodName, cacheName, clusterName, size);
+    }
+
+    protected InfinispanEventRecorder createCacheWideEventRecorder(InvocationContext context, IdProducer idProducer) {
+        String traceId = idProducer.getTraceId();
+        String spanId = idProducer.getSpanId();
+        RemoteCache remoteCache = (RemoteCache) context.getTarget();
+        String cacheName = remoteCache.getName();
+        String clusterName = remoteCache.getRemoteCacheContainer().getCurrentClusterName();
+        Method method = context.getMethod();
+        String methodName = method.getName();
+        return InfinispanEventRecorder.createCacheWideEventRecorder(traceId, spanId, methodName, cacheName, clusterName);
+    }
+
+    protected Object invokeSync(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        try {
+            return context.proceed();
+        } finally {
+            eventRecorder.commitPeriodEvent().createAndCommitEndEvent();
+        }
+    }
+
+    protected Object invokeAsync(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        return ((CompletableFuture<?>) (context.proceed())).whenComplete(new AsyncEventEndHandler(eventRecorder));
+    }
+
+    record AsyncEventEndHandler(InfinispanEventRecorder eventRecorder) implements BiConsumer<Object, Throwable> {
+
+        @Override
+        public void accept(Object result, Throwable throwable) {
+            eventRecorder.commitPeriodEvent().createAndCommitEndEvent();
+
+            if (throwable != null) {
+                throw new RuntimeException(throwable);
+            }
+        }
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AsyncCacheWideInterceptor.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AsyncCacheWideInterceptor.java
@@ -1,0 +1,27 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.ASYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.Scope.CACHE_WIDE;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.InfinispanEventRecorder;
+import io.quarkus.jfr.api.IdProducer;
+
+@JfrCacheOperation(executionMode = ASYNC, scope = CACHE_WIDE)
+@Interceptor
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+public class AsyncCacheWideInterceptor extends AbstractCacheOperationInterceptor {
+
+    @Override
+    InfinispanEventRecorder createEventRecorder(InvocationContext context, IdProducer idProducer) {
+        return super.createCacheWideEventRecorder(context, idProducer);
+    }
+
+    @Override
+    Object invoke(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        return invokeAsync(context, eventRecorder);
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AsyncMultiEntryInterceptor.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AsyncMultiEntryInterceptor.java
@@ -1,0 +1,27 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.ASYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.Scope.MULTI;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.InfinispanEventRecorder;
+import io.quarkus.jfr.api.IdProducer;
+
+@JfrCacheOperation(executionMode = ASYNC, scope = MULTI)
+@Interceptor
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+public class AsyncMultiEntryInterceptor extends AbstractCacheOperationInterceptor {
+
+    @Override
+    InfinispanEventRecorder createEventRecorder(InvocationContext context, IdProducer idProducer) {
+        return createMultiEntryEventRecorder(context, idProducer);
+    }
+
+    @Override
+    Object invoke(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        return invokeAsync(context, eventRecorder);
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AsyncSingleEntryInterceptor.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/AsyncSingleEntryInterceptor.java
@@ -1,0 +1,27 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.ASYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.Scope.SINGLE;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.InfinispanEventRecorder;
+import io.quarkus.jfr.api.IdProducer;
+
+@JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+@Interceptor
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+public class AsyncSingleEntryInterceptor extends AbstractCacheOperationInterceptor {
+
+    @Override
+    InfinispanEventRecorder createEventRecorder(InvocationContext context, IdProducer idProducer) {
+        return super.createSingleEntryEventRecorder(context, idProducer);
+    }
+
+    @Override
+    Object invoke(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        return invokeAsync(context, eventRecorder);
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/JfrCacheOperation.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/JfrCacheOperation.java
@@ -1,0 +1,30 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface JfrCacheOperation {
+
+    ExecutionMode executionMode();
+
+    Scope scope();
+
+    enum ExecutionMode {
+        SYNC,
+        ASYNC
+    }
+
+    enum Scope {
+        SINGLE,
+        MULTI,
+        CACHE_WIDE
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/JfrInfinispanBean.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/JfrInfinispanBean.java
@@ -1,0 +1,54 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.*;
+import io.quarkus.jfr.api.config.JfrRuntimeConfig;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import jdk.jfr.FlightRecorder;
+
+@ApplicationScoped
+public class JfrInfinispanBean {
+
+    @Inject
+    JfrRuntimeConfig jfrRuntimeConfig;
+
+    public void enable() {
+        FlightRecorder.register(SingleEntryPeriodEvent.class);
+        FlightRecorder.register(SingleEntryStartEvent.class);
+        FlightRecorder.register(SingleEntryEndEvent.class);
+        FlightRecorder.register(MultiEntryPeriodEvent.class);
+        FlightRecorder.register(MultiEntryStartEvent.class);
+        FlightRecorder.register(MultiEntryEndEvent.class);
+        FlightRecorder.register(CacheWidePeriodEvent.class);
+        FlightRecorder.register(CacheWideStartEvent.class);
+        FlightRecorder.register(CacheWideEndEvent.class);
+    }
+
+    public void disable() {
+        FlightRecorder.unregister(SingleEntryPeriodEvent.class);
+        FlightRecorder.unregister(SingleEntryStartEvent.class);
+        FlightRecorder.unregister(SingleEntryEndEvent.class);
+        FlightRecorder.unregister(MultiEntryPeriodEvent.class);
+        FlightRecorder.unregister(MultiEntryStartEvent.class);
+        FlightRecorder.unregister(MultiEntryEndEvent.class);
+        FlightRecorder.unregister(CacheWidePeriodEvent.class);
+        FlightRecorder.unregister(CacheWideStartEvent.class);
+        FlightRecorder.unregister(CacheWideEndEvent.class);
+    }
+
+    public void onStart(@Observes StartupEvent event) {
+        if (jfrRuntimeConfig.infinispanEnabled()) {
+            enable();
+        }
+    }
+
+    public void onStop(@Observes ShutdownEvent event) {
+        if (jfrRuntimeConfig.infinispanEnabled()) {
+            disable();
+        }
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/JfrRemoteCacheWrapper.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/JfrRemoteCacheWrapper.java
@@ -1,0 +1,802 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.ASYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.SYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.Scope.*;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import jakarta.transaction.TransactionManager;
+
+import org.infinispan.client.hotrod.*;
+import org.infinispan.client.hotrod.jmx.RemoteCacheClientStatisticsMXBean;
+import org.infinispan.commons.api.query.ContinuousQuery;
+import org.infinispan.commons.api.query.Query;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorCollection;
+import org.infinispan.commons.util.CloseableIteratorSet;
+import org.infinispan.commons.util.IntSet;
+import org.reactivestreams.Publisher;
+
+public class JfrRemoteCacheWrapper<K, V> implements RemoteCache<K, V> {
+
+    public JfrRemoteCacheWrapper(RemoteCache<K, V> delegate) {
+        this.delegate = delegate;
+    }
+
+    RemoteCache<K, V> delegate;
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean removeWithVersion(K key, long version) {
+        return delegate.removeWithVersion(key, version);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V remove(Object key) {
+        return delegate.remove(key);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean remove(Object key, Object value) {
+        return delegate.remove(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        return delegate.replace(key, oldValue, newValue);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean replace(K key, V oldValue, V value, long lifespan, TimeUnit unit) {
+        return delegate.replace(key, oldValue, value, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean replace(K key, V oldValue, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime,
+            TimeUnit maxIdleTimeUnit) {
+        return delegate.replace(key, oldValue, value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> removeWithVersionAsync(K key, long version) {
+        return delegate.removeWithVersionAsync(key, version);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean replaceWithVersion(K key, V newValue, long version) {
+        return delegate.replaceWithVersion(key, newValue, version);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds) {
+        return delegate.replaceWithVersion(key, newValue, version, lifespanSeconds);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds, int maxIdleTimeSeconds) {
+        return delegate.replaceWithVersion(key, newValue, version, lifespanSeconds, maxIdleTimeSeconds);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean replaceWithVersion(K key, V newValue, long version, long lifespan, TimeUnit lifespanTimeUnit, long maxIdle,
+            TimeUnit maxIdleTimeUnit) {
+        return delegate.replaceWithVersion(key, newValue, version, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> replaceWithVersionAsync(K key, V newValue, long version) {
+        return delegate.replaceWithVersionAsync(key, newValue, version);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> replaceWithVersionAsync(K key, V newValue, long version, int lifespanSeconds) {
+        return delegate.replaceWithVersionAsync(key, newValue, version, lifespanSeconds);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> replaceWithVersionAsync(K key, V newValue, long version, int lifespanSeconds,
+            int maxIdleSeconds) {
+        return delegate.replaceWithVersionAsync(key, newValue, version, lifespanSeconds, maxIdleSeconds);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> replaceWithVersionAsync(K key, V newValue, long version, long lifespanSeconds,
+            TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
+        return delegate.replaceWithVersionAsync(key, newValue, version, lifespanSeconds, lifespanTimeUnit, maxIdle,
+                maxIdleTimeUnit);
+    }
+
+    @Override
+    public CloseableIterator<Entry<Object, Object>> retrieveEntries(String filterConverterFactory, Set<Integer> segments,
+            int batchSize) {
+        return delegate.retrieveEntries(filterConverterFactory, segments, batchSize);
+    }
+
+    @Override
+    public CloseableIterator<Entry<Object, Object>> retrieveEntries(String filterConverterFactory,
+            Object[] filterConverterParams, Set<Integer> segments, int batchSize) {
+        return delegate.retrieveEntries(filterConverterFactory, filterConverterParams, segments, batchSize);
+    }
+
+    @Override
+    public <E> Publisher<Entry<K, E>> publishEntries(String filterConverterFactory, Object[] filterConverterParams,
+            Set<Integer> segments, int batchSize) {
+        return delegate.publishEntries(filterConverterFactory, filterConverterParams, segments, batchSize);
+    }
+
+    @Override
+    public CloseableIterator<Entry<Object, Object>> retrieveEntries(String filterConverterFactory, int batchSize) {
+        return delegate.retrieveEntries(filterConverterFactory, batchSize);
+    }
+
+    @Override
+    public CloseableIterator<Entry<Object, Object>> retrieveEntriesByQuery(Query<?> filterQuery, Set<Integer> segments,
+            int batchSize) {
+        return delegate.retrieveEntriesByQuery(filterQuery, segments, batchSize);
+    }
+
+    @Override
+    public <E> Publisher<Entry<K, E>> publishEntriesByQuery(Query<?> filterQuery, Set<Integer> segments, int batchSize) {
+        return delegate.publishEntriesByQuery(filterQuery, segments, batchSize);
+    }
+
+    @Override
+    public CloseableIterator<Entry<Object, MetadataValue<Object>>> retrieveEntriesWithMetadata(Set<Integer> segments,
+            int batchSize) {
+        return delegate.retrieveEntriesWithMetadata(segments, batchSize);
+    }
+
+    @Override
+    public Publisher<Entry<K, MetadataValue<V>>> publishEntriesWithMetadata(Set<Integer> segments, int batchSize) {
+        return delegate.publishEntriesWithMetadata(segments, batchSize);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public MetadataValue<V> getWithMetadata(K key) {
+        return delegate.getWithMetadata(key);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<MetadataValue<V>> getWithMetadataAsync(K key) {
+        return delegate.getWithMetadataAsync(key);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public CloseableIteratorSet<K> keySet() {
+        return delegate.keySet();
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public CloseableIteratorSet<K> keySet(IntSet segments) {
+        return delegate.keySet(segments);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public CloseableIteratorCollection<V> values() {
+        return delegate.values();
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public CloseableIteratorCollection<V> values(IntSet segments) {
+        return delegate.values(segments);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public CloseableIteratorSet<Entry<K, V>> entrySet() {
+        return delegate.entrySet();
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public CloseableIteratorSet<Entry<K, V>> entrySet(IntSet segments) {
+        return delegate.entrySet(segments);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = MULTI)
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map, long lifespan, TimeUnit unit) {
+        delegate.putAll(map, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = MULTI)
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map, long lifespan, TimeUnit lifespanUnit, long maxIdleTime,
+            TimeUnit maxIdleTimeUnit) {
+        delegate.putAll(map, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = MULTI)
+    @Override
+    public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data) {
+        return delegate.putAllAsync(data);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = MULTI)
+    @Override
+    public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data, long lifespan, TimeUnit unit) {
+        return delegate.putAllAsync(data, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = MULTI)
+    @Override
+    public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data, long lifespan, TimeUnit lifespanUnit,
+            long maxIdle, TimeUnit maxIdleUnit) {
+        return delegate.putAllAsync(data, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = MULTI)
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        delegate.putAll(m);
+    }
+
+    @Override
+    public RemoteCacheClientStatisticsMXBean clientStatistics() {
+        return delegate.clientStatistics();
+    }
+
+    @Override
+    public ServerStatistics serverStatistics() {
+        return delegate.serverStatistics();
+    }
+
+    @Override
+    public CompletionStage<ServerStatistics> serverStatisticsAsync() {
+        return delegate.serverStatisticsAsync();
+    }
+
+    @Override
+    public RemoteCache<K, V> withFlags(Flag... flags) {
+        return delegate.withFlags(flags);
+    }
+
+    @Override
+    public RemoteCache<K, V> noFlags() {
+        return delegate.noFlags();
+    }
+
+    @Override
+    public Set<Flag> flags() {
+        return delegate.flags();
+    }
+
+    @Override
+    public RemoteCacheContainer getRemoteCacheContainer() {
+        return delegate.getRemoteCacheContainer();
+    }
+
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
+    @Override
+    public RemoteCacheManager getRemoteCacheManager() {
+        return delegate.getRemoteCacheManager();
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = MULTI)
+    @Override
+    public Map<K, V> getAll(Set<? extends K> keys) {
+        return delegate.getAll(keys);
+    }
+
+    @Override
+    public String getProtocolVersion() {
+        return delegate.getProtocolVersion();
+    }
+
+    @Override
+    public void addClientListener(Object listener) {
+        delegate.addClientListener(listener);
+    }
+
+    @Override
+    public void addClientListener(Object listener, Object[] filterFactoryParams, Object[] converterFactoryParams) {
+        delegate.addClientListener(listener, filterFactoryParams, converterFactoryParams);
+    }
+
+    @Override
+    public void removeClientListener(Object listener) {
+        delegate.removeClientListener(listener);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public <T> T execute(String taskName) {
+        return delegate.execute(taskName);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public <T> T execute(String taskName, Map<String, ?> params) {
+        return delegate.execute(taskName, params);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public <T> T execute(String taskName, Map<String, ?> params, Object key) {
+        return delegate.execute(taskName, params, key);
+    }
+
+    @Override
+    public CacheTopologyInfo getCacheTopologyInfo() {
+        return delegate.getCacheTopologyInfo();
+    }
+
+    @Override
+    public StreamingRemoteCache<K> streaming() {
+        return delegate.streaming();
+    }
+
+    @Override
+    public <T, U> RemoteCache<T, U> withDataFormat(DataFormat dataFormat) {
+        return delegate.withDataFormat(dataFormat);
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return delegate.getDataFormat();
+    }
+
+    @Override
+    public boolean isTransactional() {
+        return delegate.isTransactional();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public String getVersion() {
+        return delegate.getVersion();
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V put(K key, V value) {
+        return delegate.put(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V put(K key, V value, long lifespan, TimeUnit unit) {
+        return delegate.put(key, value, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V putIfAbsent(K key, V value, long lifespan, TimeUnit unit) {
+        return delegate.putIfAbsent(key, value, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V replace(K key, V value, long lifespan, TimeUnit unit) {
+        return delegate.replace(key, value, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V put(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        return delegate.put(key, value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V putIfAbsent(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        return delegate.putIfAbsent(key, value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V replace(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        return delegate.replace(key, value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction, long lifespan,
+            TimeUnit lifespanUnit) {
+        return delegate.merge(key, value, remappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction, long lifespan,
+            TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        return delegate.merge(key, value, remappingFunction, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction, long lifespan,
+            TimeUnit lifespanUnit) {
+        return delegate.compute(key, remappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction, long lifespan,
+            TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        return delegate.compute(key, remappingFunction, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction, long lifespan,
+            TimeUnit lifespanUnit) {
+        return delegate.computeIfPresent(key, remappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction, long lifespan,
+            TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        return delegate.computeIfPresent(key, remappingFunction, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction, long lifespan, TimeUnit lifespanUnit) {
+        return delegate.computeIfAbsent(key, mappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction, long lifespan, TimeUnit lifespanUnit,
+            long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        return delegate.computeIfAbsent(key, mappingFunction, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+    }
+
+    @Override
+    public <T> org.infinispan.commons.api.query.Query<T> query(String query) {
+        return delegate.query(query);
+    }
+
+    @Override
+    public ContinuousQuery<K, V> continuousQuery() {
+        return delegate.continuousQuery();
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> putAsync(K key, V value) {
+        return delegate.putAsync(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> putAsync(K key, V value, long lifespan, TimeUnit unit) {
+        return delegate.putAsync(key, value, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> putAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle,
+            TimeUnit maxIdleUnit) {
+        return delegate.putAsync(key, value, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = CACHE_WIDE)
+    @Override
+    public CompletableFuture<Void> clearAsync() {
+        return delegate.clearAsync();
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Long> sizeAsync() {
+        return delegate.sizeAsync();
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> putIfAbsentAsync(K key, V value) {
+        return delegate.putIfAbsentAsync(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit unit) {
+        return delegate.putIfAbsentAsync(key, value, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle,
+            TimeUnit maxIdleUnit) {
+        return delegate.putIfAbsentAsync(key, value, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> removeAsync(Object key) {
+        return delegate.removeAsync(key);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> removeAsync(Object key, Object value) {
+        return delegate.removeAsync(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> replaceAsync(K key, V value) {
+        return delegate.replaceAsync(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> replaceAsync(K key, V value, long lifespan, TimeUnit unit) {
+        return delegate.replaceAsync(key, value, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> replaceAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle,
+            TimeUnit maxIdleUnit) {
+        return delegate.replaceAsync(key, value, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue) {
+        return delegate.replaceAsync(key, oldValue, newValue);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue, long lifespan, TimeUnit unit) {
+        return delegate.replaceAsync(key, oldValue, newValue, lifespan, unit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue, long lifespan, TimeUnit lifespanUnit,
+            long maxIdle, TimeUnit maxIdleUnit) {
+        return delegate.replaceAsync(key, oldValue, newValue, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> getAsync(K key) {
+        return delegate.getAsync(key);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<Boolean> containsKeyAsync(K key) {
+        return delegate.containsKeyAsync(key);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = MULTI)
+    @Override
+    public CompletableFuture<Map<K, V>> getAllAsync(Set<?> keys) {
+        return delegate.getAllAsync(keys);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeAsync(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return delegate.computeAsync(key, remappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeAsync(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction,
+            long lifespan, TimeUnit lifespanUnit) {
+        return delegate.computeAsync(key, remappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeAsync(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction,
+            long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+        return delegate.computeAsync(key, remappingFunction, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeIfAbsentAsync(K key, Function<? super K, ? extends V> mappingFunction) {
+        return delegate.computeIfAbsentAsync(key, mappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeIfAbsentAsync(K key, Function<? super K, ? extends V> mappingFunction, long lifespan,
+            TimeUnit lifespanUnit) {
+        return delegate.computeIfAbsentAsync(key, mappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeIfAbsentAsync(K key, Function<? super K, ? extends V> mappingFunction, long lifespan,
+            TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+        return delegate.computeIfAbsentAsync(key, mappingFunction, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeIfPresentAsync(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return delegate.computeIfPresentAsync(key, remappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeIfPresentAsync(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction,
+            long lifespan, TimeUnit lifespanUnit) {
+        return delegate.computeIfPresentAsync(key, remappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> computeIfPresentAsync(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction,
+            long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+        return delegate.computeIfPresentAsync(key, remappingFunction, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> mergeAsync(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return delegate.mergeAsync(key, value, remappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> mergeAsync(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction,
+            long lifespan, TimeUnit lifespanUnit) {
+        return delegate.mergeAsync(key, value, remappingFunction, lifespan, lifespanUnit);
+    }
+
+    @JfrCacheOperation(executionMode = ASYNC, scope = SINGLE)
+    @Override
+    public CompletableFuture<V> mergeAsync(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction,
+            long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+        return delegate.mergeAsync(key, value, remappingFunction, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V getOrDefault(Object key, V defaultValue) {
+        return delegate.getOrDefault(key, defaultValue);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        delegate.forEach(action);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V putIfAbsent(K key, V value) {
+        return delegate.putIfAbsent(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V replace(K key, V value) {
+        return delegate.replace(key, value);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        delegate.replaceAll(function);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        return delegate.computeIfAbsent(key, mappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return delegate.computeIfPresent(key, remappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return delegate.compute(key, remappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return delegate.merge(key, value, remappingFunction);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean containsKey(Object key) {
+        return delegate.containsKey(key);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public boolean containsValue(Object value) {
+        return delegate.containsValue(value);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+    @Override
+    public V get(Object key) {
+        return delegate.get(key);
+    }
+
+    @JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public void start() {
+        delegate.start();
+    }
+
+    @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    @Override
+    public TransactionManager getTransactionManager() {
+        return delegate.getTransactionManager();
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/SyncCacheWideInterceptor.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/SyncCacheWideInterceptor.java
@@ -1,0 +1,27 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.SYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.Scope.CACHE_WIDE;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.InfinispanEventRecorder;
+import io.quarkus.jfr.api.IdProducer;
+
+@JfrCacheOperation(executionMode = SYNC, scope = CACHE_WIDE)
+@Interceptor
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+public class SyncCacheWideInterceptor extends AbstractCacheOperationInterceptor {
+
+    @Override
+    InfinispanEventRecorder createEventRecorder(InvocationContext context, IdProducer idProducer) {
+        return super.createCacheWideEventRecorder(context, idProducer);
+    }
+
+    @Override
+    Object invoke(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        return invokeSync(context, eventRecorder);
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/SyncMultiEntryInterceptor.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/SyncMultiEntryInterceptor.java
@@ -1,0 +1,27 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.SYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.Scope.MULTI;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.InfinispanEventRecorder;
+import io.quarkus.jfr.api.IdProducer;
+
+@JfrCacheOperation(executionMode = SYNC, scope = MULTI)
+@Interceptor
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+public class SyncMultiEntryInterceptor extends AbstractCacheOperationInterceptor {
+
+    @Override
+    InfinispanEventRecorder createEventRecorder(InvocationContext context, IdProducer idProducer) {
+        return super.createMultiEntryEventRecorder(context, idProducer);
+    }
+
+    @Override
+    Object invoke(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        return invokeSync(context, eventRecorder);
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/SyncSingleEntryInterceptor.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/SyncSingleEntryInterceptor.java
@@ -1,0 +1,27 @@
+package io.quarkus.infinispan.client.runtime.jfr;
+
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.ExecutionMode.SYNC;
+import static io.quarkus.infinispan.client.runtime.jfr.JfrCacheOperation.Scope.SINGLE;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.infinispan.client.runtime.jfr.event.InfinispanEventRecorder;
+import io.quarkus.jfr.api.IdProducer;
+
+@JfrCacheOperation(executionMode = SYNC, scope = SINGLE)
+@Interceptor
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+public class SyncSingleEntryInterceptor extends AbstractCacheOperationInterceptor {
+
+    @Override
+    InfinispanEventRecorder createEventRecorder(InvocationContext context, IdProducer idProducer) {
+        return super.createSingleEntryEventRecorder(context, idProducer);
+    }
+
+    @Override
+    Object invoke(InvocationContext context, InfinispanEventRecorder eventRecorder) throws Exception {
+        return invokeSync(context, eventRecorder);
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/AbstractCacheEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/AbstractCacheEvent.java
@@ -1,0 +1,32 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import io.quarkus.jfr.api.SpanIdRelational;
+import io.quarkus.jfr.api.TraceIdRelational;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+
+abstract class AbstractCacheEvent extends Event {
+
+    @Label("Trace ID")
+    @Description("Trace ID to identify the request")
+    @TraceIdRelational
+    protected String traceId;
+
+    @Label("Span ID")
+    @Description("Span ID to identify the request if necessary")
+    @SpanIdRelational
+    protected String spanId;
+
+    @Label("Method")
+    @Description("The cache API method that was invoked")
+    protected String method;
+
+    @Label("Cache Name")
+    @Description("The name of the cache")
+    protected String cacheName;
+
+    @Label("Cluster Name")
+    @Description("The name of the cluster")
+    protected String clusterName;
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/AbstractMultiEntryEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/AbstractMultiEntryEvent.java
@@ -1,0 +1,11 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+
+public class AbstractMultiEntryEvent extends AbstractCacheEvent {
+
+    @Label("Element Count")
+    @Description("The number of entries that were targeted")
+    protected int elementCount;
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/CacheWideEndEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/CacheWideEndEvent.java
@@ -1,0 +1,11 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.*;
+
+@Label("Cache-Wide Operation Completed")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanCacheWideEnd")
+@Description("A cache-wide operation completed")
+@Enabled(false)
+public class CacheWideEndEvent extends AbstractCacheEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/CacheWidePeriodEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/CacheWidePeriodEvent.java
@@ -1,0 +1,13 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Cache-Wide Operation")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanCacheWide")
+@Description("A cache-wide operation was in progress")
+public class CacheWidePeriodEvent extends AbstractCacheEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/CacheWideStartEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/CacheWideStartEvent.java
@@ -1,0 +1,11 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.*;
+
+@Label("Cache-Wide Operation Started")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanCacheWideStart")
+@Description("A cache-wide operation started")
+@Enabled(false)
+public class CacheWideStartEvent extends AbstractCacheEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/InfinispanEventRecorder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/InfinispanEventRecorder.java
@@ -1,0 +1,228 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+public sealed interface InfinispanEventRecorder permits InfinispanEventRecorder.CacheWideEventRecorder,
+        InfinispanEventRecorder.MultiEntriesEventRecorder, InfinispanEventRecorder.SingleEntryEventRecorder {
+
+    InfinispanEventRecorder createAndCommitStartEvent();
+
+    InfinispanEventRecorder createPeriodEvent();
+
+    InfinispanEventRecorder commitPeriodEvent();
+
+    InfinispanEventRecorder createAndCommitEndEvent();
+
+    static InfinispanEventRecorder createSingleEntryEventRecorder(String traceId, String spanId, String methodName,
+            String cacheName, String clusterName) {
+        return new SingleEntryEventRecorder(traceId, spanId, methodName, cacheName, clusterName);
+    }
+
+    static InfinispanEventRecorder createMultiEntryEventRecorder(String traceId, String spanId, String methodName,
+            String cacheName, String clusterName, int size) {
+        return new MultiEntriesEventRecorder(traceId, spanId, methodName, cacheName, clusterName, size);
+    }
+
+    static InfinispanEventRecorder createCacheWideEventRecorder(String traceId, String spanId, String methodName,
+            String cacheName, String clusterName) {
+        return new CacheWideEventRecorder(traceId, spanId, methodName, cacheName, clusterName);
+    }
+
+    final class SingleEntryEventRecorder implements InfinispanEventRecorder {
+
+        SingleEntryPeriodEvent periodEvent = null;
+        private final String traceId;
+        private final String spanId;
+        private final String methodName;
+        private final String cacheName;
+        private final String clusterName;
+
+        public SingleEntryEventRecorder(String traceId, String spanId, String methodName, String cacheName,
+                String clusterName) {
+            this.traceId = traceId;
+            this.spanId = spanId;
+            this.methodName = methodName;
+            this.cacheName = cacheName;
+            this.clusterName = clusterName;
+        }
+
+        @Override
+        public InfinispanEventRecorder createAndCommitStartEvent() {
+            SingleEntryStartEvent startEvent = new SingleEntryStartEvent();
+            if (startEvent.shouldCommit()) {
+                populateCacheEventInfo(startEvent);
+                startEvent.commit();
+            }
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder createPeriodEvent() {
+            periodEvent = new SingleEntryPeriodEvent();
+            periodEvent.begin();
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder commitPeriodEvent() {
+            if (periodEvent != null) {
+                periodEvent.end();
+                if (periodEvent.shouldCommit()) {
+                    populateCacheEventInfo(periodEvent);
+                    periodEvent.commit();
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder createAndCommitEndEvent() {
+            SingleEntryEndEvent endEvent = new SingleEntryEndEvent();
+            if (endEvent.shouldCommit()) {
+                populateCacheEventInfo(endEvent);
+                endEvent.commit();
+            }
+            return this;
+        }
+
+        private void populateCacheEventInfo(AbstractCacheEvent event) {
+            event.traceId = traceId;
+            event.spanId = spanId;
+            event.clusterName = clusterName;
+            event.cacheName = cacheName;
+            event.method = methodName;
+        }
+    }
+
+    final class MultiEntriesEventRecorder implements InfinispanEventRecorder {
+
+        MultiEntryPeriodEvent periodEvent = null;
+        private final String traceId;
+        private final String spanId;
+        private final String methodName;
+        private final String cacheName;
+        private final String clusterName;
+        private final int size;
+
+        public MultiEntriesEventRecorder(String traceId, String spanId, String methodName, String cacheName, String clusterName,
+                int size) {
+            this.traceId = traceId;
+            this.spanId = spanId;
+            this.methodName = methodName;
+            this.cacheName = cacheName;
+            this.clusterName = clusterName;
+            this.size = size;
+        }
+
+        @Override
+        public InfinispanEventRecorder createAndCommitStartEvent() {
+            MultiEntryStartEvent startEvent = new MultiEntryStartEvent();
+            if (startEvent.shouldCommit()) {
+                populateCacheEventInfo(startEvent);
+                startEvent.commit();
+            }
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder createPeriodEvent() {
+            periodEvent = new MultiEntryPeriodEvent();
+            periodEvent.begin();
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder commitPeriodEvent() {
+            if (periodEvent != null) {
+                periodEvent.end();
+                if (periodEvent.shouldCommit()) {
+                    populateCacheEventInfo(periodEvent);
+                    periodEvent.commit();
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder createAndCommitEndEvent() {
+            MultiEntryEndEvent endEvent = new MultiEntryEndEvent();
+            if (endEvent.shouldCommit()) {
+                populateCacheEventInfo(endEvent);
+                endEvent.commit();
+            }
+            return this;
+        }
+
+        private void populateCacheEventInfo(AbstractMultiEntryEvent event) {
+            event.traceId = traceId;
+            event.spanId = spanId;
+            event.clusterName = clusterName;
+            event.cacheName = cacheName;
+            event.method = methodName;
+            event.elementCount = size;
+        }
+    }
+
+    final class CacheWideEventRecorder implements InfinispanEventRecorder {
+
+        CacheWidePeriodEvent periodEvent = null;
+        private final String traceId;
+        private final String spanId;
+        private final String methodName;
+        private final String cacheName;
+        private final String clusterName;
+
+        public CacheWideEventRecorder(String traceId, String spanId, String methodName, String cacheName, String clusterName) {
+            this.traceId = traceId;
+            this.spanId = spanId;
+            this.methodName = methodName;
+            this.cacheName = cacheName;
+            this.clusterName = clusterName;
+        }
+
+        @Override
+        public InfinispanEventRecorder createAndCommitStartEvent() {
+            CacheWideStartEvent startEvent = new CacheWideStartEvent();
+            if (startEvent.shouldCommit()) {
+                populateCacheEventInfo(startEvent);
+                startEvent.commit();
+            }
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder createPeriodEvent() {
+            periodEvent = new CacheWidePeriodEvent();
+            periodEvent.begin();
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder commitPeriodEvent() {
+            if (periodEvent != null) {
+                periodEvent.end();
+                if (periodEvent.shouldCommit()) {
+                    populateCacheEventInfo(periodEvent);
+                    periodEvent.commit();
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public InfinispanEventRecorder createAndCommitEndEvent() {
+            CacheWideEndEvent endEvent = new CacheWideEndEvent();
+            if (endEvent.shouldCommit()) {
+                populateCacheEventInfo(endEvent);
+                endEvent.commit();
+            }
+            return this;
+        }
+
+        private void populateCacheEventInfo(AbstractCacheEvent event) {
+            event.traceId = traceId;
+            event.spanId = spanId;
+            event.clusterName = clusterName;
+            event.cacheName = cacheName;
+            event.method = methodName;
+        }
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/MultiEntryEndEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/MultiEntryEndEvent.java
@@ -1,0 +1,15 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Multi-Entry Operation Completed")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanMultiEntryEnd")
+@Description("A multi-entry cache operation completed")
+@Enabled(false)
+public class MultiEntryEndEvent extends AbstractMultiEntryEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/MultiEntryPeriodEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/MultiEntryPeriodEvent.java
@@ -1,0 +1,13 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Multi-Entry Operation")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanMultiEntry")
+@Description("A multi-entry cache operation was in progress")
+public class MultiEntryPeriodEvent extends AbstractMultiEntryEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/MultiEntryStartEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/MultiEntryStartEvent.java
@@ -1,0 +1,15 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Multi-Entry Operation Started")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanMultiEntryStart")
+@Description("A multi-entry cache operation started")
+@Enabled(false)
+public class MultiEntryStartEvent extends AbstractMultiEntryEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/SingleEntryEndEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/SingleEntryEndEvent.java
@@ -1,0 +1,15 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Single-Entry Operation Completed")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanSingleEntryEnd")
+@Description("A single-entry cache operation completed")
+@Enabled(false)
+public class SingleEntryEndEvent extends AbstractCacheEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/SingleEntryPeriodEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/SingleEntryPeriodEvent.java
@@ -1,0 +1,13 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Single-Entry Operation")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanSingleEntry")
+@Description("A single-entry cache operation was in progress")
+public class SingleEntryPeriodEvent extends AbstractCacheEvent {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/SingleEntryStartEvent.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/jfr/event/SingleEntryStartEvent.java
@@ -1,0 +1,15 @@
+package io.quarkus.infinispan.client.runtime.jfr.event;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Single-Entry Operation Started")
+@Category({ "Quarkus", "Cache" })
+@Name("quarkus.InfinispanSingleEntryStart")
+@Description("A single-entry cache operation started")
+@Enabled(false)
+public class SingleEntryStartEvent extends AbstractCacheEvent {
+}

--- a/extensions/jfr/deployment/pom.xml
+++ b/extensions/jfr/deployment/pom.xml
@@ -14,7 +14,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jfr</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/deployment/JfrConfigurationTest.java
+++ b/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/deployment/JfrConfigurationTest.java
@@ -7,7 +7,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.jfr.runtime.internal.config.JfrRuntimeConfig;
+import io.quarkus.jfr.api.config.JfrRuntimeConfig;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class JfrConfigurationTest {

--- a/extensions/jfr/runtime-api/pom.xml
+++ b/extensions/jfr/runtime-api/pom.xml
@@ -11,6 +11,12 @@
     <artifactId>quarkus-jfr-api</artifactId>
     <name>Quarkus - JFR - Runtime API</name>
     <description>API for Monitoring your applications with JDK Flight Recorder</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/extensions/jfr/runtime-api/src/main/java/io/quarkus/jfr/api/config/JfrRuntimeConfig.java
+++ b/extensions/jfr/runtime-api/src/main/java/io/quarkus/jfr/api/config/JfrRuntimeConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.jfr.runtime.internal.config;
+package io.quarkus.jfr.api.config;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -37,4 +37,14 @@ public interface JfrRuntimeConfig {
     @WithName("runtime.enabled")
     @WithDefault("true")
     boolean runtimeEnabled();
+
+    /**
+     * If false, only Infinispan events in quarkus-jfr are not recorded even if JFR is enabled.
+     * In this case, other quarkus-jfr, Java standard API and virtual machine information will be recorded according to the
+     * setting.
+     * Default value is <code>true</code>
+     */
+    @WithName("infinispan.enabled")
+    @WithDefault("true")
+    boolean infinispanEnabled();
 }

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/JfrRecorder.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/JfrRecorder.java
@@ -5,7 +5,7 @@ import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.jfr.runtime.internal.config.JfrRuntimeConfig;
+import io.quarkus.jfr.api.config.JfrRuntimeConfig;
 import io.quarkus.jfr.runtime.internal.http.rest.RestEndEvent;
 import io.quarkus.jfr.runtime.internal.http.rest.RestPeriodEvent;
 import io.quarkus.jfr.runtime.internal.http.rest.RestStartEvent;

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/runtime/JfrRuntimeBean.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/runtime/JfrRuntimeBean.java
@@ -6,7 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
-import io.quarkus.jfr.runtime.internal.config.JfrRuntimeConfig;
+import io.quarkus.jfr.api.config.JfrRuntimeConfig;
 import io.quarkus.runtime.ApplicationConfig;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;

--- a/integration-tests/jfr-blocking/noEvent.jfc
+++ b/integration-tests/jfr-blocking/noEvent.jfc
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="NoEvent" description="For test" provider="Quarkus">
+
+    <event name="quarkus.extension">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.runtime">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.application">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanSingleEntry">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanSingleEntryStart">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanSingleEntryEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanMultiEntry">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanMultiEntryStart">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanMultiEntryEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanCacheWide">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanCacheWideStart">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanCacheWideEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+</configuration>

--- a/integration-tests/jfr-blocking/pom.xml
+++ b/integration-tests/jfr-blocking/pom.xml
@@ -12,6 +12,7 @@
     <name>Quarkus - Integration Tests - JFR Blocking</name>
     <properties>
         <skipITs>true</skipITs>
+        <skipTests>true</skipTests>
     </properties>
     <dependencies>
         <dependency>
@@ -36,10 +37,49 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jfr-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -94,6 +134,18 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>test-containers</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>false</skipITs>
+                <skipTests>false</skipTests>
+            </properties>
+        </profile>
         <profile>
             <id>native-image</id>
             <activation>

--- a/integration-tests/jfr-blocking/src/test/java/io/quarkus/jfr/it/InfinispanJfrTest.java
+++ b/integration-tests/jfr-blocking/src/test/java/io/quarkus/jfr/it/InfinispanJfrTest.java
@@ -1,0 +1,133 @@
+package io.quarkus.jfr.it;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.infinispan.client.Remote;
+import io.quarkus.test.junit.QuarkusTest;
+import jdk.jfr.Configuration;
+import jdk.jfr.consumer.RecordingStream;
+
+@ActivateRequestContext
+@QuarkusTest
+public class InfinispanJfrTest {
+
+    private static final String DEFAULT_CLUSTER = "___DEFAULT-CLUSTER___";
+    private static final String DEFAULT_CACHE_NAME = "test";
+    private static final int TIMEOUT_SECONDS = 2;
+
+    @Remote(DEFAULT_CACHE_NAME)
+    @Inject
+    RemoteCache<String, String> remoteCache;
+
+    @Test
+    void testSyncSingle() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.enable("quarkus.InfinispanSingleEntry");
+            stream.enable("quarkus.InfinispanSingleEntryStart");
+            stream.enable("quarkus.InfinispanSingleEntryEnd");
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("put", e.getString("method"));
+            });
+            stream.startAsync();
+
+            remoteCache.put("key", "value");
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void testSyncAll() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.enable("quarkus.InfinispanMultiEntry");
+            stream.enable("quarkus.InfinispanMultiEntryStart");
+            stream.enable("quarkus.InfinispanMultiEntryEnd");
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("getAll", e.getString("method"));
+                Assertions.assertEquals(2, e.getInt("elementCount"));
+            });
+            stream.startAsync();
+
+            remoteCache.getAll(Set.of("key1", "key2"));
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void testCacheWide() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.enable("quarkus.InfinispanCacheWide");
+            stream.enable("quarkus.InfinispanCacheWideStart");
+            stream.enable("quarkus.InfinispanCacheWideEnd");
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("clear", e.getString("method"));
+            });
+            stream.startAsync();
+
+            remoteCache.clear();
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void testSyncException() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            stream.enable("quarkus.InfinispanSingleEntry");
+            stream.enable("quarkus.InfinispanSingleEntryStart");
+            stream.enable("quarkus.InfinispanSingleEntryEnd");
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("compute", e.getString("method"));
+            });
+            stream.startAsync();
+
+            try {
+                remoteCache.compute("key", (k, v) -> {
+                    throw new RuntimeException();
+                });
+                Assertions.fail("Expected exception");
+            } catch (RuntimeException e) {
+                // expected
+            }
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+}

--- a/integration-tests/jfr-reactive/noEvent.jfc
+++ b/integration-tests/jfr-reactive/noEvent.jfc
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="NoEvent" description="For test" provider="Quarkus">
+
+    <event name="quarkus.extension">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.runtime">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.application">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanSingleEntry">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanSingleEntryStart">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanSingleEntryEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanMultiEntry">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanMultiEntryStart">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanMultiEntryEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanCacheWide">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanCacheWideStart">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="quarkus.infinispanCacheWideEnd">
+      <setting name="enabled">false</setting>
+    </event>
+
+
+</configuration>

--- a/integration-tests/jfr-reactive/pom.xml
+++ b/integration-tests/jfr-reactive/pom.xml
@@ -12,6 +12,7 @@
     <name>Quarkus - Integration Tests - JFR Reactive</name>
     <properties>
         <skipITs>true</skipITs>
+        <skipTests>true</skipTests>
     </properties>
     <dependencies>
         <dependency>
@@ -36,10 +37,49 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jfr-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -94,6 +134,18 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>test-containers</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>false</skipITs>
+                <skipTests>false</skipTests>
+            </properties>
+        </profile>
         <profile>
             <id>native-image</id>
             <activation>

--- a/integration-tests/jfr-reactive/src/test/java/io/quarkus/jfr/it/InfinispanJfrTest.java
+++ b/integration-tests/jfr-reactive/src/test/java/io/quarkus/jfr/it/InfinispanJfrTest.java
@@ -1,0 +1,133 @@
+package io.quarkus.jfr.it;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.infinispan.client.Remote;
+import io.quarkus.test.junit.QuarkusTest;
+import jdk.jfr.Configuration;
+import jdk.jfr.consumer.RecordingStream;
+
+@ActivateRequestContext
+@QuarkusTest
+public class InfinispanJfrTest {
+
+    private static final String DEFAULT_CLUSTER = "___DEFAULT-CLUSTER___";
+    private static final String DEFAULT_CACHE_NAME = "test";
+    private static final int TIMEOUT_SECONDS = 2;
+
+    @Remote(DEFAULT_CACHE_NAME)
+    @Inject
+    RemoteCache<String, String> remoteCache;
+
+    @Test
+    void testAsyncSingle() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.enable("quarkus.InfinispanSingleEntry");
+            stream.enable("quarkus.InfinispanSingleEntryStart");
+            stream.enable("quarkus.InfinispanSingleEntryEnd");
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("putAsync", e.getString("method"));
+            });
+            stream.startAsync();
+
+            remoteCache.putAsync("key", "value");
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void testAsyncAll() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.enable("quarkus.InfinispanMultiEntry");
+            stream.enable("quarkus.InfinispanMultiEntryStart");
+            stream.enable("quarkus.InfinispanMultiEntryEnd");
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("getAllAsync", e.getString("method"));
+                Assertions.assertEquals(2, e.getInt("elementCount"));
+            });
+            stream.startAsync();
+
+            remoteCache.getAllAsync(Set.of("key1", "key2"));
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void testCacheWide() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.enable("quarkus.InfinispanCacheWide");
+            stream.enable("quarkus.InfinispanCacheWideStart");
+            stream.enable("quarkus.InfinispanCacheWideEnd");
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("clearAsync", e.getString("method"));
+            });
+            stream.startAsync();
+
+            remoteCache.clearAsync();
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void testAsyncException() throws IOException, ParseException, InterruptedException {
+        Configuration config = Configuration.create(Paths.get("./noEvent.jfc"));
+        try (RecordingStream stream = new RecordingStream(config)) {
+            stream.enable("quarkus.InfinispanSingleEntry");
+            stream.enable("quarkus.InfinispanSingleEntryStart");
+            stream.enable("quarkus.InfinispanSingleEntryEnd");
+            CountDownLatch latch = new CountDownLatch(3);
+            stream.onEvent(e -> {
+                latch.countDown();
+                Assertions.assertNotNull(e.getString("traceId"));
+                Assertions.assertEquals(DEFAULT_CACHE_NAME, e.getString("cacheName"));
+                Assertions.assertEquals(DEFAULT_CLUSTER, e.getString("clusterName"));
+                Assertions.assertEquals("computeAsync", e.getString("method"));
+            });
+            stream.startAsync();
+
+            try {
+                remoteCache.computeAsync("key", (k, v) -> {
+                    throw new RuntimeException();
+                }).join();
+                Assertions.fail("Expected exception");
+            } catch (RuntimeException e) {
+                // expected
+            }
+
+            Assertions.assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+    }
+}


### PR DESCRIPTION
This change adds JFR event emission for Infinispan RemoteCache operations (single-entry, multi-entry, and cache-wide), enabling analysis of latency and runtime behavior. For each operation, three event variants are recorded: Start (disabled by default), Duration, and End (disabled by default). Events include the method name, cache name, and cluster name (and the entry count for multi-entry operations).

The implementation wraps and intercepts cache invocations, ensuring the duration event is reliably committed at the correct completion point for both synchronous and asynchronous executions. In addition, the integration is only enabled when JFR is available, and each Infinispan event can be individually toggled on/off via runtime configuration.