### PR TITLE
Check @Consumes duplicates in REST Client

### DIFF
--- a/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/deployment/test/AccessTokenPropagationService.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/deployment/test/AccessTokenPropagationService.java
@@ -1,6 +1,8 @@
 package io.quarkus.oidc.token.propagation.reactive.deployment.test;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -10,8 +12,13 @@ import io.quarkus.oidc.token.propagation.common.AccessToken;
 @RegisterRestClient
 @AccessToken
 @Path("/")
+@Consumes("text/plain")
 public interface AccessTokenPropagationService {
 
     @GET
     String getUserName();
+
+    @POST
+    @Consumes("text/plain")
+    String echoUserName(String name);
 }

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -2652,12 +2653,19 @@ public class JaxrsClientReactiveProcessor {
             if (consumes != null && consumes.length > 0) {
 
                 if (consumes.length > 1) {
-                    throw new IllegalArgumentException(
-                            "Multiple `@Consumes` values used in a MicroProfile Rest Client: " +
-                                    restClientInterface.name().toString()
-                                    + " Unable to determine a single `Content-Type`.");
+                    Set<String> uniqueConsumes = new HashSet<>(Arrays.asList(consumes));
+                    if (uniqueConsumes.size() > 1) {
+                        // Consider picking up the first @Consumes instead
+                        throw new IllegalArgumentException(
+                                "Multiple `@Consumes` values used in a MicroProfile Rest Client: " +
+                                        restClientInterface.name().toString()
+                                        + " Unable to determine a single `Content-Type`.");
+                    } else {
+                        mediaTypeValue = uniqueConsumes.iterator().next();
+                    }
+                } else {
+                    mediaTypeValue = consumes[0];
                 }
-                mediaTypeValue = consumes[0];
             } else if (formParams != null) {
                 mediaTypeValue = multipart ? MediaType.MULTIPART_FORM_DATA : MediaType.APPLICATION_FORM_URLENCODED;
             }


### PR DESCRIPTION
Related to #51910.

This PR updates REST Client to check `@Consumes` duplicates before failing a build, to unblock #51903.
