### PR TITLE
Transform Netty's `isSharable` check to use a marker interface

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettySharable.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettySharable.java
@@ -1,0 +1,10 @@
+package io.quarkus.netty.runtime;
+
+import io.netty.channel.ChannelHandlerAdapter;
+
+/**
+ * Custom marker interface used to do faster {@link ChannelHandlerAdapter#isSharable()} checks as an interface instanceof
+ * is much faster than looking up an annotation
+ */
+public interface NettySharable {
+}


### PR DESCRIPTION
The check does fallback to the old check for classes we have not transformed