### PR TITLE
ListeningAddress to be Optional.empty when port and protocol are null

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ValueRegistryImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ValueRegistryImpl.java
@@ -34,10 +34,22 @@ public class ValueRegistryImpl implements ValueRegistry {
     }
 
     public <T> void register(final RuntimeKey<T> key, final T value) {
+        if (key == null || key.key() == null) {
+            throw new IllegalArgumentException("Key cannot be null");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("Value cannot be null");
+        }
         registerInfo(key, SimpleRuntimeInfo.of(value));
     }
 
     public <T> void registerInfo(final RuntimeKey<T> key, final RuntimeInfo<T> runtimeInfo) {
+        if (key == null || key.key() == null) {
+            throw new IllegalArgumentException("Key cannot be null");
+        }
+        if (runtimeInfo == null) {
+            throw new IllegalArgumentException("Value cannot be null");
+        }
         RuntimeInfo<?> mapValue = values.putIfAbsent(key.key(), runtimeInfo);
         if (mapValue != null) {
             throw new IllegalArgumentException("Key already registered " + key.key());

--- a/integration-tests/core/pom.xml
+++ b/integration-tests/core/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>quarkus-integration-tests-parent</artifactId>
+    <groupId>io.quarkus</groupId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>quarkus-integration-test-core</artifactId>
+
+  <name>Quarkus - Integration Tests - Core</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integration-tests/core/src/main/java/io/quarkus/it/core/MainApplication.java
+++ b/integration-tests/core/src/main/java/io/quarkus/it/core/MainApplication.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.core;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class MainApplication {
+    public static void main(String... args) {
+        Quarkus.run(args);
+    }
+}

--- a/integration-tests/core/src/test/java/io/quarkus/it/core/CoreIT.java
+++ b/integration-tests/core/src/test/java/io/quarkus/it/core/CoreIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.core;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CoreIT extends CoreTest {
+}

--- a/integration-tests/core/src/test/java/io/quarkus/it/core/CoreTest.java
+++ b/integration-tests/core/src/test/java/io/quarkus/it/core/CoreTest.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.core;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class CoreTest {
+    @Test
+    void core() {
+
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -160,6 +160,7 @@
                 </property>
             </activation>
             <modules>
+                <module>core</module>
                 <module>avro-reload</module>
                 <module>awt</module>
                 <module>awt-packaging</module>

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -296,9 +296,9 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
             return Optional.empty();
         } else {
             log.info("Wait for server to start by capturing listening data...");
-            ListeningAddress result = waitForCapturedListeningData(containerProcess, logPath, waitTimeSeconds);
-            log.infof("Server started on port %s", result.port());
-            return Optional.of(result);
+            Optional<ListeningAddress> result = waitForCapturedListeningData(containerProcess, logPath, waitTimeSeconds);
+            result.ifPresent(listeningAddress -> log.infof("Server started on port %s", listeningAddress.port()));
+            return result;
         }
     }
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -79,9 +79,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
             waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logFile);
             return Optional.empty();
         } else {
-            ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(),
-                    waitTimeSeconds);
-            return Optional.of(result);
+            return waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(), waitTimeSeconds);
         }
     }
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -92,9 +92,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
             waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logRuntimeConfig.file().path().toPath());
             return Optional.empty();
         } else {
-            ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(),
-                    waitTimeSeconds);
-            return Optional.of(result);
+            return waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(), waitTimeSeconds);
         }
     }
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -86,7 +87,7 @@ public final class LauncherUtil {
      * listening on.
      * If the wait time is exceeded an {@code IllegalStateException} is thrown.
      */
-    static ListeningAddress waitForCapturedListeningData(Process quarkusProcess, Path logFile, long waitTimeSeconds) {
+    static Optional<ListeningAddress> waitForCapturedListeningData(Process quarkusProcess, Path logFile, long waitTimeSeconds) {
         ensureProcessIsAlive(quarkusProcess);
 
         CountDownLatch signal = new CountDownLatch(1);
@@ -98,7 +99,7 @@ public final class LauncherUtil {
             signal.await(waitTimeSeconds + 2, TimeUnit.SECONDS); // wait enough for the signal to be given by the capturing thread
             ListeningAddress result = resultReference.get();
             if (result != null) {
-                return result;
+                return result.port() != null && result.protocol() != null ? Optional.of(result) : Optional.empty();
             }
             // a null result means that we could not determine the status of the process so we need to abort testing
             destroyProcess(quarkusProcess);


### PR DESCRIPTION
For https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Quarkus.203.2E31.2E0.20NPE.20-.20ValueRegistry.2EgetOrDefault/with/569337863

The return `Optional<ListeningAddress>` from `io.quarkus.test.common.ArtifactLauncher#start` was not a proper `Optional`, because it could return an instance of `ListeningAddress`, but with `port` and `protocol` set to `null`, which caused:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "io.quarkus.registry.ValueRegistry.getOrDefault(io.quarkus.registry.ValueRegistry$RuntimeKey, Object)" is null
    at io.quarkus.test.common.http.TestHTTPResourceManager.testUrl(TestHTTPResourceManager.java:159)
    at io.quarkus.test.common.ListeningAddress.register(ListeningAddress.java:19)
    at io.quarkus.test.junit.QuarkusIntegrationTestExtension.lambda$doProcessStart$0(QuarkusIntegrationTestExtension.java:331)
    at java.base/java.util.Optional.ifPresent(Optional.java:178)
```

When querying the `ValueRegistry`. 

The `ValueRegistry` shouldn't accept `null` keys or values, so I've also added a guard there.

This issue only occurs with `@QuarkusIntegrationTest` and without `quarkus-vertx-http`, so a workaround is to add that extension to the project.