### PR TITLE
Do not leak internal host port into Host header when host is taken from Forwarded header without proto or scheme directives

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/AllowForwardedAndXForwardedHeadersTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/AllowForwardedAndXForwardedHeadersTest.java
@@ -129,4 +129,21 @@ public class AllowForwardedAndXForwardedHeadersTest {
                 .then()
                 .statusCode(400);
     }
+
+    /**
+     * Reproducer for <a href="https://github.com/quarkusio/quarkus/issues/46078">GitHub issue #46078</a>.
+     * Verifies that the behavior for "Forwarded" host and "X-Forwarded-Host" host without port is same, as the equality
+     * is verified by the 'strict-forwarded-control' policy.
+     * See the linked issue for reasoning behind the expectation that the Host header should not leak internal port.
+     */
+    @Test
+    public void testHostWithoutPortMatches() {
+        RestAssured.given()
+                .header("Forwarded", "host=somehost")
+                .header("X-Forwarded-Host", "somehost")
+                .get("/path")
+                .then()
+                .statusCode(200)
+                .body(Matchers.startsWith("http|somehost|"));
+    }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHeaderTest.java
@@ -97,4 +97,19 @@ public class ForwardedHeaderTest {
                 .then()
                 .body(Matchers.equalTo("https|somehost|[2001:db8:cafe::17]:47011"));
     }
+
+    /**
+     * Reproducer for <a href="https://github.com/quarkusio/quarkus/issues/46078">GitHub issue #46078</a>.
+     * See the linked issue for reasoning behind the expectation that the Host header should not leak internal port.
+     */
+    @Test
+    public void testForwardedHostWithoutProtoShouldNotLeakPort() {
+        assertThat(RestAssured.get("/forward").asString()).startsWith("http|");
+
+        RestAssured.given()
+                .header("Forwarded", "host=somehost")
+                .get("/forward")
+                .then()
+                .body(Matchers.startsWith("http|somehost|"));
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
@@ -218,7 +218,7 @@ class ForwardedParser {
 
         matcher = FORWARDED_HOST_PATTERN.matcher(forwarded);
         if (matcher.find()) {
-            setHostAndPort(matcher.group(1).trim(), port);
+            setHostAndPort(matcher.group(1).trim(), -1);
             log.debugf("Using Forwarded 'host' to set host to %s and port to %d", host, port);
             forwardedValues.setHost(host);
             forwardedValues.setPort(port);


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/46078
* Without this PR, when 'Forwarded' header is used and its proxy is enabled, we added internal Host port into response Host header if the Forwarded header did not contain proto or scheme directives
* The new behavior follows the behavior already in place for 'X-Forwarded-Host'
