### PR TITLE
Correctly enrich @ArquillianResource URL

### DIFF
--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/ArquillianResourceURLEnricher.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/ArquillianResourceURLEnricher.java
@@ -3,6 +3,7 @@ package io.quarkus.arquillian;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
@@ -66,7 +67,11 @@ public class ArquillianResourceURLEnricher implements TestEnricher {
             ArquillianResource resource = getResourceAnnotation(method.getParameterAnnotations()[i]);
             if (resource != null) {
                 if (parameterTypes[i].equals(URL.class)) {
-                    values[i] = testUrl(deployment);
+                    try {
+                        values[i] = new URL(testUrl(deployment));
+                    } catch (MalformedURLException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
                 if (parameterTypes[i].equals(URI.class)) {
                     values[i] = URI.create(testUrl(deployment));


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/51867 caused a couple of issues with the MP LRA TCK, namely the way that it uses `@ArquillianResource` to inject the current app `URL` or `URI`.

Previous to #51867, an URL or URI annotated with `@ArquillianResource` would be correctly injected with `ArquillianResourceURLEnricher`, which uses `ValueRegistry` and `Config` to determine the application address, but it didn't provide an implementation to support method parameters, so it would fallback to `InjectionEnricher`, which only injects CDI Beans, so MP LRA TCK, was using something like https://github.com/quarkusio/quarkus/pull/51867/files#diff-a5594009a3298cd5eacdafeb0402ab7ced7429f116cd7c9a612a45ec5e0c56a8L1-L20 to support injection of such parameters.

The #51867 added support for method parameter injection, but the URL was not being properly created. Apparently, this was not caught in the CI runner, probably because of the issues with https://github.com/quarkusio/quarkus/pull/51958.