### PR TITLE
Enable native access for mongodb-crypt

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -57,6 +57,7 @@ import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ModuleEnableNativeAccessBuildItem;
 import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -517,5 +518,11 @@ public class MongoClientProcessor {
                                 + String.join(", ", entry.getValue()))));
             }
         }
+    }
+
+    @BuildStep
+    ModuleEnableNativeAccessBuildItem mongoCryptEnableNativeAccess() {
+        // mongodb-crypt uses JNI to load libmongocrypt native library for client-side encryption
+        return new ModuleEnableNativeAccessBuildItem("com.mongodb.crypt.capi");
     }
 }


### PR DESCRIPTION
Following up on [#52171](https://github.com/quarkusio/quarkus/issues/52171) for MongoDB needs