### PR TITLE
Don't invalidate cache on failure

### DIFF
--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/UniReturnTypeWithFailureTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/UniReturnTypeWithFailureTest.java
@@ -2,6 +2,18 @@ package io.quarkus.cache.test.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -17,10 +29,14 @@ import io.vertx.core.impl.NoStackTraceException;
 public class UniReturnTypeWithFailureTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withApplicationRoot((jar) -> jar.addClass(CachedService.class));
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClass(CachedService.class).addClass(ConcurrentFailureService.class));
 
     @Inject
     CachedService cachedService;
+
+    @Inject
+    ConcurrentFailureService concurrentFailureService;
 
     @Test
     void testCacheResult() {
@@ -30,6 +46,56 @@ public class UniReturnTypeWithFailureTest {
         assertEquals(2, cachedService.getCacheResultInvocations());
         assertEquals("", cachedService.cacheResult("k1").await().indefinitely());
         assertEquals(2, cachedService.getCacheResultInvocations());
+    }
+
+    /**
+     * Reproducer for #51928: After a failed Uni, several concurrent invocations
+     * may result in multiple method invocations instead of being synchronized.
+     */
+    @Test
+    void testConcurrentAccessAndRecovery() throws InterruptedException {
+        String key = "retry-resource-" + System.currentTimeMillis();
+        int numberOfConcurrentThreads = 30;
+        ExecutorService executor = Executors.newFixedThreadPool(numberOfConcurrentThreads);
+        CyclicBarrier startBarrier = new CyclicBarrier(numberOfConcurrentThreads + 1);
+
+        concurrentFailureService.resetCounter(key);
+
+        for (int i = 0; i < numberOfConcurrentThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    startBarrier.await();
+                    try {
+                        concurrentFailureService.getSingleArgData(key).await().indefinitely();
+                    } catch (NoStackTraceException e) {
+                        try {
+                            concurrentFailureService.getSingleArgData(key).await().indefinitely();
+                        } catch (Exception e2) {
+                            // Ignore
+                        }
+                    }
+                } catch (Exception e) {
+                    // Ignore
+                }
+            });
+        }
+
+        try {
+            startBarrier.await(5, TimeUnit.SECONDS);
+        } catch (BrokenBarrierException | TimeoutException e) {
+            // Ignore
+        }
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        int invocations = concurrentFailureService.getInvocations(key);
+        if (invocations > 2) {
+            assertTrue(false,
+                    String.format("Expected <= 2, but was %d for key %s. " +
+                            "This reproduces issue #51928 - multiple concurrent invocations after " +
+                            "failed Uni are not properly synchronized.",
+                            invocations, key));
+        }
     }
 
     @ApplicationScoped
@@ -48,6 +114,34 @@ public class UniReturnTypeWithFailureTest {
 
         public int getCacheResultInvocations() {
             return cacheResultInvocations;
+        }
+    }
+
+    @ApplicationScoped
+    static class ConcurrentFailureService {
+
+        private final Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+        public void resetCounter(String key) {
+            counters.put(key, new AtomicInteger(0));
+        }
+
+        public int getInvocations(String key) {
+            return counters.getOrDefault(key, new AtomicInteger(0)).get();
+        }
+
+        @CacheResult(cacheName = "concurrent-test-cache")
+        public Uni<String> getSingleArgData(String key) {
+            AtomicInteger counter = counters.computeIfAbsent(key, k -> new AtomicInteger(0));
+            int invocationNumber = counter.incrementAndGet();
+
+            if (invocationNumber == 1) {
+                return Uni.createFrom().item("delay")
+                        .onItem().delayIt().by(Duration.ofMillis(200))
+                        .onItem().transformToUni(s -> Uni.createFrom().failure(new NoStackTraceException("First call fails")));
+            } else {
+                return Uni.createFrom().item("success-" + key);
+            }
         }
     }
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
@@ -65,11 +65,6 @@ public class CacheResultInterceptor extends CacheInterceptor {
                             throw new CacheException(e);
                         }
                     }
-                }).onFailure().call(new Function<>() {
-                    @Override
-                    public Uni<?> apply(Throwable throwable) {
-                        return cache.invalidate(key).replaceWith(throwable);
-                    }
                 });
 
                 if (binding.lockTimeout() <= 0) {


### PR DESCRIPTION
I took a quick stab at #51928 

Reading the issue and attempting to reproduce I ended up convinced that @gsmet was right [here](https://github.com/quarkusio/quarkus/pull/39762/files#r1561078913) and we should not invalidate on failure.
The test is heavily inspired by what is happening in the QE testsuite (thanks @michalvavrik ).

- Fixes: #51928
