### PR TITLE
Avoid looking up Netty's `@Skip` annotation at runtime

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
@@ -1,10 +1,16 @@
 package io.quarkus.netty.runtime;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Map;
 import java.util.function.Supplier;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.annotations.StaticInit;
 
 @Recorder
 public class NettyRecorder {
@@ -26,5 +32,42 @@ public class NettyRecorder {
                 return val;
             }
         };
+    }
+
+    private static final VarHandle CHANNEL_HANDLER_MASKS;
+    private static volatile Map<String, Integer> channelHandlerMask;
+
+    static {
+        try {
+            CHANNEL_HANDLER_MASKS = MethodHandles.lookup()
+                    .findStaticVarHandle(NettyRecorder.class, "channelHandlerMask", Map.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @StaticInit
+    public void setChannelHandlerMasks(Map<String, Integer> masks) {
+        CHANNEL_HANDLER_MASKS.setRelease(masks);
+    }
+
+    @SuppressWarnings("unused") // used in generated code
+    public static Integer channelHandlerMask(Class<? extends ChannelHandler> handlerType) {
+        @SuppressWarnings("unchecked")
+        Map<String, Integer> map = (Map<String, Integer>) CHANNEL_HANDLER_MASKS.getAcquire();
+        if (map == null) {
+            return null;
+        }
+        return map.get(handlerType.getName());
+    }
+
+    public void cleanUp(ShutdownContext shutdown) {
+        shutdown.addShutdownTask(new Runnable() {
+            @Override
+            public void run() {
+                channelHandlerMask = null;
+            }
+        });
+
     }
 }

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -57,6 +57,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.PreInitRunnableBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
@@ -382,5 +383,10 @@ class VertxProcessor {
                             }
                         })
                 .build());
+    }
+
+    @BuildStep
+    void indexTransports(BuildProducer<IndexDependencyBuildItem> producer) {
+        producer.produce(new IndexDependencyBuildItem("io.vertx", "vertx-core"));
     }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-test-profile/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-test-profile/pom.xml
@@ -65,6 +65,9 @@
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>\${quarkus-plugin.version}</version>
                 <extensions>true</extensions>
+                <configuration>
+                    <jvmArgs>-XX:MaxMetaspaceSize=256m</jvmArgs>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The idea here is to determine all the masks at build time, thus making reflection at runtime for the `@Skip` annotation redundant.