### PR TITLE
Hibernate ORM - Generate empty package-info if AOT enabled

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/AotClassLoadingEnabled.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/AotClassLoadingEnabled.java
@@ -1,0 +1,19 @@
+package io.quarkus.deployment.pkg;
+
+import java.util.function.BooleanSupplier;
+
+public class AotClassLoadingEnabled implements BooleanSupplier {
+
+    private final PackageConfig packageConfig;
+
+    AotClassLoadingEnabled(PackageConfig packageConfig) {
+        this.packageConfig = packageConfig;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return packageConfig.jar().enabled() &&
+                packageConfig.jar().appcds().enabled() &&
+                packageConfig.jar().appcds().useAot();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/PackageInfoGenerationTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/PackageInfoGenerationTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.orm.packageinfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.packageinfo.withoutpackageinfo.EntityWithoutPackageInfo;
+import io.quarkus.hibernate.orm.packageinfo.withpackageinfo.EntityWithPackageInfo;
+import io.quarkus.hibernate.orm.packageinfo.withpackageinfo.TestAnnotation;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that package-info files are generated for packages with entities when AOT class loading is enabled.
+ * - Existing package-info files should NOT be overwritten
+ * - Missing package-info files should be generated (empty)
+ */
+public class PackageInfoGenerationTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addPackage(EntityWithPackageInfo.class.getPackage())
+                    .addPackage(EntityWithoutPackageInfo.class.getPackage()))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.package.jar.enabled", "true")
+            .overrideConfigKey("quarkus.package.jar.appcds.enabled", "true")
+            .overrideConfigKey("quarkus.package.jar.appcds.use-aot", "true");
+
+    @Test
+    public void testExistingPackageInfoNotOverwritten() throws Exception {
+        // Verify that the existing package-info with @TestAnnotation is preserved
+        Class<?> packageInfoClass = Class.forName(
+                "io.quarkus.hibernate.orm.packageinfo.withpackageinfo.package-info", true,
+                Thread.currentThread().getContextClassLoader());
+        assertThat(packageInfoClass).isNotNull();
+
+        // Check that our custom annotation is still present
+        TestAnnotation annotation = packageInfoClass.getAnnotation(TestAnnotation.class);
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.value()).isEqualTo("original");
+    }
+
+    @Test
+    public void testMissingPackageInfoGenerated() throws Exception {
+        // Verify that a package-info was generated for the package without one
+        Class<?> packageInfoClass = Class.forName(
+                "io.quarkus.hibernate.orm.packageinfo.withoutpackageinfo.package-info", true,
+                Thread.currentThread().getContextClassLoader());
+        assertThat(packageInfoClass).isNotNull();
+
+        // It should be a synthetic interface
+        assertThat(packageInfoClass.isInterface()).isTrue();
+        assertThat(packageInfoClass.isSynthetic()).isTrue();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withoutpackageinfo/EntityWithoutPackageInfo.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withoutpackageinfo/EntityWithoutPackageInfo.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.packageinfo.withoutpackageinfo;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class EntityWithoutPackageInfo {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public EntityWithoutPackageInfo() {
+    }
+
+    public EntityWithoutPackageInfo(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withpackageinfo/EntityWithPackageInfo.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withpackageinfo/EntityWithPackageInfo.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.packageinfo.withpackageinfo;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class EntityWithPackageInfo {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public EntityWithPackageInfo() {
+    }
+
+    public EntityWithPackageInfo(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withpackageinfo/TestAnnotation.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withpackageinfo/TestAnnotation.java
@@ -1,0 +1,12 @@
+package io.quarkus.hibernate.orm.packageinfo.withpackageinfo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PACKAGE)
+public @interface TestAnnotation {
+    String value();
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withpackageinfo/package-info.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/withpackageinfo/package-info.java
@@ -1,0 +1,2 @@
+@TestAnnotation("original")
+package io.quarkus.hibernate.orm.packageinfo.withpackageinfo;

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -66,7 +66,6 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -303,7 +302,7 @@ class ReactiveRoutesProcessor {
                         return true;
                     }
                 }
-                return GeneratedClassGizmoAdaptor.isApplicationClass(className);
+                return GeneratedClassGizmo2Adaptor.isApplicationClass(className);
             }
         };
         Gizmo gizmo = Gizmo.create(new GeneratedClassGizmo2Adaptor(generatedClass, generatedResource, appClassPredicate))


### PR DESCRIPTION
When a package contains managed classes and there is no package-info to be found, we generate an empty one to avoid a negative lookup.

This is useful when we build an AOT class loading cache (and only enabled if we do) as it prevents the cost of a lookup in all jars of the classpath.

Note that if at some point, we can use our very own class loader with Project Leyden, this might not be useful anymore.

The fix is related to this profiling data:

<img width="2926" height="1099" alt="Screenshot From 2026-01-29 17-11-29" src="https://github.com/user-attachments/assets/d119adb4-d5b9-43ed-bef1-439d0518af35" />

<img width="2926" height="1099" alt="Screenshot From 2026-01-29 17-11-53" src="https://github.com/user-attachments/assets/bda6113d-da88-4dec-914d-7a36afdf73e4" />

Obtained from this profile: 
[aot-cpu.html](https://github.com/user-attachments/files/24942494/aot-cpu.html)

Note that it was obtained with an application with a lot of entities, all in different packages, so not really representative of the reality.
Still, we are getting the package information way too often.