### PR TITLE
Add support for new model in datasources, convert Oracle

### DIFF
--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatasourceStartable.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatasourceStartable.java
@@ -3,6 +3,30 @@ package io.quarkus.datasource.deployment.spi;
 import io.quarkus.deployment.builditem.Startable;
 
 public interface DatasourceStartable extends Startable {
-    DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevServicesDatasource();
+
+    /**
+     * Gets a record which can be used to interrogate the datasource, after it has been started.
+     * This should not be called before the container has been started.
+     * If the datasource has not been started, an IllegalStateException will be thrown.
+     *
+     * @return a RunningDevServicesDatasource, populated with the container id and urls and credentials of the running
+     *         datasource
+     */
+    default DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevServicesDatasource() {
+        if (getContainerId() == null) {
+            throw new IllegalStateException(
+                    "Cannot create a RunningDevServicesDatasource before the datasource has been started.");
+        }
+        return new DevServicesDatasourceProvider.RunningDevServicesDatasource(getContainerId(), getEffectiveJdbcUrl(),
+                getReactiveUrl(), getUsername(), getPassword());
+    }
+
+    String getPassword();
+
+    String getUsername();
+
+    String getReactiveUrl();
+
+    String getEffectiveJdbcUrl();
 
 }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatasourceStartable.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatasourceStartable.java
@@ -1,0 +1,8 @@
+package io.quarkus.datasource.deployment.spi;
+
+import io.quarkus.deployment.builditem.Startable;
+
+public interface DatasourceStartable extends Startable {
+    DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevServicesDatasource();
+
+}

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatasourceStartable.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatasourceStartable.java
@@ -17,6 +17,7 @@ public interface DatasourceStartable extends Startable {
             throw new IllegalStateException(
                     "Cannot create a RunningDevServicesDatasource before the datasource has been started.");
         }
+        // It would be nice to cache this, but since this is an interface, it can't be done at this level, and would have to be done by every implementing class
         return new DevServicesDatasourceProvider.RunningDevServicesDatasource(getContainerId(), getEffectiveJdbcUrl(),
                 getReactiveUrl(), getUsername(), getPassword());
     }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DeferredDevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DeferredDevServicesDatasourceProvider.java
@@ -13,10 +13,10 @@ public interface DeferredDevServicesDatasourceProvider extends GenericDevService
             Optional<String> password,
             String datasourceName,
             DevServicesDatasourceContainerConfig devServicesDatasourceContainerConfig,
-            LaunchMode launchMode,
+            LaunchMode launchMode, boolean useSharedNetwork,
             Optional<Duration> startupTimeout);
 
-    Optional<DevServicesResultBuildItem.DiscoveredServiceBuilder> getComposeBuilder(LaunchMode launchMode,
+    Optional<BuilderAndDatasource> getComposeBuilder(LaunchMode launchMode,
             boolean useSharedNetwork, DevServicesDatasourceContainerConfig containerConfig,
             DevServicesComposeProjectBuildItem composeProjectBuildItem);
 
@@ -24,4 +24,7 @@ public interface DeferredDevServicesDatasourceProvider extends GenericDevService
         return true;
     }
 
+    record BuilderAndDatasource(DevServicesResultBuildItem.DiscoveredServiceBuilder builder,
+            DevServicesDatasourceProvider.RunningDevServicesDatasource datasource) {
+    }
 }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DeferredDevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DeferredDevServicesDatasourceProvider.java
