### PR TITLE
Initialize `RemoteCacheManager` at application startup

### DIFF
--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -554,7 +554,7 @@ class InfinispanClientProcessor {
         for (String clientName : clientNames) {
             syntheticBeanBuildItemBuildProducer.produce(
                     configureAndCreateSyntheticBean(clientName, RemoteCacheManager.class,
-                            recorder.infinispanClientSupplier(clientName)));
+                            recorder.infinispanRemoteCacheManagerSupplier(clientName)));
             syntheticBeanBuildItemBuildProducer.produce(
                     configureAndCreateSyntheticBean(clientName, CounterManager.class,
                             recorder.infinispanCounterManagerSupplier(clientName)));
@@ -564,7 +564,7 @@ class InfinispanClientProcessor {
         for (RemoteCacheBean remoteCacheBean : remoteCacheBeans) {
             syntheticBeanBuildItemBuildProducer.produce(
                     configureAndCreateSyntheticBean(remoteCacheBean,
-                            recorder.infinispanRemoteCacheClientSupplier(remoteCacheBean.clientName,
+                            recorder.infinispanRemoteCacheSupplier(remoteCacheBean.clientName,
                                     remoteCacheBean.cacheName)));
         }
     }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -607,7 +607,7 @@ class InfinispanClientProcessor {
     }
 
     @BuildStep
-    @Record(value = RUNTIME_INIT, optional = true)
+    @Record(value = RUNTIME_INIT)
     List<InfinispanClientBuildItem> infinispanClients(InfinispanRecorder recorder,
             List<InfinispanClientNameBuildItem> infinispanClientNames,
             // make sure all beans have been initialized
@@ -615,7 +615,7 @@ class InfinispanClientProcessor {
         List<InfinispanClientBuildItem> result = new ArrayList<>(infinispanClientNames.size());
         for (InfinispanClientNameBuildItem ic : infinispanClientNames) {
             String name = ic.getName();
-            result.add(new InfinispanClientBuildItem(recorder.getClient(name), name));
+            result.add(new InfinispanClientBuildItem(recorder.initializeClient(name), name));
         }
         return result;
     }

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
@@ -1,10 +1,11 @@
 package io.quarkus.infinispan.client.runtime;
 
 import java.net.URL;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PreDestroy;
@@ -50,7 +51,7 @@ public class InfinispanClientProducer {
     public static final String PROTOBUF_FILE_PREFIX = "infinispan.client.hotrod.protofile.";
     public static final String PROTOBUF_SCHEMAS = "infinispan.client.hotrod.proto-schemas";
 
-    private final Map<String, RemoteCacheManager> remoteCacheManagers = new HashMap<>();
+    private final Map<String, RemoteCacheManager> remoteCacheManagers = new ConcurrentHashMap<>();
 
     @Inject
     private BeanManager beanManager;
@@ -131,29 +132,6 @@ public class InfinispanClientProducer {
                 cacheManager.switchToDefaultCluster();
             }
         });
-    }
-
-    private void initialize(String infinispanConfigName, Map<String, Properties> properties) {
-        log.debug("Initializing default RemoteCacheManager");
-        if (properties.isEmpty()) {
-            // We already loaded and it wasn't present - so don't initialize the cache manager
-            return;
-        }
-
-        ConfigurationBuilder conf = builderFromProperties(infinispanConfigName, properties);
-        if (conf.servers().isEmpty()) {
-            return;
-        }
-        // Build de cache manager if the server list is present
-        InfinispanClientsRuntimeConfig infinispanClientsRuntimeConfig = this.infinispanClientsRuntimeConfigHandle.get();
-
-        RemoteCacheManager cacheManager = new RemoteCacheManager(conf.build(),
-                infinispanClientsRuntimeConfig.startClient().orElse(Boolean.TRUE));
-        remoteCacheManagers.put(infinispanConfigName, cacheManager);
-
-        if (infinispanClientsRuntimeConfig.useSchemaRegistration().orElse(Boolean.TRUE)) {
-            registerSchemaInServer(infinispanConfigName, properties, cacheManager);
-        }
     }
 
     /**
@@ -503,10 +481,32 @@ public class InfinispanClientProducer {
     }
 
     public RemoteCacheManager getNamedRemoteCacheManager(String clientName) {
-        if (!remoteCacheManagers.containsKey(clientName)) {
-            initialize(clientName, properties);
-        }
-        return remoteCacheManagers.get(clientName);
+        return remoteCacheManagers.computeIfAbsent(clientName, new Function<>() {
+            @Override
+            public RemoteCacheManager apply(String cn) {
+                if (properties.isEmpty()) {
+                    // TODO: this should probably be an error, but keeping `null` as that's what the previous version of the code did
+                    return null;
+                }
+
+                ConfigurationBuilder conf = builderFromProperties(cn, properties);
+                if (conf.servers().isEmpty()) {
+                    // TODO: this should probably be an error, but keeping `null` as that's what the previous version of the code did
+                    return null;
+                }
+                // Build the cache manager if the server list is present
+                InfinispanClientsRuntimeConfig infinispanClientsRuntimeConfig = infinispanClientsRuntimeConfigHandle.get();
+
+                RemoteCacheManager result = new RemoteCacheManager(conf.build(),
+                        infinispanClientsRuntimeConfig.startClient().orElse(Boolean.TRUE));
+
+                if (infinispanClientsRuntimeConfig.useSchemaRegistration().orElse(Boolean.TRUE)) {
+                    registerSchemaInServer(cn, properties, result);
+                }
+
+                return result;
+            }
+        });
     }
 
     public CounterManager getNamedCounterManager(String clientName) {

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
@@ -10,9 +10,7 @@ import java.util.stream.Collectors;
 
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.literal.NamedLiteral;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
@@ -36,8 +34,6 @@ import org.infinispan.protostream.FileDescriptorSource;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.protostream.schema.Schema;
-
-import io.quarkus.arc.Arc;
 
 /**
  * Produces a configured remote cache manager instance
@@ -441,13 +437,7 @@ public class InfinispanClientProducer {
     }
 
     public <K, V> RemoteCache<K, V> getRemoteCache(String clientName, String cacheName) {
-        RemoteCacheManager cacheManager;
-        if (InfinispanClientUtil.isDefault(clientName)) {
-            cacheManager = Arc.container().instance(RemoteCacheManager.class, Default.Literal.INSTANCE).get();
-        } else {
-            cacheManager = Arc.container().instance(RemoteCacheManager.class, NamedLiteral.of(clientName))
-                    .get();
-        }
+        RemoteCacheManager cacheManager = getNamedRemoteCacheManager(clientName);
 
         if (cacheManager != null && cacheName != null && !cacheName.isEmpty()) {
             RemoteCache<K, V> cache = cacheManager.getCache(cacheName);

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
@@ -30,7 +30,7 @@ public class InfinispanRecorder {
     }
 
     public Supplier<RemoteCacheManager> infinispanRemoteCacheManagerSupplier(String clientName) {
-        return new InfinispanClientSupplier<>(new Function<InfinispanClientProducer, RemoteCacheManager>() {
+        return new InfinispanClientSupplier<>(new Function<>() {
             @Override
             public RemoteCacheManager apply(InfinispanClientProducer infinispanClientProducer) {
                 return infinispanClientProducer.getNamedRemoteCacheManager(clientName);
@@ -39,7 +39,7 @@ public class InfinispanRecorder {
     }
 
     public Supplier<CounterManager> infinispanCounterManagerSupplier(String clientName) {
-        return new InfinispanClientSupplier<>(new Function<InfinispanClientProducer, CounterManager>() {
+        return new InfinispanClientSupplier<>(new Function<>() {
             @Override
             public CounterManager apply(InfinispanClientProducer infinispanClientProducer) {
                 return infinispanClientProducer.getNamedCounterManager(clientName);
@@ -48,7 +48,7 @@ public class InfinispanRecorder {
     }
 
     public <K, V> Supplier<RemoteCache<K, V>> infinispanRemoteCacheSupplier(String clientName, String cacheName) {
-        return new InfinispanClientSupplier<>(new Function<InfinispanClientProducer, RemoteCache<K, V>>() {
+        return new InfinispanClientSupplier<>(new Function<>() {
             @Override
             public RemoteCache<K, V> apply(InfinispanClientProducer infinispanClientProducer) {
                 return infinispanClientProducer.getRemoteCache(clientName, cacheName);

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
@@ -29,7 +29,7 @@ public class InfinispanRecorder {
         };
     }
 
-    public Supplier<RemoteCacheManager> infinispanClientSupplier(String clientName) {
+    public Supplier<RemoteCacheManager> infinispanRemoteCacheManagerSupplier(String clientName) {
         return new InfinispanClientSupplier<>(new Function<InfinispanClientProducer, RemoteCacheManager>() {
             @Override
             public RemoteCacheManager apply(InfinispanClientProducer infinispanClientProducer) {
@@ -47,7 +47,7 @@ public class InfinispanRecorder {
         });
     }
 
-    public <K, V> Supplier<RemoteCache<K, V>> infinispanRemoteCacheClientSupplier(String clientName, String cacheName) {
+    public <K, V> Supplier<RemoteCache<K, V>> infinispanRemoteCacheSupplier(String clientName, String cacheName) {
         return new InfinispanClientSupplier<>(new Function<InfinispanClientProducer, RemoteCache<K, V>>() {
             @Override
             public RemoteCache<K, V> apply(InfinispanClientProducer infinispanClientProducer) {

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
@@ -1,7 +1,9 @@
 package io.quarkus.infinispan.client.runtime;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -29,7 +31,10 @@ public class InfinispanRecorder {
         };
     }
 
+    private final Set<String> clientNames = new HashSet<>();
+
     public Supplier<RemoteCacheManager> infinispanRemoteCacheManagerSupplier(String clientName) {
+        clientNames.add(clientName);
         return new InfinispanClientSupplier<>(new Function<>() {
             @Override
             public RemoteCacheManager apply(InfinispanClientProducer infinispanClientProducer) {
@@ -39,6 +44,7 @@ public class InfinispanRecorder {
     }
 
     public Supplier<CounterManager> infinispanCounterManagerSupplier(String clientName) {
+        clientNames.add(clientName);
         return new InfinispanClientSupplier<>(new Function<>() {
             @Override
             public CounterManager apply(InfinispanClientProducer infinispanClientProducer) {
@@ -48,6 +54,7 @@ public class InfinispanRecorder {
     }
 
     public <K, V> Supplier<RemoteCache<K, V>> infinispanRemoteCacheSupplier(String clientName, String cacheName) {
+        clientNames.add(clientName);
         return new InfinispanClientSupplier<>(new Function<>() {
             @Override
             public RemoteCache<K, V> apply(InfinispanClientProducer infinispanClientProducer) {
@@ -56,8 +63,12 @@ public class InfinispanRecorder {
         });
     }
 
-    public RuntimeValue<RemoteCacheManager> getClient(String name) {
-        return new RuntimeValue<>(Arc.container().instance(RemoteCacheManager.class, literal(name)).get());
+    public RuntimeValue<RemoteCacheManager> initializeClient(String name) {
+        RemoteCacheManager remoteCacheManager = Arc.container().instance(RemoteCacheManager.class, literal(name)).get();
+        //noinspection ResultOfMethodCallIgnored
+        // used to initialize the bean
+        remoteCacheManager.getConfiguration();
+        return new RuntimeValue<>(remoteCacheManager);
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
The basic fix is in the final commit, the rest of the commits are just small things that on their own don't change anything from a functionality PoV.

FWIW, the CDI handling of the Infinispan client needs work to be on par with what we have in other extensions, but let's leave that for a future PR

- Fixes: #52141
- Deals with: https://github.com/quarkusio/quarkus/issues/6588