### PR TITLE
Make kubernetes-client aware of proxy-registry extension

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -634,6 +634,66 @@ implementation("io.fabric8:kubernetes-model-apps")
 // ...
 ----
 
+== Proxy Configuration
+
+The Kubernetes Client supports sending requests through a proxy. You can configure a default proxy as well as multiple named proxy configurations, which can then be referenced by the Kubernetes Client.
+
+=== Registering a proxy configuration
+
+First, define a proxy configuration in your application configuration. Each proxy is identified by a unique name:
+
+[source,properties]
+----
+quarkus.proxy.my-proxy.host=http://localhost <1>
+quarkus.proxy.my-proxy.port=8162
+quarkus.proxy.my-proxy.username=username
+quarkus.proxy.my-proxy.password=password
+quarkus.proxy.my-proxy.non-proxy-hosts=my.company.com
+
+quarkus.proxy.host=http://localhost <2>
+quarkus.proxy.port=8888
+----
+
+1. Named proxy `my-proxy` configuration
+2. Default proxy configuration
+
+=== Referencing the proxy configuration
+
+Next, instruct the Kubernetes Client to use the registered proxy configuration by referencing its name:
+
+[source,properties]
+----
+quarkus.kubernetes-client.proxy-configuration-name=my-proxy
+----
+
+At runtime, the Kubernetes Client will be automatically configured using the `my-proxy` proxy settings.
+
+[NOTE]
+====
+When no named proxy configuration is provided, the Kubernetes Client falls back to the default proxy configuration, if available.
+====
+
+=== HTTPS and HTTP proxy configurations
+
+HTTPS and HTTP proxy considerations
+
+The Kubernetes Client also supports HTTP and HTTPS proxies via deprecated properties such as:
+
+* `quarkus.kubernetes-client.http-proxy`
+* `quarkus.kubernetes-client.https-proxy`
+
+If you want to use the Proxy Registry for HTTP or HTTPS proxies, ensure that the host property includes the appropriate scheme:
+
+* `http://` for HTTP proxies
+
+* `https://` for HTTPS proxies
+
+
+[NOTE]
+====
+If either `quarkus.kubernetes-client.http-proxy` or `quarkus.kubernetes-client.https-proxy` is configured, the Proxy Registry mechanism is disabled and will not be used.
+====
+
 == Configuration Reference
 
 include::{generated-dir}/config/quarkus-kubernetes-client.adoc[opts=optional, leveloffset=+1]

--- a/extensions/kubernetes-client/deployment-internal/pom.xml
+++ b/extensions/kubernetes-client/deployment-internal/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-proxy-registry-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client-internal</artifactId>
         </dependency>
         <dependency>

--- a/extensions/kubernetes-client/deployment/pom.xml
+++ b/extensions/kubernetes-client/deployment/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/kubernetes-client/deployment/src/test/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProxyConfigHttpTest.java
+++ b/extensions/kubernetes-client/deployment/src/test/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProxyConfigHttpTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class KubernetesClientProxyConfigHttpTest {
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withConfigurationResource("using-http-proxy-configuration.properties");
+
+    @Test
+    public void usingSameNamedProxyConfiguration() {
+        SoftAssertions.assertSoftly(softly -> {
+            Config configuration = kubernetesClient.getConfiguration();
+            softly.assertThat(configuration.getHttpProxy()).isEqualTo("http://localhost:8080");
+            softly.assertThat(configuration.getHttpsProxy()).isNull();
+            softly.assertThat(configuration.getNoProxy()).contains("kubernetes-client-test.com", "api.example.com");
+        });
+    }
+}

--- a/extensions/kubernetes-client/deployment/src/test/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProxyConfigHttpsTest.java
+++ b/extensions/kubernetes-client/deployment/src/test/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProxyConfigHttpsTest.java
@@ -17,15 +17,16 @@ public class KubernetesClientProxyConfigHttpsTest {
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
-            .withConfigurationResource("using-same-named-proxy-configuration.properties");
+            .withConfigurationResource("using-https-proxy-configuration.properties");
 
     @Test
     public void usingSameNamedProxyConfiguration() {
         SoftAssertions.assertSoftly(softly -> {
             Config configuration = kubernetesClient.getConfiguration();
-            softly.assertThat(configuration.getHttpsProxy()).isEqualTo("https://localhost:8443");
+            softly.assertThat(configuration.getHttpsProxy()).isEqualTo("https://secure.localhost:8443");
             softly.assertThat(configuration.getHttpProxy()).isNull();
-            softly.assertThat(configuration.getNoProxy()).contains("kubernetes-client-test.com", "api.example.com");
+            softly.assertThat(configuration.getNoProxy()).contains("secure.kubernetes-client-test.com",
+                    "secure.api.example.com");
         });
     }
 }

--- a/extensions/kubernetes-client/deployment/src/test/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProxyConfigHttpsTest.java
+++ b/extensions/kubernetes-client/deployment/src/test/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProxyConfigHttpsTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class KubernetesClientProxyConfigHttpsTest {
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withConfigurationResource("using-same-named-proxy-configuration.properties");
+
+    @Test
+    public void usingSameNamedProxyConfiguration() {
+        SoftAssertions.assertSoftly(softly -> {
+            Config configuration = kubernetesClient.getConfiguration();
+            softly.assertThat(configuration.getHttpsProxy()).isEqualTo("https://localhost:8443");
+            softly.assertThat(configuration.getHttpProxy()).isNull();
+            softly.assertThat(configuration.getNoProxy()).contains("kubernetes-client-test.com", "api.example.com");
+        });
+    }
+}

