### PR TITLE
New Assistant component to navigate to the chat screen

### DIFF
--- a/docs/src/main/asciidoc/assistant.adoc
+++ b/docs/src/main/asciidoc/assistant.adoc
@@ -300,6 +300,7 @@ To maintain visual consistency with other Dev Assistant features, use the follow
 
 - `<qui-assistant-button>`: A pre-styled pink button with a robot icon.
 - `<qui-assistant-warning>`: A standard warning message with the text: `"Quarkus assistant can make mistakes. Check responses."`
+- `<qui-assistant-chat>`: A button that deep-link to the chat screen with the current chat.`
 
 You can also use the CSS var `--quarkus-assistant` anywhere you want to apply the assistant's theme color.
 

--- a/extensions/assistant/runtime-dev/src/main/java/io/quarkus/assistant/runtime/dev/Assistant.java
+++ b/extensions/assistant/runtime-dev/src/main/java/io/quarkus/assistant/runtime/dev/Assistant.java
@@ -38,6 +38,29 @@ public interface Assistant {
         return new AssistBuilder(this);
     }
 
+    /**
+     * Return the memory Id from the last assistance. Could be null
+     *
+     * @return
+     */
+    public String getMemoryId();
+
+    /**
+     * Return the path to the assistant implementation chat screen
+     *
+     * @return
+     */
+    public String getChatPath();
+
+    /**
+     * Get the link to the chat screen given the current active chat
+     *
+     * @return
+     */
+    default String getLinkToChatScreen() {
+        return getChatPath() + "?memoryId=" + getMemoryId();
+    }
+
     // Builder class
     class AssistBuilder {
         private final Assistant assistant;

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -133,6 +133,7 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("qui-themed-code-block", contextRoot + "qui/qui-themed-code-block.js");
         internalImportMapBuildItem.add("qui-assistant-warning", contextRoot + "qui/qui-assistant-warning.js");
         internalImportMapBuildItem.add("qui-assistant-button", contextRoot + "qui/qui-assistant-button.js");
+        internalImportMapBuildItem.add("qui-assistant-chat", contextRoot + "qui/qui-assistant-chat.js");
 
         // Echarts
         internalImportMapBuildItem.add("echarts/", contextRoot + "echarts/");

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -69,6 +69,7 @@ import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.devui.deployment.extension.Codestart;
 import io.quarkus.devui.deployment.extension.Extension;
 import io.quarkus.devui.deployment.jsonrpc.DevUIDatabindCodec;
+import io.quarkus.devui.runtime.AssistantJsonRPCService;
 import io.quarkus.devui.runtime.DevUIBuildTimeStaticService;
 import io.quarkus.devui.runtime.DevUIRecorder;
 import io.quarkus.devui.runtime.VertxRouteInfoService;
@@ -452,6 +453,11 @@ public class DevUIProcessor {
         String countryCode = locale.getCountry();
 
         locales.add(new LanguageCountry(code, displayLanguage + " (" + countryCode + ")"));
+    }
+
+    @BuildStep
+    JsonRPCProvidersBuildItem createAssistantJsonRPCService() {
+        return new JsonRPCProvidersBuildItem("devui-assistant", AssistantJsonRPCService.class);
     }
 
     /**

--- a/extensions/devui/resources/src/main/resources/dev-ui/controller/router-controller.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/controller/router-controller.js
@@ -163,6 +163,13 @@ export class RouterController {
         Router.go({pathname: pageRef});
     }
 
+    goToPath(path){
+        const [before, after] = path.split("?", 2);
+        const pathname = RouterController.getBasePath() + before;
+        const search = after ? `?${new URLSearchParams(after).toString()}` : "";
+        Router.go({ pathname, search });
+    }
+
     navigate(pageRef){
         Router.go(pageRef);
     }

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/de.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/de.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'Keine Daten gefunden',
     'assistant-warning-explanation': 'Der Quarkus-Assistent kann Fehler machen. Überprüfen Sie die Antworten.',
     'assistant-warning': 'Warnung',
+    'assistant-chat-title' : 'Zum Assistenten-Chat wechseln, um diese Unterhaltung fortzusetzen.',
+    'assistant-chat-button' : 'Chat',
     'footer-server': 'Server',
     'footer-testing': 'Testen',
     'footer-dev_ui': 'Entwickler-UI',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/el.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/el.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'Δεν βρέθηκαν δεδομένα.',
     'assistant-warning-explanation': 'Ο βοηθός Quarkus μπορεί να κάνει λάθη. Ελέγξτε τις απαντήσεις.',
     'assistant-warning': 'Προειδοποίηση',
+    'assistant-chat-title' : 'Μετάβαση στη συνομιλία του βοηθού για να συνεχίσετε τη συζήτηση.',
+    'assistant-chat-button' : 'Συνομιλία',
     'footer-server': 'Διακομιστής',
     'footer-testing': 'Δοκιμή',
     'footer-dev_ui': 'Διεπαφή Προγραμματιστή',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/en.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/en.js
@@ -62,6 +62,8 @@ export const templates = {
     // Assistant
     'assistant-warning-explanation': 'Quarkus assistant can make mistakes. Check responses.',
     'assistant-warning': 'Warning',
+    'assistant-chat-title' : 'Go to the assistant chat screen to continue this discussion.',
+    'assistant-chat-button' : 'Chat',
     
     // Footer
     'footer-server': 'Server',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/es.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/es.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'No se encontraron datos.',
     'assistant-warning-explanation': 'El asistente de Quarkus puede cometer errores. Verifica las respuestas.',
     'assistant-warning': 'Advertencia',
+    'assistant-chat-title' : 'Ir al chat del asistente para continuar la conversación.',
+    'assistant-chat-button' : 'Chat',
     'footer-server': 'Servidor',
     'footer-testing': 'Pruebas',
     'footer-dev_ui': 'Interfaz de Desarrollo',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/fr.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/fr.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'Aucune donnée trouvée',
     'assistant-warning-explanation': 'L\'assistant Quarkus peut faire des erreurs. Vérifiez les réponses.',
     'assistant-warning': 'Avertissement',
+    'assistant-chat-title' : 'Aller au chat de l’assistant pour continuer la discussion.',
+    'assistant-chat-button' : 'Chat',
     'footer-server': 'Serveur',
     'footer-testing': 'Test de fonctionnement',
     'footer-dev_ui': 'Interface de développement',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/hi-IN.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/hi-IN.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'कोई डेटा नहीं मिला',
     'assistant-warning-explanation': 'क्वार्कस सहायक गलतियाँ कर सकता है। उत्तरों की जाँच करें।',
     'assistant-warning': 'चेतावनी',
+    'assistant-chat-title' : 'चर्चा जारी रखने के लिए सहायक चैट पर जाएँ।',
+    'assistant-chat-button' : 'चैट',
     'footer-server': 'सर्वर',
     'footer-testing': 'परीक्षण',
     'footer-dev_ui': 'डेव UI',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/it.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/it.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'Nessun dato trovato',
     'assistant-warning-explanation': 'L\'assistente di Quarkus può fare errori. Controlla le risposte.',
     'assistant-warning': 'Attenzione',
+    'assistant-chat-title' : 'Vai alla chat dell’assistente per continuare la conversazione.',
+    'assistant-chat-button' : 'Chat',
     'footer-server': 'Server',
     'footer-testing': 'Testare',
     'footer-dev_ui': 'Interfaccia di sviluppo',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/ja-JP.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/ja-JP.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'データが見つかりませんでした。',
     'assistant-warning-explanation': 'Quarkusアシスタントは間違いを犯すことがあります。応答を確認してください。',
     'assistant-warning': '警告',
+    'assistant-chat-title' : '会話を続けるにはアシスタントのチャットへ移動',
+    'assistant-chat-button' : 'チャット',
     'footer-server': 'サーバー',
     'footer-testing': 'テスト中',
     'footer-dev_ui': '開発者 UI',

--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/pt.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/pt.js
@@ -56,6 +56,8 @@ export const templates = {
     'devmcp-no-data': 'Nenhum dado encontrado',
     'assistant-warning-explanation': 'O assistente do Quarkus pode cometer erros. Verifique as respostas.',
     'assistant-warning': 'Aviso',
+    'assistant-chat-title' : 'Ir para o chat do assistente para continuar a conversa.',
+    'assistant-chat-button' : 'Chat',
     'footer-server': 'Servidor',
     'footer-testing': 'Teste',
     'footer-dev_ui': 'Interface de Desenvolvimento',

--- a/extensions/devui/resources/src/main/resources/dev-ui/qui/qui-assistant-button.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qui/qui-assistant-button.js
@@ -32,7 +32,7 @@ export class QuiAssistantButton extends LitElement {
         return html`
             <vaadin-button
                 ?disabled=${this.disabled}
