### PR TITLE
Implement aot-jar packaging on top of fast-jar packaging

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/cmd/RunCommandProcessor.java
@@ -37,7 +37,7 @@ public class RunCommandProcessor {
             // todo: legacy JAR should be using runnerSuffix()
             case LEGACY_JAR -> jar.getOutputDirectory()
                     .resolve(jar.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
-            case FAST_JAR, MUTABLE_JAR -> jar.getOutputDirectory()
+            case FAST_JAR, MUTABLE_JAR, AOT_JAR -> jar.getOutputDirectory()
                     .resolve(DEFAULT_FAST_JAR_DIRECTORY_NAME).resolve(QUARKUS_RUN_JAR);
         };
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -325,15 +325,22 @@ public interface PackageConfig {
             /**
              * The "fast JAR" packaging type.
              */
-            FAST_JAR("fast-jar", "jar"),
+            FAST_JAR(true, "fast-jar", "jar"),
+            /**
+             * The AOT-optimized packaging type.
+             * <p>
+             * Similar to fast-jar in the approach but taking into account the limitations of AOT class loading (i.e. all class
+             * loading delegated to JDK class loader).
+             */
+            AOT_JAR(true, "aot-jar", "aot-fast-jar"),
             /**
              * The "Uber-JAR" packaging type.
              */
-            UBER_JAR("uber-jar"),
+            UBER_JAR(false, "uber-jar"),
             /**
              * The "mutable JAR" packaging type (for remote development mode).
              */
-            MUTABLE_JAR("mutable-jar"),
+            MUTABLE_JAR(true, "mutable-jar"),
             /**
              * The "legacy JAR" packaging type.
              * This corresponds to the packaging type used in Quarkus before version 1.12.
@@ -341,7 +348,7 @@ public interface PackageConfig {
              * @deprecated This packaging type is no longer recommended for use.
              */
             @Deprecated
-            LEGACY_JAR("legacy-jar", "legacy"),
+            LEGACY_JAR(false, "legacy-jar", "legacy"),
             ;
 
             public static final List<JarType> values = List.of(JarType.values());
@@ -352,16 +359,19 @@ public interface PackageConfig {
 
             private final List<String> names;
 
-            JarType(final List<String> names) {
+            private final boolean fastJarLayout;
+
+            JarType(final boolean fastJarLayout, final List<String> names) {
+                this.fastJarLayout = fastJarLayout;
                 this.names = names;
             }
 
-            JarType(final String... names) {
-                this(List.of(names));
+            JarType(final boolean fastJarLayout, final String... names) {
+                this(fastJarLayout, List.of(names));
             }
 
-            JarType(final String name) {
-                this(List.of(name));
+            JarType(final boolean fastJarLayout, final String name) {
+                this(fastJarLayout, List.of(name));
             }
 
             /**
@@ -370,6 +380,10 @@ public interface PackageConfig {
              */
             public List<String> names() {
                 return names;
+            }
+
+            public boolean usesFastJarLayout() {
+                return fastJarLayout;
             }
 
             /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -1,0 +1,576 @@
+package io.quarkus.deployment.pkg.jar;
+
+import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
+import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.model.MutableJarApplicationModel;
+import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem.TransformedClass;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
+import io.quarkus.deployment.pkg.JarUnsigner;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.util.FileUtil;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.sbom.ApplicationComponent;
+import io.quarkus.sbom.ApplicationManifestConfig;
+
+abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
+
+    private static final Logger LOG = Logger.getLogger(AbstractFastJarBuilder.class);
+
+    private final List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives;
+    private final Set<ArtifactKey> parentFirstArtifactKeys;
+
+    AbstractFastJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            Set<ArtifactKey> parentFirstArtifactKeys,
+            Set<ArtifactKey> removedArtifactKeys,
+            ExecutorService executorService,
+            ResolvedJVMRequirements jvmRequirements) {
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
+                generatedClasses, generatedResources, removedArtifactKeys, executorService, jvmRequirements);
+        this.additionalApplicationArchives = additionalApplicationArchives;
+        this.parentFirstArtifactKeys = parentFirstArtifactKeys;
+    }
+
+    public JarBuildItem build() throws IOException {
+        boolean rebuild = outputTarget.isRebuild();
+
+        Path buildDir;
+
+        if (packageConfig.outputDirectory().isPresent()) {
+            buildDir = outputTarget.getOutputDirectory();
+        } else {
+            buildDir = outputTarget.getOutputDirectory().resolve(FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME);
+        }
+
+        final ApplicationManifestConfig.Builder manifestConfig = ApplicationManifestConfig.builder()
+                .setApplicationModel(curateOutcome.getApplicationModel())
+                .setDistributionDirectory(buildDir);
+        //unmodified 3rd party dependencies
+        Path libDir = buildDir.resolve(FastJarFormat.LIB);
+        Path mainLib = libDir.resolve(FastJarFormat.MAIN);
+        //parent first entries
+        Path baseLib = libDir.resolve(FastJarFormat.BOOT_LIB);
+        Files.createDirectories(baseLib);
+
+        Path appDir = buildDir.resolve(FastJarFormat.APP);
+        Path quarkus = buildDir.resolve(FastJarFormat.QUARKUS);
+        Path userProviders = null;
+        if (packageConfig.jar().userProvidersDirectory().isPresent()) {
+            userProviders = buildDir.resolve(packageConfig.jar().userProvidersDirectory().get());
+        }
+        if (!rebuild) {
+            IoUtils.createOrEmptyDir(buildDir);
+            Files.createDirectories(mainLib);
+            Files.createDirectories(baseLib);
+            Files.createDirectories(appDir);
+            Files.createDirectories(quarkus);
+            if (userProviders != null) {
+                Files.createDirectories(userProviders);
+                //we add this dir so that it can be copied into container images if required
+                //and will still be copied even if empty
+                Path keepFile = userProviders.resolve(".keep");
+                if (!keepFile.toFile().exists()) {
+                    // check if the file exists to avoid a FileAlreadyExistsException
+                    Files.createFile(keepFile);
+                }
+            }
+        } else {
+            IoUtils.createOrEmptyDir(quarkus);
+        }
+
+        Path decompiledOutputDir = null;
+        boolean wasDecompiledSuccessfully = true;
+        Decompiler decompiler = null;
+        PackageConfig.DecompilerConfig decompilerConfig = packageConfig.jar().decompiler();
+        if (decompilerConfig.enabled()) {
+            decompiledOutputDir = buildDir.getParent().resolve(decompilerConfig.outputDirectory());
+            FileUtil.deleteDirectory(decompiledOutputDir);
+            Files.createDirectory(decompiledOutputDir);
+            decompiler = new VineflowerDecompiler();
+            Path jarDirectory = Paths.get(decompilerConfig.jarDirectory());
+            if (!Files.exists(jarDirectory)) {
+                Files.createDirectory(jarDirectory);
+            }
+            decompiler.init(new Decompiler.Context(jarDirectory, decompiledOutputDir));
+            decompiler.downloadIfNecessary();
+        }
+
+        FastJarJars.FastJarJarsBuilder fastJarJarsBuilder = new FastJarJars.FastJarJarsBuilder();
+        fastJarJarsBuilder.setApplicationRoot(buildDir);
+        List<Path> parentFirst = new ArrayList<>();
+        //we process in order of priority
+        //transformed classes first
+        if (!transformedClasses.getTransformedClassesByJar().isEmpty()) {
+            Path transformedZip = quarkus.resolve(FastJarFormat.TRANSFORMED_BYTECODE_JAR);
+            fastJarJarsBuilder.setTransformedJar(transformedZip);
+            try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(transformedZip,
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    outputTarget.getOutputDirectory(), executorService)) {
+                // we make sure the entries are added in a reproducible order
+                // we use Path#toString() to get a reproducible order on both Unix-based OSes and Windows
+                for (Entry<Path, Set<TransformedClass>> transformedClassEntry : transformedClasses
+                        .getTransformedClassesByJar().entrySet().stream()
+                        .sorted(Comparator.comparing(e -> e.getKey().toString())).toList()) {
+                    for (TransformedClass transformed : transformedClassEntry.getValue().stream()
+                            .sorted(Comparator.comparing(TransformedClass::getFileName)).toList()) {
+                        if (transformed.getData() != null) {
+                            archiveCreator.addFile(transformed.getData(), transformed.getFileName());
+                        }
+                    }
+                }
+            }
+            if (decompiler != null) {
+                wasDecompiledSuccessfully = decompiler.decompile(transformedZip);
+            }
+        }
+        //now generated classes and resources
+        Path generatedZip = quarkus.resolve(FastJarFormat.GENERATED_BYTECODE_JAR);
+        fastJarJarsBuilder.setGeneratedJar(generatedZip);
+        try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(generatedZip,
+                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null), outputTarget.getOutputDirectory(),
+                executorService)) {
+            // make sure we write the elements in order
+            for (GeneratedClassBuildItem i : generatedClasses.stream()
+                    .sorted(Comparator.comparing(GeneratedClassBuildItem::binaryName)).toList()) {
+                String fileName = fromClassNameToResourceName(i.internalName());
+                archiveCreator.addFile(i.getClassData(), fileName);
+            }
+
+            // make sure we write the elements in order
+            for (GeneratedResourceBuildItem i : generatedResources.stream()
+                    .sorted(Comparator.comparing(GeneratedResourceBuildItem::getName)).toList()) {
+                archiveCreator.addFile(i.getData(), i.getName());
+            }
+        }
+        if (decompiler != null) {
+            wasDecompiledSuccessfully &= decompiler.decompile(generatedZip);
+        }
+
+        if (wasDecompiledSuccessfully && (decompiledOutputDir != null)) {
+            LOG.info("The decompiled output can be found at: " + decompiledOutputDir.toAbsolutePath().toString());
+        }
+
+        //now the application classes
+        Path runnerJar = appDir.resolve(outputTarget.getBaseName() + DOT_JAR);
+        fastJarJarsBuilder.setRunnerJar(runnerJar);
+
+        if (!rebuild) {
+            manifestConfig.addComponent(ApplicationComponent.builder()
+                    .setResolvedDependency(applicationArchives.getRootArchive().getResolvedDependency())
+                    .setPath(runnerJar));
+            Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
+            try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    outputTarget.getOutputDirectory(), executorService)) {
+                copyFiles(applicationArchives.getRootArchive(), archiveCreator, null, ignoredEntriesPredicate);
+            }
+        }
+        final Map<ArtifactKey, List<Path>> copiedArtifacts = new HashMap<>();
+        for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
+            if (!rebuild) {
+                copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, mainLib, baseLib,
+                        fastJarJarsBuilder::addDependency, fastJarJarsBuilder::addParentFirstDependency, true,
+                        appDep, transformedClasses, removedArtifactKeys, packageConfig, manifestConfig,
+                        executorService);
+            } else if (includeAppDependency(appDep, outputTarget.getIncludedOptionalDependencies(), removedArtifactKeys)) {
+                appDep.getResolvedPaths().forEach(fastJarJarsBuilder::addDependency);
+            }
+            if (parentFirstArtifactKeys.contains(appDep.getKey())) {
+                appDep.getResolvedPaths().forEach(parentFirst::add);
+            }
+        }
+        for (AdditionalApplicationArchiveBuildItem i : additionalApplicationArchives) {
+            for (Path path : i.getResolvedPaths()) {
+                if (!path.getParent().equals(userProviders)) {
+                    throw new RuntimeException(
+                            "Additional application archives can only be provided from the user providers directory. " + path
+                                    + " is not present in " + userProviders);
+                }
+                fastJarJarsBuilder.addDependency(path);
+            }
+        }
+
+        Path appInfo = buildDir.resolve(QuarkusEntryPoint.QUARKUS_APPLICATION_DAT);
+        FastJarJars fastJarJars = fastJarJarsBuilder.build();
+        try (OutputStream out = Files.newOutputStream(appInfo)) {
+            List<Path> allJars = new ArrayList<>();
+            if (fastJarJars.transformedJar != null) {
+                allJars.add(fastJarJars.transformedJar);
+            }
+            allJars.add(fastJarJars.generatedJar);
+            allJars.add(fastJarJars.runnerJar);
+            List<Path> sortedDeps = new ArrayList<>(fastJarJars.dependencies);
+            Collections.sort(sortedDeps);
+            allJars.addAll(sortedDeps);
+            List<Path> sortedParentFirst = new ArrayList<>(parentFirst);
+            Collections.sort(sortedParentFirst);
+            writeSerializedApplication(out, buildDir, allJars, sortedParentFirst);
+        }
+
+        runnerJar.toFile().setReadable(true, false);
+        Path initJar = buildDir.resolve(FastJarFormat.QUARKUS_RUN_JAR);
+        manifestConfig.setMainComponent(ApplicationComponent.builder()
+                .setPath(initJar)
+                .setDependencies(List.of(curateOutcome.getApplicationModel().getAppArtifact())))
+                .setRunnerPath(initJar);
+        boolean mutableJar = packageConfig.jar().type() == MUTABLE_JAR;
+        if (mutableJar) {
+            //we output the properties in a reproducible manner, so we remove the date comment
+            //and sort them
+            //we still use Properties to get the escaping right though, so basically we write out the lines
+            //to memory, split them, discard comments, sort them, then write them to disk
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            outputTarget.getBuildSystemProperties().store(out, null);
+            List<String> lines = Arrays.stream(out.toString(StandardCharsets.UTF_8).split("\n"))
+                    .filter(s -> !s.startsWith("#")).sorted().collect(Collectors.toList());
+            Path buildSystemProps = quarkus.resolve(FastJarFormat.BUILD_SYSTEM_PROPERTIES);
+            manifestConfig.addComponent(ApplicationComponent.builder().setPath(buildSystemProps).setDevelopmentScope());
+            try (OutputStream fileOutput = Files.newOutputStream(buildSystemProps)) {
+                fileOutput.write(String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        if (!rebuild) {
+            try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(initJar,
+                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                    outputTarget.getOutputDirectory(), executorService)) {
+                ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
+                generateManifest(archiveCreator, getClassPath(fastJarJars), packageConfig, appArtifact,
+                        jvmRequirements,
+                        getEntryPoint().getName(),
+                        applicationInfo);
+            }
+
+            //now copy the deployment artifacts, if required
+            if (mutableJar) {
+                Path deploymentLib = libDir.resolve(FastJarFormat.DEPLOYMENT_LIB);
+                Files.createDirectories(deploymentLib);
+                for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getDependencies()) {
+                    copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, deploymentLib, baseLib, p -> {
+                    }, p -> {
+                    }, false, appDep, new TransformedClassesBuildItem(Map.of()), removedArtifactKeys, packageConfig,
+                            manifestConfig, executorService); //we don't care about transformation here, so just pass in an empty item
+                }
+                Map<ArtifactKey, List<String>> relativePaths = new HashMap<>();
+                for (Entry<ArtifactKey, List<Path>> e : copiedArtifacts.entrySet()) {
+                    relativePaths.put(e.getKey(),
+                            e.getValue().stream().map(s -> buildDir.relativize(s).toString().replace('\\', '/'))
+                                    .collect(Collectors.toList()));
+                }
+
+                //now we serialize the data needed to build up the reaugmentation class path
+                //first the app model
+                MutableJarApplicationModel model = new MutableJarApplicationModel(outputTarget.getBaseName(),
+                        relativePaths,
+                        curateOutcome.getApplicationModel(),
+                        packageConfig.jar().userProvidersDirectory().orElse(null), buildDir.relativize(runnerJar).toString());
+                Path appmodelDat = deploymentLib.resolve(FastJarFormat.APPMODEL_DAT);
+                manifestConfig.addComponent(ApplicationComponent.builder().setPath(appmodelDat).setDevelopmentScope());
+                try (OutputStream out = Files.newOutputStream(appmodelDat)) {
+                    ObjectOutputStream obj = new ObjectOutputStream(out);
+                    obj.writeObject(model);
+                    obj.close();
+                }
+                //now the bootstrap CP
+                //we just include all deployment deps, even though we only really need bootstrap
+                //as we don't really have a resolved bootstrap CP
+                //once we have the app model it will all be done in QuarkusClassLoader anyway
+                Path deploymentCp = deploymentLib.resolve(FastJarFormat.DEPLOYMENT_CLASS_PATH_DAT);
+                manifestConfig.addComponent(ApplicationComponent.builder().setPath(deploymentCp).setDevelopmentScope());
+                try (OutputStream out = Files.newOutputStream(deploymentCp)) {
+                    ObjectOutputStream obj = new ObjectOutputStream(out);
+                    List<String> paths = new ArrayList<>();
+                    for (ResolvedDependency i : curateOutcome.getApplicationModel().getDependencies()) {
+                        final List<String> list = relativePaths.get(i.getKey());
+                        // some of the dependencies may have been filtered out
+                        if (list != null) {
+                            paths.addAll(list);
+                        }
+                    }
+                    obj.writeObject(paths);
+                    obj.close();
+                }
+            }
+
+            if (packageConfig.jar().includeDependencyList()) {
+                Path deplist = buildDir.resolve(FastJarFormat.QUARKUS_APP_DEPS);
+                List<String> lines = new ArrayList<>();
+                for (ResolvedDependency i : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
+                    lines.add(i.toGACTVString());
+                }
+                lines.sort(Comparator.naturalOrder());
+                Files.write(deplist, lines);
+            }
+        } else {
+            //if it is a rebuild we might have classes
+        }
+        try (Stream<Path> files = Files.walk(buildDir)) {
+            files.forEach(new Consumer<Path>() {
+                @Override
+                public void accept(Path path) {
+                    path.toFile().setReadable(true, false);
+                }
+            });
+        }
+        return new JarBuildItem(initJar, null, libDir, packageConfig.jar().type(), null, manifestConfig.build());
+    }
+
+    protected abstract void writeSerializedApplication(OutputStream out, Path buildDir, List<Path> allJars,
+            List<Path> sortedParentFirst) throws IOException;
+
+    protected abstract Class<?> getEntryPoint();
+
+    protected abstract String getClassPath(FastJarJars fastJarJars);
+
+    protected static Predicate<String> getThinJarIgnoredEntriesPredicate(PackageConfig packageConfig) {
+        return packageConfig.jar().userConfiguredIgnoredEntries().map(Set::copyOf).orElse(Set.of())::contains;
+    }
+
+    private static void copyDependency(Set<ArtifactKey> parentFirstArtifacts, OutputTargetBuildItem outputTargetBuildItem,
+            Map<ArtifactKey, List<Path>> runtimeArtifacts, Path libDir, Path baseLib, Consumer<Path> dependenciesConsumer,
+            Consumer<Path> parentFirstDependenciesConsumer, boolean allowParentFirst, ResolvedDependency appDep,
+            TransformedClassesBuildItem transformedClasses, Set<ArtifactKey> removedDeps,
+            PackageConfig packageConfig, ApplicationManifestConfig.Builder manifestConfig, ExecutorService executorService)
+            throws IOException {
+
+        // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
+        // and are not part of the optional dependencies to include
+        if (!includeAppDependency(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDeps)) {
+            return;
+        }
+        if (runtimeArtifacts.containsKey(appDep.getKey())) {
+            return;
+        }
+        Set<GACT> forceUseArtifactIdOnlyAsNameSet = packageConfig.jar().forceUseArtifactIdOnlyAsName()
+                .orElse(Collections.emptySet());
+        boolean forceUseArtifactIdOnlyAsName = forceUseArtifactIdOnlyAsNameSet.stream()
+                .anyMatch(gact -> gact.getGroupId().equals(appDep.getGroupId())
+                        && gact.getArtifactId().equals(appDep.getArtifactId())
+                        && gact.getType().equals(appDep.getType())
+                        && gact.getClassifier().equals(appDep.getClassifier()));
+        for (Path resolvedDep : appDep.getResolvedPaths()) {
+            String fileName;
+            if (forceUseArtifactIdOnlyAsName) {
+                fileName = appDep.getArtifactId() + "." + appDep.getType();
+            } else {
+                fileName = FastJarFormat.getJarFileName(appDep, resolvedDep);
+            }
+            final Path targetPath;
+
+            if (allowParentFirst && parentFirstArtifacts.contains(appDep.getKey())) {
+                targetPath = baseLib.resolve(fileName);
+                parentFirstDependenciesConsumer.accept(targetPath);
+            } else {
+                targetPath = libDir.resolve(fileName);
+                dependenciesConsumer.accept(targetPath);
+            }
+            runtimeArtifacts.computeIfAbsent(appDep.getKey(), (s) -> new ArrayList<>(1)).add(targetPath);
+
+            if (Files.isDirectory(resolvedDep)) {
+                // This case can happen when we are building a jar from inside the Quarkus repository
+                // and Quarkus Bootstrap's localProjectDiscovery has been set to true. In such a case
+                // the non-jar dependencies are the Quarkus dependencies picked up on the file system
+                packageClasses(resolvedDep, targetPath, packageConfig, outputTargetBuildItem, executorService);
+            } else {
+                Set<TransformedClass> transformedFromThisArchive = transformedClasses
+                        .getTransformedClassesByJar().get(resolvedDep);
+                Set<String> removedFromThisArchive = new HashSet<>();
+                if (transformedFromThisArchive != null) {
+                    for (TransformedClass i : transformedFromThisArchive) {
+                        if (i.getData() == null) {
+                            removedFromThisArchive.add(i.getFileName());
+                        }
+                    }
+                }
+                var appComponent = ApplicationComponent.builder()
+                        .setPath(targetPath)
+                        .setResolvedDependency(appDep);
+                if (removedFromThisArchive.isEmpty()) {
+                    // let's not use COPY_ATTRIBUTES to make sure we respect the system umask
+                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                    Files.setLastModifiedTime(targetPath, Files.getLastModifiedTime(resolvedDep));
+                } else {
+                    // we copy jars for which we remove entries to the same directory
+                    // which seems a bit odd to me
+                    JarUnsigner.unsignJar(resolvedDep, targetPath, Predicate.not(removedFromThisArchive::contains));
+
+                    var list = new ArrayList<>(removedFromThisArchive);
+                    Collections.sort(list);
+                    var sb = new StringBuilder("Removed ").append(list.get(0));
+                    for (int i = 1; i < list.size(); ++i) {
+                        sb.append(",").append(list.get(i));
+                    }
+                    appComponent.setPedigree(sb.toString());
+                }
+                manifestConfig.addComponent(appComponent);
+            }
+        }
+    }
+
+    private static void packageClasses(Path resolvedDep, final Path targetPath, PackageConfig packageConfig,
+            OutputTargetBuildItem outputTargetBuildItem, ExecutorService executorService) throws IOException {
+        try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(targetPath,
+                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
+                outputTargetBuildItem.getOutputDirectory(), executorService)) {
+            Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                    new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                                throws IOException {
+                            final Path relativePath = resolvedDep.relativize(file);
+                            archiveCreator.addFile(file, relativePath.toString()); //replace only needed for testing
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+        }
+    }
+
+    protected static class FastJarJars {
+        private final Path applicationRoot;
+        private final Path transformedJar;
+        private final Path generatedJar;
+        private final Path runnerJar;
+        private final List<Path> dependencies;
+        private final List<Path> parentFirstDependencies;
+
+        public FastJarJars(FastJarJarsBuilder builder) {
+            this.applicationRoot = builder.applicationRoot;
+            this.transformedJar = builder.transformedJar;
+            this.generatedJar = builder.generatedJar;
+            this.runnerJar = builder.runnerJar;
+            this.dependencies = builder.dependencies;
+            this.parentFirstDependencies = builder.parentFirstDependencies;
+        }
+
+        public String getParentFirstClassPath() {
+            StringBuilder builder = new StringBuilder();
+
+            for (Path parentFirstDependency : parentFirstDependencies) {
+                if (!builder.isEmpty()) {
+                    builder.append(" ");
+                }
+
+                builder.append(getClassPathEntry(applicationRoot, parentFirstDependency));
+            }
+
+            return builder.toString();
+        }
+
+        public String getFullClassPath() {
+            StringBuilder builder = new StringBuilder();
+
+            if (transformedJar != null) {
+                builder.append(getClassPathEntry(applicationRoot, transformedJar));
+                builder.append(" ");
+            }
+
+            builder.append(getClassPathEntry(applicationRoot, generatedJar));
+            builder.append(" ").append(getClassPathEntry(applicationRoot, runnerJar));
+
+            for (Path dependency : dependencies) {
+                builder.append(" ").append(getClassPathEntry(applicationRoot, dependency));
+            }
+
+            for (Path parentFirstDependency : parentFirstDependencies) {
+                builder.append(" ").append(getClassPathEntry(applicationRoot, parentFirstDependency));
+            }
+
+            return builder.toString();
+        }
+
+        private static String getClassPathEntry(Path applicationRoot, Path dependency) {
+            return applicationRoot.relativize(dependency).toString().replace('\\', '/');
+        }
+
+        private static class FastJarJarsBuilder {
+            private Path applicationRoot;
+            private Path transformedJar;
+            private Path generatedJar;
+            private Path runnerJar;
+            private final List<Path> dependencies = new ArrayList<>();
+            private final List<Path> parentFirstDependencies = new ArrayList<>();
+
+            public void setApplicationRoot(Path applicationRoot) {
+                this.applicationRoot = applicationRoot;
+            }
+
+            public void setTransformedJar(Path transformedJar) {
+                this.transformedJar = transformedJar;
+            }
+
+            public void setGeneratedJar(Path generatedJar) {
+                this.generatedJar = generatedJar;
+            }
+
+            public void setRunnerJar(Path runnerJar) {
+                this.runnerJar = runnerJar;
+            }
+
+            public void addDependency(Path dependency) {
+                this.dependencies.add(dependency);
+            }
+
+            public void addParentFirstDependency(Path dependency) {
+                this.parentFirstDependencies.add(dependency);
+            }
+
+            public AbstractFastJarBuilder.FastJarJars build() {
+                return new AbstractFastJarBuilder.FastJarJars(this);
+            }
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AotFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AotFastJarBuilder.java
@@ -1,0 +1,65 @@
+package io.quarkus.deployment.pkg.jar;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.runner.AotQuarkusEntryPoint;
+import io.quarkus.bootstrap.runner.AotSerializedApplication;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+public class AotFastJarBuilder extends AbstractFastJarBuilder {
+
+    private static final Logger LOG = Logger.getLogger(AotFastJarBuilder.class);
+
+    public AotFastJarBuilder(CurateOutcomeBuildItem curateOutcome,
+            OutputTargetBuildItem outputTarget,
+            ApplicationInfoBuildItem applicationInfo,
+            PackageConfig packageConfig,
+            MainClassBuildItem mainClass,
+            ApplicationArchivesBuildItem applicationArchives,
+            List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives,
+            TransformedClassesBuildItem transformedClasses,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            Set<ArtifactKey> parentFirstArtifactKeys,
+            Set<ArtifactKey> removedArtifactKeys,
+            ExecutorService executorService,
+            ResolvedJVMRequirements jvmRequirements) {
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives,
+                additionalApplicationArchives, transformedClasses, generatedClasses, generatedResources,
+                parentFirstArtifactKeys, removedArtifactKeys, executorService, jvmRequirements);
+    }
+
+    @Override
+    protected void writeSerializedApplication(OutputStream out, Path buildDir, List<Path> allJars, List<Path> sortedParentFirst)
+            throws IOException {
+        AotSerializedApplication.write(out, mainClass.getClassName(), allJars);
+    }
+
+    @Override
+    protected Class<?> getEntryPoint() {
+        return AotQuarkusEntryPoint.class;
+    }
+
+    @Override
+    protected String getClassPath(FastJarJars fastJarJars) {
+        return fastJarJars.getFullClassPath();
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/FastJarBuilder.java
@@ -1,44 +1,16 @@
 package io.quarkus.deployment.pkg.jar;
 
-import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
-import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
-
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileVisitOption;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.bootstrap.model.MutableJarApplicationModel;
 import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
 import io.quarkus.bootstrap.runner.SerializedApplication;
-import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
@@ -46,26 +18,15 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
-import io.quarkus.deployment.builditem.TransformedClassesBuildItem.TransformedClass;
 import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
-import io.quarkus.deployment.pkg.JarUnsigner;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
-import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
-import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.maven.dependency.ArtifactKey;
-import io.quarkus.maven.dependency.GACT;
-import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.sbom.ApplicationComponent;
-import io.quarkus.sbom.ApplicationManifestConfig;
 
-public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
+public class FastJarBuilder extends AbstractFastJarBuilder {
 
     private static final Logger LOG = Logger.getLogger(FastJarBuilder.class);
-
-    private final List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives;
-    private final Set<ArtifactKey> parentFirstArtifactKeys;
 
     public FastJarBuilder(CurateOutcomeBuildItem curateOutcome,
             OutputTargetBuildItem outputTarget,
@@ -81,440 +42,24 @@ public class FastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             Set<ArtifactKey> removedArtifactKeys,
             ExecutorService executorService,
             ResolvedJVMRequirements jvmRequirements) {
-        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives, transformedClasses,
-                generatedClasses, generatedResources, removedArtifactKeys, executorService, jvmRequirements);
-        this.additionalApplicationArchives = additionalApplicationArchives;
-        this.parentFirstArtifactKeys = parentFirstArtifactKeys;
+        super(curateOutcome, outputTarget, applicationInfo, packageConfig, mainClass, applicationArchives,
+                additionalApplicationArchives, transformedClasses, generatedClasses, generatedResources,
+                parentFirstArtifactKeys, removedArtifactKeys, executorService, jvmRequirements);
     }
 
-    public JarBuildItem build() throws IOException {
-        boolean rebuild = outputTarget.isRebuild();
-
-        Path buildDir;
-
-        if (packageConfig.outputDirectory().isPresent()) {
-            buildDir = outputTarget.getOutputDirectory();
-        } else {
-            buildDir = outputTarget.getOutputDirectory().resolve(FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME);
-        }
-
-        final ApplicationManifestConfig.Builder manifestConfig = ApplicationManifestConfig.builder()
-                .setApplicationModel(curateOutcome.getApplicationModel())
-                .setDistributionDirectory(buildDir);
-        //unmodified 3rd party dependencies
-        Path libDir = buildDir.resolve(FastJarFormat.LIB);
-        Path mainLib = libDir.resolve(FastJarFormat.MAIN);
-        //parent first entries
-        Path baseLib = libDir.resolve(FastJarFormat.BOOT_LIB);
-        Files.createDirectories(baseLib);
-
-        Path appDir = buildDir.resolve(FastJarFormat.APP);
-        Path quarkus = buildDir.resolve(FastJarFormat.QUARKUS);
-        Path userProviders = null;
-        if (packageConfig.jar().userProvidersDirectory().isPresent()) {
-            userProviders = buildDir.resolve(packageConfig.jar().userProvidersDirectory().get());
-        }
-        if (!rebuild) {
-            IoUtils.createOrEmptyDir(buildDir);
-            Files.createDirectories(mainLib);
-            Files.createDirectories(baseLib);
-            Files.createDirectories(appDir);
-            Files.createDirectories(quarkus);
-            if (userProviders != null) {
-                Files.createDirectories(userProviders);
-                //we add this dir so that it can be copied into container images if required
-                //and will still be copied even if empty
-                Path keepFile = userProviders.resolve(".keep");
-                if (!keepFile.toFile().exists()) {
-                    // check if the file exists to avoid a FileAlreadyExistsException
-                    Files.createFile(keepFile);
-                }
-            }
-        } else {
-            IoUtils.createOrEmptyDir(quarkus);
-        }
-
-        Path decompiledOutputDir = null;
-        boolean wasDecompiledSuccessfully = true;
-        Decompiler decompiler = null;
-        PackageConfig.DecompilerConfig decompilerConfig = packageConfig.jar().decompiler();
-        if (decompilerConfig.enabled()) {
-            decompiledOutputDir = buildDir.getParent().resolve(decompilerConfig.outputDirectory());
-            FileUtil.deleteDirectory(decompiledOutputDir);
-            Files.createDirectory(decompiledOutputDir);
-            decompiler = new VineflowerDecompiler();
-            Path jarDirectory = Paths.get(decompilerConfig.jarDirectory());
-            if (!Files.exists(jarDirectory)) {
-                Files.createDirectory(jarDirectory);
-            }
-            decompiler.init(new Decompiler.Context(jarDirectory, decompiledOutputDir));
-            decompiler.downloadIfNecessary();
-        }
-
-        FastJarJars.FastJarJarsBuilder fastJarJarsBuilder = new FastJarJars.FastJarJarsBuilder();
-        List<Path> parentFirst = new ArrayList<>();
-        //we process in order of priority
-        //transformed classes first
-        if (!transformedClasses.getTransformedClassesByJar().isEmpty()) {
-            Path transformedZip = quarkus.resolve(FastJarFormat.TRANSFORMED_BYTECODE_JAR);
-            fastJarJarsBuilder.setTransformedJar(transformedZip);
-            try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(transformedZip,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                    outputTarget.getOutputDirectory(), executorService)) {
-                // we make sure the entries are added in a reproducible order
-                // we use Path#toString() to get a reproducible order on both Unix-based OSes and Windows
-                for (Entry<Path, Set<TransformedClass>> transformedClassEntry : transformedClasses
-                        .getTransformedClassesByJar().entrySet().stream()
-                        .sorted(Comparator.comparing(e -> e.getKey().toString())).toList()) {
-                    for (TransformedClass transformed : transformedClassEntry.getValue().stream()
-                            .sorted(Comparator.comparing(TransformedClass::getFileName)).toList()) {
-                        if (transformed.getData() != null) {
-                            archiveCreator.addFile(transformed.getData(), transformed.getFileName());
-                        }
-                    }
-                }
-            }
-            if (decompiler != null) {
-                wasDecompiledSuccessfully = decompiler.decompile(transformedZip);
-            }
-        }
-        //now generated classes and resources
-        Path generatedZip = quarkus.resolve(FastJarFormat.GENERATED_BYTECODE_JAR);
-        fastJarJarsBuilder.setGeneratedJar(generatedZip);
-        try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(generatedZip,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null), outputTarget.getOutputDirectory(),
-                executorService)) {
-            // make sure we write the elements in order
-            for (GeneratedClassBuildItem i : generatedClasses.stream()
-                    .sorted(Comparator.comparing(GeneratedClassBuildItem::binaryName)).toList()) {
-                String fileName = fromClassNameToResourceName(i.internalName());
-                archiveCreator.addFile(i.getClassData(), fileName);
-            }
-
-            // make sure we write the elements in order
-            for (GeneratedResourceBuildItem i : generatedResources.stream()
-                    .sorted(Comparator.comparing(GeneratedResourceBuildItem::getName)).toList()) {
-                archiveCreator.addFile(i.getData(), i.getName());
-            }
-        }
-        if (decompiler != null) {
-            wasDecompiledSuccessfully &= decompiler.decompile(generatedZip);
-        }
-
-        if (wasDecompiledSuccessfully && (decompiledOutputDir != null)) {
-            LOG.info("The decompiled output can be found at: " + decompiledOutputDir.toAbsolutePath().toString());
-        }
-
-        //now the application classes
-        Path runnerJar = appDir.resolve(outputTarget.getBaseName() + DOT_JAR);
-        fastJarJarsBuilder.setRunnerJar(runnerJar);
-
-        if (!rebuild) {
-            manifestConfig.addComponent(ApplicationComponent.builder()
-                    .setResolvedDependency(applicationArchives.getRootArchive().getResolvedDependency())
-                    .setPath(runnerJar));
-            Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
-            try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                    outputTarget.getOutputDirectory(), executorService)) {
-                copyFiles(applicationArchives.getRootArchive(), archiveCreator, null, ignoredEntriesPredicate);
-            }
-        }
-        final StringBuilder classPath = new StringBuilder();
-        final Map<ArtifactKey, List<Path>> copiedArtifacts = new HashMap<>();
-        for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
-            if (!rebuild) {
-                copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, mainLib, baseLib,
-                        fastJarJarsBuilder::addDependency, true,
-                        classPath, appDep, transformedClasses, removedArtifactKeys, packageConfig, manifestConfig,
-                        executorService);
-            } else if (includeAppDependency(appDep, outputTarget.getIncludedOptionalDependencies(), removedArtifactKeys)) {
-                appDep.getResolvedPaths().forEach(fastJarJarsBuilder::addDependency);
-            }
-            if (parentFirstArtifactKeys.contains(appDep.getKey())) {
-                appDep.getResolvedPaths().forEach(parentFirst::add);
-            }
-        }
-        for (AdditionalApplicationArchiveBuildItem i : additionalApplicationArchives) {
-            for (Path path : i.getResolvedPaths()) {
-                if (!path.getParent().equals(userProviders)) {
-                    throw new RuntimeException(
-                            "Additional application archives can only be provided from the user providers directory. " + path
-                                    + " is not present in " + userProviders);
-                }
-                fastJarJarsBuilder.addDependency(path);
-            }
-        }
-
-        Path appInfo = buildDir.resolve(QuarkusEntryPoint.QUARKUS_APPLICATION_DAT);
-        try (OutputStream out = Files.newOutputStream(appInfo)) {
-            FastJarJars fastJarJars = fastJarJarsBuilder.build();
-            List<Path> allJars = new ArrayList<>();
-            if (fastJarJars.transformedJar != null) {
-                allJars.add(fastJarJars.transformedJar);
-            }
-            allJars.add(fastJarJars.generatedJar);
-            allJars.add(fastJarJars.runnerJar);
-            List<Path> sortedDeps = new ArrayList<>(fastJarJars.dependencies);
-            Collections.sort(sortedDeps);
-            allJars.addAll(sortedDeps);
-            List<Path> sortedParentFirst = new ArrayList<>(parentFirst);
-            Collections.sort(sortedParentFirst);
-            SerializedApplication.write(out, mainClass.getClassName(), buildDir, allJars, sortedParentFirst);
-        }
-
-        runnerJar.toFile().setReadable(true, false);
-        Path initJar = buildDir.resolve(FastJarFormat.QUARKUS_RUN_JAR);
-        manifestConfig.setMainComponent(ApplicationComponent.builder()
-                .setPath(initJar)
-                .setDependencies(List.of(curateOutcome.getApplicationModel().getAppArtifact())))
-                .setRunnerPath(initJar);
-        boolean mutableJar = packageConfig.jar().type() == MUTABLE_JAR;
-        if (mutableJar) {
-            //we output the properties in a reproducible manner, so we remove the date comment
-            //and sort them
-            //we still use Properties to get the escaping right though, so basically we write out the lines
-            //to memory, split them, discard comments, sort them, then write them to disk
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            outputTarget.getBuildSystemProperties().store(out, null);
-            List<String> lines = Arrays.stream(out.toString(StandardCharsets.UTF_8).split("\n"))
-                    .filter(s -> !s.startsWith("#")).sorted().collect(Collectors.toList());
-            Path buildSystemProps = quarkus.resolve(FastJarFormat.BUILD_SYSTEM_PROPERTIES);
-            manifestConfig.addComponent(ApplicationComponent.builder().setPath(buildSystemProps).setDevelopmentScope());
-            try (OutputStream fileOutput = Files.newOutputStream(buildSystemProps)) {
-                fileOutput.write(String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
-            }
-        }
-        if (!rebuild) {
-            try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(initJar,
-                    packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                    outputTarget.getOutputDirectory(), executorService)) {
-                ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
-                generateManifest(archiveCreator, classPath.toString(), packageConfig, appArtifact,
-                        jvmRequirements,
-                        QuarkusEntryPoint.class.getName(),
-                        applicationInfo);
-            }
-
-            //now copy the deployment artifacts, if required
-            if (mutableJar) {
-                Path deploymentLib = libDir.resolve(FastJarFormat.DEPLOYMENT_LIB);
-                Files.createDirectories(deploymentLib);
-                for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getDependencies()) {
-                    copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, deploymentLib, baseLib, p -> {
-                    }, false, classPath, appDep, new TransformedClassesBuildItem(Map.of()), removedArtifactKeys, packageConfig,
-                            manifestConfig, executorService); //we don't care about transformation here, so just pass in an empty item
-                }
-                Map<ArtifactKey, List<String>> relativePaths = new HashMap<>();
-                for (Map.Entry<ArtifactKey, List<Path>> e : copiedArtifacts.entrySet()) {
-                    relativePaths.put(e.getKey(),
-                            e.getValue().stream().map(s -> buildDir.relativize(s).toString().replace('\\', '/'))
-                                    .collect(Collectors.toList()));
-                }
-
-                //now we serialize the data needed to build up the reaugmentation class path
-                //first the app model
-                MutableJarApplicationModel model = new MutableJarApplicationModel(outputTarget.getBaseName(),
-                        relativePaths,
-                        curateOutcome.getApplicationModel(),
-                        packageConfig.jar().userProvidersDirectory().orElse(null), buildDir.relativize(runnerJar).toString());
-                Path appmodelDat = deploymentLib.resolve(FastJarFormat.APPMODEL_DAT);
-                manifestConfig.addComponent(ApplicationComponent.builder().setPath(appmodelDat).setDevelopmentScope());
-                try (OutputStream out = Files.newOutputStream(appmodelDat)) {
-                    ObjectOutputStream obj = new ObjectOutputStream(out);
-                    obj.writeObject(model);
-                    obj.close();
-                }
-                //now the bootstrap CP
-                //we just include all deployment deps, even though we only really need bootstrap
-                //as we don't really have a resolved bootstrap CP
-                //once we have the app model it will all be done in QuarkusClassLoader anyway
-                Path deploymentCp = deploymentLib.resolve(FastJarFormat.DEPLOYMENT_CLASS_PATH_DAT);
-                manifestConfig.addComponent(ApplicationComponent.builder().setPath(deploymentCp).setDevelopmentScope());
-                try (OutputStream out = Files.newOutputStream(deploymentCp)) {
-                    ObjectOutputStream obj = new ObjectOutputStream(out);
-                    List<String> paths = new ArrayList<>();
-                    for (ResolvedDependency i : curateOutcome.getApplicationModel().getDependencies()) {
-                        final List<String> list = relativePaths.get(i.getKey());
-                        // some of the dependencies may have been filtered out
-                        if (list != null) {
-                            paths.addAll(list);
-                        }
-                    }
-                    obj.writeObject(paths);
-                    obj.close();
-                }
-            }
-
-            if (packageConfig.jar().includeDependencyList()) {
-                Path deplist = buildDir.resolve(FastJarFormat.QUARKUS_APP_DEPS);
-                List<String> lines = new ArrayList<>();
-                for (ResolvedDependency i : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
-                    lines.add(i.toGACTVString());
-                }
-                lines.sort(Comparator.naturalOrder());
-                Files.write(deplist, lines);
-            }
-        } else {
-            //if it is a rebuild we might have classes
-        }
-        try (Stream<Path> files = Files.walk(buildDir)) {
-            files.forEach(new Consumer<Path>() {
-                @Override
-                public void accept(Path path) {
-                    path.toFile().setReadable(true, false);
-                }
-            });
-        }
-        return new JarBuildItem(initJar, null, libDir, packageConfig.jar().type(), null, manifestConfig.build());
-    }
-
-    private static Predicate<String> getThinJarIgnoredEntriesPredicate(PackageConfig packageConfig) {
-        return packageConfig.jar().userConfiguredIgnoredEntries().map(Set::copyOf).orElse(Set.of())::contains;
-    }
-
-    private static void copyDependency(Set<ArtifactKey> parentFirstArtifacts, OutputTargetBuildItem outputTargetBuildItem,
-            Map<ArtifactKey, List<Path>> runtimeArtifacts, Path libDir, Path baseLib, Consumer<Path> targetPathConsumer,
-            boolean allowParentFirst, StringBuilder classPath, ResolvedDependency appDep,
-            TransformedClassesBuildItem transformedClasses, Set<ArtifactKey> removedDeps,
-            PackageConfig packageConfig, ApplicationManifestConfig.Builder manifestConfig, ExecutorService executorService)
+    @Override
+    protected void writeSerializedApplication(OutputStream out, Path buildDir, List<Path> allJars, List<Path> sortedParentFirst)
             throws IOException {
-
-        // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
-        // and are not part of the optional dependencies to include
-        if (!includeAppDependency(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removedDeps)) {
-            return;
-        }
-        if (runtimeArtifacts.containsKey(appDep.getKey())) {
-            return;
-        }
-        Set<GACT> forceUseArtifactIdOnlyAsNameSet = packageConfig.jar().forceUseArtifactIdOnlyAsName()
-                .orElse(Collections.emptySet());
-        boolean forceUseArtifactIdOnlyAsName = forceUseArtifactIdOnlyAsNameSet.stream()
-                .anyMatch(gact -> gact.getGroupId().equals(appDep.getGroupId())
-                        && gact.getArtifactId().equals(appDep.getArtifactId())
-                        && gact.getType().equals(appDep.getType())
-                        && gact.getClassifier().equals(appDep.getClassifier()));
-        for (Path resolvedDep : appDep.getResolvedPaths()) {
-            String fileName;
-            if (forceUseArtifactIdOnlyAsName) {
-                fileName = appDep.getArtifactId() + "." + appDep.getType();
-            } else {
-                fileName = FastJarFormat.getJarFileName(appDep, resolvedDep);
-            }
-            final Path targetPath;
-
-            if (allowParentFirst && parentFirstArtifacts.contains(appDep.getKey())) {
-                targetPath = baseLib.resolve(fileName);
-                classPath.append(" ").append(FastJarFormat.LIB).append("/").append(FastJarFormat.BOOT_LIB).append("/")
-                        .append(fileName);
-            } else {
-                targetPath = libDir.resolve(fileName);
-                targetPathConsumer.accept(targetPath);
-            }
-            runtimeArtifacts.computeIfAbsent(appDep.getKey(), (s) -> new ArrayList<>(1)).add(targetPath);
-
-            if (Files.isDirectory(resolvedDep)) {
-                // This case can happen when we are building a jar from inside the Quarkus repository
-                // and Quarkus Bootstrap's localProjectDiscovery has been set to true. In such a case
-                // the non-jar dependencies are the Quarkus dependencies picked up on the file system
-                packageClasses(resolvedDep, targetPath, packageConfig, outputTargetBuildItem, executorService);
-            } else {
-                Set<TransformedClassesBuildItem.TransformedClass> transformedFromThisArchive = transformedClasses
-                        .getTransformedClassesByJar().get(resolvedDep);
-                Set<String> removedFromThisArchive = new HashSet<>();
-                if (transformedFromThisArchive != null) {
-                    for (TransformedClassesBuildItem.TransformedClass i : transformedFromThisArchive) {
-                        if (i.getData() == null) {
-                            removedFromThisArchive.add(i.getFileName());
-                        }
-                    }
-                }
-                var appComponent = ApplicationComponent.builder()
-                        .setPath(targetPath)
-                        .setResolvedDependency(appDep);
-                if (removedFromThisArchive.isEmpty()) {
-                    // let's not use COPY_ATTRIBUTES to make sure we respect the system umask
-                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING);
-                    Files.setLastModifiedTime(targetPath, Files.getLastModifiedTime(resolvedDep));
-                } else {
-                    // we copy jars for which we remove entries to the same directory
-                    // which seems a bit odd to me
-                    JarUnsigner.unsignJar(resolvedDep, targetPath, Predicate.not(removedFromThisArchive::contains));
-
-                    var list = new ArrayList<>(removedFromThisArchive);
-                    Collections.sort(list);
-                    var sb = new StringBuilder("Removed ").append(list.get(0));
-                    for (int i = 1; i < list.size(); ++i) {
-                        sb.append(",").append(list.get(i));
-                    }
-                    appComponent.setPedigree(sb.toString());
-                }
-                manifestConfig.addComponent(appComponent);
-            }
-        }
+        SerializedApplication.write(out, mainClass.getClassName(), buildDir, allJars, sortedParentFirst);
     }
 
