### PR TITLE
Add missing "requires org.eclipse.lsp4j.jsonrpc.debug"

### DIFF
--- a/independent-projects/qute/debug/src/main/java/module-info.java
+++ b/independent-projects/qute/debug/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module io.quarkus.qute.debug {
 
     requires org.eclipse.lsp4j.debug;
     requires org.eclipse.lsp4j.jsonrpc;
+    requires org.eclipse.lsp4j.jsonrpc.debug;
 
     exports io.quarkus.qute.debug;
     exports io.quarkus.qute.debug.adapter;


### PR DESCRIPTION
Add missing "requires org.eclipse.lsp4j.jsonrpc.debug"

This PR avoid compilation problem that you should see on CI build.