### PR TITLE
Reduce number of created ReflectiveClassBuildItem instances

### DIFF
--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
@@ -42,13 +42,11 @@ public class AvroProcessor {
 
         Collection<AnnotationInstance> annotations = indexBuildItem.getIndex()
                 .getAnnotations(DotName.createSimple(AvroGenerated.class.getName()));
-        for (AnnotationInstance annotation : annotations) {
-            if (annotation.target().kind() == AnnotationTarget.Kind.CLASS) {
-                String className = annotation.target().asClass().name().toString();
-                reflectiveClass.produce(
-                        ReflectiveClassBuildItem.builder(className).methods().fields().build());
-            }
-        }
+        final var classesForReflection = annotations.stream()
+                .filter(annotation -> annotation.target().kind() == AnnotationTarget.Kind.CLASS)
+                .map(annotation -> annotation.target().asClass().name().toString())
+                .toList();
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(classesForReflection).methods().fields().build());
 
         builder.addRuntimeInitializedClass("org.apache.avro.reflect.ReflectData");
         conf.produce(builder.build());


### PR DESCRIPTION
Collect class names instead of creating a build item instance for each.
