### PR TITLE
Move `OidcClientRequestFilter` as necessary pre-step to fix split packages in OIDC client filter

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -658,7 +658,7 @@ Add the following Maven Dependency:
 
 NOTE: It will also bring `io.quarkus:quarkus-oidc-client`.
 
-`quarkus-resteasy-client-oidc-filter` extension provides `io.quarkus.oidc.client.filter.OidcClientRequestFilter` Jakarta REST ClientRequestFilter which uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization Bearer` scheme value.
+`quarkus-resteasy-client-oidc-filter` extension provides `io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter` Jakarta REST ClientRequestFilter which uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization Bearer` scheme value.
 
 By default, this filter will get `OidcClient` to acquire the first pair of access and refresh tokens at its initialization time. If the access tokens are short-lived and refresh tokens are unavailable, then the token acquisition should be delayed with `quarkus.oidc-client.early-tokens-acquisition=false`.
 
@@ -709,7 +709,7 @@ or
 ----
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.quarkus.oidc.client.filter.OidcClientRequestFilter;
+import io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 

--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
@@ -23,10 +23,10 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.client.deployment.OidcClientBuildStep.IsEnabled;
 import io.quarkus.oidc.client.deployment.OidcClientFilterDeploymentHelper;
 import io.quarkus.oidc.client.filter.OidcClientFilter;
-import io.quarkus.oidc.client.filter.OidcClientRequestFilter;
 import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
 import io.quarkus.oidc.client.filter.runtime.DetectUnauthorizedClientResponseFilter;
 import io.quarkus.oidc.client.filter.runtime.OidcClientFilterConfig;
+import io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter;
 import io.quarkus.restclient.deployment.RestClientPredicateProviderBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
@@ -46,6 +46,12 @@ public class OidcClientFilterBuildStep {
 
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(OidcClientRequestFilter.class));
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(OidcClientRequestFilter.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
+
+        additionalBeans
+                .produce(AdditionalBeanBuildItem.unremovableOf(io.quarkus.oidc.client.filter.OidcClientRequestFilter.class));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(io.quarkus.oidc.client.filter.OidcClientRequestFilter.class)
                 .reason(getClass().getName())
                 .methods().fields().build());
 

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ExtendedOidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ExtendedOidcClientRequestFilter.java
@@ -3,6 +3,8 @@ package io.quarkus.oidc.client.filter;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 
+import io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter;
+
 @Priority(Priorities.AUTHENTICATION)
 public class ExtendedOidcClientRequestFilter extends OidcClientRequestFilter {
 }

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
@@ -6,6 +6,8 @@ import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter;
+
 @RegisterProvider(OidcClientRequestFilter.class)
 @RegisterRestClient
 @Path("/")

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/resteasy/filter/OidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/resteasy/filter/OidcClientRequestFilter.java
@@ -1,4 +1,4 @@
-package io.quarkus.oidc.client.filter;
+package io.quarkus.oidc.client.resteasy.filter;
 
 import java.util.Optional;
 
@@ -11,10 +11,6 @@ import jakarta.ws.rs.ext.Provider;
 import io.quarkus.oidc.client.filter.runtime.AbstractOidcClientRequestFilter;
 import io.quarkus.oidc.client.filter.runtime.OidcClientFilterConfig;
 
-/**
- * @deprecated use the {@link io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter} filter instead
- */
-@Deprecated(since = "3.31", forRemoval = true)
 @Provider
 @Singleton
 @Priority(Priorities.AUTHENTICATION)

--- a/integration-tests/oidc-client/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceRegisterProvider.java
+++ b/integration-tests/oidc-client/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceRegisterProvider.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.client.filter.OidcClientRequestFilter;
+import io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter;
 
 @RegisterRestClient
 @RegisterProvider(OidcClientRequestFilter.class)


### PR DESCRIPTION
* Pre-step for: https://github.com/quarkusio/quarkus/issues/51872
* After some time, we will remove the filter class, thus fixing the split packages
* I am going to create Quarkus Update recipe to migrate users applications automatically
* Old filter still works (that is done by registering the filter as a CDI bean)