### PR TITLE
QuarkusComponentTest: illegal bean type is unmockable

### DIFF
--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/UnmockablePrimitiveFailureTest.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/UnmockablePrimitiveFailureTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.test.component;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class UnmockablePrimitiveFailureTest {
+
+    @RegisterExtension
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .addComponentClasses(MyBean.class)
+            .buildShouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable failure = extension.getBuildFailure();
+        assertTrue(failure instanceof IllegalStateException);
+        assertTrue(failure.getMessage().startsWith(
+                "Unsatisfied injection point with required type 'int' cannot be mocked automatically: io.quarkus.test.component.UnmockablePrimitiveFailureTest$MyBean#val"));
+    }
+
+    @Singleton
+    public static class MyBean {
+
+        @Inject
+        int val;
+
+    }
+
+}

--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/UnmockableWildcardFailureTest.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/UnmockableWildcardFailureTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.test.component;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.Callable;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class UnmockableWildcardFailureTest {
+
+    @RegisterExtension
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .addComponentClasses(MyBean.class)
+            .buildShouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable failure = extension.getBuildFailure();
+        assertTrue(failure instanceof IllegalStateException);
+        assertTrue(failure.getMessage().startsWith(
+                "Unsatisfied injection point with required type 'java.util.concurrent.Callable<?>' cannot be mocked automatically: io.quarkus.test.component.UnmockableWildcardFailureTest$MyBean#instance"));
+    }
+
+    @Singleton
+    public static class MyBean {
+
+        // Callable<?> is illegal bean type
+        @Inject
+        Instance<Callable<?>> instance;
+
+    }
+
+}


### PR DESCRIPTION
- fail the build if the required type of an unsatisfied injection point is an illegal bean type and thus cannot be mocked automatically