### PR TITLE
Better duplicate files warning

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
@@ -104,7 +104,7 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
             return false;
         if (!(obj instanceof ResolvableDependency other))
             return false;
-        return Objects.equals(module, other.getWorkspaceModule()) && Objects.equals(paths, other.getResolvedPaths());
+        return Objects.equals(paths, other.getResolvedPaths()) && Objects.equals(module, other.getWorkspaceModule());
     }
 
     @Override


### PR DESCRIPTION
Running `mvn test -Dtest=OpenshiftWithUberJarDeploymentConfigTest` results in the following warning

```
2026-01-20 11:07:48,264 WARN  [io.quarkus.deployment.pkg.jar.UberJarBuilder] (build-24) Dependencies with duplicate files detected. The dependencies [io.quarkus:quarkus-kubernetes-client-internal::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/target/quarkus-kubernetes-client-internal-999-SNAPSHOT.jar;] io.quarkus:quarkus-kubernetes-client-internal:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal sources: [dir=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/kubernetes-client/runtime-internal/target/test-classes], io.quarkus:quarkus-vertx::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/vertx/runtime/target/quarkus-vertx-999-SNAPSHOT.jar;] io.quarkus:quarkus-vertx:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/vertx/runtime sources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/vertx/runtime/target/test-classes], io.quarkus:quarkus-core::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/core/runtime/target/quarkus-core-999-SNAPSHOT.jar;] io.quarkus:quarkus-core:999-SNAPSHOT /home/aloubyansky/git/quarkus/core/runtime sources: [dir=/home/aloubyansky/git/quarkus/core/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/core/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/core/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/core/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/core/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/core/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/core/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/core/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/core/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/core/runtime/target/test-classes], io.quarkus:quarkus-smallrye-health::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/target/quarkus-smallrye-health-999-SNAPSHOT.jar;] io.quarkus:quarkus-smallrye-health:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime sources: [dir=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/smallrye-health/runtime/target/test-classes], io.quarkus:quarkus-tls-registry::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/target/quarkus-tls-registry-999-SNAPSHOT.jar;] io.quarkus:quarkus-tls-registry:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/tls-registry/runtime sources: [dir=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/tls-registry/runtime/target/test-classes], io.quarkus:quarkus-vertx-http::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/target/quarkus-vertx-http-999-SNAPSHOT.jar;] io.quarkus:quarkus-vertx-http:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/vertx-http/runtime sources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/vertx-http/runtime/target/test-classes], io.quarkus:quarkus-rest::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/target/quarkus-rest-999-SNAPSHOT.jar;] io.quarkus:quarkus-rest:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime sources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest/runtime/target/test-classes], io.quarkus:quarkus-rest-common::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/target/quarkus-rest-common-999-SNAPSHOT.jar;] io.quarkus:quarkus-rest-common:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime sources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/resteasy-reactive/rest-common/runtime/target/test-classes], io.quarkus:quarkus-virtual-threads::jar:999-SNAPSHOT[paths: /home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/target/quarkus-virtual-threads-999-SNAPSHOT.jar;] io.quarkus:quarkus-virtual-threads:999-SNAPSHOT /home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime sources: [dir=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/src/main/java, dest=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/target/generated-sources/annotations] resources: [dir=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/src/main/resources, dest=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/target/classes  gen-src-dir=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/target/generated-sources/annotations] tests sources: [dir=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/src/test/java, dest=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/target/test-classes] resources: [dir=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/src/test/resources, dest=/home/aloubyansky/git/quarkus/extensions/virtual-threads/runtime/target/test-classes]] contain duplicate files, e.g. META-INF/quarkus-config-doc/quarkus-config-model-version
2026-01-20 11:07:48,267 WARN  [io.quarkus.deployment.pkg.jar.UberJarBuilder] (build-24) Dependencies with duplicate files detected. The dependencies [org.jctools:jctools-core::jar:4.0.5[paths: /home/aloubyansky/.m2/repository/org/jctools/jctools-core/4.0.5/jctools-core-4.0.5.jar;], io.netty:netty-common::jar:4.1.130.Final[paths: /home/aloubyansky/.m2/repository/io/netty/netty-common/4.1.130.Final/netty-common-4.1.130.Final.jar;]] contain duplicate files, e.g. META-INF/maven/org.jctools/jctools-core/pom.xml
```

With this change it becomes
```
2026-01-20 11:34:24,657 WARN  [io.quarkus.deployment.pkg.jar.UberJarBuilder] (build-25) Dependencies:
- org.jctools:jctools-core:4.0.5
- io.netty:netty-common:4.1.130.Final
contain duplicate files:
- META-INF/maven/org.jctools/jctools-core/pom.xml
- META-INF/maven/org.jctools/jctools-core/pom.properties
2026-01-20 11:34:24,658 WARN  [io.quarkus.deployment.pkg.jar.UberJarBuilder] (build-25) Dependencies:
- io.quarkus:quarkus-rest-common:999-SNAPSHOT
- io.quarkus:quarkus-smallrye-health:999-SNAPSHOT
- io.quarkus:quarkus-rest:999-SNAPSHOT
- io.quarkus:quarkus-kubernetes-client-internal:999-SNAPSHOT
- io.quarkus:quarkus-core:999-SNAPSHOT
- io.quarkus:quarkus-virtual-threads:999-SNAPSHOT
- io.quarkus:quarkus-vertx-http:999-SNAPSHOT
- io.quarkus:quarkus-tls-registry:999-SNAPSHOT
- io.quarkus:quarkus-vertx:999-SNAPSHOT
contain duplicate files:
- META-INF/quarkus-config-doc/quarkus-config-model-version
- META-INF/quarkus-config-doc/quarkus-config-model.json
```