### PR TITLE
Quarkus component test - add note about potential conflict with other JUnit extensions

### DIFF
--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -490,3 +490,29 @@ public class FooTest {
 ----
 <1> The interceptor bindings of the resulting interceptor are specified by annotating the method with the interceptor binding types.
 <2> Defines the interception type.
+
+== Testing alongside other JUnit Extensions
+
+While using different JUnit extensions in combination with Quarkus component testing works fine most of the time, there are cases where it can become problematic.
+
+The reason behind this is that Quarkus needs to juggle with class loading and, due to nature of extension initialization in JUnit, there is limited guarantee as to which extension comes first and when exactly they get instantiated.
+
+Note that this problem should only exhibit for extensions that are declared on the class level using `@ExtendWith` or their respective aliases. On top of that, they also need to operate with class loader early in their lifecycle - for example using the `ServiceLoader` mechanism in their constructors.
+
+A potential workaround is to register the other extension programmatically as an instance field via `@RegisterExtension`. This alone is enough to delay its instantiation and prevent the issue from occurring. Here is an example:
+
+[source,java]
+----
+@QuarkusComponentTest
+class TestWithMultipleJUnitExtensions {
+
+  @RegisterExtension <1>
+  MyOtherJUnitExtension extension = new MyOtherJUnitExtension();
+
+  @Test
+  void myTest() {
+    // some testing logic
+  }
+}
+----
+<1> Programmatically declared extensions are always instantiated later in the test lifecycle, hence circumventing the issue.


### PR DESCRIPTION
Fixes #52149 

I am not super happy with the text because it makes it sounds as if it were common encounter.
Though I was struggling to come up with anything better :shrug: 

The occurrence of this issue should be rare to begin with - it takes another extension declared at class level *and* performing some CL-oriented tasks during its initialization (such as `ServiceLoader` usage).

Programmatic declaration circumvents the issue but is not always an option.
And if the extension delays its init that's fine as well.