### PR TITLE
Enable test classloading tests which are now passing 

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/testing/repro13261/Repro13261Test.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/testing/repro13261/Repro13261Test.java
@@ -4,14 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.file.Path;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.test.junit.QuarkusTest;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/13261")
-// fails with `expected: not <null>`
 @QuarkusTest
 public class Repro13261Test {
     @TempDir

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/CallbackDevModeIT.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/CallbackDevModeIT.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -15,7 +14,6 @@ import io.quarkus.maven.it.RunAndCheckMojoTestBase;
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
 
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
-@Disabled // Tracked by #22611
 public class CallbackDevModeIT extends RunAndCheckMojoTestBase {
 
     /*

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/src/test/java/org/acme/QuarkusTestAccessingBeanInCallback.java
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/src/test/java/org/acme/QuarkusTestAccessingBeanInCallback.java
@@ -1,5 +1,6 @@
 package org.acme;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;


### PR DESCRIPTION
We've had some very old issues, #13261 and #22611 fixed by https://github.com/quarkusio/quarkus/pull/51891. 🎉 #13261 was five and a half years old and #22611 was four years old, so these issues were old enough to go to kindergarden. 

@Ladicek and I had added disabled reproducers, so we can now start running those tests. 


