### PR TITLE
Avoid ServiceLoader lookup for ConfigProviderResolver

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -366,6 +366,7 @@ public class ConfigGenerationBuildStep {
 
         RunTimeConfigurationGenerator.GenerateOperation
                 .builder()
+                .setLaunchMode(launchModeBuildItem.getLaunchMode())
                 .setBuildTimeReadResult(configItem.getReadResult())
                 .setClassOutput(new GeneratedClassGizmoAdaptor(generatedClass, false))
                 .setLiveReloadPossible(launchModeBuildItem.getLaunchMode() == LaunchMode.DEVELOPMENT

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
@@ -19,10 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-
 import com.oracle.svm.core.annotate.Alias;
-import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
@@ -33,13 +30,6 @@ import io.smallrye.config.ConfigMappingLoader;
 import io.smallrye.config.ConfigMappingMetadata;
 
 final class Substitutions {
-    @TargetClass(ConfigProviderResolver.class)
-    static final class Target_ConfigurationProviderResolver {
-
-        @Alias
-        @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
-        private static volatile ConfigProviderResolver instance;
-    }
 
     @TargetClass(ConfigMappingLoader.class)
     static final class Target_ConfigMappingLoader {


### PR DESCRIPTION
Ideally, it should be done for all modes, but due to all the CL switching in tests, the `ConfigProviderResolver` is registered by the test mode before Quarkus (and we need to keep that), and there is no API to check whether something is already registered.

This is the quick way to do it. I'll be exploring alternatives to support this properly.