### PR TITLE
Fixed the webauthn guide status

### DIFF
--- a/docs/src/main/asciidoc/security-webauthn.adoc
+++ b/docs/src/main/asciidoc/security-webauthn.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 [id="security-webauthn"]
 = Using Security with WebAuthn
 include::_attributes.adoc[]
-:extension-status: preview
+:extension-status: experimental
 :categories: security
 :topics: security,webauthn,authorization
 :extensions: io.quarkus:quarkus-security-webauthn


### PR DESCRIPTION
We demoted the extension to experimental after we rebased on webauthn4j

As discovered in https://github.com/rolfedh/quarkus/pull/6
