### PR TITLE
Add Gradle support for proper dependency tracking to app model

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -3,6 +3,7 @@ package io.quarkus.gradle;
 import static io.quarkus.gradle.GradleUtils.composeDevFiles;
 import static io.quarkus.gradle.extension.QuarkusPluginExtension.combinedOutputSourceDirs;
 import static io.quarkus.gradle.tasks.QuarkusGradleUtils.getSourceSet;
+import static io.quarkus.gradle.tooling.dependency.DependencyDataCollector.declaredDependencyCollectorEnabled;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -76,6 +77,7 @@ import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
 import io.quarkus.gradle.tooling.GradleApplicationModelBuilder;
 import io.quarkus.gradle.tooling.ProjectDescriptorBuilder;
 import io.quarkus.gradle.tooling.ToolingUtils;
+import io.quarkus.gradle.tooling.dependency.DependencyDataCollector;
 import io.quarkus.gradle.tooling.dependency.DependencyUtils;
 import io.quarkus.gradle.tooling.dependency.ExtensionDependency;
 import io.quarkus.gradle.tooling.dependency.ProjectExtensionDependency;
@@ -201,21 +203,25 @@ public class QuarkusPlugin implements Plugin<Project> {
                 LaunchMode.DEVELOPMENT);
 
         Provider<DefaultProjectDescriptor> projectDescriptor = ProjectDescriptorBuilder.buildForApp(project);
