### PR TITLE
When REST Client @Consumes has multiple values, choose the first one

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1268,6 +1268,47 @@ public interface ExtensionsService {
 org.eclipse.microprofile.rest.client.propagateHeaders=Authorization,Proxy-Authorization
 ----
 
+== Multiple `@Consumes` media types
+
+Some REST Client interface methods may have a `@Consumes` annotation with multiple media type values, for example:
+
+[source, java]
+----
+@Path("/orders")
+@RegisterRestClient
+public interface OrderService {
+
+    record OrderReference(String orderReference) {
+    };
+
+    @POST
+    @Consumes({"application/json", "application/yaml"}) <1>
+    Response addOrderReference(OrderReference orderReference);
+}
+----
+<1> REST server accepts OrderReference representations in either JSON or YAML formats.
+
+REST Client must set a `Content-Type` for the `POST /orders` requests. When it sees `@Consumes` with multiple media type values, it sorts them and chooses the first media type as a `Content-Type` value. It must not impact the client code that makes calls such as `OrderService#addOrderReference` as all the listed `@Consumes` values are expected to be supported by the REST server.
+
+Register a custom `ClientRequestFiler` as explained in the <<customize-rest-client-request>> section if you prefer to set a different `Content-Type` such as `application/yaml` which is also supported according to the `OrderService` interface definition:
+
+[source, java]
+----
+@Provider
+public class RestClientContentTypeRequestFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext rc) throws IOException {
+        String contentType = rc.getHeaderString("Content-Type"));
+        if ("application/json".equals(contentType)) {
+            rc.getHeaders().putSingle("Content-Type", "application/yaml");
+        }
+    }
+
+}
+----
+
+[[customize-rest-client-request]]
 == Customizing the request
 
 The REST Client supports further customization of the final request to be sent to the server via filters. The filters must implement either the interface `ClientRequestFilter` or `ResteasyReactiveClientRequestFilter`.

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -34,7 +34,6 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -2653,15 +2652,15 @@ public class JaxrsClientReactiveProcessor {
             if (consumes != null && consumes.length > 0) {
 
                 if (consumes.length > 1) {
-                    Set<String> uniqueConsumes = new HashSet<>(Arrays.asList(consumes));
+                    Set<String> uniqueConsumes = Set.of(consumes);
+                    mediaTypeValue = uniqueConsumes.iterator().next();
                     if (uniqueConsumes.size() > 1) {
-                        // Consider picking up the first @Consumes instead
-                        throw new IllegalArgumentException(
-                                "Multiple `@Consumes` values used in a MicroProfile Rest Client: " +
-                                        restClientInterface.name().toString()
-                                        + " Unable to determine a single `Content-Type`.");
-                    } else {
-                        mediaTypeValue = uniqueConsumes.iterator().next();
+                        log.debugf("MicroProfile Rest Client `%s`'s method `%s` has multiple `@Consumes` values `%s`,"
+                                + " Content-Type will be set to `%s`."
+                                + " You can change Content-Type in a custom jakarta.ws.rs.ClientRequestFilter implementation.",
+                                restClientInterface.name().toString(), jandexMethod.name(),
+                                uniqueConsumes.stream().collect(Collectors.joining(", ")),
+                                mediaTypeValue);
                     }
                 } else {
                     mediaTypeValue = consumes[0];

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -45,7 +45,8 @@ public class FrontendResource {
     @Path("userNameReactive")
     @Produces("text/plain")
     public Uni<String> userNameReactive() {
-        return protectedResourceServiceReactiveFilter.getUserName();
+        return protectedResourceServiceReactiveFilter.getUserName().onItem()
+                .transformToUni(name -> protectedResourceServiceReactiveFilter.echoUserName(name));
     }
 
     @GET

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -4,7 +4,9 @@ import java.security.Principal;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 
@@ -23,6 +25,15 @@ public class ProtectedResource {
     @Path("userName")
     public String principalName() {
         return principal.getName();
+    }
+
+    @POST
+    @RolesAllowed("user")
+    @Produces("text/plain")
+    @Consumes("text/plain")
+    @Path("userNameReactive")
+    public String echoPrincipalName(String name) {
+        return principal.getName() + ":" + name;
     }
 
     @GET

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceReactiveFilter.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceReactiveFilter.java
@@ -1,6 +1,8 @@
 package io.quarkus.it.keycloak;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 
@@ -18,4 +20,10 @@ public interface ProtectedResourceServiceReactiveFilter {
     @Produces("text/plain")
     @Path("userNameReactive")
     Uni<String> getUserName();
+
+    @POST
+    @Produces("text/plain")
+    @Consumes({ "text/plain", "application/json" })
+    @Path("userNameReactive")
+    Uni<String> echoUserName(String name);
 }

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/RestClientContentTypeRequestFilter.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/RestClientContentTypeRequestFilter.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.keycloak;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
+
+@Provider
+public class RestClientContentTypeRequestFilter implements ClientRequestFilter {
+    private static final Logger log = Logger.getLogger(RestClientContentTypeRequestFilter.class);
+
+    @Override
+    public void filter(ClientRequestContext rc) throws IOException {
+        if ("POST".equals(rc.getMethod())) {
+            log.debugf("Content-Type is set to %s, replacing it with text/plain", rc.getHeaderString("Content-Type"));
+            rc.getHeaders().putSingle("Content-Type", "text/plain");
+        }
+    }
+
+}

--- a/integration-tests/oidc-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-reactive/src/main/resources/application.properties
@@ -42,5 +42,7 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=T
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
 quarkus.log.category."io.quarkus.it.keycloak.TokenEndpointResponseFilter".min-level=TRACE
 quarkus.log.category."io.quarkus.it.keycloak.TokenEndpointResponseFilter".level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.RestClientContentTypeRequestFilter".min-level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.RestClientContentTypeRequestFilter".level=TRACE
 quarkus.log.file.enabled=true
 quarkus.log.file.format=%C - %s%n

--- a/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -33,7 +34,7 @@ public class OidcClientTest {
                 .when().get("/frontend/userNameReactive")
                 .then()
                 .statusCode(200)
-                .body(equalTo("alice"));
+                .body(equalTo("alice:alice"));
     }
 
     @Test
@@ -78,7 +79,7 @@ public class OidcClientTest {
                 .when().get("/frontend/userNameReactive")
                 .then()
                 .statusCode(200)
-                .body(equalTo("alice"));
+                .body(equalTo("alice:alice"));
 
         // Wait until the access token has expired
         long expiredTokenTime = System.currentTimeMillis() + 5000;
@@ -95,7 +96,7 @@ public class OidcClientTest {
                 .when().get("/frontend/userNameReactive")
                 .then()
                 .statusCode(200)
-                .body(equalTo("alice"));
+                .body(equalTo("alice:alice"));
         checkLog();
     }
 
@@ -118,6 +119,7 @@ public class OidcClientTest {
                         int tokenAcquisitionCount = 0;
                         int tokenRefreshedOidcClientLogCount = 0;
                         int tokenRefreshResponseFilterLogCount = 0;
+                        boolean contentTypeUpdated = false;
 
                         try (BufferedReader reader = new BufferedReader(
                                 new InputStreamReader(new ByteArrayInputStream(Files.readAllBytes(accessLogFilePath)),
@@ -132,6 +134,9 @@ public class OidcClientTest {
                                 if (line.contains("Tokens have been refreshed")) {
                                     tokenRefreshResponseFilterLogCount++;
                                 }
+                                if (line.contains("Content-Type is set to application/json, replacing it with text/plain")) {
+                                    contentTypeUpdated = true;
+                                }
 
                             }
                         }
@@ -144,6 +149,9 @@ public class OidcClientTest {
 
                         assertEquals(1, tokenRefreshResponseFilterLogCount,
                                 "Log file must contain a single OidcResponseFilter token refresh confirmation");
+
+                        assertTrue(contentTypeUpdated,
+                                "Log file must contain a confirmation of application/json replaced with text/plain ");
                     }
                 });
     }


### PR DESCRIPTION
- Fixes: #51910

This PR does the following updates:

* When REST Client `@Consumes` has multiple values, the first one is chosen from the set
* Added test confirming that a custom `ClientRequestFilter` can replace the `Content-Type`, the test emulates a situation where an interface advertizes that `application/json` is supported without syncing up with the actual REST server that is still on `text/plain` only, with REST Client still letting users handle such a buggy REST Client interface.
* Updated docs