### PR TITLE
WebSockets Next Security: use identity stored on connection for @TestSecurity and fallback to deferred identity for lazy authentication in all situations

### DIFF
--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
@@ -83,6 +83,7 @@ import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
+import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -92,6 +93,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
@@ -914,6 +916,16 @@ public class WebSocketProcessor {
             BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer) {
         if (capabilities.isPresent(Capability.SECURITY)) {
             additionalBeanProducer.produce(AdditionalBeanBuildItem.unremovableOf(WebSocketSecurityIdentityAssociation.class));
+        }
+    }
+
+    @BuildStep(onlyIf = IsTest.class)
+    void delegateToWebSocketSecurityIdentityAssociationFromTestSecurity(Capabilities capabilities,
+            BuildProducer<SystemPropertyBuildItem> systemPropertyProducer) {
+        if (capabilities.isPresent(Capability.SECURITY)) {
+            systemPropertyProducer
+                    .produce(new SystemPropertyBuildItem("test.quarkus.test-security.delegate-identity-association",
+                            WebSocketSecurityIdentityAssociation.class.getName()));
         }
     }
 

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
@@ -210,6 +210,9 @@ public class WebSocketServerRecorder {
             if (ctx.user() instanceof QuarkusHttpUser user) {
                 return connection -> new SecuritySupport(user.getSecurityIdentity(), connection, ctx);
             }
+            if (ctx.get(QuarkusHttpUser.DEFERRED_IDENTITY_KEY) != null) {
+                return connection -> new SecuritySupport(null, connection, ctx);
+            }
         }
         return ignored -> SecuritySupport.NOOP;
     }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/TestSecurityWebSocketsNextTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/TestSecurityWebSocketsNextTest.java
