### PR TITLE
Use sealed interfaces in bootstrap JSON

### DIFF
--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonMultiValue.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonMultiValue.java
@@ -1,6 +1,6 @@
 package io.quarkus.bootstrap.json;
 
-public interface JsonMultiValue extends JsonValue {
+public sealed interface JsonMultiValue extends JsonValue permits JsonArray, JsonObject {
     default void forEach(JsonTransform transform) {
         transform.accept(null, this);
     }

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonNumber.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonNumber.java
@@ -1,4 +1,4 @@
 package io.quarkus.bootstrap.json;
 
-public interface JsonNumber extends JsonValue {
+public sealed interface JsonNumber extends JsonValue permits JsonDouble, JsonInteger {
 }

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonValue.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/JsonValue.java
@@ -1,4 +1,4 @@
 package io.quarkus.bootstrap.json;
 
-public interface JsonValue {
+public sealed interface JsonValue permits JsonBoolean, JsonMember, JsonMultiValue, JsonNull, JsonNumber, JsonString {
 }


### PR DESCRIPTION
This is done because it allows for enhanced
switch statements when testing the type