### PR TITLE
Improve Panache queries

### DIFF
--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -21,7 +21,7 @@ public class PanacheJpaUtil {
         // FIXME: not true?
         // Escape the entity name just in case some keywords are used
         // in package names that will prevent ORM from executing a query
-        return "`%s`".formatted(entityClass.getName());
+        return '`' + entityClass.getName() + '`';
     }
 
     /**


### PR DESCRIPTION
This is fixing a misuse of `String::format` in the very hot path while performing queries, see 

<img width="1921" height="697" alt="image" src="https://github.com/user-attachments/assets/3efa206e-5ed1-4ca9-8d4f-558395ce2d10" />

It's a drop in the ocean, but a no brain, in term of simplicity of the fix.

NOTE: I'm not a fan of string indy, but this is really happening for each panache query...
