### PR TITLE
Trivial: Add missing @Override annotations on CustomLauncherInterceptor

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
@@ -162,10 +162,12 @@ public class CustomLauncherInterceptor
      * <p>
      * Called from the same thread as {@link #testPlanExecutionFinished(TestPlan)}.
      *
-     * In continuous testing, the test plan listener seems not to be called, perhaps because of a different execution model.
+     * In continuous testing, the test plan listener seems not to be called, perhaps because it passes in its own
+     * TestExecutionListener and that overrides what is found with service loading.
      *
      * @param testPlan describes the tree of tests about to be executed
      */
+    @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
         // Do nothing, but have the method here for symmetry :)
     }
@@ -180,10 +182,12 @@ public class CustomLauncherInterceptor
      * If tests failed and are rerun by surefire, the same session will be used for all runs, so we need to get rid of the
      * FacadeClassLoader associated with the previous run, since its app will be closed and its classloaders will all be stale.
      *
-     * In continuous testing, the test plan listener seems not to be called, perhaps because of a different execution model.
+     * In continuous testing, the test plan listener seems not to be called, perhaps because it passes in its own
+     * TestExecutionListener and that overrides what is found with service loading.
      *
      * @param testPlan describes the tree of tests that have been executed
      */
+    @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
         clearContextClassloader();
     }


### PR DESCRIPTION
I just spotted that some override annotations were missing. It seems trivial, but it briefly confused me because I thought `CustomLauncherInterceptor` didn't implement an interface it actually did. I hate to do a whole CI run for such a small change, but I want to get the fix in before I lose it. 