### PR TITLE
Add runtime dependencies for keycloak devservices

### DIFF
--- a/extensions/keycloak-admin-rest-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-rest-client/runtime/pom.xml
@@ -60,6 +60,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-admin-client-common</artifactId>
         </dependency>
+        <!-- Required because deployment module depends on quarkus-devservices-keycloak -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
@@ -78,6 +78,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-admin-client-common</artifactId>
         </dependency>
+        <!-- Required because deployment module depends on quarkus-devservices-keycloak -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/oidc-client-registration/runtime/pom.xml
+++ b/extensions/oidc-client-registration/runtime/pom.xml
@@ -26,6 +26,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-common</artifactId>
         </dependency>
+        <!-- Required because deployment module depends on quarkus-devservices-keycloak -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>

--- a/extensions/oidc-client/runtime/pom.xml
+++ b/extensions/oidc-client/runtime/pom.xml
@@ -29,6 +29,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-client-spi</artifactId>
         </dependency>
+        <!-- Required because deployment module depends on quarkus-devservices-keycloak -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>

--- a/extensions/oidc/runtime/pom.xml
+++ b/extensions/oidc/runtime/pom.xml
@@ -41,6 +41,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-websockets-next-spi</artifactId>
         </dependency>
+        <!-- Required because deployment module depends on quarkus-devservices-keycloak -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt</artifactId>


### PR DESCRIPTION
Incremental prerequisite for https://github.com/quarkusio/quarkus/pull/51829.

A consequence of https://github.com/quarkusio/quarkus/pull/49025 is that new-model dev services need to depend on the devservices runtime module. This is sort of awkward for the services created in `extensions/devservices/<name>`, because those projects are structured to only have a deployment module, and the deployment module doesn't have `-deployment` in the name. 

I can see a few solutions: 

1. Move everything back to `core/runtime` and decide the runtime module is just too much of a headache
2. Restructure what's in `extensions/devservices` to have proper extension structures, and either 
   1.  name the runtime modules `-runtime` to avoid massive renaming headaches
   2. swap the names round and create `quarkus-devservices-keycloak-deployment`; because the new runtime module would have the same name as the old deployment module we couldn't do a redirect, so it might cause problems for quarkiverse extensions that depend on keycloak (or the other services)
3.  Just depend on the `devservices-runtime` module in cases where we'd need the runtime module, and skip having an empty intermediary module.

Doing option 3 doesn't prevent us from doing option 2 in the future, and it saves a bunch of work and a clutter of extra empty modules, and it doesn't cause anything to be brought into the dependency tree that wouldn't end up there with option 2 anyway, so I think it's maybe the sensible choice.

Although we probably wouldn't choose to do this if we weren't converting keycloak, it's mostly harmless to do anyway. While the old model is still active, adding the runtime dependency brings one new module and one or two classes onto the runtime classpath, but nothing worse than that.

I initially put dependencies into `runtime` modules, but then I felt guilty, so I made new `runtime-dev` modules where they didn't exist.