### PR TITLE
JaCoCo: resolve data-file and report-location against the project root

### DIFF
--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
@@ -30,7 +30,7 @@ public interface JacocoConfig {
 
     /**
      * The Jacoco data file.
-     * The path can be relative (to the module) or absolute.
+     * The path can be relative (to the project/module root) or absolute.
      */
     @ConfigDocDefault(TARGET_JACOCO_QUARKUS_EXEC)
     Optional<String> dataFile();
@@ -100,7 +100,7 @@ public interface JacocoConfig {
 
     /**
      * The location of the report files.
-     * The path can be relative (to the module) or absolute.
+     * The path can be relative (to the project/module root) or absolute.
      */
     @ConfigDocDefault(TARGET_JACOCO_REPORT)
     Optional<String> reportLocation();


### PR DESCRIPTION
- this commit reverts a change introduced in #30315 which caused regression by resolving the data-file and report-location against the build output dir (e.g. target)
- we also clarify the config docs
- fixes #52264

To be honest I'm not 100% sure this would not break anything. I only verified this PR with the reproducer from #52264 and the https://github.com/mkouba/quarkus-mcp-server/tree/jacoco branch in the MCP server.

It would be great if someone else could try it as well. CC @snazy @wesleysalimansdvb @vsevel @famod 