### PR TITLE
BuildMetrics: fix produced items when extended capture is enabled

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildMetrics.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildMetrics.java
@@ -146,9 +146,9 @@ public class BuildMetrics {
                 }
                 recObject.put("dependents", dependentsArray);
                 if (buildItemsExtended != null) {
-                    JsonArrayBuilder producedItems = Json.array();
                     List<String> items = buildItemsExtended.get(rec.stepInfo.getBuildStep().getId());
                     if (items != null) {
+                        JsonArrayBuilder producedItems = Json.array();
                         // build item class -> count
                         Map<String, Long> counts = items
                                 .stream()
@@ -158,7 +158,7 @@ public class BuildMetrics {
                         for (Entry<String, Long> e : sortedItems) {
                             producedItems.add(Json.object()
                                     .put("item", e.getKey())
-                                    .put("count", e.getValue()));
+                                    .put("count", e.getValue().longValue()));
                         }
                         recObject.put("producedItems", producedItems);
                     }

--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/Json.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/Json.java
@@ -129,7 +129,7 @@ public final class Json {
          */
         abstract boolean isEmpty();
 
-        abstract void appendTo(Appendable appendable) throws IOException;
+        public abstract void appendTo(Appendable appendable) throws IOException;
 
         /**
          * @param value value to check
@@ -201,22 +201,22 @@ public final class Json {
             return this;
         }
 
-        JsonArrayBuilder add(boolean value) {
+        public JsonArrayBuilder add(boolean value) {
             addInternal(value);
             return this;
         }
 
-        JsonArrayBuilder add(int value) {
+        public JsonArrayBuilder add(int value) {
             addInternal(value);
             return this;
         }
 
-        JsonArrayBuilder add(long value) {
+        public JsonArrayBuilder add(long value) {
             addInternal(value);
             return this;
         }
 
-        JsonArrayBuilder addAll(List<JsonObjectBuilder> value) {
+        public JsonArrayBuilder addAll(List<JsonObjectBuilder> value) {
             if (value != null && !value.isEmpty()) {
                 values.addAll(value);
             }
@@ -385,17 +385,17 @@ public final class Json {
             return this;
         }
 
-        JsonObjectBuilder put(String name, int value) {
+        public JsonObjectBuilder put(String name, int value) {
             putInternal(name, value);
             return this;
         }
 
-        JsonObjectBuilder put(String name, long value) {
+        public JsonObjectBuilder put(String name, long value) {
             putInternal(name, value);
             return this;
         }
 
-        boolean has(String name) {
+        public boolean has(String name) {
             return properties.containsKey(name);
         }
 

--- a/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonDeserializerTest.java
+++ b/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonDeserializerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.bootstrap.json;
+package io.quarkus.bootstrap.json.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -8,6 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.json.JsonArray;
+import io.quarkus.bootstrap.json.JsonBoolean;
+import io.quarkus.bootstrap.json.JsonDouble;
+import io.quarkus.bootstrap.json.JsonInteger;
+import io.quarkus.bootstrap.json.JsonNull;
+import io.quarkus.bootstrap.json.JsonObject;
+import io.quarkus.bootstrap.json.JsonReader;
+import io.quarkus.bootstrap.json.JsonString;
 
 class JsonDeserializerTest {
 

--- a/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonRoundTripTest.java
+++ b/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonRoundTripTest.java
@@ -1,10 +1,18 @@
-package io.quarkus.bootstrap.json;
+package io.quarkus.bootstrap.json.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.json.Json;
+import io.quarkus.bootstrap.json.JsonArray;
+import io.quarkus.bootstrap.json.JsonBoolean;
+import io.quarkus.bootstrap.json.JsonInteger;
+import io.quarkus.bootstrap.json.JsonObject;
+import io.quarkus.bootstrap.json.JsonReader;
+import io.quarkus.bootstrap.json.JsonString;
 
 class JsonRoundTripTest {
 

--- a/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonSerializerTest.java
+++ b/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonSerializerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.bootstrap.json;
+package io.quarkus.bootstrap.json.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -6,7 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.json.Json;
+import io.quarkus.bootstrap.json.Json.JsonArrayBuilder;
+import io.quarkus.bootstrap.json.Json.JsonObjectBuilder;
+import io.quarkus.bootstrap.json.JsonArray;
+import io.quarkus.bootstrap.json.JsonBoolean;
+import io.quarkus.bootstrap.json.JsonInteger;
+import io.quarkus.bootstrap.json.JsonObject;
+import io.quarkus.bootstrap.json.JsonReader;
+import io.quarkus.bootstrap.json.JsonString;
 
 class JsonSerializerTest {
 
@@ -193,5 +204,17 @@ class JsonSerializerTest {
         String json = toJson(Json.object()
                 .put("emoji", "Hello 🌍"));
         assertEquals("{\"emoji\":\"Hello 🌍\"}", json);
+    }
+
+    @Disabled("https://github.com/quarkusio/quarkus/issues/52196")
+    @Test
+    void testFluentApiIncompatibility() throws IOException {
+        JsonObjectBuilder obj = Json.object();
+        // calls JsonObjectBuilder#put(String, Object) and results in {"bar":null} instead of {"bar":{"val":30}}
+        obj.put("bar", Json.object().put("val", Long.valueOf(30)));
+        JsonArrayBuilder arr = Json.array();
+        // calls JsonArrayBuilder#add(Object) and results in {"foo":true} instead of {"foo":[30]}
+        obj.put("foo", arr.add(Long.valueOf(30)));
+        assertEquals("{\"bar\":{\"val\":30},\"foo\":[30]}", toJson(obj));
     }
 }


### PR DESCRIPTION
- fix the problem caused by https://github.com/quarkusio/quarkus/issues/52196
- also change the visibility of some io.quarkus.builder.Json members so that they are part of the public API