### PR TITLE
Don't rely on exact JSON match in `HibernateOrmDataTest`

### DIFF
--- a/integration-tests/hibernate-orm-data/src/test/java/io/quarkus/it/hibernate/processor/data/HibernateOrmDataTest.java
+++ b/integration-tests/hibernate-orm-data/src/test/java/io/quarkus/it/hibernate/processor/data/HibernateOrmDataTest.java
@@ -107,6 +107,8 @@ public class HibernateOrmDataTest {
                 .when().get("/data/sqlonly/myuser/by/username/{name}")
                 .then()
                 .statusCode(200)
-                .body(equalTo("{\"id\":42,\"username\":\"admin\",\"role\":\"admin\"}"));
+                .body("id", equalTo(42))
+                .body("username", equalTo("admin"))
+                .body("role", equalTo("admin"));
     }
 }


### PR DESCRIPTION
This is done because with https://github.com/quarkusio/quarkus/pull/51802 the order of the json fields is different,
but the result is the same semantically