### PR TITLE
Support multiple named mongoclients while using panache

### DIFF
--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/MultipleMongoClientsTest.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/MultipleMongoClientsTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.mongodb.panache;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.mongodb.MongoClientName;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleMongoClientsTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.mongodb.devservices.enabled", "false")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("named-clients.properties"));
+
+    @Inject
+    WithDefaultMongoClientEntityRepository withDefaultMongoClientEntityRepository;
+
+    @Inject
+    WithMongoClient1EntityRepository withMongoClient1EntityRepository;
+
+    @Inject
+    WithMongoClient2EntityRepository withMongoClient2EntityRepository;
+
+    @Inject
+    @MongoClientName("mongoclient1")
+    MongoClient mongoClient1;
+
+    @Inject
+    @MongoClientName("mongoclient1")
+    ReactiveMongoClient reactiveMongoClient1;
+
+    @Inject
+    @MongoClientName("mongoclient2")
+    MongoClient mongoClient2;
+
+    @Inject
+    @MongoClientName("mongoclient2")
+    ReactiveMongoClient reactiveMongoClient2;
+
+    @Test
+    public void testMongoEntity() {
+        assertAll(
+                () -> assertEquals("default-mongoclient-db", withDefaultMongoClientEntityRepository.mongoDatabase().getName()),
+                () -> assertEquals("mongoclient1-db", withMongoClient1EntityRepository.mongoDatabase().getName()),
+                () -> assertEquals("mongoclient2-db", withMongoClient2EntityRepository.mongoDatabase().getName()),
+                () -> assertNotNull(reactiveMongoClient1),
+                () -> assertNotNull(reactiveMongoClient2));
+    }
+
+    @MongoEntity(database = "default-mongoclient-db")
+    public static class WithDefaultMongoClientEntity extends PanacheMongoEntity {
+        public String field;
+    }
+
+    @MongoEntity(database = "mongoclient1-db", clientName = "mongoclient1")
+    public static class WithMongoClient1Entity extends PanacheMongoEntity {
+        public String field;
+    }
+
+    @MongoEntity(database = "mongoclient2-db", clientName = "mongoclient2")
+    public static class WithMongoClient2Entity extends PanacheMongoEntity {
+        public String field;
+    }
+
+    @ApplicationScoped
+    public static class WithDefaultMongoClientEntityRepository implements PanacheMongoRepository<WithDefaultMongoClientEntity> {
+    }
+
+    @ApplicationScoped
+    public static class WithMongoClient1EntityRepository implements PanacheMongoRepository<WithMongoClient1Entity> {
+    }
+
+    @ApplicationScoped
+    public static class WithMongoClient2EntityRepository implements PanacheMongoRepository<WithMongoClient2Entity> {
+    }
+
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/resources/named-clients.properties
+++ b/extensions/panache/mongodb-panache/deployment/src/test/resources/named-clients.properties
@@ -1,0 +1,8 @@
+quarkus.mongodb.devservices.enabled=false
+
+quarkus.mongodb.connection-string=mongodb://localhost:27018
+quarkus.mongodb.database=default-mongoclient-db
+quarkus.mongodb.mongoclient1.connection-string=mongodb://localhost:27018
+quarkus.mongodb.mongoclient1.database=mongoclient1-db
+quarkus.mongodb.mongoclient2.connection-string=mongodb://localhost:27018
+quarkus.mongodb.mongoclient2.database=mongoclient2-db


### PR DESCRIPTION
Fixes a bug, where injection of named `MongoClient`'s (via @MongoClientName) breaks the internal bean resolution in mongodb-panache, causing a `java.lang.IllegalStateException` at runtime.

* Fixes #37168
* Fixes #41400