-    private static void packageClasses(Path resolvedDep, final Path targetPath, PackageConfig packageConfig,
-            OutputTargetBuildItem outputTargetBuildItem, ExecutorService executorService) throws IOException {
-        try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(targetPath,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                outputTargetBuildItem.getOutputDirectory(), executorService)) {
-            Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
-                    new SimpleFileVisitor<Path>() {
-                        @Override
-                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                                throws IOException {
-                            final Path relativePath = resolvedDep.relativize(file);
-                            archiveCreator.addFile(file, relativePath.toString()); //replace only needed for testing
-                            return FileVisitResult.CONTINUE;
-                        }
-                    });
-        }
+    @Override
+    protected Class<?> getEntryPoint() {
+        return QuarkusEntryPoint.class;
     }
 
-    private static class FastJarJars {
-        private final Path transformedJar;
-        private final Path generatedJar;
-        private final Path runnerJar;
-        private final List<Path> dependencies;
-
-        public FastJarJars(FastJarJarsBuilder builder) {
-            this.transformedJar = builder.transformedJar;
-            this.generatedJar = builder.generatedJar;
-            this.runnerJar = builder.runnerJar;
-            this.dependencies = builder.dependencies;
-        }
-
-        public static class FastJarJarsBuilder {
-            private Path transformedJar;
-            private Path generatedJar;
-            private Path runnerJar;
-            private final List<Path> dependencies = new ArrayList<>();
-
-            public FastJarJarsBuilder setTransformedJar(Path transformedJar) {
-                this.transformedJar = transformedJar;
-                return this;
-            }
-
-            public FastJarJarsBuilder setGeneratedJar(Path generatedJar) {
-                this.generatedJar = generatedJar;
-                return this;
-            }
-
-            public FastJarJarsBuilder setRunnerJar(Path runnerJar) {
-                this.runnerJar = runnerJar;
-                return this;
-            }
-
-            public FastJarJarsBuilder addDependency(Path dependency) {
-                this.dependencies.add(dependency);
-                return this;
-            }
-
-            public FastJarJars build() {
-                return new FastJarJars(this);
-            }
-        }
+    @Override
+    protected String getClassPath(FastJarJars fastJarJars) {
+        return fastJarJars.getParentFirstClassPath();
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1,8 +1,5 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
-import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.UBER_JAR;
-
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,6 +37,7 @@ import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.UberJarIgnoredResourceBuildItem;
 import io.quarkus.deployment.pkg.builditem.UberJarMergedResourceBuildItem;
+import io.quarkus.deployment.pkg.jar.AotFastJarBuilder;
 import io.quarkus.deployment.pkg.jar.FastJarBuilder;
 import io.quarkus.deployment.pkg.jar.LegacyThinJarBuilder;
 import io.quarkus.deployment.pkg.jar.NativeImageSourceJarBuilder;
@@ -146,6 +144,20 @@ public class JarResultBuildStep {
                     buildExecutor,
                     jvmRequirements).build();
             case FAST_JAR, MUTABLE_JAR -> new FastJarBuilder(curateOutcomeBuildItem,
+                    outputTargetBuildItem,
+                    applicationInfo,
+                    packageConfig,
+                    mainClassBuildItem,
+                    applicationArchivesBuildItem,
+                    additionalApplicationArchiveBuildItems,
+                    transformedClasses,
+                    generatedClasses,
+                    generatedResources,
+                    parentFirstArtifactKeys,
+                    removedArtifactKeys,
+                    buildExecutor,
+                    jvmRequirements).build();
+            case AOT_JAR -> new AotFastJarBuilder(curateOutcomeBuildItem,
                     outputTargetBuildItem,
                     applicationInfo,
                     packageConfig,

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
@@ -1,6 +1,5 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.FAST_JAR;
 import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
 import static io.quarkus.deployment.util.ContainerRuntimeUtil.detectContainerRuntime;
 
@@ -86,7 +85,7 @@ public class JvmStartupOptimizerArchiveBuildStep {
         Path archivePath;
         JvmStartupOptimizerArchiveType archiveType = requested.get().getType();
         log.infof("Launching %s creation process.", archiveType);
-        boolean isFastJar = packageConfig.jar().type() == FAST_JAR;
+        boolean isFastJar = packageConfig.jar().type().usesFastJarLayout();
         if (archiveType == JvmStartupOptimizerArchiveType.AppCDS) {
             archivePath = createAppCDSFromExit(jarResult, outputTarget, javaBinPath, containerImage,
                     isFastJar);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -117,7 +117,7 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
                     outputs.put("fast-jar", fastJar());
                     outputs.put("legacy-lib", gradleBuildDir().resolve("lib").toFile());
                 }
-                case FAST_JAR -> outputs.put("fast-jar", fastJar());
+                case FAST_JAR, AOT_JAR -> outputs.put("fast-jar", fastJar());
                 case MUTABLE_JAR, UBER_JAR -> {
                     outputs.put("fast-jar", fastJar());
                     outputs.put("generated", genBuildDir().toFile());
@@ -148,7 +148,7 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
                     outputs.put("runner-jar", runnerJar());
                     outputs.put("artifact-properties", artifactProperties());
                 }
-                case FAST_JAR, MUTABLE_JAR -> outputs.put("artifact-properties", artifactProperties());
+                case FAST_JAR, MUTABLE_JAR, AOT_JAR -> outputs.put("artifact-properties", artifactProperties());
             }
         }
         return outputs;
@@ -174,7 +174,7 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
         } else if (jarEnabled()) {
             PackageConfig.JarConfig.JarType packageType = jarType();
             switch (packageType) {
-                case FAST_JAR -> {
+                case FAST_JAR, AOT_JAR -> {
                     Path appBuildBaseDir = appBuildDir();
                     inputs.add(genBuildDir().toFile());
                     inputs.add(appBuildBaseDir.resolve(outputDirectory()).toFile());
@@ -224,7 +224,7 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
             }
         } else if (jarEnabled()) {
             switch (jarType()) {
-                case FAST_JAR -> assembleFastJar();
+                case FAST_JAR, AOT_JAR -> assembleFastJar();
                 case LEGACY_JAR -> assembleLegacyJar();
                 case MUTABLE_JAR, UBER_JAR -> {
                     generateBuild();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildCacheableAppParts.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildCacheableAppParts.java
@@ -31,7 +31,7 @@ public abstract class QuarkusBuildCacheableAppParts extends QuarkusBuildTask {
             return false;
         }
         return switch (jarType()) {
-            case FAST_JAR, LEGACY_JAR -> true;
+            case FAST_JAR, LEGACY_JAR, AOT_JAR -> true;
             default -> false;
         };
     }
@@ -52,7 +52,7 @@ public abstract class QuarkusBuildCacheableAppParts extends QuarkusBuildTask {
             }
         } else {
             switch (jarType()) {
-                case FAST_JAR, LEGACY_JAR -> outputs.put("app-build-dir", appBuildDir().toFile());
+                case FAST_JAR, LEGACY_JAR, AOT_JAR -> outputs.put("app-build-dir", appBuildDir().toFile());
                 case MUTABLE_JAR, UBER_JAR -> {
                 }
             }
@@ -78,7 +78,7 @@ public abstract class QuarkusBuildCacheableAppParts extends QuarkusBuildTask {
             }
         } else {
             switch (jarType()) {
-                case FAST_JAR -> fastJarBuild();
+                case FAST_JAR, AOT_JAR -> fastJarBuild();
                 case LEGACY_JAR -> legacyJarBuild();
                 case MUTABLE_JAR, UBER_JAR -> getLogger().info(
                         "Falling back to 'full quarkus application build' for JAR type {}, this task's output is empty for this package type",

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
@@ -63,7 +63,7 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
         } else {
             PackageConfig.JarConfig.JarType packageType = jarType();
             switch (packageType) {
-                case FAST_JAR, LEGACY_JAR -> outputs.put("dependencies-dir", depBuildDir().toFile());
+                case FAST_JAR, LEGACY_JAR, AOT_JAR -> outputs.put("dependencies-dir", depBuildDir().toFile());
                 case MUTABLE_JAR, UBER_JAR -> {
                 }
             }
@@ -90,7 +90,7 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
         } else {
             PackageConfig.JarConfig.JarType packageType = jarType();
             switch (packageType) {
-                case FAST_JAR -> fastJarDependencies();
+                case FAST_JAR, AOT_JAR -> fastJarDependencies();
                 case LEGACY_JAR -> legacyJarDependencies();
                 case MUTABLE_JAR, UBER_JAR -> getLogger().info(
                         "Falling back to 'full quarkus application build' for JAR type {}, this task's output is empty for this build type",

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -259,7 +259,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
                 delete.delete(fastJar());
             } else if (jarEnabled()) {
                 switch (jarType()) {
-                    case FAST_JAR -> {
+                    case FAST_JAR, AOT_JAR -> {
                         delete.delete(buildDir.resolve(nativeImageSourceJarDirName()));
                         delete.delete(fastJar());
                     }
@@ -324,7 +324,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
                 }
             } else if (jarEnabled()) {
                 switch (jarType()) {
-                    case FAST_JAR -> {
+                    case FAST_JAR, AOT_JAR -> {
                         copy.include(outputDirectory() + "/**");
                         copy.include(QUARKUS_ARTIFACT_PROPERTIES);
                     }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -171,7 +171,7 @@ public class JibProcessor {
                 createContainerBuilderFromLegacyJar(determineBaseJvmImage(jibConfig, compiledJavaVersion),
                         jibConfig, containerImageConfig,
                         sourceJar, outputTarget, mainClass, containerImageLabels);
-            case FAST_JAR, MUTABLE_JAR ->
+            case FAST_JAR, MUTABLE_JAR, AOT_JAR ->
                 createContainerBuilderFromFastJar(determineBaseJvmImage(jibConfig, compiledJavaVersion),
                         jibConfig, containerImageConfig, sourceJar, curateOutcome,
                         containerImageLabels,

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -3,8 +3,6 @@ package io.quarkus.container.image.openshift.deployment;
 import static io.quarkus.container.image.openshift.deployment.OpenshiftUtils.getDeployStrategy;
 import static io.quarkus.container.image.openshift.deployment.OpenshiftUtils.getNamespace;
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
-import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.FAST_JAR;
-import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.MUTABLE_JAR;
 import static io.quarkus.deployment.pkg.jar.FastJarFormat.DEFAULT_FAST_JAR_DIRECTORY_NAME;
 
 import java.io.BufferedReader;
@@ -281,11 +279,11 @@ public class OpenshiftProcessor {
             //For s2i kind of builds where jars are expected directly in the '/' we have to use null.
             String outputDirName = out.getOutputDirectory().getFileName().toString();
             PackageConfig.JarConfig.JarType jarType = packageConfig.jar().type();
-            String contextRoot = getContextRoot(outputDirName, jarType == FAST_JAR || jarType == MUTABLE_JAR,
+            String contextRoot = getContextRoot(outputDirName, jarType.usesFastJarLayout(),
                     config.buildStrategy());
             KubernetesClientBuilder clientBuilder = newClientBuilderWithoutHttp2(kubernetesClient.getConfiguration(),
                     kubernetesClientBuilder.getHttpClientFactory());
-            if (jarType == FAST_JAR || jarType == MUTABLE_JAR) {
+            if (jarType.usesFastJarLayout()) {
                 createContainerImage(clientBuilder, openshiftYml.get(), config, contextRoot, jar.getPath().getParent(),
                         jar.getPath().getParent());
             } else if (jar.getLibraryDir() != null) { //When using uber-jar the libraryDir is going to be null, potentially causing NPE.

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -270,7 +270,7 @@ class KubernetesProcessor {
         return switch (jarType) {
             case LEGACY_JAR, UBER_JAR -> outputTarget.getOutputDirectory()
                     .resolve(outputTarget.getBaseName() + packageConfig.computedRunnerSuffix() + ".jar");
-            case FAST_JAR, MUTABLE_JAR -> {
+            case FAST_JAR, MUTABLE_JAR, AOT_JAR -> {
                 //thin JAR
                 Path buildDir;
 

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/forkjoin/QuarkusForkJoinWorkerThread.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/forkjoin/QuarkusForkJoinWorkerThread.java
@@ -3,8 +3,6 @@ package io.quarkus.bootstrap.forkjoin;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 
-import io.quarkus.bootstrap.runner.RunnerClassLoader;
-
 public class QuarkusForkJoinWorkerThread extends ForkJoinWorkerThread {
 
     private static volatile ClassLoader qClassloader;
@@ -13,7 +11,7 @@ public class QuarkusForkJoinWorkerThread extends ForkJoinWorkerThread {
         super(pool);
     }
 
-    public static synchronized void setQuarkusAppClassloader(RunnerClassLoader runnerClassLoader) {
+    public static synchronized void setQuarkusAppClassloader(ClassLoader runnerClassLoader) {
         qClassloader = runnerClassLoader;
     }
 

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotQuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotQuarkusEntryPoint.java
@@ -1,0 +1,73 @@
+package io.quarkus.bootstrap.runner;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThread;
+import io.quarkus.bootstrap.logging.InitialConfigurator;
+
+/**
+ * Entry point for AOT (Ahead-of-Time)-optimized jar packaging.
+ *
+ * This entry point sets up a thin class loader layer that caches frequently-accessed
+ * resources (service files) while delegating all class loading to
+ * standard Java class loaders for optimal AOT compilation performance.
+ */
+public class AotQuarkusEntryPoint {
+
+    public static final String QUARKUS_APPLICATION_DAT = QuarkusEntryPoint.QUARKUS_APPLICATION_DAT;
+
+    public static void main(String... args) throws Throwable {
+        System.setProperty("java.util.logging.manager", org.jboss.logmanager.LogManager.class.getName());
+        System.setProperty("java.util.concurrent.ForkJoinPool.common.threadFactory",
+                "io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory");
+        Timing.staticInitStarted(false);
+
+        try {
+            doRun(args);
+        } catch (RuntimeException | Error e) {
+            InitialConfigurator.DELAYED_HANDLER.close();
+            throw e;
+        } catch (Throwable t) {
+            InitialConfigurator.DELAYED_HANDLER.close();
+            throw new UndeclaredThrowableException(t);
+        }
+    }
+
+    private static void doRun(String... args) throws Throwable {
+        String path = AotQuarkusEntryPoint.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        Path appRoot = new File(decodedPath).toPath().getParent().getParent().getParent();
+
+        // Load cached resources and main class name
+        AotSerializedApplication app;
+        Path cacheFile = appRoot.resolve(QUARKUS_APPLICATION_DAT);
+        if (Files.isReadable(cacheFile)) {
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(cacheFile), 8192)) {
+                app = AotSerializedApplication.read(in);
+            }
+        } else {
+            throw new IllegalStateException("Serialized application file not found or not readable: " + cacheFile
+                    + ". The application may not have been packaged correctly with aot-jar type.");
+        }
+
+        final AotRunnerClassLoader aotRunnerClassLoader = app.getRunnerClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(aotRunnerClassLoader);
+            QuarkusForkJoinWorkerThread.setQuarkusAppClassloader(aotRunnerClassLoader);
+            Class<?> mainClass = aotRunnerClassLoader.loadClass(app.getMainClass());
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            lookup.findStatic(mainClass, "main", MethodType.methodType(void.class, String[].class)).invokeExact(args);
+        } finally {
+            QuarkusForkJoinWorkerThread.setQuarkusAppClassloader(null);
+        }
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
@@ -1,0 +1,280 @@
+package io.quarkus.bootstrap.runner;
+
+import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
+import static io.quarkus.commons.classloading.ClassLoaderHelper.isInJdkPackage;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A ClassLoader that behaves similarly to the RunnerClassLoader for resources
+ * but delegates all class loading to the JDK application class loader.
+ *
+ * The idea is that it lets us optimize the resource case, while still benefiting from AOT.
+ * Our hope is that we will be able to use a fully custom ClassLoader with Project Leyden at some point but we are not there
+ * yet.
+ *
+ * Key characteristics:
+ * - All class loading is delegated to the parent
+ * - Resource lookups are intercepted for the service files and otherwise delegated to the parent
+ * - For some selected directories, we have a full index of the content so that we can avoid negative lookups in the parent
+ *
+ * Note that not all ServiceLoader calls will hit this ClassLoader as some low levels one are directly hitting
+ * the ClassLoader used to load the classes, thus circumventing the optimizations we have in this ClassLoader.
+ * It is an expected behavior though, and will be vastly improved once we can use a custom ClassLoader with Leyden.
+ */
+public class AotRunnerClassLoader extends ClassLoader {
+
+    static {
+        registerAsParallelCapable();
+    }
+
+    // the following two fields go hand in hand - they need to both be populated from the same data
+    // in order for the resource loading to work properly
+    private final Set<String> fullyIndexedDirectories;
+    private final Set<String> fullyIndexedResources;
+
+    private final Map<String, byte[]> serviceFiles;
+
+    AotRunnerClassLoader(ClassLoader parent, Set<String> fullyIndexedDirectories, Set<String> fullyIndexedResources,
+            Map<String, byte[]> serviceFiles) {
+        super(parent);
+        this.fullyIndexedDirectories = fullyIndexedDirectories;
+        this.fullyIndexedResources = fullyIndexedResources;
+        this.serviceFiles = serviceFiles;
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        return loadClass(name, false);
+    }
+
+    @Override
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        // fast path for JDK classes
+        if (isInJdkPackage(name)) {
+            return getParent().loadClass(name);
+        }
+
+        // this infrastructure is not used for classes at the moment but could be in the future
+        String classResource = fromClassNameToResourceName(name);
+        String dirName = getDirNameFromResourceName(classResource);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(classResource)) {
+            throw new ClassNotFoundException(name);
+        }
+
+        return getParent().loadClass(name);
+    }
+
+    /**
+     * This method is needed to make packages work correctly on JDK9+, as it will be called
+     * to load the package-info class.
+     */
+    @Override
+    protected Class<?> findClass(String moduleName, String name) {
+        try {
+            return loadClass(name, false);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public URL getResource(String name) {
+        name = sanitizeName(name);
+
+        // If cached, return it immediately, no need to scan the jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return createCachedResourceURL(name, data);
+            }
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return null;
+        }
+
+        // if it exists, and is not cached, then delegate to the parent
+        return super.getResource(name);
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        name = sanitizeName(name);
+
+        // If cached, return it immediately, no need to scan the jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return createCachedResourceURL(name, data);
+            }
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return null;
+        }
+
+        return super.findResource(name);
+    }
+
+    /**
+     * Gets all resources with the given name.
+     * This is the method called by ServiceLoader and other resource loading mechanisms.
+     * If the resource is cached, returns ONLY the cached version without jar scanning.
+     * This is the key optimization - service files and config files are pre-cached,
+     * so ServiceLoader and config loading don't need to scan jars.
+     *
+     * @param name the resource name
+     * @return an enumeration of URLs for the resources
+     * @throws IOException if I/O errors occur
+     */
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        name = sanitizeName(name);
+
+        // The cached version already contains the concatenated content from all jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return Collections.enumeration(Collections.singletonList(
+                        createCachedResourceURL(name, data)));
+            }
+            return Collections.emptyEnumeration();
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return Collections.emptyEnumeration();
+        }
+
+        return super.getResources(name);
+    }
+
+    /**
+     * Finds all resources with the given name.
+     * If the resource is cached, returns ONLY the cached version without jar scanning.
+     *
+     * @param name the resource name
+     * @return an enumeration of URLs for the resources
+     * @throws IOException if I/O errors occur
+     */
+    @Override
+    public Enumeration<URL> findResources(String name) throws IOException {
+        name = sanitizeName(name);
+
+        // The cached version already contains the concatenated content from all jars
+        if (serviceFiles.containsKey(name)) {
+            byte[] data = serviceFiles.get(name);
+            if (data != null) {
+                return Collections.enumeration(Collections.singletonList(
+                        createCachedResourceURL(name, data)));
+            }
+            return Collections.emptyEnumeration();
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return Collections.emptyEnumeration();
+        }
+
+        // Not cached - delegate to parent implementation (will scan jars)
+        return super.findResources(name);
+    }
+
+    private URL createCachedResourceURL(String name, byte[] data) {
+        try {
+            return new URL(null, "cached:" + name, new CachedResourceURLStreamHandler(data));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Failed to create URL for cached resource: " + name, e);
+        }
+    }
+
+    /**
+     * URL stream handler for cached resources.
+     */
+    private static class CachedResourceURLStreamHandler extends URLStreamHandler {
+        private final byte[] data;
+
+        CachedResourceURLStreamHandler(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        protected URLConnection openConnection(URL url) {
+            return new CachedResourceURLConnection(url, data);
+        }
+    }
+
+    /**
+     * URL connection for cached resources.
+     */
+    private static class CachedResourceURLConnection extends URLConnection {
+        private final byte[] data;
+
+        CachedResourceURLConnection(URL url, byte[] data) {
+            super(url);
+            this.data = data;
+        }
+
+        @Override
+        public void connect() {
+            // No-op for in-memory resources
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public int getContentLength() {
+            return data.length;
+        }
+    }
+
+    private static String sanitizeName(String name) {
+        if (name != null && !name.isEmpty() && name.charAt(0) == '/') {
+            return name.substring(1);
+        }
+        return name;
+    }
+
+    private static String getDirNameFromResourceName(String resourceName) {
+        final int index = resourceName.lastIndexOf('/');
+        if (index == -1) {
+            // Return empty string for resources in the root directory (no package/directory)
+            return "";
+        }
+        return resourceName.substring(0, index);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        //see comment in hashCode
+        return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+        //We can return a constant as we expect to have a single instance of these;
+        //this is useful to avoid triggering a call to the identity hashcode,
+        //which could be rather inefficient as there's good chances that some component
+        //will have inflated the monitor of this instance.
+        //A hash collision would be unfortunate but unexpected, and shouldn't be a problem
+        //as the equals implementation still does honour the identity contract .
+        //See also discussion on https://github.com/smallrye/smallrye-context-propagation/pull/443
+        return 1;
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotSerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotSerializedApplication.java
@@ -1,0 +1,247 @@
+package io.quarkus.bootstrap.runner;
+
+import static io.quarkus.bootstrap.runner.JarVisitor.visitJar;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+/**
+ * Serialization and deserialization of cached resources for AOT-optimized jar packaging.
+ *
+ * This class handles the serialization of frequently-accessed resources (like service loader files)
+ * to avoid classpath scanning at runtime, while maintaining compatibility
+ * with standard Java classloaders for optimal AOT performance.
+ *
+ * The format is versioned and includes a magic number for validation.
+ */
+public class AotSerializedApplication {
+
+    private static final int MAGIC = 0xA07CA3E; // AOT CACHE
+    private static final int VERSION = 1;
+    // the files immediately (i.e. not recursively) under these paths should all be indexed
+    private static final List<String> FULLY_INDEXED_DIRECTORIES = List.of("", "META-INF", "META-INF/services");
+
+    private final AotRunnerClassLoader runnerClassLoader;
+    private final String mainClass;
+
+    public AotSerializedApplication(AotRunnerClassLoader runnerClassLoader, String mainClass) {
+        this.runnerClassLoader = runnerClassLoader;
+        this.mainClass = mainClass;
+    }
+
+    public String getMainClass() {
+        return mainClass;
+    }
+
+    public AotRunnerClassLoader getRunnerClassLoader() {
+        return runnerClassLoader;
+    }
+
+    /**
+     * Writes cached resources to an output stream in a binary format.
+     *
+     * Format:
+     * - Magic number (int)
+     * - Version (int)
+     * - Main class name (UTF string)
+     * - Fully indexed directory count (int)
+     * - For each fully indexed directory:
+     * . Directory path (UTF string)
+     * - Fully indexed resource count (int)
+     * - For each fully indexed resource:
+     * . Resource path (UTF string)
+     * - Service file count (int)
+     * - For each service file:
+     * . Resource path (UTF string)
+     * . Data length (int)
+     * . Data bytes
+     *
+     * @param out the output stream to write to
+     * @param mainClass the main class name
+     * @param classPath the full class path of the application
+     * @throws IOException if an I/O error occurs
+     */
+    public static void write(OutputStream out, String mainClass, List<Path> classPath) throws IOException {
+        try (DataOutputStream data = new DataOutputStream(out)) {
+            data.writeInt(MAGIC);
+            data.writeInt(VERSION);
+            data.writeUTF(mainClass);
+
+            // Write tracked directories
+            data.writeInt(FULLY_INDEXED_DIRECTORIES.size());
+            for (String directory : FULLY_INDEXED_DIRECTORIES) {
+                data.writeUTF(directory);
+            }
+
+            FullyIndexedJarVisitor fullyIndexedVisitor = new FullyIndexedJarVisitor(FULLY_INDEXED_DIRECTORIES);
+            ServiceLoaderFileJarVisitor serviceLoaderFileJarVisitor = new ServiceLoaderFileJarVisitor();
+            for (Path classPathElement : classPath) {
+                visitJar(classPathElement, fullyIndexedVisitor, serviceLoaderFileJarVisitor);
+            }
+
+            // Write directory contents
+            data.writeInt(fullyIndexedVisitor.getFullyIndexedResources().size());
+            for (String path : fullyIndexedVisitor.getFullyIndexedResources()) {
+                data.writeUTF(path);
+            }
+
+            Map<String, byte[]> serviceFiles = concatenateServiceFiles(serviceLoaderFileJarVisitor.getServiceFiles());
+
+            // Write service files
+            data.writeInt(serviceFiles.size());
+            for (Map.Entry<String, byte[]> entry : serviceFiles.entrySet()) {
+                data.writeUTF(entry.getKey());
+                byte[] content = entry.getValue();
+                data.writeInt(content.length);
+                data.write(content);
+            }
+            data.flush();
+        }
+    }
+
+    /**
+     * Reads cached resources from an input stream.
+     *
+     * @param in the input stream to read from
+     * @return an AotSerializedApplication containing the main class and cached resources
+     * @throws IOException if an I/O error occurs or the format is invalid
+     */
+    public static AotSerializedApplication read(InputStream in) throws IOException {
+        try (DataInputStream data = new DataInputStream(in)) {
+            int magic = data.readInt();
+            if (magic != MAGIC) {
+                throw new IOException("Invalid magic number in AOT cache file: expected 0x"
+                        + Integer.toHexString(MAGIC) + " but got 0x" + Integer.toHexString(magic));
+            }
+
+            int version = data.readInt();
+            if (version != VERSION) {
+                throw new IOException("Unsupported AOT cache version: expected " + VERSION + " but got " + version);
+            }
+
+            String mainClass = data.readUTF();
+
+            // Read tracked directories
+            int fullyIndexedDirectoryCount = data.readInt();
+            Set<String> fullyIndexedDirectories = new HashSet<>((int) Math.ceil(fullyIndexedDirectoryCount / 0.75f));
+            for (int i = 0; i < fullyIndexedDirectoryCount; i++) {
+                fullyIndexedDirectories.add(data.readUTF());
+            }
+
+            // Read directory contents
+            int fullyIndexedResourceCount = data.readInt();
+            Set<String> fullyIndexedResources = new HashSet<>((int) Math.ceil(fullyIndexedResourceCount / 0.75f));
+            for (int i = 0; i < fullyIndexedResourceCount; i++) {
+                fullyIndexedResources.add(data.readUTF());
+            }
+
+            // Read cached resources
+            int serviceFileCount = data.readInt();
+            Map<String, byte[]> serviceFiles = new HashMap<>((int) Math.ceil(serviceFileCount / 0.75f));
+
+            for (int i = 0; i < serviceFileCount; i++) {
+                String resourcePath = data.readUTF();
+                int dataLength = data.readInt();
+                byte[] content = new byte[dataLength];
+
+                int totalRead = 0;
+                while (totalRead < dataLength) {
+                    int read = data.read(content, totalRead, dataLength - totalRead);
+                    if (read == -1) {
+                        throw new IOException("Unexpected end of stream while reading resource: " + resourcePath);
+                    }
+                    totalRead += read;
+                }
+
+                serviceFiles.put(resourcePath, content);
+            }
+
+            AotRunnerClassLoader runnerClassLoader = new AotRunnerClassLoader(AotSerializedApplication.class.getClassLoader(),
+                    fullyIndexedDirectories, fullyIndexedResources, serviceFiles);
+
+            return new AotSerializedApplication(runnerClassLoader, mainClass);
+        }
+    }
+
+    private static class ServiceLoaderFileJarVisitor implements JarVisitor {
+
+        private final Map<String, List<byte[]>> serviceFiles = new LinkedHashMap<>();
+
+        public Map<String, List<byte[]>> getServiceFiles() {
+            return serviceFiles;
+        }
+
+        @Override
+        public void visitJarFileEntry(JarFile jarFile, ZipEntry fileEntry) {
+            if (!isServiceFile(fileEntry.getName())) {
+                return;
+            }
+
+            try (var is = jarFile.getInputStream(fileEntry)) {
+                serviceFiles.computeIfAbsent(fileEntry.getName(), k -> new ArrayList<>())
+                        .add(is.readAllBytes());
+            } catch (IOException e) {
+                throw new UncheckedIOException("Unable to read entry: " + fileEntry.getName() + " from jar: " + jarFile, e);
+            }
+        }
+
+        @Override
+        public void visitRegularFile(Path jar, Path file, String relativePath) {
+            if (!isServiceFile(relativePath)) {
+                return;
+            }
+
+            try {
+                serviceFiles.computeIfAbsent(relativePath, k -> new ArrayList<>())
+                        .add(Files.readAllBytes(file));
+            } catch (IOException e) {
+                throw new UncheckedIOException("Unable to read file: " + relativePath, e);
+            }
+        }
+
+        private static boolean isServiceFile(String resourcePath) {
+            return resourcePath.startsWith("META-INF/services/") && resourcePath.length() > 18;
+        }
+    }
+
+    private static Map<String, byte[]> concatenateServiceFiles(Map<String, List<byte[]>> files) throws IOException {
+        Map<String, byte[]> concatenatedServiceFiles = new TreeMap<>();
+
+        for (Entry<String, List<byte[]>> entry : files.entrySet()) {
+            if (entry.getValue().size() == 1) {
+                concatenatedServiceFiles.put(entry.getKey(), entry.getValue().get(0));
+                continue;
+            }
+
+            // Concatenate with newlines between files
+            ByteArrayOutputStream concatenatedEntry = new ByteArrayOutputStream();
+            for (int i = 0; i < entry.getValue().size(); i++) {
+                concatenatedEntry.write(entry.getValue().get(i));
+                if (i < entry.getValue().size() - 1) {
+                    concatenatedEntry.write('\n');
+                }
+            }
+            concatenatedServiceFiles.put(entry.getKey(), concatenatedEntry.toByteArray());
+        }
+
+        return concatenatedServiceFiles;
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/FullyIndexedJarVisitor.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/FullyIndexedJarVisitor.java
@@ -1,0 +1,58 @@
+package io.quarkus.bootstrap.runner;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+class FullyIndexedJarVisitor implements JarVisitor {
+
+    private final List<String> fullyIndexedDirectories;
+    private final Set<String> fullyIndexedResources = new LinkedHashSet<>();
+
+    FullyIndexedJarVisitor(List<String> fullyIndexedDirectories) {
+        this.fullyIndexedDirectories = fullyIndexedDirectories;
+    }
+
+    public Set<String> getFullyIndexedResources() {
+        return fullyIndexedResources;
+    }
+
+    @Override
+    public void visitJarFileEntry(JarFile jarFile, ZipEntry entry) {
+        // collect data for fully indexed directories, we collect both files and directories present there
+        for (String prefix : fullyIndexedDirectories) {
+            if (prefix.isEmpty()) {
+                int firstSlash = entry.getName().indexOf('/');
+                String topLevel = (firstSlash == -1) ? entry.getName() : entry.getName().substring(0, firstSlash);
+                fullyIndexedResources.add(topLevel);
+                continue;
+            }
+
+            String slashedPrefix = prefix + '/';
+
+            if (!entry.getName().startsWith(slashedPrefix)) {
+                continue;
+            }
+
+            if (entry.getName().equals(slashedPrefix)) {
+                fullyIndexedResources.add(prefix);
+                continue;
+            }
+
+            int nextSlash = entry.getName().indexOf('/', slashedPrefix.length());
+            String result;
+
+            if (nextSlash != -1) {
+                // we index the subdirectory part only
+                result = entry.getName().substring(0, nextSlash);
+            } else {
+                // It's a file or directory at the current level
+                result = entry.getName();
+            }
+
+            fullyIndexedResources.add(result);
+        }
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarVisitor.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarVisitor.java
@@ -1,0 +1,99 @@
+package io.quarkus.bootstrap.runner;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Enumeration;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+
+interface JarVisitor {
+
+    static void visitJar(Path jar, JarVisitor... jarVisitors) throws IOException {
+        for (JarVisitor jarVisitor : jarVisitors) {
+            jarVisitor.preVisit(jar);
+        }
+
+        if (Files.isDirectory(jar)) {
+            // this can only really happen when testing quarkus itself
+            // but is included for completeness
+            Files.walkFileTree(jar, new FileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    for (JarVisitor jarVisitor : jarVisitors) {
+                        jarVisitor.visitRegularDirectory(jar, dir, jar.relativize(dir).toString().replace('\\', '/'));
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    for (JarVisitor jarVisitor : jarVisitors) {
+                        jarVisitor.visitRegularFile(jar, file, jar.relativize(file).toString().replace('\\', '/'));
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } else {
+            try (JarFile jarFile = new JarFile(jar.toFile())) {
+                for (JarVisitor jarVisitor : jarVisitors) {
+                    Manifest manifest = jarFile.getManifest();
+                    if (manifest != null) {
+                        jarVisitor.visitJarManifest(jar, jarFile.getManifest());
+                    }
+                }
+
+                Enumeration<? extends ZipEntry> entries = jarFile.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+
+                    if (entry.getName().isEmpty()) {
+                        continue;
+                    }
+
+                    if (entry.isDirectory()) {
+                        for (JarVisitor jarVisitor : jarVisitors) {
+                            jarVisitor.visitJarDirectoryEntry(jarFile, entry);
+                        }
+                    } else {
+                        for (JarVisitor jarVisitor : jarVisitors) {
+                            jarVisitor.visitJarFileEntry(jarFile, entry);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    default void preVisit(Path jar) {
+    }
+
+    default void visitRegularDirectory(Path jar, Path directory, String relativePath) {
+    }
+
+    default void visitRegularFile(Path jar, Path file, String relativePath) {
+    }
+
+    default void visitJarManifest(Path jar, Manifest manifest) {
+    }
+
+    default void visitJarDirectoryEntry(JarFile jarFile, ZipEntry directoryEntry) {
+    }
+
+    default void visitJarFileEntry(JarFile jarFile, ZipEntry fileEntry) {
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -43,7 +43,7 @@ public final class RunnerClassLoader extends ClassLoader {
     // in order for the resource loading to work properly
     // normally this field would be a set, but it only contains 2 elements, so making it a list is actually better
     private final List<String> fullyIndexedDirectories;
-    private final Map<String, ClassLoadingResource[]> directlyIndexedResourcesIndexMap;
+    private final Map<String, ClassLoadingResource[]> fullyIndexedResourcesIndexMap;
 
     private final ClassLoadingResource generatedBytecodeClassLoadingResource;
     private final Set<String> generatedBytecode;
@@ -57,14 +57,14 @@ public final class RunnerClassLoader extends ClassLoader {
 
     RunnerClassLoader(ClassLoader parent, Map<String, ClassLoadingResource[]> resourceDirectoryMap,
             Set<String> parentFirstPackages,
-            List<String> fullyIndexedDirectories, Map<String, ClassLoadingResource[]> directlyIndexedResourcesIndexMap,
+            List<String> fullyIndexedDirectories, Map<String, ClassLoadingResource[]> fullyIndexedResourcesIndexMap,
             ClassLoadingResource generatedBytecodeClassLoadingResource, Set<String> generatedBytecode,
             ClassLoadingResource transformedBytecodeClassLoadingResource, Set<String> transformedBytecode) {
         super(parent);
         this.resourceDirectoryMap = resourceDirectoryMap;
         this.parentFirstPackages = parentFirstPackages;
         this.fullyIndexedDirectories = fullyIndexedDirectories;
-        this.directlyIndexedResourcesIndexMap = directlyIndexedResourcesIndexMap;
+        this.fullyIndexedResourcesIndexMap = fullyIndexedResourcesIndexMap;
         this.generatedBytecodeClassLoadingResource = generatedBytecodeClassLoadingResource;
         this.generatedBytecode = generatedBytecode;
         this.transformedBytecodeClassLoadingResource = transformedBytecodeClassLoadingResource;
@@ -243,7 +243,7 @@ public final class RunnerClassLoader extends ClassLoader {
     }
 
     private ClassLoadingResource[] getClassLoadingResources(final String name) {
-        ClassLoadingResource[] resources = directlyIndexedResourcesIndexMap.get(name);
+        ClassLoadingResource[] resources = fullyIndexedResourcesIndexMap.get(name);
         if (resources != null) {
             return resources;
         }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -299,14 +299,14 @@ public final class RunnerClassLoader extends ClassLoader {
     }
 
     /**
-     * This method is needed to make packages work correctly on JDK9+, as it will be called
+     * This method is needed to make packages work correctly, as it will be called
      * to load the package-info class.
      *
      * @param moduleName
      * @param name
      * @return
      */
-    //@Override
+    @Override
     protected Class<?> findClass(String moduleName, String name) {
         try {
             return loadClass(name, false);

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -252,10 +252,7 @@ public final class RunnerClassLoader extends ClassLoader {
             return resources;
         }
         String dirName = getDirNameFromResourceName(name);
-        if (!dirName.equals(name) && fullyIndexedDirectories.contains(dirName)) {
-            if (dirName.isEmpty()) {
-                return resourceDirectoryMap.get(name);
-            }
+        if (fullyIndexedDirectories.contains(dirName)) {
             // If we arrive here, we know that resource being queried belongs to one of the fully indexed directories
             // Had that resource existed however, it would have been present in directlyIndexedResourcesIndexMap
             return null;

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -252,9 +252,6 @@ public final class RunnerClassLoader extends ClassLoader {
             return resources;
         }
         String dirName = getDirNameFromResourceName(name);
-        if (dirName == null) {
-            dirName = "";
-        }
         if (!dirName.equals(name) && fullyIndexedDirectories.contains(dirName)) {
             if (dirName.isEmpty()) {
                 return resourceDirectoryMap.get(name);
@@ -305,10 +302,8 @@ public final class RunnerClassLoader extends ClassLoader {
     private String getDirNameFromResourceName(String resourceName) {
         final int index = resourceName.lastIndexOf('/');
         if (index == -1) {
-            // we return null here since in this case no package is defined
-            // this is same behavior as Package.getPackage(clazz) exhibits
-            // when the class is in the default package
-            return null;
+            // return the root directory as it was fully indexed
+            return "";
         }
         return resourceName.substring(0, index);
     }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
@@ -373,7 +373,7 @@ public class SerializedApplication {
                 Enumeration<? extends ZipEntry> entries = zip.entries();
                 while (entries.hasMoreElements()) {
                     ZipEntry entry = entries.nextElement();
-                    if (!entry.isDirectory()) {
+                    if (!entry.isDirectory() && !entry.getName().startsWith("META-INF/")) {
                         //some jars don't have correct  directory entries
                         //so we look at the file paths instead
                         //looking at you h2

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
@@ -194,7 +194,7 @@ public class SerializedApplication {
             // this map is populated correctly because the JarResource entries are added to allClassLoadingResources
             // in the same order as the classpath was written during the writing of the index
             int directlyIndexedSize = in.readUnsignedShort();
-            Map<String, ClassLoadingResource[]> directlyIndexedResourcesIndexMap = new HashMap<>(
+            Map<String, ClassLoadingResource[]> fullyIndexedResourcesIndexMap = new HashMap<>(
                     (int) Math.ceil(directlyIndexedSize / 0.75f));
             for (int i = 0; i < directlyIndexedSize; i++) {
                 String resource = in.readUTF();
@@ -203,11 +203,11 @@ public class SerializedApplication {
                 for (int j = 0; j < indexesSize; j++) {
                     matchingResources[j] = allClassLoadingResources[in.readUnsignedShort()];
                 }
-                directlyIndexedResourcesIndexMap.put(resource, matchingResources);
+                fullyIndexedResourcesIndexMap.put(resource, matchingResources);
             }
             RunnerClassLoader runnerClassLoader = new RunnerClassLoader(ClassLoader.getSystemClassLoader(),
                     resourceDirectoryTracker.getResult(), parentFirstPackages,
-                    FULLY_INDEXED_DIRECTORIES, directlyIndexedResourcesIndexMap,
+                    FULLY_INDEXED_DIRECTORIES, fullyIndexedResourcesIndexMap,
                     generatedBytecodeClassLoadingResource, generatedBytecode,
                     transformedBytecodeClassLoadingResource, transformedBytecode);
             for (ClassLoadingResource classLoadingResource : allClassLoadingResources) {

--- a/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/RunnerClassLoaderTest.java
+++ b/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/RunnerClassLoaderTest.java
@@ -37,7 +37,7 @@ public class RunnerClassLoaderTest {
                 createProjectJarResource("trivial-project-1.0.jar") });
 
         RunnerClassLoader runnerClassLoader = new RunnerClassLoader(ClassLoader.getSystemClassLoader(), resourceDirectoryMap,
-                Collections.emptySet(), Collections.emptySet(),
+                Collections.emptySet(),
                 Collections.emptyList(), Collections.emptyMap(),
                 null, Collections.emptySet(),
                 null, Collections.emptySet());
@@ -111,7 +111,7 @@ public class RunnerClassLoaderTest {
                 "org/simple", classLoadingResources);
 
         RunnerClassLoader runnerClassLoader = new RunnerClassLoader(ClassLoader.getSystemClassLoader(), resourceDirectoryMap,
-                Collections.emptySet(), Collections.emptySet(),
+                Collections.emptySet(),
                 Collections.emptyList(), Collections.emptyMap(),
                 null, Collections.emptySet(),
                 null, Collections.emptySet());

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -183,12 +183,22 @@ public class JarRunnerIT extends MojoTestBase {
 
     @Test
     public void testThatFastJarFormatWorks() throws Exception {
-        assertThatFastJarFormatWorks(null);
+        assertThatFastJarFormatWorks(null, "fast-jar");
     }
 
     @Test
     public void testThatFastJarCustomOutputDirFormatWorks() throws Exception {
-        assertThatFastJarFormatWorks("custom");
+        assertThatFastJarFormatWorks("custom", "fast-jar");
+    }
+
+    @Test
+    public void testThatAotJarFormatWorks() throws Exception {
+        assertThatFastJarFormatWorks(null, "aot-jar");
+    }
+
+    @Test
+    public void testThatAotJarCustomOutputDirFormatWorks() throws Exception {
+        assertThatFastJarFormatWorks("custom", "aot-jar");
     }
 
     @Test
@@ -807,14 +817,14 @@ public class JarRunnerIT extends MojoTestBase {
         }
     }
 
-    private void assertThatFastJarFormatWorks(String outputDir) throws Exception {
+    private void assertThatFastJarFormatWorks(String outputDir, String format) throws Exception {
         File testDir = initProject("projects/rr-with-json-logging", "projects/rr-with-json-logging" + outputDir);
         RunningInvoker running = new RunningInvoker(testDir, false);
 
         MavenProcessInvocationResult result = running
                 .execute(Arrays.asList("package",
                         "-DskipTests",
-                        "-Dquarkus.package.jar.type=fast-jar",
+                        "-Dquarkus.package.jar.type=" + format,
                         outputDir == null ? "" : "-Dquarkus.package.output-directory=" + outputDir), Collections.emptyMap());
 
         await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)


### PR DESCRIPTION
Better reviewed commit per commit.

This PR:

- introduces some enhancements/refactorings for the fast-jar packaging, making the code clearer, more flexible, and more extensible
- introduces an `aot-jar` packaging with the exact same approach presented here https://github.com/quarkusio/quarkus/pull/52047 but based on the fast-jar layout

I was able to start the simple REST app in less than 100 ms on my laptop, with this new packaging and the AOT training using an IT.