### PR TITLE
Minor datasource dev services refactorings

### DIFF
--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -307,21 +307,7 @@ public class DevServicesDatasourceProcessor {
                 loggingSetupBuildItem);
 
         try {
-            DevServicesDatasourceContainerConfig containerConfig = new DevServicesDatasourceContainerConfig(
-                    dataSourceBuildTimeConfig.devservices().imageName(),
-                    dataSourceBuildTimeConfig.devservices().containerEnv(),
-                    dataSourceBuildTimeConfig.devservices().containerProperties(),
-                    dataSourceBuildTimeConfig.devservices().properties(),
-                    dataSourceBuildTimeConfig.devservices().port(),
-                    dataSourceBuildTimeConfig.devservices().command(),
-                    dataSourceBuildTimeConfig.devservices().dbName(),
-                    dataSourceBuildTimeConfig.devservices().username(),
-                    dataSourceBuildTimeConfig.devservices().password(),
-                    dataSourceBuildTimeConfig.devservices().initScriptPath(),
-                    dataSourceBuildTimeConfig.devservices().initPrivilegedScriptPath(),
-                    dataSourceBuildTimeConfig.devservices().volumes(),
-                    dataSourceBuildTimeConfig.devservices().reuse(),
-                    dataSourceBuildTimeConfig.devservices().showLogs());
+            DevServicesDatasourceContainerConfig containerConfig = getContainerConfig(dataSourceBuildTimeConfig);
 
             DevServicesDatasourceProvider.RunningDevServicesDatasource datasource = devDbProvider
                     .startDatabase(
@@ -399,6 +385,25 @@ public class DevServicesDatasourceProcessor {
             compressor.closeAndDumpCaptured();
             throw new RuntimeException(t);
         }
+    }
+
+    private static DevServicesDatasourceContainerConfig getContainerConfig(
+            DataSourceBuildTimeConfig dataSourceBuildTimeConfig) {
+        return new DevServicesDatasourceContainerConfig(
+                dataSourceBuildTimeConfig.devservices().imageName(),
+                dataSourceBuildTimeConfig.devservices().containerEnv(),
+                dataSourceBuildTimeConfig.devservices().containerProperties(),
+                dataSourceBuildTimeConfig.devservices().properties(),
+                dataSourceBuildTimeConfig.devservices().port(),
+                dataSourceBuildTimeConfig.devservices().command(),
+                dataSourceBuildTimeConfig.devservices().dbName(),
+                dataSourceBuildTimeConfig.devservices().username(),
+                dataSourceBuildTimeConfig.devservices().password(),
+                dataSourceBuildTimeConfig.devservices().initScriptPath(),
+                dataSourceBuildTimeConfig.devservices().initPrivilegedScriptPath(),
+                dataSourceBuildTimeConfig.devservices().volumes(),
+                dataSourceBuildTimeConfig.devservices().reuse(),
+                dataSourceBuildTimeConfig.devservices().showLogs());
     }
 
     private void setDataSourceProperties(Map<String, String> propertiesMap, String dbName, String propertyKeyRadical,


### PR DESCRIPTION
As part of #52123, and the more general conversion of datasource dev services to the new model, there ends up being a lot of duplicated code. The method signatures are just different enough that we need two paths through a lot of the code (annoying!). Even when all the core datasource services are completed, I think we'll need to keep the old SPI methods hanging around while the Quarkiverse catches up. 

I'm trying to do some refactorings before the big PR to reduce duplicated code and to make it less horrifyingly big. 

In this one, I've:
- Pulled out a long set of code into its own method
- Replaced a very clever piece of streaming code with one which is much more old-fashioned and boring and imperative, but also is clearer. It doesn’t look as cool, but it avoids the need to have lambdas with ignored arguments and identity functions. So I think it's perhaps slightly more efficient, and also re-usable. 