### PR TITLE
Fix minor grammar and punctuation in documentation

### DIFF
--- a/docs/src/main/asciidoc/amqp-dev-services.adoc
+++ b/docs/src/main/asciidoc/amqp-dev-services.adoc
@@ -19,7 +19,7 @@ The application is configured automatically.
 Dev Services for AMQP is automatically enabled unless:
 
 - `quarkus.amqp.devservices.enabled` is set to `false`
-- the `amqp-host` or `amqp-port` is configured
+- the `amqp-host` or `amqp-port` are configured
 - all the Reactive Messaging AMQP channels have the `host` or `port` attributes set
 
 Dev Services for AMQP relies on Docker to start the broker.
@@ -28,7 +28,7 @@ You can configure the broker access using the `amqp-host`, `amqp-port`, `amqp-us
 
 == Shared broker
 
-Most of the time you need to share the broker between applications.
+Most of the time, you need to share the broker between applications.
 Dev Services for AMQP implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single broker.
 
 NOTE: Dev Services for AMQP starts the container with the `quarkus-dev-service-amqp` label which is used to identify the container.

--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -218,7 +218,7 @@ The AMQP connector supports six strategies:
 
 * `fail` - fail the application; no more AMQP messages will be processed (default).
 The AMQP message is marked as rejected.
-* `accept` - this strategy marks the AMQP message as _accepted_. The processing continues ignoring the failure.
+* `accept` - this strategy marks the AMQP message as _accepted_. The processing continues, ignoring the failure.
 Refer to the https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-accepted[accepted delivery state documentation].
 * `release` - this strategy marks the AMQP message as _released_. The processing continues with the next message. The broker can redeliver the message.
 Refer to the https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-released[released delivery state documentation].
@@ -290,7 +290,7 @@ NOTE: To be able to set the address per message, the connector is using an _anon
 
 === Acknowledgement
 
-By default, the Reactive Messaging `Message` is acknowledged when the broker acknowledged the message.
+By default, the Reactive Messaging `Message` is acknowledged when the broker acknowledges the message.
 When using routers, this acknowledgement may not be enabled.
 In this case, configure the `auto-acknowledgement` attribute to acknowledge the message as soon as it has been sent to the router.
 
@@ -317,7 +317,7 @@ mp.messaging.outgoing.orders.address=my-order-queue
 
 If the `address` attribute is not set, the connector uses the channel name.
 
-To use an existing queue, you need to configure the `address`, `container-id` and, optionally, the `link-name` attributes.
+To use an existing queue, you need to configure the `address`, `container-id`, and, optionally, the `link-name` attributes.
 For example, if you have an Apache ActiveMQ Artemis broker configured with:
 
 [source, xml]
@@ -376,7 +376,7 @@ More details about the AMQP Address model can be found in the https://activemq.a
 
 Reactive Messaging invokes your method on an I/O thread.
 See the xref:quarkus-reactive-architecture.adoc[Quarkus Reactive Architecture documentation] for further details on this topic.
-But, you often need to combine Reactive Messaging with blocking processing such as database interactions.
+But, you often need to combine Reactive Messaging with blocking processing, such as database interactions.
 For this, you need to use the `@Blocking` annotation indicating that the processing is _blocking_ and should not be run on the caller thread.
 
 For example, The following code illustrates how you can store incoming payloads to a database using Hibernate with Panache:
@@ -731,7 +731,7 @@ Type: _string_ | false |
 
 Type: _boolean_ | false | `true`
 
-| [.no-hyphens]#*cloud-events-mode*# | The Cloud Event mode (`structured` or `binary` (default)). Indicates how are written the cloud events in the outgoing record
+| [.no-hyphens]#*cloud-events-mode*# | The Cloud Event mode (`structured` or `binary` (default)). Indicates how the cloud events are written in the outgoing record
 
 Type: _string_ | false | `binary`
 
@@ -827,7 +827,7 @@ Type: _boolean_ | false | `true`
 
 Type: _long_ | false | `0`
 
-| [.no-hyphens]#*use-anonymous-sender*# | Whether the connector should use an anonymous sender. Default value is `true` if the broker supports it, `false` otherwise. If not supported, it is not possible to dynamically change the destination address.
+| [.no-hyphens]#*use-anonymous-sender*# | Whether the connector should use an anonymous sender. The default value is `true` if the broker supports it, `false` otherwise. If not supported, it is not possible to dynamically change the destination address.
 
 Type: _boolean_ | false |
 

--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -33,11 +33,11 @@ image::amqp-qs-architecture.png[alt=Architecture, align=center,width=80%]
 
 The first application, the `producer`, will let the user request some quotes over an HTTP endpoint.
 For each quote request, a random identifier is generated and returned to the user, to put the quote request on _pending_.
-At the same time the generated request id is sent over the `quote-requests` queue.
+At the same time, the generated request id is sent over the `quote-requests` queue.
 
 image::amqp-qs-app-screenshot.png[alt=Producer App UI, align=center]
 
-The second application, the `processor`, in turn, will read from the `quote-requests` queue put a random price to the quote, and send it to a queue named `quotes`.
+The second application, the `processor`, in turn, will read from the `quote-requests` queue, put a random price to the quote, and send it to a queue named `quotes`.
 
 Lastly, the `producer` will read the quotes and send them to the browser using server-sent events.
 The user will therefore see the quote price updated from _pending_ to the received price in real-time.
@@ -62,7 +62,7 @@ To create the _producer_ project, in a terminal run:
 :create-app-post-command:
 include::{includes}/devtools/create-app.adoc[]
 
-This command creates the project structure and select the two Quarkus extensions we will be using:
+This command creates the project structure and selects the two Quarkus extensions we will be using:
 
 1. Quarkus REST (formerly RESTEasy Reactive) and its Jackson support to handle JSON payloads
 2. The Reactive Messaging AMQP connector
@@ -74,7 +74,7 @@ To create the _processor_ project, from the same directory, run:
 :create-app-post-command:
 include::{includes}/devtools/create-app.adoc[]
 
-At that point you should have the following structure:
+At that point, you should have the following structure:
 
 [source, text]
 ----
@@ -108,7 +108,7 @@ Open the two projects in your favorite IDE.
 == The Quote object
 
 The `Quote` class will be used in both `producer` and `processor` projects.
-For the sake of simplicity we will duplicate the class.
+For the sake of simplicity, we will duplicate the class.
 In both projects, create the `src/main/java/org/acme/amqp/model/Quote.java` file, with the following content:
 
 [source,java]
@@ -159,7 +159,7 @@ More details about the `@RegisterForReflection` annotation can be found on  the 
 
 == Sending quote request
 
-Inside the `producer` project locate the generated  `src/main/java/org/acme/amqp/producer/QuotesResource.java` file, and update the content to be:
+Inside the `producer` project, locate the generated  `src/main/java/org/acme/amqp/producer/QuotesResource.java` file, and update the content to be:
 
 [source,java]
 ----
@@ -355,7 +355,7 @@ And, in a separate terminal:
 > mvn -f amqp-quickstart-processor quarkus:dev
 ----
 
-Quarkus starts a AMQP broker automatically, configures the application and shares the broker instance between different applications.
+Quarkus starts an AMQP broker automatically, configures the application, and shares the broker instance between different applications.
 See xref:amqp-dev-services.adoc[Dev Services for AMQP] for more details.
 
 

--- a/docs/src/main/asciidoc/ansible.adoc
+++ b/docs/src/main/asciidoc/ansible.adoc
@@ -28,7 +28,7 @@ You'll need to https://docs.ansible.com/ansible/latest/installation_guide/intro_
 $ ansible-galaxy collection install middleware_automation.quarkus
 ----
 
-NOTE: The Ansible collection we just installed only supports RHEL, Fedora, and other Linux distribution using RPMs. Ansible defines these as "RedHat family". Using the content on other platforms (Windows, Debian, Ubuntu, ...), while not impossible, will require a few adjustments.
+NOTE: The Ansible collection we just installed only supports RHEL, Fedora, and other Linux distributions using RPMs. Ansible defines these as "RedHat family". Using the content on other platforms (Windows, Debian, Ubuntu, ...), while not impossible, will require a few adjustments.
 
 === Inventory file
 
@@ -212,7 +212,7 @@ last-modified: Thu, 2 Mar 2023 11:03:18 GMT
 date: Thu, 2 Mar 2023 11:03:18 GMT
 ----
 
-We'll see how to automate those validation in the next and last part of this tutorial.
+We'll see how to automate those validations in the next and last part of this tutorial.
 
 === Writing a playbook
 
@@ -248,7 +248,7 @@ To run this playbook, you use again the ansible-playbook command, but providing 
 $ ansible-playbook -i inventory playbook.yml
 ----
 
-You also can automate the validation part we mentioned in the previous section. You can use the https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assert_module.html[ansible.builtin.assert] module and populate the https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_facts_module.html#examples[service facts] to ensure the systemd service of the Quarkus app is running, along with https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html[ansible.builtin.uri] to check that the Quarkus app is accessible.
+You can also automate the validation part we mentioned in the previous section. You can use the https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assert_module.html[ansible.builtin.assert] module and populate the https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_facts_module.html#examples[service facts] to ensure the systemd service of the Quarkus app is running, along with https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html[ansible.builtin.uri] to check that the Quarkus app is accessible.
 
 ```
  post_tasks:

