### PR TITLE
Avoid using BigDecimal.divide to measure time

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -557,7 +557,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
                 restartCallback.accept(filesChanged, changedClassResults);
                 long timeNanoSeconds = System.nanoTime() - startNanoseconds;
-                log.infof("Live reload total time: %ss ", Timing.convertToBigDecimalSeconds(timeNanoSeconds));
+                log.infof("Live reload total time: %ss ", Timing.convertToSecondsString(timeNanoSeconds));
                 for (Runnable step : postRestartSteps) {
                     try {
                         step.run();
@@ -585,10 +585,10 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                 }
 
                 log.infof("Files changed but restart not needed - notified extensions in: %ss ",
-                        Timing.convertToBigDecimalSeconds(System.nanoTime() - startNanoseconds));
+                        Timing.convertToSecondsString(System.nanoTime() - startNanoseconds));
             } else if (instrumentationChange) {
                 log.infof("Live reload performed via instrumentation, no restart needed, total time: %ss ",
-                        Timing.convertToBigDecimalSeconds(System.nanoTime() - startNanoseconds));
+                        Timing.convertToSecondsString(System.nanoTime() - startNanoseconds));
             }
             return false;
 

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
@@ -141,10 +141,18 @@ public class Timing {
     }
 
     public static String convertToSecondsString(long timeNanoSeconds) {
-        long millis = Math.round(timeNanoSeconds / 1_000_000.0);
+        long millis = (timeNanoSeconds + 500_000) / 1_000_000;
         long seconds = millis / 1000;
         int fraction = (int) (millis % 1000);
-        return seconds + "." + fraction;
+
+        StringBuilder sb = new StringBuilder(16);
+        sb.append(seconds).append('.');
+        if (fraction < 10)
+            sb.append("00");
+        else if (fraction < 100)
+            sb.append('0');
+        sb.append(fraction);
+        return sb.toString();
     }
 
     /**

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
@@ -94,8 +94,7 @@ public class Timing {
         Timing t = get(anc);
         final long bootTimeNanoSeconds = System.nanoTime() - t.bootStartTime;
         final Logger logger = Logger.getLogger("io.quarkus");
-        //Use a BigDecimal so we can render in seconds with 3 digits precision, as requested:
-        final BigDecimal secondsRepresentation = convertToBigDecimalSeconds(bootTimeNanoSeconds);
+        final String secondsRepresentation = convertToSecondsString(bootTimeNanoSeconds);
         String safeAppName = (name == null || name.trim().isEmpty()) ? UNSET_VALUE : name;
         String safeAppVersion = (version == null || version.trim().isEmpty() || "null".equals(version)) ? UNSET_VALUE : version;
         final String nativeOrJvm = ImageInfo.inImageRuntimeCode() ? "native" : "on JVM";
@@ -120,7 +119,7 @@ public class Timing {
         Timing t = get(auxiliaryApplication);
         final long stopTimeNanoSeconds = System.nanoTime() - t.bootStopTime;
         final Logger logger = Logger.getLogger("io.quarkus");
-        final BigDecimal secondsRepresentation = convertToBigDecimalSeconds(stopTimeNanoSeconds);
+        final String secondsRepresentation = convertToSecondsString(stopTimeNanoSeconds);
         logger.infof("%s%s stopped in %ss",
                 (UNSET_VALUE.equals(name) || name == null || name.trim().isEmpty()) ? "Quarkus" : name,
                 auxiliaryApplication ? "(test application)" : "",
@@ -141,11 +140,21 @@ public class Timing {
         }
     }
 
+    public static String convertToSecondsString(long timeNanoSeconds) {
+        long millis = Math.round(timeNanoSeconds / 1_000_000.0);
+        long seconds = millis / 1000;
+        int fraction = (int) (millis % 1000);
+        return seconds + "." + fraction;
+    }
+
+    /**
+     * @deprecated use {@link #convertToSecondsString(long)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "3.31")
     public static BigDecimal convertToBigDecimalSeconds(final long timeNanoSeconds) {
         final BigDecimal secondsRepresentation = BigDecimal.valueOf(timeNanoSeconds) // As nanoseconds
                 .divide(BigDecimal.valueOf(1_000_000), RoundingMode.HALF_UP) // Convert to milliseconds, discard remaining digits while rounding
                 .divide(BigDecimal.valueOf(1_000), 3, RoundingMode.HALF_UP); // Convert to seconds, while preserving 3 digits
         return secondsRepresentation;
     }
-
 }


### PR DESCRIPTION
This is actually quite slow so we are better off using dumber code. Also it's intentional I don't use a String.format as it instantiates a Formatter and some locale stuff and it's also quite slow.

You can make fun of me... but...

<img width="2481" height="1020" alt="Screenshot From 2026-01-09 16-15-21" src="https://github.com/user-attachments/assets/719b8495-39ad-4b6c-b59b-93262c7137d8" />

That is with Java 25 and some AOT cache.