@@ -1,0 +1,259 @@
+package io.quarkus.it.keycloak;
+
+import static io.quarkus.it.keycloak.AnnotationBasedTenantTest.getTokenWithRole;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.Tenant;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.PermissionChecker;
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.UpgradeRejectedException;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+@QuarkusTest
+public class TestSecurityWebSocketsNextTest {
+
+    @TestHTTPResource("/ws/echo/authenticated-http-upgrade")
+    URI authenticatedHttpUpgradeUri;
+
+    @TestHTTPResource("/ws/echo/payload-authorization")
+    URI payloadAuthorizationUri;
+
+    @TestHTTPResource("/ws/echo/security-identity-injection")
+    URI securityIdentityInjectionUri;
+
+    @TestHTTPResource("/ws/echo/authorized-security-identity-injection")
+    URI authorizedSecurityIdentityInjectionUri;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    @TestSecurity(user = "Martin")
+    public void testHttpUpgradeAuthenticated() throws ExecutionException, InterruptedException, TimeoutException {
+        callWebSocketEndpoint(false, authenticatedHttpUpgradeUri);
+    }
+
+    @Test
+    public void testHttpUpgradeAuthenticated_failure() {
+        RuntimeException actualFailure = assertThrows(RuntimeException.class,
+                () -> callWebSocketEndpoint(true, authenticatedHttpUpgradeUri));
+        assertInstanceOf(UpgradeRejectedException.class, actualFailure.getCause());
+    }
+
+    @Test
+    @TestSecurity(user = "Martin")
+    public void testPayloadAuthorization() throws ExecutionException, InterruptedException, TimeoutException {
+        callWebSocketEndpoint(false, payloadAuthorizationUri);
+    }
+
+    @Test
+    @TestSecurity(user = "Martin")
+    public void testPayloadAuthorization_failure() throws ExecutionException, InterruptedException, TimeoutException {
+        callWebSocketEndpoint(false, payloadAuthorizationUri, "access denied");
+    }
+
+    @Test
+    @TestSecurity(user = "Martin")
+    public void testSecurityIdentityInjection() throws ExecutionException, InterruptedException, TimeoutException {
+        callWebSocketEndpoint(null, false, securityIdentityInjectionUri, "Martin", "Hey");
+    }
+
+    @Test
+    @TestSecurity(user = "Martin", authMechanism = "Bearer")
+    public void testInjectionPoint_bearerTokenMechanism() throws ExecutionException, InterruptedException, TimeoutException {
+        String aliceToken = getTokenWithRole("admin");
+        callWebSocketEndpoint(aliceToken, false, securityIdentityInjectionUri, "alice", "Hey");
+    }
+
+    @Test
+    @TestSecurity(user = "Martin", authMechanism = "Bearer")
+    public void testSecuredInjectionPoint_bearerTokenMechanism()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        // the endpoint is unreachable with 'Martin', because he does not have the 'admin' role
+        // hence we know that the token overrides the @TestSecurity
+        String aliceToken = getTokenWithRole("admin");
+        callWebSocketEndpoint(aliceToken, false, authorizedSecurityIdentityInjectionUri, "alice", "Hey");
+    }
+
+    private void callWebSocketEndpoint(boolean expectFailure, URI endpointURI, String message)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        callWebSocketEndpoint(null, expectFailure, endpointURI, null, message);
+    }
+
+    private void callWebSocketEndpoint(boolean expectFailure, URI endpointURI)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        callWebSocketEndpoint(expectFailure, endpointURI, "hello");
+    }
+
+    private void callWebSocketEndpoint(String token, boolean expectFailure, URI endpointURI, String expectedPrincipal,
+            String expectedMessage) throws InterruptedException, ExecutionException, TimeoutException {
+        CountDownLatch connectedLatch = new CountDownLatch(1);
+        CountDownLatch messagesLatch = new CountDownLatch(2);
+        List<String> messages = new CopyOnWriteArrayList<>();
+        AtomicReference<io.vertx.core.http.WebSocket> ws1 = new AtomicReference<>();
+        WebSocketClient client = vertx.createWebSocketClient();
+        WebSocketConnectOptions options = new WebSocketConnectOptions();
+        options.setHost(endpointURI.getHost());
+        options.setPort(endpointURI.getPort());
+        options.setURI(endpointURI.getPath());
+        if (token != null) {
+            options.addHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + token);
+        }
+        CountDownLatch throwableLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> throwable = new AtomicReference<>();
+        try {
+            var connection = client.connect(options);
+            connection
+                    .onComplete(r -> {
+                        if (r.succeeded()) {
+                            io.vertx.core.http.WebSocket ws = r.result();
+                            ws.textMessageHandler(msg -> {
+                                messages.add(msg);
+                                messagesLatch.countDown();
+                            });
+                            // We will use this socket to write a message later on
+                            ws1.set(ws);
+                            connectedLatch.countDown();
+                        } else {
+                            throwable.set(r.cause());
+                            throwableLatch.countDown();
+                        }
+                    });
+            if (expectFailure) {
+                throwableLatch.await(5, TimeUnit.SECONDS);
+                var cause = throwable.get();
+                if (cause != null) {
+                    throw new RuntimeException(throwable.get());
+                } else {
+                    Assertions.fail("Expected HTTP upgrade failure");
+                }
+            } else {
+                Assertions.assertTrue(connectedLatch.await(5, TimeUnit.SECONDS));
+                ws1.get().writeTextMessage(expectedMessage);
+                Assertions.assertTrue(messagesLatch.await(5, TimeUnit.SECONDS), "Messages: " + messages);
+                Assertions.assertEquals(2, messages.size(), "Messages: " + messages);
+                Assertions.assertEquals("ready", messages.get(0));
+                if (expectedPrincipal != null) {
+                    Assertions.assertEquals("message: " + expectedMessage + " " + expectedPrincipal, messages.get(1));
+                } else {
+                    Assertions.assertEquals("message: " + expectedMessage, messages.get(1));
+                }
+                ws1.get().close();
+            }
+        } finally {
+            if (ws1.get() != null && !ws1.get().isClosed()) {
+                ws1.get().close();
+            }
+            client.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Authenticated
+    @WebSocket(path = "/ws/echo/authenticated-http-upgrade")
+    public static class AuthenticatedHttpUpgradeEndpoint {
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @OnTextMessage
+        String echo(String message) {
+            return "message: " + message;
+        }
+
+    }
+
+    @WebSocket(path = "/ws/echo/payload-authorization")
+    public static class PayloadAuthorizationEndpoint {
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @PermissionsAllowed("canReadMessage")
+        @OnTextMessage
+        String echo(String message) {
+            return "message: " + message;
+        }
+
+        @PermissionChecker("canReadMessage")
+        boolean canReadMessage(String message) {
+            return "hello".equals(message);
+        }
+
+        @OnError
+        String onError(ForbiddenException forbiddenException) {
+            return "message: access denied";
+        }
+    }
+
+    @Tenant("tenant-public-key")
+    @WebSocket(path = "/ws/echo/security-identity-injection")
+    public static class SecurityIdentityInjectionEndpoint {
+
+        @Inject
+        SecurityIdentity securityIdentity;
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @OnTextMessage
+        String echo(String message) {
+            return "message: " + message + " " + securityIdentity.getPrincipal().getName();
+        }
+
+    }
+
+    @RolesAllowed("admin")
+    @Tenant("tenant-public-key")
+    @WebSocket(path = "/ws/echo/authorized-security-identity-injection")
+    public static class AuthorizedSecurityIdentityInjectionEndpoint {
+
+        @Inject
+        SecurityIdentity securityIdentity;
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @OnTextMessage
+        String echo(String message) {
+            return "message: " + message + " " + securityIdentity.getPrincipal().getName();
+        }
+
+    }
+}

