### PR TITLE
Add missing space when quarkus cli throws ExclusiveProviderConflictException

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -669,7 +669,7 @@ public class ExtensionCatalogResolver {
                 buf.append(
                         "The following registries were configured as exclusive providers of the ");
                 buf.append(PlatformArtifacts.ensureBomArtifact(bom).toCompactCoords());
-                buf.append("platform: ").append(e.conflictingRegistries.get(0).getId());
+                buf.append(" platform: ").append(e.conflictingRegistries.get(0).getId());
                 for (int i = 1; i < e.conflictingRegistries.size(); ++i) {
                     buf.append(", ").append(e.conflictingRegistries.get(i).getId());
                 }


### PR DESCRIPTION
When the `ExclusiveProviderConflictException` is thrown the error looks something like 
```
Unable to create extension: The following registries were configured as exclusive providers of the 
com.redhat.quarkus.platform:quarkus-bom:pom:3.27.2.redhat-00002platform:
testingregistry, registry.quarkus.redhat.com
```

This adding the missing space between the Quarkus version and "platform"

