### PR TITLE
Upgrade to Hibernate ORM 7.2.1 + Flyway integration test fix

### DIFF
--- a/integration-tests/flyway/src/main/java/io/quarkus/it/flyway/AppEntity.java
+++ b/integration-tests/flyway/src/main/java/io/quarkus/it/flyway/AppEntity.java
@@ -2,6 +2,7 @@ package io.quarkus.it.flyway;
 
 import java.util.Objects;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -18,6 +19,7 @@ public class AppEntity {
 
     private String name;
 
+    @Column(nullable = false)
     private String createdBy;
 
     public int getId() {

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.4.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.2.0.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.2.1.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

The upgrade was causing the IT to fail since we [now validate](https://hibernate.atlassian.net/browse/HHH-3192) db column nullability matches the entity mapping.

* Fixes #50440

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

