### PR TITLE
Vert.x - Avoid reflection when creating virtual thread factory

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -8,10 +8,13 @@ import static io.quarkus.vertx.deployment.VertxConstants.UNI;
 import static io.quarkus.vertx.deployment.VertxConstants.isMessage;
 import static io.quarkus.vertx.deployment.VertxConstants.isMessageHeaders;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.BiFunction;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
@@ -20,6 +23,7 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.jboss.logging.Logger;
+import org.objectweb.asm.ClassVisitor;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AutoAddScopeBuildItem;
@@ -46,6 +50,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AnnotationProxyBuildItem;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -59,7 +64,13 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
+import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem.JavaVersion.Status;
 import io.quarkus.deployment.recording.RecorderContext;
+import io.quarkus.gizmo.ClassTransformer;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.vertx.ConsumeEvent;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
@@ -70,6 +81,7 @@ import io.quarkus.vertx.runtime.VertxProducer;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.impl.VertxImpl;
 
 class VertxProcessor {
 
@@ -293,5 +305,70 @@ class VertxProcessor {
         reflectiveMethods.produce(new ReflectiveMethodBuildItem("java.lang.Thread$Builder$OfVirtual", "name",
                 String.class, long.class));
         reflectiveMethods.produce(new ReflectiveMethodBuildItem("java.lang.Thread$Builder", "factory", new Class[0]));
+    }
+
+    @BuildStep
+    void simplifyVertxImplGetVirtualThreadFactoryOnJava21(CompiledJavaVersionBuildItem compiledJavaVersion,
+            BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformers) {
+        // if we haven't been able to determine the compilation target, we don't do anything
+        if (compiledJavaVersion.getJavaVersion().isJava21OrHigher() == Status.UNKNOWN) {
+            return;
+        }
+
+        String className = VertxImpl.class.getName();
+        bytecodeTransformers.produce(new BytecodeTransformerBuildItem.Builder().setClassToTransform(className)
+                .setCacheable(true).setVisitorFunction(
+                        new BiFunction<>() {
+                            @Override
+                            public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                                ClassTransformer transformer = new ClassTransformer(className);
+
+                                MethodDescriptor virtualThreadFactoryDescriptor = MethodDescriptor.ofMethod(
+                                        className,
+                                        "virtualThreadFactory",
+                                        ThreadFactory.class);
+
+                                transformer.removeMethod(virtualThreadFactoryDescriptor);
+
+                                MethodCreator method = transformer.addMethod(virtualThreadFactoryDescriptor)
+                                        .setModifiers(Modifier.STATIC | Modifier.PRIVATE);
+
+                                if (compiledJavaVersion.getJavaVersion()
+                                        .isJava21OrHigher() == CompiledJavaVersionBuildItem.JavaVersion.Status.TRUE) {
+                                    // 1. Invoke Thread.ofVirtual() -> returns Thread.Builder.OfVirtual
+                                    ResultHandle builderOfVirtual = method.invokeStaticMethod(
+                                            MethodDescriptor.ofMethod(Thread.class, "ofVirtual",
+                                                    "java.lang.Thread$Builder$OfVirtual"));
+
+                                    // 2. Invoke builder.name(String, long) -> returns Thread.Builder.OfVirtual
+                                    // Note: long requires a ResultHandle; 0L is loaded as a constant
+                                    ResultHandle namePrefix = method.load("vert.x-virtual-thread-");
+                                    ResultHandle startValue = method.load(0L);
+
+                                    ResultHandle namedBuilder = method.invokeInterfaceMethod(
+                                            MethodDescriptor.ofMethod("java.lang.Thread$Builder$OfVirtual", "name",
+                                                    "java.lang.Thread$Builder$OfVirtual", String.class, long.class),
+                                            builderOfVirtual,
+                                            namePrefix,
+                                            startValue);
+
+                                    // 3. Invoke builder.factory() -> returns ThreadFactory
+                                    // This method is defined on the parent interface Thread.Builder
+                                    ResultHandle factory = method.invokeInterfaceMethod(
+                                            MethodDescriptor.ofMethod("java.lang.Thread$Builder", "factory",
+                                                    ThreadFactory.class),
+                                            namedBuilder);
+
+                                    // 4. Return the factory
+                                    method.returnValue(factory);
+                                } else {
+                                    // return null if JDK < 21
+                                    method.returnValue(method.loadNull());
+                                }
+
+                                return transformer.applyTo(classVisitor);
+                            }
+                        })
+                .build());
     }
 }


### PR DESCRIPTION
Similar to what was done in #51931.

Hopefully, in future Vert.x, we'll be able to use MR jars.
