### PR TITLE
Switch to grpc-zero-codegen

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2478,6 +2478,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-grpc-zero-codegen</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-grpc-stubs</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -6440,6 +6445,11 @@
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-core</artifactId>
                 <version>${javaparser.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.roastedroot</groupId>
+                <artifactId>protobuf4j-v4</artifactId>
+                <version>${protobuf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.aesh</groupId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -36,6 +36,7 @@
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <htmlunit.version>4.21.0</htmlunit.version>
         <javaparser-core.version>3.28.0</javaparser-core.version>
+        <protobuf4j.version>0.0.4</protobuf4j.version>
         <jdeparser.version>2.1.0</jdeparser.version>
         <subethasmtp.version>6.0.1</subethasmtp.version>
 
@@ -216,6 +217,11 @@
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-core</artifactId>
                 <version>${javaparser-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.roastedroot</groupId>
+                <artifactId>protobuf4j-v4</artifactId>
+                <version>${protobuf4j.version}</version>
             </dependency>
 
             <!-- Miscellaneous -->

--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -291,7 +291,36 @@ plugins {
 IMPORTANT: It is recommended to package the `proto` files in a dependency instead of the generated classes, so Quarkus can generate optimized classes.
 Refer to the <<scan-for-proto, dedicated section>> for more information.
 
-== Argument files
+== Using native `protoc`
+
+By default `quarkus-grpc` uses a portable version of `protoc` embedded as Java bytecode.
+You can esily switch back to use the official `protoc` binary by:
+
+.Step 1: Exclusion of gRPC Zero:
+[source, xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-grpc</artifactId>
+    <exclusions>
+        <exclusion>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-zero-codegen</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+----
+
+.Step 1: Add the dependency that relies on the `protoc` binary:
+[source, xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-grpc-codegen</artifactId>
+</dependency>
+----
+
+=== Argument files
 
 When the `protoc` command line exceeds the maximum command length, you can ask Quarkus to use an argument file to pass the arguments to the `protoc` command.
 
@@ -299,9 +328,9 @@ To enable this feature, set the `quarkus.generate-code.grpc.use-arg-file` proper
 
 If you are on Windows, and the command line exceeds 8190 characters, Quarkus automatically uses an argument file to pass the arguments to the `protoc` command.
 
-== Local vs. Downloaded `protoc`
+=== Local vs. Downloaded `protoc`
 
-To generate gRPC classes, Quarkus uses the `protoc` artifact from the `com.google.protobuf` group id.
+To generate gRPC classes, when using `quarkus-grpc-codegen`, Quarkus uses the `protoc` artifact from the `com.google.protobuf` group id.
 However, to ensure the support of various platforms, Quarkus automatically downloads _all_ the possible variants of the `protoc` artifact.
 In addition, Quarkus downloads both `protoc` and the plugin used to generate gRPC classes in Java.
 For example, even if you are using Linux, Quarkus downloads the `protoc` and the Java plugin artifacts for Windows and MacOS.

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -66,7 +66,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-grpc-codegen</artifactId>
+            <artifactId>quarkus-grpc-zero-codegen</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>protoc</module>
         <module>codegen</module>
+        <module>zero-codegen</module>
         <module>api</module>
         <module>stubs</module>
         <module>reflection</module>

--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-zero-codegen</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
@@ -106,7 +111,7 @@
                 <dependencies>
                     <dependency>
                         <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-grpc-codegen</artifactId>
+                        <artifactId>quarkus-grpc-zero-codegen</artifactId>
                         <version>${project.version}</version>
                     </dependency>
                 </dependencies>
@@ -122,12 +127,12 @@
                             <includePluginDependencies>true</includePluginDependencies>
                             <executableDependency>
                                 <groupId>io.quarkus</groupId>
-                                <artifactId>quarkus-grpc-codegen</artifactId>
+                                <artifactId>quarkus-grpc-zero-codegen</artifactId>
                             </executableDependency>
                             <arguments>
                                 <argument>${project.build.directory}/generated-sources/protobuf/grpc-java</argument>
                             </arguments>
-                            <mainClass>io.quarkus.grpc.codegen.GrpcPostProcessing</mainClass>
+                            <mainClass>io.quarkus.grpc.zero.codegen.GrpcZeroPostProcessing</mainClass>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/grpc/zero-codegen/pom.xml
+++ b/extensions/grpc/zero-codegen/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-grpc-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-grpc-zero-codegen</artifactId>
+    <name>Quarkus - gRPC Zero - Code Gen</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-os</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.roastedroot</groupId>
+            <artifactId>protobuf4j-v4</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-protoc-plugin</artifactId>
+            <classifier>shaded</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
+++ b/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
@@ -276,7 +276,8 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
                 if (isInSubtree(Path.of(dir), protoFilePath)) {
                     Path base = Path.of(dir).toAbsolutePath().normalize();
                     Path file = protoFilePath.toAbsolutePath().normalize();
-                    return base.relativize(file).toString();
+                    // Use forward slashes for protobuf compatibility (Windows uses backslashes)
+                    return base.relativize(file).toString().replace("\\", "/");
                 }
             } catch (IllegalArgumentException e) {
                 // cannot be relativized, skip

--- a/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
+++ b/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
@@ -107,7 +107,9 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
 
     @Override
     public boolean trigger(CodeGenContext context) throws CodeGenException {
-        if (TRUE.toString().equalsIgnoreCase(System.getProperties().getProperty("grpc.zero.codegen.skip", "false"))
+        if (TRUE.toString().equalsIgnoreCase(System.getProperties().getProperty("grpc.codegen.skip", "false"))
+                || TRUE.toString().equalsIgnoreCase(System.getProperties().getProperty("grpc.zero.codegen.skip", "false"))
+                || context.config().getOptionalValue("quarkus.grpc.codegen.skip", Boolean.class).orElse(false)
                 || context.config().getOptionalValue("quarkus.zero.grpc.codegen.skip", Boolean.class).orElse(false)) {
             log.info("Skipping gRPC zero code generation on user's request");
             return false;

--- a/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
+++ b/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
@@ -177,43 +177,47 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
                 DescriptorProtos.FileDescriptorSet.Builder descriptorSetBuilder = DescriptorProtos.FileDescriptorSet
                         .newBuilder();
                 PluginProtos.CodeGeneratorRequest.Builder requestBuilder = PluginProtos.CodeGeneratorRequest.newBuilder();
+                DescriptorProtos.FileDescriptorSet descriptorSet;
 
-                var protobuf = Protobuf.builder().withWorkdir(workdir).build();
+                // Use try-with-resources to close the Protobuf instance promptly, releasing
+                // the Chicory WASM runtime resources and helping classloader GC reclaim Metaspace
+                try (var protobuf = Protobuf.builder().withWorkdir(workdir).build()) {
+                    for (String protoFile : protoFiles) {
+                        try (InputStream is = Files.newInputStream(Path.of(protoFile))) {
+                            Files.copy(is, workdir.resolve(Path.of(protoFile).getFileName().toString()),
+                                    StandardCopyOption.REPLACE_EXISTING);
+                        }
 
-                for (String protoFile : protoFiles) {
-                    try (InputStream is = Files.newInputStream(Path.of(protoFile))) {
-                        Files.copy(is, workdir.resolve(Path.of(protoFile).getFileName().toString()),
-                                StandardCopyOption.REPLACE_EXISTING);
+                        log.info("resolving proto file: " + protoFile);
+                        var protoName = realitivizeProtoFile(protoFile, protoDirs);
+                        log.info("final proto name: " + protoName);
+
+                        try {
+                            descriptorSetBuilder
+                                    .addAllFile(protobuf.getDescriptors(List.of(protoName)).getFileList());
+                        } catch (RuntimeException e) {
+                            throw new CodeGenException(
+                                    "Grpc Zero failed while parsing proto '" + protoName + "' (source: " + protoFile
+                                            + "). "
+                                            + "This is commonly caused by malformed proto syntax, unresolved imports, or duplicated "
+                                            + "merged content in a single file.",
+                                    e);
+                        }
+                        requestBuilder.addFileToGenerate(protoName);
                     }
 
-                    log.info("resolving proto file: " + protoFile);
-                    var protoName = realitivizeProtoFile(protoFile, protoDirs);
-                    log.info("final proto name: " + protoName);
+                    descriptorSet = descriptorSetBuilder.build();
 
+                    // Add all FileDescriptorProto entries from the descriptor set
+                    // and all from dependencies
                     try {
-                        descriptorSetBuilder.addAllFile(protobuf.getDescriptors(List.of(protoName)).getFileList());
+                        resolveDependencies(protobuf, descriptorSet, requestBuilder);
                     } catch (RuntimeException e) {
                         throw new CodeGenException(
-                                "Grpc Zero failed while parsing proto '" + protoName + "' (source: " + protoFile + "). "
-                                        + "This is commonly caused by malformed proto syntax, unresolved imports, or duplicated "
-                                        + "merged content in a single file.",
+                                "Grpc Zero failed while resolving transitive proto dependencies. "
+                                        + "Check gathered proto imports and file integrity before code generation.",
                                 e);
                     }
-                    requestBuilder.addFileToGenerate(protoName);
-                }
-
-                // Load the previously generated descriptor
-                DescriptorProtos.FileDescriptorSet descriptorSet = descriptorSetBuilder.build();
-
-                // Add all FileDescriptorProto entries from the descriptor set
-                // and all from dependencies
-                try {
-                    resolveDependencies(protobuf, descriptorSet, requestBuilder);
-                } catch (RuntimeException e) {
-                    throw new CodeGenException(
-                            "Grpc Zero failed while resolving transitive proto dependencies. "
-                                    + "Check gathered proto imports and file integrity before code generation.",
-                            e);
                 }
 
                 PluginProtos.CodeGeneratorRequest codeGeneratorRequest = requestBuilder.build();

--- a/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
+++ b/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroCodeGen.java
@@ -1,0 +1,574 @@
+package io.quarkus.grpc.zero.codegen;
+
+import static io.roastedroot.protobuf4j.common.Protobuf.collectDependencies;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.nio.file.Files.copy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.logging.Logger;
+
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.compiler.PluginProtos;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.prebuild.CodeGenException;
+import io.quarkus.deployment.CodeGenContext;
+import io.quarkus.deployment.CodeGenProvider;
+import io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.paths.PathFilter;
+import io.quarkus.runtime.util.HashUtil;
+import io.roastedroot.protobuf4j.v4.Protobuf;
+import io.roastedroot.zerofs.Configuration;
+import io.roastedroot.zerofs.ZeroFs;
+import io.smallrye.common.os.OS;
+
+/**
+ * Code generation for gRPC. Generates java classes from proto files placed in either src/main/proto or src/test/proto
+ * Inspired by <a href="https://github.com/xolstice/protobuf-maven-plugin">Protobuf Maven Plugin</a>
+ */
+public class GrpcZeroCodeGen implements CodeGenProvider {
+    private static final Logger log = Logger.getLogger(GrpcZeroCodeGen.class);
+
+    private static final String PROTO = ".proto";
+
+    private static final String SCAN_DEPENDENCIES_FOR_PROTO = "quarkus.generate-code.grpc.scan-for-proto";
+    private static final String SCAN_DEPENDENCIES_FOR_PROTO_INCLUDE_PATTERN = "quarkus.generate-code.grpc.scan-for-proto-include.\"%s\"";
+    private static final String SCAN_DEPENDENCIES_FOR_PROTO_EXCLUDE_PATTERN = "quarkus.generate-code.grpc.scan-for-proto-exclude.\"%s\"";
+    private static final String SCAN_FOR_IMPORTS = "quarkus.generate-code.grpc.scan-for-imports";
+
+    private static final String POST_PROCESS_SKIP = "quarkus.generate.code.grpc-post-processing.skip";
+    private static final String GENERATE_DESCRIPTOR_SET = "quarkus.generate-code.grpc.descriptor-set.generate";
+    private static final String DESCRIPTOR_SET_OUTPUT_DIR = "quarkus.generate-code.grpc.descriptor-set.output-dir";
+    private static final String DESCRIPTOR_SET_FILENAME = "quarkus.generate-code.grpc.descriptor-set.name";
+
+    private static final String GENERATE_KOTLIN = "quarkus.generate-code.grpc.kotlin.generate";
+
+    private String input;
+    private boolean hasQuarkusKotlinDependency;
+
+    @Override
+    public String providerId() {
+        return "grpc";
+    }
+
+    @Override
+    public String[] inputExtensions() {
+        return new String[] { "proto" };
+    }
+
+    @Override
+    public String inputDirectory() {
+        return "proto";
+    }
+
+    @Override
+    public Path getInputDirectory() {
+        if (input != null) {
+            return Path.of(input);
+        }
+        return null;
+    }
+
+    @Override
+    public void init(ApplicationModel model, Map<String, String> properties) {
+        this.input = properties.get("quarkus.grpc.codegen.proto-directory");
+        this.hasQuarkusKotlinDependency = containsQuarkusKotlin(model.getDependencies());
+    }
+
+    @Override
+    public boolean trigger(CodeGenContext context) throws CodeGenException {
+        if (TRUE.toString().equalsIgnoreCase(System.getProperties().getProperty("grpc.zero.codegen.skip", "false"))
+                || context.config().getOptionalValue("quarkus.zero.grpc.codegen.skip", Boolean.class).orElse(false)) {
+            log.info("Skipping gRPC zero code generation on user's request");
+            return false;
+        }
+        // Detect if the old native-protoc codegen is also on the classpath
+        try {
+            Class.forName("io.quarkus.grpc.codegen.GrpcCodeGen");
+            throw new CodeGenException(
+                    "Both 'quarkus-grpc-zero-codegen' and 'quarkus-grpc-codegen' are on the classpath. "
+                            + "Only one gRPC code generator can be active at a time. "
+                            + "Either remove the 'quarkus-grpc-codegen' dependency, "
+                            + "or exclude 'quarkus-grpc-zero-codegen' from 'quarkus-grpc' and add 'quarkus-grpc-codegen' explicitly.");
+        } catch (ClassNotFoundException e) {
+            // expected: the old codegen is not present
+        }
+
+        Path outDir = context.outDir();
+        Path workDir = context.workDir();
+        Path inputDir = CodeGenProvider.resolve(context.inputDir());
+        Set<String> protoDirs = new LinkedHashSet<>();
+
+        List<String> protoFiles = new ArrayList<>();
+        if (Files.isDirectory(inputDir)) {
+            try (Stream<Path> protoFilesPaths = Files.walk(inputDir)) {
+                protoFilesPaths
+                        .filter(Files::isRegularFile)
+                        .filter(s -> s.toString().endsWith(PROTO))
+                        .map(Path::normalize)
+                        .map(Path::toAbsolutePath)
+                        .map(Path::toString)
+                        .forEach(protoFiles::add);
+                protoDirs.add(inputDir.normalize().toAbsolutePath().toString());
+            } catch (IOException e) {
+                throw new CodeGenException("Failed to walk inputDir", e);
+            }
+        }
+        Path dirWithProtosFromDependencies = workDir.resolve("protoc-protos-from-dependencies");
+        Collection<Path> protoFilesFromDependencies = gatherProtosFromDependencies(dirWithProtosFromDependencies, protoDirs,
+                context);
+        if (!protoFilesFromDependencies.isEmpty()) {
+            for (Path files : protoFilesFromDependencies) {
+                var pathToProtoFile = files.normalize().toAbsolutePath();
+                var pathToParentDir = files.getParent();
+                // Add the proto file to the list of proto to compile, but also add the directory containing the
+                // proto file to the list of directories to include (it's a set, so no duplicate).
+                protoFiles.add(pathToProtoFile.toString());
+                protoDirs.add(pathToParentDir.toString());
+            }
+        }
+
+        if (!protoFiles.isEmpty()) {
+            Collection<String> protosToImport = gatherDirectoriesWithImports(workDir.resolve("protoc-dependencies"),
+                    context);
+
+            try (FileSystem fs = ZeroFs.newFileSystem(
+                    Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+                var workdir = fs.getPath(".");
+                for (String protoDir : protoDirs) {
+                    copyDirectory(Path.of(protoDir), workdir);
+                }
+                for (String protoImportDir : protosToImport) {
+                    copyDirectory(Path.of(protoImportDir), workdir);
+                }
+
+                DescriptorProtos.FileDescriptorSet.Builder descriptorSetBuilder = DescriptorProtos.FileDescriptorSet
+                        .newBuilder();
+                PluginProtos.CodeGeneratorRequest.Builder requestBuilder = PluginProtos.CodeGeneratorRequest.newBuilder();
+
+                var protobuf = Protobuf.builder().withWorkdir(workdir).build();
+
+                for (String protoFile : protoFiles) {
+                    try (InputStream is = Files.newInputStream(Path.of(protoFile))) {
+                        Files.copy(is, workdir.resolve(Path.of(protoFile).getFileName().toString()),
+                                StandardCopyOption.REPLACE_EXISTING);
+                    }
+
+                    log.info("resolving proto file: " + protoFile);
+                    var protoName = realitivizeProtoFile(protoFile, protoDirs);
+                    log.info("final proto name: " + protoName);
+
+                    try {
+                        descriptorSetBuilder.addAllFile(protobuf.getDescriptors(List.of(protoName)).getFileList());
+                    } catch (RuntimeException e) {
+                        throw new CodeGenException(
+                                "Grpc Zero failed while parsing proto '" + protoName + "' (source: " + protoFile + "). "
+                                        + "This is commonly caused by malformed proto syntax, unresolved imports, or duplicated "
+                                        + "merged content in a single file.",
+                                e);
+                    }
+                    requestBuilder.addFileToGenerate(protoName);
+                }
+
+                // Load the previously generated descriptor
+                DescriptorProtos.FileDescriptorSet descriptorSet = descriptorSetBuilder.build();
+
+                // Add all FileDescriptorProto entries from the descriptor set
+                // and all from dependencies
+                try {
+                    resolveDependencies(protobuf, descriptorSet, requestBuilder);
+                } catch (RuntimeException e) {
+                    throw new CodeGenException(
+                            "Grpc Zero failed while resolving transitive proto dependencies. "
+                                    + "Check gathered proto imports and file integrity before code generation.",
+                            e);
+                }
+
+                PluginProtos.CodeGeneratorRequest codeGeneratorRequest = requestBuilder.build();
+
+                // protoc based plugins
+                var javaResponse = Protobuf.runNativePlugin(
+                        io.roastedroot.protobuf4j.common.Protobuf.NativePlugin.JAVA,
+                        codeGeneratorRequest,
+                        workdir);
+                writeResultToDisk(javaResponse.getFileList(), outDir);
+                var grpcJavaResponse = Protobuf.runNativePlugin(
+                        io.roastedroot.protobuf4j.common.Protobuf.NativePlugin.GRPC_JAVA,
+                        codeGeneratorRequest,
+                        workdir);
+                writeResultToDisk(grpcJavaResponse.getFileList(), outDir);
+
+                log.info("Running MutinyGrpcGenerator plugin");
+                List<PluginProtos.CodeGeneratorResponse.File> mutinyResponse = new MutinyGrpcGenerator()
+                        .generateFiles(codeGeneratorRequest);
+
+                writeResultToDisk(mutinyResponse, outDir);
+
+                if (shouldGenerateKotlin(context.config())) {
+                    log.info("Running KotlinGenerator plugin");
+                    var grpcKotlinResponse = Protobuf.runNativePlugin(
+                            io.roastedroot.protobuf4j.common.Protobuf.NativePlugin.KOTLIN,
+                            codeGeneratorRequest,
+                            workdir);
+                    writeResultToDisk(grpcKotlinResponse.getFileList(), outDir);
+                }
+
+                if (shouldGenerateDescriptorSet(context.config())) {
+                    Files.write(getDescriptorSetOutputFile(context), descriptorSet.toByteArray());
+                }
+
+                postprocessing(context, outDir);
+                log.info("Grpc Zero: Successfully finished generating and post-processing sources from proto files");
+
+                return true;
+            } catch (IOException e) {
+                throw new CodeGenException("Failed to generate files from proto file in " + inputDir.toAbsolutePath(), e);
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isInSubtree(Path baseDir, Path candidate) {
+        Path base = baseDir.toAbsolutePath().normalize();
+        Path cand = candidate.toAbsolutePath().normalize();
+
+        return cand.startsWith(base);
+    }
+
+    // TODO: verify is all this dance can be simplified somehow ...
+    private static String realitivizeProtoFile(String protoFile, Set<String> protoDir) {
+        Path protoFilePath = Path.of(protoFile);
+        for (String dir : protoDir) {
+            try {
+                if (isInSubtree(Path.of(dir), protoFilePath)) {
+                    Path base = Path.of(dir).toAbsolutePath().normalize();
+                    Path file = protoFilePath.toAbsolutePath().normalize();
+                    return base.relativize(file).toString();
+                }
+            } catch (IllegalArgumentException e) {
+                // cannot be relativized, skip
+            }
+        }
+        return protoFilePath.getFileName().toString();
+    }
+
+    private static void writeResultToDisk(List<PluginProtos.CodeGeneratorResponse.File> responseFileList, Path outDir)
+            throws IOException {
+        for (PluginProtos.CodeGeneratorResponse.File file : responseFileList) {
+            Path outputPath = outDir.resolve(file.getName());
+            // TODO: add a check when hitting root?
+            Files.createDirectories(outputPath.getParent());
+            log.info("grpc file generated: " + outputPath);
+            Files.writeString(outputPath, file.getContent());
+        }
+    }
+
+    private static void resolveDependencies(Protobuf protobuf,
+            DescriptorProtos.FileDescriptorSet descriptorSet, PluginProtos.CodeGeneratorRequest.Builder requestBuilder)
+            throws CodeGenException {
+        // Use protobuf4j's buildFileDescriptors to resolve all dependencies
+        List<Descriptors.FileDescriptor> fileDescriptors = protobuf.buildFileDescriptors(descriptorSet);
+
+        // Collect all file descriptors (including transitive dependencies) into a new descriptor set
+        DescriptorProtos.FileDescriptorSet.Builder allDescriptorsBuilder = DescriptorProtos.FileDescriptorSet.newBuilder();
+        Set<String> added = new HashSet<>();
+
+        // For each file descriptor in the original set, collect all its dependencies
+        for (Descriptors.FileDescriptor fileDescriptor : fileDescriptors) {
+            collectDependencies(fileDescriptor, allDescriptorsBuilder, added);
+        }
+
+        // Add all collected FileDescriptorProto objects to the request builder
+        DescriptorProtos.FileDescriptorSet allDescriptors = allDescriptorsBuilder.build();
+        requestBuilder.addAllProtoFile(allDescriptors.getFileList());
+    }
+
+    public static void copyDirectory(final Path source, final Path target) throws IOException {
+        java.nio.file.Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                if (java.nio.file.Files.isSymbolicLink(dir)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                } else {
+                    Path relativePath = source.relativize(dir).normalize();
+                    String relative = relativePath.toString().replace("\\", "/");
+                    Path directory = target.resolve(relative).normalize();
+                    if (!directory.toString().equals("/")) {
+                        FileAttribute<?>[] attributes = new FileAttribute[0];
+                        PosixFileAttributeView attributeView = (PosixFileAttributeView) java.nio.file.Files
+                                .getFileAttributeView(dir, PosixFileAttributeView.class);
+                        if (attributeView != null) {
+                            Set<PosixFilePermission> permissions = attributeView.readAttributes().permissions();
+                            FileAttribute<Set<PosixFilePermission>> attribute = PosixFilePermissions
+                                    .asFileAttribute(permissions);
+                            attributes = new FileAttribute[] { attribute };
+                        }
+
+                        java.nio.file.Files.createDirectories(directory, attributes);
+                    }
+
+                    return FileVisitResult.CONTINUE;
+                }
+            }
+
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Path relativePath = source.relativize(file).normalize();
+                String relative = relativePath.toString().replace("\\", "/");
+                Path path = target.resolve(relative).normalize();
+                java.nio.file.Files.copy(file, path, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void copySanitizedProtoFile(ResolvedDependency artifact, Path protoPath, Path outProtoPath)
+            throws IOException {
+        boolean genericServicesFound = false;
+
+        try (var reader = Files.newBufferedReader(protoPath);
+                var writer = Files.newBufferedWriter(outProtoPath)) {
+
+            String line = reader.readLine();
+            while (line != null) {
+                // filter java_generic_services to avoid "Tried to write the same file twice"
+                // when set to true. Generic services are deprecated and replaced by classes generated by
+                // this plugin
+                if (!line.contains("java_generic_services")) {
+                    writer.write(line);
+                    writer.newLine();
+                } else {
+                    genericServicesFound = true;
+                }
+
+                line = reader.readLine();
+            }
+        }
+
+        if (genericServicesFound) {
+            log.infof("Ignoring option java_generic_services in %s:%s%s.", artifact.getGroupId(), artifact.getArtifactId(),
+                    protoPath);
+        }
+    }
+
+    private void postprocessing(CodeGenContext context, Path outDir) {
+        if (TRUE.toString().equalsIgnoreCase(System.getProperties().getProperty(POST_PROCESS_SKIP, "false"))
+                || context.config().getOptionalValue(POST_PROCESS_SKIP, Boolean.class).orElse(false)) {
+            log.info("Skipping gRPC Post-Processing on user's request");
+            return;
+        }
+
+        new GrpcZeroPostProcessing(context, outDir).postprocess();
+
+    }
+
+    private Collection<Path> gatherProtosFromDependencies(Path workDir, Set<String> protoDirectories,
+            CodeGenContext context) throws CodeGenException {
+        if (context.test()) {
+            return Collections.emptyList();
+        }
+        Config properties = context.config();
+        String scanDependencies = properties.getOptionalValue(SCAN_DEPENDENCIES_FOR_PROTO, String.class)
+                .orElse("none");
+
+        if ("none".equalsIgnoreCase(scanDependencies)) {
+            return Collections.emptyList();
+        }
+        boolean scanAll = "all".equalsIgnoreCase(scanDependencies);
+
+        List<String> dependenciesToScan = Arrays.stream(scanDependencies.split(",")).map(String::trim)
+                .collect(Collectors.toList());
+
+        ApplicationModel appModel = context.applicationModel();
+        List<Path> protoFilesFromDependencies = new ArrayList<>();
+        for (ResolvedDependency artifact : appModel.getRuntimeDependencies()) {
+            String packageId = String.format("%s:%s", artifact.getGroupId(), artifact.getArtifactId());
+            Collection<String> includes = properties
+                    .getOptionalValue(String.format(SCAN_DEPENDENCIES_FOR_PROTO_INCLUDE_PATTERN, packageId), String.class)
+                    .map(s -> Arrays.stream(s.split(",")).map(String::trim).collect(Collectors.toList()))
+                    .orElse(List.of());
+
+            Collection<String> excludes = properties
+                    .getOptionalValue(String.format(SCAN_DEPENDENCIES_FOR_PROTO_EXCLUDE_PATTERN, packageId), String.class)
+                    .map(s -> Arrays.stream(s.split(",")).map(String::trim).collect(Collectors.toList()))
+                    .orElse(List.of());
+
+            if (scanAll
+                    || dependenciesToScan.contains(packageId)) {
+                extractProtosFromArtifact(workDir, protoFilesFromDependencies, protoDirectories, artifact, includes, excludes,
+                        true);
+            }
+        }
+        return protoFilesFromDependencies;
+    }
+
+    @Override
+    public boolean shouldRun(Path sourceDir, Config config) {
+        return CodeGenProvider.super.shouldRun(sourceDir, config)
+                || isGeneratingFromAppDependenciesEnabled(config);
+    }
+
+    private boolean isGeneratingFromAppDependenciesEnabled(Config config) {
+        return config.getOptionalValue(SCAN_DEPENDENCIES_FOR_PROTO, String.class)
+                .filter(value -> !"none".equals(value)).isPresent();
+    }
+
+    private boolean shouldGenerateKotlin(Config config) {
+        return config.getOptionalValue(GENERATE_KOTLIN, Boolean.class).orElse(
+                hasQuarkusKotlinDependency);
+    }
+
+    private boolean shouldGenerateDescriptorSet(Config config) {
+        return config.getOptionalValue(GENERATE_DESCRIPTOR_SET, Boolean.class).orElse(FALSE);
+    }
+
+    private Path getDescriptorSetOutputFile(CodeGenContext context) throws IOException {
+        var dscOutputDir = context.config().getOptionalValue(DESCRIPTOR_SET_OUTPUT_DIR, String.class)
+                .map(context.workDir()::resolve)
+                .orElseGet(context::outDir);
+
+        if (Files.notExists(dscOutputDir)) {
+            Files.createDirectories(dscOutputDir);
+        }
+
+        var dscFilename = context.config().getOptionalValue(DESCRIPTOR_SET_FILENAME, String.class)
+                .orElse("descriptor_set.dsc");
+
+        return dscOutputDir.resolve(dscFilename).normalize();
+    }
+
+    private Collection<String> gatherDirectoriesWithImports(Path workDir, CodeGenContext context) throws CodeGenException {
+        Config properties = context.config();
+
+        String scanForImports = properties.getOptionalValue(SCAN_FOR_IMPORTS, String.class)
+                .orElse("com.google.protobuf:protobuf-java");
+
+        if ("none".equals(scanForImports.toLowerCase(Locale.getDefault()))) {
+            return Collections.emptyList();
+        }
+
+        boolean scanAll = "all".equals(scanForImports.toLowerCase(Locale.getDefault()));
+        List<String> dependenciesToScan = Arrays.stream(scanForImports.split(",")).map(String::trim)
+                .collect(Collectors.toList());
+
+        Set<String> importDirectories = new HashSet<>();
+        ApplicationModel appModel = context.applicationModel();
+        for (ResolvedDependency artifact : appModel.getRuntimeDependencies()) {
+            if (scanAll
+                    || dependenciesToScan.contains(
+                            String.format("%s:%s", artifact.getGroupId(), artifact.getArtifactId()))) {
+                extractProtosFromArtifact(workDir, new ArrayList<>(), importDirectories, artifact, List.of(),
+                        List.of(), false);
+            }
+        }
+        return importDirectories;
+    }
+
+    private void extractProtosFromArtifact(Path workDir, Collection<Path> protoFiles,
+            Set<String> protoDirectories, ResolvedDependency artifact, Collection<String> filesToInclude,
+            Collection<String> filesToExclude, boolean isDependency) throws CodeGenException {
+
+        try {
+            artifact.getContentTree(new PathFilter(filesToInclude, filesToExclude)).walk(
+                    pathVisit -> {
+                        Path path = pathVisit.getPath();
+                        if (Files.isRegularFile(path) && path.getFileName().toString().endsWith(PROTO)) {
+                            Path root = pathVisit.getRoot();
+                            if (Files.isDirectory(root)) {
+                                protoFiles.add(path);
+                                protoDirectories.add(path.getParent().normalize().toAbsolutePath().toString());
+                            } else { // archive
+                                Path relativePath = path.getRoot().relativize(path);
+                                String uniqueName = artifact.getGroupId() + ":" + artifact.getArtifactId();
+                                if (artifact.getVersion() != null) {
+                                    uniqueName += ":" + artifact.getVersion();
+                                }
+                                if (artifact.getClassifier() != null) {
+                                    uniqueName += "-" + artifact.getClassifier();
+                                }
+                                Path protoUnzipDir = workDir
+                                        .resolve(HashUtil.sha1(uniqueName))
+                                        .normalize().toAbsolutePath();
+                                try {
+                                    Files.createDirectories(protoUnzipDir);
+                                    protoDirectories.add(protoUnzipDir.toString());
+                                } catch (IOException e) {
+                                    throw new GrpcCodeGenException("Failed to create directory: " + protoUnzipDir, e);
+                                }
+                                Path outPath = protoUnzipDir;
+                                for (Path part : relativePath) {
+                                    outPath = outPath.resolve(part.toString());
+                                }
+                                try {
+                                    Files.createDirectories(outPath.getParent());
+                                    if (isDependency) {
+                                        copySanitizedProtoFile(artifact, path, outPath);
+                                    } else {
+                                        copy(path, outPath, StandardCopyOption.REPLACE_EXISTING);
+                                    }
+                                    protoFiles.add(outPath);
+                                } catch (IOException e) {
+                                    throw new GrpcCodeGenException("Failed to extract proto file" + path + " to target: "
+                                            + outPath, e);
+                                }
+                            }
+                        }
+                    });
+        } catch (GrpcCodeGenException e) {
+            throw new CodeGenException(e.getMessage(), e);
+        }
+    }
+
+    private String escapeWhitespace(String path) {
+        if (OS.current() == OS.LINUX) {
+            return path.replace(" ", "\\ ");
+        } else {
+            return path;
+        }
+    }
+
+    private static boolean containsQuarkusKotlin(Collection<ResolvedDependency> dependencies) {
+        return dependencies.stream().anyMatch(new Predicate<ResolvedDependency>() {
+            @Override
+            public boolean test(ResolvedDependency rd) {
+                return rd.getGroupId().equalsIgnoreCase("io.quarkus")
+                        && rd.getArtifactId().equalsIgnoreCase("quarkus-kotlin");
+            }
+        });
+    }
+
+    private static class GrpcCodeGenException extends RuntimeException {
+        private GrpcCodeGenException(String message, Exception cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroPostProcessing.java
+++ b/extensions/grpc/zero-codegen/src/main/java/io/quarkus/grpc/zero/codegen/GrpcZeroPostProcessing.java
@@ -1,0 +1,136 @@
+package io.quarkus.grpc.zero.codegen;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.jboss.logging.Logger;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.utils.SourceRoot;
+
+import io.quarkus.deployment.CodeGenContext;
+
+public class GrpcZeroPostProcessing {
+
+    private static final Logger log = Logger.getLogger(GrpcZeroPostProcessing.class);
+
+    private static final String POST_PROCESS_QUARKUS_GENERATED_ANNOTATION = "quarkus.generate-code.grpc-post-processing.use-quarkus-generated-annotation";
+    private static final String POST_PROCESS_NO_FINAL = "quarkus.generate-code.grpc-post-processing.no-final";
+    // this is intentionally split so that it doesn't get replaced by the Jakarta transformer
+    public static final String JAVAX_GENERATED = "javax" + ".annotation.Generated";
+    public static final String QUARKUS_GENERATED = "io.quarkus.Generated";
+    public static final String STUB = "Stub";
+    public static final String BIND_METHOD = "bindService";
+
+    private final Path root;
+    private final boolean replaceGeneratedAnnotation;
+    private final boolean removeFinal;
+
+    public GrpcZeroPostProcessing(CodeGenContext context, Path root) {
+        this.root = root;
+        this.replaceGeneratedAnnotation = isEnabled(context, POST_PROCESS_QUARKUS_GENERATED_ANNOTATION, true);
+        this.removeFinal = isEnabled(context, POST_PROCESS_NO_FINAL, true);
+    }
+
+    public GrpcZeroPostProcessing(Path root) {
+        this.root = root;
+        this.replaceGeneratedAnnotation = true;
+        this.removeFinal = true;
+    }
+
+    /**
+     * Methods used for the quarkus-grpc-stub project post-processing (as it's not a quarkus app)
+     *
+     * @param args expects the path to the source root of the files to post-process.
+     */
+    public static void main(String[] args) {
+        for (String arg : args) {
+            Path path = new File(arg).toPath();
+            var postprocessing = new GrpcZeroPostProcessing(path);
+            postprocessing.postprocess();
+        }
+
+    }
+
+    private boolean isEnabled(CodeGenContext context, String name, boolean def) {
+        return Boolean.getBoolean(name) || context.config().getOptionalValue(name, Boolean.class).orElse(def);
+    }
+
+    public void postprocess() {
+        SourceRoot sr = new SourceRoot(root);
+        try {
+            sr.parse("", new SourceRoot.Callback() {
+                @Override
+                public com.github.javaparser.utils.SourceRoot.Callback.Result process(Path localPath, Path absolutePath,
+                        com.github.javaparser.ParseResult<CompilationUnit> result) {
+                    if (result.isSuccessful()) {
+                        CompilationUnit unit = result.getResult().orElseThrow(); // the parsing succeed, so we can retrieve the cu
+
+                        if (unit.getPrimaryType().isPresent()) {
+                            TypeDeclaration<?> type = unit.getPrimaryType().get();
+                            postprocess(unit, type);
+                            return Result.SAVE;
+                        }
+
+                    } else {
+                        // Compilation issue - report and skip
+                        log.errorf(
+                                "Unable to parse a class generated using protoc, skipping post-processing for this " +
+                                        "file. Reported problems are %s",
+                                result.toString());
+                    }
+
+                    return Result.DONT_SAVE;
+                }
+            });
+        } catch (Exception e) {
+            // read issue, report and exit
+            log.error("Unable to parse the classes generated using protoc - skipping gRPC post processing", e);
+        }
+    }
+
+    private void postprocess(CompilationUnit unit, TypeDeclaration<?> primary) {
+        log.debugf("Post-processing %s", primary.getFullyQualifiedName().orElse(primary.getNameAsString()));
+
+        unit.accept(new ModifierVisitor<Void>() {
+
+            @Override
+            public Visitable visit(NormalAnnotationExpr n, Void arg) {
+                if (replaceGeneratedAnnotation) {
+                    if (n.getNameAsString().equals(JAVAX_GENERATED)) {
+                        n.setName(QUARKUS_GENERATED);
+                    }
+                }
+                return super.visit(n, arg);
+            }
+
+            @Override
+            public Visitable visit(ClassOrInterfaceDeclaration n, Void arg) {
+                if (removeFinal) {
+                    if (n.hasModifier(Modifier.Keyword.FINAL) && n.getNameAsString().endsWith(STUB)) {
+                        n.removeModifier(Modifier.Keyword.FINAL);
+                    }
+                }
+                return super.visit(n, arg);
+            }
+
+            @Override
+            public Visitable visit(MethodDeclaration n, Void arg) {
+                if (removeFinal) {
+                    if (n.hasModifier(Modifier.Keyword.FINAL)
+                            && n.getNameAsString().equalsIgnoreCase(BIND_METHOD)) {
+                        n.removeModifier(Modifier.Keyword.FINAL);
+                    }
+                }
+                return super.visit(n, arg);
+            }
+        }, null);
+    }
+}

--- a/extensions/grpc/zero-codegen/src/main/resources/META-INF/services/io.quarkus.deployment.CodeGenProvider
+++ b/extensions/grpc/zero-codegen/src/main/resources/META-INF/services/io.quarkus.deployment.CodeGenProvider
@@ -1,0 +1,1 @@
+io.quarkus.grpc.zero.codegen.GrpcZeroCodeGen

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
@@ -36,7 +36,7 @@ public class GrpcMultiModuleQuarkusBuildTest extends QuarkusGradleWrapperTestBas
         Files.copy(projectDir.toPath().resolve("invalid.proto"), protoDirectory.resolve("invalid.proto"));
         try {
             final BuildResult buildResult = runGradleWrapper(true, projectDir, ":application:quarkusBuild", "--info");
-            assertTrue(buildResult.getOutput().contains("invalid.proto:5:1: Missing field number."));
+            assertTrue(buildResult.getOutput().contains("Grpc Zero failed while parsing proto 'invalid.proto'"));
         } finally {
             Files.delete(protoDirectory.resolve("invalid.proto"));
         }

--- a/integration-tests/grpc-proto3/pom.xml
+++ b/integration-tests/grpc-proto3/pom.xml
@@ -109,6 +109,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-stubs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-grpc-zero-codegen</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->

--- a/integration-tests/grpc-proto4/pom.xml
+++ b/integration-tests/grpc-proto4/pom.xml
@@ -29,6 +29,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-stubs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-grpc-zero-codegen</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,9 @@
                                             <!-- com.google.auth -->
                                             <!-- perfmark.version https://central.sonatype.com/artifact/io.grpc/grpc-core  -->
         <grpc-jprotoc.version>1.2.2</grpc-jprotoc.version>
-        <protoc.version>4.33.2</protoc.version>
+        <protoc.version>4.34.1</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
+        <protobuf4j.version>0.0.4</protobuf4j.version>
         <protobuf-kotlin.version>${protoc.version}</protobuf-kotlin.version>
         <proto-google-common-protos.version>2.70.0</proto-google-common-protos.version>
         <perfmark.version>0.27.0</perfmark.version><!-- dependency of io.grpc:grpc-core not managed in io.grpc:grpc-bom -->


### PR DESCRIPTION
This is the technical implementation we agreed on.
The integration tests are running mostly on GrpcZero, but `grpc-proto3` is using the current implementation demonstrating that is possible and easy to roll-back, basically:
add:
```xml
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-grpc-codegen</artifactId>
        </dependency>
```
and exclude:
```xml
             <exclusions>
                <exclusion>
                    <groupId>io.quarkus</groupId>
                    <artifactId>quarkus-grpc-zero-codegen</artifactId>
                </exclusion>
            </exclusions>
```

I believe that this setup is "enough" as the integration tests are not really exercising the codegen bits.
I'm open to add more tests when requested.

As soon as we have an agreement on the implementation I'll move on updating the documentation.

- Closes: #51420