### PR TITLE
Avoid ServiceLoader in ValueRegistry

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -223,7 +223,7 @@ public final class ExtensionLoader {
                     }
                 };
 
-                proxies.put(ValueRegistry.class, new ValueRegistryImpl.Builder().build());
+                proxies.put(ValueRegistry.class, ValueRegistryImpl.builder().build());
                 ObjectLoader valueRegistryLoader = new ObjectLoader() {
                     @Override
                     public ResultHandle load(BytecodeCreator body, Object obj, boolean staticInit) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/RuntimeConfigSetupCompleteBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/RuntimeConfigSetupCompleteBuildItem.java
@@ -3,8 +3,12 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.EmptyBuildItem;
 
 /**
- * Marker used by Build Steps that consume runtime configuration to ensure that they run after the runtime config has been set
- * up.
+ * Marker used by Build Steps that consume runtime configuration to ensure that they run after the runtime config has
+ * been set up.
+ *
+ * @deprecated this build item has no effect. The runtime config is now always set up before build steps execute. Build
+ *             steps consuming this annotation can safely remove it.
  */
+@Deprecated(forRemoval = true, since = "3.31")
 public final class RuntimeConfigSetupCompleteBuildItem extends EmptyBuildItem {
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ValueRegistryRuntimeInfoProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ValueRegistryRuntimeInfoProviderBuildItem.java
@@ -1,0 +1,16 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.registry.RuntimeInfoProvider;
+
+public final class ValueRegistryRuntimeInfoProviderBuildItem extends MultiBuildItem {
+    private final Class<? extends RuntimeInfoProvider> runtimeInfoProvider;
+
+    public ValueRegistryRuntimeInfoProviderBuildItem(Class<? extends RuntimeInfoProvider> runtimeInfoProvider) {
+        this.runtimeInfoProvider = runtimeInfoProvider;
+    }
+
+    public Class<? extends RuntimeInfoProvider> getRuntimeInfoProvider() {
+        return runtimeInfoProvider;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -58,6 +58,7 @@ import io.quarkus.deployment.builditem.QuarkusApplicationClassBuildItem;
 import io.quarkus.deployment.builditem.RecordableConstructorBuildItem;
 import io.quarkus.deployment.builditem.StaticBytecodeRecorderBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
+import io.quarkus.deployment.builditem.ValueRegistryRuntimeInfoProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
@@ -76,6 +77,8 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TryBlock;
+import io.quarkus.registry.RuntimeInfoProvider;
+import io.quarkus.registry.RuntimeInfoProvider.RuntimeSource;
 import io.quarkus.registry.ValueRegistry;
 import io.quarkus.runtime.Application;
 import io.quarkus.runtime.ExecutionModeManager;
@@ -86,6 +89,7 @@ import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.StartupContext;
 import io.quarkus.runtime.StartupTask;
+import io.quarkus.runtime.ValueRegistryImpl.ConfigRuntimeSource;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.util.StepTiming;
@@ -124,8 +128,10 @@ public class MainClassBuildStep {
     private static final Type STRING_ARRAY = Type.create(DotName.createSimple(String[].class.getName()), Type.Kind.ARRAY);
 
     @BuildStep
-    void build(List<StaticBytecodeRecorderBuildItem> staticInitTasks,
+    void build(
+            List<StaticBytecodeRecorderBuildItem> staticInitTasks,
             List<ObjectSubstitutionBuildItem> substitutions,
+            List<ValueRegistryRuntimeInfoProviderBuildItem> runtimeInfoProviders,
             List<MainBytecodeRecorderBuildItem> mainMethod,
             List<SystemPropertyBuildItem> properties,
             List<GeneratedRuntimeSystemPropertyBuildItem> generatedRuntimeSystemProperties,
@@ -224,6 +230,15 @@ public class MainClassBuildStep {
         mv = file.getMethodCreator("doStart", void.class, String[].class);
         mv.setModifiers(Modifier.PROTECTED | Modifier.FINAL);
 
+        startupContext = mv.readStaticField(scField.getFieldDescriptor());
+
+        // Register ValueRegistry with StartupContext, so it can be injected into Recorders
+        ResultHandle valueRegistry = mv
+                .invokeVirtualMethod(ofMethod(Application.class, "getValueRegistry", ValueRegistry.class), mv.getThis());
+        MethodDescriptor putValueInStartupContext = ofMethod(StartupContext.class, "putValue", void.class, String.class,
+                Object.class);
+        mv.invokeVirtualMethod(putValueInStartupContext, startupContext, mv.load(ValueRegistry.class.getName()), valueRegistry);
+
         // Make sure we set properties in doStartup as well. This is necessary because setting them in the static-init
         // sets them at build-time, on the host JVM, while SVM has substitutions for System. get/setProperty at
         // run-time which will never see those properties unless we also set them at run-time.
@@ -265,7 +280,6 @@ public class MainClassBuildStep {
         }
 
         mv.invokeStaticMethod(ofMethod(Timing.class, "mainStarted", void.class));
-        startupContext = mv.readStaticField(scField.getFieldDescriptor());
 
         //now set the command line arguments
         mv.invokeVirtualMethod(
@@ -274,16 +288,23 @@ public class MainClassBuildStep {
 
         mv.invokeStaticMethod(CONFIGURE_STEP_TIME_ENABLED);
 
-        // Register ValueRegistry
-        MethodDescriptor getValueRegistry = ofMethod(Application.class, "getValueRegistry", ValueRegistry.class);
-        ResultHandle valueRegistry = mv.invokeVirtualMethod(getValueRegistry, mv.getThis());
-        MethodDescriptor putValueInStartupContext = ofMethod(StartupContext.class, "putValue", void.class, String.class,
-                Object.class);
-        mv.invokeVirtualMethod(putValueInStartupContext, startupContext, mv.load(ValueRegistry.class.getName()),
-                valueRegistry);
-
         tryBlock = mv.tryBlock();
         tryBlock.invokeStaticMethod(CONFIGURE_STEP_TIME_START);
+
+        // Create Runtime Config and associate it with the current classloader
+        tryBlock.invokeStaticMethod(RunTimeConfigurationGenerator.C_CREATE_RUN_TIME_CONFIG, valueRegistry);
+
+        // Register RuntimeInfoProviders with ValueRegistry
+        for (ValueRegistryRuntimeInfoProviderBuildItem runtimeInfoProviderClass : runtimeInfoProviders) {
+            ResultHandle runtimeInfoProvider = tryBlock
+                    .newInstance(ofConstructor(runtimeInfoProviderClass.getRuntimeInfoProvider()));
+            tryBlock.invokeInterfaceMethod(
+                    ofMethod(RuntimeInfoProvider.class, "register", void.class, ValueRegistry.class, RuntimeSource.class),
+                    runtimeInfoProvider,
+                    valueRegistry,
+                    tryBlock.invokeStaticMethod(ofMethod(ConfigRuntimeSource.class, "runtimeSource", RuntimeSource.class)));
+        }
+
         for (MainBytecodeRecorderBuildItem holder : mainMethod) {
             writeRecordedBytecode(holder.getBytecodeRecorder(), holder.getGeneratedStartupContextClassName(), substitutions,
                     recordableConstructorBuildItems,

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RuntimeConfigSetupBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RuntimeConfigSetupBuildStep.java
@@ -1,61 +1,18 @@
 package io.quarkus.deployment.steps;
 
-import static io.quarkus.deployment.configuration.RunTimeConfigurationGenerator.C_CREATE_RUN_TIME_CONFIG;
-import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
-
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.MainBytecodeRecorderBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
-import io.quarkus.registry.ValueRegistry;
-import io.quarkus.runtime.StartupContext;
-import io.quarkus.runtime.StartupTask;
 
+@Deprecated(forRemoval = true, since = "3.31")
 public class RuntimeConfigSetupBuildStep {
-    private static final String RUNTIME_CONFIG_STARTUP_TASK_CLASS_NAME = "io.quarkus.deployment.steps.RuntimeConfigSetup";
-
-    /**
-     * Generates a StartupTask that sets up the final runtime configuration and thus runs before any StartupTask that uses
-     * runtime configuration.
-     * If there are recorders that produce a ConfigSourceProvider, these objects are used to set up the final runtime
-     * configuration
-     */
     @BuildStep
     @Produce(RuntimeConfigSetupCompleteBuildItem.class)
     void setupRuntimeConfig(
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             BuildProducer<MainBytecodeRecorderBuildItem> mainBytecodeRecorder) {
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
-
-        try (ClassCreator clazz = ClassCreator.builder().classOutput(classOutput)
-                .className(RUNTIME_CONFIG_STARTUP_TASK_CLASS_NAME)
-                .interfaces(StartupTask.class).build()) {
-
-            try (MethodCreator method = clazz.getMethodCreator("deploy", void.class, StartupContext.class)) {
-                ResultHandle startupContext = method.getMethodParam(0);
-
-                method.invokeVirtualMethod(ofMethod(StartupContext.class, "setCurrentBuildStepName", void.class, String.class),
-                        startupContext, method.load("RuntimeConfigSetupBuildStep.setupRuntimeConfig"));
-
-                // Pass ValueRegistry to Config, so we can have a bridge and support querying runtime values directly
-                MethodDescriptor getValue = MethodDescriptor.ofMethod(StartupContext.class, "getValue", Object.class,
-                        String.class);
-                ResultHandle valueRegistry = method.invokeVirtualMethod(getValue, startupContext,
-                        method.load(ValueRegistry.class.getName()));
-
-                method.invokeStaticMethod(C_CREATE_RUN_TIME_CONFIG, valueRegistry);
-                method.returnValue(null);
-            }
-        }
-
-        mainBytecodeRecorder.produce(new MainBytecodeRecorderBuildItem(RUNTIME_CONFIG_STARTUP_TASK_CLASS_NAME));
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ValueRegistryProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ValueRegistryProcessor.java
@@ -1,13 +1,24 @@
 package io.quarkus.deployment.steps;
 
+import static io.quarkus.deployment.util.ServiceUtil.classNamesNamedIn;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.deployment.builditem.ValueRegistryRuntimeInfoProviderBuildItem;
 import io.quarkus.registry.RuntimeInfoProvider;
 
 class ValueRegistryProcessor {
     @BuildStep
-    void serviceProvider(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
-        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(RuntimeInfoProvider.class.getName()));
+    @SuppressWarnings("unchecked")
+    void discoverRuntimeInfos(BuildProducer<ValueRegistryRuntimeInfoProviderBuildItem> runtimeInfoProviders) throws Exception {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        for (String service : classNamesNamedIn(classLoader, "META-INF/services/" + RuntimeInfoProvider.class.getName())) {
+            if (QuarkusClassLoader.isClassPresentAtRuntime(service)) {
+                Class<? extends RuntimeInfoProvider> provider = (Class<? extends RuntimeInfoProvider>) classLoader
+                        .loadClass(service);
+                runtimeInfoProviders.produce(new ValueRegistryRuntimeInfoProviderBuildItem(provider));
+            }
+        }
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/Application.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Application.java
@@ -4,7 +4,6 @@ import java.io.Closeable;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.logging.Logger;
 import org.wildfly.common.lock.Locks;
@@ -14,7 +13,6 @@ import io.quarkus.dev.appstate.ApplicationStateNotification;
 import io.quarkus.registry.ValueRegistry;
 import io.quarkus.runtime.shutdown.ShutdownRecorder;
 import io.smallrye.common.constraint.Assert;
-import io.smallrye.config.SmallRyeConfig;
 
 /**
  * The application base class, which is extended and implemented by a generated class which implements the application
@@ -59,10 +57,7 @@ public abstract class Application implements Closeable {
      */
     protected Application(boolean auxiliaryApplication) {
         this.auxiliaryApplication = auxiliaryApplication;
-        this.valueRegistry = new ValueRegistryImpl.Builder()
-                .addDiscoveredInfos()
-                .withRuntimeSource(ConfigProvider.getConfig().unwrap(SmallRyeConfig.class))
-                .build();
+        this.valueRegistry = ValueRegistryImpl.builder().build();
     }
 
     /**

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -234,7 +234,7 @@ public class QuarkusDevModeTest
             ExtensionContext extensionContext) throws Throwable {
         T actualTestInstance = invocation.proceed();
         // TODO - QuarkusDevModeTest does not read the actual port from the logs. We need to implement it
-        ValueRegistry valueRegistry = new ValueRegistryImpl.Builder().build();
+        ValueRegistry valueRegistry = ValueRegistryImpl.builder().build();
         valueRegistry.register(ListeningAddress.HTTP_TEST_PORT, 8080);
         TestHTTPResourceManager.inject(actualTestInstance, valueRegistry);
         return actualTestInstance;

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -321,7 +321,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
 
             activateLogging();
             Optional<ListeningAddress> listeningAddress = startLauncher(launcher, additionalProperties);
-            ValueRegistry valueRegistry = new ValueRegistryImpl.Builder().addDiscoveredInfos()
+            ValueRegistry valueRegistry = ValueRegistryImpl.builder().addDiscoveredInfos()
                     .withRuntimeSource(new SmallRyeConfigBuilder()
                             .withSources(new MapBackedConfigSource("Test Properties", additionalProperties, MAX_VALUE) {
                             }).build())


### PR DESCRIPTION
Some cleanup following #51209 and #52005:

- `ValueRegistry` provides a way to register values with `ServiceLoader`. While this is not strictly required when running in prod mode, since values can be registered in the extension Recorder, we need it when running in integration tests so both modes behave the same.
-  This PR, removed the `ServiceLoader` discovery in prod mode by discovering the classes to run during compile time and executing them directly at application startup.
- Because of the compatibility layer between `ValueRegistry` and `Config`, I've also dropped the build step that registered the runtime config, and it is now done directly at application startup. In most cases, it was already the first step to execute, but required many steps to depend on `RuntimeConfigSetupCompleteBuildItem`. This is now deprecated, and has no effect, since runtime Config is always resolved before build steps execute. We were already doing this for static config, so I think it makes sense to do it for runtime config as well.

- Fixes: #52069