### PR TITLE
Add documentation about `quarkus.proxy` configuration for REST Client

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1828,37 +1828,65 @@ quarkus.rest-client.my-client.enable-compression=true
 The REST Client falls back onto the Quarkus wide `quarkus.http.enable-compression` configuration property (which defaults to `false`) if no REST Client specific property is set.
 
 == Proxy support
-REST Client supports sending requests through a proxy.
-It honors the JVM settings for it but also allows to specify both:
 
-* global client proxy settings, with `quarkus.rest-client.proxy-address`, `quarkus.rest-client.proxy-user`, `quarkus.rest-client.proxy-password`, `quarkus.rest-client.non-proxy-hosts`
+REST Client supports sending requests through a proxy. You can still rely on JVM proxy settings, but REST Client allows you to define a default proxy and any number of named proxy configurations that clients can reference.
 
-* per-client proxy settings, with `quarkus.rest-client.<my-client>.proxy-address`, etc. These are applied only to clients injected with CDI, that is the ones created with `@RegisterRestClient`
+Proxy configuration is centralized in a Proxy Registry; configure proxies under the `quarkus.proxy` configuration root.
 
-If `proxy-address` is set on the client level, the client uses its specific proxy settings. No proxy settings are propagated from the global configuration or JVM properties.
+=== Global proxy configuration
 
-If `proxy-address` is not set for the client but is set on the global level, the client uses the global settings.
-Otherwise, the client uses the JVM settings.
-
-
-An example configuration for setting proxy:
-
+You can define a default proxy configuration that will be used by all REST Clients that do not explicitly reference a named proxy configuration.
 [source,properties]
 ----
-# global proxy configuration is used for all clients
-quarkus.rest-client.proxy-address=localhost:8182
-quarkus.rest-client.proxy-user=<proxy user name>
-quarkus.rest-client.proxy-password=<proxy password>
-quarkus.rest-client.non-proxy-hosts=example.com
+quarkus.proxy.host=localhost
+quarkus.proxy.port=8182
+quarkus.proxy.username=username
+quarkus.proxy.password=password
+quarkus.proxy.non-proxy-hosts=my.company.com
 
-# per-client configuration overrides the global settings for a specific client
-quarkus.rest-client.my-client.proxy-address=localhost:8183
-quarkus.rest-client.my-client.proxy-user=<proxy user name>
-quarkus.rest-client.my-client.proxy-password=<proxy password>
-quarkus.rest-client.my-client.url=...
+quarkus.rest-client.my-client.url=http://example.com/api
 ----
 
