### PR TITLE
Reduce number of created ReflectiveClassBuildItem instances

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -70,13 +70,12 @@ public final class HibernateReactiveProcessor {
 
     private static final String HIBERNATE_REACTIVE = "Hibernate Reactive";
     private static final Logger LOG = Logger.getLogger(HibernateReactiveProcessor.class);
-    static final String[] REFLECTIVE_CONSTRUCTORS_NEEDED = {
+    static final List<String> REFLECTIVE_CONSTRUCTORS_NEEDED = List.of(
             "org.hibernate.reactive.persister.entity.impl.ReactiveSingleTableEntityPersister",
             "org.hibernate.reactive.persister.entity.impl.ReactiveJoinedSubclassEntityPersister",
             "org.hibernate.reactive.persister.entity.impl.ReactiveUnionSubclassEntityPersister",
             "org.hibernate.reactive.persister.collection.impl.ReactiveOneToManyPersister",
-            "org.hibernate.reactive.persister.collection.impl.ReactiveBasicCollectionPersister",
-    };
+            "org.hibernate.reactive.persister.collection.impl.ReactiveBasicCollectionPersister");
 
     @BuildStep
     void registerServicesForReflection(BuildProducer<ServiceProviderBuildItem> services) {

--- a/extensions/hibernate-search-backend-elasticsearch-common/deployment/src/main/java/io/quarkus/hibernate/search/backend/elasticsearch/common/deployment/HibernateSearchBackendElasticsearchProcessor.java
+++ b/extensions/hibernate-search-backend-elasticsearch-common/deployment/src/main/java/io/quarkus/hibernate/search/backend/elasticsearch/common/deployment/HibernateSearchBackendElasticsearchProcessor.java
@@ -44,8 +44,7 @@ class HibernateSearchBackendElasticsearchProcessor {
         if (enabled.isEmpty()) {
             return;
         }
-        String[] reflectiveClasses = GsonClasses.typesRequiringReflection().toArray(String[]::new);
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(reflectiveClasses)
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(GsonClasses.typesRequiringReflection())
                 .reason(getClass().getName())
                 .methods().fields().build());
     }

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -33,7 +33,7 @@ class HibernateSearchOutboxPollingProcessor {
             BuildProducer<AdditionalJpaModelBuildItem> additionalJpaModel) {
         String[] avroTypes = HibernateOrmMapperOutboxPollingClasses.avroTypes().toArray(String[]::new);
         additionalIndexedClasses.produce(new AdditionalIndexedClassesBuildItem(avroTypes));
-        String[] hibernateOrmTypes = HibernateOrmMapperOutboxPollingClasses.hibernateOrmTypes().toArray(String[]::new);
+        Set<String> hibernateOrmTypes = HibernateOrmMapperOutboxPollingClasses.hibernateOrmTypes();
         reflectiveClasses.produce(ReflectiveClassBuildItem.builder(hibernateOrmTypes)
                 .reason(getClass().getName())
                 .methods().fields().build());

--- a/extensions/panache/hibernate-reactive-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/kotlin/deployment/HibernateReactivePanacheKotlinProcessor.java
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/kotlin/deployment/HibernateReactivePanacheKotlinProcessor.java
@@ -84,36 +84,36 @@ public class HibernateReactivePanacheKotlinProcessor {
             Optional<JpaModelPersistenceUnitMappingBuildItem> jpaModelPersistenceUnitMapping) {
 
         List<PanacheMethodCustomizer> methodCustomizers = methodCustomizersBuildItems.stream()
-                .map(bi -> bi.getMethodCustomizer()).collect(Collectors.toList());
+                .map(PanacheMethodCustomizerBuildItem::getMethodCustomizer).collect(Collectors.toList());
 
-        processRepositories(index, transformers, reflectiveClass,
+        List<String> forReflection = new ArrayList<>(100); // to avoid too many repeated array growths
+        processRepositories(index, transformers, forReflection,
                 new KotlinPanacheRepositoryEnhancer(index.getComputingIndex(), methodCustomizers, TYPE_BUNDLE));
-
-        processEntities(index, transformers, reflectiveClass,
+        processEntities(index, transformers, forReflection,
                 new KotlinPanacheEntityEnhancer(index.getComputingIndex(), methodCustomizers, TYPE_BUNDLE), recorder,
                 jpaModelPersistenceUnitMapping);
-
-        processCompanions(index, transformers, reflectiveClass,
+        processCompanions(index, transformers, forReflection,
                 new KotlinPanacheCompanionEnhancer(index.getComputingIndex(), methodCustomizers, TYPE_BUNDLE));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(forReflection).methods().fields().build());
     }
 
     private void processEntities(CombinedIndexBuildItem index, BuildProducer<BytecodeTransformerBuildItem> transformers,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClass, PanacheEntityEnhancer entityEnhancer,
+            List<String> classNamesToRegisterForReflection, PanacheEntityEnhancer entityEnhancer,
             PanacheKotlinReactiveRecorder recorder,
             Optional<JpaModelPersistenceUnitMappingBuildItem> jpaModelPersistenceUnitMapping) {
 
         Set<String> modelClasses = new HashSet<>();
         // Note that we do this in two passes because for some reason Jandex does not give us subtypes
-        for (ClassInfo classInfo : index.getComputingIndex().getAllKnownImplementors(TYPE_BUNDLE.entityBase().dotName())) {
+        for (ClassInfo classInfo : index.getComputingIndex().getAllKnownImplementations(TYPE_BUNDLE.entityBase().dotName())) {
             if (classInfo.name().equals(TYPE_BUNDLE.entity().dotName())) {
                 continue;
             }
             String name = classInfo.name().toString();
             if (modelClasses.add(name)) {
                 transformers.produce(new BytecodeTransformerBuildItem(name, entityEnhancer));
-                reflectiveClass.produce(ReflectiveClassBuildItem.builder(name).methods().fields().build());
             }
         }
+        classNamesToRegisterForReflection.addAll(modelClasses);
 
         Map<String, Set<String>> collectedEntityToPersistenceUnits;
         boolean incomplete;
@@ -144,12 +144,12 @@ public class HibernateReactivePanacheKotlinProcessor {
     }
 
     private void processCompanions(CombinedIndexBuildItem index, BuildProducer<BytecodeTransformerBuildItem> transformers,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            List<String> classNamesToRegisterForReflection,
             KotlinPanacheCompanionEnhancer enhancer) {
 
         Set<org.jboss.jandex.Type> typeParameters = new HashSet<>();
         for (ClassInfo classInfo : index.getComputingIndex()
-                .getAllKnownImplementors(TYPE_BUNDLE.entityCompanionBase().dotName())) {
+                .getAllKnownImplementations(TYPE_BUNDLE.entityCompanionBase().dotName())) {
             if (classInfo.name().equals(TYPE_BUNDLE.entityCompanion().dotName())) {
                 continue;
             }
@@ -160,17 +160,17 @@ public class HibernateReactivePanacheKotlinProcessor {
         }
 
         for (org.jboss.jandex.Type parameterType : typeParameters) {
-            // Register for reflection the type parameters of the repository: this should be the entity class and the ID class
-            reflectiveClass
-                    .produce(ReflectiveClassBuildItem.builder(parameterType.name().toString()).methods().fields().build());
+            // Register for reflection the type parameters of the companion: this should be the entity class and the ID class
+            classNamesToRegisterForReflection.add(parameterType.name().toString());
         }
     }
 
     private void processRepositories(CombinedIndexBuildItem index, BuildProducer<BytecodeTransformerBuildItem> transformers,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClass, PanacheRepositoryEnhancer enhancer) {
+            List<String> classNamesToRegisterForReflection, PanacheRepositoryEnhancer enhancer) {
 
         Set<org.jboss.jandex.Type> typeParameters = new HashSet<>();
-        for (ClassInfo classInfo : index.getComputingIndex().getAllKnownImplementors(TYPE_BUNDLE.repositoryBase().dotName())) {
+        for (ClassInfo classInfo : index.getComputingIndex()
+                .getAllKnownImplementations(TYPE_BUNDLE.repositoryBase().dotName())) {
             if (classInfo.name().equals(TYPE_BUNDLE.repository().dotName()) || enhancer.skipRepository(classInfo)) {
                 continue;
             }
@@ -179,10 +179,10 @@ public class HibernateReactivePanacheKotlinProcessor {
                     .addAll(resolveTypeParameters(classInfo.name(), TYPE_BUNDLE.repositoryBase().dotName(),
                             index.getComputingIndex()));
         }
+
         for (org.jboss.jandex.Type parameterType : typeParameters) {
             // Register for reflection the type parameters of the repository: this should be the entity class and the ID class
-            reflectiveClass
-                    .produce(ReflectiveClassBuildItem.builder(parameterType.name().toString()).methods().fields().build());
+            classNamesToRegisterForReflection.add(parameterType.name().toString());
         }
     }
 


### PR DESCRIPTION
- Use builder instead of deprecated constructors
- Use getAllKnownImplementations instead of deprecated getAllKnownImplementors
- Depends on #52059
