### PR TITLE
JaCoCo: add support for QuarkusUnitTest

### DIFF
--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -2,12 +2,13 @@ package io.quarkus.jacoco.deployment;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -16,6 +17,7 @@ import org.codehaus.plexus.util.FileUtils;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
@@ -28,12 +30,16 @@ import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.index.IndexDependencyConfig;
+import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.jacoco.runtime.JacocoConfig;
 import io.quarkus.jacoco.runtime.ReportCreator;
 import io.quarkus.jacoco.runtime.ReportInfo;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
 public class JacocoProcessor {
@@ -45,10 +51,8 @@ public class JacocoProcessor {
         return new FeatureBuildItem("jacoco");
     }
 
-    private static final Map<String, BytecodeTransformerBuildItem> transformedClasses = new HashMap<>();
-
     @BuildStep(onlyIf = IsTest.class)
-    void transformerBuildItem(BuildProducer<BytecodeTransformerBuildItem> transformers,
+    void transform(BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformers,
             OutputTargetBuildItem outputTargetBuildItem,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             BuildSystemTargetBuildItem buildSystemTargetBuildItem,
@@ -67,55 +71,90 @@ public class JacocoProcessor {
         Path outputDir = outputTargetBuildItem.getOutputDirectory().toAbsolutePath();
         Files.createDirectories(outputDir);
 
+        // JaCoCo destFile - path to the output file for execution data
         Path dataFilePath = outputDir.resolve(config.dataFile().orElse(JacocoConfig.JACOCO_QUARKUS_EXEC));
         String dataFile = dataFilePath.toString();
 
         System.setProperty("jacoco-agent.destfile", dataFile);
         System.setProperty("jacoco-agent.jmx", "true");
 
+        // Use offline instrumentation to modify the bytecode of classes that should be analyzed
+        Set<ApplicationArchive> appArchives = applicationArchivesBuildItem.getAllApplicationArchives();
+        ApplicationModel appModel = curateOutcomeBuildItem.getApplicationModel();
         Instrumenter instrumenter = new Instrumenter(new OfflineInstrumentationAccessGenerator());
-        for (ApplicationArchive archive : applicationArchivesBuildItem.getAllApplicationArchives()) {
-            for (ClassInfo i : archive.getIndex().getKnownClasses()) {
-                String className = i.name().toString();
-                BytecodeTransformerBuildItem bytecodeTransformerBuildItem = transformedClasses.get(className);
-                if (bytecodeTransformerBuildItem == null) {
-                    bytecodeTransformerBuildItem = new BytecodeTransformerBuildItem.Builder().setClassToTransform(className)
-                            .setCacheable(true)
-                            .setInputTransformer(new BiFunction<>() {
-                                @Override
-                                public byte[] apply(String className, byte[] bytes) {
-                                    try {
-                                        byte[] enhanced = instrumenter.instrument(bytes, className);
-                                        if (enhanced == null) {
-                                            return bytes;
-                                        }
-                                        return enhanced;
-                                    } catch (IOException e) {
-                                        if (!log.isDebugEnabled()) {
-                                            log.warnf(
-                                                    "Unable to instrument class %s with JaCoCo: %s, keeping the original class",
-                                                    className, e.getMessage());
-                                        } else {
-                                            log.warnf(e,
-                                                    "Unable to instrument class %s with JaCoCo, keeping the original class",
-                                                    className);
-                                        }
-                                        return bytes;
-                                    }
-                                }
-                            }).build();
-                    transformedClasses.put(className, bytecodeTransformerBuildItem);
+        Set<String> transformed = new HashSet<>();
+        Collection<IndexDependencyConfig> instrumentArtifacts = config.instrumentArtifacts().values();
+        Set<GAC> instrumented = new HashSet<>();
+        if (instrumentArtifacts.isEmpty()) {
+            // By default, instrument classes from all application archives
+            for (ApplicationArchive archive : appArchives) {
+                instrument(instrumenter, transformed, archive.getIndex(), bytecodeTransformers);
+            }
+        } else {
+            // Instrument only artifacts from the config
+            for (IndexDependencyConfig artifact : instrumentArtifacts) {
+                IndexView index = null;
+                for (ApplicationArchive archive : appArchives) {
+                    if (archiveMatches(archive.getKey(), artifact.groupId(), artifact.artifactId(), artifact.classifier())) {
+                        index = archive.getIndex();
+                        instrumented.add(new GAC(archive.getKey().getGroupId(), archive.getKey().getArtifactId(),
+                                archive.getKey().getClassifier()));
+                        log.debugf("Instrument app archive %s", archive.getKey());
+                        break;
+                    }
                 }
-                transformers.produce(bytecodeTransformerBuildItem);
+                if (index == null) {
+                    // Not an app archive - make sure it's a resolved dependency and build the index
+                    for (ResolvedDependency d : appModel.getDependencies()) {
+                        if (dependencyMatches(d, artifact.groupId(), artifact.artifactId(), artifact.classifier())) {
+                            try {
+                                index = IndexingUtil.indexTree(d.getContentTree().open(), null);
+                                instrumented.add(new GAC(d.getGroupId(), d.getArtifactId(), d.getClassifier()));
+                                log.debugf("Instrument non-app archive artifact %s:%s", d.getGroupId(), d.getArtifactId());
+                            } catch (IOException ioe) {
+                                throw new UncheckedIOException(ioe);
+                            }
+                            break;
+                        }
+                    }
+                }
+                if (index != null) {
+                    instrument(instrumenter, transformed, index, bytecodeTransformers);
+                }
             }
         }
+
+        // Generating a report is a bit tricky, especially if we want to aggregate data from several modules.
+        // JaCoCo writes the coverage data on VM shutdown by default.
+        // So we register a shutdown hook that waits for the JaCoCo data file and generates the report afterwards.
+        // In a single-module Quarkus app/extension all we need is to prevent multiple shutdown hook registrations
+        // for a single test suite execution (all tests executed in a single module).
+        // Note that for @QuarkusTest a new build can be triggered e.g. by @TestProfile.
+        // And for @QuarkusUnitTest each test class triggers a separate build.
+        // So the system property check below will help.
+        // However, it will not help for multi-module projects:
+        //
+        // /my-extension-project
+        // │
+        // ├── /foo
+        // │   ├── runtime
+        // │   ├── deployment
+        // └── /bar (depends on foo)
+        //     ├── runtime
+        //     └── deployment
+        //
+        // Where each deployment module runs the test suite (in a separate VM), instruments classes
+        // and registers a shutdown hook to generate a report.
+        //
+        // For this use case, the JacocoConfig#aggregateReportData() must be set in order to serialize
+        // the source directories and class files for the report so that each ReportCreator can see the same configuration.
 
         String sysPropName = "io.quarkus.internal.jacoco.report-data-file";
         String currentDataFile = System.setProperty(sysPropName, dataFile);
         if (currentDataFile != null) {
             if (!currentDataFile.equals(dataFile)) {
                 System.err.println("Quarkus will use the Jacoco data file " + currentDataFile
-                        + ", not the configured data file " + dataFile + ", because another build item triggered a report.");
+                        + ", not the configured data file " + dataFile + ", because another build step triggered a report.");
             }
             return;
         }
@@ -125,38 +164,77 @@ public class JacocoProcessor {
         }
 
         if (config.report()) {
-            ReportInfo info = new ReportInfo();
+            ReportInfo info = new ReportInfo(config.aggregateReportData());
             info.dataFile = dataFilePath;
 
             Path targetPath = outputDir.resolve(config.reportLocation().orElse(JacocoConfig.JACOCO_REPORT));
             info.reportDir = targetPath.toString();
             info.errorFile = targetPath.resolve("error.txt");
             Files.deleteIfExists(info.errorFile);
-            String includes = String.join(",", config.includes());
-            String excludes = String.join(",", config.excludes().orElse(Collections.emptyList()));
             Set<String> classes = new HashSet<>();
             info.classFiles = classes;
 
             Set<String> sources = new HashSet<>();
-            final ApplicationModel model = curateOutcomeBuildItem.getApplicationModel();
-            if (model.getApplicationModule() != null) {
-                addProjectModule(model.getAppArtifact(), config, info, includes, excludes, classes, sources);
-            }
-            for (ResolvedDependency d : model.getDependencies()) {
-                // we can't use d.isWorkspaceModule() for now for some Gradle projects, which is why we check whether a workspace module is not null
-                if (d.isRuntimeCp() && d.getWorkspaceModule() != null) {
-                    addProjectModule(d, config, info, includes, excludes, classes, sources);
+            info.sourceDirectories = sources;
+            info.artifactId = buildSystemTargetBuildItem.getBaseName();
+
+            ReportCreator reportCreator = new ReportCreator(info, config);
+
+            String includes = String.join(",", config.includes());
+            String excludes = String.join(",", config.excludes().orElse(Collections.emptyList()));
+
+            // Add classes and sources for the current build
+            if (instrumentArtifacts.isEmpty()) {
+                if (appModel.getApplicationModule() != null) {
+                    addDependency(appModel.getAppArtifact(), config, info, includes, excludes);
+                }
+                for (ResolvedDependency d : appModel.getDependencies()) {
+                    // we can't use d.isWorkspaceModule() for now for some Gradle projects, which is why we check whether a workspace module is not null
+                    if (d.isRuntimeCp() && d.getWorkspaceModule() != null) {
+                        addDependency(d, config, info, includes, excludes);
+                    }
+                }
+            } else {
+                for (ResolvedDependency d : appModel.getDependencies()) {
+                    if (d.isRuntimeCp()
+                            && d.getWorkspaceModule() != null
+                            && instrumented.contains(new GAC(d.getGroupId(), d.getArtifactId(), d.getClassifier()))) {
+                        addDependency(d, config, info, includes, excludes);
+                    }
                 }
             }
 
-            info.sourceDirectories = sources;
-            info.artifactId = buildSystemTargetBuildItem.getBaseName();
-            Runtime.getRuntime().addShutdownHook(new Thread(new ReportCreator(info, config)));
+            Path reportSourcesFilePath = dataFilePath.getParent().resolve("report-sources.txt");
+            Path reportClassesFilePath = dataFilePath.getParent().resolve("report-classes.txt");
+
+            // Add classes and sources from previous builds
+            if (Files.isReadable(reportSourcesFilePath)) {
+                for (String line : Files.readAllLines(reportSourcesFilePath)) {
+                    String source = line.strip();
+                    if (!source.isEmpty()) {
+                        info.sourceDirectories.add(source);
+                    }
+                }
+            }
+            if (Files.isReadable(reportClassesFilePath)) {
+                for (String line : Files.readAllLines(reportClassesFilePath)) {
+                    String classFile = line.strip();
+                    if (!classFile.isEmpty()) {
+                        info.classFiles.add(classFile);
+                    }
+                }
+            }
+
+            // Write the current data
+            Files.write(reportSourcesFilePath, info.sourceDirectories);
+            Files.write(reportClassesFilePath, info.classFiles);
+
+            Runtime.getRuntime().addShutdownHook(new Thread(reportCreator));
         }
     }
 
-    private void addProjectModule(ResolvedDependency module, JacocoConfig config, ReportInfo info, String includes,
-            String excludes, Set<String> classes, Set<String> sources) throws Exception {
+    private void addDependency(ResolvedDependency module, JacocoConfig config, ReportInfo info, String includes,
+            String excludes) throws Exception {
         String dataFile = getFilePath(config.dataFile(), module.getWorkspaceModule().getBuildDir().toPath(),
                 JacocoConfig.JACOCO_QUARKUS_EXEC);
         info.savedData.add(new File(dataFile).getAbsolutePath());
@@ -165,13 +243,13 @@ public class JacocoProcessor {
         }
         for (SourceDir src : module.getSources().getSourceDirs()) {
             for (Path p : src.getSourceTree().getRoots()) {
-                sources.add(p.toAbsolutePath().toString());
+                info.sourceDirectories.add(p.toAbsolutePath().toString());
             }
             if (Files.isDirectory(src.getOutputDir())) {
                 for (final File file : FileUtils.getFiles(src.getOutputDir().toFile(), includes, excludes,
                         true)) {
                     if (file.getName().endsWith(".class")) {
-                        classes.add(file.getAbsolutePath());
+                        info.classFiles.add(file.getAbsolutePath());
                     }
                 }
             }
@@ -180,5 +258,71 @@ public class JacocoProcessor {
 
     private static String getFilePath(Optional<String> path, Path outputDirectory, String defaultRelativePath) {
         return path.orElse(outputDirectory.toAbsolutePath() + File.separator + defaultRelativePath);
+    }
+
+    private void instrument(Instrumenter instrumenter, Set<String> transformed, IndexView index,
+            BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformers) {
+        for (ClassInfo i : index.getKnownClasses()) {
+            String className = i.name().toString();
+            if (transformed.add(className)) {
+                BytecodeTransformerBuildItem bytecodeTransformer = new BytecodeTransformerBuildItem.Builder()
+                        .setClassToTransform(className)
+                        .setCacheable(true)
+                        .setInputTransformer(new BiFunction<>() {
+                            @Override
+                            public byte[] apply(String className, byte[] bytes) {
+                                try {
+                                    byte[] enhanced = instrumenter.instrument(bytes, className);
+                                    if (enhanced == null) {
+                                        return bytes;
+                                    }
+                                    return enhanced;
+                                } catch (IOException e) {
+                                    if (!log.isDebugEnabled()) {
+                                        log.warnf(
+                                                "Unable to instrument class %s with JaCoCo: %s, keeping the original class",
+                                                className, e.getMessage());
+                                    } else {
+                                        log.warnf(e,
+                                                "Unable to instrument class %s with JaCoCo, keeping the original class",
+                                                className);
+                                    }
+                                    return bytes;
+                                }
+                            }
+                        }).build();
+                bytecodeTransformers.produce(bytecodeTransformer);
+            }
+
+        }
+    }
+
+    public static boolean archiveMatches(ArtifactKey key, String groupId, Optional<String> artifactId,
+            Optional<String> classifier) {
+        if (Objects.equals(key.getGroupId(), groupId)
+                && (artifactId.isEmpty() || Objects.equals(key.getArtifactId(), artifactId.get()))) {
+            if (classifier.isPresent() && Objects.equals(key.getClassifier(), classifier.get())) {
+                return true;
+            } else if (!classifier.isPresent() && ArtifactCoords.DEFAULT_CLASSIFIER.equals(key.getClassifier())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean dependencyMatches(ResolvedDependency dependency, String groupId, Optional<String> artifactId,
+            Optional<String> classifier) {
+        if (Objects.equals(dependency.getGroupId(), groupId)
+                && (artifactId.isEmpty() || Objects.equals(dependency.getArtifactId(), artifactId.get()))) {
+            if (classifier.isPresent() && Objects.equals(dependency.getClassifier(), classifier.get())) {
+                return true;
+            } else if (!classifier.isPresent() && ArtifactCoords.DEFAULT_CLASSIFIER.equals(dependency.getClassifier())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    record GAC(String groupId, String artifactId, String classifier) {
     }
 }

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
@@ -1,9 +1,13 @@
 package io.quarkus.jacoco.runtime;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.deployment.index.IndexDependencyConfig;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -59,13 +63,13 @@ public interface JacocoConfig {
     /**
      * Footer text used in HTML report pages.
      */
-    public Optional<String> footer();
+    Optional<String> footer();
 
     /**
      * Encoding of the source files.
      */
     @WithDefault("UTF-8")
-    public String sourceEncoding();
+    String sourceEncoding();
 
     /**
      * A list of class files to include in the report. May use wildcard
@@ -79,7 +83,7 @@ public interface JacocoConfig {
      * </ul>
      */
     @WithDefault("**")
-    public List<String> includes();
+    List<String> includes();
 
     /**
      * A list of class files to exclude from the report. May use wildcard
@@ -92,12 +96,29 @@ public interface JacocoConfig {
      * <li><code>&#42;&#42;/&#42;BAR&#42;.class</code> targets classes that contain BAR in their name regardless of path</li>
      * </ul>
      */
-    public Optional<List<String>> excludes();
+    Optional<List<String>> excludes();
 
     /**
      * The location of the report files.
      * The path can be relative (to the module) or absolute.
      */
     @ConfigDocDefault(TARGET_JACOCO_REPORT)
-    public Optional<String> reportLocation();
+    Optional<String> reportLocation();
+
+    /**
+     * Artifacts that should be instrumented.
+     * <p>
+     * By default, all application archives are instrumented. This property allows for fine-grained configuration. It
+     * is also necessary for extension authors, because runtime modules are usually not application archives.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("dependency-name")
+    Map<String, IndexDependencyConfig> instrumentArtifacts();
+
+    /**
+     * If set to {@code true} then the report data (source directories and class files) are aggregated so that a single report
+     * can be generated.
+     */
+    @WithDefault("false")
+    boolean aggregateReportData();
 }

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportInfo.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportInfo.java
@@ -6,15 +6,18 @@ import static java.nio.file.StandardOpenOption.CREATE;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public class ReportInfo {
 
+    public final boolean preferSerializedData;
     public String reportDir;
     public Path dataFile;
     public final List<String> savedData = new ArrayList<>();
@@ -23,8 +26,54 @@ public class ReportInfo {
     public String artifactId;
     public Path errorFile;
 
+    public ReportInfo(boolean preferSerializedData) {
+        this.preferSerializedData = preferSerializedData;
+    }
+
     public void emitError(String msg) {
         emitError(msg, null);
+    }
+
+    public Set<String> getSourceDirectories() {
+        if (preferSerializedData) {
+            Path reportSourcesFilePath = dataFile.getParent().resolve("report-sources.txt");
+            if (Files.isReadable(reportSourcesFilePath)) {
+                Set<String> ret = new HashSet<>();
+                try {
+                    for (String line : Files.readAllLines(reportSourcesFilePath)) {
+                        String source = line.strip();
+                        if (!source.isEmpty()) {
+                            ret.add(source);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                return ret;
+            }
+        }
+        return sourceDirectories;
+    }
+
+    public Set<String> getClassFiles() {
+        if (preferSerializedData) {
+            Path reportClassesFilePath = dataFile.getParent().resolve("report-classes.txt");
+            if (Files.isReadable(reportClassesFilePath)) {
+                Set<String> ret = new HashSet<>();
+                try {
+                    for (String line : Files.readAllLines(reportClassesFilePath)) {
+                        String classFile = line.strip();
+                        if (!classFile.isEmpty()) {
+                            ret.add(classFile);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                return ret;
+            }
+        }
+        return classFiles;
     }
 
     @SuppressWarnings("CallToPrintStackTrace")


### PR DESCRIPTION
- also make it possible to aggregate report data so that it's possible to generate a single report for a multi-module project

The motivation for this PR was to make it possible to measure the test coverage for an extension project (potentially multi-module). In extensions, we usually use the `QuarkusUnitTest`s. Currently, `quarkus-jacoco` uses an offline instrumenter for all classes in all application archives to modify the bytecode of classes that should be analyzed. However, runtime modules and SPIs are usually not application archives. Therefore, it was not possible to measure the coverage (or at least I did not find a way ;-).

In this PR we:
- introduce the `JacocoConfig.instrumentArtifacts()` config that can be used to explicitly define artifacts that should be instrumented; this is how it looks in practice: https://github.com/mkouba/quarkus-mcp-server/blob/jacoco/transports/http/deployment/pom.xml#L148-L151 (here the deployment module includes tests for both `quarkus-mcp-server-core` and `quarkus-mcp-server-http` artifacts)
- introduce the `JacocoConfig.aggregateReportData()` config that must be used if we want to aggregate data from several modules in a single report

I'm no JaCoCo expert and I have to admit that the current status of the extension is far from being ideal. Especially the implementation of the reporting part is really confusing. But I didn't find a better solution TBH, also any major refactoring would be out of scope (and beyond my knowledge :shrug:).

If this gets merged I'd like to write a blogpost about how to configure an extension project to leverage the `quarkus-jacoco` extension. Basically describe what I did in the MCP server: https://github.com/mkouba/quarkus-mcp-server/tree/jacoco.