### PR TITLE
Use namespaced name in default guides link in extension template

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -261,6 +261,8 @@ public class CreateExtension {
         String namespaceName = computeDefaultNamespaceName(data.getRequiredStringValue(NAMESPACE_ID));
         String resolvedExtensionId = resolveExtensionId();
         ensureRequiredStringData(EXTENSION_ID, resolvedExtensionId);
+        // For example, quarkus-my-extension
+        String namespacedExtensionId = namespaceId + resolvedExtensionId;
         data.putIfAbsent(EXTENSION_NAME, capitalize(extensionId));
         data.putIfAbsent(NAMESPACE_NAME, namespaceName);
         data.putIfAbsent(CLASS_NAME_BASE, toCapCamelCase(extensionId));
@@ -312,7 +314,7 @@ public class CreateExtension {
                 data.putIfAbsent(QUARKUS_BOM_VERSION, DEFAULT_BOM_VERSION);
                 data.putIfAbsent(MAVEN_COMPILER_PLUGIN_VERSION, DEFAULT_COMPILER_PLUGIN_VERSION);
                 data.putIfAbsent(EXTENSION_GUIDE,
-                        String.format(DEFAULT_QUARKIVERSE_GUIDE_URL, resolvedExtensionId));
+                        String.format(DEFAULT_QUARKIVERSE_GUIDE_URL, namespacedExtensionId));
                 ensureRequiredStringData(QUARKUS_VERSION);
                 data.putIfAbsent(HAS_DOCS_MODULE, true);
                 data.put(EXTENSION_FULL_NAME,

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
@@ -3,7 +3,7 @@ name: My Quarkiverse extension
 metadata:
 #  keywords:
 #    - my-quarkiverse-ext
-#  guide: https://docs.quarkiverse.io/my-quarkiverse-ext/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+#  guide: https://docs.quarkiverse.io/quarkus-my-quarkiverse-ext/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
 #  categories:
 #    - "miscellaneous"
 #  status: "preview"


### PR DESCRIPTION
I've fixed many dead guide links for Quarkiverse extensions over the past few years. In the majority of recent cases, the fix is just adding the namespace. Our quarkiverse docs links usually have the namespaced extension name (eg `quarkus-pact`), but the template just uses the short name (eg `pact`). See, for example, https://github.com/quarkiverse/quarkus-redoc/pull/21/changes or https://github.com/quarkiverse/quarkus-mapstruct/pull/23/changes.

We should have the template default to using the name we expect people to use.