### PR TITLE
ArC: allow stereotyping the `@LookupIf|UnlessProperty` annotations

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -718,7 +718,8 @@ public class TracerConfiguration {
 
 NOTE: The runtime profile has absolutely no effect on the bean resolution using `@IfBuildProfile` and `@UnlessBuildProfile`.
 
-TIP: It is also possible to use `@IfBuildProfile` and `@UnlessBuildProfile` on stereotypes.
+TIP: `@IfBuildProfile` and `@UnlessBuildProfile` may be put on a stereotype.
+A bean will only be enabled if **all** the conditions defined by these annotations are satisfied.
 
 [[enable_build_properties]]
 === Enabling Beans for Quarkus Build Properties
@@ -748,7 +749,8 @@ public class TracerConfiguration {
 }
 ----
 
-TIP: `@IfBuildProperty` and `@UnlessBuildProperty` are repeatable annotations, i.e. a bean will only be enabled if **all** the conditions defined by these annotations are satisfied.
+TIP: `@IfBuildProperty` and `@UnlessBuildProperty` are repeatable annotations and may be put on a stereotype.
+A bean will only be enabled if **all** the conditions defined by these annotations are satisfied.
 
 If instead, it is required that the `RealTracer` bean is only used if the `some.tracer.enabled` property is not `false`, then `@UnlessBuildProperty` would be ideal. The code would look like:
 
@@ -771,9 +773,7 @@ public class TracerConfiguration {
 }
 ----
 
-NOTE: Properties set at runtime have absolutely no effect on the bean resolution using `@IfBuildProperty`.
-
-TIP: It is also possible to use `@IfBuildProperty` and `@UnlessBuildProperty` on stereotypes.
+NOTE: Properties set at runtime have absolutely no effect on the bean resolution using `@IfBuildProperty` / `@UnlessBuildProperty`.
 
 === Declaring Selected Alternatives
 
@@ -1064,6 +1064,9 @@ Alternatively, you can use the `@LookupIfProperty` and `@LookupUnlessProperty` a
     }
  }
 ----
+
+TIP: `@LookupIfProperty` and `@LookupUnlessProperty` are repeatable annotations and may be put on a stereotype.
+A bean will only be obtained if **all** the conditions defined by these annotations are satisfied.
 
 === Sorting beans obtained with programmatic lookup
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
@@ -1,7 +1,9 @@
 package io.quarkus.arc.deployment;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -11,15 +13,19 @@ import java.util.function.Function;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.quarkus.arc.lookup.LookupUnlessProperty;
 import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.arc.processor.StereotypeInfo;
 import io.quarkus.arc.runtime.SuppressConditions;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.creator.BlockCreator;
@@ -46,25 +52,88 @@ public class LookupConditionsProcessor {
             boolean.class, String.class, String.class, boolean.class);
 
     @BuildStep
