### PR TITLE
Provide a converter for InheritableLevel

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevelConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevelConverter.java
@@ -1,0 +1,26 @@
+package io.quarkus.runtime.logging;
+
+import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
+
+import java.io.Serializable;
+
+import jakarta.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * A simple converter for inheritable logging levels.
+ */
+@Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
+public final class InheritableLevelConverter implements Converter<InheritableLevel>, Serializable {
+
+    private static final long serialVersionUID = 704275577610445233L;
+
+    public InheritableLevel convert(final String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
+        return InheritableLevel.of(value);
+    }
+}

--- a/core/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/core/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -9,3 +9,4 @@ io.quarkus.runtime.configuration.MemorySizeConverter
 io.quarkus.runtime.configuration.LocaleConverter
 io.quarkus.runtime.configuration.ZoneIdConverter
 io.quarkus.runtime.logging.LevelConverter
+io.quarkus.runtime.logging.InheritableLevelConverter


### PR DESCRIPTION
This is actually the only conversion in the core/REST layer that requires StaticMethodConverter.

Now, don't get me wrong, we will have extensions that will end up requiring it, but getting our base layer free from it has value.

<img width="3292" height="2127" alt="Screenshot From 2026-01-31 13-11-40" src="https://github.com/user-attachments/assets/fc90315e-8581-443f-b1cf-6be82913f5dd" />


