### PR TITLE
Include "derived status" based on statuses of extensions referenced in the guides metadata

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -521,7 +521,6 @@ triage:
         - docs/src/main/asciidoc/_includes/devtools/extension-list.adoc
         - docs/src/main/asciidoc/_includes/devtools/maven-opts.adoc
         - docs/src/main/asciidoc/_includes/duration-format-note.adoc
-        - docs/src/main/asciidoc/_includes/extension-status.adoc
         - docs/src/main/asciidoc/_includes/platform-include.adoc
         - docs/src/main/asciidoc/_includes/prerequisites.adoc
         - docs/src/main/asciidoc/datasource.adoc

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3429,6 +3429,29 @@
                             <arguments>
                                 <argument>${project.basedir}/target/asciidoc/sources</argument>
                                 <argument>${project.basedir}/target</argument>
+                                <argument>${project.basedir}/../core/deployment</argument>
+                                <argument>${project.basedir}/../extensions</argument>
+                            </arguments>
+                            <environmentVariables>
+                                <MAVEN_CMD_LINE_ARGS>${env.MAVEN_CMD_LINE_ARGS}</MAVEN_CMD_LINE_ARGS>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-extension-statuses-include</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipDocs}</skip>
+                            <!-- Don't wait for unkillable reference reaper threads -->
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                            <mainClass>io.quarkus.docs.generation.ExtensionStatusGenerator</mainClass>
+                            <arguments>
+                                <argument>${project.build.directory}/quarkus-generated-doc/extensions</argument>
+                                <argument>${project.basedir}/../core/deployment</argument>
+                                <argument>${project.basedir}/../extensions</argument>
                             </arguments>
                             <environmentVariables>
                                 <MAVEN_CMD_LINE_ARGS>${env.MAVEN_CMD_LINE_ARGS}</MAVEN_CMD_LINE_ARGS>

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -101,3 +101,4 @@
 :name-image-ubi9-open-jdk-21-short: ubi9/openjdk-21
 // .
 include::_attributes-local.adoc[]
+include::{generated-dir}/extensions/extension-statuses.adoc[opts=optional]

--- a/docs/src/main/asciidoc/_examples/acme-serve-http-requests-tutorial.adoctxt
+++ b/docs/src/main/asciidoc/_examples/acme-serve-http-requests-tutorial.adoctxt
@@ -14,8 +14,6 @@ Create an application that uses unique annotations from the experimental acme ex
 a simple HTTP endpoint and an endpoint that emits server-sent events (SSE).
 We will also use Quarkus dev mode for iterative development and testing.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-time: 30 minutes

--- a/docs/src/main/asciidoc/_templates/template-concept.adoc
+++ b/docs/src/main/asciidoc/_templates/template-concept.adoc
@@ -23,11 +23,6 @@ The document header ends at the first blank line. Do not remove the blank line b
 A short introduction that summarizes or frames the concept.
 This summary should help a reader determine whether or not this document is what they want to read.
 
-////
-TODO: If this is a concept related to an experimental or tech-preview extension, uncomment the following (otherwise delete)
-include::{includes}/extension-status.adoc[]
-////
-
 == Create additional sections
 
 - xref:../doc-concept.adoc#concept[Quarkus documentation content types: Concept guides]

--- a/docs/src/main/asciidoc/_templates/template-howto.adoc
+++ b/docs/src/main/asciidoc/_templates/template-howto.adoc
@@ -22,11 +22,6 @@ The document header ends at the first blank line. Do not remove the blank line b
 
 How-to guides are goal-oriented and should help the reader accomplish a task (where there may be forks in the path).
 
-////
-TODO: If this is a reference for an experimental or tech-preview extension, uncomment the following (otherwise delete)
-include::{includes}/extension-status.adoc[]
-////
-
 == Prerequisites
 
 ////

--- a/docs/src/main/asciidoc/_templates/template-reference.adoc
+++ b/docs/src/main/asciidoc/_templates/template-reference.adoc
@@ -23,11 +23,6 @@ The document header ends at the first blank line. Do not remove the blank line b
 A short introduction that describes the content of this reference.
 This summary should help a reader determine if this document is likely to contain the information they are looking for.
 
