### PR TITLE
Drop two method references in ArC initialization

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableObserverMethod.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableObserverMethod.java
@@ -19,7 +19,7 @@ import io.quarkus.arc.impl.EventMetadataImpl;
  *
  * @param <T>
  */
-public interface InjectableObserverMethod<T> extends ObserverMethod<T> {
+public interface InjectableObserverMethod<T> extends ObserverMethod<T>, Comparable<InjectableObserverMethod<?>> {
 
     @Override
     default Set<Annotation> getObservedQualifiers() {
@@ -57,8 +57,9 @@ public interface InjectableObserverMethod<T> extends ObserverMethod<T> {
      */
     String getDeclaringBeanIdentifier();
 
-    static int compare(InjectableObserverMethod<?> o1, InjectableObserverMethod<?> o2) {
-        return Integer.compare(o1.getPriority(), o2.getPriority());
+    @Override
+    default int compareTo(InjectableObserverMethod<?> other) {
+        return Integer.compare(this.getPriority(), other.getPriority());
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -886,7 +886,7 @@ public class ArcContainerImpl implements ArcContainer {
             }
         }
         // Observers with smaller priority values are called first
-        resolvedObservers.sort(InjectableObserverMethod::compare);
+        Collections.sort(resolvedObservers);
         return resolvedObservers;
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -68,7 +69,9 @@ public final class Qualifiers {
 
     // in various cases, specification requires to check qualifiers for duplicates and throw IAE
     private static void checkQualifiersForDuplicates(Map<Class<? extends Annotation>, Integer> timesQualifierSeen) {
-        timesQualifierSeen.forEach(Qualifiers::checkQualifiersForDuplicates);
+        for (Entry<Class<? extends Annotation>, Integer> entry : timesQualifierSeen.entrySet()) {
+            checkQualifiersForDuplicates(entry.getKey(), entry.getValue());
+        }
     }
 
     private static void checkQualifiersForDuplicates(Class<? extends Annotation> aClass, Integer times) {


### PR DESCRIPTION
That's not something you notice when you profile without AOT caching, but once you get rid of most of the class loading noise by using the AOT cache, you start to notice it.

From 0.31% of the samples:

<img width="3286" height="1164" alt="Screenshot From 2026-01-09 16-49-01" src="https://github.com/user-attachments/assets/1bf556e5-d377-4741-bb96-c198a326a98b" />

To 0.08% (the gain is actually even better as the first number was without any optimizations and the second improved numbers is with all my other optimizations so compared to less samples):

<img width="3286" height="1164" alt="Screenshot From 2026-01-09 16-49-09" src="https://github.com/user-attachments/assets/c10f0b40-feee-4a1d-83c8-93e8b724e351" />


