### PR TITLE
Dev UI: Fix the Add and remove extension issues

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension.js
@@ -2,7 +2,7 @@ import { LitElement, html, css} from 'lit';
 import { observeState } from 'lit-element-state';
 import '@vaadin/icon';
 import '@vaadin/dialog';
-import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { dialogHeaderRenderer, dialogRenderer, dialogFooterRenderer } from '@vaadin/dialog/lit.js';
 import '@qomponent/qui-badge';
 import { JsonRpc } from 'jsonrpc';
 import { notifier } from 'notifier';
@@ -76,6 +76,7 @@ export class QwcExtension extends observeState(LitElement) {
     
         .guide, .more, .config, .fav {
             visibility:hidden;
+            --vaadin-icon-size: var(--lumo-font-size-m);
         }
 
         .icon {
@@ -130,7 +131,8 @@ export class QwcExtension extends observeState(LitElement) {
                   `,
                   []
                 )}
-                ${dialogRenderer(() => this._renderDialog(), this.name)}
+                ${dialogRenderer(() => this._renderDialog(), [])}
+                ${dialogFooterRenderer(() => this._renderUninstallButton(), [this.installed, connectionState.current.isConnected])}
             ></vaadin-dialog>
 
             <div class="card ${this.clazz}">
@@ -275,7 +277,6 @@ export class QwcExtension extends observeState(LitElement) {
                     <td>${this._renderExtensionDependencies()}</td>
                 </tr>
             </table>
-            ${this._renderUninstallButton()}
         `;
     }
 
@@ -296,11 +297,11 @@ export class QwcExtension extends observeState(LitElement) {
 
     _uninstall(){
         this._dialogOpened = false;
-        notifier.showInfoMessage(this.name + " removal in progress");
+        notifier.showInfoMessage(this.name + " " + msg('removal in progress', { id: 'extensions-removing' }));
         this.jsonRpc.removeExtension({extensionArtifactId:this.artifact}).then(jsonRpcResponse => {
             let outcome = jsonRpcResponse.result;
             if(!outcome){
-                notifier.showErrorMessage(name + " " + msg('removal in progress', { id: 'extensions-removing' }));
+                notifier.showErrorMessage(this.name + " " + msg('removal failed', { id: 'extensions-remove-failed' }));
             }
         });
     }

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -85,8 +85,8 @@ export class QwcExtensions extends observeState(LitElement) {
             cursor: grab;
         }
         .addExtensionButton {
-            position: absolute;
-            bottom: 40px;
+            position: fixed;
+            bottom: calc(var(--footer-height, 38px) + 10px);
             right: 40px;
             width: 3em;
             height: 3em;

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -252,7 +252,19 @@ export class QwcExtensions extends observeState(LitElement) {
                     builtWith="${extension.builtWith}"
                     providesCapabilities="${extension.providesCapabilities}"
                     extensionDependencies="${extension.extensionDependencies}"
-                    ?installed=${this._installedExtensions.includes(extension.namespace)}
+                    ?installed=${(() => {
+                        // Build full namespace from artifact (e.g., "io.quarkus:quarkus-arc:999-SNAPSHOT" -> "io.quarkus.quarkus-arc")
+                        let fullNamespace = extension.namespace; // fallback
+                        if (extension.artifact) {
+                            const parts = extension.artifact.split(':');
+                            if (parts.length >= 2) {
+                                const groupId = parts[0]; // "io.quarkus"
+                                const artifactId = parts[1]; // "quarkus-arc"
+                                fullNamespace = `${groupId}.${artifactId}`; // "io.quarkus.quarkus-arc"
+                            }
+                        }
+                        return this._installedExtensions.includes(fullNamespace);
+                    })()}
                     ?favourite=${fav} 
                     @favourite=${this._favourite}
                     logoUrl="${logoUrl}">

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-footer.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-footer.js
@@ -210,8 +210,16 @@ export class QwcFooter extends observeState(LitElement) {
         super.connectedCallback();
         this._controlButtons = [];
         this._originalMouseY = 0;
-        
+
         this._restoreFromLocalStorage();
+    }
+
+    updated(changedProperties) {
+        super.updated(changedProperties);
+        // Expose footer height as CSS custom property for other components
+        // Use actual rendered height: 38px when closed, _height when open
+        const actualHeight = this._isOpen ? this._height : 38;
+        document.documentElement.style.setProperty('--footer-height', `${actualHeight}px`);
     }
 
     _restoreHeight(){


### PR DESCRIPTION
As discussed, this PR makes sure the add extension button move with the footer so that it does not cover the footer when the footer is open. It also fix the remove extension button on the more details dialog:

<img width="1598" height="768" alt="footer_close" src="https://github.com/user-attachments/assets/fae31b51-f1f9-4c6e-ac73-18dee245be0b" />
<img width="1598" height="768" alt="footer_open" src="https://github.com/user-attachments/assets/bca82c35-0050-4069-b5ef-7900c078fe3c" />
<img width="1598" height="768" alt="remove_ext" src="https://github.com/user-attachments/assets/5d6e25e3-754e-4b7b-93d0-2a007b0f544d" />