-NOTE: MicroProfile REST Client specification does not allow setting proxy credentials. In order to specify proxy user and proxy password programmatically, you need to cast your `RestClientBuilder` to `RestClientBuilderImpl`.
+This configuration will cause all REST Clients, including `my-client`, to use the proxy at `localhost:8182` with the provided credentials.
+
+=== Named proxy configuration
+
+You can define named proxy configurations and have specific REST Clients use them.
+[source,properties]
+----
+quarkus.proxy.my-proxy.host=localhost
+quarkus.proxy.my-proxy.port=8183
+quarkus.proxy.my-proxy.username=username
+quarkus.proxy.my-proxy.password=password
+
+quarkus.rest-client.client1.proxy-configuration-name=my-proxy <1>
+quarkus.rest-client.client1.url=http://c1.example.com/api
+
+quarkus.rest-client.client2.url=http://c2.example.com/api <2>
+----
+<1> `client1` is configured to use the `my-proxy` proxy configuration.
+<2> `client2` does not specify a proxy configuration name, so it will not use any proxy unless a default proxy configuration is defined.
+
+=== Using Credentials Provider
+
+In addition to the `quarkus.proxy` settings, REST Client can obtain proxy credentials from the Quarkus Credentials Provider.
+See link:https://quarkus.io/guides/credentials-provider[Credentials Provider] for more details.
+[source,properties]
+----
+quarkus.proxy.baby-proxy.host=localhost <1>
+quarkus.proxy.baby-proxy.port=3838
+
+quarkus.proxy.credentials-provider.name=credential <2>
+quarkus.proxy.credentials-provider.bean-name=credentialBean
+quarkus.proxy.credentials-provider.username-key=userKey
+quarkus.proxy.credentials-provider.password-key=passwordKey
+----
+
+<1> Define a named proxy configuration `baby-proxy` without username and password.
+<2> Configure the Credentials Provider to obtain the username and password for the proxy.
+
+[NOTE]
+The Credentials Provider is not used when `quarkus.proxy.password` (for global) or `quarkus.proxy.<named>.password` (for named) is not set.
 
 === Local proxy for dev mode
 

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -78,6 +78,7 @@ public interface RestClientsConfig {
      *
      * @deprecated use {@code quarkus.rest-client.proxy-configuration-name} instead
      */
+    @Deprecated
     Optional<@WithConverter(TrimmedStringConverter.class) String> proxyAddress();
 
     /**
@@ -90,6 +91,7 @@ public interface RestClientsConfig {
      *
      * @deprecated use {@code quarkus.rest-client.proxy-configuration-name} instead
      */
+    @Deprecated
     Optional<String> proxyUser();
 
     /**
@@ -102,6 +104,7 @@ public interface RestClientsConfig {
      *
      * @deprecated use {@code quarkus.rest-client.proxy-configuration-name} instead
      */
+    @Deprecated
     Optional<String> proxyPassword();
 
     /**
@@ -115,6 +118,7 @@ public interface RestClientsConfig {
      *
      * @deprecated use {@code quarkus.rest-client.proxy-configuration-name} instead
      */
+    @Deprecated
     Optional<String> nonProxyHosts();
 
     /**
@@ -127,6 +131,7 @@ public interface RestClientsConfig {
      *
      * @deprecated use {@code quarkus.rest-client.proxy-configuration-name} instead
      */
+    @Deprecated
     @ConfigDocDefault("10s")
     Optional<Duration> proxyConnectTimeout();
 
@@ -135,6 +140,7 @@ public interface RestClientsConfig {
      * <p>
      * Can be overwritten by client-specific settings.
      */
+    @Deprecated
     @WithDefault("15000")
     Long connectTimeout();
 
@@ -520,6 +526,7 @@ public interface RestClientsConfig {
          *
          * @deprecated use {@code quarkus.rest-client."client".proxy-configuration-name} instead
          */
+        @Deprecated
         Optional<@WithConverter(TrimmedStringConverter.class) String> proxyAddress();
 
         /**
@@ -530,6 +537,7 @@ public interface RestClientsConfig {
          *
          * @deprecated use {@code quarkus.rest-client."client".proxy-configuration-name} instead
          */
+        @Deprecated
         Optional<String> proxyUser();
 
         /**
@@ -540,6 +548,7 @@ public interface RestClientsConfig {
          *
          * @deprecated use {@code quarkus.rest-client."client".proxy-configuration-name} instead
          */
+        @Deprecated
         Optional<String> proxyPassword();
 
         /**
@@ -550,6 +559,7 @@ public interface RestClientsConfig {
          *
          * @deprecated use {@code quarkus.rest-client."client".proxy-configuration-name} instead
          */
+        @Deprecated
         Optional<String> nonProxyHosts();
 
         /**
@@ -560,6 +570,7 @@ public interface RestClientsConfig {
          *
          * @deprecated use {@code quarkus.rest-client."client".proxy-configuration-name} instead
          */
+        @Deprecated
         @ConfigDocDefault("10s")
         Optional<Duration> proxyConnectTimeout();
 


### PR DESCRIPTION
# Context

Align documentation with recent REST Client Proxy code changes: https://github.com/quarkusio/quarkus/pull/50709

## Documentation
What the documentation tell to the reader:

* In a brief way, behind the scenes the REST Client extension uses `quarkus.proxy` for configuring Proxy to REST clients.
* Talk about the possibility of create a global Proxy configuration.
* Talk about the possibility of create a named proxy configuration and to apply for only necessary REST Client.

## Code

Additionally, I added `@Deprecated` annotations to reflect in the configuration reference what is the suggested approach from Quarkus team.

Closes #50820