### PR TITLE
Arc: support non-blocking @Startup methods

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/Startup.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Startup.java
@@ -59,6 +59,25 @@ import jakarta.enterprise.inject.spi.ObserverMethod;
  * }
  * </pre>
  *
+ * <h2>Reactive startup methods</h2>
+ *
+ * <p>
+ * You can also declare startup methods that return a <code>Uni</code>, in which case your startup method will
+ * be executed in a non-blocking thread.
+ * </p>
+ *
+ * <pre>
+ * &#064;ApplicationScoped
+ * class Bean4 {
+ *
+ *     &#064;Startup
+ *     Uni&lt;Void&gt; init() {
+ *         // place the logic here
+ *         return Uni.createFrom().voidItem();
+ *     }
+ * }
+ * </pre>
+ *
  * @see StartupEvent
  */
 @Target({ TYPE, METHOD, FIELD })

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -1519,6 +1519,12 @@ Further, if the observer declares a return type of `Uni<>`, the returned `Uni` w
 
 Therefore, it is recommended that observer methods, both synchronous and asynchronous, are always declared `void`.
 
+=== Reactive startup methods
+
+As documented in xref:lifecycle.adoc#startup_annotation[the `@Startup` method documentation], you may define startup
+methods that return a `Uni`, in which case they will be invoked on an event thread instead of a blocking thread, and
+their returned `Uni` will be subscribed to and awaited.
+
 [[build_time_apis]]
 == Build Time Extensions
 

--- a/docs/src/main/asciidoc/hibernate-panache-next.adoc
+++ b/docs/src/main/asciidoc/hibernate-panache-next.adoc
@@ -1067,25 +1067,18 @@ public class OnStart {
 }
 ----
 
