### PR TITLE
ArC - Do not add @Any if already there

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -743,7 +743,9 @@ public final class Beans {
                 .allMatch(a -> DotNames.NAMED.equals(a.name()) || DotNames.ANY.equals(a.name())))) {
             qualifiers.add(BuiltinQualifier.DEFAULT.getInstance());
         }
-        qualifiers.add(BuiltinQualifier.ANY.getInstance());
+        if (qualifiers.stream().noneMatch(a -> DotNames.ANY.equals(a.name()))) {
+            qualifiers.add(BuiltinQualifier.ANY.getInstance());
+        }
         return qualifiers;
     }
 


### PR DESCRIPTION
It is a Set of AnnotationInstance and thus the target will prevent deduplication. We need to be more careful here.

Note that this is important for an incoming patch but it has value anyway.
