### PR TITLE
Log discovered OIDC metadata

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -616,7 +616,9 @@ public class OidcCommonUtils {
                 .flatMap(resp -> filterHttpResponse(requestProps, resp, responseFilters, Type.DISCOVERY)
                         .map(buffer -> {
                             if (resp.statusCode() == 200) {
-                                return buffer.toJsonObject();
+                                JsonObject discoveredJson = buffer.toJsonObject();
+                                LOG.debugf("Discovered OIDC metadata: %s", discoveredJson);
+                                return discoveredJson;
                             } else if (resp.statusCode() == 302) {
                                 throw createOidcClientRedirectException(resp);
                             } else {


### PR DESCRIPTION
Fixes #52006

Making it easier to check the discovered metadata, all other OIDC resposnes to the token endpoint, etc are logged, but discovery one was not