### PR TITLE
Bump smallrye-reactive-messaging.version from 4.32.0 to 4.32.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -56,7 +56,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.21.4</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.32.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.32.1</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.7</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
Fixes issue found in https://github.com/quarkiverse/quarkus-amazon-services/pull/1964