--- a/docs/src/main/asciidoc/apicurio-registry-dev-services.adoc
+++ b/docs/src/main/asciidoc/apicurio-registry-dev-services.adoc
@@ -12,7 +12,7 @@ include::_attributes.adoc[]
 
 If an extension for schema registry, such as `quarkus-apicurio-registry-avro` or `quarkus-confluent-registry-avro`, is present, Dev Services for Apicurio Registry automatically starts an Apicurio Registry instance in dev mode and when running tests.
 Also, all Kafka channels in SmallRye Reactive Messaging are automatically configured to use this registry.
-This automatic configuration only applies to serializers and deserializers from Apicurio Registry serde libraries and Confluent Schema Registry serde libraries, because there properties are set:
+This automatic configuration only applies to serializers and deserializers from Apicurio Registry serde libraries and Confluent Schema Registry serde libraries, because their properties are set:
 
 [source,properties]
 ----
@@ -51,10 +51,10 @@ mp.messaging.connector.smallrye-kafka.schema.registry.url=... your Confluent Sch
 
 == Shared registry
 
-Most of the time you need to share the registry between applications.
+Most of the time, you need to share the registry between applications.
 Dev Services for Apicurio Registry implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single registry.
 
-NOTE: Dev Services for Apicurio Registry starts the container with the `quarkus-dev-service-apicurio-registry` label which is used to identify the container.
+NOTE: Dev Services for Apicurio Registry starts the container with the `quarkus-dev-service-apicurio-registry` label, which is used to identify the container.
 
 If you need multiple (shared) registries, you can configure the `quarkus.apicurio-registry.devservices.service-name` attribute and indicate the registry name.
 It looks for a container with the same value, or starts a new one if none can be found.

--- a/docs/src/main/asciidoc/appcds.adoc
+++ b/docs/src/main/asciidoc/appcds.adoc
@@ -18,13 +18,13 @@ This is achieved by having the JVM create a pre-processed shared archived of cla
 As these classes
 are loaded every time the application starts, AppCDS is a conceptually simple way of improving the application startup time,
 without the application itself having to be coded or configured in a specific way.
-How much of an improvement depends on many factors, such as the number of classes loaded, the underlying hardware etc.
+How much of an improvement depends on many factors, such as the number of classes loaded, the underlying hardware, etc.
 
 == Vanilla AppCDS generation
 
 The main downside of creating AppCDS manually for an application is that their generation requires launching the application with special flags and obtaining the archive in a step before the application is deployed to production.
 
-NOTE: The exact process depends on the JVM version being used as newer JVM have incrementally made the process easier.
+NOTE: The exact process depends on the JVM version being used, as newer JVM have incrementally made the process easier.
 
 This fact makes AppCDS difficult to use for real world deployments where a CI pipeline is responsible for building and deploying applications.
 
@@ -86,7 +86,7 @@ Given what was mentioned above about how the application needs to be launched in
 The answer is that at application build time, right after the application archive is built, Quarkus launches the application, but only the parts of the launch process that are safe are run.
 More specifically, the application is run up until the steps that actually open sockets or run application logic.
 
-This results in an archive generation process that on one hand is completely safe, but on the other hand is unable to archive every single class that the application might need at boot time.
+This results in an archive generation process that, on one hand, is completely safe, but on the other hand, is unable to archive every single class that the application might need at boot time.
 As a result, users are expected to get a slightly more effective archive if they manually go through the hoops of generating the AppCDS archive.
 ====
 

--- a/docs/src/main/asciidoc/assistant.adoc
+++ b/docs/src/main/asciidoc/assistant.adoc
@@ -145,7 +145,7 @@ You can add an assistant function to a workspace item using the same approach as
                     .systemMessage(JOKE_SYSTEM_MESSAGE) // <2>
                     .userMessage(JOKE_USER_MESSAGE) // <3>
                     .variables(params)
-                    .responseType(ExpectedResponse.class) // <4>   
+                    .responseType(ExpectedResponse.class) // <4>
                     .assist();
 
         })
@@ -159,8 +159,8 @@ You can add an assistant function to a workspace item using the same approach as
         final record ExpectedResponse(String result, String markdown) {
         }
 ----
-<1> Use `assistantFunction` to receive the `Assistant` instance and xref:dev-ui.adoc#input[input] parameters.  
-<2> Provide an optional *system message* to guide the assistant's behavior.  
+<1> Use `assistantFunction` to receive the `Assistant` instance and xref:dev-ui.adoc#input[input] parameters.
+<2> Provide an optional *system message* to guide the assistant's behavior.
 <3> Provide a *user message* as the primary prompt.
 <4> Provide a class defining your expected response structure.
 
