### PR TITLE
ArC - Avoid array + list + array + set allocations

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -743,7 +743,9 @@ public final class Beans {
                 .allMatch(a -> DotNames.NAMED.equals(a.name()) || DotNames.ANY.equals(a.name())))) {
             qualifiers.add(BuiltinQualifier.DEFAULT.getInstance());
         }
-        qualifiers.add(BuiltinQualifier.ANY.getInstance());
+        if (qualifiers.stream().noneMatch(a -> DotNames.ANY.equals(a.name()))) {
+            qualifiers.add(BuiltinQualifier.ANY.getInstance());
+        }
         return qualifiers;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescs.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescs.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,7 +43,6 @@ import io.quarkus.arc.impl.InvocationContexts;
 import io.quarkus.arc.impl.MapValueSupplier;
 import io.quarkus.arc.impl.Reflections;
 import io.quarkus.arc.impl.RemovedBeanImpl;
-import io.quarkus.arc.impl.Sets;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
@@ -155,13 +153,13 @@ final class MethodDescs {
     static final MethodDesc CREATIONAL_CTX_ADD_DEP_TO_PARENT = MethodDesc.of(CreationalContextImpl.class,
             "addDependencyToParent", void.class, InjectableBean.class, Object.class, CreationalContext.class);
 
-    static final MethodDesc COLLECTIONS_SINGLETON = MethodDesc.of(Collections.class,
-            "singleton", Set.class, Object.class);
+    static final MethodDesc SET_OF_0 = MethodDesc.of(Set.class, "of", Set.class);
 
-    static final MethodDesc COLLECTIONS_SINGLETON_LIST = MethodDesc.of(Collections.class,
-            "singletonList", List.class, Object.class);
+    static final MethodDesc SET_OF_1 = MethodDesc.of(Set.class, "of", Set.class, Object.class);
 
-    static final MethodDesc SETS_OF = MethodDesc.of(Sets.class, "of", Set.class, Object[].class);
+    static final MethodDesc SET_OF_2 = MethodDesc.of(Set.class, "of", Set.class, Object.class, Object.class);
+
+    static final MethodDesc SET_OF_VARARGS = MethodDesc.of(Set.class, "of", Set.class, Object[].class);
 
     static final MethodDesc ARC_REQUIRE_CONTAINER = MethodDesc.of(Arc.class, "requireContainer", ArcContainer.class);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -537,19 +537,11 @@ public class SubclassGenerator extends AbstractGenerator {
 
         return bindings -> {
             String key = "b" + bindingIdx.i++;
-            Expr value;
-            if (bindings.size() == 1) {
-                value = bc.invokeStatic(MethodDescs.COLLECTIONS_SINGLETON,
-                        bindingsLiterals.computeIfAbsent(bindings.iterator().next(), bindingsLiteralFun));
-            } else {
-                LocalVar bindingsArray = bc.localVar("bindings", bc.newEmptyArray(Object.class, bindings.size()));
-                int bindingsIndex = 0;
-                for (AnnotationInstanceEquivalenceProxy binding : bindings) {
-                    bc.set(bindingsArray.elem(bindingsIndex), bindingsLiterals.computeIfAbsent(binding, bindingsLiteralFun));
-                    bindingsIndex++;
-                }
-                value = bc.invokeStatic(MethodDescs.SETS_OF, bindingsArray);
+            List<Expr> bindingsList = new ArrayList<>();
+            for (AnnotationInstanceEquivalenceProxy binding : bindings) {
+                bindingsList.add(bindingsLiterals.computeIfAbsent(binding, bindingsLiteralFun));
             }
+            Expr value = createSetOf(bc, bindingsList);
             bc.withMap(bindingsMap).put(Const.of(key), value);
             return key;
         };


### PR DESCRIPTION
We used to use Sets.of(), with a newly created array, which in the case where we have more than 2 elements was calling Set.copyOf(), which is implemented as:

```
Set.copyOf(Arrays.asList(elements))
```
then
```
return (Set<E>)Set.of(new HashSet<>(coll).toArray());
```

This is not really optimal as far as allocations are concerned and it shows when you have a lot of beans having more than 2 types. Which is quite common for Panache repositories, AFAICS from my profiling.
This alone represented 1.4% of the allocations from a very large Hibernate ORM application (where Hibernate ORM is extremely heavy on allocations so it would represent a lot more if ORM wasn't around).

The new implementation is a lot more optimal as it avoids array + list creation in <= 2 case, and avoid creating a list, a HashSet and then another an array in the > 2 case.

There is one VERY important thing though: the elements have to be strictly unique, thus why #52297 is important.

I think it's something we should ensure anyway.

<img width="1545" height="355" alt="Screenshot From 2026-01-30 22-13-54" src="https://github.com/user-attachments/assets/c2482eda-4533-4d3c-a8c2-60e102032937" />



Created as draft as CI won't pass until #52297 is merged. And we need to discuss it with the ArC team before even thinking about merging it. Also I need @Ladicek to validate what I did with Gizmo 2 isn't stupid or dangerous :).

For the big picture, on the large Hibernate ORM application that I am using as a sample (it has a lot of beans but most of the init phase is Hibernate ORM initialization) - check the numbers as the graph is not really explicit:

<img width="3292" height="1514" alt="Screenshot From 2026-01-31 17-53-06" src="https://github.com/user-attachments/assets/2134babd-1e3f-4d61-99da-00dea7769e81" />

<img width="3292" height="1514" alt="Screenshot From 2026-01-31 17-53-18" src="https://github.com/user-attachments/assets/141f17a5-40aa-4daf-aa58-ceba0e613fa1" />

