### PR TITLE
Bump Mandrel version to 25 in CI jobs

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1443,7 +1443,7 @@ jobs:
         if: startsWith(matrix.os-name, 'windows')
         with:
           version: 'mandrel-latest'
-          java-version: '21'
+          java-version: '25'
           distribution: 'mandrel'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       # We do this so we can get better analytics for the downloaded version of the build images

--- a/.github/workflows/native-it-selected-graalvm.yml
+++ b/.github/workflows/native-it-selected-graalvm.yml
@@ -21,12 +21,12 @@ on:
       NATIVE_COMPILER_VERSION:
         description: 'the native compiler version to use'
         required: true
-        default: '21'
+        default: '25'
         type: choice
         options:
           - '17'
           - '21'
-          - '22'
+          - '25'
 
 env:
   # Workaround testsuite locale issue


### PR DESCRIPTION
Make it consistent with the default builder image.