--- a/test-framework/security/src/main/java/io/quarkus/test/security/TestIdentityAssociation.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/TestIdentityAssociation.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptor;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.IdentityProviderManager;
@@ -20,13 +21,11 @@ import io.smallrye.mutiny.Uni;
 @ApplicationScoped
 public class TestIdentityAssociation implements CurrentIdentityAssociation {
 
-    @PostConstruct
-    public void check() {
-        if (LaunchMode.current() != LaunchMode.TEST) {
-            //paranoid check
-            throw new RuntimeException("TestAuthController can only be used in tests");
-        }
-    }
+    /**
+     * {@link CurrentIdentityAssociation} delegate class name, if some extension needs to declare their own delegate.
+     * The main motivation is the WebSockets Next extension.
+     */
+    private static final String DELEGATE_IDENTITY_ASSOCIATION_KEY = "test.quarkus.test-security.delegate-identity-association";
 
     private volatile SecurityIdentity testIdentity;
 
@@ -39,8 +38,19 @@ public class TestIdentityAssociation implements CurrentIdentityAssociation {
      * A request scoped delegate that allows the system to function as normal when
      * the user has not been explicitly overridden
      */
-    @Inject
-    DelegateSecurityIdentityAssociation delegate;
+    private final CurrentIdentityAssociation delegate;
+
+    TestIdentityAssociation(DelegateSecurityIdentityAssociation defaultDelegate) {
+        this.delegate = determineDelegate(defaultDelegate);
+    }
+
+    @PostConstruct
+    public void check() {
+        if (LaunchMode.current() != LaunchMode.TEST) {
+            //paranoid check
+            throw new RuntimeException("TestAuthController can only be used in tests");
+        }
+    }
 
     public SecurityIdentity getTestIdentity() {
         return testIdentity;
@@ -82,11 +92,32 @@ public class TestIdentityAssociation implements CurrentIdentityAssociation {
                 return testIdentity;
             }
         }
-        return delegate.getIdentity();
+        return underlying;
     }
 
     void setPathBasedIdentity(boolean pathBasedIdentity) {
         isPathBasedIdentity = pathBasedIdentity;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CurrentIdentityAssociation determineDelegate(DelegateSecurityIdentityAssociation defaultDelegate) {
+        String delegateIdentityAssociationClassName = System.getProperty(DELEGATE_IDENTITY_ASSOCIATION_KEY);
+        if (delegateIdentityAssociationClassName != null) {
+            final Class<? extends CurrentIdentityAssociation> delegateClass;
+            try {
+                delegateClass = (Class<? extends CurrentIdentityAssociation>) Thread.currentThread().getContextClassLoader()
+                        .loadClass(delegateIdentityAssociationClassName);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Failed to load " + delegateIdentityAssociationClassName, e);
+            }
+
+            CurrentIdentityAssociation delegate = Arc.requireContainer().select(delegateClass).orNull();
+            if (delegate == null) {
+                throw new IllegalStateException("CDI bean " + delegateIdentityAssociationClassName + "is not available");
+            }
+            return delegate;
+        }
+        return defaultDelegate;
     }
 }
 

--- a/test-framework/security/src/test/java/io/quarkus/test/security/TestIdentityAssociationTest.java
+++ b/test-framework/security/src/test/java/io/quarkus/test/security/TestIdentityAssociationTest.java
@@ -18,8 +18,7 @@ public class TestIdentityAssociationTest {
 
     @BeforeEach
     void init() {
-        sut = new TestIdentityAssociation();
-        sut.delegate = new DelegateSecurityIdentityAssociation();
+        sut = new TestIdentityAssociation(new DelegateSecurityIdentityAssociation());
 
         BlockingOperationControl.setIoThreadDetector(new IOThreadDetector[0]);
     }


### PR DESCRIPTION
* Closes https://github.com/quarkusio/quarkus/issues/52094
* Before this PR:
  * With `@TestSecurity` we ignored the `SecurityIdentity` stored on the connection and served anonymous identity in some situations (it is not as easy to reproduce as you may think, I'd say main scenarios worked)
    * it was probably caused by https://github.com/quarkusio/quarkus/pull/48845 (Quarkus 3.29) and only Quarkus Test Security (in test mode) was affected; tested by `TestSecurityWebSocketsNextTest#testInjectionPoint_bearerTokenMechanism`
  * We only used the `SecurityIdentity` that was ready on HTTP upgrade and the deferred identity wasn't used as a source when proactive authentication was disabled
    * I think to certain extent, this was also true before 3.29, but the issues is hard to separate as it also affects reported issue with the `@TestSecurity` as well; tested by `TestSecurityWebSocketsNextTest#testSecuredInjectionPoint_bearerTokenMechanism`
* Basic test coverage is added in this PR for combination of `@TestSecurity` and the WebSockets Next, which showed me:
  * There were some (not all) scenarios where `@PermissionChecker` didn't work with `@TestSecurity`, namely when path-based authentication wasn't and when user did not use access token explicitly, so this PR makes sure the proper augmentor is applied in the test; see `TestSecurityWebSocketsNextTest#testPayloadAuthorization`