@@ -176,7 +176,7 @@ cardPageBuildItem.addPage(Page.assistantPageBuilder() // <1>
 ----
 <1> Use the assistant page builder.
 
-=== Communicating to the backend 
+=== Communicating to the backend
 
 You can invoke the assistant from backend code using xref:dev-ui.adoc#communicating-to-the-backend[standard Dev UI JSON-RPC] patterns — both against the *runtime* and *deployment* classpaths.
 
@@ -281,7 +281,7 @@ export class QwcExtensionPage extends observeState(LitElement) {  // <3>
 <2> import the state you are interested in, in this case assistant state.
 <3> Wrap the LitElement in `observerState`
 
-Now you can access the assistant state anywhere in your page, and when that state changes it will act exactly the same as a local state - re-render the relevant parts of the page:
+Now you can access the assistant state anywhere in your page, and when that state changes, it will act exactly the same as a local state - re-render the relevant parts of the page:
 
 [source,javascript]
 ----
@@ -305,7 +305,7 @@ You can also use the CSS var `--quarkus-assistant` anywhere you want to apply th
 
 === Quarkus Log Participation
 
-Extensions can contribute entries to the interactive *Quarkus log menu* by integrating with the Dev Assistant. 
+Extensions can contribute entries to the interactive *Quarkus log menu* by integrating with the Dev Assistant.
 This allows developers to invoke assistant-powered actions directly from the quarkus log using keyboard shortcuts.
 
 First, add the `quarkus-assistant-deployment-spi` to the *deployment* module of your extension:
@@ -339,7 +339,7 @@ AssistantConsoleBuildItem createCliAssistantEntry() {
 final record JokeResponse(String joke) {}
 
 ----
-<1> This is the description that appears in the Assistant section of the log menu.  
+<1> This is the description that appears in the Assistant section of the log menu.
 <2> This is the keyboard shortcut that triggers the assistant function.
 <3> Provide a class defining your expected response structure.
 

--- a/docs/src/main/asciidoc/aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-http.adoc
@@ -12,11 +12,11 @@ include::_attributes.adoc[]
 :topics: aws,lambda,serverless,function,cloud
 :extensions: io.quarkus:quarkus-amazon-lambda,io.quarkus:quarkus-amazon-lambda-http
 
-With Quarkus you can deploy your favorite Java HTTP frameworks as AWS Lambda's using either the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html[AWS Gateway HTTP API]
+With Quarkus, you can deploy your favorite Java HTTP frameworks as AWS Lambda's using either the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html[AWS Gateway HTTP API]
 or https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html[AWS Gateway REST API].  This means that you can deploy your microservices written with Quarkus REST (our Jakarta REST implementation),
 Undertow (servlet), Reactive Routes, xref:funqy-http.adoc[Funqy HTTP] or any other Quarkus HTTP framework as an AWS Lambda.
 
-IMPORTANT: You should only use single HTTP framework together with AWS Lambda extension to avoid unexpected conflicts and errors.
+IMPORTANT: You should only use a single HTTP framework together with the AWS Lambda extension to avoid unexpected conflicts and errors.
 
 You can deploy your Lambda as a pure Java jar, or you can compile your project to a native image and deploy that for a smaller
 memory footprint and startup time.  Our integration also generates SAM deployment files that can be consumed by https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html[Amazon's SAM framework].
@@ -163,8 +163,8 @@ public class AmazonLambdaSimpleTestCase {
 
 The above example simulates sending a Cognito principal with an HTTP request to your HTTP Lambda.
 
-If you want to hand code raw events for the AWS HTTP API, the AWS Lambda library has the request event type which is
-`com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent` and the response event type
+If you want to hand code raw events for the AWS HTTP API, the AWS Lambda library has the request event type, which is
+`com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent`, and the response event type
 of `com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse`.  This corresponds
 to the `quarkus-amazon-lambda-http` extension and the AWS HTTP API.
 
@@ -172,7 +172,7 @@ If you want to hand code raw events for the AWS REST API, Quarkus has its own im
 and `io.quarkus.amazon.lambda.http.model.AwsProxyResponse`.  This corresponds
 to `quarkus-amazon-lambda-rest` extension and the AWS REST API.
 
-The mock event server is also started for `@QuarkusIntegrationTest` tests so will work
+The mock event server is also started for `@QuarkusIntegrationTest` tests, so it will work
 with native binaries too.  All this provides similar functionality to the SAM CLI local testing, without the overhead of Docker.
 
 Finally, if port 8080 or port 8081 is not available on your computer, you can modify the dev
@@ -204,11 +204,11 @@ sam local start-api --template target/sam.jvm.yaml
 ----
 
 This will start a Docker container that mimics Amazon's Lambda's deployment environment. Once the environment
-is started you can invoke the example lambda in your browser by going to:
+is started, you can invoke the example lambda in your browser by going to:
 
 http://127.0.0.1:3000/hello
 
-In the console you'll see startup messages from the lambda.  This particular deployment starts a JVM and loads your
+In the console, you'll see startup messages from the lambda.  This particular deployment starts a JVM and loads your
 lambda as pure Java.
 
 
@@ -219,7 +219,7 @@ lambda as pure Java.
 sam deploy -t target/sam.jvm.yaml -g
 ----
 
-Answer all the questions and your lambda will be deployed and the necessary hooks to the API Gateway will be set up. If
+Answer all the questions, and your lambda will be deployed, and the necessary hooks to the API Gateway will be set up. If
 everything deploys successfully, the root URL of your microservice will be output to the console.  Something like this:
 
 ----
@@ -232,8 +232,8 @@ The `Value` attribute is the root URL for your lambda. Copy it to your browser a
 
 [NOTE]
 Responses for binary types will be automatically encoded with base64.  This is different from the behavior using
-`quarkus:dev` which will return the raw bytes.  Amazon's API has additional restrictions requiring the base64 encoding.
-In general, client code will automatically handle this encoding but in certain custom situations, you should be aware
+`quarkus:dev`, which will return the raw bytes.  Amazon's API has additional restrictions requiring the base64 encoding.
+In general, client code will automatically handle this encoding, but in certain custom situations, you should be aware
 you may need to manually manage that encoding.
 
 == Deploying a native executable
@@ -267,7 +267,7 @@ remove the other dependencies to shrink your deployment.
 
 === Examine sam.yaml
 
-The `sam.yaml` syntax is beyond the scope of this document.  There's a couple of things that must be highlighted just in case you are
+The `sam.yaml` syntax is beyond the scope of this document.  There are a couple of things that must be highlighted just in case you are
 going to craft your own custom `sam.yaml` deployment files.
 
 The first thing to note is that for pure Java lambda deployments require a specific handler class.
@@ -434,11 +434,11 @@ quarkus.lambda-http.cognito-claim-matcher=[^\[\] \t]+
 == Custom Security Integration
 
 The default support for AWS security only maps the principal name to Quarkus security
-APIs and does nothing to map claims or roles or permissions.  You have full control on
+APIs and do nothing to map claims, or roles, or permissions.  You have full control on
 how security metadata in the lambda HTTP event is mapped to Quarkus Security APIs using
 implementations of the `io.quarkus.amazon.lambda.http.LambdaIdentityProvider`
 interface.  By implementing this interface, you can do things like define role mappings for your principal
-or publish additional attributes provided by IAM or Cognito or your Custom Lambda security integration.
+or publish additional attributes provided by IAM, or Cognito, or your Custom Lambda security integration.
 
 .HTTP `quarkus-amazon-lambda-http`
 [source, java]

--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -69,12 +69,12 @@ rerun the build when you are ready.
 == Configuring Root Paths
 
 The default route prefix for an Azure Function is `/api`.  All of your Jakarta REST, Servlet, Reactive Routes, and xref:funqy-http.adoc[Funqy HTTP] endpoints must
-explicitly take this into account.  In the generated project this is handled by the
+explicitly take this into account.  In the generated project, this is handled by the
 `quarkus.http.root-path` switch in `application.properties`
 
 == Quarkus dev mode
 
-Quarkus dev mode works by just running your application as a HTTP endpoint.  In dev mode,
+Quarkus dev mode works by just running your application as an HTTP endpoint.  In dev mode,
 there is no special interaction with the Azure Functions local runtime.
 
 include::{includes}/devtools/dev.adoc[]
@@ -145,7 +145,7 @@ The `quarkus-azure-functions-http` extension handles all the work to deploy to A
 Quarkus will use the Azure CLI in the background to authenticate and deploy to Azure. If you have
 multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id`
 property in your `application.properties` file to the subscription you want to use.
-For other authentication mechanisms and deployment options see <<#configuration-reference>>.
+For other authentication mechanisms and deployment options, see <<#configuration-reference>>.
 
 To deploy your application, after you built your project, execute:
 

--- a/docs/src/main/asciidoc/azure-functions.adoc
+++ b/docs/src/main/asciidoc/azure-functions.adoc
@@ -88,10 +88,10 @@ It includes an example.
 
 == Examining the project
 
-If you open the `pom.xml` or `build.gradle` build file of the generated project you'll see that
+If you open the `pom.xml` or `build.gradle` build file of the generated project, you'll see that
 the project is similar to any other Quarkus project.
 The `quarkus-azure-functions` extension is the integration point between
-Quarkus and Azure Functions. It registers callbacsk with the Azure Functions runtime to bootstrap
+Quarkus and Azure Functions. It registers callbacks with the Azure Functions runtime to bootstrap
 Quarkus and to set up Quarkus/ArC as the function factory for your function classes.
 
 The current implementation of the `quarkus-azure-functions` extension no longer requires the
@@ -120,8 +120,8 @@ include::{includes}/devtools/run.adoc[]
 
 [TIP]
 ====
-Gradle is a bit quirky with process management, so you need the `--no-daemon` switch or control-c will not
-destroy the process cleanly and you'll have open ports.
+Gradle is a bit quirky with process management, so you need the `--no-daemon` switch, or control-c will not
+destroy the process cleanly, and you'll have open ports.
 ====
 
 [NOTE]
@@ -177,7 +177,7 @@ The `quarkus-azure-functions` extension handles all the work to deploy to Azure.
 Quarkus will use the Azure CLI in the background to authenticate and deploy to Azure. If you have
 multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id`
 property in your `application.properties` file to the subscription you want to use.
-For other authentication mechanisms and deployment options see our config properties <<#configuration-reference>>.
+For other authentication mechanisms and deployment options, see our config properties <<#configuration-reference>>.
 
 To deploy your application, after you built your project, execute:
 

--- a/docs/src/main/asciidoc/build-analytics.adoc
+++ b/docs/src/main/asciidoc/build-analytics.adoc
@@ -170,7 +170,7 @@ mvn clean install -Dquarkus.analytics.disabled=true
 
 Values can be `true` or `false`.
 
-Setting this property to `true` will disable the collection of analytics data on that specific project regardless of any other configuration.
+Setting this property to `true` will disable the collection of analytics data on that specific project, regardless of any other configuration.
 | boolean
 | false
 | [[build-analytics-quarkus-analytics-uri-base]]`link:#build-analytics.quarkus-analytics-uri-base[quarkus.analytics.uri.base]`

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -14,12 +14,12 @@ The role of the extensions is to leverage Quarkus paradigms to integrate seamles
 This is how you can use your battle-tested ecosystem and take advantage of Quarkus performance and native compilation.
 Go to https://code.quarkus.io/[code.quarkus.io] to get the list of the supported extensions.
 
-In this guide we are going to develop the *Sample Greeting Extension*.
-The extension will expose a customizable HTTP endpoint which simply greets the visitor.
+In this guide, we are going to develop the *Sample Greeting Extension*.
+The extension will expose a customizable HTTP endpoint that simply greets the visitor.
 
 [NOTE]
 .Disclaimer
-To be sure it's extra clear you don't need an extension to add a Servlet to your application.
+To be sure it's extra clear that you don't need an extension to add a Servlet to your application.
 This guide is a simplified example to explain the concepts of extensions development, see the xref:writing-extensions.adoc[full documentation] if you need more information.
 Keep in mind it's not representative of the power of moving things to build time or simplifying the build of native images.
 
@@ -31,7 +31,7 @@ include::{includes}/prerequisites.adoc[]
 
 [CAUTION]
 ====
-Writing extension with any other than Java and Maven has **not** been tested by the Quarkus team so your mileage may vary
+Writing extension with any other than Java and Maven has **not** been tested by the Quarkus team, so your mileage may vary
 if you stray off this path
 ====
 
@@ -40,7 +40,7 @@ if you stray off this path
 First things first, we will need to start with some basic concepts.
 
 * JVM mode vs Native mode
-  ** Quarkus is first and foremost a Java framework, that means you can develop, package and run classic JAR applications, that's what we call *JVM mode*.
+  ** Quarkus is first and foremost a Java framework, that means you can develop, package, and run classic JAR applications, that's what we call *JVM mode*.
   ** Thanks to https://graalvm.org/[GraalVM] you can compile your Java application into machine specific code (like you do in Go or C++) and that's what we call *Native mode*.
 
 The operation of compiling Java bytecode into a native system-specific machine code is named *Ahead of Time Compilation* (aka AoT).
@@ -65,7 +65,7 @@ A Quarkus extension consists of two parts:
 
 * The *runtime module* which represents the capabilities the extension developer exposes to the application's developer (an authentication filter, an enhanced data layer API, etc).
 Runtime dependencies are the ones the users will add as their application dependencies (in Maven POMs or Gradle build scripts).
-* The *deployment module* which is used during the augmentation phase of the build, it describes how to "deploy" a library
+* The *deployment module*, which is used during the augmentation phase of the build, describes how to "deploy" a library
 following the Quarkus philosophy.
 In other words, it applies all the Quarkus optimizations to your application during the build.
 The deployment module is also where we prepare things for GraalVM's native compilation.
@@ -73,7 +73,7 @@ The deployment module is also where we prepare things for GraalVM's native compi
 IMPORTANT: Users should not be adding the deployment modules of extension as application dependencies. The deployment dependencies are resolved by
 Quarkus during the augmentation phase from the runtime dependencies of the application.
 
-At this point, you should have understood that most of the magic will happen at the Augmentation build time thanks to the deployment module.
+At this point, you should have understood that most of the magic will happen at the Augmentation build time, thanks to the deployment module.
 
 == Quarkus Application Bootstrap
 
@@ -81,7 +81,7 @@ There are three distinct bootstrap phases of a Quarkus application.
 
 * *Augmentation*. During the build time, the Quarkus extensions will load and scan your application's bytecode (including the dependencies) and configuration.
 At this stage, the extension can read configuration files, scan classes for specific annotations, etc.
-Once all the metadata has been collected, the extensions can pre-process the libraries bootstrap actions like your ORM, DI or REST controllers configurations.
+Once all the metadata has been collected, the extensions can pre-process the libraries bootstrap actions like your ORM, DI, or REST controllers configurations.
 The result of the bootstrap is directly recorded into bytecode and will be part of your final application package.
 * *Static Init*. During the run time, Quarkus will execute first a static init method which contains some extensions actions/configurations.
 When you will do your native packaging, this static method will be pre-processed during the build time and the objects it has generated will be serialized into the final native executable, so the initialization code will not be executed in the native mode (imagine you execute a Fibonacci function during this phase, the result of the computation will be directly recorded in the native executable).
@@ -149,7 +149,7 @@ applying codestarts...
 <4> From a directory with no pom.xml and without any further options, the generator will automatically pick the 'standalone' extension layout
 <5> With the 'standalone' layout, the `namespaceId` is empty by default, so the computed runtime module artifactId is the `extensionId`
 
-Maven has generated a `greeting-extension` directory containing the extension project which consists of the parent `pom.xml`, the `runtime` and the `deployment` modules.
+Maven has generated a `greeting-extension` directory containing the extension project, which consists of the parent `pom.xml`, the `runtime`, and the `deployment` modules.
 
 ==== The parent pom.xml
 
@@ -322,7 +322,7 @@ The name of the feature gets displayed in the log during application bootstrap.
 An extension should provide at most one feature.
 
 Be patient, we will explain the `Build Step Processor` concept and all the extension deployment API later on.
-At this point, you just need to understand that this class explains to Quarkus how to deploy a feature named `greeting` which is your extension.
+At this point, you just need to understand that this class explains to Quarkus how to deploy a feature named `greeting`, which is your extension.
 In other words, you are augmenting your application to use the `greeting` extension with all the Quarkus benefits (build time optimization, native support, etc.).
 
 ==== The Runtime module
@@ -392,7 +392,7 @@ The key points are:
 
 <1> By convention, the runtime module has no suffix (`greeting-extension`) as it is the artifact exposed to the end user.
 <2> The runtime module depends on the `quarkus-arc` artifact.
-<3> We add  the `quarkus-extension-maven-plugin` to generate the Quarkus extension descriptor included into the runtime artifact which links it with the corresponding deployment artifact.
+<3> We add  the `quarkus-extension-maven-plugin` to generate the Quarkus extension descriptor included into the runtime artifact, which links it with the corresponding deployment artifact.
 <4> We add  the `quarkus-extension-processor` to the compiler annotation processors.
 
 === Gradle setup
@@ -471,7 +471,7 @@ dependencies {
 
 The runtime module applies the `io.quarkus.extension` plugin. This will:
 
-* Add `quarkus-extension-process` as annotation processor to both modules.
+* Add `quarkus-extension-process` as an annotation processor to both modules.
 * Generate extension description files.
 
 Here is an example of `build.gradle` file for the `runtime` module:
@@ -501,10 +501,10 @@ To do so, our extension will deploy, in the user application, a Servlet exposing
 
 The `runtime` module is where you develop the feature you want to propose to your users, so it's time to create our Web Servlet.
 
-To use Servlets in your applications you need to have a Servlet Container such as https://undertow.io[Undertow].
+To use Servlets in your applications, you need to have a Servlet Container such as https://undertow.io[Undertow].
 Luckily, `quarkus-bom` imported by our parent `pom.xml` already includes the Undertow Quarkus extension.
 
-All we need to do is add `quarkus-undertow` as dependency to our `./greeting-extension/runtime/pom.xml`:
+All we need to do is add `quarkus-undertow` as a dependency to our `./greeting-extension/runtime/pom.xml`:
 [source, xml]
 ----
     <dependency>
@@ -556,7 +556,7 @@ public class GreetingExtensionServlet extends HttpServlet { // <1>
 === Deploying the Greeting feature
 
 Quarkus magic relies on bytecode generation at build time rather than waiting for the runtime code evaluation, that's the role of your extension's `deployment` module.
-Calm down, we know, bytecode is hard and you don't want to do it manually. Quarkus proposes a high level API to make your life easier.
+Calm down, we know, bytecode is hard, and you don't want to do it manually. Quarkus proposes a high level API to make your life easier.
 Thanks to basic concepts, you will describe the items to produce/consume and the corresponding steps in order to generate the bytecode to produce during the deployment time.
 
 The `io.quarkus.builder.item.BuildItem` concept represents object instances you will produce or consume (and at some point convert into bytecode) thanks to methods annotated with `@io.quarkus.deployment.annotations.BuildStep` which describe your extension's deployment tasks.
@@ -658,14 +658,14 @@ class GreetingExtensionProcessor {
 <1> We add a `createServlet` method which returns a `ServletBuildItem` and annotate it with `@BuildStep`.
 Now, Quarkus will process this new task which will result in the bytecode generation of the Servlet registration at build time.
 
-<2> `ServletBuildItem` proposes a fluent API to instantiate a Servlet named `greeting-extension` of type `GreetingExtensionServlet` (it's our class provided by our extension `runtime` module), and map it the `/greeting` path.
+<2> `ServletBuildItem` proposes a fluent API to instantiate a Servlet named `greeting-extension` of type `GreetingExtensionServlet` (it's our class provided by our extension `runtime` module), and map it to the `/greeting` path.
 
 === Testing the Greeting Extension feature
 
-When developing a Quarkus extension, you mainly want to test your feature is properly deployed in an application and works as expected.
+When developing a Quarkus extension, you mainly want to test that your feature is properly deployed in an application and works as expected.
 That's why the tests will be hosted in the `deployment` module.
 
-Quarkus proposes facilities to test extensions via the `quarkus-junit-internal` artifact (which should already be in the deployment pom.xml), in particular the `io.quarkus.test.QuarkusUnitTest` runner which starts an application with your extension.
+Quarkus proposes facilities to test extensions via the `quarkus-junit-internal` artifact (which should already be in the deployment pom.xml), in particular the `io.quarkus.test.QuarkusUnitTest` runner, which starts an application with your extension.
 
 We will use https://rest-assured.io[RestAssured] (massively used in Quarkus) to test our HTTP endpoint.
 Let's add the `rest-assured` dependency into the  `./greeting-extension/deployment/pom.xml`.
@@ -834,7 +834,7 @@ By default, Maven will wait for a connection on `localhost:5005`.
 
 === Time to use your new extension
 
-Now that you just finished building your first extension you should be eager to use it in a Quarkus application!
+Now that you just finished building your first extension, you should be eager to use it in a Quarkus application!
 
 *Classic Maven publication*
 
@@ -885,7 +885,7 @@ __  ____  __  _____   ___  __ ____  ______
 2022-11-20 04:25:36,913 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, greetin-extension, resteasy-reactive, smallrye-context-propagation, vertx]
 ----
 
-From an extension developer standpoint the Maven publication strategy is very handy and fast but Quarkus wants to go one step further by also ensuring a reliability of the ecosystem for the people who will use the extensions.
+From an extension developer standpoint, the Maven publication strategy is very handy and fast, but Quarkus wants to go one step further by also ensuring a reliability of the ecosystem for the people who will use the extensions.
 Think about it, we all had a poor Developer Experience with an unmaintained library, an incompatibility between dependencies (and we don't even talk about legal issues).
 That's why there is the Quarkus Platform.
 
@@ -915,9 +915,9 @@ For more information, check link:https://github.com/quarkiverse/quarkiverse/wiki
 
 == Conclusion
 
-Creating new extensions may appear to be an intricate task at first but once you understood the Quarkus game-changer paradigm (build time vs runtime) the structure of an extension makes perfectly sense.
+Creating new extensions may appear to be an intricate task at first, but once you understand the Quarkus game-changer paradigm (build time vs runtime) the structure of an extension makes perfectly sense.
 
-As usual, along the path Quarkus simplifies things under the hood (Maven Mojo, bytecode generation or testing) to make it pleasant to develop new features.
+As usual, along the path, Quarkus simplifies things under the hood (Maven Mojo, bytecode generation, or testing) to make it pleasant to develop new features.
 
 == Further reading
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -423,7 +423,7 @@ These are regular Quarkus config properties, so if you always want to build in a
 it is recommended you add these to your `application.properties` in order to avoid specifying them every time.
 ====
 
-Executable built that way with the container runtime will be a 64-bit Linux executable, so depending on your operating system it may no longer be runnable.
+Executable built that way with the container runtime will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
 
 [IMPORTANT]
 ====
@@ -433,7 +433,7 @@ So, if you plan to build a container, make sure that the base image in your `Doc
 The native executable will not run on UBI 8 base images.
 
 You can configure the builder image used for the container build by setting the `quarkus.native.builder-image` property.
-For example to switch back to an UBI8 _builder image_ you can use:
+For example, to switch back to an UBI8 _builder image_ you can use:
 
 `quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
 
@@ -502,7 +502,7 @@ See the xref:container-image.adoc[Container Image guide] for more details.
 === Manually using the micro base image
 
 You can run the application in a container using the JAR produced by the Quarkus Maven Plugin.
-However, in this section we focus on creating a container image using the produced native executable.
+However, in this section, we focus on creating a container image using the produced native executable.
 
 image:containerization-process.png[Containerization Process]
 
@@ -510,7 +510,7 @@ When using a local GraalVM installation, the native executable targets your loca
 However, as a container may not use the same _executable_ format as the one produced by your operating system,
 we will instruct the Maven build to produce an executable by leveraging a container runtime (as described in <<#container-runtime,this section>>):
 
-The produced executable will be a 64-bit Linux executable, so depending on your operating system it may no longer be runnable.
+The produced executable will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
 However, it's not an issue as we are going to copy it to a container.
 The project generation has provided a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
 
@@ -867,7 +867,7 @@ You will find the debug symbols for the native executable in a `.debug` file nex
 [NOTE]
 ====
 The generation of the `.debug` file depends on `objcopy`.
-As a result, when using a local GraalVM installation on common Linux distributions you will need to install the `binutils` package:
+As a result, when using a local GraalVM installation on common Linux distributions, you will need to install the `binutils` package:
 
 [source,bash]
 ----
@@ -877,14 +877,14 @@ sudo dnf install binutils
 sudo apt-get install binutils
 ----
 
-When `objcopy` is not available debug symbols are embedded in the executable.
+When `objcopy` is not available, debug symbols are embedded in the executable.
 ====
 
 Aside from debug symbols,
 setting `-Dquarkus.native.debug.enabled=true` flag generates a cache of source files
-for any JDK runtime classes, GraalVM classes and application classes resolved during native executable generation.
+for any JDK runtime classes, GraalVM classes, and application classes resolved during native executable generation.
 This source cache is useful for native debugging tools,
-to establish the link between the symbols and matching source code.
+to establish the link between the symbols and the matching source code.
 It provides a convenient way of making just the necessary sources available to the debugger/IDE when debugging a native executable.
 
 Sources for third party jar dependencies, including Quarkus source code,
@@ -924,7 +924,7 @@ For a more detailed guide about debugging native images please refer to the xref
 
 == Using Monitoring Options
 
-Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX 
+Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX
 can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
 include at build time.
 [source,bash]

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -267,7 +267,7 @@ Let's see what happens if we start from one day in the future using the `http://
 You should get an answer two seconds later since two of the requested days were already loaded in the cache.
 
 You can also try calling the same URL with a different city and see the cache in action again.
-The first call will take six seconds and the following ones will be answered immediately.
+The first call will take six seconds, and the following ones will be answered immediately.
 
 Congratulations! You just added application data caching to your Quarkus application with a single line of code!
 
@@ -291,12 +291,12 @@ Loads a method result from the cache without executing the method body whenever 
 
 When a method annotated with `@CacheResult` is invoked, Quarkus will compute a cache key and use it to check in the cache whether the method has been already invoked.
 See the <<cache-keys-building-logic>> section of this guide to learn how the cache key is computed.
-If a value is found in the cache, it is returned and the annotated method is never actually executed.
-If no value is found, the annotated method is invoked and the returned value is stored in the cache using the computed key.
+If a value is found in the cache, it is returned, and the annotated method is never actually executed.
+If no value is found, the annotated method is invoked, and the returned value is stored in the cache using the computed key.
 
 A method annotated with `CacheResult` is protected by a lock on cache miss mechanism.
 If several concurrent invocations try to retrieve a cache value from the same missing key, the method will only be invoked once.
-The first concurrent invocation will trigger the method invocation while the subsequent concurrent invocations will wait for the end of the method invocation to get the cached result.
+The first concurrent invocation will trigger the method invocation, while the subsequent concurrent invocations will wait for the end of the method invocation to get the cached result.
 The `lockTimeout` parameter can be used to interrupt the lock after a given delay.
 The lock timeout is disabled by default, meaning the lock is never interrupted.
 See the parameter Javadoc for more details.
@@ -495,8 +495,8 @@ public class CachedService {
 WARNING: This API is experimental and may change in the future.
 
 The `@io.quarkus.cache.CachedResults` qualifier may be applied to injection points to instruct the container to inject a _generated wrapper bean_ that
-delegates all method invocations to the original bean but the return values of selected business methods are cached. 
-By default, all non-void non-static business methods are included. 
+delegates all method invocations to the original bean but the return values of selected business methods are cached.
+By default, all non-void non-static business methods are included.
 However, it is possible to exclude methods whose names match one of the regular expressions defined by `@CachedResults#exclude()`.
 The injected class must be either an interface or declare a no-args constructor.
 
@@ -515,7 +515,7 @@ public class MyBean {
     @Inject
     @CachedResults
     PingService service; <1>
-   
+
     int ping() {
         return service.ping(); <2>
     }
@@ -1116,7 +1116,7 @@ We are registering the most common implementations but, depending on your cache 
 <1> `PSAMS` is one of the many cache implementation classes of Caffeine so this part may vary.
 
 When you encounter this error, you can easily fix it by adding the following annotation to any of your application classes
-(or you can create a new class such as `Reflections` just to host this annotation if you prefer):
+(or you can create a new class, such as `Reflections` just to host this annotation if you prefer):
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/capabilities.adoc
+++ b/docs/src/main/asciidoc/capabilities.adoc
@@ -144,7 +144,7 @@ quarkusExtension {
 ----
 <1> condition that must be resolved to `true` by a class implementing `java.util.function.BooleanSupplier`
 
-NOTE: It is possible to specify `onlyIfNot` conditions as well. . Conditions can also be set for required capabilities.
+NOTE: It is possible to specify `onlyIfNot` conditions as well. Conditions can also be set for required capabilities.
 ****
 
 In this case, `io.quarkus.container.image.openshift.deployment.OpenshiftBuild` should be included in one of the extension deployment dependencies and implement `java.util.function.BooleanSupplier`. At build time, the Quarkus bootstrap will create an instance of it and register `io.quarkus.container.image.openshift` capability only if its `getAsBoolean()` method returns true.
@@ -212,4 +212,4 @@ Given that only a single provider of a given capability is allowed in an applica
 * `io.quarkus.resteasy.json.jsonb`
 * `io.quarkus.resteasy.json.jsonb.client`
 
-Including any one of those extensions in an application will enable the RESTEasy JSON serializer. In case a build step needs to check whether the RESTEasy JSON serializer is already enabled in an application, instead of checking whether any of those capabilities is present, it could simply check whether an extension with prefix `io.quarkus.resteasy.json` is present.
+Including any one of those extensions in an application will enable the RESTEasy JSON serializer. In case a build step needs to check whether the RESTEasy JSON serializer is already enabled in an application, instead of checking whether any of those capabilities is present, it could simply check whether an extension with the prefix `io.quarkus.resteasy.json` is present.

--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -88,7 +88,7 @@ mapper will generate proper CQL queries underneath.
 
 This is why the `Fruit` class is annotated with `@Entity`: this annotation marks it as an _entity
 class_ that is mapped to a Cassandra table. Its instances are meant to be automatically persisted
-into, and retrieved from, the Cassandra database. Here, the table name will be inferred from the
+into, and retrieved from the Cassandra database. Here, the table name will be inferred from the
 class name: `fruit`.
 
 Also, the `name` field represents a Cassandra partition key, and so we are annotating it with
@@ -131,8 +131,8 @@ public interface FruitMapper {
 }
 ----
 
-The `@Mapper` annotation is yet another annotation recognized by the DataStax Object Mapper. A
-mapper is responsible for constructing DAO instances – in this case, out mapper is constructing
+The `@Mapper` annotation is yet another annotation recognised by the DataStax Object Mapper. A
+mapper is responsible for constructing DAO instances – in this case, our mapper is constructing
 an instance of our only DAO, `FruitDao`.
 
 Think of the mapper interface as a factory for DAO beans. If you intend to construct and inject a
@@ -211,7 +211,7 @@ in use. Also, never use both annotation processors together.
 </dependency>
 ----
 
-IMPORTANT: Although this module is called "runtime", it must be declared in compile scope.
+IMPORTANT: Although this module is called "runtime", it must be declared in the compile scope.
 
 If your project is correctly set up, you should now be able to compile it without errors, and you
 should see the generated code in the `target/generated-sources/annotations` directory (if you are
@@ -240,7 +240,7 @@ public class FruitService {
 }
 ----
 
-Note how the service is being injected a `FruitDao` instance. This DAO instance is injected
+Note how the service is being injected with a `FruitDao` instance. This DAO instance is injected
 automatically, thanks to the generated implementations.
 
 The Cassandra Quarkus extension allows you to inject any of the following beans in your own
@@ -428,7 +428,7 @@ one in the background:
 docker run --name local-cassandra-instance -p 9042:9042 -d cassandra
 ----
 
-Next you need to create the keyspace and table that will be used by your application. If you are
+Next, you need to create the keyspace and table that will be used by your application. If you are
 using Docker, run the following commands:
 
 [source,shell]
@@ -521,7 +521,7 @@ Similarly, the method `updateAsync` returns a `Uni` - it is automatically conver
 original result set returned by the driver.
 
 NOTE: The Cassandra driver uses the Reactive Streams `Publisher` API for reactive calls. The Quarkus
-framework however uses Mutiny. Because of that, the `CqlQuarkusSession` interface transparently
+framework, however uses Mutiny. Because of that, the `CqlQuarkusSession` interface transparently
 converts the `Publisher` instances returned by the driver into the reactive type `Multi`.
 `CqlQuarkusSession` is also capable of converting a `Publisher` into a `Uni` – in this case, the
 publisher is expected to emit at most one row, then complete. This is suitable for write queries

--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -25,7 +25,7 @@ From a high level perspective these phases go as follows:
 3. Registration of synthetic components
 4. Validation
 
-In the _initialization_ phase the preparatory work is being carried out and custom contexts are registered.
+In the _initialization_ phase, the preparatory work is being carried out, and custom contexts are registered.
 _Bean discovery_ is then the process where the container analyzes all application classes, identifies beans and wires them all together based on the provided metadata.
 Subsequently, the extensions can register _synthetic components_.
 Attributes of these components are fully controlled by the extensions, i.e. are not derived from an existing class.
@@ -35,7 +35,7 @@ For example, the container validates every injection point in the application an
 TIP: You can see more information about the bootstrap by enabling additional logging. Simply run the Maven build with `-X` or `--debug` and grep the lines that contain `io.quarkus.arc`. In <<cdi-reference.adoc#dev_mode,dev mode>>, you can use `quarkus.log.category."io.quarkus.arc.processor".level=DEBUG` and two special endpoints are also registered automatically to provide some basic debug info in the JSON format.
 
 Quarkus build steps can produce and consume various build items and hook into each phase.
-In the following sections we will describe all the relevant build items and common scenarios.
+In the following sections, we will describe all the relevant build items and common scenarios.
 
 == Metadata Sources
 
@@ -56,7 +56,7 @@ For example, a class that declares a `@Scheduled` method is always registered as
 An `UnsatisfiedResolutionException` indicates a problem during <<cdi.adoc#typesafe_resolution,typesafe resolution>>.
 Sometimes an injection point cannot be satisfied even if there is a class on the classpath that appears to be eligible for injection.
 There are several reasons why a class is not recognized and also several ways to fix it.
-In the first step we should identify the _reason_.
+In the first step, we should identify the _reason_.
 
 [[additional_bean_build_item]]
 === _Reason 1_: Class Is Not discovered
@@ -86,7 +86,7 @@ If the container considers them <<cdi-reference.adoc#remove_unused_beans,unused>
 However, you can use `AdditionalBeanBuildItem.Builder.setUnremovable()` method to instruct the container to never remove bean classes registered via this build item.
 See also <<cdi-reference.adoc#remove_unused_beans,Removing Unused Beans>> and <<unremovable_builditem>> for more details.
 
-It is aso possible to set the default scope via `AdditionalBeanBuildItem.Builder#setDefaultScope()`.
+It is also possible to set the default scope via `AdditionalBeanBuildItem.Builder#setDefaultScope()`.
 The default scope is only used if there is no scope declared on the bean class.
 
 NOTE: If no default scope is specified the `@Dependent` pseudo-scope is used.
@@ -112,7 +112,7 @@ AutoAddScopeBuildItem autoAddScope() {
 <1> Find all classes annotated with `@Scheduled`.
 <2> Add `@Singleton` as default scope. Classes already annotated with a scope are skipped automatically.
 
-_Solution 2_: If you need to process classes annotated with a specific annotation then it's possible to extend the set of bean defining annotations via the `BeanDefiningAnnotationBuildItem`.
+_Solution 2_: If you need to process classes annotated with a specific annotation, then it's possible to extend the set of bean defining annotations via the `BeanDefiningAnnotationBuildItem`.
 
 .`BeanDefiningAnnotationBuildItem` Example
 [source,java]
@@ -125,7 +125,7 @@ BeanDefiningAnnotationBuildItem additionalBeanDefiningAnnotation() {
 <1> Add `org.eclipse.microprofile.graphql.GraphQLApi` to the set of bean defining annotations.
 
 Bean classes added via `BeanDefiningAnnotationBuildItem` are _not removable_ by default, i.e. the resulting beans must not be removed even if they are considered unused.
-However, you can change the default behavior.
+However, you can change the default behaviour.
 See also <<cdi-reference.adoc#remove_unused_beans,Removing Unused Beans>> and <<unremovable_builditem>> for more details.
 
 It is also possible to specify the default scope.
@@ -138,7 +138,7 @@ NOTE: If no default scope is specified the `@Dependent` pseudo-scope is used.
 
 The container attempts to <<cdi-reference.adoc#remove_unused_beans,remove all unused beans>> during the build by default.
 This optimization allows for _framework-level dead code elimination_.
-In few special cases, it's not possible to correctly identify an unused bean.
+In a few special cases, it's not possible to correctly identify an unused bean.
 In particular, Quarkus is not able to detect the usage of the `CDI.current()` static method yet.
 Extensions can eliminate possible false positives by producing an `UnremovableBeanBuildItem`.
 
@@ -529,7 +529,7 @@ void syntheticObserver(ObserverRegistrationPhaseBuildItem observerRegistrationPh
 }
 ----
 
-The output of a `ObserverConfigurator` is recorded as bytecode.
+The output of an `ObserverConfigurator` is recorded as bytecode.
 Therefore, there are some limitations in how a synthetic observer is invoked at runtime.
 Currently, you must generate the bytecode of the method body directly.
 
@@ -537,7 +537,7 @@ Currently, you must generate the bytecode of the method body directly.
 == Use Case - I Have a Generated Bean Class
 
 No problem.
-You can generate the bytecode of a bean class manually and then all you need to do is to produce a `GeneratedBeanBuildItem` instead of `GeneratedClassBuildItem`.
+You can generate the bytecode of a bean class manually, and then all you need to do is to produce a `GeneratedBeanBuildItem` instead of `GeneratedClassBuildItem`.
 
 .`GeneratedBeanBuildItem` Example
 [source,java]
@@ -559,7 +559,7 @@ void generatedBean(BuildProducer<GeneratedBeanBuildItem> generatedBeans) {
 
 Sometimes extensions need to inspect the beans, observers and injection points, then perform additional validations and fail the build if something is wrong.
 
-_Solution_: If an extension needs to validate the deployment it should use the `ValidationPhaseBuildItem`.
+_Solution_: If an extension needs to validate the deployment, it should use the `ValidationPhaseBuildItem`.
 
 IMPORTANT: A build step that consumes the `ValidationPhaseBuildItem` should always produce a `ValidationErrorBuildItem` or at least inject a `BuildProducer` for this build item, otherwise it could be ignored or processed at the wrong time (e.g. after the correct CDI bootstrap phase).
 
@@ -614,7 +614,7 @@ _Solution_: You can inject the `CustomScopeAnnotationsBuildItem` in a build step
 [[additional_interceptor_bindings]]
 == Use Case - Additional Interceptor Bindings
 
-In rare cases it might be handy to programmatically register an existing annotation that is not annotated with `@jakarta.interceptor.InterceptorBinding` as an interceptor binding.
+In rare cases, it might be handy to programmatically register an existing annotation that is not annotated with `@jakarta.interceptor.InterceptorBinding` as an interceptor binding.
 This is similar to what CDI achieves through `BeforeBeanDiscovery#addInterceptorBinding()`.
 We are going to use `InterceptorBindingRegistrarBuildItem` to get it done.
 
@@ -678,9 +678,9 @@ If the newly registered stereotype annotation doesn't have the appropriate meta-
 [[injection_point_transformation]]
 == Use Case - Injection Point Transformation
 
-Every now and then it is handy to be able to change the qualifiers of an injection point programmatically.
+Every now and then, it is handy to be able to change the qualifiers of an injection point programmatically.
 You can do just that with `InjectionPointTransformerBuildItem`.
-The following sample shows how to apply transformation to injection points with type `Foo` that contain qualifier `MyQualifier`:
+The following sample shows how to apply a transformation to injection points with type `Foo` that contain a qualifier `MyQualifier`:
 
 .`InjectionPointTransformerBuildItem` Example
 [source,java]
@@ -741,7 +741,7 @@ INTERCEPTOR_BINDINGS:: `Map<DotName, ClassInfo>` containing all interceptor bind
 STEREOTYPES:: `Map<DotName, StereotypeInfo>` containing all stereotypes
 
 To get hold of these, simply query the extension context object for given key.
-Note that these metadata are made available as build proceeds which means that extensions can only leverage metadata that were built before the extensions are invoked.
+Note that these metadata are made available as build proceeds, which means that extensions can only leverage metadata that were built before the extensions are invoked.
 If your extension attempts to retrieve metadata that wasn't yet produced, `null` will be returned.
 Here is a summary of which extensions can access which metadata:
 

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -49,7 +49,7 @@ NOTE: Quarkus extensions may declare additional discovery rules. For example, `@
 === How to Generate a Jandex Index
 
 A dependency with a Jandex index is automatically scanned for beans.
-To generate the index just add the following plugin to your build file:
+To generate the index, just add the following plugin to your build file:
 
 [role="primary asciidoc-tabs-sync-maven"]
 .Maven
@@ -231,7 +231,7 @@ public class Consumer {
 ----
 
 Only the first producer will get the `@Default` qualifier, the second will not.
-Hence, there will be no error and everything will work as expected.
+Hence, there will be no error, and everything will work as expected.
 
 === When To Use `@Named`?
 
@@ -274,12 +274,12 @@ Outside of this use-case, just use `@Identifier`.
 
 Quarkus is using GraalVM to build a native executable.
 One of the limitations of GraalVM is the usage of link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/Reflection/[Reflection, window="_blank"].
-Reflective operations are supported but all relevant members must be registered for reflection explicitly.
+Reflective operations are supported, but all relevant members must be registered for reflection explicitly.
 Those registrations result in a bigger native executable.
 
-And if Quarkus DI needs to access a private member it *has to use reflection*.
+And if Quarkus DI needs to access a private member it, *has to use reflection*.
 That's why Quarkus users are encouraged __not to use private members__ in their beans.
-This involves injection fields, constructors and initializers, observer methods, producer methods and fields, disposers and interceptor methods.
+This involves injection fields, constructors and initializers, observer methods, producer methods and fields, disposers, and interceptor methods.
 
 How to avoid using private members?
 You can use package-private modifiers:
@@ -391,7 +391,7 @@ public class PingResource {
 [[startup_event]]
 ==== Startup Event
 
-However, if you really need to instantiate a bean eagerly you can:
+However, if you really need to instantiate a bean eagerly, you can:
 
 * Declare an observer of the `StartupEvent` - the scope of the bean does not matter in this case:
 +
@@ -537,7 +537,7 @@ In such cases, you'll notice a big warning in the log.
 Users and extension authors have several options <<eliminate_false_positives,how to eliminate false positives>>.
 
 The optimization can be disabled by setting `quarkus.arc.remove-unused-beans` to `none` or `false`.
-Quarkus also provides a middle ground where application beans are never removed whether or not they are unused, while the optimization proceeds normally for non application classes.
+Quarkus also provides a middle ground where application beans are never removed, whether or not they are unused, while the optimization proceeds normally for non application classes.
 To use this mode, set `quarkus.arc.remove-unused-beans` to `fwk` or `framework`.
 
 ==== What's Removed?
@@ -601,7 +601,7 @@ Furthermore, extensions can eliminate false positives by producing an `Unremovab
 Quarkus adds a capability that CDI currently does not support which is to conditionally declare a bean if no other bean with equal types and qualifiers was declared by any available means (bean class, producer, synthetic bean, ...)
 This is done using the `@io.quarkus.arc.DefaultBean` annotation and is best explained with an example.
 
-Say there is a Quarkus extension that among other things declares a few CDI beans like the following code does:
+Say there is a Quarkus extension that, among other things, declares a few CDI beans like the following code does:
 
 [source,java]
 ----
@@ -669,11 +669,11 @@ public class CustomizedDefaultConfiguration {
 [[enable_build_profile]]
 === Enabling Beans for Quarkus Build Profile
 
-Quarkus adds a capability that CDI currently does not support which is to conditionally enable a bean when a Quarkus build time profile is enabled,
+Quarkus adds a capability that CDI currently does not support, which is to conditionally enable a bean when a Quarkus build time profile is enabled,
 via the `@io.quarkus.arc.profile.IfBuildProfile` and `@io.quarkus.arc.profile.UnlessBuildProfile` annotations.
 When used in conjunction with `@io.quarkus.arc.DefaultBean`, these annotations allow for the creation of different bean configurations for different build profiles.
 
-Imagine for instance that an application contains a bean named `Tracer`, which needs to do nothing when in tests or in dev mode, but works in its normal capacity for the production artifact.
+Imagine, for instance that an application contains a bean named `Tracer`, which needs to do nothing when in tests or in dev mode, but works in its normal capacity for the production artifact.
 An elegant way to create such beans is the following:
 
 [source,java]
@@ -778,11 +778,11 @@ TIP: It is also possible to use `@IfBuildProperty` and `@UnlessBuildProperty` on
 === Declaring Selected Alternatives
 
 In CDI, an alternative bean may be selected either globally for an application by means of `@Priority`, or for a bean archive using a `beans.xml` descriptor.
-Quarkus has a simplified bean discovery and the content of `beans.xml` is ignored.
+Quarkus has a simplified bean discovery, and the content of `beans.xml` is ignored.
 
 However, it is also possible to select alternatives for an application using the unified configuration.
 The `quarkus.arc.selected-alternatives` property accepts a list of string values that are used to match alternative beans.
-If any value matches then the priority of `Integer#MAX_VALUE` is used for the relevant bean.
+If any value matches, then the priority of `Integer#MAX_VALUE` is used for the relevant bean.
 The priority declared via `@Priority` or inherited from a stereotype is overridden.
 
 .Value Examples
@@ -863,7 +863,7 @@ class Services {
 
 * Only *method-level bindings* are considered for backward compatibility reasons (otherwise static methods of bean classes that declare class-level bindings would be suddenly intercepted)
 * Private static methods are never intercepted
-* `InvocationContext#getTarget()` returns `null` for obvious reasons; therefore not all existing interceptors may behave correctly when intercepting static methods
+* `InvocationContext#getTarget()` returns `null` for obvious reasons; therefore, not all existing interceptors may behave correctly when intercepting static methods
 +
 NOTE: Interceptors can use `InvocationContext.getMethod()` to detect static methods and adjust the behavior accordingly.
 
@@ -872,7 +872,7 @@ NOTE: Interceptors can use `InvocationContext.getMethod()` to detect static meth
 
 In normal CDI, classes that are marked as `final` and / or have `final` methods are not eligible for proxy creation,
 which in turn means that interceptors and normal scoped beans don't work properly.
-This situation is very common when trying to use CDI with alternative JVM languages like Kotlin where classes and methods are `final` by default.
+This situation is very common when trying to use CDI with alternative JVM languages like Kotlin, where classes and methods are `final` by default.
 
 Quarkus however, can overcome these limitations when `quarkus.arc.transform-unproxyable-classes` is set to `true` (which is the default value).
 
@@ -880,7 +880,7 @@ Quarkus however, can overcome these limitations when `quarkus.arc.transform-unpr
 
 There is no standard concurrency control mechanism for CDI beans.
 Nevertheless, a bean instance can be shared and accessed concurrently from multiple threads.
-In that case it should be thread-safe.
+In that case, it should be thread-safe.
 You can use standard Java constructs (`volatile`, `synchronized`, `ReadWriteLock`, etc.) or let the container control the concurrent access.
 Quarkus provides `@io.quarkus.arc.Lock` and a built-in interceptor for this interceptor binding.
 Each interceptor instance associated with a contextual instance of an intercepted bean holds a separate `ReadWriteLock` with non-fair ordering policy.
@@ -962,13 +962,13 @@ Other interceptors could be provided to log method invocations to different targ
 === Caching the Result of Programmatic Lookup
 
 In certain situations, it is practical to obtain a bean instance programmatically via an injected `jakarta.enterprise.inject.Instance` and `Instance.get()`.
-However, according to the specification the `get()` method must identify the matching bean and obtain a contextual reference.
+However, according to the specification, the `get()` method must identify the matching bean and obtain a contextual reference.
 As a consequence, a new instance of a  `@Dependent` bean is returned from each invocation of `get()`.
 Moreover, this instance is a dependent object of the injected `Instance`.
 This behavior is well-defined, but it may lead to unexpected errors and memory leaks.
 Therefore, Quarkus comes with the `io.quarkus.arc.WithCaching` annotation.
 An injected `Instance` annotated with this annotation will cache the result of the `Instance#get()` operation.
-The result is computed on the first call and the same value is returned for all subsequent calls, even for `@Dependent` beans.
+The result is computed on the first call, and the same value is returned for all subsequent calls, even for `@Dependent` beans.
 
 [source,java]
 ----
@@ -1200,7 +1200,7 @@ public void doSomethingElse() {
 }
 ----
 
-The `@NoClassInterceptors` annotation may be put on methods and constructors and means that all class-level interceptors are ignored for these methods and constructors.
+The `@NoClassInterceptors` annotation may be put on methods and constructors, and means that all class-level interceptors are ignored for these methods and constructors.
 In other words, if a method/constructor is annotated `@NoClassInterceptors`, then the only interceptors that will apply to this method/constructor are interceptors declared directly on the method/constructor.
 
 This annotation affects only business method interceptors (`@AroundInvoke`) and constructor lifecycle callback interceptors (`@AroundConstruct`).
@@ -1369,7 +1369,7 @@ class MyClass<T> {
 }
 ----
 
-the bindings source class must also use `T` as the name of the type variable:
+The bindings source class must also use `T` as the name of the type variable:
 
 [source,java]
 ----
@@ -1514,7 +1514,7 @@ If some observers have thrown an exception, the `CompletionStage` completes exce
 The return type of the observer _does not matter_.
 The return value of the observer is _ignored_.
 
-You may declare an observer method that has a return type of `CompletionStage<>` or `Uni<>`, but neither the return type nor the actual return value affect the result of `Event.fireAsync()`.
+You may declare an observer method that has a return type of `CompletionStage<>` or `Uni<>`, but neither the return type nor the actual return value affects the result of `Event.fireAsync()`.
 Further, if the observer declares a return type of `Uni<>`, the returned `Uni` will not be subscribed to, so it is quite possible that part of the observer logic will not even execute.
 
 Therefore, it is recommended that observer methods, both synchronous and asynchronous, are always declared `void`.

--- a/docs/src/main/asciidoc/cdi.adoc
+++ b/docs/src/main/asciidoc/cdi.adoc
@@ -20,7 +20,7 @@ The xref:cdi-integration.adoc[CDI integration guide] has more detail on common C
 
 == OK. Let's start simple. What is a bean?
 
-Well, a bean is a _container-managed_ object that supports a set of basic services, such as injection of dependencies, lifecycle callbacks and interceptors.
+Well, a bean is a _container-managed_ object that supports a set of basic services, such as injection of dependencies, lifecycle callbacks, and interceptors.
 
 == Wait a minute. What does "container-managed" mean?
 
@@ -106,7 +106,7 @@ public class Translator {
 == Can I use setter and constructor injection?
 
 Yes, you can.
-In fact, in CDI the "setter injection" is superseded by more powerful https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1.html#initializer_methods[initializer methods, window="_blank"].
+In fact, in CDI, the "setter injection" is superseded by more powerful https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1.html#initializer_methods[initializer methods, window="_blank"].
 Initializers may accept multiple parameters and don't have to follow the JavaBean naming conventions.
 
 .Initialized and Constructor Injection Example
@@ -129,7 +129,7 @@ public class Translator {
 ----
 <1> This is a constructor injection.
 In fact, this code would not work in regular CDI implementations where a bean with a normal scope must always declare a no-args constructor and the bean constructor must be annotated with `@Inject`.
-However, in Quarkus we detect the absence of no-args constructor and "add" it directly in the bytecode.
+However, in Quarkus, we detect the absence of no-args constructor and "add" it directly in the bytecode.
 It's also not necessary to add `@Inject` if there is only one constructor present.
 <2> An initializer method must be annotated with `@Inject`.
 <3> An initializer may accept multiple parameters - each one is an injection point.
@@ -137,8 +137,8 @@ It's also not necessary to add `@Inject` if there is only one constructor presen
 == You talked about some qualifiers?
 
 https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1.html#qualifiers[Qualifiers, window="_blank"] are annotations that help the container to distinguish beans that implement the same type.
-As we already said a bean is assignable to an injection point if it has all the required qualifiers.
-If you declare no qualifier at an injection point the `@Default` qualifier is assumed.
+As we already said, a bean is assignable to an injection point if it has all the required qualifiers.
+If you declare no qualifier at an injection point, the `@Default` qualifier is assumed.
 
 A qualifier type is a Java annotation defined as `@Retention(RUNTIME)` and annotated with the `@jakarta.inject.Qualifier` meta-annotation:
 

--- a/docs/src/main/asciidoc/doc-create-tutorial.adoc
+++ b/docs/src/main/asciidoc/doc-create-tutorial.adoc
@@ -226,7 +226,7 @@ We'll start with the steps required to create and add an endpoint to a file.
 -----
 == Hello, World! as an Acme REST service
 
-Let's create a Http endpoint using the `@Anvil` annotation.
+Let's create an Http endpoint using the `@Anvil` annotation.
 
 Create a new source file, `src/main/java/org/acme/MyAcmeApplication.java`, and define the `MyAcmeApplication` bean as follows:
 

--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -220,7 +220,7 @@ If a message produced from a RabbitMQ message is nacked, a failure strategy is a
 three strategies, controlled by the failure-strategy channel setting:
 
 * `fail` - fail the application; no more RabbitMQ messages will be processed. The RabbitMQ message is marked as rejected.
-* `accept` - this strategy marks the RabbitMQ message as _accepted_. The processing continues ignoring the failure.
+* `accept` - this strategy marks the RabbitMQ message as _accepted_. The processing continues, ignoring the failure.
 * `reject` - this strategy marks the RabbitMQ message as rejected (default). The processing continues with the next message.
 
 == Sending RabbitMQ messages
@@ -413,7 +413,7 @@ On the inbound side (receiving messages from RabbitMQ), the check verifies that 
 
 On the outbound side (sending records to RabbitMQ), the check verifies that the sender is not disconnected from the broker; the sender _may_ still be in an initialised state (connection not yet attempted), but this is regarded as live/ready.
 
-Note that a message processing failures nacks the message, which is then handled by the `failure-strategy`.
+Note that a message processing failure nacks the message, which is then handled by the `failure-strategy`.
 It's the responsibility of the `failure-strategy` to report the failure and influence the outcome of the checks.
 The `fail` failure strategy reports the failure, and so the check will report the fault.
 

--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -2408,7 +2408,7 @@ public class MyExceptionWrapper extends RuntimeException {
 }
 ----
 
-If you don't control that exception wrapper type, you can place the annotation on any class and specify the exception wrapper types it applies to as annotation parameter:
+If you don't control that exception wrapper type, you can place the annotation on any class and specify the exception wrapper types it applies to as an annotation parameter:
 
 [source,java]
 ----


### PR DESCRIPTION
This PR contains small documentation improvements across several `.adoc` files.

Changes include:
- Grammar corrections
- Punctuation fixes
- Minor wording improvements for clarity

No functional or behavioral changes were made.