### PR TITLE
Bump version of Postgres/MariaDB used in DevService and our own tests from 17 to 18 and 10.11 to 12.1 (respectively)

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -85,8 +85,8 @@
         <junit-pioneer.version>2.3.0</junit-pioneer.version>
 
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
-        <postgres.image>docker.io/library/postgres:17</postgres.image>
-        <postgis.image>docker.io/postgis/postgis:17-3.5</postgis.image>
+        <postgres.image>docker.io/library/postgres:18</postgres.image>
+        <postgis.image>docker.io/postgis/postgis:18-3.6</postgis.image>
         <mariadb.image>docker.io/library/mariadb:10.11</mariadb.image>
         <db2.image>icr.io/db2_community/db2:12.1.0.0</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -87,7 +87,7 @@
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
         <postgres.image>docker.io/library/postgres:18</postgres.image>
         <postgis.image>docker.io/postgis/postgis:18-3.6</postgis.image>
-        <mariadb.image>docker.io/library/mariadb:10.11</mariadb.image>
+        <mariadb.image>docker.io/library/mariadb:12.1</mariadb.image>
         <db2.image>icr.io/db2_community/db2:12.1.0.0</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>
         <mysql.image>docker.io/library/mysql:9.5</mysql.image>

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -187,7 +187,7 @@ you can set the database version explicitly:
 .`{config-file}` with an explicit `db-version`
 ----
 quarkus.datasource.db-kind = postgresql
-quarkus.datasource.db-version = 14.0 <1>
+quarkus.datasource.db-version = 18.1 <1>
 
 %prod.quarkus.datasource.username = hibernate
 %prod.quarkus.datasource.password = hibernate
@@ -255,7 +255,7 @@ you can configure the DB version explicitly to get the most out of Hibernate ORM
 .`{config-file}` with an explicit `dialect` and `db-version`
 ----
 quarkus.datasource.db-kind = postgresql
-quarkus.datasource.db-version = 22.2 <1>
+quarkus.datasource.db-version = 25.4 <1>
 
 quarkus.hibernate-orm.dialect=Cockroach <2>
 

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -178,10 +178,8 @@
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
-                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>healthcheck.sh --connect --innodb_initialized</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -179,9 +179,9 @@
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
                                             <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
@@ -216,9 +216,9 @@
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
                                             <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
@@ -215,10 +215,8 @@
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
-                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>healthcheck.sh --connect --innodb_initialized</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
@@ -213,10 +213,8 @@
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
-                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>healthcheck.sh --connect --innodb_initialized</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
@@ -214,9 +214,9 @@
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
                                             <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>
@@ -240,7 +240,7 @@
                                             <healthy>true</healthy>
                                             <exec>
                                                 <breakOnError>true</breakOnError>
-                                                <postStart>bash -c eval\ ${@} -- mysql -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
+                                                <postStart>bash -c eval\ ${@} -- mariadb -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
                                             </exec>
                                         </wait>
                                         <volumes>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
@@ -212,9 +212,9 @@
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
                                             <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>
@@ -238,7 +238,7 @@
                                             <healthy>true</healthy>
                                             <exec>
                                                 <breakOnError>true</breakOnError>
-                                                <postStart>bash -c eval\ ${@} -- mysql -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
+                                                <postStart>bash -c eval\ ${@} -- mariadb -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
                                             </exec>
                                         </wait>
                                         <volumes>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
@@ -211,10 +211,8 @@
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
-                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>healthcheck.sh --connect --innodb_initialized</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
@@ -226,10 +226,8 @@
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
-                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>healthcheck.sh --connect --innodb_initialized</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
@@ -227,9 +227,9 @@
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
                                             <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
-                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            Note that mariadb-admin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>mariadb-admin ping -h localhost -u root -psecret|| exit 1</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>
@@ -253,7 +253,7 @@
                                             <healthy>true</healthy>
                                             <exec>
                                                 <breakOnError>true</breakOnError>
-                                                <postStart>bash -c eval\ ${@} -- mysql -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
+                                                <postStart>bash -c eval\ ${@} -- mariadb -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
                                             </exec>
                                         </wait>
                                         <volumes>

--- a/integration-tests/jpa-mariadb/src/main/resources/application.properties
+++ b/integration-tests/jpa-mariadb/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=io.quarkus.it.jpa.mariadb
 
 quarkus.datasource."offline".db-kind=mariadb
-quarkus.datasource."offline".db-version=10.11
+quarkus.datasource."offline".db-version=12.1
 quarkus.hibernate-orm."offline".database.start-offline=true
 quarkus.hibernate-orm."offline".dialect.mariadb.bytes-per-character=1
 quarkus.hibernate-orm."offline".dialect.mariadb.no-backslash-escapes=true
@@ -13,7 +13,7 @@ quarkus.hibernate-orm."offline".datasource=offline
 quarkus.hibernate-orm."offline".packages=io.quarkus.it.jpa.mariadb
 
 quarkus.datasource."offline2".db-kind=mariadb
-quarkus.datasource."offline2".db-version=10.11
+quarkus.datasource."offline2".db-version=12.1
 quarkus.hibernate-orm."offline2".database.start-offline=true
 quarkus.hibernate-orm."offline2".dialect.mariadb.bytes-per-character=1
 quarkus.hibernate-orm."offline2".dialect.mariadb.no-backslash-escapes=true


### PR DESCRIPTION
Since we're doing the same for MySQL in #51989