@@ -1,0 +1,27 @@
+package io.quarkus.datasource.deployment.spi;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.runtime.LaunchMode;
+
+public interface DeferredDevServicesDatasourceProvider extends GenericDevServicesDatasourceProvider {
+
+    DevServicesResultBuildItem.OwnedServiceBuilder<DatasourceStartable> createDatabaseBuilder(Optional<String> username,
+            Optional<String> password,
+            String datasourceName,
+            DevServicesDatasourceContainerConfig devServicesDatasourceContainerConfig,
+            LaunchMode launchMode,
+            Optional<Duration> startupTimeout);
+
+    Optional<DevServicesResultBuildItem.DiscoveredServiceBuilder> getComposeBuilder(LaunchMode launchMode,
+            boolean useSharedNetwork, DevServicesDatasourceContainerConfig containerConfig,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem);
+
+    default boolean isDockerRequired() {
+        return true;
+    }
+
+}

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DeferredDevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DeferredDevServicesDatasourceProvider.java
@@ -4,27 +4,32 @@ import java.time.Duration;
 import java.util.Optional;
 
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
-import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.runtime.LaunchMode;
 
 public interface DeferredDevServicesDatasourceProvider extends GenericDevServicesDatasourceProvider {
 
-    DevServicesResultBuildItem.OwnedServiceBuilder<DatasourceStartable> createDatabaseBuilder(Optional<String> username,
+    /**
+     * Ecosystem implementations may not have access to a Feature object, so we return a String.
+     *
+     * @return the result of feature.getName(), or a String representing the feature name
+     */
+    String getFeature();
+
+    /**
+     * The DatasourceStartable should *not* have had `start()` called.
+     */
+    DatasourceStartable createDatasourceStartable(Optional<String> username,
             Optional<String> password,
             String datasourceName,
             DevServicesDatasourceContainerConfig devServicesDatasourceContainerConfig,
             LaunchMode launchMode, boolean useSharedNetwork,
             Optional<Duration> startupTimeout);
 
-    Optional<BuilderAndDatasource> getComposeBuilder(LaunchMode launchMode,
+    Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningComposeDatasource(LaunchMode launchMode,
             boolean useSharedNetwork, DevServicesDatasourceContainerConfig containerConfig,
             DevServicesComposeProjectBuildItem composeProjectBuildItem);
 
     default boolean isDockerRequired() {
         return true;
-    }
-
-    record BuilderAndDatasource(DevServicesResultBuildItem.DiscoveredServiceBuilder builder,
-            DevServicesDatasourceProvider.RunningDevServicesDatasource datasource) {
     }
 }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
@@ -111,7 +111,7 @@ public final class DevServicesDatasourceConfigurationHandlerBuildItem extends Mu
 
     private static List<String> datasourceURLPropNames(String dsName) {
         // we use datasourceURLPropNames to generate quoted and unquoted versions of the property key,
-        // because depending on whether a user configured deferred JDBC properties
+        // because depending on whether a user configured other JDBC properties
         // one of the URLs may be ignored
         // see https://github.com/quarkusio/quarkus/issues/21387
         return DataSourceUtil.dataSourcePropertyKeys(dsName, "jdbc.url");

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.runtime.LaunchMode;
 
-public interface DevServicesDatasourceProvider {
+public interface DevServicesDatasourceProvider extends GenericDevServicesDatasourceProvider {
 
     /**
      * @deprecated implement
@@ -40,8 +40,17 @@ public interface DevServicesDatasourceProvider {
     }
 
     record RunningDevServicesDatasource(String id, String jdbcUrl, String reactiveUrl, String username, String password,
-            Closeable closeTask) {
+            @Deprecated Closeable closeTask) {
 
+        //In the new dev services model, the RunningDevServicesDatasource is used, but its close() method is not
+        public RunningDevServicesDatasource(String id, String jdbcUrl, String reactiveUrl, String username, String password) {
+            this(id, jdbcUrl, reactiveUrl, username, password, new Closeable() {
+                @Override
+                public void close() {
+                    // No-op
+                }
+            });
+        }
     }
 
 }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProviderBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProviderBuildItem.java
@@ -9,17 +9,41 @@ public final class DevServicesDatasourceProviderBuildItem extends MultiBuildItem
 
     private final String database;
     private final DevServicesDatasourceProvider devDBProvider;
+    private final DeferredDevServicesDatasourceProvider deferredDevServicesDatasourceProvider;
 
+    @Deprecated(since = "3.32", forRemoval = true)
     public DevServicesDatasourceProviderBuildItem(String database, DevServicesDatasourceProvider devDBProvider) {
         this.database = database;
         this.devDBProvider = devDBProvider;
+        this.deferredDevServicesDatasourceProvider = null;
+    }
+
+    public DevServicesDatasourceProviderBuildItem(String database,
+            DeferredDevServicesDatasourceProvider deferredDevServicesDatasourceProvider) {
+        this.database = database;
+        this.deferredDevServicesDatasourceProvider = deferredDevServicesDatasourceProvider;
+        this.devDBProvider = null;
     }
 
     public String getDatabase() {
         return database;
     }
 
+    /**
+     * May be null if the new-model dev services API is being used
+     *
+     */
+    @Deprecated(since = "3.32", forRemoval = true)
     public DevServicesDatasourceProvider getDevServicesProvider() {
         return devDBProvider;
     }
+
+    /**
+     * May be null if the old-model dev services API is being used
+     *
+     */
+    public DeferredDevServicesDatasourceProvider getDeferredDevServicesProvider() {
+        return deferredDevServicesDatasourceProvider;
+    }
+
 }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/GenericDevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/GenericDevServicesDatasourceProvider.java
@@ -1,0 +1,5 @@
+package io.quarkus.datasource.deployment.spi;
+
+public interface GenericDevServicesDatasourceProvider {
+    boolean isDockerRequired();
+}

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -9,18 +9,22 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.datasource.deployment.spi.DatasourceStartable;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
+import io.quarkus.datasource.deployment.spi.DeferredDevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceResultBuildItem;
+import io.quarkus.datasource.deployment.spi.GenericDevServicesDatasourceProvider;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.deployment.Capabilities;
@@ -51,10 +55,13 @@ public class DevServicesDatasourceProcessor {
     private static final Logger log = Logger.getLogger(DevServicesDatasourceProcessor.class);
     private static final int DOCKER_PS_ID_LENGTH = 12;
 
+    @Deprecated(since = "3.32", forRemoval = true) // Use the new model from https://github.com/orgs/quarkusio/projects/49, avoid statics in processors
     static volatile List<RunningDevService> databases;
 
+    @Deprecated(since = "3.32", forRemoval = true) // Use the new model from https://github.com/orgs/quarkusio/projects/49, avoid statics in processors
     static volatile Map<String, Object> cachedProperties;
 
+    @Deprecated(since = "3.32", forRemoval = true) // Use the new model from https://github.com/orgs/quarkusio/projects/49, avoid statics in processors
     static volatile boolean first = true;
 
     @BuildStep
@@ -78,7 +85,7 @@ public class DevServicesDatasourceProcessor {
         boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                 devServicesSharedNetworkBuildItem);
 
-        boolean shouldStartServices = !checkRunningDatabasesAreSuitableAndCloseIfNot(composeProjectBuildItem,
+        boolean shouldStartOldStyleServices = !checkRunningDatabasesAreSuitableAndCloseIfNot(composeProjectBuildItem,
                 dataSourcesBuildTimeConfig,
                 devServicesResultBuildItemBuildProducer);
 
@@ -90,7 +97,6 @@ public class DevServicesDatasourceProcessor {
         //to keep things simpler for now we are only going to support this for the default datasource
         //support for named datasources will come later
 
-        Map<String, String> propertiesMap = new HashMap<>();
         List<RunningDevService> runningDevServices = new ArrayList<>();
         Map<String, List<DevServicesDatasourceConfigurationHandlerBuildItem>> configHandlersByDbType = configurationHandlerBuildItems
                 .stream()
@@ -103,14 +109,19 @@ public class DevServicesDatasourceProcessor {
                             return ret;
                         }));
         Map<String, DevServicesDatasourceProvider> devDBProviderMap = devDBProviders.stream()
+                .filter(d -> d.getDevServicesProvider() != null)
                 .collect(Collectors.toMap(DevServicesDatasourceProviderBuildItem::getDatabase,
                         DevServicesDatasourceProviderBuildItem::getDevServicesProvider));
+        Map<String, DeferredDevServicesDatasourceProvider> deferredDevDBProviderMap = devDBProviders.stream()
+                .filter(d -> d.getDeferredDevServicesProvider() != null)
+                .collect(Collectors.toMap(DevServicesDatasourceProviderBuildItem::getDatabase,
+                        DevServicesDatasourceProviderBuildItem::getDeferredDevServicesProvider));
 
-        if (shouldStartServices) {
+        if (shouldStartOldStyleServices) {
             for (Map.Entry<String, DataSourceBuildTimeConfig> entry : dataSourcesBuildTimeConfig.dataSources().entrySet()) {
                 RunningDevService devService = startDevDb(entry.getKey(), capabilities, curateOutcomeBuildItem,
                         installedDrivers, dataSourcesBuildTimeConfig.hasNamedDataSources(),
-                        devDBProviderMap, entry.getValue(), configHandlersByDbType, propertiesMap,
+                        devDBProviderMap, deferredDevDBProviderMap, entry.getValue(), configHandlersByDbType,
                         dockerStatusBuildItem,
                         launchMode.getLaunchMode(), consoleInstalledBuildItem, loggingSetupBuildItem,
                         devServicesConfig, useSharedNetwork);
@@ -147,6 +158,21 @@ public class DevServicesDatasourceProcessor {
                 devServicesResultBuildItemBuildProducer.produce(database.toBuildItem());
             }
         }
+
+        Map<String, Object> newDatasourceConfigs = buildMapFromBuildConfig(dataSourcesBuildTimeConfig);
+
+        for (Map.Entry<String, DataSourceBuildTimeConfig> entry : dataSourcesBuildTimeConfig.dataSources().entrySet()) {
+            DevServicesResultBuildItem devService = deferredStartDevDb(entry.getKey(), capabilities, curateOutcomeBuildItem,
+                    installedDrivers, dataSourcesBuildTimeConfig.hasNamedDataSources(),
+                    devDBProviderMap, deferredDevDBProviderMap, entry.getValue(), configHandlersByDbType,
+                    dockerStatusBuildItem, composeProjectBuildItem,
+                    launchMode.getLaunchMode(), consoleInstalledBuildItem, loggingSetupBuildItem,
+                    devServicesConfig, useSharedNetwork, newDatasourceConfigs);
+            if (devService != null) {
+                devServicesResultBuildItemBuildProducer.produce(devService);
+            }
+        }
+
         return new DevServicesDatasourceResultBuildItem(results);
     }
 
@@ -226,6 +252,104 @@ public class DevServicesDatasourceProcessor {
         return res;
     }
 
+    private DevServicesResultBuildItem deferredStartDevDb(
+            String dbName,
+            Capabilities capabilities,
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            List<DefaultDataSourceDbKindBuildItem> installedDrivers,
+            boolean hasNamedDatasources,
+            Map<String, DevServicesDatasourceProvider> devDBProviderMap,
+            Map<String, DeferredDevServicesDatasourceProvider> devDBProviders,
+            DataSourceBuildTimeConfig dataSourceBuildTimeConfig,
+            Map<String, List<DevServicesDatasourceConfigurationHandlerBuildItem>> configurationHandlerBuildItems,
+            DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem, LaunchMode launchMode,
+            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
+            LoggingSetupBuildItem loggingSetupBuildItem, DevServicesConfig devServicesConfig, boolean useSharedNetwork,
+            Map<String, Object> configForWhichChangesShouldTriggerARestart) {
+
+        String dataSourcePrettyName = getDataSourcePrettyName(dbName);
+
+        if (!shouldStart(dbName, dataSourceBuildTimeConfig, useSharedNetwork, dataSourcePrettyName)) {
+            return null;
+        }
+
+        Optional<String> maybeDefaultDbKind = getDefaultDbKind(dbName, curateOutcomeBuildItem, installedDrivers,
+                hasNamedDatasources,
+                dataSourceBuildTimeConfig);
+
+        if (maybeDefaultDbKind.isEmpty()) {
+            //nothing we can do
+            log.warn("Unable to determine a database type for " + dataSourcePrettyName);
+            return null;
+        }
+
+        String defaultDbKind = maybeDefaultDbKind.get();
+
+        DeferredDevServicesDatasourceProvider devDbProvider = devDBProviders.get(defaultDbKind);
+        List<DevServicesDatasourceConfigurationHandlerBuildItem> configHandlers = configurationHandlerBuildItems
+                .get(defaultDbKind);
+
+        if (!shouldStartBasedOnConfigHandler(dbName, devDBProviderMap, devDBProviders, dataSourceBuildTimeConfig,
+                configurationHandlerBuildItems, dockerStatusBuildItem, launchMode, devDbProvider, configHandlers, defaultDbKind,
+                dataSourcePrettyName)) {
+            return null;
+        }
+
+        //ok, so we know we need to start one
+        StartupLogCompressor compressor = getCompressor(launchMode, consoleInstalledBuildItem, loggingSetupBuildItem,
+                dataSourcePrettyName, defaultDbKind);
+
+        try {
+            DevServicesDatasourceContainerConfig containerConfig = getContainerConfig(dataSourceBuildTimeConfig);
+
+            Map<String, Function<DatasourceStartable, String>> devDebProperties = new HashMap<>();
+            for (DevServicesDatasourceConfigurationHandlerBuildItem devDbConfigurationHandlerBuildItem : configHandlers) {
+                Map<String, Function<DatasourceStartable, String>> properties = devDbConfigurationHandlerBuildItem
+                        .getDeferredConfigProviderFunction().apply(
+                                dbName);
+                for (Map.Entry<String, Function<DatasourceStartable, String>> entry : properties.entrySet()) {
+                    if (entry.getKey().contains(".jdbc.") && entry.getKey().endsWith(".url")) {
+                        if (capabilities.isCapabilityWithPrefixPresent(Capability.AGROAL)) {
+                            devDebProperties.put(entry.getKey(), entry.getValue());
+                        }
+                    } else {
+                        devDebProperties.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+
+            setDataSourceProperties(devDebProperties, dbName, "username", d -> d.runningDevServicesDatasource().username());
+            setDataSourceProperties(devDebProperties, dbName, "password", d -> d.runningDevServicesDatasource().password());
+
+            DevServicesResultBuildItem buildItem = devDbProvider
+                    .getComposeBuilder(launchMode, useSharedNetwork, containerConfig, composeProjectBuildItem)
+                    .map(b -> b.build())
+                    .orElseGet(() -> devDbProvider
+                            .createDatabaseBuilder(
+                                    ConfigUtils.getFirstOptionalValue(DataSourceUtil.dataSourcePropertyKeys(dbName, "username"),
+                                            String.class),
+                                    ConfigUtils.getFirstOptionalValue(DataSourceUtil.dataSourcePropertyKeys(dbName, "password"),
+                                            String.class),
+                                    dbName, containerConfig,
+                                    launchMode, devServicesConfig.timeout())
+                            .serviceConfig(configForWhichChangesShouldTriggerARestart)
+                            .configProvider(devDebProperties)
+                            .postStartHook((s) -> {
+                                String id = s.runningDevServicesDatasource().id();
+                                logStart(id, dataSourcePrettyName, defaultDbKind);
+                            })
+                            .build());
+
+            compressor.close();
+
+            return buildItem;
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw new RuntimeException(t);
+        }
+    }
+
     private static void logStart(String id, String dataSourcePrettyName, String defaultDbKind) {
         if (id == null) {
             log.infof("Dev Services for %s (%s) started", dataSourcePrettyName, defaultDbKind);
@@ -268,9 +392,11 @@ public class DevServicesDatasourceProcessor {
 
     private static void maybeWarnAboutMissingProvider(Map<String, DevServicesDatasourceProvider> devDBProviderMap,
             Map<String, List<DevServicesDatasourceConfigurationHandlerBuildItem>> configurationHandlerBuildItems,
+            Map<String, DeferredDevServicesDatasourceProvider> deferredDevDBProviderMap,
             String defaultDbKind, String dataSourcePrettyName) {
-        // Before warning, check if there are providers and handlers on the other API path
-        boolean hasProvider = devDBProviderMap.containsKey(defaultDbKind);
+        // Before warning, check if there are providers and handlers on the deferred API path
+        boolean hasProvider = devDBProviderMap.containsKey(defaultDbKind)
+                || deferredDevDBProviderMap.containsKey(defaultDbKind);
         boolean hasConfigHandler = configurationHandlerBuildItems
                 .containsKey(defaultDbKind);
         if (!hasProvider || !hasConfigHandler) {
@@ -286,10 +412,9 @@ public class DevServicesDatasourceProcessor {
             List<DefaultDataSourceDbKindBuildItem> installedDrivers,
             boolean hasNamedDatasources,
             Map<String, DevServicesDatasourceProvider> devDBProviders,
+            Map<String, DeferredDevServicesDatasourceProvider> deferredDevDBProviderMap,
             DataSourceBuildTimeConfig dataSourceBuildTimeConfig,
             Map<String, List<DevServicesDatasourceConfigurationHandlerBuildItem>> configurationHandlerBuildItems,
-            Map<String, String> propertiesMap,
-
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchMode launchMode, Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem, DevServicesConfig devServicesConfig, boolean useSharedNetwork) {
@@ -315,13 +440,14 @@ public class DevServicesDatasourceProcessor {
         DevServicesDatasourceProvider devDbProvider = devDBProviders.get(defaultDbKind);
         List<DevServicesDatasourceConfigurationHandlerBuildItem> configHandlers = configurationHandlerBuildItems
                 .get(defaultDbKind);
-        if (!shouldStartBasedOnConfigHandler(dbName, devDBProviders, dataSourceBuildTimeConfig,
+        if (!shouldStartBasedOnConfigHandler(dbName, devDBProviders, deferredDevDBProviderMap, dataSourceBuildTimeConfig,
                 configurationHandlerBuildItems, dockerStatusBuildItem, launchMode, devDbProvider, configHandlers, defaultDbKind,
                 dataSourcePrettyName)) {
             return null;
         }
 
         //ok, so we know we need to start one
+        Map<String, String> propertiesMap = new HashMap<>();
         StartupLogCompressor compressor = getCompressor(launchMode, consoleInstalledBuildItem, loggingSetupBuildItem,
                 dataSourcePrettyName, defaultDbKind);
 
@@ -402,14 +528,16 @@ public class DevServicesDatasourceProcessor {
 
     private static boolean shouldStartBasedOnConfigHandler(String dbName,
             Map<String, DevServicesDatasourceProvider> devDBProviders,
+            Map<String, DeferredDevServicesDatasourceProvider> deferredDevDBProviderMap,
             DataSourceBuildTimeConfig dataSourceBuildTimeConfig,
             Map<String, List<DevServicesDatasourceConfigurationHandlerBuildItem>> configurationHandlerBuildItems,
             DockerStatusBuildItem dockerStatusBuildItem, LaunchMode launchMode,
-            DevServicesDatasourceProvider devDbProvider,
+            GenericDevServicesDatasourceProvider devDbProvider,
             List<DevServicesDatasourceConfigurationHandlerBuildItem> configHandlers, String defaultDbKind,
             String dataSourcePrettyName) {
         if (devDbProvider == null || configHandlers == null) {
-            maybeWarnAboutMissingProvider(devDBProviders, configurationHandlerBuildItems, defaultDbKind,
+            maybeWarnAboutMissingProvider(devDBProviders, configurationHandlerBuildItems, deferredDevDBProviderMap,
+                    defaultDbKind,
                     dataSourcePrettyName);
             return false;
         }
@@ -487,6 +615,14 @@ public class DevServicesDatasourceProcessor {
 
     private void setDataSourceProperties(Map<String, String> propertiesMap, String dbName, String propertyKeyRadical,
             String value) {
+        for (String key : DataSourceUtil.dataSourcePropertyKeys(dbName, propertyKeyRadical)) {
+            propertiesMap.put(key, value);
+        }
+    }
+
+    private void setDataSourceProperties(Map<String, Function<DatasourceStartable, String>> propertiesMap, String dbName,
+            String propertyKeyRadical,
+            Function<DatasourceStartable, String> value) {
         for (String key : DataSourceUtil.dataSourcePropertyKeys(dbName, propertyKeyRadical)) {
             propertiesMap.put(key, value);
         }

--- a/extensions/datasource/runtime/pom.xml
+++ b/extensions/datasource/runtime/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-credentials</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -19,7 +19,6 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DatasourceStartable;
 import io.quarkus.datasource.deployment.spi.DeferredDevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
-import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -169,11 +168,6 @@ public class OracleDevServicesProcessor {
         }
 
         @Override
-        public void start() {
-            super.start();
-        }
-
-        @Override
         public void close() {
             super.close();
         }
@@ -183,10 +177,5 @@ public class OracleDevServicesProcessor {
             return getEffectiveJdbcUrl();
         }
 
-        @Override
-        public DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevServicesDatasource() {
-            return new DevServicesDatasourceProvider.RunningDevServicesDatasource(getContainerId(), getEffectiveJdbcUrl(),
-                    getReactiveUrl(), getUsername(), getPassword());
-        }
     }
 }

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleProcessor.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleProcessor.java
@@ -39,7 +39,7 @@ public class OracleProcessor {
 
     @BuildStep
     DevServicesDatasourceConfigurationHandlerBuildItem devDbHandler() {
-        return DevServicesDatasourceConfigurationHandlerBuildItem.jdbc(DatabaseKind.ORACLE);
+        return DevServicesDatasourceConfigurationHandlerBuildItem.deferredJdbc(DatabaseKind.ORACLE);
     }
 
     @BuildStep

--- a/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
+++ b/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
@@ -124,7 +124,7 @@ class ReactiveOracleClientProcessor {
 
     @BuildStep
     DevServicesDatasourceConfigurationHandlerBuildItem devDbHandler() {
-        return DevServicesDatasourceConfigurationHandlerBuildItem.reactive(DatabaseKind.ORACLE);
+        return DevServicesDatasourceConfigurationHandlerBuildItem.deferredReactive(DatabaseKind.ORACLE);
     }
 
     @BuildStep


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/52123. 

This PR: 
- Adds support into our datasource dev services layer for the new dev services model
- Converts Oracle to use the model, as a canary

I couldn't come up with an implementation which preserved the current SPI and also moved all users of the SPI transparently to the new model, so instead I've had to do a lot of duplication of code and domain models (yuck). I could probably convert everything in the core Quarkus repo in one go, but [seven Quarkiverse extensions](https://github.com/search?q=org%3Aquarkiverse%20DevServicesDatasourceConfigurationHandlerBuildItem&type=code) use the SPI, and that would break them. 

Simultaneous support for the old and new models has a couple of ickinesses:
- There's a lot more code 
- What do we name everything?

For the naming, I've used a `deferred` prefix on new-model methods and classes, but I don't love that. When the old methods are removed, we could rename everything back to the original names, except that we'd have to keep the new `DeferredWhatever` classes around, to avoid breaking quarkiverse extensions that had migrated to the new model. I guess after a second period of transition we'd be able to remove the old 'new' methods, but it's a bit awkward.

The design is similar to what we've done elsewhere for new-model dev services:

- No lifecycle management is done by the owning extension, and no state is stored in static variables
- The datasource isn't started until after the build phase, and configuration is stored as a map of functions, rather than a map of values
- The `buildMapFromBuildConfig()` seemed to be exactly what I needed as a map of properties for which changes trigger restarts, so that was handy
- I kept `DevServicesDatasourceProviderBuildItem` but now it can be constructed in a new-model or old-model way (which has the benefit that I didn't need to find a name for a new build item, but the drawback that now half its methods always return null)
- I kept the `RunningDevServicesDatasource` to reduce churn on code that used it, but the `closeTask()` method/field should eventually go away

There seemed to be less new-path config code than old-path config code, which worried me, but I *think* I got what I needed to?