### PR TITLE
Bump smallrye-open-api.version from 4.2.3 to 4.2.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,7 +48,7 @@
         <smallrye-common.version>2.15.0</smallrye-common.version>
         <smallrye-config.version>3.15.1</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
-        <smallrye-open-api.version>4.2.3</smallrye-open-api.version>
+        <smallrye-open-api.version>4.2.4</smallrye-open-api.version>
         <smallrye-graphql.version>2.17.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.10.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>
@@ -152,6 +152,7 @@
         <kotlin.version>2.3.0</kotlin.version>
         <kotlin.coroutine.version>1.10.2</kotlin.coroutine.version>
         <kotlin-serialization.version>1.10.0</kotlin-serialization.version>
+        <kotlin-metadata.version>0.9.0</kotlin-metadata.version>
         <azure.toolkit-lib.version>0.53.0</azure.toolkit-lib.version>
         <dekorate.version>4.1.5</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
@@ -534,6 +535,12 @@
                 <version>${kotlin.coroutine.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Kotlin metadata processing used by OpenAPI for Kotlin classes -->
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-metadata-jvm</artifactId>
+                <version>${kotlin-metadata.version}</version>
             </dependency>
 
             <!-- Mockito BOM -->

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -69,6 +69,11 @@
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api-vertx</artifactId>
         </dependency>
+        <!-- SmallRye OpenAPI processes Kotlin metadata optionally when present -->
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-metadata-jvm</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
@@ -268,10 +268,10 @@ public class TestResource {
     @GET
     @Path("/openapi/responses/{version}")
     @Produces("application/json")
-    @APIResponses({
-            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class))),
-            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV2.class)))
-    })
+    @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, anyOf = {
+            MyOpenApiEntityV1.class,
+            MyOpenApiEntityV2.class
+    })))
     public Response openApiResponses(@PathParam("version") String version) {
         if ("v1".equals(version)) {
             MyOpenApiEntityV1 entityV1 = new MyOpenApiEntityV1();


### PR DESCRIPTION
Bump smallrye-open-api.version from 4.2.3 to 4.2.4 ([release notes](https://github.com/smallrye/smallrye-open-api/releases/tag/4.2.4)).


PR adds management of org.jetbrains.kotlinx:kotlinx-metadata-jvm for use by smallrye-open-api when scanning annotations on Kotlin classes. Functionality added to OpenAPI in smallrye/smallrye-open-api#2428.

- Fixes #50752
