### PR TITLE
Deprecate long obsoleted `JniBuildItem`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/JniProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/JniProcessor.java
@@ -3,9 +3,6 @@ package io.quarkus.deployment;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -15,7 +12,11 @@ public class JniProcessor {
 
     /**
      * JNI
+     *
+     * @deprecated This configuration was previously used to enable JNI from Quarkus extensions,
+     *             but JNI is always enabled starting from GraalVM 19.3.1.
      */
+    @Deprecated(since = "3.32", forRemoval = true)
     @ConfigMapping(prefix = "quarkus.jni")
     @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
     interface JniConfig {
@@ -23,12 +24,5 @@ public class JniProcessor {
          * Paths of library to load.
          */
         Optional<List<String>> libraryPaths();
-    }
-
-    @BuildStep
-    void setupJni(BuildProducer<JniBuildItem> jniProducer) {
-        if (jni.libraryPaths().isPresent()) {
-            jniProducer.produce(new JniBuildItem(jni.libraryPaths().get()));
-        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/JniBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/JniBuildItem.java
@@ -5,23 +5,26 @@ import java.util.List;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * @deprecated This build item was previously used to enable JNI from Quarkus extensions,
+ *             but JNI is always enabled starting from GraalVM 19.3.1.
+ */
+@Deprecated(since = "3.32", forRemoval = true)
 public final class JniBuildItem extends MultiBuildItem {
 
     private final List<String> libraryPaths;
 
-    /**
-     * @deprecated This method was previously used to enable JNI from Quarkus extensions, but JNI is always enabled starting
-     *             from GraalVM 19.3.1.
-     */
-    @Deprecated
+    @Deprecated(since = "3.32", forRemoval = true)
     public JniBuildItem() {
         this(Collections.emptyList());
     }
 
+    @Deprecated(since = "3.32", forRemoval = true)
     public JniBuildItem(List<String> libraryPaths) {
         this.libraryPaths = libraryPaths;
     }
 
+    @Deprecated(since = "3.32", forRemoval = true)
     public List<String> getLibraryPaths() {
         return libraryPaths;
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
@@ -11,11 +11,8 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
-import io.quarkus.deployment.builditem.JavaLibraryPathAdditionalPathBuildItem;
-import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.deployment.builditem.NativeImageEnableAllCharsetsBuildItem;
 import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
-import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.InlineBeforeAnalysisBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
@@ -37,16 +34,13 @@ class NativeImageConfigBuildStep {
             SslContextConfigurationRecorder sslContextConfigurationRecorder,
             List<NativeImageConfigBuildItem> nativeImageConfigBuildItems,
             SslNativeConfigBuildItem sslNativeConfig,
-            List<JniBuildItem> jniBuildItems,
             List<NativeImageEnableAllCharsetsBuildItem> nativeImageEnableAllCharsetsBuildItems,
             List<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
             List<InlineBeforeAnalysisBuildItem> inlineBeforeAnalysisBuildItems,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxy,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle,
             BuildProducer<RuntimeInitializedClassBuildItem> runtimeInit,
-            BuildProducer<NativeImageSystemPropertyBuildItem> nativeImage,
-            BuildProducer<SystemPropertyBuildItem> systemProperty,
-            BuildProducer<JavaLibraryPathAdditionalPathBuildItem> javaLibraryPathAdditionalPath) {
+            BuildProducer<NativeImageSystemPropertyBuildItem> nativeImage) {
         for (NativeImageConfigBuildItem nativeImageConfigBuildItem : nativeImageConfigBuildItems) {
             for (String i : nativeImageConfigBuildItem.getRuntimeInitializedClasses()) {
                 runtimeInit.produce(new RuntimeInitializedClassBuildItem(i));
@@ -77,14 +71,6 @@ class NativeImageConfigBuildStep {
             nativeImage.produce(new NativeImageSystemPropertyBuildItem("quarkus.native.monitoring",
                     nativeConfig.monitoring().get().stream().map(x -> x.toString().toLowerCase())
                             .collect(Collectors.joining(","))));
-        }
-
-        for (JniBuildItem jniBuildItem : jniBuildItems) {
-            if (jniBuildItem.getLibraryPaths() != null && !jniBuildItem.getLibraryPaths().isEmpty()) {
-                for (String path : jniBuildItem.getLibraryPaths()) {
-                    javaLibraryPathAdditionalPath.produce(new JavaLibraryPathAdditionalPathBuildItem(path));
-                }
-            }
         }
 
         if (!nativeImageEnableAllCharsetsBuildItems.isEmpty()) {


### PR DESCRIPTION
This build item is obsolete since GraalVM 19.3.1
(released in Q3 of 2019)