### PR TITLE
Introduce ResolvedDependency.getDirectDependencies() 

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifact.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifact.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathList;
@@ -131,6 +132,11 @@ public class AppArtifact extends AppArtifactCoords implements ResolvedDependency
 
     @Override
     public Collection<ArtifactCoords> getDependencies() {
+        return List.of();
+    }
+
+    @Override
+    public Collection<Dependency> getDirectDependencies() {
         return List.of();
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppDependency.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathCollection;
@@ -137,6 +138,11 @@ public class AppDependency implements ResolvedDependency, Serializable {
 
     @Override
     public Collection<ArtifactCoords> getDependencies() {
+        return List.of();
+    }
+
+    @Override
+    public Collection<Dependency> getDirectDependencies() {
         return List.of();
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
@@ -1,5 +1,7 @@
 package io.quarkus.bootstrap.model;
 
+import static io.quarkus.bootstrap.util.BootstrapUtils.matches;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -198,6 +200,15 @@ public class ApplicationModelBuilder {
         return this;
     }
 
+    public Collection<ArtifactCoordsPattern> getExcludedArtifacts() {
+        return excludedArtifacts;
+    }
+
+    public ApplicationModelBuilder clearExcludedArtifacts() {
+        this.excludedArtifacts.clear();
+        return this;
+    }
+
     public ApplicationModelBuilder addRemovedResources(ArtifactKey key, Collection<String> resources) {
         this.excludedResources.computeIfAbsent(key, k -> new HashSet<>(resources.size())).addAll(resources);
         return this;
@@ -387,15 +398,6 @@ public class ApplicationModelBuilder {
             }
         }
         return result;
-    }
-
-    private static boolean matches(ArtifactCoords coords, ArtifactCoordsPattern[] patterns) {
-        for (int i = 0; i < patterns.length; ++i) {
-            if (patterns[i].matches(coords)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static Collection<ArtifactCoords> ensureNoMatches(Collection<ArtifactCoords> artifacts,

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
@@ -14,6 +14,8 @@ import org.jboss.logging.Logger;
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactCoordsPattern;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.GACT;
@@ -224,6 +226,7 @@ public class BootstrapUtils {
         appendFlagIfSet(sb, flags, DependencyFlags.CLASSLOADER_LESSER_PRIORITY, "classloader-lesser-priority");
         appendFlagIfSet(sb, flags, DependencyFlags.COMPILE_ONLY, "compile-only");
         appendFlagIfSet(sb, flags, DependencyFlags.VISITED, "visited");
+        appendFlagIfSet(sb, flags, DependencyFlags.MISSING_FROM_APPLICATION, "missing-from-application");
         return sb.toString();
     }
 
@@ -234,5 +237,14 @@ public class BootstrapUtils {
             }
             sb.append(flagName);
         }
+    }
+
+    public static boolean matches(ArtifactCoords coords, ArtifactCoordsPattern[] patterns) {
+        for (int i = 0; i < patterns.length; ++i) {
+            if (patterns[i].matches(coords)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
@@ -47,6 +47,13 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
         this.exclusions = List.of();
     }
 
+    public ArtifactDependency(String groupId, String artifactId, String classifier, String type, String version, int flags) {
+        super(groupId, artifactId, classifier, type, version);
+        this.scope = SCOPE_COMPILE;
+        this.flags = flags;
+        this.exclusions = List.of();
+    }
+
     public ArtifactDependency(ArtifactCoords coords, int... flags) {
         this(coords, SCOPE_COMPILE, flags);
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
@@ -22,6 +22,15 @@ public interface Dependency extends ArtifactCoords, Mappable {
         return new ArtifactDependency(groupId, artifactId, null, ArtifactCoords.TYPE_POM, version, SCOPE_IMPORT, false);
     }
 
+    static Dependency withFlags(String groupId, String artifactId, String classifier, String type, String version, int flags) {
+        return new ArtifactDependency(groupId, artifactId, classifier, type, version,
+                flags);
+    }
+
+    static Dependency jarWithFlags(String groupId, String artifactId, String version, int flags) {
+        return withFlags(groupId, artifactId, ArtifactCoords.DEFAULT_CLASSIFIER, ArtifactCoords.TYPE_JAR, version, flags);
+    }
+
     String getScope();
 
     default Collection<ArtifactKey> getExclusions() {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
@@ -1,5 +1,7 @@
 package io.quarkus.maven.dependency;
 
+import io.quarkus.bootstrap.util.BootstrapUtils;
+
 public interface DependencyFlags {
 
     /* @formatter:off */
@@ -44,5 +46,21 @@ public interface DependencyFlags {
      * this flag as an argument.
      */
     int COMPILE_ONLY                         = 0b01000000000000;
+
+    /**
+     * This flag is used for dependencies returned from {@link ResolvedDependency#getDirectDependencies()}.
+     * It indicates a dependency was configured for a given artifact but is missing among the application dependencies.
+     */
+    int MISSING_FROM_APPLICATION             = 0b10000000000000;
     /* @formatter:on */
+
+    /**
+     * Generates a comma-separated list of flag names for a given integer value.
+     *
+     * @param flags flags as an integer value
+     * @return comma-separated list of the flag names
+     */
+    static String toNames(int flags) {
+        return BootstrapUtils.toTextFlags(flags);
+    }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
@@ -20,6 +20,7 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
     private PathCollection paths;
     private final WorkspaceModule module;
     private final Collection<ArtifactCoords> deps;
+    private final Collection<Dependency> directDeps;
     private volatile transient PathTree contentTree;
 
     public ResolvedArtifactDependency(ArtifactCoords coords) {
@@ -41,6 +42,7 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
         this.paths = resolvedPath;
         this.module = null;
         this.deps = List.of();
+        this.directDeps = List.of();
     }
 
     public ResolvedArtifactDependency(ArtifactCoords coords, PathCollection resolvedPaths) {
@@ -48,6 +50,7 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
         this.paths = resolvedPaths;
         this.module = null;
         this.deps = List.of();
+        this.directDeps = List.of();
     }
 
     public ResolvedArtifactDependency(ResolvedDependencyBuilder builder) {
@@ -55,6 +58,7 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
         this.paths = builder.getResolvedPaths();
         this.module = builder.getWorkspaceModule();
         this.deps = builder.getDependencies();
+        this.directDeps = builder.getDirectDependencies();
     }
 
     @Override
@@ -79,6 +83,11 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
     @Override
     public Collection<ArtifactCoords> getDependencies() {
         return deps;
+    }
+
+    @Override
+    public Collection<Dependency> getDirectDependencies() {
+        return directDeps;
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
@@ -16,7 +16,29 @@ public interface ResolvedDependency extends Dependency {
 
     PathCollection getResolvedPaths();
 
+    /**
+     * A collection of all the resolved direct dependencies of the artifact of this dependency.
+     * <p/>
+     * Note that this method will include only direct dependencies that are found among application dependencies.
+     * This is one of the differences between this method and {@link #getDirectDependencies()}.
+     *
+     * @return all the resolved direct dependencies of the artifact of this dependency
+     */
     Collection<ArtifactCoords> getDependencies();
+
+    /**
+     * A collection of the all the configured direct dependencies of the artifact of this dependency
+     * (except test dependencies of transitive dependencies).
+     * <p/>
+     * Note that some of the configured direct dependencies might not be resolved due to scope, optionality
+     * or exclusions. The resulting collection returned from this method will still include such dependencies
+     * with {@link DependencyFlags#MISSING_FROM_APPLICATION} flag.
+     * <p/>
+     * Every dependency returned from this method will {@link DependencyFlags#DIRECT} set.
+     *
+     * @return all the direct dependencies of the artifact of this dependency
+     */
+    Collection<Dependency> getDirectDependencies();
 
     default boolean isResolved() {
         final PathCollection paths = getResolvedPaths();

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
@@ -42,6 +42,7 @@ public class ResolvedDependencyBuilder extends AbstractDependencyBuilder<Resolve
     WorkspaceModule workspaceModule;
     private volatile ArtifactCoords coords;
     private Collection<ArtifactCoords> deps = Set.of();
+    private Collection<Dependency> directDeps = Set.of();
 
     @Override
     public ResolvedDependencyBuilder fromMap(Map<String, Object> map) {
@@ -132,6 +133,16 @@ public class ResolvedDependencyBuilder extends AbstractDependencyBuilder<Resolve
     @Override
     public Collection<ArtifactCoords> getDependencies() {
         return deps;
+    }
+
+    public ResolvedDependencyBuilder setDirectDependencies(Collection<Dependency> directDeps) {
+        this.directDeps = directDeps;
+        return this;
+    }
+
+    @Override
+    public Collection<Dependency> getDirectDependencies() {
+        return directDeps;
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDevModelTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDevModelTestCase.java
@@ -11,6 +11,7 @@ import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
@@ -110,57 +111,192 @@ public class ConditionalDependenciesDevModelTestCase extends CollectDependencies
         for (var d : buildDeps) {
             switch (d.getArtifactId()) {
                 case "ext-a":
+                case "ext-d":
+                    assertThat(d.getFlags()).isEqualTo(
+                            DependencyFlags.DIRECT |
+                                    DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.RUNTIME_EXTENSION_ARTIFACT |
+                                    DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
+                    assertThat(d.getDependencies()).isEmpty();
+                    break;
                 case "ext-b":
                 case "ext-c":
-                case "ext-d":
                 case "ext-h":
+                    assertThat(d.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.RUNTIME_EXTENSION_ARTIFACT);
+                    assertThat(d.getDependencies()).isEmpty();
+                    break;
                 case "lib-e":
+                    assertThat(d.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP);
+                    assertThat(d.getDependencies()).isEmpty();
+                    break;
                 case "lib-e-build-time":
+                    assertThat(d.getFlags()).isEqualTo(DependencyFlags.DEPLOYMENT_CP);
                     assertThat(d.getDependencies()).isEmpty();
                     break;
                 case "ext-a-deployment":
-                case "ext-b-deployment":
-                case "ext-c-deployment":
                 case "ext-d-deployment":
-                case "ext-h-deployment":
+                    assertThat(d.getFlags()).isEqualTo(DependencyFlags.DEPLOYMENT_CP);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID,
                                     d.getArtifactId().substring(0, d.getArtifactId().length() - "-deployment".length()),
                                     TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID,
+                                    d.getArtifactId().substring(0, d.getArtifactId().length() - "-deployment".length()),
+                                    TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT |
+                                            DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT |
+                                            DependencyFlags.DIRECT));
+                    break;
+                case "ext-b-deployment":
+                case "ext-c-deployment":
+                case "ext-h-deployment":
+                    assertThat(d.getFlags()).isEqualTo(DependencyFlags.DEPLOYMENT_CP);
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID,
+                                    d.getArtifactId().substring(0, d.getArtifactId().length() - "-deployment".length()),
+                                    TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID,
+                                    d.getArtifactId().substring(0, d.getArtifactId().length() - "-deployment".length()),
+                                    TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT));
                     break;
                 case "ext-e":
+                    assertThat(d.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.RUNTIME_EXTENSION_ARTIFACT);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "lib-e", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "lib-e", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP));
                     break;
                 case "ext-e-deployment":
+                    assertThat(d.getFlags()).isEqualTo(DependencyFlags.DEPLOYMENT_CP);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-e", TsArtifact.DEFAULT_VERSION),
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "lib-e-build-time", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-e", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT),
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "lib-e-build-time", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.DEPLOYMENT_CP));
                     break;
                 case "ext-f":
+                    assertThat(d.getFlags()).isEqualTo(
+                            DependencyFlags.DIRECT |
+                                    DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.RUNTIME_EXTENSION_ARTIFACT |
+                                    DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-c", TsArtifact.DEFAULT_VERSION),
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-e", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-c", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT),
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-e", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT));
                     break;
                 case "ext-f-deployment":
+                    assertThat(d.getFlags()).isEqualTo(DependencyFlags.DEPLOYMENT_CP);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-f", TsArtifact.DEFAULT_VERSION),
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION),
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-e-deployment", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-f", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT |
+                                            DependencyFlags.DIRECT |
+                                            DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT),
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.DEPLOYMENT_CP),
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-e-deployment", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.DEPLOYMENT_CP));
                     break;
                 case "ext-g":
+                    assertThat(d.getFlags()).isEqualTo(
+                            DependencyFlags.DIRECT |
+                                    DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.RUNTIME_EXTENSION_ARTIFACT |
+                                    DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-b", TsArtifact.DEFAULT_VERSION),
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "dev-only-lib", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-b", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT),
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "dev-only-lib", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP));
                     break;
                 case "ext-g-deployment":
+                    assertThat(d.getFlags()).isEqualTo(DependencyFlags.DEPLOYMENT_CP);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-g", TsArtifact.DEFAULT_VERSION),
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-g", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT |
+                                            DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT |
+                                            DependencyFlags.DIRECT),
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.DEPLOYMENT_CP));
                     break;
                 case "dev-only-lib":
+                    assertThat(d.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP);
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
-                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-h", TsArtifact.DEFAULT_VERSION));
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-h", TsArtifact.DEFAULT_VERSION),
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-h-deployment", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-h", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT),
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-h-deployment", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.DEPLOYMENT_CP));
                     break;
                 default:
                     throw new RuntimeException("unexpected dependency " + d.toCompactCoords());

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DevUiStyleConditionalDevModeDependenciesTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DevUiStyleConditionalDevModeDependenciesTestCase.java
@@ -10,6 +10,7 @@ import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
@@ -48,16 +49,23 @@ public class DevUiStyleConditionalDevModeDependenciesTestCase extends CollectDep
                 case "ext-a":
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-lib-dev", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-lib-dev", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP));
                     break;
                 case "ext-a-deployment":
