### PR TITLE
Make dev ui read Keycloak url dynamically

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -3,7 +3,6 @@ package io.quarkus.devservices.keycloak;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
-import static io.quarkus.devservices.keycloak.KeycloakDevServicesConfigBuildItem.getKeycloakUrl;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem.getDevServicesConfigurator;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.createWebClient;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.getPasswordAccessToken;
@@ -283,14 +282,13 @@ public class KeycloakDevServicesProcessor {
     void produceDevUiCardWithKeycloakUrl(Optional<KeycloakDevServicesConfigBuildItem> configProps,
             List<KeycloakAdminPageBuildItem> keycloakAdminPageBuildItems,
             BuildProducer<CardPageBuildItem> cardPageProducer) {
-        final String keycloakAdminUrl = getKeycloakUrl(configProps);
-        if (keycloakAdminUrl != null) {
+        if (configProps.isPresent()) {
             keycloakAdminPageBuildItems.forEach(i -> {
                 i.cardPage.addPage(Page
                         .externalPageBuilder("Keycloak Admin")
                         .icon("font-awesome-solid:key")
                         .doNotEmbed(true)
-                        .url(keycloakAdminUrl));
+                        .dynamicUrlJsonRPCMethodName("getKeycloakAdminConsoleUrl"));
                 cardPageProducer.produce(i.cardPage);
             });
         }

--- a/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevJsonRpcService.java
+++ b/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevJsonRpcService.java
@@ -23,6 +23,11 @@ public class OidcDevJsonRpcService {
     Vertx vertx;
 
     @NonBlocking
+    public String getAdminConsoleUrl() {
+        return props.getKeycloakAdminUrl();
+    }
+
+    @NonBlocking
     public OidcDevUiRuntimePropertiesDTO getProperties() {
         return new OidcDevUiRuntimePropertiesDTO(props.getAuthorizationUrl(), props.getTokenUrl(), props.getLogoutUrl(),
                 ConfigProvider.getConfig(), httpConfig.port(),


### PR DESCRIPTION
On the surface, this seems like a change which is both pointless (the behaviour stays the same) and silly (the behaviour is less efficient). But it's another Incremental piece of https://github.com/quarkusio/quarkus/pull/51829. Once the dev service is started post-build, the dev ui url needs to be dynamic. I've checked and this code works now, and also works with #51829 (although with #51829 the method signature of the build step and guard needs to change a bit to use the `Prepared` build item instead of the config build item, but that's minor). 

Putting the constant on the recorder is a bit arbitrary, but I put it there because in https://github.com/quarkusio/quarkus/pull/51829, there are uses of the constant in that class already. 