### PR TITLE
Make `ValueRegistryParameterResolver` a bit more relaxed

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/ValueRegistryParameterResolver.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/ValueRegistryParameterResolver.java
@@ -26,7 +26,7 @@ public class ValueRegistryParameterResolver implements ParameterResolver {
         if (parameterContext.getParameter().getType().equals(ValueRegistry.class)) {
             return true;
         }
-        return valueRegistry.containsKey(key(parameterContext.getParameter().getType()));
+        return valueRegistry != null && valueRegistry.containsKey(key(parameterContext.getParameter().getType()));
     }
 
     @Override
@@ -36,6 +36,9 @@ public class ValueRegistryParameterResolver implements ParameterResolver {
         if (parameterContext.getParameter().getType().equals(ValueRegistry.class)) {
             return valueRegistry;
         }
+        if (valueRegistry == null) {
+            throw new ParameterResolutionException("Could not retrieve parameter: " + parameterContext.getParameter());
+        }
         return valueRegistry.get(key(parameterContext.getParameter().getType()));
     }
 
@@ -43,7 +46,7 @@ public class ValueRegistryParameterResolver implements ParameterResolver {
         Store store = extensionContext.getStore(Namespace.GLOBAL);
         QuarkusTestExtensionState state = store.get(QuarkusTestExtensionState.class.getName(), QuarkusTestExtensionState.class);
         if (state == null || state.getValueRegistry() == null) {
-            throw new ParameterResolutionException("Could not retrieve parameter: " + parameterContext.getParameter());
+            return null;
         }
         return state.getValueRegistry();
     }


### PR DESCRIPTION
We have seen this exception during the execution of some of our quarkus integration tests.

It seems that the `ValueRegistryParameterResolver` is called for types that are not "owned by it" and can cause the following exception.

Maybe the proposed change could help here.

```
org.junit.jupiter.api.extension.ParameterResolutionException: Could not retrieve parameter: org.apache.polaris.service.it.env.PolarisApiEndpoints arg0
	at io.quarkus.test.junit.ValueRegistryParameterResolver.getValueRegistry(ValueRegistryParameterResolver.java:46)
	at io.quarkus.test.junit.ValueRegistryParameterResolver.supportsParameter(ValueRegistryParameterResolver.java:25)
	at io.quarkus.test.junit.QuarkusIntegrationTestExtension.supportsParameter(QuarkusIntegrationTestExtension.java:367)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at java.util.ArrayList.forEach(ArrayList.java:1596)
```

Such failures did not happen with 3.30.x and earlier. I did not run these tests with 3.31.0.CR1.