--- a/extensions/kubernetes-client/deployment/src/test/resources/using-http-proxy-configuration.properties
+++ b/extensions/kubernetes-client/deployment/src/test/resources/using-http-proxy-configuration.properties
@@ -1,0 +1,9 @@
+quarkus.kubernetes-client.devservices.enabled=false
+
+quarkus.proxy.http-proxy.host=http://localhost
+quarkus.proxy.http-proxy.port=8080
+quarkus.proxy.http-proxy.non-proxy-hosts=kubernetes-client-test.com,api.example.com
+
+quarkus.kubernetes-client.proxy-configuration-name=http-proxy
+
+

--- a/extensions/kubernetes-client/deployment/src/test/resources/using-https-proxy-configuration.properties
+++ b/extensions/kubernetes-client/deployment/src/test/resources/using-https-proxy-configuration.properties
@@ -1,14 +1,9 @@
 quarkus.kubernetes-client.devservices.enabled=false
 
-quarkus.proxy.https-proxy.host=secure.localhost
+quarkus.proxy.https-proxy.host=https://secure.localhost
 quarkus.proxy.https-proxy.port=8443
 quarkus.proxy.https-proxy.non-proxy-hosts=secure.kubernetes-client-test.com,secure.api.example.com
 
-quarkus.proxy.http-proxy.host=localhost
-quarkus.proxy.http-proxy.port=8080
-quarkus.proxy.http-proxy.non-proxy-hosts=kubernetes-client-test.com,api.example.com
-
-quarkus.kubernetes-client.https-proxy-configuration-name=https-proxy
-quarkus.kubernetes-client.http-proxy-configuration-name=http-proxy
+quarkus.kubernetes-client.proxy-configuration-name=https-proxy
 
 

--- a/extensions/kubernetes-client/deployment/src/test/resources/using-https-proxy-configuration.properties
+++ b/extensions/kubernetes-client/deployment/src/test/resources/using-https-proxy-configuration.properties
@@ -1,0 +1,14 @@
+quarkus.kubernetes-client.devservices.enabled=false
+
+quarkus.proxy.https-proxy.host=secure.localhost
+quarkus.proxy.https-proxy.port=8443
+quarkus.proxy.https-proxy.non-proxy-hosts=secure.kubernetes-client-test.com,secure.api.example.com
+
+quarkus.proxy.http-proxy.host=localhost
+quarkus.proxy.http-proxy.port=8080
+quarkus.proxy.http-proxy.non-proxy-hosts=kubernetes-client-test.com,api.example.com
+
+quarkus.kubernetes-client.https-proxy-configuration-name=https-proxy
+quarkus.kubernetes-client.http-proxy-configuration-name=http-proxy
+
+

--- a/extensions/kubernetes-client/runtime-internal/pom.xml
+++ b/extensions/kubernetes-client/runtime-internal/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>quarkus-tls-registry</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-proxy-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <scope>provided</scope> <!-- we don't want this ending up on the runtime classpath -->

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientBuildConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientBuildConfig.java
@@ -129,27 +129,56 @@ public interface KubernetesClientBuildConfig {
     Optional<Duration> requestRetryBackoffInterval();
 
     /**
-     * HTTP proxy used to access the Kubernetes API server
+     * The name of the proxy configuration to use for configuring <b>HTTP</b> proxy; ignored if
+     * {@code quarkus.kubernetes-client.http-proxy} or
+     * {@code quarkus.kubernetes-client.https-proxy} is set.
+     * <p>
+     * If not set and the default proxy configuration is configured ({@code quarkus.proxy.*}) then that will be used.
+     * If the proxy configuration name is set, the configuration from {@code quarkus.proxy.<name>.*} will be used.
+     * If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown
+     * at runtime.
+     * <p>
+     * Can be overwritten by Kubernetes client-specific settings.
+     * <p>
+     * Use the value {@code none} to disable using the default configuration defined via {@code quarkus.proxy.*}.
      */
+    Optional<String> proxyConfigurationName();
+
+    /**
+     * HTTP proxy used to access the Kubernetes API server
+     *
+     * @deprecated Use {@code quarkus.kubernetes-client.proxy-configuration-name} instead
+     */
+    @Deprecated
     Optional<String> httpProxy();
 
     /**
      * HTTPS proxy used to access the Kubernetes API server
+     *
+     * @deprecated Use {@code quarkus.kubernetes-client.proxy-configuration-name} instead
      */
+    @Deprecated
     Optional<String> httpsProxy();
 
     /**
      * Proxy username
+     *
+     * @deprecated Use {@code quarkus.kubernetes-client.proxy-configuration-name} instead
      */
+    @Deprecated
     Optional<String> proxyUsername();
 
     /**
      * Proxy password
+     *
+     * @deprecated Use {@code quarkus.kubernetes-client.proxy-configuration-name} instead
      */
     Optional<String> proxyPassword();
 
     /**
      * IP addresses or hosts to exclude from proxying
+     *
+     * @deprecated Use {@code quarkus.kubernetes-client.proxy-configuration-name} instead
      */
     Optional<List<String>> noProxy();
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

Closes #50824 

Make `kubernetes-client` extension aware of `proxy-registry` extension, this pull requet:

* Deprecate `kubernetes-client` proxy configuration
* Use `Proxy Registry` configurations for registering proxy.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

