### PR TITLE
Fix compatibility of `ProxyAddressUtil#HostAndPort`

### DIFF
--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ProxyAddressUtil.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ProxyAddressUtil.java
@@ -19,6 +19,7 @@ public class ProxyAddressUtil {
         return new HostAndPort(host, port);
     }
 
+    @SuppressWarnings("ClassCanBeRecord") // don't convert to record because we have code that accesses the public field
     public static class HostAndPort {
         public final String host;
         public final int port;

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ProxyAddressUtil.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ProxyAddressUtil.java
@@ -27,5 +27,13 @@ public class ProxyAddressUtil {
             this.host = host;
             this.port = port;
         }
+
+        public String host() {
+            return host;
+        }
+
+        public int port() {
+            return port;
+        }
     }
 }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ProxyAddressUtil.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ProxyAddressUtil.java
@@ -19,6 +19,13 @@ public class ProxyAddressUtil {
         return new HostAndPort(host, port);
     }
 
-    public record HostAndPort(String host, int port) {
+    public static class HostAndPort {
+        public final String host;
+        public final int port;
+
+        public HostAndPort(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
     }
 }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -639,8 +639,8 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
         } else if (restClients.proxyAddress().isPresent()) {
             HostAndPort globalProxy = ProxyAddressUtil.parseAddress(restClients.proxyAddress().get());
             configureProxy(
-                    globalProxy.host(),
-                    globalProxy.port(),
+                    globalProxy.host,
+                    globalProxy.port,
                     restClients.proxyUser().orElse(null),
                     restClients.proxyPassword().orElse(null),
                     restClients.nonProxyHosts().orElse(null),

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -193,7 +193,7 @@ public class RestClientCDIDelegateBuilder<T> {
                 builder.proxyAddress("none", 0);
             } else {
                 ProxyAddressUtil.HostAndPort hostAndPort = ProxyAddressUtil.parseAddress(proxyAddress);
-                builder.proxyAddress(hostAndPort.host(), hostAndPort.port());
+                builder.proxyAddress(hostAndPort.host, hostAndPort.port);
 
                 oneOf(restClientConfig.proxyUser(), configRoot.proxyUser()).ifPresent(builder::proxyUser);
                 oneOf(restClientConfig.proxyPassword(), configRoot.proxyPassword()).ifPresent(builder::proxyPassword);


### PR DESCRIPTION
Done because the build of Quarkus LangChain4j against `main` is failing with:

```
2026-01-29T04:04:13.1337185Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project quarkus-langchain4j-bedrock: Compilation failure: Compilation failure: 
2026-01-29T04:04:13.1349979Z [ERROR] /home/runner/work/quarkus-langchain4j/quarkus-langchain4j/current-repo/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/jaxrsclient/DefaultJaxRsSdkClientBuilder.java:[269,42] host has private access in io.quarkus.rest.client.reactive.runtime.ProxyAddressUtil.HostAndPort
2026-01-29T04:04:13.1356794Z [ERROR] /home/runner/work/quarkus-langchain4j/quarkus-langchain4j/current-repo/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/jaxrsclient/DefaultJaxRsSdkClientBuilder.java:[269,60] port has private access in io.quarkus.rest.client.reactive.runtime.ProxyAddressUtil.HostAndPort
```