### PR TITLE
Vertx: move re-initialization of DevModeExecutor before the restart

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -109,6 +109,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     private Map<DotName, Set<DotName>> classToRecompilationTargets = new HashMap<>();
 
     private final List<Runnable> preScanSteps = new CopyOnWriteArrayList<>();
+    private final List<Runnable> preRestartSteps = new CopyOnWriteArrayList<>();
     private final List<Runnable> postRestartSteps = new CopyOnWriteArrayList<>();
     private final List<Consumer<Set<String>>> noRestartChangesConsumers = new CopyOnWriteArrayList<>();
     private final List<HotReplacementSetup> hotReplacementSetup = new ArrayList<>();
@@ -554,7 +555,13 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                 } else if (forceRestart && userInitiated) {
                     log.info("Restarting as requested by the user.");
                 }
-
+                for (Runnable step : preRestartSteps) {
+                    try {
+                        step.run();
+                    } catch (Throwable t) {
+                        log.error("Pre Restart step failed", t);
+                    }
+                }
                 restartCallback.accept(filesChanged, changedClassResults);
                 long timeNanoSeconds = System.nanoTime() - startNanoseconds;
                 log.infof("Live reload total time: %ss ", Timing.convertToBigDecimalSeconds(timeNanoSeconds));
@@ -642,6 +649,11 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     @Override
     public void addPreScanStep(Runnable runnable) {
         preScanSteps.add(runnable);
+    }
+
+    @Override
+    public void addPreRestartStep(Runnable runnable) {
+        preRestartSteps.add(runnable);
     }
 
     @Override

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
@@ -70,6 +70,11 @@ public interface HotReplacementContext {
     Set<String> syncState(Map<String, String> fileHashes);
 
     /**
+     * Adds a task that is run before the restart is performed.
+     */
+    void addPreRestartStep(Runnable runnable);
+
+    /**
      * Adds a task that is run after the restart is performed.
      */
     void addPostRestartStep(Runnable runnable);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
@@ -53,7 +53,7 @@ public class VertxHttpHotReplacementSetup implements HotReplacementSetup {
                 RemoteSyncHandler.doPreScan();
             }
         });
-        hotReplacementContext.addPostRestartStep(new Runnable() {
+        hotReplacementContext.addPreRestartStep(new Runnable() {
             @Override
             public void run() {
                 // If not on a worker thread then attempt to re-initialize the dev mode executor


### PR DESCRIPTION
- fixes #51882
- this is a follow-up to #38478