### PR TITLE
Clean up `GraalVM.Version` implementations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -192,38 +192,41 @@ public final class GraalVM {
         // Get access to GRAAL_MAPPING without making it public
         private static final Map<String, String> GRAAL_MAPPING = io.quarkus.runtime.graal.GraalVM.Version.GRAAL_MAPPING;
 
-        public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
-        public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
-        public static final Version VERSION_24_0_999 = new Version("GraalVM 24.0.999", "24.0.999", "22", Distribution.GRAALVM);
-        public static final Version VERSION_24_1_0 = new Version("GraalVM 24.1.0", "24.1.0", "23", Distribution.GRAALVM);
-        public static final Version VERSION_24_1_999 = new Version("GraalVM 24.1.999", "24.1.999", "23", Distribution.GRAALVM);
-        public static final Version VERSION_24_2_0 = new Version("GraalVM 24.2.0", "24.2.0", "24", Distribution.GRAALVM);
-        private static final Version VERSION_25_0_0 = new Version("GraalVM 25.0.0", "25.0.0", "25", Distribution.GRAALVM);
+        /*
+         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.VERSION_23_1_0} instead.
+         */
+        @Deprecated(since = "3.32", forRemoval = true)
+        public static final Version VERSION_23_1_0 = new Version(io.quarkus.runtime.graal.GraalVM.Version.VERSION_23_1_0);
+        /*
+         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_0_0} instead.
+         */
+        @Deprecated(since = "3.32", forRemoval = true)
+        public static final Version VERSION_24_0_0 = new Version(io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_0_0);
+        /*
+         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_0_999} instead.
+         */
+        @Deprecated(since = "3.32", forRemoval = true)
+        public static final Version VERSION_24_0_999 = new Version(io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_0_999);
+        /*
+         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_1_0} instead.
+         */
+        @Deprecated(since = "3.32", forRemoval = true)
+        public static final Version VERSION_24_1_0 = new Version(io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_1_0);
+        /*
+         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_1_999} instead.
+         */
+        @Deprecated(since = "3.32", forRemoval = true)
+        public static final Version VERSION_24_1_999 = new Version(io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_1_999);
+        /*
+         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_2_0} instead.
+         */
+        @Deprecated(since = "3.32", forRemoval = true)
+        public static final Version VERSION_24_2_0 = new Version(io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_2_0);
+        private static final Version VERSION_25_0_0 = new Version(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_0_0);
 
-        /**
-         * The minimum version of GraalVM supported by Quarkus.
-         * Versions prior to this are expected to cause major issues.
-         *
-         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.MINIMUM} instead.
-         */
-        @Deprecated
-        public static final Version MINIMUM = VERSION_23_1_0;
-        /**
-         * The current version of GraalVM supported by Quarkus.
-         * This version is the one actively being tested and is expected to give the best experience.
-         *
-         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.CURRENT} instead.
-         */
-        @Deprecated
-        public static final Version CURRENT = VERSION_25_0_0;
-        /**
-         * The minimum version of GraalVM officially supported by Quarkus.
-         * Versions prior to this are expected to work but are not given the same level of testing or priority.
-         *
-         * @deprecated Use {@link io.quarkus.runtime.graal.GraalVM.Version.MINIMUM_SUPPORTED} instead.
-         */
-        @Deprecated
-        public static final Version MINIMUM_SUPPORTED = MINIMUM;
+        Version(io.quarkus.runtime.graal.GraalVM.Version version) {
+            super(version);
+        }
 
         Version(String fullVersion, String version, Distribution distro) {
             this(fullVersion, version, "11", distro);
@@ -235,10 +238,6 @@ public final class GraalVM {
 
         Version(String fullVersion, String version, Runtime.Version javaVersion, Distribution distro) {
             super(fullVersion, version, javaVersion, distro);
-        }
-
-        public int compareTo(GraalVM.Version o) {
-            return compareTo((io.quarkus.runtime.graal.GraalVM.Version) o);
         }
 
         Distribution getDistribution() {
@@ -255,14 +254,6 @@ public final class GraalVM {
 
         boolean isSupported() {
             return this.compareTo(io.quarkus.runtime.graal.GraalVM.Version.MINIMUM_SUPPORTED) >= 0;
-        }
-
-        boolean isNewerThan(Version version) {
-            return this.compareTo(version) > 0;
-        }
-
-        boolean isOlderThan(Version version) {
-            return this.compareTo(version) < 0;
         }
 
         /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -698,8 +698,8 @@ public class NativeImageBuildStep {
                 return this;
             }
 
-            public Builder setGraalVMVersion(GraalVM.Version graalVMVersion) {
-                this.graalVMVersion = graalVMVersion;
+            public Builder setGraalVMVersion(io.quarkus.runtime.graal.GraalVM.Version graalVMVersion) {
+                this.graalVMVersion = new GraalVM.Version(graalVMVersion);
                 return this;
             }
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -358,7 +358,7 @@ public class GraalVMTest {
      * Asserts that one version is newer than the other.
      */
     static void assertNewerThan(String version, String other) {
-        assertThat(Version.of(Stream.of(version)).isNewerThan(Version.of(Stream.of(other)))).isTrue();
+        assertThat(Version.of(Stream.of(version)).compareTo(Version.of(Stream.of(other))) > 0).isTrue();
     }
 
     @ParameterizedTest

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -89,6 +89,10 @@ public final class GraalVM {
     public static class Version implements Comparable<Version> {
 
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
+        public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
+        public static final Version VERSION_24_0_999 = new Version("GraalVM 24.0.999", "24.0.999", "22", Distribution.GRAALVM);
+        public static final Version VERSION_24_1_0 = new Version("GraalVM 24.1.0", "24.1.0", "23", Distribution.GRAALVM);
+        public static final Version VERSION_24_1_999 = new Version("GraalVM 24.1.999", "24.1.999", "23", Distribution.GRAALVM);
         public static final Version VERSION_24_2_0 = new Version("GraalVM 24.2.0", "24.2.0", "24", Distribution.GRAALVM);
         public static final Version VERSION_25_0_0 = new Version("GraalVM 25.0.0", "25.0.0", "25", Distribution.GRAALVM);
 
@@ -144,6 +148,14 @@ public final class GraalVM {
 
         Version(String fullVersion, String version, String javaVersion, Distribution distro) {
             this(fullVersion, version, Runtime.Version.parse(javaVersion), distro);
+        }
+
+        protected Version(Version version) {
+            this.fullVersion = version.fullVersion;
+            this.javaVersion = version.javaVersion;
+            this.distribution = version.distribution;
+            this.versions = version.versions;
+            this.suffix = version.suffix;
         }
 
         protected Version(String fullVersion, String version, Runtime.Version javaVersion, Distribution distro) {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
@@ -1,6 +1,6 @@
 package io.quarkus.test.junit;
 
-import io.quarkus.deployment.pkg.steps.GraalVM;
+import io.quarkus.runtime.graal.GraalVM;
 
 public enum GraalVMVersion {
     GRAALVM_23_1_0(GraalVM.Version.VERSION_23_1_0),


### PR DESCRIPTION
* Remove deprecated fields
* Deprecate more fields
* Reduce duplication

Follow up to https://github.com/quarkusio/quarkus/pull/51970