### PR TITLE
Provide ClientHeadersFactory that uses HttpServerRequest headers

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/VertxRequestClientHeadersFactoryTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/VertxRequestClientHeadersFactoryTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.rest.client.reactive;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static io.restassured.RestAssured.given;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+import io.restassured.http.Header;
+import io.smallrye.mutiny.Uni;
+
+public class VertxRequestClientHeadersFactoryTest {
+
+    private static final int port = 8922;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(SimpleRestClient.class, SimpleVertxRoute.class,
+                    VertxRequestClientHeadersFactory.class))
+            .overrideConfigKey("org.eclipse.microprofile.rest.client.propagateHeaders", "X-Flow-Instance-Id,X-Flow-Task-Ids")
+            .overrideConfigKey("quarkus.rest-client.simple.url", "http://localhost:" + port);
+
+    private static WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void configureWireMock() {
+
+        wireMockServer = new WireMockServer(port);
+        wireMockServer.start();
+        wireMockServer.stubFor(WireMock.get("/sayHello")
+                .withHeader("X-Flow-Instance-Id", equalTo("JJJJJ"))
+                .withHeader("X-Flow-Task-Ids", containing("great-value"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody(
+                                "hello")));
+    }
+
+    @AfterAll
+    public static void shutDownWireMock() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void shouldPropagate() {
+        given()
+                .header(new Header("X-Flow-Instance-Id", "JJJJJ"))
+                .header(new Header("X-Flow-Task-Ids", "great-value, another-value, some-value"))
+                .get("/use-rest-client/greeting")
+                .then()
+                .body(Matchers.containsString("hello"));
+    }
+
+    public static int getRandomFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+
+    @RegisterRestClient(configKey = "simple")
+    @RegisterClientHeaders(VertxRequestClientHeadersFactory.class)
+    interface SimpleRestClient {
+
+        @GET
+        @Path("/sayHello")
+        Uni<String> sayHello();
+    }
+
+    @RouteBase(path = "/use-rest-client")
+    public static class SimpleVertxRoute {
+
+        @Inject
+        @RestClient
+        SimpleRestClient call;
+
+        @Route(path = "/greeting", methods = Route.HttpMethod.GET)
+        public Uni<String> greeting() {
+            return call.sayHello();
+        }
+
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/VertxRequestClientHeadersFactory.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/VertxRequestClientHeadersFactory.java
@@ -1,0 +1,72 @@
+package io.quarkus.rest.client.reactive;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+
+import io.vertx.core.http.HttpServerRequest;
+
+/**
+ * A {@link ClientHeadersFactory} implementation that propagates HTTP headers from the incoming request
+ * to outgoing REST client requests.
+ * <p>
+ * This factory reads the
+ * {@code org.eclipse.microprofile.rest.client.propagateHeaders} configuration property to determine
+ * which headers should be propagated from the incoming HTTP request to the REST client calls.
+ * <p>
+ * The propagated headers are extracted from the {@link HttpServerRequest} and added to the outgoing
+ * request headers of the REST client.
+ */
+@Provider
+public class VertxRequestClientHeadersFactory implements ClientHeadersFactory {
+
+    private static final String PROPAGATE_PROPERTY = "org.eclipse.microprofile.rest.client.propagateHeaders";
+
+    private final HttpServerRequest httpServerRequest;
+
+    public VertxRequestClientHeadersFactory(HttpServerRequest httpServerRequest) {
+        this.httpServerRequest = httpServerRequest;
+    }
+
+    private static Optional<Config> config() {
+        try {
+            return Optional.ofNullable(ConfigProvider.getConfig());
+        } catch (NoClassDefFoundError | IllegalStateException | ExceptionInInitializerError var1) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> getHeadersProperty() {
+        Optional<Config> c = config();
+        return c
+                .flatMap(config -> config.getOptionalValue(PROPAGATE_PROPERTY, String.class));
+    }
+
+    @Override
+    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> ignore,
+            MultivaluedMap<String, String> clientOutgoingHeaders) {
+
+        MultivaluedMap<String, String> propagatedHeaders = new MultivaluedHashMap<>();
+        Optional<String> optionalPropagateHeaders = getHeadersProperty();
+
+        optionalPropagateHeaders.ifPresent(s -> Arrays.stream(s.split(","))
+                .forEach(header -> {
+                    String httpServerRequestHeader = httpServerRequest.getHeader(header);
+                    if (httpServerRequestHeader != null) {
+                        List<String> headers = Arrays.stream(httpServerRequestHeader.split(","))
+                                .toList();
+                        propagatedHeaders.put(header, headers);
+                    }
+                }));
+
+        return propagatedHeaders;
+    }
+}


### PR DESCRIPTION
# Changes

Provide a `ClientHeadersFactory` implementation that propagate `HttpServerRequest's` headers. 

It looks the same property as the [DefaultHeaderFactory](https://quarkus.io/guides/rest-client#default-header-factory) (`org.eclipse.microprofile.rest.client.propagateHeaders`). 

In addition, was added a documentation about this provided `ClientHeadersFactory`,


- Closes: #50120 

