### PR TITLE
Upgrade protoc & protobuf-java to 4.33.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
                                             <!-- com.google.auth -->
                                             <!-- perfmark.version https://central.sonatype.com/artifact/io.grpc/grpc-core  -->
         <grpc-jprotoc.version>1.2.2</grpc-jprotoc.version>
-        <protoc.version>4.32.1</protoc.version>
+        <protoc.version>4.33.2</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
         <protobuf-kotlin.version>${protoc.version}</protobuf-kotlin.version>
         <proto-google-common-protos.version>2.65.0</proto-google-common-protos.version>


### PR DESCRIPTION
Required due to recent upgrade of `com.google.api.grpc:proto-google-common-protos` to 2.65.0.

See conversation in https://github.com/quarkusio/quarkus/pull/52179.