### PR TITLE
Register `HttpServer.getLocalBaseUri` in integration tests

### DIFF
--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/HttpServerRandomPortsTest.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/HttpServerRandomPortsTest.java
@@ -24,6 +24,7 @@ class HttpServerRandomPortsTest {
         assertTrue(httpServer.getPort() > 0);
         assertTrue(httpServer.getPort() != 8080);
         assertTrue(httpServer.getPort() != 8081);
+        assertEquals(httpServer.getPort(), httpServer.getLocalBaseUri().getPort());
 
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         Optional<Integer> httpPort = config.getOptionalValue("quarkus.http.port", Integer.class);

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/HttpServerTest.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/HttpServerTest.java
@@ -12,5 +12,6 @@ class HttpServerTest {
     @Test
     void httpServer(HttpServer httpServer) {
         assertEquals(8081, httpServer.getPort());
+        assertEquals(8081, httpServer.getLocalBaseUri().getPort());
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
@@ -1,7 +1,11 @@
 package io.quarkus.test.common;
 
+import java.net.URI;
+
 import io.quarkus.registry.ValueRegistry;
 import io.quarkus.registry.ValueRegistry.RuntimeKey;
+import io.quarkus.test.common.http.TestHTTPResourceManager;
+import io.smallrye.config.SmallRyeConfig;
 
 public record ListeningAddress(Integer port, String protocol) {
 
@@ -9,9 +13,10 @@ public record ListeningAddress(Integer port, String protocol) {
         return "https".equals(protocol);
     }
 
-    public void register(ValueRegistry valueRegistry) {
+    public void register(ValueRegistry valueRegistry, SmallRyeConfig config) {
         valueRegistry.register(isSsl() ? HTTPS_PORT : HTTP_PORT, port);
         valueRegistry.register(isSsl() ? HTTPS_TEST_PORT : HTTP_TEST_PORT, port);
+        valueRegistry.register(LOCAL_BASE_URI, URI.create(TestHTTPResourceManager.testUrl(valueRegistry, config)));
     }
 
     // Compatibility with Config and io.quarkus.vertx.http.HttpServer
@@ -19,4 +24,5 @@ public record ListeningAddress(Integer port, String protocol) {
     public static final RuntimeKey<Integer> HTTP_TEST_PORT = RuntimeKey.intKey("quarkus.http.test-port");
     public static final RuntimeKey<Integer> HTTPS_PORT = RuntimeKey.intKey("quarkus.http.ssl-port");
     public static final RuntimeKey<Integer> HTTPS_TEST_PORT = RuntimeKey.intKey("quarkus.http.test-ssl-port");
+    public static final RuntimeKey<URI> LOCAL_BASE_URI = RuntimeKey.key("quarkus.http.local-base-uri");
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -328,7 +328,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                     .withRuntimeSource(config)
                     .build();
             context.getStore(LAUNCHER_SESSION, CONFIG).put(ValueRegistry.class, valueRegistry);
-            listeningAddress.ifPresent(address -> address.register(valueRegistry));
+            listeningAddress.ifPresent(address -> address.register(valueRegistry, config));
 
             Closeable resource = new IntegrationTestExtensionStateResource(launcher,
                     devServicesLaunchResult.getCuratedApplication());


### PR DESCRIPTION
This was added in https://github.com/quarkusio/quarkus/pull/51867, but it is missing the register to provide the correct value in integration tests.