### PR TITLE
Quarkus Update - Display warning about duplicated recipes

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
@@ -86,7 +86,7 @@ public final class QuarkusUpdates {
             recipe.addRecipes(QuarkusUpdateRecipeIO.readRecipesYaml(s));
         }
 
-        QuarkusUpdateRecipeIO.write(target, recipe);
+        QuarkusUpdateRecipeIO.write(log, target, recipe);
         return result;
     }
 

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateRecipeIOTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateRecipeIOTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.update.rewrite.operations.UpdateManagedDependencyVersionOperation;
 import io.quarkus.devtools.project.update.rewrite.operations.UpdatePropertyOperation;
 
@@ -22,7 +23,7 @@ class QuarkusUpdateRecipeIOTest {
         recipe.addOperation(new UpdatePropertyOperation("quarkus.version", "3.0.0.Alpha1"));
         // Just an example
         recipe.addOperation(new UpdateManagedDependencyVersionOperation("io.quarkus", "quarkus-bom", "example"));
-        final String output = QuarkusUpdateRecipeIO.toYaml(recipe);
+        final String output = QuarkusUpdateRecipeIO.toYaml(new Log(), recipe);
         System.out.println(output);
         assertThat(output)
                 .contains("org.openrewrite.maven.ChangePropertyValue")
@@ -30,7 +31,54 @@ class QuarkusUpdateRecipeIOTest {
                 .contains("newVersion: example")
                 .contains("name: org.openrewrite.java.migrate.JavaxActivationMigrationToJakartaActivation")
                 .contains("- org.openrewrite.java.migrate.JavaxActivationMigrationToJakartaActivation")
-                .contains("name: org.openrewrite.java.migrate.JavaxXmlSoapToJakartaXmlSoap")
-                .contains("- org.openrewrite.java.migrate.JavaxXmlSoapToJakartaXmlSoap");
+                .contains("name: org.openrewrite.java.migrate.JavaxXmlSoapToJakartaXmlSoap");
     }
+
+    @Test
+    void shoulWarnAboutDuplicatedRecipes() throws IOException {
+        final QuarkusUpdateRecipe recipe = new QuarkusUpdateRecipe();
+
+        recipe.addRecipes(QuarkusUpdateRecipeIO
+                .readRecipesYaml(
+                        new String(QuarkusUpdateRecipeIOTest.class.getResourceAsStream("/duplicated-recipes.yaml")
+                                .readAllBytes())));
+        Log log = new Log();
+        final String output = QuarkusUpdateRecipeIO.toYaml(log, recipe);
+        System.out.println(output);
+        assertThat(output)
+                .contains("org.apache.camel.upgrade.camel411.CamelMigrationRecipe")
+                .contains("org.apache.camel.upgrade.camel410.CamelMigrationRecipe");
+        assertThat(log.getWarnings())
+                .contains("Duplicated recipes found:    - 'io.quarkus.updates.camel.camel410.CamelQuarkusMigrationRecipe'");
+    }
+
+    class Log implements MessageWriter {
+        private StringBuffer warnings = new StringBuffer();
+
+        @Override
+        public void info(String msg) {
+        }
+
+        @Override
+        public void error(String msg) {
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return false;
+        }
+
+        @Override
+        public void debug(String msg) {
+        }
+
+        @Override
+        public void warn(String msg) {
+            warnings.append(msg);
+        }
+
+        public StringBuffer getWarnings() {
+            return warnings;
+        }
+    };
 }

--- a/independent-projects/tools/devtools-common/src/test/resources/duplicated-recipes.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/duplicated-recipes.yaml
@@ -1,0 +1,23 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.camel.camel411.CamelQuarkusMigrationRecipe
+displayName: Migrates `camel 4.10` application to `camel 4.11`
+description: Migrates `camel 4.10` quarkus application to `camel 4.11`.
+recipeList:
+  #  use the recipe from camel upgrade recipes project
+  - org.apache.camel.upgrade.camel411.CamelMigrationRecipe
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.camel.camel410.CamelQuarkusMigrationRecipe
+displayName: Migrates `camel 4.9` application to `camel 4.10`
+description: Migrates `camel 4.9` quarkus application to `camel 4.10`.
+recipeList:
+ #  use the recipe from camel upgrade recipes project
+  - org.apache.camel.upgrade.camel410.CamelMigrationRecipe
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.camel.camel410.CamelQuarkusMigrationRecipe
+displayName: Migrates `camel 4.10` application to `camel 4.10.4`
+description: Migrates `camel 4.10` quarkus application to `camel 4.10.4`.
+recipeList:
+  #  use the recipe from camel upgrade recipes project
+  - org.apache.camel.upgrade.camel410_4.CamelMigrationRecipe


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/49898

Adds warning into console in case that the final generated yaml recipe contains duplicated sub-recipes.
Adds test covering this scenario. 

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