+        DependencyDataCollector depDataCollector = new DependencyDataCollector(project);
+
         TaskProvider<QuarkusApplicationModelTask> quarkusGenerateTestAppModelTask = tasks.register(
                 "quarkusGenerateTestAppModel",
                 QuarkusApplicationModelTask.class, task -> {
-                    configureApplicationModelTask(project, task, projectDescriptor, testClasspath, LaunchMode.TEST,
+                    configureApplicationModelTask(project, task, projectDescriptor,
+                            testClasspath, depDataCollector, LaunchMode.TEST,
                             "quarkus/application-model/quarkus-app-test-model.dat");
                 });
         TaskProvider<QuarkusApplicationModelTask> quarkusGenerateDevAppModelTask = tasks.register("quarkusGenerateDevAppModel",
                 QuarkusApplicationModelTask.class, task -> {
-                    configureApplicationModelTask(project, task, projectDescriptor, devClasspath, LaunchMode.DEVELOPMENT,
+                    configureApplicationModelTask(project, task, projectDescriptor,
+                            devClasspath, depDataCollector, LaunchMode.DEVELOPMENT,
                             "quarkus/application-model/quarkus-app-dev-model.dat");
                 });
         TaskProvider<QuarkusApplicationModelTask> quarkusGenerateAppModelTask = tasks.register("quarkusGenerateAppModel",
                 QuarkusApplicationModelTask.class, task -> {
                     configureApplicationModelTask(project, task, projectDescriptor,
-                            normalClasspath, LaunchMode.NORMAL,
+                            normalClasspath, depDataCollector, LaunchMode.NORMAL,
                             "quarkus/application-model/quarkus-app-model.dat");
                 });
 
@@ -248,7 +254,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                 QuarkusApplicationModelTask.class, task -> {
                     task.dependsOn(tasks.named(JavaPlugin.CLASSES_TASK_NAME));
                     configureApplicationModelTask(project, task, projectDescriptor,
-                            normalClasspath, LaunchMode.NORMAL,
+                            normalClasspath, depDataCollector, LaunchMode.NORMAL,
                             "quarkus/application-model/quarkus-app-model-build.dat");
                 });
         tasks.register(QUARKUS_SHOW_EFFECTIVE_CONFIG_TASK_NAME,
@@ -580,9 +586,16 @@ public class QuarkusPlugin implements Plugin<Project> {
     private static void configureApplicationModelTask(Project project, QuarkusApplicationModelTask task,
             Provider<DefaultProjectDescriptor> projectDescriptor,
             ApplicationDeploymentClasspathBuilder classpath,
+            DependencyDataCollector dependencyDataCollector,
             LaunchMode launchMode, String quarkusModelFile) {
+        var declaredDepsProvider = project.getProviders()
+                .provider(() -> dependencyDataCollector.collectDeclaredDependencies(
+                        project, classpath.getDeploymentConfiguration()));
         task.getProjectDescriptor().set(projectDescriptor);
+        task.getDeclaredDependencyCollectorEnabled().set(declaredDependencyCollectorEnabled(project));
         task.getLaunchMode().set(launchMode);
+        task.getDeclaredDependencies().set(declaredDepsProvider);
+        task.getDeclaredDependenciesSnapshot().set(declaredDepsProvider.map(DependencyDataCollector::toSnapshot));
         task.getTypeModel().set(task.getPath());
         task.getOriginalClasspath().setFrom(classpath.getOriginalRuntimeClasspathAsInput());
         task.getAppClasspath().configureFrom(classpath.getRuntimeConfigurationWithoutResolvingDeployment());

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -2,6 +2,7 @@ package io.quarkus.gradle.tasks;
 
 import static io.quarkus.gradle.tooling.GradleApplicationModelBuilder.clearFlag;
 import static io.quarkus.gradle.tooling.GradleApplicationModelBuilder.isFlagOn;
+import static io.quarkus.gradle.tooling.dependency.DependencyUtils.getKey;
 import static java.util.stream.Collectors.toList;
 
 import java.io.BufferedReader;
@@ -41,6 +42,8 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
@@ -66,6 +69,7 @@ import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.gradle.tooling.DefaultProjectDescriptor;
 import io.quarkus.gradle.tooling.ProjectDescriptor;
 import io.quarkus.gradle.tooling.ToolingUtils;
+import io.quarkus.gradle.tooling.dependency.DependencyDataCollector;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -130,6 +134,19 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     @Input
     public abstract Property<DefaultProjectDescriptor> getProjectDescriptor();
 
+    @Input
+    public abstract Property<Boolean> getDeclaredDependencyCollectorEnabled();
+
+    @Internal
+    public abstract MapProperty<ArtifactKey, DependencyDataCollector.DeclaredDepsResult> getDeclaredDependencies();
+
+    /**
+     * Snapshot here is declared as input, since it's used for incremental builds/caching,
+     * while the actual map of declared dependencies is declared as internal.
+     */
+    @Input
+    public abstract ListProperty<String> getDeclaredDependenciesSnapshot();
+
     @OutputFile
     public abstract RegularFileProperty getApplicationModel();
 
@@ -151,6 +168,15 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
         collectDependencies(getAppClasspath(), modelBuilder, projectDescriptor.getWorkspaceModule(), projectDescriptor);
         collectExtensionDependencies(getDeploymentClasspath(), modelBuilder);
         collectCompileOnlyDependencies(getCompileOnlyClasspath(), modelBuilder);
+
+        if (getDeclaredDependencyCollectorEnabled().get()) {
+            var declaredDependencies = getDeclaredDependencies().get();
+            DependencyDataCollector.setDirectDeps(appArtifact, modelBuilder, declaredDependencies, getLogger());
+            for (ResolvedDependencyBuilder dep : modelBuilder.getDependencies()) {
+                DependencyDataCollector.setDirectDeps(dep, modelBuilder, declaredDependencies, getLogger());
+            }
+        }
+
         DefaultApplicationModel model = modelBuilder.build();
         ToolingUtils.serializeAppModel(model, getApplicationModel().get().getAsFile().toPath());
     }
@@ -284,11 +310,11 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
         byte newFlags = flags;
         for (QuarkusResolvedArtifact artifact : artifacts) {
             collectedArtifactFiles.add(artifact.file);
-            String classifier = resolveClassifier(moduleId, artifact.file);
-            final ArtifactKey artifactKey = ArtifactKey.of(
+            final ArtifactKey artifactKey = getKey(
                     moduleId.getGroup(),
                     moduleId.getName(),
-                    classifier,
+                    moduleId.getVersion(),
+                    artifact.file,
                     artifact.type);
             if (!isDependency(artifact)
                     || modelBuilder.getDependency(artifactKey) != null
@@ -389,10 +415,11 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
         final ModuleVersionIdentifier moduleVersionIdentifier = getModuleVersion(resolvedDependency);
         boolean clearReloadableFlagChildren = clearReloadableFlag;
         for (QuarkusResolvedArtifact artifact : artifacts) {
-
-            String classifier = resolveClassifier(moduleVersionIdentifier, artifact.file);
-            ArtifactKey artifactKey = ArtifactKey.of(moduleVersionIdentifier.getGroup(), moduleVersionIdentifier.getName(),
-                    classifier,
+            ArtifactKey artifactKey = getKey(
+                    moduleVersionIdentifier.getGroup(),
+                    moduleVersionIdentifier.getName(),
+                    moduleVersionIdentifier.getVersion(),
+                    artifact.file,
                     artifact.type);
             if (!isDependency(artifact)
                     // test fixtures depend on the default jar artifact, which could be the root one
@@ -454,11 +481,11 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
             if (!isDependency(artifact)) {
                 continue;
             }
-            String classifier = resolveClassifier(moduleId, artifact.file);
-            final ArtifactKey artifactKey = ArtifactKey.of(
+            final ArtifactKey artifactKey = getKey(
                     moduleId.getGroup(),
                     moduleId.getName(),
-                    classifier,
+                    moduleId.getVersion(),
+                    artifact.file,
                     artifact.type);
             if (isApplicationRoot(modelBuilder, artifactKey)) {
                 continue;
@@ -488,18 +515,6 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     private static List<QuarkusResolvedArtifact> getResolvedModuleArtifacts(
             Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> artifacts, ComponentIdentifier moduleId) {
         return artifacts.getOrDefault(moduleId, List.of());
-    }
-
-    private static String resolveClassifier(ModuleVersionIdentifier moduleVersionIdentifier, File file) {
-        String artifactIdVersion = moduleVersionIdentifier.getVersion().isEmpty()
-                || "unspecified".equals(moduleVersionIdentifier.getVersion())
-                        ? moduleVersionIdentifier.getName()
-                        : moduleVersionIdentifier.getName() + "-" + moduleVersionIdentifier.getVersion();
-        if ((file.getName().endsWith(".jar") || file.getName().endsWith(".pom") || file.getName().endsWith(".exe"))
-                && file.getName().startsWith(artifactIdVersion + "-")) {
-            return file.getName().substring(artifactIdVersion.length() + 1, file.getName().length() - 4);
-        }
-        return "";
     }
 
     static ResolvedDependencyBuilder toDependency(ArtifactCoords artifactCoords, File file, int... flags) {

--- a/devtools/gradle/gradle-model/build.gradle.kts
+++ b/devtools/gradle/gradle-model/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly(libs.kotlin.gradle.plugin.api)
+    implementation("org.apache.maven:maven-core")
     gradleApi()
 }
 

--- a/devtools/gradle/gradle-model/pom.xml
+++ b/devtools/gradle/gradle-model/pom.xml
@@ -19,6 +19,17 @@
         <artifactFilePrefix>gradle-model</artifactFilePrefix>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <!-- Compile -->
         <dependency>

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle.tooling;
 
 import static io.quarkus.gradle.tooling.ToolingUtils.getClassesOutputDir;
+import static io.quarkus.gradle.tooling.dependency.DependencyDataCollector.declaredDependencyCollectorEnabled;
 import static io.quarkus.gradle.tooling.dependency.DependencyUtils.getArtifactCoords;
 import static io.quarkus.gradle.tooling.dependency.DependencyUtils.getKey;
 
@@ -34,6 +35,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.initialization.IncludedBuild;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskCollection;
@@ -60,6 +62,7 @@ import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
+import io.quarkus.gradle.tooling.dependency.DependencyDataCollector;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -106,7 +109,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         final LaunchMode mode = LaunchMode.valueOf(parameter.getMode());
 
         final ApplicationDeploymentClasspathBuilder classpathBuilder = new ApplicationDeploymentClasspathBuilder(project, mode);
-        final Configuration classpathConfig = classpathBuilder.getRuntimeConfiguration();
+        final Configuration runtimeConfig = classpathBuilder.getRuntimeConfiguration();
         final Configuration deploymentConfig = classpathBuilder.getDeploymentConfiguration();
         final PlatformImports platformImports = classpathBuilder.getPlatformImports();
 
@@ -119,13 +122,17 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
             }
         }
 
+        final DependencyDataCollector collector = new DependencyDataCollector(project);
+        // we only collect from deployment config, since it is a superset of the runtime config.
+        final Map<ArtifactKey, DependencyDataCollector.DeclaredDepsResult> declaredDeps = collector
+                .collectDeclaredDependencies(project, deploymentConfig);
         final ResolvedDependencyBuilder appArtifact = getProjectArtifact(project, workspaceDiscovery);
         final ApplicationModelBuilder modelBuilder = new ApplicationModelBuilder()
                 .setAppArtifact(appArtifact)
                 .addReloadableWorkspaceModule(appArtifact.getKey())
                 .setPlatformImports(platformImports);
 
-        collectDependencies(classpathConfig.getResolvedConfiguration(), classpathConfig.getIncoming(), workspaceDiscovery,
+        collectDependencies(runtimeConfig.getResolvedConfiguration(), runtimeConfig.getIncoming(), workspaceDiscovery,
                 project, modelBuilder, appArtifact.getWorkspaceModule().mutable());
         collectExtensionDependencies(project, deploymentConfig, modelBuilder);
         for (var dep : modelBuilder.getDependencies()) {
@@ -134,6 +141,14 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
             }
         }
         addCompileOnly(project, classpathBuilder, modelBuilder);
+
+        if (declaredDependencyCollectorEnabled(project)) {
+            Logger logger = project.getLogger();
+            DependencyDataCollector.setDirectDeps(appArtifact, modelBuilder, declaredDeps, logger);
+            for (var dep : modelBuilder.getDependencies()) {
+                DependencyDataCollector.setDirectDeps(dep, modelBuilder, declaredDeps, logger);
+            }
+        }
 
         return modelBuilder.build();
     }
@@ -350,8 +365,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                 dep = toDependency(a);
                 modelBuilder.addDependency(dep);
             }
-        }
-        if (dep != null) {
+        } else {
             dep.setDeploymentCp();
             dep.clearFlag(DependencyFlags.RELOADABLE);
         }
@@ -400,6 +414,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                         .setRuntimeCp()
                         .setDeploymentCp();
                 processQuarkusDependency(artifactBuilder, modelBuilder);
+                // depInfoCollector is not used to handle artifact dependencies at this point.
                 modelBuilder.addDependency(artifactBuilder);
             }
         }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleAssistedMavenModelResolverImpl.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleAssistedMavenModelResolverImpl.java
@@ -1,0 +1,119 @@
+package io.quarkus.gradle.tooling;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Parent;
+import org.apache.maven.model.Repository;
+import org.apache.maven.model.building.ModelSource2;
+import org.apache.maven.model.resolution.ModelResolver;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.maven.MavenModule;
+import org.gradle.maven.MavenPomArtifact;
+
+import io.quarkus.maven.dependency.GAV;
+
+public class GradleAssistedMavenModelResolverImpl implements ModelResolver {
+
+    private final Project project;
+    private final Map<GAV, Optional<File>> pomCache = new ConcurrentHashMap<>();
+
+    public GradleAssistedMavenModelResolverImpl(Project project) {
+        this.project = project;
+    }
+
+    private static GAV cacheKey(String groupId, String artifactId, String version) {
+        return new GAV(groupId, artifactId, version);
+    }
+
+    @Override
+    public ModelSource2 resolveModel(String groupId, String artifactId, String version)
+            throws UnresolvableModelException {
+        GAV key = cacheKey(groupId, artifactId, version);
+
+        File pomFile = pomCache
+                .computeIfAbsent(key, this::resolvePomViaQuery)
+                .orElse(null);
+
+        if (pomFile == null) {
+            throw new UnresolvableModelException(
+                    "Could not resolve POM for " + groupId + ":" + artifactId + ":" + version,
+                    groupId, artifactId, version);
+        }
+
+        final File resolvedPom = pomFile;
+        return new ModelSource2() {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return new FileInputStream(resolvedPom);
+            }
+
+            @Override
+            public String getLocation() {
+                return resolvedPom.getAbsolutePath();
+            }
+
+            @Override
+            public ModelSource2 getRelatedSource(String relPath) {
+                return null;
+            }
+
+            @Override
+            public URI getLocationURI() {
+                return resolvedPom.toURI();
+            }
+        };
+    }
+
+    private Optional<File> resolvePomViaQuery(GAV gav) {
+        @SuppressWarnings("unchecked")
+        var componentId = project.getDependencies()
+                .createArtifactResolutionQuery()
+                .forModule(gav.getGroupId(), gav.getArtifactId(), gav.getVersion())
+                .withArtifacts(MavenModule.class, MavenPomArtifact.class)
+                .execute();
+
+        for (var component : componentId.getResolvedComponents()) {
+            for (var artifactResult : component.getArtifacts(MavenPomArtifact.class)) {
+                if (artifactResult instanceof ResolvedArtifactResult resolved) {
+                    return Optional.of(resolved.getFile());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public ModelSource2 resolveModel(Parent parent) throws UnresolvableModelException {
+        return resolveModel(parent.getGroupId(), parent.getArtifactId(), parent.getVersion());
+    }
+
+    @Override
+    public ModelSource2 resolveModel(Dependency dependency) throws UnresolvableModelException {
+        return resolveModel(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+    }
+
+    @Override
+    public void addRepository(Repository repository) {
+        // ignore
+    }
+
+    @Override
+    public void addRepository(Repository repository, boolean replace) {
+        // ignore
+    }
+
+    @Override
+    public ModelResolver newCopy() {
+        return this;
+    }
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyDataCollector.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyDataCollector.java
@@ -1,0 +1,446 @@
+package io.quarkus.gradle.tooling.dependency;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.DefaultModelBuilder;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.DefaultModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ArtifactCollection;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.internal.composite.IncludedBuildInternal;
+
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.gradle.tooling.GradleAssistedMavenModelResolverImpl;
+import io.quarkus.gradle.tooling.ToolingUtils;
+import io.quarkus.gradle.tooling.taskrunner.MavenModelResolutionTaskRunner;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyBuilder;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.GAV;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+public class DependencyDataCollector {
+
+    private static final String ENABLE_DECLARED_DEPENDENCY_COLLECTOR = "enableDeclaredDependencyCollector";
+
+    private static final String SCOPE_RUNTIME = "runtime";
+    private static final String SCOPE_TEST = "test";
+
+    private final GradleAssistedMavenModelResolverImpl mavenModelResolver;
+    private final DefaultModelBuilder modelBuilder;
+
+    private final Map<DeclaredDepsCacheKey, DeclaredDepsResult> declaredDependenciesCache = new ConcurrentHashMap<>();
+
+    public DependencyDataCollector(Project project) {
+        this.mavenModelResolver = new GradleAssistedMavenModelResolverImpl(project);
+        this.modelBuilder = new DefaultModelBuilderFactory().newInstance();
+    }
+
+    /**
+     * Setting the project property to 'true' will enable declared dependency collection
+     * for this project.
+     */
+    public static boolean declaredDependencyCollectorEnabled(Project project) {
+        final Object value = project.getProperties().get(ENABLE_DECLARED_DEPENDENCY_COLLECTOR);
+        return value != null && Boolean.parseBoolean(String.valueOf(value));
+    }
+
+    /**
+     * Sets direct dependencies for the given dependency builder based on the provided declared dependencies.
+     * <p>
+     * The intention here is to use this method right before we build the model, making sure that the modelBuilder
+     * hass all the info about all dependencies, so we can properly set the flags for direct dependencies (e.g.
+     * MISSING_FROM_APPLICATION).
+     */
+    public static void setDirectDeps(
+            ResolvedDependencyBuilder depBuilder,
+            ApplicationModelBuilder modelBuilder,
+            Map<ArtifactKey, DeclaredDepsResult> declaredDependencies, Logger logger) {
+        final DeclaredDepsResult declaredDepsResult = declaredDependencies.get(depBuilder.getKey());
+        if (declaredDepsResult == null || !declaredDepsResult.isResolved()) {
+            logger.info("Declared dependencies not found for {}", depBuilder.getArtifactCoords().toGACTVString());
+            return;
+        }
+        final List<DependencyDataCollector.DeclaredDependency> declaredDeps = declaredDepsResult.getDeclaredDependencies();
+
+        final List<io.quarkus.maven.dependency.Dependency> directDeps = new ArrayList<>(declaredDeps.size());
+        final List<ArtifactCoords> depCoords = new ArrayList<>(declaredDeps.size());
+
+        for (var declaredDep : declaredDeps) {
+            var builder = DependencyBuilder.newInstance()
+                    .setGroupId(declaredDep.getGroupId())
+                    .setArtifactId(declaredDep.getArtifactId())
+                    .setClassifier(defaultIfNull(declaredDep.getClassifier(), ArtifactCoords.DEFAULT_CLASSIFIER))
+                    .setType(defaultIfNull(declaredDep.getType(), ArtifactCoords.TYPE_JAR))
+                    .setVersion(declaredDep.getVersion());
+
+            if (declaredDep.getScope() != null) {
+                builder.setScope(declaredDep.getScope());
+            }
+
+            var appDep = modelBuilder.getDependency(builder.getKey());
+            if (appDep == null) {
+                builder.setFlags(DependencyFlags.MISSING_FROM_APPLICATION);
+            } else {
+                builder.setVersion(appDep.getVersion())
+                        .setFlags(appDep.getFlags());
+            }
+
+            builder.setOptional(declaredDep.isOptional())
+                    .setFlags(DependencyFlags.DIRECT);
+
+            var directDep = builder.build();
+            directDeps.add(directDep);
+
+            if (appDep != null) {
+                depCoords.add(toPlainArtifactCoords(directDep));
+            }
+        }
+
+        depBuilder.setDependencies(depCoords)
+                .setDirectDependencies(directDeps);
+    }
+
+    /**
+     * Builds a deterministic snapshot of declared dependencies for task inputs.
+     */
+    public static List<String> toSnapshot(Map<ArtifactKey, DeclaredDepsResult> declaredDependencies) {
+        if (declaredDependencies.isEmpty()) {
+            return List.of();
+        }
+        final Map<String, DeclaredDepsResult> sorted = new TreeMap<>();
+        for (var entry : declaredDependencies.entrySet()) {
+            ArtifactKey key = entry.getKey();
+            String keyString = key.getGroupId() + ":" + key.getArtifactId()
+                    + ":" + defaultIfNull(key.getClassifier(), "")
+                    + ":" + defaultIfNull(key.getType(), "");
+            sorted.put(keyString, entry.getValue());
+        }
+
+        final List<String> snapshot = new ArrayList<>(sorted.size());
+        for (var entry : sorted.entrySet()) {
+            DeclaredDepsResult result = entry.getValue();
+            snapshot.add("k:" + entry.getKey() + "|resolved=" + result.isResolved());
+            List<String> deps = new ArrayList<>(result.getDeclaredDependencies().size());
+            for (var dep : result.getDeclaredDependencies()) {
+                deps.add("d:" + dep.getGroupId() + ":" + dep.getArtifactId()
+                        + ":" + defaultIfNull(dep.getVersion(), "")
+                        + ":" + defaultIfNull(dep.getClassifier(), "")
+                        + ":" + defaultIfNull(dep.getType(), "")
+                        + ":" + defaultIfNull(dep.getScope(), "")
+                        + ":" + dep.isOptional());
+            }
+            Collections.sort(deps);
+            snapshot.addAll(deps);
+        }
+
+        return List.copyOf(snapshot);
+    }
+
+    /**
+     * Collects and returns declared dependencies for the given configuration.
+     */
+    public Map<ArtifactKey, DeclaredDepsResult> collectDeclaredDependencies(Project project, Configuration configuration) {
+        if (!declaredDependencyCollectorEnabled(project)) {
+            return Collections.emptyMap();
+        }
+
+        var startTime = project.getLogger().isDebugEnabled() ? System.currentTimeMillis() : -1;
+        ArtifactCollection artifacts = configuration.getIncoming().getArtifacts();
+        boolean isTestConfig = configuration.getName().toLowerCase().contains("test");
+        MavenModelResolutionTaskRunner taskRunner = new MavenModelResolutionTaskRunner((task, error) -> project.getLogger()
+                .error("Error during declared dependencies collection task execution: {}", error.getMessage(), error));
+        Map<ArtifactKey, DeclaredDepsResult> result = new ConcurrentHashMap<>();
+        collectDeclaredFromRootProject(project, isTestConfig, result);
+        for (ResolvedArtifactResult artifact : artifacts.getArtifacts()) {
+            var componentId = artifact.getId().getComponentIdentifier();
+            if (componentId instanceof ModuleComponentIdentifier moduleId) {
+                taskRunner.run(() -> collectDeclaredFromModule(project, artifact, moduleId, result));
+            } else if (componentId instanceof ProjectComponentIdentifier projectId) {
+                collectDeclaredFromNonRootProject(project, artifact, projectId, result);
+            }
+        }
+        taskRunner.waitForCompletion();
+        if (startTime > 0) {
+            project.getLogger().debug("Declared dependencies collection for configuration {} took {} ms",
+                    configuration.getName(), System.currentTimeMillis() - startTime);
+        }
+        return result;
+    }
+
+    private void collectDeclaredFromModule(
+            Project project,
+            ResolvedArtifactResult artifact,
+            ModuleComponentIdentifier moduleId,
+            Map<ArtifactKey, DeclaredDepsResult> resultMap) {
+
+        String groupId = moduleId.getGroup();
+        String artifactId = moduleId.getModule();
+        String version = moduleId.getVersion();
+        String type = resolveArtifactType(artifact);
+        ArtifactKey moduleKey = DependencyUtils.getKey(groupId, artifactId, version, artifact.getFile(), type);
+        DeclaredDepsResult result = declaredDependenciesCache.computeIfAbsent(new DeclaredDepsCacheKey(moduleKey, false),
+                key -> {
+                    try {
+                        var modelSource = mavenModelResolver.resolveModel(moduleKey.getGroupId(), moduleKey.getArtifactId(),
+                                version);
+                        var request = new DefaultModelBuildingRequest();
+                        request.setModelSource(modelSource);
+                        request.setModelResolver(mavenModelResolver);
+                        request.getSystemProperties().putAll(System.getProperties());
+                        request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+                        Model effectiveModel = modelBuilder.build(request).getEffectiveModel();
+                        List<DeclaredDependency> declaredDeps = toDeclaredDependencies(effectiveModel);
+                        return DeclaredDepsResult.resolved(declaredDeps);
+                    } catch (UnresolvableModelException | ModelBuildingException e) {
+                        project.getLogger().warn("Unable to resolve effective model for {}:{}:{}: {}",
+                                moduleKey.getGroupId(), moduleKey.getArtifactId(), version, e.getMessage());
+                        return DeclaredDepsResult.unresolved();
+                    }
+                });
+        resultMap.put(moduleKey, result);
+    }
+
+    private void collectDeclaredFromNonRootProject(
+            Project project,
+            ResolvedArtifactResult artifact,
+            ProjectComponentIdentifier projectId,
+            Map<ArtifactKey, DeclaredDepsResult> resultMap) {
+        final Project depProject = getProject(project, projectId);
+        if (depProject == null) {
+            throw new GradleException("Project dependency not found for path: " + projectId.getProjectPath());
+        }
+        String groupId = String.valueOf(depProject.getGroup());
+        String artifactId = depProject.getName();
+        String version = String.valueOf(depProject.getVersion());
+        String type = resolveArtifactType(artifact);
+        ArtifactKey projectKey = DependencyUtils.getKey(groupId, artifactId, version, artifact.getFile(), type);
+        // from this code branche, depProject is never a root project, so we set collectTestScopes to false
+        DeclaredDepsResult result = declaredDependenciesCache.computeIfAbsent(new DeclaredDepsCacheKey(projectKey, false),
+                key -> DeclaredDepsResult.resolved(collectDeclaredFromProject(depProject, false)));
+        resultMap.put(projectKey, result);
+    }
+
+    private static Project getProject(Project project, ProjectComponentIdentifier projectId) {
+        var includedBuild = ToolingUtils.includedBuild(project, projectId.getBuild().getBuildPath());
+        final Project depProject;
+        if (includedBuild != null) {
+            if (includedBuild instanceof IncludedBuildInternal ib) {
+                depProject = ToolingUtils.includedBuildProject(ib, projectId.getProjectPath());
+            } else {
+                depProject = null;
+            }
+        } else {
+            depProject = project.getRootProject().findProject(projectId.getProjectPath());
+        }
+        return depProject;
+    }
+
+    private void collectDeclaredFromRootProject(Project project, boolean isTestConfig,
+            Map<ArtifactKey, DeclaredDepsResult> resultMap) {
+        String groupId = String.valueOf(project.getGroup());
+        String artifactId = project.getName();
+        ArtifactKey projectKey = ArtifactKey.of(groupId, artifactId,
+                ArtifactCoords.DEFAULT_CLASSIFIER, ArtifactCoords.TYPE_JAR);
+        DeclaredDepsCacheKey cacheKey = new DeclaredDepsCacheKey(projectKey, isTestConfig);
+        DeclaredDepsResult result = declaredDependenciesCache.computeIfAbsent(
+                cacheKey,
+                k -> DeclaredDepsResult.resolved(collectDeclaredFromProject(project, isTestConfig)));
+        resultMap.put(projectKey, result);
+    }
+
+    private record DeclaredDepsCacheKey(ArtifactKey artifactKey, boolean includeTestScopes) {
+    }
+
+    private static List<DeclaredDependency> collectDeclaredFromProject(Project project,
+            boolean collectTestScopes) {
+        // Configuration to scope mapping:
+        // api/implementation -> compile
+        // runtimeOnly -> runtime
+        // compileOnly -> ignored altogether
+        // test* -> test
+        final Map<GAV, DeclaredDependency> declaredDeps = new LinkedHashMap<>();
+
+        addDeclaredFromConfig(project, JavaPlugin.API_CONFIGURATION_NAME,
+                io.quarkus.maven.dependency.Dependency.SCOPE_COMPILE, declaredDeps);
+        addDeclaredFromConfig(project, JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME,
+                io.quarkus.maven.dependency.Dependency.SCOPE_COMPILE, declaredDeps);
+        addDeclaredFromConfig(project, JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, SCOPE_RUNTIME, declaredDeps);
+        if (collectTestScopes) {
+            addDeclaredFromConfig(project, JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, SCOPE_TEST, declaredDeps);
+            addDeclaredFromConfig(project, JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, SCOPE_TEST, declaredDeps);
+            // addDeclaredFromConfig(project, JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME, SCOPE_TEST, declaredDeps);
+        }
+
+        return new ArrayList<>(declaredDeps.values());
+    }
+
+    private static void addDeclaredFromConfig(Project p, String cfgName, String scope,
+            Map<GAV, DeclaredDependency> out) {
+        final Configuration cfg = p.getConfigurations().findByName(cfgName);
+        if (cfg == null) {
+            return;
+        }
+
+        for (var d : cfg.getDependencies()) {
+            var gav = new GAV(
+                    String.valueOf(d.getGroup()),
+                    d.getName(),
+                    String.valueOf(d.getVersion()));
+            if (d instanceof ProjectDependency pd) {
+                Project dp = p.findProject(pd.getPath());
+                if (dp == null) {
+                    // should not happen
+                    throw new GradleException("Failed to find project for dependency: " + pd.getPath());
+                }
+            }
+            out.put(gav, new DeclaredDependency(
+                    gav.getGroupId(),
+                    gav.getArtifactId(),
+                    gav.getVersion(),
+                    null,
+                    null,
+                    scope,
+                    false));
+
+        }
+    }
+
+    private static List<DeclaredDependency> toDeclaredDependencies(Model model) {
+        final List<DeclaredDependency> declaredDeps = new ArrayList<>();
+        for (org.apache.maven.model.Dependency dep : model.getDependencies()) {
+            if (!SCOPE_TEST.equals(dep.getScope())) {
+                declaredDeps.add(new DeclaredDependency(dep));
+            }
+        }
+        return declaredDeps;
+    }
+
+    private static String resolveArtifactType(ResolvedArtifactResult artifact) {
+        return artifact.getVariant().getAttributes().getAttribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE);
+    }
+
+    private static ArtifactCoords toPlainArtifactCoords(io.quarkus.maven.dependency.Dependency dep) {
+        return ArtifactCoords.of(dep.getGroupId(), dep.getArtifactId(), dep.getClassifier(), dep.getType(), dep.getVersion());
+    }
+
+    private static String defaultIfNull(String value, String fallback) {
+        return value == null ? fallback : value;
+    }
+
+    public static class DeclaredDependency implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final String groupId;
+        private final String artifactId;
+        private final String classifier;
+        private final String type;
+        private final String version;
+        private final String scope;
+        private final boolean optional;
+
+        DeclaredDependency(org.apache.maven.model.Dependency dep) {
+            this.groupId = dep.getGroupId();
+            this.artifactId = dep.getArtifactId();
+            this.classifier = defaultIfNull(dep.getClassifier(), ArtifactCoords.DEFAULT_CLASSIFIER);
+            this.type = defaultIfNull(dep.getType(), ArtifactCoords.TYPE_JAR);
+            this.version = dep.getVersion();
+            this.scope = defaultIfNull(dep.getScope(), io.quarkus.maven.dependency.Dependency.SCOPE_COMPILE);
+            this.optional = Boolean.parseBoolean(dep.getOptional());
+        }
+
+        DeclaredDependency(String groupId, String artifactId, String version,
+                String classifier, String type, String scope, boolean optional) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.version = version;
+            this.classifier = classifier;
+            this.type = type;
+            this.scope = scope;
+            this.optional = optional;
+        }
+
+        String getGroupId() {
+            return groupId;
+        }
+
+        String getArtifactId() {
+            return artifactId;
+        }
+
+        String getClassifier() {
+            return classifier;
+        }
+
+        String getType() {
+            return type;
+        }
+
+        String getVersion() {
+            return version;
+        }
+
+        String getScope() {
+            return scope;
+        }
+
+        boolean isOptional() {
+            return optional;
+        }
+    }
+
+    public static class DeclaredDepsResult implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final List<DeclaredDependency> declaredDependencies;
+        private final boolean resolved;
+
+        private DeclaredDepsResult(List<DeclaredDependency> declaredDependencies, boolean resolved) {
+            this.declaredDependencies = declaredDependencies;
+            this.resolved = resolved;
+        }
+
+        public static DeclaredDepsResult resolved(List<DeclaredDependency> declaredDependencies) {
+            return new DeclaredDepsResult(declaredDependencies, true);
+        }
+
+        public static DeclaredDepsResult unresolved() {
+            return new DeclaredDepsResult(List.of(), false);
+        }
+
+        public List<DeclaredDependency> getDeclaredDependencies() {
+            return declaredDependencies;
+        }
+
+        public boolean isResolved() {
+            return resolved;
+        }
+    }
+
+}

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
@@ -387,6 +387,22 @@ public class DependencyUtils {
                 artifact.getExtension() == null ? ArtifactCoords.TYPE_JAR : artifact.getExtension());
     }
 
+    public static ArtifactKey getKey(String groupId, String artifactId, String version, File file, String type) {
+        String classifier = resolveClassifier(artifactId, version, file);
+        return ArtifactKey.of(groupId, artifactId, classifier, type);
+    }
+
+    private static String resolveClassifier(String artifactId, String version, File file) {
+        String artifactIdVersion = version == null || version.isEmpty() || "unspecified".equals(version)
+                ? artifactId
+                : artifactId + "-" + version;
+        if ((file.getName().endsWith(".jar") || file.getName().endsWith(".pom") || file.getName().endsWith(".exe"))
+                && file.getName().startsWith(artifactIdVersion + "-")) {
+            return file.getName().substring(artifactIdVersion.length() + 1, file.getName().length() - 4);
+        }
+        return "";
+    }
+
     public static ArtifactCoords getArtifactCoords(ResolvedArtifact artifact) {
         return ArtifactCoords.of(artifact.getModuleVersion().getId().getGroup(), artifact.getName(),
                 artifact.getClassifier() == null ? ArtifactCoords.DEFAULT_CLASSIFIER : artifact.getClassifier(),

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/taskrunner/MavenModelResolutionTaskRunner.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/taskrunner/MavenModelResolutionTaskRunner.java
@@ -1,0 +1,52 @@
+package io.quarkus.gradle.tooling.taskrunner;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Phaser;
+
+/**
+ * This is a copy of io.quarkus.bootstrap.resolver.maven.NonBlockingModelResolutionTaskRunner
+ * with the same implementation, with Task and ErrorHandler interfaces defined as inner interfaces to avoid
+ * dependency on the maven-resolver module.
+ */
+public class MavenModelResolutionTaskRunner {
+
+    private final Phaser phaser = new Phaser(1);
+
+    private final ErrorHandler errorHandler;
+
+    public MavenModelResolutionTaskRunner(ErrorHandler errorHandler) {
+        this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler cannot be null");
+    }
+
+    public void run(Task task) {
+        phaser.register();
+        CompletableFuture.runAsync(() -> {
+            try {
+                task.run();
+            } catch (Exception e) {
+                errorHandler.handleError(task, e);
+            } finally {
+                phaser.arriveAndDeregister();
+            }
+        });
+    }
+
+    public void waitForCompletion() {
+        phaser.arriveAndAwaitAdvance();
+        errorHandler.allTasksFinished();
+    }
+
+    public interface Task {
+
+        void run();
+    }
+
+    public interface ErrorHandler {
+        void handleError(Task task, Exception error);
+
+        default void allTasksFinished() {
+        }
+    }
+
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/local-lib/build.gradle
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/local-lib/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+group = 'org.acme.local'
+version = '1.0.0'
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroup 'org.acme.deps'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.acme.deps:lib-c:1.0.0'
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/local-lib/src/main/java/org/acme/local/LocalUtil.java
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/local-lib/src/main/java/org/acme/local/LocalUtil.java
@@ -1,0 +1,10 @@
+package org.acme.local;
+
+public final class LocalUtil {
+    private LocalUtil() {
+    }
+
+    public static String value() {
+        return "local-lib";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/runner/build.gradle
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/runner/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+group = 'org.acme'
+version = '1.0.0'
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroup 'org.acme.deps'
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-rest'
+    implementation project(':local-lib')
+    implementation 'org.acme.deps:lib-a:1.0.0'
+    testImplementation 'org.acme.deps:lib-e:1.0.0'
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/runner/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/runner/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,13 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/consumer-gradle/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroup 'org.acme.deps'
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+include 'runner', 'local-lib'

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/build.gradle
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/build.gradle
@@ -1,0 +1,8 @@
+def isWindows() {
+    System.getProperty('os.name').toLowerCase().contains('win')
+}
+
+tasks.register('publishToMavenLocal', Exec) {
+    commandLine = isWindows() ? ['cmd', '/c', 'mvn', '-q', 'clean', 'install']
+                              : ['mvn', '-q', 'clean', 'install']
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-a/pom.xml
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-a/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme.deps</groupId>
+        <artifactId>declared-deps-minimal-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>lib-a</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.acme.deps</groupId>
+            <artifactId>lib-b</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.acme.deps</groupId>
+            <artifactId>lib-c</artifactId>
+            <version>1.0.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.acme.deps</groupId>
+            <artifactId>lib-d</artifactId>
+            <version>1.0.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.acme.deps</groupId>
+            <artifactId>lib-e</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-a/src/main/java/org/acme/deps/LibA.java
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-a/src/main/java/org/acme/deps/LibA.java
@@ -1,0 +1,10 @@
+package org.acme.deps;
+
+public final class LibA {
+    private LibA() {
+    }
+
+    public static String name() {
+        return "lib-a";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-b/pom.xml
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-b/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme.deps</groupId>
+        <artifactId>declared-deps-minimal-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>lib-b</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-b/src/main/java/org/acme/deps/LibB.java
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-b/src/main/java/org/acme/deps/LibB.java
@@ -1,0 +1,10 @@
+package org.acme.deps;
+
+public final class LibB {
+    private LibB() {
+    }
+
+    public static String name() {
+        return "lib-b";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-c/pom.xml
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-c/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme.deps</groupId>
+        <artifactId>declared-deps-minimal-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>lib-c</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-c/src/main/java/org/acme/deps/LibC.java
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-c/src/main/java/org/acme/deps/LibC.java
@@ -1,0 +1,10 @@
+package org.acme.deps;
+
+public final class LibC {
+    private LibC() {
+    }
+
+    public static String name() {
+        return "lib-c";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-d/pom.xml
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-d/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme.deps</groupId>
+        <artifactId>declared-deps-minimal-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>lib-d</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-d/src/main/java/org/acme/deps/LibD.java
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-d/src/main/java/org/acme/deps/LibD.java
@@ -1,0 +1,10 @@
+package org.acme.deps;
+
+public final class LibD {
+    private LibD() {
+    }
+
+    public static String name() {
+        return "lib-d";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-e/pom.xml
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-e/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme.deps</groupId>
+        <artifactId>declared-deps-minimal-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>lib-e</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-e/src/main/java/org/acme/deps/LibE.java
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/lib-e/src/main/java/org/acme/deps/LibE.java
@@ -1,0 +1,10 @@
+package org.acme.deps;
+
+public final class LibE {
+    private LibE() {
+    }
+
+    public static String name() {
+        return "lib-e";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/pom.xml
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme.deps</groupId>
+    <artifactId>declared-deps-minimal-parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>lib-a</module>
+        <module>lib-b</module>
+        <module>lib-c</module>
+        <module>lib-d</module>
+        <module>lib-e</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "declared-deps-minimal-producer"

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/DeclaredDependenciesMinimalTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/DeclaredDependenciesMinimalTest.java
@@ -1,0 +1,185 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.bootstrap.app.ApplicationModelSerializer;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+// @formatter:off
+/**
+ * runner
+ * ├─ org.acme.deps:lib-e (test)
+ * ├─ project :local-lib
+ * │  └─ org.acme.deps:lib-c
+ * └─ org.acme.deps:lib-a
+ *    ├─ org.acme.deps:lib-b
+ *    ├─ org.acme.deps:lib-c (optional)
+ *    ├─ org.acme.deps:lib-d (optional)
+ *    └─ org.acme.deps:lib-e (test)
+ */
+// @formatter:on
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Declared dependencies (Gradle)")
+public class DeclaredDependenciesMinimalTest extends QuarkusGradleWrapperTestBase {
+
+    private static final String CONSUMER_PROJECT_PATH = "declared-deps-minimal/consumer-gradle";
+    private static final String PRODUCER_PROJECT_PATH = "declared-deps-minimal/producer-maven";
+
+    private static final Set<String> EXPECTED_GROUPS = Set.of("org.acme.local", "org.acme.deps");
+
+    private static final String GRADLE_SUBPROJECT = "org.acme.local:local-lib:1.0.0";
+    private static final String LIB_A = "org.acme.deps:lib-a:1.0.0";
+    private static final String LIB_B = "org.acme.deps:lib-b:1.0.0";
+    private static final String LIB_C = "org.acme.deps:lib-c:1.0.0";
+    private static final String LIB_D = "org.acme.deps:lib-d:1.0.0";
+    private static final String LIB_E = "org.acme.deps:lib-e:1.0.0";
+
+    @Test
+    @Order(1)
+    @DisplayName("Publish Maven test artifact to local repository")
+    public void publishTestArtifacts() throws Exception {
+        File producerProject = getProjectDir(PRODUCER_PROJECT_PATH);
+        runGradleWrapper(producerProject, "publishToMavenLocal");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Generate app model and verify direct dependencies")
+    public void generateAppModel() throws Exception {
+        File projectDir = getProjectDir(CONSUMER_PROJECT_PATH);
+        runGradleWrapper(projectDir, "clean", ":runner:quarkusGenerateAppModel", "-PenableDeclaredDependencyCollector=true");
+
+        ApplicationModel appModel = ApplicationModelSerializer.deserialize(
+                projectDir.toPath().resolve("runner/build/quarkus/application-model/quarkus-app-model.dat"));
+
+        // App artifact declared deps
+        Set<String> appArtifactDeclared = getDeclared(appModel.getAppArtifact()).keySet();
+        assertThat(appArtifactDeclared).containsOnly(LIB_A, GRADLE_SUBPROJECT);
+
+        // App artifact resolved deps
+        Set<String> appArtifactResolved = getResolved(appModel.getAppArtifact());
+        assertThat(appArtifactResolved).containsOnly(LIB_A, GRADLE_SUBPROJECT);
+
+        // All resolved deps
+        Set<String> allResolved = getAll(appModel).keySet();
+        assertThat(allResolved).containsOnly(LIB_A, GRADLE_SUBPROJECT, LIB_B, LIB_C);
+
+        // Lib A
+        ResolvedDependency libA = findDependency(appModel, LIB_A);
+        assertThat(libA).isNotNull();
+
+        // Lib A declared deps
+        Map<String, Dependency> libADeclaredDeps = getDeclared(libA);
+
+        Dependency libB = libADeclaredDeps.get(LIB_B);
+        assertThat(libB).isNotNull();
+        assertThat(libB.isFlagSet(DependencyFlags.MISSING_FROM_APPLICATION)).isFalse();
+
+        Dependency libC = libADeclaredDeps.get(LIB_C);
+        assertThat(libC).isNotNull();
+        assertThat(libC.isFlagSet(DependencyFlags.MISSING_FROM_APPLICATION)).isFalse();
+
+        Dependency libD = libADeclaredDeps.get(LIB_D);
+        assertThat(libD).isNotNull();
+        assertThat(libD.isFlagSet(DependencyFlags.MISSING_FROM_APPLICATION)).isTrue();
+
+        assertThat(libADeclaredDeps).doesNotContainKey(LIB_E);
+
+        // Lib A resolved deps
+        Set<String> libAResolvedCoords = getResolved(libA);
+        assertThat(libAResolvedCoords).containsOnly(LIB_B, LIB_C);
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Generate test app model and verify test-scope root dependencies")
+    public void generateTestAppModel() throws Exception {
+        File projectDir = getProjectDir(CONSUMER_PROJECT_PATH);
+        runGradleWrapper(projectDir, "clean", ":runner:quarkusGenerateTestAppModel",
+                "-PenableDeclaredDependencyCollector=true");
+
+        ApplicationModel appModel = ApplicationModelSerializer.deserialize(
+                projectDir.toPath().resolve("runner/build/quarkus/application-model/quarkus-app-test-model.dat"));
+
+        // Lib E is found on app artifact (since we are in test scope and it's app artifact)
+        Dependency declaredLibE = getDeclared(appModel.getAppArtifact()).get(LIB_E);
+        assertThat(declaredLibE).isNotNull();
+        assertThat(declaredLibE.getScope()).isEqualTo("test");
+
+        // Same for resolved
+        var appArtifactResolved = getResolved(appModel.getAppArtifact());
+        assertThat(appArtifactResolved).contains(LIB_E);
+
+        // Lib E is NOT found in lib A though, since lib A is not root
+        ResolvedDependency libA = findDependency(appModel, LIB_A);
+        assertThat(libA).isNotNull();
+        Map<String, Dependency> libADeclaredDeps = getDeclared(libA);
+        assertThat(libADeclaredDeps).doesNotContainKey(LIB_E);
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Normal model does not leak test deps after test model run")
+    public void normalModelDoesNotLeakTestDeps() throws Exception {
+        File projectDir = getProjectDir(CONSUMER_PROJECT_PATH);
+        runGradleWrapper(projectDir, "clean", ":runner:quarkusGenerateAppModel", ":runner:quarkusGenerateTestAppModel",
+                "-PenableDeclaredDependencyCollector=true");
+
+        ApplicationModel normalModel = ApplicationModelSerializer.deserialize(
+                projectDir.toPath().resolve("runner/build/quarkus/application-model/quarkus-app-model.dat"));
+        ApplicationModel testModel = ApplicationModelSerializer.deserialize(
+                projectDir.toPath().resolve("runner/build/quarkus/application-model/quarkus-app-test-model.dat"));
+
+        Dependency normalLibE = getDeclared(normalModel.getAppArtifact()).get(LIB_E);
+        Dependency testLibE = getDeclared(testModel.getAppArtifact()).get(LIB_E);
+
+        assertThat(normalLibE).isNull();
+        assertThat(testLibE).isNotNull();
+        assertThat(testLibE.getScope()).isEqualTo("test");
+    }
+
+    private static Map<String, ResolvedDependency> getAll(ApplicationModel appModel) {
+        return appModel.getDependencies().stream()
+                .filter(rd -> EXPECTED_GROUPS.contains(rd.getGroupId()))
+                .collect(Collectors.toMap(
+                        rd -> toCoords(rd.getGroupId(), rd.getArtifactId(), rd.getVersion()),
+                        rd -> rd));
+    }
+
+    private static ResolvedDependency findDependency(ApplicationModel model, String coords) {
+        return getAll(model).get(coords);
+    }
+
+    private static Set<String> getResolved(ResolvedDependency resolvedDependency) {
+        return resolvedDependency.getDependencies().stream()
+                .filter(c -> EXPECTED_GROUPS.contains(c.getGroupId()))
+                .map(c -> toCoords(c.getGroupId(), c.getArtifactId(), c.getVersion()))
+                .collect(Collectors.toSet());
+    }
+
+    private static Map<String, Dependency> getDeclared(ResolvedDependency resolvedDependency) {
+        return resolvedDependency.getDirectDependencies().stream()
+                .filter(d -> EXPECTED_GROUPS.contains(d.getGroupId()))
+                .collect(Collectors.toMap(
+                        dep -> toCoords(dep.getGroupId(), dep.getArtifactId(), dep.getVersion()),
+                        dep -> dep));
+    }
+
+    private static String toCoords(String groupId, String artifactId, String version) {
+        return groupId + ":" + artifactId + ":" + version;
+    }
+}


### PR DESCRIPTION
With this change we provide a way tocollect declared
and resolved dependencies for Gradle builds and wire
them into the application model.

A boolean prop 'enableDeclaredDependencyCollector'
is available to enable this feature.

Usage:
`<your gradle command> -PenableDeclaredDependencyCollector=true`

Co-authored-by: Alexey Loubyansky <olubyans@redhat.com>