### PR TITLE
Only create one ReflectiveClassBuildItem when possible

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -523,14 +523,20 @@ public class ConfigBuildStep {
         if (configProperty.getPropertyType().kind() == Kind.PARAMETERIZED_TYPE) {
             List<Type> argumentTypes = configProperty.getPropertyType().asParameterizedType().arguments();
             typeArgumentNames = new ArrayList<>(argumentTypes.size());
+            final List<String> forReflection = new ArrayList<>(argumentTypes.size());
+            final var reason = ConfigBuildStep.class.getSimpleName() + " Configuration property's " + typeName
+                    + " parameter";
             for (Type argumentType : argumentTypes) {
-                typeArgumentNames.add(argumentType.name().toString());
+                final var argTypeClassName = argumentType.name().toString();
+                typeArgumentNames.add(argTypeClassName);
                 if (argumentType.kind() != Kind.PRIMITIVE) {
-                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(argumentType.name().toString())
-                            .reason(ConfigBuildStep.class.getSimpleName() + " Configuration property's " + typeName
-                                    + " parameter")
-                            .build());
+                    forReflection.add(argTypeClassName);
                 }
+            }
+            if (!forReflection.isEmpty()) {
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(forReflection)
+                        .reason(reason)
+                        .build());
             }
         }
 

--- a/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
+++ b/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
@@ -46,7 +46,7 @@ public class CaffeineProcessor {
                     .reason(getClass().getName())
                     .methods().build());
 
-            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(effectiveImplementorNames.toArray(new String[0]))
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(effectiveImplementorNames)
                     .reason(getClass().getName())
                     .methods().build());
         }

--- a/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
+++ b/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
@@ -61,7 +61,7 @@ public final class HibernateEnversProcessor {
             pu.revisionListener().ifPresent(classes::add);
             pu.auditStrategy().ifPresent(classes::add);
         }
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(classes.toArray(new String[0]))
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(classes)
                 .reason("Configured Envers listeners and audit strategies")
                 .methods().fields().build());
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -560,7 +560,7 @@ public final class HibernateOrmProcessor {
             for (DotName name : ClassNames.HIBERNATE_MAPPING_ANNOTATIONS) {
                 annotationClassNames.add(name.toString());
             }
-            reflective.produce(ReflectiveClassBuildItem.builder(annotationClassNames.toArray(new String[0]))
+            reflective.produce(ReflectiveClassBuildItem.builder(annotationClassNames)
                     .reason(ClassNames.HIBERNATE_ORM_PROCESSOR.toString())
                     .methods().fields().build());
             for (String annotationClassName : annotationClassNames) {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateUserTypeProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateUserTypeProcessor.java
@@ -43,7 +43,7 @@ public final class HibernateUserTypeProcessor {
         }
 
         if (!userTypes.isEmpty()) {
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(userTypes.toArray(new String[] {}))
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(userTypes)
                     .reason(ClassNames.HIBERNATE_USER_TYPE_PROCESSOR.toString())
                     .methods().fields().build());
         }


### PR DESCRIPTION
Sample of changes that could be made to reduce the number of `ReflectiveClassBuildItem` instances that are created.