### PR TITLE
Bump kubernetes-client-bom from 7.5.1 to 7.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Properties below are set in this file because they are used
              in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.14</jacoco.version>
-        <kubernetes-client.version>7.5.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>7.5.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
         <hibernate-orm.version>7.2.1.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
Kubernetes Client 7.5.2 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v7.5.2

The patch release just includes a version bump for the latest Vert.x 4 release.
Given Quarkus has its own HTTP client implementation and its own Vert.x dependencies, it should not have any effect.

/cc @metacosm