-////
-TODO: If this is a reference for an experimental or tech-preview extension, uncomment the following (otherwise delete)
-include::{includes}/extension-status.adoc[]
-////
-
 == Add additional sections
 
 - xref:../doc-concept.adoc#reference[Quarkus documentation content types: Reference guides]

--- a/docs/src/main/asciidoc/_templates/template-tutorial.adoc
+++ b/docs/src/main/asciidoc/_templates/template-tutorial.adoc
@@ -23,11 +23,6 @@ The document header ends at the first blank line. Do not remove the blank line b
 Describe what the learner will accomplish (examples: build, create, construct, deploy; not: “you will learn...”).
 This short summary should help a reader determine if they want to engage with the content.
 
-////
-TODO: If this is a tutorial for an experimental or tech-preview extension, uncomment the following (otherwise delete)
-include::{includes}/extension-status.adoc[]
-////
-
 == Prerequisites
 
 ////

--- a/docs/src/main/asciidoc/aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-http.adoc
@@ -27,8 +27,6 @@ Amazon has a https://docs.aws.amazon.com/apigateway/latest/developerguide/http-a
 
 Like most Quarkus extensions, the Quarkus AWS Lambda HTTP/REST extensions support Live Coding.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-time: 30 minutes

--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -17,8 +17,6 @@ In other words, this extension is a bridge from the Azure Functions HttpTrigger 
 of HTTP APIs.
 One azure function deployment can represent any number of Jakarta REST, servlet, Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] endpoints.
 
-include::{includes}/extension-status.adoc[]
-
 NOTE: Only text based media types are supported at the moment as Azure Functions HTTP Trigger for Java does not support a binary format
 
 == Prerequisites

--- a/docs/src/main/asciidoc/azure-functions.adoc
+++ b/docs/src/main/asciidoc/azure-functions.adoc
@@ -19,8 +19,6 @@ This allows you to inject any service or component initialized by Quarkus direct
 classes. You can also change the lifecycle of your function class from request scoped (the default)
 to application scoped too if you want your function class to be a singleton.
 
-include::{includes}/extension-status.adoc[]
-
 [source, java]
 ----
 import com.microsoft.azure.functions.ExecutionContext;

--- a/docs/src/main/asciidoc/cache-infinispan-reference.adoc
+++ b/docs/src/main/asciidoc/cache-infinispan-reference.adoc
@@ -14,8 +14,6 @@ include::_attributes.adoc[]
 By default, Quarkus Cache uses Caffeine as backend.
 It's possible to use Infinispan instead.
 
-include::{includes}/extension-status.adoc[]
-
 == Infinispan as cache backend
 
 When using Infinispan as the backend for Quarkus cache, each cached item will be stored in Infinispan:

--- a/docs/src/main/asciidoc/cache-redis-reference.adoc
+++ b/docs/src/main/asciidoc/cache-redis-reference.adoc
@@ -14,8 +14,6 @@ include::_attributes.adoc[]
 By default, Quarkus Cache uses Caffeine as backend.
 It's possible to use Redis instead.
 
-include::{includes}/extension-status.adoc[]
-
 == Redis as cache backend
 
 When using Redis as the backend for Quarkus cache, each cached item will be stored in Redis:

