### PR TITLE
First version of an aot-jar packaging

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
@@ -37,6 +37,8 @@ public class RunCommandProcessor {
             // todo: legacy JAR should be using runnerSuffix()
             case LEGACY_JAR -> jar.getOutputDirectory()
                     .resolve(jar.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
+            case AOT_JAR -> jar.getOutputDirectory()
+                    .resolve(jar.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
             case FAST_JAR, MUTABLE_JAR -> jar.getOutputDirectory()
                     .resolve(DEFAULT_FAST_JAR_DIRECTORY_NAME).resolve(QUARKUS_RUN_JAR);
         };

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -335,6 +335,13 @@ public interface PackageConfig {
              */
             MUTABLE_JAR("mutable-jar"),
             /**
+             * The "AOT JAR" packaging type.
+             * This packaging type is optimized for Ahead-of-Time (AOT) compilation with Java 25 and Project Leyden.
+             * It uses standard Java classloaders for maximum AOT compatibility while maintaining a thin caching layer
+             * for frequently-accessed resources like service files and configuration files.
+             */
+            AOT_JAR("aot-jar"),
+            /**
              * The "legacy JAR" packaging type.
              * This corresponds to the packaging type used in Quarkus before version 1.12.
              *

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -137,7 +137,7 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
         }
     }
 
-    private static Predicate<String> getThinJarIgnoredEntriesPredicate(PackageConfig packageConfig) {
+    protected static Predicate<String> getThinJarIgnoredEntriesPredicate(PackageConfig packageConfig) {
         return packageConfig.jar().userConfiguredIgnoredEntries().map(Set::copyOf).orElse(Set.of())::contains;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AotJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AotJarBuilder.java
@@ -1,0 +1,232 @@
+package io.quarkus.deployment.pkg.jar;
+
+import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Predicate;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.runneraot.AotEntryPoint;
+import io.quarkus.bootstrap.runneraot.AotSerializedApplication;
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.paths.OpenPathTree;
+
+public class AotJarBuilder extends AbstractLegacyThinJarBuilder<JarBuildItem> {
+
+    private static final Logger LOG = Logger.getLogger(AotJarBuilder.class);
+
+    private static final List<String> FULLY_INDEXED_DIRECTORIES = List.of(
+            "", // root directory
+            "META-INF",
+            "META-INF/services");
+
+    private final String actualMainClass;
+
+    public AotJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            Set<ArtifactKey> removedArtifactKeys,
+            ExecutorService executorService,
+            ResolvedJVMRequirements jvmRequirements) {
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig,
+                new MainClassBuildItem(AotEntryPoint.class.getName()), applicationArchives, transformedClasses,
+                generatedClasses, generatedResources, removedArtifactKeys, executorService, jvmRequirements);
+        // Store the actual application main class for serialization
+        this.actualMainClass = mainClass.getClassName();
+    }
+
+    public JarBuildItem build() throws IOException {
+        Path runnerJar = outputTarget.getOutputDirectory()
+                .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + DOT_JAR);
+        Path libDir = outputTarget.getOutputDirectory().resolve("lib");
+        Path quarkusApplicationDat = outputTarget.getOutputDirectory().resolve(AotEntryPoint.QUARKUS_APPLICATION_DAT);
+
+        Files.deleteIfExists(runnerJar);
+        IoUtils.createOrEmptyDir(libDir);
+        IoUtils.createOrEmptyDir(quarkusApplicationDat.getParent());
+
+        doBuild(runnerJar, libDir);
+
+        final Map<String, List<byte[]>> services = new HashMap<>();
+        Set<String> fullyIndexedResources = new HashSet<>();
+
+        final Collection<ResolvedDependency> runtimeDependencies = curateOutcome.getApplicationModel()
+                .getRuntimeDependencies();
+        final Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
+
+        ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
+        collectCacheableResourcesFromApplicationArchives(appArtifact, ignoredEntriesPredicate,
+                services, fullyIndexedResources);
+
+        for (ResolvedDependency runtimeDependency : runtimeDependencies) {
+            // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
+            // and are not part of the optional dependencies to include
+            if (!includeAppDependency(runtimeDependency, outputTarget.getIncludedOptionalDependencies(), removedArtifactKeys)) {
+                continue;
+            }
+
+            collectCacheableResourcesFromApplicationArchives(runtimeDependency, ignoredEntriesPredicate,
+                    services, fullyIndexedResources);
+        }
+
+        for (GeneratedClassBuildItem i : generatedClasses) {
+            String fileName = fromClassNameToResourceName(i.internalName());
+
+            if (ignoredEntriesPredicate.test(fileName)) {
+                continue;
+            }
+
+            if (isDirectChildOfTrackedDirectory(fileName)) {
+                fullyIndexedResources.add(fileName);
+            }
+        }
+
+        for (GeneratedResourceBuildItem i : generatedResources) {
+            if (ignoredEntriesPredicate.test(i.getName())) {
+                continue;
+            }
+
+            if (isDirectChildOfTrackedDirectory(i.getName())) {
+                fullyIndexedResources.add(i.getName());
+            }
+
+            if (isServiceFile(i.getName())) {
+                services.computeIfAbsent(i.getName(), k -> new ArrayList<>())
+                        .add(i.getData());
+            }
+        }
+
+        Map<String, byte[]> serviceFiles = new HashMap<>();
+        for (Map.Entry<String, List<byte[]>> service : services.entrySet()) {
+            byte[] concatenated = concatenateServiceFiles(service.getValue());
+            serviceFiles.put(service.getKey(), concatenated);
+        }
+
+        try (var out = Files.newOutputStream(quarkusApplicationDat)) {
+            // For thin jars, don't claim directories are fully indexed since resources are in separate lib/ jars
+            // Only cache the service files for performance
+            AotSerializedApplication.write(out, actualMainClass, FULLY_INDEXED_DIRECTORIES, fullyIndexedResources,
+                    serviceFiles);
+        }
+
+        // Debug logging for specific cached resources
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("SerializedApplication created with " + serviceFiles.size() + " service files");
+            LOG.debug("Collected " + fullyIndexedResources.size() + " directory entries from: " + FULLY_INDEXED_DIRECTORIES);
+
+            serviceFiles.keySet().stream().sorted().forEach(resource -> {
+                LOG.debug("  Service file: " + resource);
+            });
+            fullyIndexedResources.stream().sorted().forEach(entry -> {
+                LOG.debug("  Directory entry: " + entry);
+            });
+        }
+
+        return new JarBuildItem(runnerJar, null, libDir, packageConfig.jar().type(),
+                suffixToClassifier(packageConfig.computedRunnerSuffix()));
+    }
+
+    private static void collectCacheableResourcesFromApplicationArchives(ResolvedDependency dependency,
+            Predicate<String> ignoredEntriesPredicate, Map<String, List<byte[]>> services,
+            Set<String> fullyIndexedResources) throws IOException {
+        try (OpenPathTree pathTree = dependency.getContentTree().open()) {
+            pathTree.walk(visit -> {
+                try {
+                    final String relativePath = visit.getRelativePath();
+                    if (Files.isDirectory(visit.getPath())) {
+                        return;
+                    }
+
+                    if (ignoredEntriesPredicate.test(relativePath)) {
+                        return;
+                    }
+
+                    if (isDirectChildOfTrackedDirectory(relativePath)) {
+                        fullyIndexedResources.add(relativePath);
+                    }
+
+                    if (isServiceFile(relativePath)) {
+                        services.computeIfAbsent(relativePath, k -> new ArrayList<>())
+                                .add(Files.readAllBytes(visit.getPath()));
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static boolean isDirectChildOfTrackedDirectory(String path) {
+        // Check if it's a direct child of any tracked directory
+        for (String trackedDir : FULLY_INDEXED_DIRECTORIES) {
+            if (trackedDir.isEmpty()) {
+                if (path.indexOf('/') == -1) {
+                    return true;
+                }
+            } else {
+                String prefix = trackedDir + "/";
+                if (path.startsWith(prefix)) {
+                    String afterPrefix = path.substring(prefix.length());
+                    if (afterPrefix.indexOf('/') == -1) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isServiceFile(String resourcePath) {
+        return resourcePath.startsWith("META-INF/services/") && resourcePath.length() > 18;
+    }
+
+    private static byte[] concatenateServiceFiles(List<byte[]> files) throws IOException {
+        if (files.size() == 1) {
+            return files.get(0);
+        }
+
+        // Concatenate with newlines between files
+        var result = new java.io.ByteArrayOutputStream();
+        for (int i = 0; i < files.size(); i++) {
+            result.write(files.get(i));
+            if (i < files.size() - 1) {
+                result.write('\n');
+            }
+        }
+        return result.toByteArray();
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -40,6 +40,7 @@ import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.UberJarIgnoredResourceBuildItem;
 import io.quarkus.deployment.pkg.builditem.UberJarMergedResourceBuildItem;
+import io.quarkus.deployment.pkg.jar.AotJarBuilder;
 import io.quarkus.deployment.pkg.jar.FastJarBuilder;
 import io.quarkus.deployment.pkg.jar.LegacyThinJarBuilder;
 import io.quarkus.deployment.pkg.jar.NativeImageSourceJarBuilder;
@@ -134,6 +135,18 @@ public class JarResultBuildStep {
                     buildExecutor,
                     jvmRequirements).build();
             case LEGACY_JAR -> new LegacyThinJarBuilder(curateOutcomeBuildItem,
+                    outputTargetBuildItem,
+                    applicationInfo,
+                    packageConfig,
+                    mainClassBuildItem,
+                    applicationArchivesBuildItem,
+                    transformedClasses,
+                    generatedClasses,
+                    generatedResources,
+                    removedArtifactKeys,
+                    buildExecutor,
+                    jvmRequirements).build();
+            case AOT_JAR -> new AotJarBuilder(curateOutcomeBuildItem,
                     outputTargetBuildItem,
                     applicationInfo,
                     packageConfig,

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -167,7 +167,7 @@ public class JibProcessor {
         JibContainerBuilder jibContainerBuilder;
         PackageConfig.JarConfig.JarType jarType = packageConfig.jar().type();
         jibContainerBuilder = switch (jarType) {
-            case LEGACY_JAR, UBER_JAR ->
+            case LEGACY_JAR, UBER_JAR, AOT_JAR ->
                 createContainerBuilderFromLegacyJar(determineBaseJvmImage(jibConfig, compiledJavaVersion),
                         jibConfig, containerImageConfig,
                         sourceJar, outputTarget, mainClass, containerImageLabels);

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -268,7 +268,7 @@ class KubernetesProcessor {
             PackageConfig packageConfig) {
         PackageConfig.JarConfig.JarType jarType = packageConfig.jar().type();
         return switch (jarType) {
-            case LEGACY_JAR, UBER_JAR -> outputTarget.getOutputDirectory()
+            case LEGACY_JAR, UBER_JAR, AOT_JAR -> outputTarget.getOutputDirectory()
                     .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
             case FAST_JAR, MUTABLE_JAR -> {
                 //thin JAR

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/forkjoin/QuarkusForkJoinWorkerThread.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/forkjoin/QuarkusForkJoinWorkerThread.java
@@ -3,8 +3,6 @@ package io.quarkus.bootstrap.forkjoin;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 
-import io.quarkus.bootstrap.runner.RunnerClassLoader;
-
 public class QuarkusForkJoinWorkerThread extends ForkJoinWorkerThread {
 
     private static volatile ClassLoader qClassloader;
@@ -13,7 +11,7 @@ public class QuarkusForkJoinWorkerThread extends ForkJoinWorkerThread {
         super(pool);
     }
 
-    public static synchronized void setQuarkusAppClassloader(RunnerClassLoader runnerClassLoader) {
+    public static synchronized void setQuarkusAppClassloader(ClassLoader runnerClassLoader) {
         qClassloader = runnerClassLoader;
     }
 

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -314,14 +314,14 @@ public final class RunnerClassLoader extends ClassLoader {
     }
 
     /**
-     * This method is needed to make packages work correctly on JDK9+, as it will be called
+     * This method is needed to make packages work correctly, as it will be called
      * to load the package-info class.
      *
      * @param moduleName
      * @param name
      * @return
      */
-    //@Override
+    @Override
     protected Class<?> findClass(String moduleName, String name) {
         try {
             return loadClass(name, false);

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runneraot/AotEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runneraot/AotEntryPoint.java
@@ -1,0 +1,75 @@
+package io.quarkus.bootstrap.runneraot;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThread;
+import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.runner.Timing;
+
+/**
+ * Entry point for AOT-optimized jar packaging.
+ *
+ * This entry point sets up a thin class loader layer that caches frequently-accessed
+ * resources (service files) while delegating all class loading to
+ * standard Java class loaders for optimal AOT (Ahead-of-Time) compilation performance.
+ */
+public class AotEntryPoint {
+
+    public static final String QUARKUS_APPLICATION_DAT = "quarkus/quarkus-application.dat";
+    private static final String QUARKUS_DIR = "quarkus";
+
+    public static void main(String... args) throws Throwable {
+        System.setProperty("java.util.logging.manager", org.jboss.logmanager.LogManager.class.getName());
+        System.setProperty("java.util.concurrent.ForkJoinPool.common.threadFactory",
+                "io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory");
+        Timing.staticInitStarted(false);
+
+        try {
+            doRun(args);
+        } catch (RuntimeException | Error e) {
+            InitialConfigurator.DELAYED_HANDLER.close();
+            throw e;
+        } catch (Throwable t) {
+            InitialConfigurator.DELAYED_HANDLER.close();
+            throw new UndeclaredThrowableException(t);
+        }
+    }
+
+    private static void doRun(String... args) throws Throwable {
+        String path = AotEntryPoint.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        Path appRoot = new File(decodedPath).toPath().getParent().getParent();
+
+        // Load cached resources and main class name
+        AotSerializedApplication app;
+        Path cacheFile = appRoot.resolve(QUARKUS_APPLICATION_DAT);
+        if (Files.isReadable(cacheFile)) {
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(cacheFile), 8192)) {
+                app = AotSerializedApplication.read(in);
+            }
+        } else {
+            throw new IllegalStateException("Serialized application file not found or not readable: " + cacheFile
+                    + ". The application may not have been packaged correctly with aot-jar type.");
+        }
+
+        final AotRunnerClassLoader aotRunnerClassLoader = app.getRunnerClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(aotRunnerClassLoader);
+            QuarkusForkJoinWorkerThread.setQuarkusAppClassloader(aotRunnerClassLoader);
+            Class<?> mainClass = aotRunnerClassLoader.loadClass(app.getMainClass());
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            lookup.findStatic(mainClass, "main", MethodType.methodType(void.class, String[].class)).invokeExact(args);
+        } finally {
+            QuarkusForkJoinWorkerThread.setQuarkusAppClassloader(null);
+        }
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runneraot/AotRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runneraot/AotRunnerClassLoader.java
@@ -1,0 +1,280 @@
+package io.quarkus.bootstrap.runneraot;
+
+import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
+import static io.quarkus.commons.classloading.ClassLoaderHelper.isInJdkPackage;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A ClassLoader that behaves similarly to the RunnerClassLoader for resources
+ * but delegates all class loading to the JDK application class loader.
+ *
+ * The idea is that it lets us optimize the resource case, while still benefiting from AOT.
+ * Our hope is that we will be able to use a fully custom ClassLoader with Project Leyden at some point but we are not there
+ * yet.
+ *
+ * Key characteristics:
+ * - All class loading is delegated to the parent
+ * - Resource lookups are intercepted for the service files and otherwise delegated to the parent
+ * - For some selected directories, we have a full index of the content so that we can avoid negative lookups in the parent
+ *
+ * Note that not all ServiceLoader calls will hit this ClassLoader as some low levels one are directly hitting
+ * the ClassLoader used to load the classes, thus circumventing the optimizations we have in this ClassLoader.
+ * It is an expected behavior though, and will be vastly improved once we can use a custom ClassLoader with Leyden.
+ */
+public class AotRunnerClassLoader extends ClassLoader {
+
+    static {
+        registerAsParallelCapable();
+    }
+
+    // the following two fields go hand in hand - they need to both be populated from the same data
+    // in order for the resource loading to work properly
+    private final Set<String> fullyIndexedDirectories;
+    private final Set<String> fullyIndexedResources;
+
+    private final Map<String, byte[]> serviceFiles;
+
+    AotRunnerClassLoader(ClassLoader parent, Set<String> fullyIndexedDirectories, Set<String> fullyIndexedResources,
+            Map<String, byte[]> serviceFiles) {
+        super(parent);
+        this.fullyIndexedDirectories = fullyIndexedDirectories;
+        this.fullyIndexedResources = fullyIndexedResources;
+        this.serviceFiles = serviceFiles;
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        return loadClass(name, false);
+    }
+
+    @Override
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        // fast path for JDK classes
+        if (isInJdkPackage(name)) {
+            return getParent().loadClass(name);
+        }
+
+        // this infrastructure is not used for classes at the moment but could be in the future
+        String classResource = fromClassNameToResourceName(name);
+        String dirName = getDirNameFromResourceName(classResource);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(classResource)) {
+            throw new ClassNotFoundException(name);
+        }
+
+        return getParent().loadClass(name);
+    }
+
+    /**
+     * This method is needed to make packages work correctly on JDK9+, as it will be called
+     * to load the package-info class.
+     */
+    @Override
+    protected Class<?> findClass(String moduleName, String name) {
+        try {
+            return loadClass(name, false);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public URL getResource(String name) {
+        name = sanitizeName(name);
+
+        // If cached, return it immediately, no need to scan the jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return createCachedResourceURL(name, data);
+            }
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return null;
+        }
+
+        // if it exists, and is not cached, then delegate to the parent
+        return super.getResource(name);
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        name = sanitizeName(name);
+
+        // If cached, return it immediately, no need to scan the jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return createCachedResourceURL(name, data);
+            }
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return null;
+        }
+
+        return super.findResource(name);
+    }
+
+    /**
+     * Gets all resources with the given name.
+     * This is the method called by ServiceLoader and other resource loading mechanisms.
+     * If the resource is cached, returns ONLY the cached version without jar scanning.
+     * This is the key optimization - service files and config files are pre-cached,
+     * so ServiceLoader and config loading don't need to scan jars.
+     *
+     * @param name the resource name
+     * @return an enumeration of URLs for the resources
+     * @throws IOException if I/O errors occur
+     */
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        name = sanitizeName(name);
+
+        // The cached version already contains the concatenated content from all jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return Collections.enumeration(Collections.singletonList(
+                        createCachedResourceURL(name, data)));
+            }
+            return Collections.emptyEnumeration();
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return Collections.emptyEnumeration();
+        }
+
+        return super.getResources(name);
+    }
+
+    /**
+     * Finds all resources with the given name.
+     * If the resource is cached, returns ONLY the cached version without jar scanning.
+     *
+     * @param name the resource name
+     * @return an enumeration of URLs for the resources
+     * @throws IOException if I/O errors occur
+     */
+    @Override
+    public Enumeration<URL> findResources(String name) throws IOException {
+        name = sanitizeName(name);
+
+        // The cached version already contains the concatenated content from all jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return Collections.enumeration(Collections.singletonList(
+                        createCachedResourceURL(name, data)));
+            }
+            return Collections.emptyEnumeration();
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return Collections.emptyEnumeration();
+        }
+
+        // Not cached - delegate to parent implementation (will scan jars)
+        return super.findResources(name);
+    }
+
+    private URL createCachedResourceURL(String name, byte[] data) {
+        try {
+            return new URL(null, "cached:" + name, new CachedResourceURLStreamHandler(data));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Failed to create URL for cached resource: " + name, e);
+        }
+    }
+
+    /**
+     * URL stream handler for cached resources.
+     */
+    private static class CachedResourceURLStreamHandler extends URLStreamHandler {
+        private final byte[] data;
+
+        CachedResourceURLStreamHandler(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        protected URLConnection openConnection(URL url) {
+            return new CachedResourceURLConnection(url, data);
+        }
+    }
+
+    /**
+     * URL connection for cached resources.
+     */
+    private static class CachedResourceURLConnection extends URLConnection {
+        private final byte[] data;
+
+        CachedResourceURLConnection(URL url, byte[] data) {
+            super(url);
+            this.data = data;
+        }
+
+        @Override
+        public void connect() {
+            // No-op for in-memory resources
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public int getContentLength() {
+            return data.length;
+        }
+    }
+
+    private static String sanitizeName(String name) {
+        if (name != null && !name.isEmpty() && name.charAt(0) == '/') {
+            return name.substring(1);
+        }
+        return name;
+    }
+
+    private static String getDirNameFromResourceName(String resourceName) {
+        final int index = resourceName.lastIndexOf('/');
+        if (index == -1) {
+            // Return empty string for resources in the root directory (no package/directory)
+            return "";
+        }
+        return resourceName.substring(0, index);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        //see comment in hashCode
+        return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+        //We can return a constant as we expect to have a single instance of these;
+        //this is useful to avoid triggering a call to the identity hashcode,
+        //which could be rather inefficient as there's good chances that some component
+        //will have inflated the monitor of this instance.
+        //A hash collision would be unfortunate but unexpected, and shouldn't be a problem
+        //as the equals implementation still does honour the identity contract .
+        //See also discussion on https://github.com/smallrye/smallrye-context-propagation/pull/443
+        return 1;
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runneraot/AotSerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runneraot/AotSerializedApplication.java
@@ -1,0 +1,164 @@
+package io.quarkus.bootstrap.runneraot;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Serialization and deserialization of cached resources for AOT-optimized jar packaging.
+ *
+ * This class handles the serialization of frequently-accessed resources (like service loader files)
+ * to avoid classpath scanning at runtime, while maintaining compatibility
+ * with standard Java classloaders for optimal AOT performance.
+ *
+ * The format is versioned and includes a magic number for validation.
+ */
+public class AotSerializedApplication {
+
+    private static final int MAGIC = 0xA07CA3E; // AOT CACHE
+    private static final int VERSION = 1;
+
+    private final AotRunnerClassLoader runnerClassLoader;
+    private final String mainClass;
+
+    public AotSerializedApplication(AotRunnerClassLoader runnerClassLoader, String mainClass) {
+        this.runnerClassLoader = runnerClassLoader;
+        this.mainClass = mainClass;
+    }
+
+    public String getMainClass() {
+        return mainClass;
+    }
+
+    public AotRunnerClassLoader getRunnerClassLoader() {
+        return runnerClassLoader;
+    }
+
+    /**
+     * Writes cached resources to an output stream in a binary format.
+     *
+     * Format:
+     * - Magic number (int)
+     * - Version (int)
+     * - Main class name (UTF string)
+     * - Fully indexed directory count (int)
+     * - For each fully indexed directory:
+     * . Directory path (UTF string)
+     * - Fully indexed resource count (int)
+     * - For each fully indexed resource:
+     * . Resource path (UTF string)
+     * - Service file count (int)
+     * - For each service file:
+     * . Resource path (UTF string)
+     * . Data length (int)
+     * . Data bytes
+     *
+     * @param out the output stream to write to
+     * @param mainClass the main class name
+     * @param fullyIndexedDirectories list of fully indexed directory paths
+     * @param fullyIndexedResources set of resource paths that are direct children of fully indexed directories
+     * @param serviceFiles map of service files to their content
+     * @throws IOException if an I/O error occurs
+     */
+    public static void write(OutputStream out, String mainClass, List<String> fullyIndexedDirectories,
+            Set<String> fullyIndexedResources, Map<String, byte[]> serviceFiles) throws IOException {
+        try (DataOutputStream data = new DataOutputStream(out)) {
+            data.writeInt(MAGIC);
+            data.writeInt(VERSION);
+            data.writeUTF(mainClass);
+
+            // Write tracked directories
+            data.writeInt(fullyIndexedDirectories.size());
+            for (String directory : fullyIndexedDirectories) {
+                data.writeUTF(directory);
+            }
+
+            // Write directory contents
+            data.writeInt(fullyIndexedResources.size());
+            for (String path : fullyIndexedResources) {
+                data.writeUTF(path);
+            }
+
+            // Write service files
+            data.writeInt(serviceFiles.size());
+            for (Map.Entry<String, byte[]> entry : serviceFiles.entrySet()) {
+                data.writeUTF(entry.getKey());
+                byte[] content = entry.getValue();
+                data.writeInt(content.length);
+                data.write(content);
+            }
+            data.flush();
+        }
+    }
+
+    /**
+     * Reads cached resources from an input stream.
+     *
+     * @param in the input stream to read from
+     * @return an AotSerializedApplication containing the main class and cached resources
+     * @throws IOException if an I/O error occurs or the format is invalid
+     */
+    public static AotSerializedApplication read(InputStream in) throws IOException {
+        try (DataInputStream data = new DataInputStream(in)) {
+            int magic = data.readInt();
+            if (magic != MAGIC) {
+                throw new IOException("Invalid magic number in AOT cache file: expected 0x"
+                        + Integer.toHexString(MAGIC) + " but got 0x" + Integer.toHexString(magic));
+            }
+
+            int version = data.readInt();
+            if (version != VERSION) {
+                throw new IOException("Unsupported AOT cache version: expected " + VERSION + " but got " + version);
+            }
+
+            String mainClass = data.readUTF();
+
+            // Read tracked directories
+            int fullyIndexedDirectoryCount = data.readInt();
+            Set<String> fullyIndexedDirectories = new HashSet<>((int) Math.ceil(fullyIndexedDirectoryCount / 0.75f));
+            for (int i = 0; i < fullyIndexedDirectoryCount; i++) {
+                fullyIndexedDirectories.add(data.readUTF());
+            }
+
+            // Read directory contents
+            int fullyIndexedResourceCount = data.readInt();
+            Set<String> fullyIndexedResources = new HashSet<>((int) Math.ceil(fullyIndexedResourceCount / 0.75f));
+            for (int i = 0; i < fullyIndexedResourceCount; i++) {
+                fullyIndexedResources.add(data.readUTF());
+            }
+
+            // Read cached resources
+            int serviceFileCount = data.readInt();
+            Map<String, byte[]> serviceFiles = new HashMap<>((int) Math.ceil(serviceFileCount / 0.75f));
+
+            for (int i = 0; i < serviceFileCount; i++) {
+                String resourcePath = data.readUTF();
+                int dataLength = data.readInt();
+                byte[] content = new byte[dataLength];
+
+                int totalRead = 0;
+                while (totalRead < dataLength) {
+                    int read = data.read(content, totalRead, dataLength - totalRead);
+                    if (read == -1) {
+                        throw new IOException("Unexpected end of stream while reading resource: " + resourcePath);
+                    }
+                    totalRead += read;
+                }
+
+                serviceFiles.put(resourcePath, content);
+            }
+
+            AotRunnerClassLoader runnerClassLoader = new AotRunnerClassLoader(AotSerializedApplication.class.getClassLoader(),
+                    fullyIndexedDirectories, fullyIndexedResources, serviceFiles);
+
+            return new AotSerializedApplication(runnerClassLoader, mainClass);
+        }
+    }
+}


### PR DESCRIPTION
Note: it doesn't improve the packaging infrastructure but it doesn't
make thing worse either.

The thing is that with AOT caching, loading resources and especially
service files is actually representing quite a lot of time at startup.
So this prototype implements a lean CL that have the service files
in memory and delegates the rest to the standard
classpath class loader.

It also lists the content of some selected directories to make sure
we know which files are available and which are not in these directories.