-                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
-                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID,
-                                    d.getArtifactId().substring(0, d.getArtifactId().length() - "-deployment".length()),
-                                    TsArtifact.DEFAULT_VERSION));
-                    break;
                 case "ext-lib-dev":
                     assertThat(d.getDependencies()).containsExactlyInAnyOrder(
                             ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-a", TsArtifact.DEFAULT_VERSION));
+                    assertThat(d.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.jarWithFlags(TsArtifact.DEFAULT_GROUP_ID, "ext-a", TsArtifact.DEFAULT_VERSION,
+                                    DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP |
+                                            DependencyFlags.RUNTIME_EXTENSION_ARTIFACT |
+                                            DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT |
+                                            DependencyFlags.DIRECT));
                     break;
                 default:
                     throw new RuntimeException("unexpected dependency " + d.toCompactCoords());

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/OnlyDirectOptionalDepsAreCollectedTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/OnlyDirectOptionalDepsAreCollectedTestCase.java
@@ -1,8 +1,17 @@
 package io.quarkus.bootstrap.resolver.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import java.util.Collection;
+
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
 
 /**
  *
@@ -30,5 +39,73 @@ public class OnlyDirectOptionalDepsAreCollectedTestCase extends CollectDependenc
         TsArtifact common2 = install(new TsArtifact("common", "2"), true);
         installAsDep(new TsArtifact("required-dep-c")
                 .addDependency(common2), true);
+    }
+
+    @Override
+    protected void assertBuildDependencies(Collection<ResolvedDependency> buildDeps) {
+
+        for (ResolvedDependency dep : buildDeps) {
+            switch (dep.getArtifactId()) {
+                case "required-dep-a":
+                case "required-dep-b":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.DIRECT);
+                    assertThat(dep.getDirectDependencies()).isEmpty();
+                    break;
+                case "required-dep-c":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.DIRECT);
+                    assertThat(dep.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.withFlags(
+                                    TsArtifact.DEFAULT_GROUP_ID, "common", ArtifactCoords.DEFAULT_CLASSIFIER, "txt", "2",
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP));
+                    break;
+                case "optional-dep":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.DIRECT |
+                                    DependencyFlags.OPTIONAL);
+                    assertThat(dep.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.withFlags(TsArtifact.DEFAULT_GROUP_ID, "other", ArtifactCoords.DEFAULT_CLASSIFIER, "txt",
+                                    "1",
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.OPTIONAL |
+                                            DependencyFlags.MISSING_FROM_APPLICATION),
+                            Dependency.withFlags(TsArtifact.DEFAULT_GROUP_ID, "common", ArtifactCoords.DEFAULT_CLASSIFIER,
+                                    "txt", "2",
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.OPTIONAL |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP),
+                            Dependency.withFlags(TsArtifact.DEFAULT_GROUP_ID, "non-optional-common",
+                                    ArtifactCoords.DEFAULT_CLASSIFIER, "txt", "1",
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP));
+                    break;
+                case "non-optional-common":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP |
+                                    DependencyFlags.OPTIONAL);
+                    assertThat(dep.getDirectDependencies()).isEmpty();
+                    break;
+                case "common":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP);
+                    assertThat(dep.getDirectDependencies()).isEmpty();
+                    break;
+                default:
+                    fail("Unexpected dependency: " + dep.toCompactCoords() + " " + DependencyFlags.toNames(dep.getFlags()));
+            }
+        }
     }
 }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ProvidedScopeDepsAreNotCollectedTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ProvidedScopeDepsAreNotCollectedTestCase.java
@@ -1,9 +1,18 @@
 package io.quarkus.bootstrap.resolver.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import java.util.Collection;
+
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyBuilder;
 import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
 
 /**
  *
@@ -35,5 +44,56 @@ public class ProvidedScopeDepsAreNotCollectedTestCase extends CollectDependencie
                                         new TsArtifact("common", "2")),
                         "provided"),
                 false);
+    }
+
+    @Override
+    protected void assertBuildDependencies(Collection<ResolvedDependency> buildDeps) {
+        for (ResolvedDependency dep : buildDeps) {
+            switch (dep.getArtifactId()) {
+                case "required-dep":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.DIRECT |
+                                    DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP);
+                    assertThat(dep.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.withFlags(TsArtifact.DEFAULT_GROUP_ID, "common", ArtifactCoords.DEFAULT_CLASSIFIER,
+                                    "txt", "1",
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP));
+                    break;
+                case "provided-dep":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.DIRECT |
+                                    DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP);
+                    assertThat(dep.getDirectDependencies()).containsExactlyInAnyOrder(
+                            Dependency.withFlags(TsArtifact.DEFAULT_GROUP_ID, "common", ArtifactCoords.DEFAULT_CLASSIFIER,
+                                    "txt", "1",
+                                    DependencyFlags.DIRECT |
+                                            DependencyFlags.RUNTIME_CP |
+                                            DependencyFlags.DEPLOYMENT_CP));
+                    break;
+                case "common":
+                    assertThat(dep.getFlags()).isEqualTo(
+                            DependencyFlags.COMPILE_ONLY |
+                                    DependencyFlags.RUNTIME_CP |
+                                    DependencyFlags.DEPLOYMENT_CP);
+                    assertThat(dep.getDirectDependencies()).containsExactlyInAnyOrder(
+                            DependencyBuilder.newInstance()
+                                    .setGroupId(TsArtifact.DEFAULT_GROUP_ID)
+                                    .setArtifactId("not-collected")
+                                    .setType("txt")
+                                    .setVersion("1")
+                                    .setScope("provided")
+                                    .setFlags(
+                                            DependencyFlags.DIRECT |
+                                                    DependencyFlags.MISSING_FROM_APPLICATION)
+                                    .build());
+                    break;
+                default:
+                    fail("Unexpected dependency " + dep.toCompactCoords());
+            }
+        }
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyMap.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyMap.java
@@ -1,0 +1,41 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+/**
+ * Container for all the dependencies the Maven resolver came across when resolving application dependencies.
+ */
+class ApplicationDependencyMap {
+    private final Map<ArtifactCoords, ArtifactDependencyMap> deps = new ConcurrentHashMap<>();
+
+    ArtifactDependencyMap getOrCreate(Dependency dep) {
+        final Artifact a = dep.getArtifact();
+        return deps.computeIfAbsent(
+                ArtifactCoords.of(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension(), a.getVersion()),
+                k -> new ArtifactDependencyMap(this, dep));
+    }
+
+    ArtifactDependencyMap getOrCreate(Artifact artifact) {
+        return deps.computeIfAbsent(
+                ArtifactCoords.of(artifact.getGroupId(), artifact.getArtifactId(), artifact.getClassifier(),
+                        artifact.getExtension(), artifact.getVersion()),
+                k -> new ArtifactDependencyMap(this, new Dependency(artifact, JavaScopes.COMPILE)));
+    }
+
+    ArtifactDependencyMap get(ResolvedDependencyBuilder builder) {
+        return get(ArtifactCoords.of(builder.getGroupId(), builder.getArtifactId(), builder.getClassifier(),
+                builder.getType(), builder.getVersion()));
+    }
+
+    ArtifactDependencyMap get(ArtifactCoords coords) {
+        return deps.get(coords);
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ArtifactDependencyMap.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ArtifactDependencyMap.java
@@ -1,0 +1,47 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.aether.graph.Dependency;
+
+import io.quarkus.bootstrap.util.DependencyUtils;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+/**
+ * A record of direct dependencies of a given application dependency.
+ */
+class ArtifactDependencyMap {
+
+    private final ApplicationDependencyMap appDeps;
+    private final Dependency dep;
+    private final Map<ArtifactKey, Dependency> deps = new ConcurrentHashMap<>();
+
+    ArtifactDependencyMap(ApplicationDependencyMap appDeps, Dependency dep) {
+        this.appDeps = Objects.requireNonNull(appDeps);
+        this.dep = Objects.requireNonNull(dep);
+    }
+
+    Dependency getDependency() {
+        return dep;
+    }
+
+    void putDependency(Dependency dep) {
+        deps.put(DependencyUtils.getKey(dep.getArtifact()), dep);
+    }
+
+    ApplicationDependencyMap getApplicationDependencies() {
+        return appDeps;
+    }
+
+    Set<ArtifactKey> getKeys() {
+        return deps.keySet();
+    }
+
+    Collection<Dependency> getDependencies() {
+        return deps.values();
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DirectDependencyCollector.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DirectDependencyCollector.java
@@ -1,0 +1,56 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import java.util.Objects;
+
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+/**
+ * Collects direct dependencies that are selected and not selected optional and provided dependencies.
+ */
+class DirectDependencyCollector implements DependencySelector {
+
+    private final DependencySelector delegate;
+    private final ArtifactDependencyMap parent;
+
+    DirectDependencyCollector(DependencySelector delegate, ArtifactDependencyMap parent) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.parent = Objects.requireNonNull(parent);
+    }
+
+    @Override
+    public boolean selectDependency(Dependency dependency) {
+        final boolean selected = delegate.selectDependency(dependency);
+        if (selected || dependency.isOptional() || JavaScopes.PROVIDED.equals(dependency.getScope())) {
+            parent.putDependency(dependency);
+        }
+        return selected;
+    }
+
+    @Override
+    public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+        final DependencySelector derivedChildSelector = delegate.deriveChildSelector(context);
+        if (derivedChildSelector.getClass() == getClass()) {
+            throw new RuntimeException(getClass().getSimpleName() + " is not expected to be derived by a delegate");
+        }
+        return new DirectDependencyCollector(derivedChildSelector,
+                parent.getApplicationDependencies().getOrCreate(context.getDependency()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        DirectDependencyCollector that = (DirectDependencyCollector) o;
+        return parent.getDependency().equals(that.parent.getDependency())
+                && delegate.equals(that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * delegate.hashCode() + parent.hashCode();
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DirectDependencyCollectorFactory.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DirectDependencyCollectorFactory.java
@@ -1,0 +1,46 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+/**
+ * Derives {@link DirectDependencyCollector}
+ */
+class DirectDependencyCollectorFactory implements DependencySelector {
+
+    private final DependencySelector delegate;
+    private final ApplicationDependencyMap appDepMap;
+
+    public DirectDependencyCollectorFactory(DependencySelector delegate, ApplicationDependencyMap appDepMap) {
+        this.delegate = delegate;
+        this.appDepMap = appDepMap;
+    }
+
+    @Override
+    public boolean selectDependency(Dependency dependency) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+        return new DirectDependencyCollector(delegate.deriveChildSelector(context),
+                appDepMap
+                        .getOrCreate(context.getDependency() == null ? new Dependency(context.getArtifact(), JavaScopes.COMPILE)
+                                : context.getDependency()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DirectDependencyCollectorFactory that = (DirectDependencyCollectorFactory) o;
+        return delegate.equals(that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * delegate.hashCode();
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.bootstrap.app.ApplicationModelSerializer;
 import io.quarkus.bootstrap.model.ApplicationModel;
-import io.quarkus.bootstrap.util.BootstrapUtils;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyFlags;
 
 public class TestFixtureMultiModuleTest extends QuarkusGradleWrapperTestBase {
 
@@ -29,7 +29,7 @@ public class TestFixtureMultiModuleTest extends QuarkusGradleWrapperTestBase {
         final Map<ArtifactKey, String> actualDepFlags = new HashMap<>();
         for (var dep : model.getDependencies()) {
             if (dep.getGroupId().equals("my-groupId")) {
-                actualDepFlags.put(dep.getKey(), BootstrapUtils.toTextFlags(dep.getFlags()));
+                actualDepFlags.put(dep.getKey(), DependencyFlags.toNames(dep.getFlags()));
             }
         }
         assertThat(actualDepFlags).containsExactlyInAnyOrderEntriesOf(Map.of(


### PR DESCRIPTION
The method exposes all configured direct dependencies a dependency that are relevant for a launch mode, except test dependencies of a transitive dependency.

FYI @dmlloyd 