### PR TITLE
Log `InterruptedException` as `debug` for `RemoteSyncHandler`

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
@@ -68,7 +68,7 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
             try {
                 RemoteSyncHandler.class.wait(30000);
             } catch (InterruptedException e) {
-                log.error("interrupted", e);
+                log.debug("interrupted", e);
             }
         }
     }
@@ -139,7 +139,11 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                             }
                             synchronized (RemoteSyncHandler.class) {
                                 RemoteSyncHandler.class.notifyAll();
-                                RemoteSyncHandler.class.wait(10000);
+                                try {
+                                    RemoteSyncHandler.class.wait(10000);
+                                } catch (InterruptedException e) {
+                                    log.debug("interrupted", e);
+                                }
                                 if (checkForChanges) {
                                     checkForChanges = false;
                                     event.response().setStatusCode(200);


### PR DESCRIPTION
This is done because Quarkus can recover just fine, so there is 
no need to scare users with exceptions

- Closes: #40503 
