### PR TITLE
Return correct test instance in interceptTestClassConstructor

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -772,6 +772,9 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         }
 
         initTestState(extensionContext, state);
+        if (actualTestInstance != null) {
+            return (T) actualTestInstance;
+        }
         return result;
     }
 


### PR DESCRIPTION
Resolves issue described in https://github.com/quarkusio/quarkus/discussions/50370, little unsure if it breaks anything, hence the draft PR.

This improves the interoperability between the quarkus junit test extension and other test extensions.

The fix ensures that junit extension framework has the correct test instance (the one created by ArC which has had relevant fields injected).