### PR TITLE
Reduce number of created ReflectiveClassBuildItem instances

### DIFF
--- a/extensions/oidc-token-propagation-common/deployment/src/main/java/io/quarkus/oidc/token/propagation/common/deployment/AccessTokenRequestFilterGenerator.java
+++ b/extensions/oidc-token-propagation-common/deployment/src/main/java/io/quarkus/oidc/token/propagation/common/deployment/AccessTokenRequestFilterGenerator.java
@@ -16,7 +16,6 @@ import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
@@ -32,16 +31,13 @@ public final class AccessTokenRequestFilterGenerator {
     }
 
     private final BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer;
-    private final BuildProducer<ReflectiveClassBuildItem> reflectiveClassProducer;
     private final BuildProducer<GeneratedBeanBuildItem> generatedBeanProducer;
     private final Class<?> requestFilterClass;
     private final Map<RequestFilterKey, String> cache = new HashMap<>();
 
     public AccessTokenRequestFilterGenerator(BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClassProducer,
             BuildProducer<GeneratedBeanBuildItem> generatedBeanProducer, Class<?> requestFilterClass) {
         this.unremovableBeansProducer = unremovableBeansProducer;
-        this.reflectiveClassProducer = reflectiveClassProducer;
         this.generatedBeanProducer = generatedBeanProducer;
         this.requestFilterClass = requestFilterClass;
     }
@@ -106,10 +102,6 @@ public final class AccessTokenRequestFilterGenerator {
                         }
                     }
                     unremovableBeansProducer.produce(UnremovableBeanBuildItem.beanClassNames(className));
-                    reflectiveClassProducer
-                            .produce(ReflectiveClassBuildItem.builder(className)
-                                    .reason(getClass().getName())
-                                    .methods().fields().constructors().build());
                     return className;
                 });
     }

--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.token.propagation.deployment;
 import static io.quarkus.oidc.token.propagation.common.runtime.TokenPropagationConstants.JWT_PROPAGATE_TOKEN_CREDENTIAL;
 import static io.quarkus.oidc.token.propagation.common.runtime.TokenPropagationConstants.OIDC_PROPAGATE_TOKEN_CREDENTIAL;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
@@ -48,10 +49,10 @@ public class OidcTokenPropagationBuildStep {
             BuildProducer<RestClientAnnotationProviderBuildItem> restAnnotationProvider) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(AccessTokenRequestFilter.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(JsonWebTokenRequestFilter.class));
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(AccessTokenRequestFilter.class, JsonWebTokenRequestFilter.class)
-                        .reason(getClass().getName())
-                        .methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem
+                .builder(List.of(AccessTokenRequestFilter.class.getName(), JsonWebTokenRequestFilter.class.getName()))
+                .reason(getClass().getName())
+                .methods().fields().build());
 
         if (config.registerFilter()) {
             Class<?> filterClass = config.jsonWebToken() ? JsonWebTokenRequestFilter.class : AccessTokenRequestFilter.class;
@@ -60,13 +61,18 @@ public class OidcTokenPropagationBuildStep {
             restAnnotationProvider.produce(new RestClientAnnotationProviderBuildItem(JWT_ACCESS_TOKEN_CREDENTIAL,
                     JsonWebTokenRequestFilter.class));
             if (!accessTokenInstances.isEmpty()) {
-                var filterGenerator = new AccessTokenRequestFilterGenerator(unremovableBeanProducer, reflectiveClass,
+                final var forReflection = new HashSet<String>(accessTokenInstances.size());
+                var filterGenerator = new AccessTokenRequestFilterGenerator(unremovableBeanProducer,
                         generatedBeanProducer, AccessTokenRequestFilter.class);
                 for (AccessTokenInstanceBuildItem instance : accessTokenInstances) {
                     String providerClass = filterGenerator.generateClass(instance);
                     providerPredicateProducer.produce(new RestClientPredicateProviderBuildItem(providerClass,
                             ci -> instance.targetClass().equals(ci.name().toString())));
+                    forReflection.add(providerClass);
                 }
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(forReflection)
+                        .reason(getClass().getName())
+                        .methods().fields().constructors().build());
             }
         }
     }


### PR DESCRIPTION
Collect class names while processing instead of creating a build item for each.