### PR TITLE
Update Smallrye Config to 3.16.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <microprofile-lra.version>2.0.1</microprofile-lra.version>
         <microprofile-openapi.version>4.1.1</microprofile-openapi.version>
         <smallrye-common.version>2.15.0</smallrye-common.version>
-        <smallrye-config.version>3.15.1</smallrye-config.version>
+        <smallrye-config.version>3.16.0</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.2.4</smallrye-open-api.version>
         <smallrye-graphql.version>2.17.0</smallrye-graphql.version>

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/ConfigurationSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/ConfigurationSubstitutions.java
@@ -1,12 +1,11 @@
 package io.quarkus.runtime.graal;
 
-import org.eclipse.microprofile.config.Config;
-
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 import io.quarkus.runtime.configuration.QuarkusConfigFactory;
+import io.smallrye.config.Config;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
@@ -14,7 +13,17 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
 final class Target_io_smallrye_config_SmallRyeConfigProviderResolver {
     @Substitute
     public Config getConfig() {
-        final SmallRyeConfig config = Target_io_quarkus_runtime_configuration_QuarkusConfigFactory.config;
+        return get();
+    }
+
+    @Substitute
+    public Config getConfig(ClassLoader classLoader) {
+        return get();
+    }
+
+    @Substitute
+    public SmallRyeConfig get() {
+        SmallRyeConfig config = Target_io_quarkus_runtime_configuration_QuarkusConfigFactory.config;
         if (config == null) {
             throw new IllegalStateException("No configuration is available");
         }
@@ -22,17 +31,22 @@ final class Target_io_smallrye_config_SmallRyeConfigProviderResolver {
     }
 
     @Substitute
-    public Config getConfig(ClassLoader classLoader) {
-        return getConfig();
+    public SmallRyeConfig get(ClassLoader classLoader) {
+        return get();
     }
 
     @Substitute
-    public void registerConfig(Config config, ClassLoader classLoader) {
+    public void registerConfig(org.eclipse.microprofile.config.Config config, ClassLoader classLoader) {
         // no op
     }
 
     @Substitute
-    public void releaseConfig(Config config) {
+    public void releaseConfig(org.eclipse.microprofile.config.Config config) {
+        // no op
+    }
+
+    @Substitute
+    public void releaseConfig(ClassLoader classLoader) {
         // no op
     }
 }

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 plugin-publish = "2.0.0"
 
 kotlin = "2.3.0"
-smallrye-config = "3.15.1"
+smallrye-config = "3.16.0"
 
 junit = "6.0.2"
 assertj = "3.27.7"

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/devmode/ReactiveMessagingHotReplacementSetup.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/devmode/ReactiveMessagingHotReplacementSetup.java
@@ -37,10 +37,13 @@ public class ReactiveMessagingHotReplacementSetup implements HotReplacementSetup
                 synchronized (this) {
                     if (nextUpdate < System.currentTimeMillis()) {
                         CompletableFuture<Boolean> result = new CompletableFuture<>();
+                        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
                         executor.execute(new Runnable() {
                             @Override
                             public void run() {
                                 try {
+                                    // Update to the new Reloaded ClassLoader
+                                    Thread.currentThread().setContextClassLoader(contextClassLoader);
                                     boolean restarted = context.doScan(true);
                                     if (context.getDeploymentProblem() != null) {
                                         LOGGER.error("Failed to redeploy application on changes",

--- a/test-framework/junit-config/src/main/java/io/quarkus/test/config/TestConfigProviderResolver.java
+++ b/test-framework/junit-config/src/main/java/io/quarkus/test/config/TestConfigProviderResolver.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
@@ -12,6 +11,7 @@ import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import io.quarkus.deployment.dev.testing.TestConfigCustomizer;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
+import io.smallrye.config.Config;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
@@ -73,6 +73,16 @@ public class TestConfigProviderResolver extends SmallRyeConfigProviderResolver {
                 + Thread.currentThread().getContextClassLoader());
     }
 
+    @Override
+    public SmallRyeConfig get() {
+        return resolver.get();
+    }
+
+    @Override
+    public SmallRyeConfig get(ClassLoader classLoader) {
+        return resolver.get(classLoader);
+    }
+
     public void restoreConfig() {
         if (classLoader.equals(Thread.currentThread().getContextClassLoader())) {
             resolver.releaseConfig(classLoader);
@@ -99,12 +109,12 @@ public class TestConfigProviderResolver extends SmallRyeConfigProviderResolver {
     }
 
     @Override
-    public void registerConfig(final Config config, final ClassLoader classLoader) {
+    public void registerConfig(final org.eclipse.microprofile.config.Config config, final ClassLoader classLoader) {
         resolver.registerConfig(config, classLoader);
     }
 
     @Override
-    public void releaseConfig(final Config config) {
+    public void releaseConfig(final org.eclipse.microprofile.config.Config config) {
         resolver.releaseConfig(config);
     }
 


### PR DESCRIPTION
SmallRye Config Release notes:
<br>
<blockquote>
    <h2>3.16.0</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1473">#1473</a> Release 3.16.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1472">#1472</a> Deprecate and throw an Exception when using Ja>sypt</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1471">#1471</a> Generalize enforcing the locale in loggers</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1470">#1470</a> Move comparator from `getConfigurableSources` into> a field</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1469">#1469</a> Enforce locale when initializing MessageLogger</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1468">#1468</a> Use custom comparator in `getConfigurableSources`</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1466">#1466</a> Restrict the candidates property names for Environment >Variables matching</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1464">#1464</a> Fix JavaDoc generation problem for Zookeeper source</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1461">#1461</a> Move static variable that keep>s the original order of ConfigSources to an instance variable</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1459">#1459</a> Modularize SmallRye Config</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1454">#1454</a> Add get methods to retrieve SmallRyeConfig directly</li>
    </ul>
</blockquote>
<br>

With https://github.com/smallrye/smallrye-config/pull/1454, a few new methods to retrieve the `Config` were added, including proper APIs to either `get` or `getOrCreate` the `Config`. Historically, we always had issues with `ConfigProvider.getConfig` because it either retrieves a `Config` for the current CL or creates one on the fly, leading to unexpected behaviours. This was mostly solved by https://github.com/quarkusio/quarkus/pull/42715, which registers a `Config` instance as early as possible. 

We can observe this in `ReactiveMessagingHotReplacementSetup`, where the `Thread` used to do the reload, is still tied to the previous Dev class loader, meaning that it would create a totally new `Config` instance, instead of using the one created by the reloaded Quarkus application. The test just worked by accident.
