### PR TITLE
Enable configuration of (dev service) Kafka properties using the Strimzi provider

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -121,6 +121,7 @@ public class DevServicesKafkaProcessor {
                     strimzi.withPort(config.port().get());
                 }
                 strimzi.withEnv(config.containerEnv());
+                strimzi.withKafkaConfigurationMap(config.strimzi().serverConfigs());
                 configureSharedServiceLabel(strimzi, launchMode.getLaunchMode(), DEV_SERVICE_LABEL, config.serviceName());
                 yield new StartableContainer<>(strimzi, StrimziKafkaContainer::getBootstrapServers);
             }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -124,6 +124,11 @@ public interface KafkaDevServicesBuildTimeConfig {
     RedpandaBuildTimeConfig redpanda();
 
     /**
+     * Allows configuring the Strimzi broker.
+     */
+    StrimziBuildTimeConfig strimzi();
+
+    /**
      * @return the image name if set, otherwise the default image name for the provider.
      */
     default String effectiveImageName() {

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/StrimziBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/StrimziBuildTimeConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.kafka.client.deployment;
+
+import java.util.Map;
+
+/**
+ * Allows configuring the Strimzi dev services broker.
+ */
+public interface StrimziBuildTimeConfig {
+
+    /**
+     * Configuration properties that will be added to the server properties
+     * file provided to the Kafka broker by the Strimzi provider.
+     */
+    Map<String, String> serverConfigs();
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Add a mechanism to configure Strimzi test container's Kafka server properties override map. This is similar to the environment variable configuration supported for `kafka-native`, but using a map configuration exposed by Strimzi.

Configuration would look like this:

```properties
quarkus.kafka.devservices.provider=strimzi
quarkus.kafka.devservices.image-name=quay.io/strimzi-test-container/test-container:latest-kafka-4.1.0
quarkus.kafka.devservices.strimzi.server-configs."group.initial.rebalance.delete.ms"=0
quarkus.kafka.devservices.strimzi.server-configs."authorizer.class.name"=org.apache.kafka.metadata.authorizer.StandardAuthorizer
quarkus.kafka.devservices.strimzi.server-configs."super.users"=User:ANONYMOUS
```
The options are then added to the server.properties file written to the container's filesystem by the test container startup processing.
```
[strimzi@50b7fc31ff81 kraft]$ cat server.properties 
#Fri Jan 09 17:59:01 EST 2026
advertised.listeners=PLAINTEXT\://localhost\:32789,BROKER1\://172.18.0.2\:9091,CONTROLLER\://localhost\:32790
authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer <----- FROM QUARKUS CONFIGS ********
broker.id=1
controller.listener.names=CONTROLLER
controller.quorum.voters=1@broker-1\:9094
group.initial.rebalance.delete.ms=0   <----- FROM QUARKUS CONFIGS ********
inter.broker.listener.name=BROKER1
listener.security.protocol.map=PLAINTEXT\:PLAINTEXT,CONTROLLER\:PLAINTEXT,BROKER1\:PLAINTEXT
listeners=PLAINTEXT\://0.0.0.0\:9092,BROKER1\://0.0.0.0\:9091,CONTROLLER\://0.0.0.0\:9094
log.dirs=/tmp/default-log-dir
log.retention.check.interval.ms=300000
log.retention.hours=168
node.id=1
num.io.threads=8
num.network.threads=3
num.partitions=1
num.recovery.threads.per.data.dir=1
offsets.topic.replication.factor=1
process.roles=broker,controller
socket.receive.buffer.bytes=102400
socket.request.max.bytes=104857600
socket.send.buffer.bytes=102400
super.users=User\:ANONYMOUS   <----- FROM QUARKUS CONFIGS ********
transaction.state.log.min.isr=1
transaction.state.log.replication.factor=1
```


<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

