### PR TITLE
Expose metrics for Reactive SQL client connection "stealing"

### DIFF
--- a/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceProcessor.java
+++ b/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.reactive.datasource.runtime.DataSourceReactiveBuildTimeConfig;
 import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveBuildTimeConfig;
+import io.quarkus.reactive.datasource.runtime.StealingHelper;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 class ReactiveDataSourceProcessor {
@@ -124,5 +125,11 @@ class ReactiveDataSourceProcessor {
                     newDataSourceBuildItem.isDefault(),
                     newDataSourceBuildItem.getVersion()));
         }
+    }
+
+    @BuildStep
+    void registerStealingHelper(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        // Register the StealingHelper bean so it is discovered by Arc
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(StealingHelper.class));
     }
 }

--- a/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/StealingPoolWrapperGenerator.java
+++ b/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/StealingPoolWrapperGenerator.java
@@ -1,0 +1,112 @@
+package io.quarkus.reactive.datasource.deployment;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.reactive.datasource.runtime.StealingHelper;
+import io.vertx.core.Future;
+
+public class StealingPoolWrapperGenerator {
+
+    /**
+     * Generates a bytecode wrapper for the specific Pool interface (e.g., PgPool, MySQLPool).
+     *
+     * @param generatedClasses Producer for generated class files
+     * @param reflectiveClasses Producer for native image reflection config
+     * @param poolInterface The target interface to implement (e.g., io.vertx.pgclient.PgPool)
+     * @param wrapperClassName The fully qualified name for the generated wrapper
+     */
+    public static void generate(BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            Class<?> poolInterface,
+            String wrapperClassName) {
+
+        try (ClassCreator cc = ClassCreator.builder()
+                .classOutput(new GeneratedClassGizmoAdaptor(generatedClasses, true))
+                .className(wrapperClassName)
+                .interfaces(poolInterface)
+                .build()) {
+
+            FieldDescriptor delegateField = cc.getFieldCreator("delegate", poolInterface)
+                    .setModifiers(Modifier.PRIVATE | Modifier.FINAL).getFieldDescriptor();
+
+            FieldDescriptor nameField = cc.getFieldCreator("datasourceName", String.class)
+                    .setModifiers(Modifier.PRIVATE | Modifier.FINAL).getFieldDescriptor();
+
+            FieldDescriptor helperField = cc.getFieldCreator("helper", StealingHelper.class)
+                    .setModifiers(Modifier.PRIVATE | Modifier.FINAL).getFieldDescriptor();
+
+            try (MethodCreator ctor = cc.getMethodCreator("<init>", void.class, poolInterface, String.class,
+                    StealingHelper.class)) {
+                ctor.setModifiers(Modifier.PUBLIC);
+                ctor.invokeSpecialMethod(MethodDescriptor.ofConstructor(Object.class), ctor.getThis());
+
+                ctor.writeInstanceField(delegateField, ctor.getThis(), ctor.getMethodParam(0));
+                ctor.writeInstanceField(nameField, ctor.getThis(), ctor.getMethodParam(1));
+                ctor.writeInstanceField(helperField, ctor.getThis(), ctor.getMethodParam(2));
+                ctor.returnValue(null);
+            }
+
+            for (Method method : poolInterface.getMethods()) {
+
+                // SPECIAL HANDLING: withConnection / withTransaction
+                // If these are default methods, we skip generating them.
+                // This causes the wrapper to inherit the interface's default implementation,
+                // which internally calls 'this.getConnection()', ensuring our interception logic is triggered.
+                if (method.isDefault() &&
+                        (method.getName().equals("withConnection") || method.getName().equals("withTransaction"))) {
+                    continue;
+                }
+
+                MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(
+                        method.getDeclaringClass(),
+                        method.getName(),
+                        method.getReturnType(),
+                        method.getParameterTypes());
+
+                try (MethodCreator mc = cc.getMethodCreator(methodDescriptor)) {
+                    ResultHandle delegate = mc.readInstanceField(delegateField, mc.getThis());
+
+                    // Load arguments
+                    ResultHandle[] args = new ResultHandle[method.getParameterCount()];
+                    for (int i = 0; i < method.getParameterCount(); i++) {
+                        args[i] = mc.getMethodParam(i);
+                    }
+
+                    // Invoke delegate
+                    ResultHandle result = mc.invokeInterfaceMethod(methodDescriptor, delegate, args);
+
+                    // INTERCEPT: getConnection()
+                    // We only intercept the no-arg version that returns a Future.
+                    if (method.getName().equals("getConnection")
+                            && method.getParameterCount() == 0
+                            && Future.class.isAssignableFrom(method.getReturnType())) {
+
+                        ResultHandle nameVal = mc.readInstanceField(nameField, mc.getThis());
+                        ResultHandle helperVal = mc.readInstanceField(helperField, mc.getThis());
+
+                        // Call helper.wrap(result, datasourceName)
+                        result = mc.invokeVirtualMethod(
+                                MethodDescriptor.ofMethod(StealingHelper.class, "wrap", Future.class, Future.class,
+                                        String.class),
+                                helperVal, result, nameVal);
+                    }
+
+                    mc.returnValue(result);
+                }
+            }
+        }
+
+        // Register for Reflection (Required for Native Image)
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(wrapperClassName).constructors(true).build());
+    }
+}

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ConnectionStealingMonitor.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ConnectionStealingMonitor.java
@@ -1,0 +1,11 @@
+package io.quarkus.reactive.datasource.runtime;
+
+public interface ConnectionStealingMonitor {
+    /**
+     * Called whenever a reactive connection is acquired.
+     *
+     * @param datasourceName The name of the datasource (e.g., "default").
+     * @param stolen 'true' if the connection is managed by a different event loop than the caller.
+     */
+    void connectionAcquired(String datasourceName, boolean stolen);
+}

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/StealingHelper.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/StealingHelper.java
@@ -1,0 +1,66 @@
+package io.quarkus.reactive.datasource.runtime;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Future;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.Connection;
+import io.vertx.sqlclient.impl.SocketConnectionBase;
+import io.vertx.sqlclient.impl.SqlConnectionInternal;
+
+@Singleton
+public class StealingHelper {
+    private static final Logger log = Logger.getLogger(StealingHelper.class);
+
+    private final Instance<ConnectionStealingMonitor> monitors;
+
+    @Inject
+    public StealingHelper(Instance<ConnectionStealingMonitor> monitors) {
+        this.monitors = monitors;
+    }
+
+    public Future<SqlConnection> wrap(Future<SqlConnection> future, String datasourceName) {
+        ContextInternal callerContext = ContextInternal.current();
+        // We're only interested in measuring changes in EL threads
+        if (callerContext == null || !callerContext.isEventLoopContext()) {
+            return future;
+        }
+        return future.onSuccess(conn -> {
+            if (conn instanceof SqlConnectionInternal connInternal) {
+                boolean stolen = false;
+                Connection connection = connInternal
+                        // Unwrap the pooled connection
+                        .unwrap()
+                        // Unwrap the base connection
+                        .unwrap();
+                if (connection instanceof SocketConnectionBase socketConnection) {
+                    ContextInternal connContext = (ContextInternal) socketConnection.context();
+                    if (connContext.nettyEventLoop() != callerContext.nettyEventLoop()) {
+                        stolen = true;
+                    }
+                }
+                notifyMonitors(datasourceName, stolen);
+            }
+        });
+    }
+
+    private void notifyMonitors(String datasourceName, boolean stolen) {
+        if (monitors.isUnsatisfied()) {
+            if (stolen)
+                log.warnf("Connection stealing detected in datasource '%s'!", datasourceName);
+        } else {
+            for (ConnectionStealingMonitor monitor : monitors) {
+                try {
+                    monitor.connectionAcquired(datasourceName, stolen);
+                } catch (Throwable t) {
+                    log.debug("Monitor failed", t);
+                }
+            }
+        }
+    }
+}

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
@@ -47,11 +47,14 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.reactive.datasource.deployment.StealingPoolWrapperGenerator;
 import io.quarkus.reactive.datasource.deployment.VertxPoolBuildItem;
 import io.quarkus.reactive.datasource.runtime.DataSourceReactiveBuildTimeConfig;
 import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveBuildTimeConfig;
