### PR TITLE
Bump to Vert.x 4.5.24

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -55,7 +55,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.21.3</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.21.4</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.32.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.7.1.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.3.Final</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.23</vertx.version>
+        <vertx.version>4.5.24</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,9 +56,9 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>3.1.0</mutiny.version>
-        <smallrye-mutiny-vertx-core.version>3.21.3</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.21.4</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.15.0</smallrye-common.version>
-        <vertx.version>4.5.23</vertx.version>
+        <vertx.version>4.5.24</vertx.version>
         <rest-assured.version>5.5.6</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.20.1</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.23</vertx.version>
+        <vertx.version>4.5.24</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This Vert.x release fixes CVE-2026-1002


