### PR TITLE
Maven template: do not require the '@argLine' property to be defined in older projects

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
@@ -84,7 +84,6 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>$\{surefire-plugin.version}</version>
                     <configuration>
-                        <argLine>@\{argLine}</argLine>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <maven.home>$\{maven.home}</maven.home>
@@ -97,7 +96,6 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>$\{failsafe-plugin.version}</version>
                     <configuration>
-                        <argLine>@\{argLine}</argLine>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <maven.home>$\{maven.home}</maven.home>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -170,7 +170,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>$\{surefire-plugin.version}</version>
                 <configuration>
+                    {#if quarkus.platform.version.compareVersionTo("3.30.999") > 0}
                     <argLine>@\{argLine}</argLine>
+                    {/if}
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>$\{maven.home}</maven.home>
@@ -191,7 +193,9 @@
                     </execution>
                 </executions>
                 <configuration>
+                    {#if quarkus.platform.version.compareVersionTo("3.30.999") > 0}
                     <argLine>@\{argLine}</argLine>
+                    {/if}
                     <systemPropertyVariables>
                         {#if generate-native}
                         <native.image.path>$\{project.build.directory}/$\{project.build.finalName}-runner</native.image.path>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
@@ -46,7 +46,6 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire-plugin.version}</version>
                     <configuration>
-                        <argLine>@{argLine}</argLine>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <maven.home>${maven.home}</maven.home>
@@ -58,7 +57,6 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${failsafe-plugin.version}</version>
                     <configuration>
-                        <argLine>@{argLine}</argLine>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <maven.home>${maven.home}</maven.home>


### PR DESCRIPTION
* Fixes #51950

Solution inspired by https://github.com/quarkusio/quarkus/pull/51563/files on suggestion by @gsmet .  Tested manually locally.