-For reactive operations, it is a little more complex at the moment, because you need a regular `@Startup` method,
-from which you invoke your reactive `@WithTransaction` method from within a call to
-`VertxContextSupport.subscribeAndAwait` (don't worry, we are working on making this easier):
+For reactive operations, it is fairly similar:
 
 [source,java]
 ----
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
 import io.quarkus.runtime.Startup;
-import io.quarkus.vertx.VertxContextSupport;
 import io.smallrye.mutiny.Uni;
 
 public class OnStart {
     @Startup
-    public void start() throws Throwable {
-        VertxContextSupport.subscribeAndAwait(() -> runit());
-    }
-
     @WithTransaction
-    Uni<Void> runit(){
+    Uni<Void> startupMethod(){
         return Cat_.repo().deleteAll().replaceWithVoid();
     }
 }

--- a/docs/src/main/asciidoc/lifecycle.adoc
+++ b/docs/src/main/asciidoc/lifecycle.adoc
@@ -264,9 +264,17 @@ public class EagerAppBean {
    void init() { <1>
      doSomeCoolInit();
    }
+
+   @Startup
+   Uni<Void> initReactive() { <2>
+     return doSomeCoolReactiveInit();
+   }
 }
 ----
 <1> The bean is created and the `init()` method is invoked upon the contextual instance when the application starts.
+<2> The bean is created and the `initReactive()` method is invoked upon the contextual instance when the application
+starts, on a non-blocking thread, which requires the Quarkus Vert.x extension (there will be an error if it is not
+present).
 
 [[shutdown_annotation]]
 === Using `@Shutdown` to execute a business method of a CDI bean during application shutdown

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/startup/StartupNonBlockingAnnotationTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/startup/StartupNonBlockingAnnotationTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.arc.test.startup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.Startup;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class StartupNonBlockingAnnotationTest {
+
+    static final List<String> LOG = new CopyOnWriteArrayList<String>();
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(StartupMethods.class))
+            .assertException(x -> {
+                // Make sure we get the build-time error, not the startup one
+                Assertions.assertTrue(x instanceof IllegalStateException);
+                Assertions.assertEquals(
+                        "Failed to find any non-blocking provider for startup actions. Either import the quarkus-vertx module, or do not declare non-blocking startup actions.",
+                        x.getMessage());
+            });
+
+    @Test
+    public void testStartup() {
+        Assertions.fail("Should not start");
+    }
+
+    static class StartupMethods {
+
+        @Startup
+        Uni<Void> nonBlocking() {
+            Assertions.fail("Should not be called");
+            return Uni.createFrom().voidItem();
+        }
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NonBlockingSupport.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NonBlockingSupport.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc.runtime;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+import io.quarkus.arc.spi.NonBlockingProvider;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Utility class that allows invoking non-blocking startup methods on non-blocking threads when the Quarkus Vert.x
+ * extension is present (which provides us with support for this). This is used to avoid a circular dependency with
+ * it. This is also checked at build time so we should never have a runtime error.
+ */
+public class NonBlockingSupport {
+    private final static NonBlockingProvider PROVIDER;
+    public static final String ERROR_MSG = "Failed to find any non-blocking provider for startup actions. Either import the quarkus-vertx module, or do not declare non-blocking startup actions.";
+
+    static {
+        // If Vert.x is not present, we will complain at run-time (should not happen since we check at build time)
+        ServiceLoader<NonBlockingProvider> loader = ServiceLoader.load(NonBlockingProvider.class);
+        Optional<NonBlockingProvider> first = loader.findFirst();
+        if (first.isEmpty()) {
+            PROVIDER = null;
+        } else {
+            PROVIDER = first.get();
+        }
+    }
+
+    /**
+     * Delegates this call to the declared {@link NonBlockingProvider} implementation, hopefully Quarkus Vert.x, if
+     * it is available.
+     *
+     * @throws RuntimeException if the Quarkus Vert.x extension is not present.
+     * @see NonBlockingProvider#subscribeAndAwait(Supplier)
+     */
+    public static <T> T subscribeAndAwait(Supplier<Uni<T>> uniSupplier) throws Throwable {
+        if (PROVIDER == null) {
+            throw new RuntimeException(
+                    ERROR_MSG);
+        }
+        return PROVIDER.subscribeAndAwait(uniSupplier);
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/spi/NonBlockingProvider.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/spi/NonBlockingProvider.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.spi;
+
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * This class allows us to offload a non-blocking startup method to a non-blocking thread. This is implemented in the
+ * Quarkus Vert.x extension.
+ */
+public interface NonBlockingProvider {
+    /**
+     * Subscribes to the supplied {@link Uni} on a Vertx duplicated context; blocks the current thread and waits for the result.
+     * <p>
+     * If it's necessary, the CDI request context is activated during execution of the asynchronous code.
+     *
+     * @param uniSupplier
+     * @throws IllegalStateException If called on an event loop thread.
+     */
+    <T> T subscribeAndAwait(Supplier<Uni<T>> uniSupplier) throws Throwable;
+}

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -40,6 +40,7 @@ import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.InvokerBuilder;
 import io.quarkus.arc.processor.InvokerInfo;
 import io.quarkus.arc.processor.KotlinUtils;
+import io.quarkus.arc.spi.NonBlockingProvider;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -77,6 +78,7 @@ import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.deployment.spi.EventConsumerInvokerCustomizerBuildItem;
 import io.quarkus.vertx.runtime.EventConsumerInfo;
 import io.quarkus.vertx.runtime.VertxEventBusConsumerRecorder;
+import io.quarkus.vertx.runtime.VertxNonBlockingProvider;
 import io.quarkus.vertx.runtime.VertxProducer;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.RunOnVirtualThread;
@@ -264,6 +266,11 @@ class VertxProcessor {
                     "io.smallrye.faulttolerance.core.event.loop.EventLoop",
                     "io.smallrye.faulttolerance.vertx.VertxEventLoop"));
         }
+    }
+
+    @BuildStep
+    ServiceProviderBuildItem arcIntegration() {
+        return new ServiceProviderBuildItem(NonBlockingProvider.class.getName(), VertxNonBlockingProvider.class.getName());
     }
 
     /**

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/arc/StartupAnnotationTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/arc/StartupAnnotationTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.vertx.arc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.Dependent;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.runtime.Startup;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * This is part 2 of the same test file in the Quarkus Arc extension, because this depends on Vert.x, so we could
+ * not put it there without a cyclic dependency.
+ */
+public class StartupAnnotationTest {
+
+    static final List<String> LOG = new CopyOnWriteArrayList<String>();
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ThreadedMethods.class, DependentStartMe.class));
+
+    @Test
+    public void testStartup() {
+        assertEquals(4, LOG.size(), "Unexpected number of log messages: " + LOG);
+        int order = 0;
+        assertEquals("nonBlocking dependent, blocking allowed: false", LOG.get(order++));
+        assertEquals("blocking dependent, blocking allowed: true", LOG.get(order++));
+        assertEquals("nonBlocking, blocking allowed: false", LOG.get(order++));
+        assertEquals("blocking, blocking allowed: true", LOG.get(order++));
+    }
+
+    static class ThreadedMethods {
+        @Startup(Integer.MAX_VALUE - 30)
+        void blocking() {
+            LOG.add("blocking, blocking allowed: " + BlockingOperationControl.isBlockingAllowed());
+        }
+
+        @Startup(Integer.MAX_VALUE - 31)
+        Uni<Void> nonBlocking() {
+            LOG.add("nonBlocking, blocking allowed: " + BlockingOperationControl.isBlockingAllowed());
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    @Dependent
+    static class DependentStartMe {
+        @Startup(Integer.MAX_VALUE - 32)
+        void blocking() {
+            LOG.add("blocking dependent, blocking allowed: " + BlockingOperationControl.isBlockingAllowed());
+        }
+
+        @Startup(Integer.MAX_VALUE - 33)
+        Uni<Void> nonBlocking() {
+            LOG.add("nonBlocking dependent, blocking allowed: " + BlockingOperationControl.isBlockingAllowed());
+            return Uni.createFrom().voidItem();
+        }
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxNonBlockingProvider.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxNonBlockingProvider.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.runtime;
+
+import java.util.function.Supplier;
+
+import io.quarkus.arc.spi.NonBlockingProvider;
+import io.quarkus.vertx.VertxContextSupport;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * This is used by the Quarkus Arc extension to delegate non-blocking @Startup methods
+ * to VertxContextSupport without depending on this extension
+ */
+public class VertxNonBlockingProvider implements NonBlockingProvider {
+    @Override
+    public <T> T subscribeAndAwait(Supplier<Uni<T>> uniSupplier) throws Throwable {
+        return VertxContextSupport.subscribeAndAwait(uniSupplier);
+    }
+}

--- a/extensions/vertx/runtime/src/main/resources/META-INF/services/io.quarkus.arc.spi.NonBlockingProvider
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/services/io.quarkus.arc.spi.NonBlockingProvider
@@ -1,0 +1,1 @@
+io.quarkus.vertx.runtime.VertxNonBlockingProvider


### PR DESCRIPTION
This is delegated to Vert.x VertxContextSupport.subscribeAndAwait via a new SPI in order to avoid a circular dependency

This allows us to write:

```java
public class Startup {
    @io.quarkus.runtime.Startup
    @WithSession
    Uni<Void> runit(){
        Log.info("Startup!");
        return MyReactiveEntity_.managedReactive().deleteAll().replaceWithVoid();
    }
}
```

Instead of:

```java
public class Startup {
    @io.quarkus.runtime.Startup
    public void start() throws Throwable {
        Log.info("Startup!");

        VertxContextSupport.subscribeAndAwait(() -> runit());
    }

    @WithSession
    Uni<Void> runit(){
        return MyReactiveEntity_.managedReactive().deleteAll().replaceWithVoid();
    }
}
```

This currently requires that the method returns a `Uni` (it does not honor or read `@Blocking` or `@NonBlocking`).

It also requires that `quarkus-vertx` is imported by the user (via a new SPI to avoid a circular dependency). I currently check this at run-time, but I could check at build time, perhaps it's better? And refuse `Uni`-returning methods if it is not present?

I did not implement `@Dependent` startup method support, but it should be easy to add.

I also did not implement `@Observes StartupEvent` non-blocking methods, not sure if I should?

Any other cases I forgot, @mkouba ?

- Closes: #50175