### PR TITLE
Snapshots - Only enable logs from Njord

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -54,7 +54,7 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |
-          ./mvnw -e -B -X --no-transfer-progress --settings .github/release-settings.xml \
+          ./mvnw -e -B --no-transfer-progress --settings .github/release-settings.xml \
             -Dnjord.autoPublish \
             -DskipTests -DskipITs -Dno-format -Dinvoker.skip=true \
             -Dno-test-modules \


### PR DESCRIPTION
Using -X, the logs are so large it's impossible to download them from GitHub, even zipped...
