### PR TITLE
Add simple dev services test

### DIFF
--- a/integration-tests/devservices/pom.xml
+++ b/integration-tests/devservices/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-devservices</artifactId>
+    <name>Quarkus - Integration Tests - Dev services</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>simple-extension</module>
+        <module>tests</module>
+    </modules>
+</project>

--- a/integration-tests/devservices/simple-extension/deployment/pom.xml
+++ b/integration-tests/devservices/simple-extension/deployment/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-test-devservices-simple-extension-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-devservices-simple-extension-deployment</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-devservices-simple-extension</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <compilerArgs>
+                                <arg>-AgenerateDoc=false</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleContainer.java
+++ b/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleContainer.java
@@ -1,0 +1,37 @@
+package io.quarkus.tests.simpleextension.deployment;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.deployment.builditem.Startable;
+
+public class SimpleContainer extends GenericContainer<io.quarkus.tests.simpleextension.deployment.SimpleContainer>
+        implements Startable {
+
+    // Normally, this would be a remote image, but we need to build one with the right mods, so use a local one
+    private static final DockerImageName dockerImageName = DockerImageName.parse("httpd");
+    public static final int HTTPD_PORT = 80;
+
+    public SimpleContainer() {
+        super(dockerImageName);
+        this //.waitingFor(Wait.forLogMessage(".*" + "resuming normal operations" + ".*", 1))
+                .withReuse(true)
+                .withExposedPorts(HTTPD_PORT);
+    }
+
+    @Override
+    public void start() {
+        super.start();
+    }
+
+    @Override
+    public String getConnectionInfo() {
+        System.out.println("HOLLY container " + "http://" + getHost() + ":" + getMappedPort(HTTPD_PORT));
+        return "http://" + getHost() + ":" + getMappedPort(HTTPD_PORT);
+    }
+
+    @Override
+    public void close() {
+        super.close();
+    }
+}

--- a/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleDevServicesProcessor.java
+++ b/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleDevServicesProcessor.java
@@ -1,0 +1,36 @@
+package io.quarkus.tests.simpleextension.deployment;
+
+import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_BASE_URL;
+import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_STATIC_THING;
+
+import java.util.Map;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+
+public class SimpleDevServicesProcessor {
+
+    private static final String FEATURE = "Basic-A";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+    public DevServicesResultBuildItem createContainer() {
+
+        return DevServicesResultBuildItem.owned()
+                .name("quarkus-Basic")
+                .serviceName(FEATURE)
+                .startable(() -> new io.quarkus.tests.simpleextension.deployment.SimpleContainer()) // Builds could be speeded up a bit by using an in-process service, but coverage is probably better with a container
+                .config(Map.of(QUARKUS_SIMPLE_EXTENSION_STATIC_THING, "some value"))
+                .configProvider(Map.of(QUARKUS_SIMPLE_EXTENSION_BASE_URL,
+                        c -> c.getConnectionInfo()))
+                .build();
+
+    }
+}

--- a/integration-tests/devservices/simple-extension/pom.xml
+++ b/integration-tests/devservices/simple-extension/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-test-devservices</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-devservices-simple-extension-parent</artifactId>
+    <name>Quarkus - Integration Tests - Dev Services - Extension A</name>
+    <packaging>pom</packaging>
+
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/integration-tests/devservices/simple-extension/runtime/pom.xml
+++ b/integration-tests/devservices/simple-extension/runtime/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-test-devservices-simple-extension-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-devservices-simple-extension</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.test-extension</provides>
+                    </capabilities>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <compilerArgs>
+                                <arg>-AgenerateDoc=false</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/integration-tests/devservices/simple-extension/runtime/src/main/java/io/quarkus/tests/simpleextension/Constants.java
+++ b/integration-tests/devservices/simple-extension/runtime/src/main/java/io/quarkus/tests/simpleextension/Constants.java
@@ -1,0 +1,7 @@
+package io.quarkus.tests.simpleextension;
+
+public class Constants {
+    public static final String QUARKUS_SIMPLE_EXTENSION_BASE_URL = "acme.simpleextension.base-url";
+    public static final String QUARKUS_SIMPLE_EXTENSION_STATIC_THING = "acme.simpleextension.static-thing";
+
+}

--- a/integration-tests/devservices/tests/pom.xml
+++ b/integration-tests/devservices/tests/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-devservices-tests</artifactId>
+    <name>Quarkus - Integration Tests - Dev Services - Tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-devservices-simple-extension</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-devservices-simple-extension-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources-filtered</directory>
+                <filtering>true</filtering>
+                <excludes>
+                    <exclude>**/target/**
+                    </exclude> <!-- Target folders sometimes creep in when manually executing locally-->
+                </excludes>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-all</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_BASE_URL;
+import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_STATIC_THING;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class DevServicesTest {
+    @ConfigProperty(name = QUARKUS_SIMPLE_EXTENSION_BASE_URL)
+    String url;
+
+    @ConfigProperty(name = QUARKUS_SIMPLE_EXTENSION_STATIC_THING)
+    String staticProperty;
+
+    @Test
+    public void testTheLazyDevServicesConfigIsAvailable() {
+        assertNotNull(url);
+    }
+
+    @Test
+    public void testTheBuildTimeServicesConfigIsAvailable() {
+        assertNotNull(staticProperty);
+    }
+
+    @Test
+    public void testServiceIsListeningOnTheDeclaredPort() {
+        given()
+                .relaxedHTTPSValidation()
+                .when()
+                .head(url)
+                .then()
+                .statusCode(200);
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -283,6 +283,7 @@
                 <module>reactive-mysql-client</module>
                 <module>reactive-mssql-client</module>
                 <module>reactive-oracle-client</module>
+                <module>devservices</module>
                 <module>test-extension</module>
                 <module>amazon-lambda</module>
                 <module>amazon-lambda-s3event</module>


### PR DESCRIPTION
At the moment, our testing of dev services comes from the integration tests of projects which use them (although there was less of that than we might have hoped, pre-#44124). As we continue to do dev services development, it would be nice to have a dedicated test suite. This is extra important as we add features, such as dependency chaining, that are exercised by Quarkiverse projects but not by the core projects.

For now, I've just added basic tests that services started and get their config into the config system. 

There may be some other dev services-related tests in the `main` and `maven`suites  that should move to the new suite, but I’ll look at that later.

I deliberately didn't add this project to the native matrices, but can if we think that's better for completeness. 