### PR TITLE
Fix NPE in HibernateSearchElasticsearcRecorder

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -244,7 +244,7 @@ public class HibernateSearchElasticsearchRecorder {
             // 2. Then we check if any configurers were supplied by a user be it through a property or via an extension:
             Optional<List<BeanReference<HibernateOrmSearchMappingConfigurer>>> beanReferences = HibernateSearchBeanUtil
                     .multiExtensionBeanReferencesFor(
-                            buildTimeConfig.mapping().configurer(),
+                            buildTimeConfig == null ? Optional.empty() : buildTimeConfig.mapping().configurer(),
                             HibernateOrmSearchMappingConfigurer.class,
                             persistenceUnitName, null, null);
             if (beanReferences.isPresent()) {


### PR DESCRIPTION
Why would this be null, you ask? That is a very good question. On the surface, it would make sense because you could just not set any configuration. Looking deeper, that's strange though, because the Elasticsearch version must be set at build time, and we will fail the build if it's not.

But... evidently we've always assumed it can be null, and we have a report in the wild that it is indeed null, so... Let's fix this.

See https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Quarkus.20startup.20fails.20after.20migrating.20to.203.2E31.2E1/with/570729132
