### PR TITLE
Bump GraalVM `CURRENT` version

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -198,6 +198,7 @@ public final class GraalVM {
         public static final Version VERSION_24_1_0 = new Version("GraalVM 24.1.0", "24.1.0", "23", Distribution.GRAALVM);
         public static final Version VERSION_24_1_999 = new Version("GraalVM 24.1.999", "24.1.999", "23", Distribution.GRAALVM);
         public static final Version VERSION_24_2_0 = new Version("GraalVM 24.2.0", "24.2.0", "24", Distribution.GRAALVM);
+        private static final Version VERSION_25_0_0 = new Version("GraalVM 25.0.0", "25.0.0", "25", Distribution.GRAALVM);
 
         /**
          * The minimum version of GraalVM supported by Quarkus.
@@ -214,7 +215,7 @@ public final class GraalVM {
          * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.CURRENT} instead.
          */
         @Deprecated
-        public static final Version CURRENT = VERSION_23_1_0;
+        public static final Version CURRENT = VERSION_25_0_0;
         /**
          * The minimum version of GraalVM officially supported by Quarkus.
          * Versions prior to this are expected to work but are not given the same level of testing or priority.
@@ -222,7 +223,7 @@ public final class GraalVM {
          * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.MINIMUM_SUPPORTED} instead.
          */
         @Deprecated
-        public static final Version MINIMUM_SUPPORTED = CURRENT;
+        public static final Version MINIMUM_SUPPORTED = MINIMUM;
 
         Version(String fullVersion, String version, Distribution distro) {
             this(fullVersion, version, "11", distro);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -821,7 +821,7 @@ public class NativeImageBuildStep {
                  * Always install exit handlers, it will become the default and the flag will be deprecated
                  * in GraalVM for JDK 25 see https://github.com/quarkusio/quarkus/issues/47799
                  */
-                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_25_0_0) < 0) {
+                if (graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_0_0) < 0) {
                     nativeImageArgs.add("--install-exit-handlers");
                 }
 
@@ -845,7 +845,7 @@ public class NativeImageBuildStep {
                  * @formatter:on
                  */
                 if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_2_0) >= 0
-                        && graalVMVersion.compareTo(GraalVM.Version.VERSION_25_0_0) < 0
+                        && graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_0_0) < 0
                         && (CPU.host() == CPU.x64)) {
                     addExperimentalVMOption(nativeImageArgs, "-H:+ForeignAPISupport");
                 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -121,14 +121,14 @@ public final class GraalVM {
          * The current version of GraalVM supported by Quarkus.
          * This version is the one actively being tested and is expected to give the best experience.
          */
-        public static final Version CURRENT = VERSION_23_1_0;
+        public static final Version CURRENT = VERSION_25_0_0;
         /**
          * The minimum version of GraalVM officially supported by Quarkus.
          * Versions prior to this are expected to work but are not given the same level of testing or priority.
          */
-        public static final Version MINIMUM_SUPPORTED = CURRENT;
+        public static final Version MINIMUM_SUPPORTED = MINIMUM;
 
-        private static final String DEFAULT_JDK_VERSION = "21";
+        private static final String DEFAULT_JDK_VERSION = "25";
         protected final String fullVersion;
         public final Runtime.Version javaVersion;
         protected final Distribution distribution;


### PR DESCRIPTION
As of https://github.com/quarkusio/quarkus/pull/51677, Mandrel 25 is the default builder image.