### PR TITLE
Dev MCP: Make sure disabled methods can not be called

### DIFF
--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpDevUIJsonRpcService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpDevUIJsonRpcService.java
@@ -16,8 +16,10 @@ import jakarta.enterprise.inject.Produces;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
 import io.quarkus.devui.runtime.spi.McpEvent;
 import io.quarkus.devui.runtime.spi.McpServerConfiguration;
+import io.quarkus.runtime.annotations.Usage;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 
@@ -99,6 +101,21 @@ public class McpDevUIJsonRpcService {
 
     public boolean isExplicitlyDisabled(String methodName) {
         return this.mcpServerConfiguration.isExplicitlyDisabled(methodName);
+    }
+
+    public boolean isEnabled(JsonRpcMethod method, Filter filter) {
+        if (method.getUsage().contains(Usage.DEV_MCP)) {
+            if (isExplicitlyEnabled(method.getMethodName())) {
+                return filter.equals(Filter.enabled);
+            } else if (isExplicitlyDisabled(method.getMethodName())) {
+                return filter.equals(Filter.disabled);
+            } else if (filter.equals(Filter.enabled)) {
+                return method.isMcpEnabledByDefault();
+            } else if (filter.equals(Filter.disabled)) {
+                return !method.isMcpEnabledByDefault();
+            }
+        }
+        return false;
     }
 
     private Properties loadConfiguration() {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpMethodNotEnabledException.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpMethodNotEnabledException.java
@@ -1,0 +1,25 @@
+package io.quarkus.devui.runtime.mcp;
+
+public class McpMethodNotEnabledException extends Exception {
+
+    public McpMethodNotEnabledException() {
+    }
+
+    public McpMethodNotEnabledException(String message) {
+        super(message);
+    }
+
+    public McpMethodNotEnabledException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public McpMethodNotEnabledException(Throwable cause) {
+        super(cause);
+    }
+
+    public McpMethodNotEnabledException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
@@ -15,7 +15,6 @@ import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
 import io.quarkus.devui.runtime.mcp.model.tool.Tool;
 import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
-import io.quarkus.runtime.annotations.Usage;
 
 /**
  * This exposes all Dev UI Runtime and Deployment JsonRPC Methods as MCP Tools
@@ -76,25 +75,9 @@ public class McpToolsService {
     }
 
     private void addTool(List<Tool> tools, JsonRpcMethod method, Filter filter) {
-        if (isEnabled(method, filter)) {
+        if (mcpDevUIJsonRpcService.isEnabled(method, filter)) {
             tools.add(toTool(method));
         }
-    }
-
-    private boolean isEnabled(JsonRpcMethod method, Filter filter) {
-
-        if (method.getUsage().contains(Usage.DEV_MCP)) {
-            if (mcpDevUIJsonRpcService.isExplicitlyEnabled(method.getMethodName())) {
-                return filter.equals(Filter.enabled);
-            } else if (mcpDevUIJsonRpcService.isExplicitlyDisabled(method.getMethodName())) {
-                return filter.equals(Filter.disabled);
-            } else if (filter.equals(Filter.enabled)) {
-                return method.isMcpEnabledByDefault();
-            } else if (filter.equals(Filter.disabled)) {
-                return !method.isMcpEnabledByDefault();
-            }
-        }
-        return false;
     }
 
     private Tool toTool(JsonRpcMethod jsonRpcMethod) {


### PR DESCRIPTION
Addressing @maxandersen concern on security. This PR makes sure that if a dev mcp method that is disabled, it's not only removed from the tools/list but also if called manually, will fail.