@@ -298,5 +301,12 @@ class ReactivePgClientProcessor {
         public boolean test(Set<Type> types) {
             return types.contains(PG_POOL_CREATOR);
         }
+    }
+
+    @BuildStep
+    void generateStealingWrapper(BuildProducer<GeneratedClassBuildItem> gen,
+            BuildProducer<ReflectiveClassBuildItem> ref) {
+        StealingPoolWrapperGenerator.generate(gen, ref, PgPool.class,
+                "io.quarkus.reactive.pg.client.runtime.StealingPgPoolWrapper");
     }
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/StealingMonitorTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/StealingMonitorTest.java
@@ -1,0 +1,110 @@
+package io.quarkus.reactive.pg.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.datasource.runtime.ConnectionStealingMonitor;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.Vertx;
+import io.vertx.pgclient.PgPool;
+
+public class StealingMonitorTest {
+
+    private static final String SYS_PROP_KEY = "quarkus.reactive-datasource.monitor-stealing";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> {
+                // Set System Property BEFORE app starts
+                System.setProperty(SYS_PROP_KEY, "true");
+
+                return ShrinkWrap.create(JavaArchive.class)
+                        .addClasses(MyTestMonitor.class);
+            })
+            // Standard Datasource Config (Application Properties)
+            .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.username", "quarkus")
+            .overrideConfigKey("quarkus.datasource.password", "quarkus")
+            .overrideConfigKey("quarkus.datasource.jdbc", "false");
+
+    @Inject
+    PgPool pool;
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    MyTestMonitor monitor;
+
+    @AfterAll
+    public static void tearDown() {
+        // Clean up the system property to avoid side effects on other tests
+        System.clearProperty(SYS_PROP_KEY);
+    }
+
+    @Test
+    public void testMonitorInterception() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        vertx.runOnContext(v -> {
+            pool.withConnection(sqlConnection -> {
+                return sqlConnection.query("SELECT 1").execute();
+            }).onComplete(ar -> {
+                if (ar.failed()) {
+                    ar.cause().printStackTrace();
+                }
+                latch.countDown();
+            });
+        });
+
+        assertTrue(latch.await(5, TimeUnit.MINUTES), "Query timed out");
+
+        assertFalse(monitor.events.isEmpty(),
+                "Monitor should have received an event. Check if System Property was picked up.");
+
+        MonitorEvent event = monitor.events.get(0);
+        assertEquals("<default>", event.datasourceName);
+    }
+
+    // --- Test Helpers ---
+
+    @Singleton
+    public static class MyTestMonitor implements ConnectionStealingMonitor {
+        public final List<MonitorEvent> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void connectionAcquired(String datasourceName, boolean stolen) {
+            events.add(new MonitorEvent(datasourceName, stolen));
+        }
+    }
+
+    public static class MonitorEvent {
+        public final String datasourceName;
+        public final boolean stolen;
+
+        public MonitorEvent(String datasourceName, boolean stolen) {
+            this.datasourceName = datasourceName;
+            this.stolen = stolen;
+        }
+
+        @Override
+        public String toString() {
+            return "MonitorEvent{datasource='" + datasourceName + "', stolen=" + stolen + "}";
+        }
+    }
+}


### PR DESCRIPTION
See #46818

The changes consist in wrapping the pool object when a system property is set. A system property has been chosen in favor of a config property because this is an advanced config that we don't to expose for now or support in this form in the long term. Perhaps it would be better to rename it to internal.

The pool wrapper calls StealingHelper when getConnection is invoked. The helper captures the calling context, if any.
If it's an event loop context and the event loop is different from the event loop of the connection, an event is recorded. We're only interested in this scenario because if the caller is not an EL thread, obviously there will be a switch to EL thread when executing queries.

To record events, we have an interface that can be implemented by the user. We could also implement it in the Micrometer extension.