-                title=${this.title}
+                title="${this.title}"
                 @click=${(e) => this._handleClick(e)}>
                     <vaadin-icon icon="font-awesome-solid:robot"></vaadin-icon>
                     <slot></slot>

--- a/extensions/devui/resources/src/main/resources/dev-ui/qui/qui-assistant-chat.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qui/qui-assistant-chat.js
@@ -1,0 +1,57 @@
+import {LitElement, html, css} from 'lit';
+import '@vaadin/button';
+import '@vaadin/icon';
+import { JsonRpc } from 'jsonrpc';
+import { msg, updateWhenLocaleChanges } from 'localization';
+import { RouterController } from 'router-controller';
+
+export class QuiAssistantChat extends LitElement {
+    
+    routerController = new RouterController(this);
+    jsonRpc = new JsonRpc("devui-assistant", true);
+
+    static styles = css`
+        vaadin-button {
+            color: var(--quarkus-assistant);
+            --lumo-button-size: var(--lumo-size-s);
+            background: var(--vaadin-button-tertiary-background);
+            --vaadin-button-min-width: 0;
+        }
+    `;
+
+    static properties = {
+        disabled: { type: Boolean, reflect: true },
+        title: { type: String }
+    };
+
+    constructor() {
+        super();
+        this.disabled = false;
+        this.title = msg('Go to the assistant chat screen to continue this discussion.', { id: 'assistant-chat-title' });
+    }
+    
+    connectedCallback() {
+        super.connectedCallback();
+    }
+
+    render() {
+        return html`
+            <vaadin-button
+                ?disabled=${this.disabled}
+                title="${this.title}"
+                @click=${(e) => this._navigateToChat(e)}>
+                    <vaadin-icon icon="font-awesome-solid:comment-dots"></vaadin-icon>
+                    <slot>${msg('Chat', { id: 'assistant-chat-button' })}</slot>
+            </vaadin-button>
+          `;
+    }
+    
+    _navigateToChat(){
+        this.jsonRpc.getLinkToChat().then(jsonRpcResponse => { 
+            this._linkToChat = jsonRpcResponse.result;
+            this.routerController.goToPath(this._linkToChat);
+        });
+    }
+}
+
+customElements.define('qui-assistant-chat', QuiAssistantChat);

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/AssistantJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/AssistantJsonRPCService.java
@@ -1,0 +1,22 @@
+package io.quarkus.devui.runtime;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.assistant.runtime.dev.Assistant;
+
+@ApplicationScoped
+public class AssistantJsonRPCService {
+
+    @Inject
+    Optional<Assistant> assistant;
+
+    public String getLinkToChat() {
+        if (assistant.isPresent()) {
+            return assistant.get().getLinkToChatScreen();
+        }
+        return null;
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/main/resources/dev-ui/qwc-graphql-generate-client.js
+++ b/extensions/smallrye-graphql/deployment/src/main/resources/dev-ui/qwc-graphql-generate-client.js
@@ -5,12 +5,13 @@ import '@vaadin/progress-bar';
 import '@vaadin/button';
 import '@vaadin/icon';
 import 'qui-themed-code-block';
+import 'qui-assistant-chat';
 import { notifier } from 'notifier';
 import { msg, str, updateWhenLocaleChanges } from 'localization';
 
 export class QwcGraphqlGenerateClient extends LitElement {
     jsonRpc = new JsonRpc(this);
-
+    
     static styles = css`
     :host {
         display: flex;
@@ -45,7 +46,10 @@ export class QwcGraphqlGenerateClient extends LitElement {
         color: var(--lumo-secondary-text-color);
         margin-bottom: 1em;
     }
-    
+    .buttons {
+        display: flex;
+        gap: 5px;
+    }
   `;
 
     static properties = {
@@ -135,10 +139,13 @@ export class QwcGraphqlGenerateClient extends LitElement {
         return html`
       <div class="generatedcode">
         <div class="heading">${msg(str`${ll} code generated from the GraphQL Schema with Quarkus assistant:`, { id: 'quarkus-smallrye-graphql-code-generated' })}
-            <vaadin-button theme="secondary" @click="${() => this._copyGeneratedContent(lang.value)}">
-                <vaadin-icon icon="font-awesome-solid:copy"></vaadin-icon>
-                ${msg('Copy', { id: 'quarkus-smallrye-graphql-copy' })}
-            </vaadin-button>
+            <div class="buttons">
+                <vaadin-button theme="secondary" @click="${() => this._copyGeneratedContent(lang.value)}">
+                    <vaadin-icon icon="font-awesome-solid:copy"></vaadin-icon>
+                    ${msg('Copy', { id: 'quarkus-smallrye-graphql-copy' })}
+                </vaadin-button>
+                <qui-assistant-chat></qui-assistant-chat>
+            </div>
         </div>
         <qui-themed-code-block
             mode="${lang.mode}"


### PR DESCRIPTION
This allows extension developers to add a button that will deep link into the chat screen to continue the chat as started by some assistant function in their dev ui.

As simple as adding `<qui-assistant-chat>`

As discussed with @alesj 