+    LookupConditionsStereotypesBuildItem findLookupConditionStereotypes(CombinedIndexBuildItem combinedIndex) {
+        IndexView index = combinedIndex.getComputingIndex();
+
+        // find all stereotypes
+        Set<DotName> stereotypeNames = new HashSet<>();
+        for (AnnotationInstance annotation : index.getAnnotations(DotNames.STEREOTYPE)) {
+            // `Stereotype` is `@Target(ANNOTATION_TYPE)`
+            stereotypeNames.add(annotation.target().asClass().name());
+        }
+        // ideally, we would also consider all `StereotypeRegistrarBuildItem`s here,
+        // but there is a build step cycle involving Spring DI and RESTEasy Reactive
+        // that I'm not capable of breaking
+
+        // for each stereotype, find all lookup annotations, present either directly or transitively
+        List<LookupConditionsStereotypesBuildItem.LookupConditionsStereotype> lookupStereotypes = new ArrayList<>();
+        for (DotName stereotypeToScan : stereotypeNames) {
+            List<AnnotationInstance> ifAnnotations = new ArrayList<>();
+            List<AnnotationInstance> unlessAnnotations = new ArrayList<>();
+
+            Set<DotName> alreadySeen = new HashSet<>(); // to guard against hypothetical stereotype cycle
+            Deque<DotName> worklist = new ArrayDeque<>();
+            worklist.add(stereotypeToScan);
+            while (!worklist.isEmpty()) {
+                DotName stereotype = worklist.poll();
+                if (!alreadySeen.add(stereotype)) {
+                    continue;
+                }
+
+                ClassInfo stereotypeClass = index.getClassByName(stereotype);
+                if (stereotypeClass == null) {
+                    continue;
+                }
+
+                ifAnnotations.addAll(stereotypeClass.declaredAnnotationsWithRepeatable(LOOK_UP_IF_PROPERTY, index));
+                unlessAnnotations.addAll(stereotypeClass.declaredAnnotationsWithRepeatable(LOOK_UP_UNLESS_PROPERTY, index));
+
+                for (AnnotationInstance metaAnn : stereotypeClass.declaredAnnotations()) {
+                    if (stereotypeNames.contains(metaAnn.name())) {
+                        worklist.add(metaAnn.name());
+                    }
+                }
+            }
+
+            if (!ifAnnotations.isEmpty() || !unlessAnnotations.isEmpty()) {
+                lookupStereotypes.add(new LookupConditionsStereotypesBuildItem.LookupConditionsStereotype(stereotypeToScan,
+                        ifAnnotations, unlessAnnotations));
+            }
+        }
+
+        return new LookupConditionsStereotypesBuildItem(lookupStereotypes);
+    }
+
+    @BuildStep
     void suppressConditionsGenerators(BuildProducer<SuppressConditionGeneratorBuildItem> generators,
+            LookupConditionsStereotypesBuildItem lookupConditionStereotypes,
             BeanArchiveIndexBuildItem beanArchiveIndex) {
         IndexView index = beanArchiveIndex.getIndex();
 
         generators.produce(new SuppressConditionGeneratorBuildItem(new Function<BeanInfo, Consumer<BlockCreator>>() {
-
             @Override
             public Consumer<BlockCreator> apply(BeanInfo bean) {
                 Optional<AnnotationTarget> maybeTarget = bean.getTarget();
                 if (maybeTarget.isPresent()) {
                     AnnotationTarget target = maybeTarget.get();
-                    List<AnnotationInstance> ifPropertyList = findAnnotations(target, LOOK_UP_IF_PROPERTY,
-                            LOOK_UP_IF_CONTAINER, index);
-                    List<AnnotationInstance> unlessPropertyList = findAnnotations(target, LOOK_UP_UNLESS_PROPERTY,
-                            LOOK_UP_UNLESS_PROPERTY_CONTAINER, index);
+                    List<AnnotationInstance> ifPropertyList = new ArrayList<>(
+                            target.declaredAnnotationsWithRepeatable(LOOK_UP_IF_PROPERTY, index));
+                    List<AnnotationInstance> unlessPropertyList = new ArrayList<>(
+                            target.declaredAnnotationsWithRepeatable(LOOK_UP_UNLESS_PROPERTY, index));
+                    for (StereotypeInfo stereotype : bean.getStereotypes()) {
+                        var conditions = lookupConditionStereotypes.get(stereotype.getName());
+                        if (conditions != null) {
+                            ifPropertyList.addAll(conditions.ifAnnotations());
+                            unlessPropertyList.addAll(conditions.unlessAnnotations());
+                        }
+                    }
                     if (!ifPropertyList.isEmpty() || !unlessPropertyList.isEmpty()) {
                         return new Consumer<BlockCreator>() {
                             @Override
                             public void accept(BlockCreator suppressed) {
+                                // if at least one condition fails, we mark the bean as suppressed
+                                // this means all conditions must pass, which is how we implement
+                                // the documented "logical AND of all conditions" behavior
                                 for (AnnotationInstance ifProperty : ifPropertyList) {
                                     String propertyName = ifProperty.value(NAME).asString();
                                     String expectedStringValue = ifProperty.value(STRING_VALUE).asString();
@@ -93,37 +162,4 @@ public class LookupConditionsProcessor {
             }
         }));
     }
-
-    List<AnnotationInstance> findAnnotations(AnnotationTarget target, DotName annotationName, DotName containingAnnotationName,
-            IndexView index) {
-        AnnotationInstance annotation;
-        AnnotationInstance container;
-        switch (target.kind()) {
-            case CLASS -> {
-                annotation = target.asClass().declaredAnnotation(annotationName);
-                container = target.asClass().declaredAnnotation(containingAnnotationName);
-            }
-            case FIELD -> {
-                annotation = target.asField().annotation(annotationName);
-                container = target.asField().annotation(containingAnnotationName);
-            }
-            case METHOD -> {
-                annotation = target.asMethod().annotation(annotationName);
-                container = target.asMethod().annotation(containingAnnotationName);
-            }
-            default -> throw new IllegalStateException("Invalid bean target: " + target);
-        }
-        if (annotation == null && container == null) {
-            return Collections.emptyList();
-        }
-        List<AnnotationInstance> ret = new ArrayList<>();
-        if (annotation != null) {
-            ret.add(annotation);
-        }
-        if (container != null) {
-            Collections.addAll(ret, container.value().asNestedArray());
-        }
-        return ret;
-    }
-
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsStereotypesBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsStereotypesBuildItem.java
@@ -1,0 +1,32 @@
+package io.quarkus.arc.deployment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class LookupConditionsStereotypesBuildItem extends SimpleBuildItem {
+    private final Map<DotName, LookupConditionsStereotype> map;
+
+    LookupConditionsStereotypesBuildItem(List<LookupConditionsStereotype> lookupConditionsStereotypes) {
+        Map<DotName, LookupConditionsStereotype> map = new HashMap<>();
+        for (LookupConditionsStereotype lookupConditionsStereotype : lookupConditionsStereotypes) {
+            map.put(lookupConditionsStereotype.name, lookupConditionsStereotype);
+        }
+        this.map = map;
+    }
+
+    LookupConditionsStereotype get(DotName stereotype) {
+        return map.get(stereotype);
+    }
+
+    record LookupConditionsStereotype(
+            DotName name,
+            List<AnnotationInstance> ifAnnotations,
+            List<AnnotationInstance> unlessAnnotations) {
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupConditionOnInheritedStereotypeTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupConditionOnInheritedStereotypeTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LookupConditionOnInheritedStereotypeTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AlphaStereotype.class, AlphaService.class,
+                    BravoStereotype.class, BravoService.class, CharlieStereotype.class, CharlieService.class))
+            .overrideConfigKey("service.alpha.enabled", "true")
+            .overrideConfigKey("service.bravo.enabled", "false");
+
+    @Inject
+    Instance<AlphaService> alpha;
+
+    @Inject
+    Instance<BravoService> bravo;
+
+    @Inject
+    Instance<CharlieService> charlie;
+
+    @Test
+    public void testConditions() {
+        assertTrue(alpha.isResolvable());
+        assertEquals("alpha", alpha.get().ping());
+        assertTrue(bravo.isUnsatisfied());
+        assertTrue(charlie.isResolvable());
+        assertEquals("charlie", charlie.get().ping());
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.alpha.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @interface AlphaStereotype {
+    }
+
+    @AlphaStereotype
+    static class AlphaServiceParent {
+    }
+
+    @Singleton
+    static class AlphaService extends AlphaServiceParent {
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.bravo.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @interface BravoStereotype {
+    }
+
+    @BravoStereotype
+    static class BravoServiceParent {
+    }
+
+    @Singleton
+    static class BravoService extends BravoServiceParent {
+        public String ping() {
+            return "bravo";
+        }
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.charlie.enabled", stringValue = "true", lookupIfMissing = true)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @interface CharlieStereotype {
+    }
+
+    @CharlieStereotype
+    static class CharlieServiceParent {
+    }
+
+    @Singleton
+    static class CharlieService extends CharlieServiceParent {
+        public String ping() {
+            return "charlie";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupConditionOnStereotypeTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupConditionOnStereotypeTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LookupConditionOnStereotypeTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AlphaStereotype.class, AlphaService.class,
+                    BravoStereotype.class, BravoService.class, CharlieStereotype.class, CharlieService.class))
+            .overrideConfigKey("service.alpha.enabled", "true")
+            .overrideConfigKey("service.bravo.enabled", "false");
+
+    @Inject
+    Instance<AlphaService> alpha;
+
+    @Inject
+    Instance<BravoService> bravo;
+
+    @Inject
+    Instance<CharlieService> charlie;
+
+    @Test
+    public void testConditions() {
+        assertTrue(alpha.isResolvable());
+        assertEquals("alpha", alpha.get().ping());
+        assertTrue(bravo.isUnsatisfied());
+        assertTrue(charlie.isResolvable());
+        assertEquals("charlie", charlie.get().ping());
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.alpha.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface AlphaStereotype {
+    }
+
+    @Singleton
+    @AlphaStereotype
+    static class AlphaService {
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.bravo.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface BravoStereotype {
+    }
+
+    @Singleton
+    @BravoStereotype
+    static class BravoService {
+        public String ping() {
+            return "bravo";
+        }
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.charlie.enabled", stringValue = "true", lookupIfMissing = true)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CharlieStereotype {
+    }
+
+    static class CharlieService {
+        public String ping() {
+            return "charlie";
+        }
+    }
+
+    @Singleton
+    static class CharlieProducer {
+        @Produces
+        @Singleton
+        @CharlieStereotype
+        public CharlieService produce() {
+            return new CharlieService();
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMultipleConditionsOnInheritedStereotypesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMultipleConditionsOnInheritedStereotypesTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LookupMultipleConditionsOnInheritedStereotypesTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AlphaStereotype.class, BravoStereotype.class,
+                    AlphaBravoStereotype.class, CharlieStereotype.class, CharlieDeltaStereotype.class,
+                    EchoFoxtrotStereotype.class, FirstService.class, SecondService.class, ThirdService.class))
+            .overrideConfigKey("service.alpha.enabled", "true")
+            .overrideConfigKey("service.delta.enabled", "true")
+            .overrideConfigKey("service.echo.enabled", "true")
+            .overrideConfigKey("service.foxtrot.enabled", "true");
+
+    @Inject
+    Instance<FirstService> first;
+
+    @Inject
+    Instance<SecondService> second;
+
+    @Inject
+    Instance<ThirdService> third;
+
+    @Test
+    public void testConditions() {
+        assertTrue(first.isResolvable());
+        assertEquals("first", first.get().ping());
+        assertTrue(second.isUnsatisfied());
+        assertTrue(third.isResolvable());
+        assertEquals("third", third.get().ping());
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.alpha.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface AlphaStereotype {
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.bravo.enabled", stringValue = "true", lookupIfMissing = true)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface BravoStereotype {
+    }
+
+    @Stereotype
+    @AlphaStereotype
+    @BravoStereotype
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @interface AlphaBravoStereotype {
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.charlie.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CharlieStereotype {
+    }
+
+    @Stereotype
+    @CharlieStereotype
+    @LookupIfProperty(name = "service.delta.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @interface CharlieDeltaStereotype {
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.echo.enabled", stringValue = "true")
+    @LookupIfProperty(name = "service.foxtrot.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @interface EchoFoxtrotStereotype {
+    }
+
+    @AlphaBravoStereotype
+    static class FirstServiceParent {
+    }
+
+    @Singleton
+    static class FirstService extends FirstServiceParent {
+        public String ping() {
+            return "first";
+        }
+    }
+
+    @CharlieDeltaStereotype
+    static class SecondServiceParent {
+    }
+
+    @Singleton
+    static class SecondService extends SecondServiceParent {
+        public String ping() {
+            return "service";
+        }
+    }
+
+    @EchoFoxtrotStereotype
+    static class ThirdServiceParent {
+    }
+
+    @Singleton
+    static class ThirdService extends ThirdServiceParent {
+        public String ping() {
+            return "third";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMultipleConditionsOnStereotypesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMultipleConditionsOnStereotypesTest.java
@@ -1,0 +1,120 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LookupMultipleConditionsOnStereotypesTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AlphaStereotype.class, BravoStereotype.class,
+                    AlphaBravoStereotype.class, CharlieStereotype.class, CharlieDeltaStereotype.class,
+                    EchoFoxtrotStereotype.class, FirstService.class, SecondService.class, ThirdService.class))
+            .overrideConfigKey("service.alpha.enabled", "true")
+            .overrideConfigKey("service.delta.enabled", "true")
+            .overrideConfigKey("service.echo.enabled", "true")
+            .overrideConfigKey("service.foxtrot.enabled", "true");
+
+    @Inject
+    Instance<FirstService> first;
+
+    @Inject
+    Instance<SecondService> second;
+
+    @Inject
+    Instance<ThirdService> third;
+
+    @Test
+    public void testConditions() {
+        assertTrue(first.isResolvable());
+        assertEquals("first", first.get().ping());
+        assertTrue(second.isUnsatisfied());
+        assertTrue(third.isResolvable());
+        assertEquals("third", third.get().ping());
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.alpha.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface AlphaStereotype {
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.bravo.enabled", stringValue = "true", lookupIfMissing = true)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface BravoStereotype {
+    }
+
+    @Stereotype
+    @AlphaStereotype
+    @BravoStereotype
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface AlphaBravoStereotype {
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.charlie.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CharlieStereotype {
+    }
+
+    @Stereotype
+    @CharlieStereotype
+    @LookupIfProperty(name = "service.delta.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CharlieDeltaStereotype {
+    }
+
+    @Stereotype
+    @LookupIfProperty(name = "service.echo.enabled", stringValue = "true")
+    @LookupIfProperty(name = "service.foxtrot.enabled", stringValue = "true")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface EchoFoxtrotStereotype {
+    }
+
+    @Singleton
+    @AlphaBravoStereotype
+    static class FirstService {
+        public String ping() {
+            return "first";
+        }
+    }
+
+    @Singleton
+    @CharlieDeltaStereotype
+    static class SecondService {
+        public String ping() {
+            return "service";
+        }
+    }
+
+    static class ThirdService {
+        public String ping() {
+            return "third";
+        }
+    }
+
+    @Singleton
+    static class ThirdProducer {
+        @Produces
+        @Singleton
+        @EchoFoxtrotStereotype
+        public ThirdService produce() {
+            return new ThirdService();
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMultipleConditionsTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMultipleConditionsTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LookupMultipleConditionsTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AlphaService.class, BravoService.class))
+            .overrideConfigKey("service.alpha.enabled", "true")
+            .overrideConfigKey("service.alpha.active", "true")
+            .overrideConfigKey("service.bravo.enabled", "true")
+            .overrideConfigKey("service.bravo.active", "false");
+
+    @Inject
+    Instance<AlphaService> alpha;
+
+    @Inject
+    Instance<BravoService> bravo;
+
+    @Test
+    public void testConditions() {
+        assertTrue(alpha.isResolvable());
+        assertEquals("alpha", alpha.get().ping());
+        assertTrue(bravo.isUnsatisfied());
+    }
+
+    @LookupIfProperty(name = "service.alpha.enabled", stringValue = "true")
+    @LookupIfProperty(name = "service.alpha.active", stringValue = "true")
+    @Singleton
+    static class AlphaService {
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    @LookupIfProperty(name = "service.bravo.enabled", stringValue = "true")
+    @LookupIfProperty(name = "service.bravo.active", stringValue = "true")
+    @Singleton
+    static class BravoService {
+        public String ping() {
+            return "bravo";
+        }
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupIfProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupIfProperty.java
@@ -11,8 +11,8 @@ import jakarta.enterprise.inject.Instance;
 /**
  * Indicates that a bean should only be obtained by programmatic lookup if the property matches the provided value.
  * <p>
- * This annotation is repeatable. A bean will be included if all the conditions defined by the {@link LookupIfProperty} and
- * {@link LookupUnlessProperty} annotations are satisfied.
+ * This annotation is repeatable and may be put on a stereotype. A bean will be included if all the conditions
+ * defined by the {@link LookupIfProperty} and {@link LookupUnlessProperty} annotations are satisfied.
  *
  * <pre>
  * <code>
@@ -60,18 +60,19 @@ import jakarta.enterprise.inject.Instance;
 public @interface LookupIfProperty {
 
     /**
-     * Name of the runtime property to check
+     * Name of the runtime property to check.
      */
     String name();
 
     /**
-     * Expected {@code String} value of the runtime property (specified by {@code name}) if the bean should be looked up at
-     * runtime.
+     * Expected {@code String} value of the runtime property (specified by {@code name})
+     * if the bean should be looked up at runtime.
      */
     String stringValue();
 
     /**
-     * Determines if the bean is to be looked up when the property name specified by {@code name} has not been specified at all
+     * Determines if the bean should be looked up when the property specified by {@code name}
+     * has not been specified at all.
      */
     boolean lookupIfMissing() default false;
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
@@ -11,8 +11,8 @@ import jakarta.enterprise.inject.Instance;
 /**
  * Indicates that a bean should only be obtained by programmatic lookup if the property does not match the provided value.
  * <p>
- * This annotation is repeatable. A bean will be included if all the conditions defined by the {@link LookupUnlessProperty}
- * and {@link LookupIfProperty} annotations are satisfied.
+ * This annotation is repeatable and may be put on a stereotype. A bean will be included if all the conditions
+ * defined by the {@link LookupUnlessProperty} and {@link LookupIfProperty} annotations are satisfied.
  *
  * <pre>
  * <code>
@@ -60,19 +60,19 @@ import jakarta.enterprise.inject.Instance;
 public @interface LookupUnlessProperty {
 
     /**
-     * Name of the runtime time property to check
+     * Name of the runtime property to check.
      */
     String name();
 
     /**
-     * Expected {@code String} value of the runtime time property (specified by {@code name}) if the bean should be skipped at
-     * runtime.
+     * Expected {@code String} value of the runtime property (specified by {@code name})
+     * if the bean should NOT be looked up at runtime.
      */
     String stringValue();
 
     /**
-     * Determines if the bean should be looked up when the property name specified by {@code name} has not been specified at
-     * all
+     * Determines if the bean should be looked up when the property specified by {@code name}
+     * has not been specified at all.
      */
     boolean lookupIfMissing() default false;
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/profile/IfBuildProfile.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/profile/IfBuildProfile.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * When applied to a bean class or producer method (or field), the bean will only be enabled
+ * When applied to a bean class or producer method or field, the bean will only be enabled
  * if the Quarkus build time profile matches the rules of the annotation values.
  *
  * <blockquote>
@@ -42,6 +42,9 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * </blockquote>
+ *
+ * This annotation may be put on a stereotype. A bean will be enabled if all the conditions
+ * defined by the {@link IfBuildProfile} and {@link UnlessBuildProfile} annotations are satisfied.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/profile/UnlessBuildProfile.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/profile/UnlessBuildProfile.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * When applied to a bean class or producer method (or field), the bean will only be enabled
+ * When applied to a bean class or producer method or field, the bean will only be enabled
  * if the Quarkus build time profile does <b>not</b> match the rules of the annotation values.
  *
  * <blockquote>
@@ -43,6 +43,9 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * </blockquote>
+ *
+ * This annotation may be put on a stereotype. A bean will be enabled if all the conditions
+ * defined by the {@link IfBuildProfile} and {@link UnlessBuildProfile} annotations are satisfied.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/IfBuildProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/IfBuildProperty.java
@@ -7,14 +7,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * When applied to a bean class or producer method (or field), the bean will only be enabled
+ * When applied to a bean class or producer method or field, the bean will only be enabled
  * if the Quarkus build time property matches the provided value.
  * <p>
  * By default, the bean is not enabled when the build time property is not defined at all, but this behavior is configurable
  * via the {@code enableIfMissing} property.
  * <p>
- * This annotation is repeatable. A bean will only be enabled if all the conditions defined by the {@link IfBuildProperty}
- * annotations are satisfied.
+ * This annotation is repeatable and may be put on a stereotype. A bean will be enabled if all the conditions
+ * defined by the {@link IfBuildProperty} and {@link UnlessBuildProperty} annotations are satisfied.
  */
 @Repeatable(IfBuildProperty.List.class)
 @Retention(RetentionPolicy.RUNTIME)

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/UnlessBuildProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/UnlessBuildProperty.java
@@ -7,14 +7,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * When applied to a bean class or producer method (or field), the bean will only be enabled
+ * When applied to a bean class or producer method or field, the bean will only be enabled
  * if the Quarkus build time property does not match the provided value.
  * <p>
  * By default, the bean is not enabled when the build time property is not defined at all, but this behavior is configurable
  * via the {@code enableIfMissing} property.
  * <p>
- * This annotation is repeatable. A bean will only be enabled if all the conditions defined by the
- * {@link UnlessBuildProperty} annotations are satisfied.
+ * This annotation is repeatable and may be put on a stereotype. A bean will be enabled if all the conditions
+ * defined by the {@link IfBuildProperty} and {@link UnlessBuildProperty} annotations are satisfied.
  */
 @Repeatable(UnlessBuildProperty.List.class)
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
This commit also improves the `BuildTimeEnabledProcessor` slightly. If we use the on-demand ("computing") index, we can safely query the index for repeated annotations (using `annotationsWithRepeatable` and similar methods), instead of doing it manually.

- Closes: #52139