--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -47,8 +47,6 @@ This guide will show how to use the `Credentials Provider` provided in the `vaul
 then we will look at implementing a custom `Credentials Provider`, and finally we will talk about additional
 considerations regarding implementing a `Credentials Provider` in a new extension.
 
-include::{includes}/extension-status.adoc[]
-
 == Vault Credentials Provider
 
 To configure a `Vault Credentials Provider` you need to provide the following properties:

--- a/docs/src/main/asciidoc/doc-create-tutorial.adoc
+++ b/docs/src/main/asciidoc/doc-create-tutorial.adoc
@@ -78,21 +78,6 @@ We will also use Quarkus dev mode for iterative development and testing.
 The preview of your document should contain the abstract as a paragraph immediately following the header.
 --
 
-== Include extension status descriptive text
-
-As the `acme` extension is experimental, we'll include `\{includes}/extension-status.adoc` that provides extension status text.
-It uses the extension status attribute defined in the header.
-
-[source,asciidoc]
-----
-\include::{includes}/extension-status.adoc[]
-----
-
-.Document Preview
---
-The preview of your document should now include an admonition box below the abstract explaining that the plugin is experimental technology, and describing what can be expected in terms of stability or support for experimental technologies.
---
-
 == Define Prerequisites
 
 We need to tell users what resources are required for completing the tutorial.

--- a/docs/src/main/asciidoc/funqy-aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/funqy-aws-lambda-http.adoc
@@ -15,8 +15,6 @@ If you want to allow HTTP clients to invoke on your Funqy functions on AWS Lambd
 Funqy functions through HTTP deployed as one AWS Lambda.  This approach does add overhead over the
 regular Funqy AWS Lambda integration and also requires you to use AWS API Gateway.
 
-include::{includes}/extension-status.adoc[]
-
 Follow the xref:aws-lambda-http.adoc[AWS Lambda Http Guide].  It walks through using a variety of HTTP
 frameworks on AWS Lambda, including Funqy.
 

--- a/docs/src/main/asciidoc/funqy-aws-lambda.adoc
+++ b/docs/src/main/asciidoc/funqy-aws-lambda.adoc
@@ -17,8 +17,6 @@ The guide walks through quickstart code to show you how you can deploy Funqy fun
 Funqy functions can be deployed using the AWS Lambda Java Runtime, or you can build a native executable and use
 Lambda Custom Runtime if you want a smaller memory footprint and faster cold boot startup time.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-time: 30 minutes

--- a/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
@@ -20,9 +20,6 @@ is very minimalistic and you will lose REST features like linking and the abilit
 HTTP features like cache-control and conditional GETs.  You may want to consider using Quarkus's
 Jakarta REST, Spring MVC, or Vert.x Web Reactive Route xref:azure-functions-http.adoc[support] instead.  They also work with Quarkus and Azure Functions.
 
-
-include::{includes}/extension-status.adoc[]
-
 Follow the xref:azure-functions-http.adoc[Azure Functions HTTP Guide].  It walks through using a variety of HTTP
 frameworks on Azure Functions.  Including Funqy.
 

--- a/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
@@ -15,8 +15,6 @@ If you want to allow HTTP clients to invoke your Funqy functions on Google Cloud
 Funqy functions through HTTP deployed as one Google Cloud Function.  This approach does add overhead over the
 regular Funqy Google Cloud Function integration.
 
-include::{includes}/extension-status.adoc[]
-
 Follow the xref:gcp-functions-http.adoc[Google Cloud Functions Http Guide].  It walks through using a variety of HTTP
 frameworks on Google Cloud Functions, including Funqy.
 

--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -13,8 +13,6 @@ include::_attributes.adoc[]
 
 The guide walks through quickstart code to show you how you can deploy Funqy functions to Google Cloud Functions.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-time: 30 minutes

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -16,8 +16,6 @@ Undertow (Servlet), Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP], and ma
 
 One Google Cloud Functions deployment can represent any number of Jakarta REST, Servlet, Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] endpoints.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-no-graalvm:

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -14,8 +14,6 @@ include::_attributes.adoc[]
 The `quarkus-google-cloud-functions` extension allows you to use Quarkus to build your Google Cloud Functions.
 Your functions can use injection annotations from CDI or Spring and other Quarkus facilities as you need them.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-no-graalvm:

--- a/docs/src/main/asciidoc/hibernate-panache-next.adoc
+++ b/docs/src/main/asciidoc/hibernate-panache-next.adoc
@@ -15,8 +15,6 @@ include::_attributes.adoc[]
 
 Hibernate with Panache Next is the perfect solution if you want to get started using Hibernate in Quarkus.
 
-include::{includes}/extension-status.adoc[]
-
 WARNING: This extension is currently experimental, so its API may change, in particular names of
 classes or packages may change, even the module name. We are in the process of making it a public preview in order
 to obtain public feedback, so please report feedback either on link:https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Panache.2ENext/with/562916276[Zulip]

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -31,8 +31,6 @@ xref:hibernate-orm.adoc[Hibernate ORM guide]. This guide will only focus on what
 for Hibernate Reactive.
 ====
 
-include::{includes}/extension-status.adoc[]
-
 == Solution
 
 We recommend that you follow the instructions in the next sections and create the application step by step.

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -14,8 +14,6 @@ include::_attributes.adoc[]
 This guide demonstrates how your Quarkus application can use JMS messaging via the
 Apache Qpid JMS AMQP client, or alternatively the Apache ActiveMQ Artemis JMS client.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 include::{includes}/prerequisites.adoc[]

--- a/docs/src/main/asciidoc/load-shedding-reference.adoc
+++ b/docs/src/main/asciidoc/load-shedding-reference.adoc
@@ -12,8 +12,6 @@ include::_attributes.adoc[]
 :extensions: io.quarkus:quarkus-load-shedding
 :extension-status: experimental
 
-include::{includes}/extension-status.adoc[]
-
 Load shedding is the practice of detecting service overload and rejecting requests.
 By rejecting requests when overloaded, load shedding keeps the application alive.
 With priority load shedding, the application even keeps working, albeit in a degraded state: only a fraction of requests is handled, others are rejected early.

--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -13,8 +13,6 @@ include::_attributes.adoc[]
 
 This guide explains how your Quarkus application can utilize https://opentelemetry.io/[OpenTelemetry] (OTel) to provide structured, contextual, vendor-neutral and centralised logging for interactive web applications.
 
-include::{includes}/extension-status.adoc[]
-
 include::{includes}/observability-include.adoc[]
 
 [NOTE]

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -14,8 +14,6 @@ include::_attributes.adoc[]
 This guide explains how your Quarkus application can utilize https://opentelemetry.io/[OpenTelemetry] (OTel) to provide
 metrics for interactive web applications.
 
-include::{includes}/extension-status.adoc[]
-
 include::{includes}/observability-include.adoc[]
 
 [NOTE]

--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -23,8 +23,6 @@ IMPORTANT: The RabbitMQ connector supports AMQP 0-9-1, which is very different f
 AMQP 1.0 connector. You can use the AMQP 1.0 connector with RabbitMQ as described in the
 xref:amqp-reference.adoc[AMQP 1.0 connector reference], albeit with *reduced functionality*.
 
-include::{includes}/extension-status.adoc[]
-
 == RabbitMQ connector extension
 
 To use the connector, you need to add the `quarkus-messaging-rabbitmq` extension.

--- a/docs/src/main/asciidoc/rabbitmq.adoc
+++ b/docs/src/main/asciidoc/rabbitmq.adoc
@@ -12,8 +12,6 @@ include::_attributes.adoc[]
 
 This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with RabbitMQ.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-docker-compose:

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -13,8 +13,6 @@ include::_attributes.adoc[]
 
 This guide demonstrates how your Quarkus application can connect to a Redis server using the Redis Client extension.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 include::{includes}/prerequisites.adoc[]

--- a/docs/src/main/asciidoc/scripting.adoc
+++ b/docs/src/main/asciidoc/scripting.adoc
@@ -14,8 +14,6 @@ Quarkus provides integration with https://jbang.dev[jbang] which allows you to w
 
 In this guide, we will see how you can write a REST application using just a single Java file.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-time: 5 minutes

--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -11,8 +11,6 @@ include::_attributes.adoc[]
 :extensions: io.quarkus:quarkus-oidc-client-registration
 :extension-status: experimental
 
-include::{includes}/extension-status.adoc[]
-
 Typically, you have to register an OIDC client (application) manually in your OIDC provider's dashboard.
 During this process, you specify the human readable application name, allowed redirect and post logout URLs, and other properties.
 After the registration has been completed, you copy the generated client id and secret to your Quarkus OIDC application properties.

--- a/docs/src/main/asciidoc/security-webauthn.adoc
+++ b/docs/src/main/asciidoc/security-webauthn.adoc
@@ -16,8 +16,6 @@ include::_attributes.adoc[]
 This guide demonstrates how your Quarkus application can use WebAuthn authentication instead of
 passwords.
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 include::{includes}/prerequisites.adoc[]

--- a/docs/src/main/asciidoc/software-transactional-memory.adoc
+++ b/docs/src/main/asciidoc/software-transactional-memory.adoc
@@ -85,8 +85,6 @@ understand what these may be. Please refer to the https://narayana.io/docs/proje
 and the https://narayana.io//docs/project/index.html#d0e16133[STM annotations guide] for more details on
 all the annotations Narayana STM provides.
 
-include::{includes}/extension-status.adoc[]
-
 == Setting it up
 
 To use the extension include it as a dependency in your build file:

--- a/docs/src/main/asciidoc/stork-kubernetes.adoc
+++ b/docs/src/main/asciidoc/stork-kubernetes.adoc
@@ -14,8 +14,6 @@ This guide explains how to use Stork with Kubernetes for service discovery and l
 
 If you are new to Stork, please read the xref:stork.adoc[Stork Getting Started Guide].
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-docker:

--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -13,8 +13,6 @@ include::_attributes.adoc[]
 This guide is the companion from the xref:stork.adoc[Stork Getting Started Guide].
 It explains the configuration and usage of SmallRye Stork integration in Quarkus.
 
-include::{includes}/extension-status.adoc[]
-
 == Supported clients
 
 The current integration of Stork supports:

--- a/docs/src/main/asciidoc/stork.adoc
+++ b/docs/src/main/asciidoc/stork.adoc
@@ -21,8 +21,6 @@ It offers:
 * Built-in support for Consul and Kubernetes
 * Customizable client load-balancing strategies
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 :prerequisites-docker:

--- a/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
@@ -15,8 +15,6 @@ include::_attributes.adoc[]
 
 This extension provides support for both Micrometer and OpenTelemetry in Quarkus applications. It streamlines integration by incorporating both extensions along with a bridge that enables sending Micrometer metrics via OpenTelemetry.
 
-include::{includes}/extension-status.adoc[]
-
 include::{includes}/observability-include.adoc[]
 
 [NOTE]

--- a/docs/src/main/java/io/quarkus/docs/generation/ExtensionStatusGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/ExtensionStatusGenerator.java
@@ -1,0 +1,151 @@
+package io.quarkus.docs.generation;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/**
+ * Generate an asciidoc include file containing attributes representing the extension statuses.
+ */
+public class ExtensionStatusGenerator {
+
+    // Tree map to keep the generated file more predictable
+    private static Map<String, String> statuses = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("[INFO] Creating Extension statuses attributes generator: " + List.of(args));
+        ExtensionStatusGenerator generator = new ExtensionStatusGenerator()
+                .setTargetDir(Path.of(args[0]))
+                .setExtensionRoots(
+                        Arrays.stream(Arrays.copyOfRange(args, 1, args.length))
+                                .map(Path::of)
+                                .toList());
+
+        System.out.println("[INFO] Reading extension statuses");
+        generator.readStatuses();
+        System.out.println("[INFO] Writing include file with extension statuses");
+        generator.writeAsciidocFile();
+        System.out.println("[INFO] Done");
+    }
+
+    Path targetDir;
+    List<Path> extensionRoots;
+    final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+
+    public ExtensionStatusGenerator setTargetDir(Path targetDir) {
+        this.targetDir = targetDir;
+        return this;
+    }
+
+    public ExtensionStatusGenerator setExtensionRoots(List<Path> extensionRoots) {
+        this.extensionRoots = extensionRoots;
+        return this;
+    }
+
+    public void writeAsciidocFile() throws IOException {
+        Files.createDirectories(targetDir);
+        try (BufferedWriter writer = Files.newBufferedWriter(targetDir.resolve("extension-statuses.adoc"),
+                StandardOpenOption.CREATE)) {
+            for (var entry : statuses.entrySet()) {
+                // Asciidoc attribute format: ":key: value"
+                writer.write(":" + entry.getKey().replace(":", "-") + "-extension-status: " + entry.getValue());
+                writer.newLine();
+            }
+        }
+    }
+
+    public void readStatuses() throws IOException {
+        if (extensionRoots == null || extensionRoots.isEmpty()) {
+            return;
+        }
+
+        for (Path path : extensionRoots) {
+            System.out.println("[INFO] Inspecting root: " + path);
+            Files.walkFileTree(path, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    // We really want the yaml from target,
+                    //  so let's try skipping sources and .cache directories to make things a bit faster:
+                    String currentFileName = dir.getFileName().toString();
+                    if (currentFileName.startsWith(".") || currentFileName.equals("src")) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path extensionYaml, BasicFileAttributes attrs) {
+                    String currentFileName = extensionYaml.getFileName().toString();
+                    if (currentFileName.equals("quarkus-extension.yaml")) {
+                        if (Files.exists(extensionYaml)) {
+                            try (InputStream is = Files.newInputStream(extensionYaml)) {
+                                Map<String, ?> map = yaml.load(is);
+                                String artifact = Objects.toString(map.get("artifact"), null);
+                                String artifactId;
+                                String groupId;
+                                if (artifact != null) {
+                                    String[] split = artifact.split(":");
+                                    if (split.length != 3) {
+                                        System.err.println(
+                                                "Artifact value is malformed. Expected the following format: groupId:artifactId:version ["
+                                                        + extensionYaml.toAbsolutePath() + "]");
+                                    }
+                                    groupId = split[0];
+                                    artifactId = split[1];
+
+                                } else {
+                                    groupId = Objects.toString(map.get("group-id"));
+                                    artifactId = Objects.toString(map.get("artifact-id"));
+                                }
+
+                                String status = statusFromObject(((Map<String, ?>) map.get("metadata")).get("status"),
+                                        extensionYaml);
+
+                                if (status == null) {
+                                    System.err.println(
+                                            "Extension status is not defined [" + extensionYaml.toAbsolutePath() + "]");
+                                } else {
+                                    statuses.put((groupId + "-" + artifactId).replace('.', '-'), status);
+                                }
+                            } catch (IOException e) {
+                                System.err.println(e.getMessage() + "[" + extensionYaml.toAbsolutePath() + "]");
+                            }
+                        }
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+    }
+
+    private static final Set<String> availableStatuses = Set.of(
+            "experimental", "preview", "stable", "deprecated");
+
+    private static String statusFromObject(Object object, Path path) {
+        if (object != null) {
+            String value = object.toString().toLowerCase();
+            if (availableStatuses.contains(value)) {
+                return value;
+            }
+            System.err.println("Unknown status: " + value + "[" + path.toAbsolutePath() + "]");
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Hi 👋🏻 🙂 

this is a followup on 
- https://github.com/quarkusio/quarkusio.github.io/pull/2508

with the idea being that we may not necessarily have extension statuses listed in the adoc guides. this patch reads  the statuses from the built extensions and generates an include file with extension statuses. 
Then on the quarkus.io side there's an asciidoc extension that checks for an explicitly specified status in the guide, and fallsback to the extension statuses (from the include file) to "automatically" insert a status label + explanation text, so with that there's no need to include the `extension-status.adoc` explicitly. 

"derived" status is also included in the yaml, so that search.quarkus.io could include that info in the index and use in search results. 

The way it would look:

<img width="1048" height="543" alt="image" src="https://github.com/user-attachments/assets/293998c9-c701-49d0-8b9f-132b78bffca5" />
<img width="1048" height="543" alt="image" src="https://github.com/user-attachments/assets/44983b80-5cce-4070-8a73-1e1a7aa35bd5" />

The website side of the change: 
- https://github.com/quarkusio/quarkusio.github.io/pull/2519
<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

