### PR TITLE
Fix trailing slash handling in forwarded prefix

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/LocationUtil.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/LocationUtil.java
@@ -52,6 +52,9 @@ final class LocationUtil {
                 if (!forwardedPrefix.startsWith("/")) {
                     forwardedPrefix = "/" + forwardedPrefix;
                 }
+                if (forwardedPrefix.endsWith("/")) {
+                    forwardedPrefix = forwardedPrefix.substring(0, forwardedPrefix.length() - 1);
+                }
                 prefix = forwardedPrefix + prefix;
             }
         }


### PR DESCRIPTION
When a forwarded prefix ends with a trailing slash (e.g., "/forwarded-prefix/"), the UriInfo base URI was incorrectly constructed with a double slash.

This fix strips trailing slashes from the forwarded prefix before concatenating it with the deployment prefix, ensuring correct URI construction.