### PR TITLE
Fix narayana-jta restart in dev mode, issue 35839

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/QuarkusRecoveryService.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/QuarkusRecoveryService.java
@@ -10,6 +10,7 @@ import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 public class QuarkusRecoveryService extends RecoveryManagerService {
     private static RecoveryManagerService recoveryManagerService;
     private List<XAResourceRecovery> xaResources;
+    private List<XAResourceRecovery> registeredXaResources;
     private boolean isCreated;
 
     public static RecoveryManagerService getInstance() {
@@ -21,6 +22,7 @@ public class QuarkusRecoveryService extends RecoveryManagerService {
 
     private QuarkusRecoveryService() {
         xaResources = new ArrayList<>();
+        registeredXaResources = new ArrayList<>();
         isCreated = false;
     }
 
@@ -28,6 +30,7 @@ public class QuarkusRecoveryService extends RecoveryManagerService {
     public void addXAResourceRecovery(XAResourceRecovery xares) {
         if (isCreated) {
             super.addXAResourceRecovery(xares);
+            registeredXaResources.add(xares);
         } else {
             xaResources.add(xares);
         }
@@ -38,24 +41,47 @@ public class QuarkusRecoveryService extends RecoveryManagerService {
         if (isCreated) {
             super.removeXAResourceRecovery(xares);
         } else {
+            // Remove from pending list if not yet created
             xaResources.remove(xares);
         }
+        // Always remove from registered list to handle datasources closing after destroy()
+        registeredXaResources.remove(xares);
     }
 
     @Override
     public void create() {
         super.create();
+
         isCreated = true;
         for (XAResourceRecovery xares : xaResources) {
             super.addXAResourceRecovery(xares);
+            registeredXaResources.add(xares);
         }
         xaResources.clear();
     }
 
     @Override
+    public void stop() {
+
+        // Deregister all recovery helpers before the recoveryMenager is terminated
+        //to prevent the periodic recovery scanner from continuing to use their connections
+        for (XAResourceRecovery xares : new ArrayList<>(registeredXaResources)) {
+            super.removeXAResourceRecovery(xares);
+        }
+        registeredXaResources.clear();
+
+        try {
+            super.stop();
+        } catch (Exception e) {
+        }
+
+        isCreated = false;
+    }
+
+    @Override
     public void destroy() {
         super.destroy();
-        isCreated = false;
         recoveryManagerService = null;
     }
+
 }


### PR DESCRIPTION
Deregister xa resources helpers in stop method before terminating the recoveryManager

Please note: stop() is called before destroy()

* Fixes [#35839](https://github.com/quarkusio/quarkus/issues/35839)