### PR TITLE
Optimize DurationConverter so that it doesn't require regexps

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -152,7 +152,7 @@ public interface TestConfig {
      * Used in {@code @QuarkusIntegrationTest} to determine how long the test will wait for the
      * application to launch
      */
-    @WithDefault("PT1M")
+    @WithDefault("1M")
     Duration waitTime();
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
@@ -4,8 +4,6 @@ import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.time.format.DateTimeParseException;
-import java.util.regex.Pattern;
 
 import jakarta.annotation.Priority;
 
@@ -17,76 +15,112 @@ import org.eclipse.microprofile.config.spi.Converter;
 @Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
 public class DurationConverter implements Converter<Duration>, Serializable {
     private static final long serialVersionUID = 7499347081928776532L;
+
     private static final String PERIOD = "P";
     private static final String PERIOD_OF_TIME = "PT";
-    public static final Pattern DIGITS = Pattern.compile("^[-+]?\\d+$");
-    private static final Pattern DIGITS_AND_UNIT = Pattern.compile("^(?:[-+]?\\d+(?:\\.\\d+)?(?i)[hms])+$");
-    private static final Pattern DAYS = Pattern.compile("^[-+]?\\d+(?i)d$");
-    private static final Pattern MILLIS = Pattern.compile("^[-+]?\\d+(?i)ms$");
 
-    public DurationConverter() {
-    }
-
-    /**
-     * If the {@code value} starts with a number, then:
-     * <ul>
-     * <li>If the value is only a number, it is treated as a number of seconds.</li>
-     * <li>If the value is a number followed by {@code ms}, it is treated as a number of milliseconds.</li>
-     * <li>If the value is a number followed by {@code h}, {@code m}, or {@code s}, it is prefixed with {@code PT}
-     * and {@link Duration#parse(CharSequence)} is called.</li>
-     * <li>If the value is a number followed by {@code d}, it is prefixed with {@code P}
-     * and {@link Duration#parse(CharSequence)} is called.</li>
-     * </ul>
-     *
-     * Otherwise, {@link Duration#parse(CharSequence)} is called.
-     *
-     * @param value a string duration
-     * @return the parsed {@link Duration}
-     * @throws IllegalArgumentException in case of parse failure
-     */
     @Override
     public Duration convert(String value) {
         return parseDuration(value);
     }
 
-    /**
-     * If the {@code value} starts with a number, then:
-     * <ul>
-     * <li>If the value is only a number, it is treated as a number of seconds.</li>
-     * <li>If the value is a number followed by {@code ms}, it is treated as a number of milliseconds.</li>
-     * <li>If the value is a number followed by {@code h}, {@code m}, or {@code s}, it is prefixed with {@code PT}
-     * and {@link Duration#parse(CharSequence)} is called.</li>
-     * <li>If the value is a number followed by {@code d}, it is prefixed with {@code P}
-     * and {@link Duration#parse(CharSequence)} is called.</li>
-     * </ul>
-     *
-     * Otherwise, {@link Duration#parse(CharSequence)} is called.
-     *
-     * @param value a string duration
-     * @return the parsed {@link Duration}
-     * @throws IllegalArgumentException in case of parse failure
-     */
     public static Duration parseDuration(String value) {
         value = value.trim();
-        if (value.isEmpty()) {
+        int len = value.length();
+        if (len == 0)
             return null;
-        }
-        if (DIGITS.asPredicate().test(value)) {
+
+        // only numbers, these are seconds
+        if (isNumeric(value)) {
             return Duration.ofSeconds(Long.parseLong(value));
-        } else if (MILLIS.asPredicate().test(value)) {
-            return Duration.ofMillis(Long.parseLong(value.substring(0, value.length() - 2)));
         }
 
-        try {
-            if (DIGITS_AND_UNIT.asPredicate().test(value)) {
-                return Duration.parse(PERIOD_OF_TIME + value);
-            } else if (DAYS.asPredicate().test(value)) {
-                return Duration.parse(PERIOD + value);
+        char last = value.charAt(len - 1);
+        char lastLower = Character.toLowerCase(last);
+
+        // single letter units, we only handle integers, decimal numbers will be handled by Duration#parse()
+        String numericPart = value.substring(0, len - 1);
+        if (isNumeric(numericPart)) {
+            long val = Long.parseLong(numericPart);
+            switch (lastLower) {
+                case 's':
+                    return Duration.ofSeconds(val);
+                case 'm':
+                    return Duration.ofMinutes(val);
+                case 'h':
+                    return Duration.ofHours(val);
+                case 'd':
+                    return Duration.ofDays(val);
             }
-
-            return Duration.parse(value);
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException(e);
         }
+
+        // specific case of milliseconds
+        if (len > 2 && lastLower == 's' && Character.toLowerCase(value.charAt(len - 2)) == 'm') {
+            String num = value.substring(0, len - 2);
+            if (isNumeric(num))
+                return Duration.ofMillis(Long.parseLong(num));
+        }
+
+        // cases handled by Duration.parse(), we add the P/PT prefix if needed
+        try {
+            if (isDecimal(numericPart)) {
+                if (lastLower == 'h' || lastLower == 'm' || lastLower == 's') {
+                    return Duration.parse(PERIOD_OF_TIME + value);
+                } else if (lastLower == 'd') {
+                    return Duration.parse(PERIOD + value);
+                }
+            }
+            // Handle "1h30m" style (DIGITS_AND_UNIT)
+            if (startsLikeDigits(value)) {
+                return Duration.parse(PERIOD_OF_TIME + value);
+            }
+            return Duration.parse(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid duration: " + value, e);
+        }
+    }
+
+    private static boolean isNumeric(String s) {
+        int len = s.length();
+        if (len == 0) {
+            return false;
+        }
+        int i = (s.charAt(0) == '-' || s.charAt(0) == '+') ? 1 : 0;
+        if (i == len) {
+            return false;
+        }
+        for (; i < len; i++) {
+            char c = s.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isDecimal(String s) {
+        int len = s.length();
+        if (len == 0) {
+            return false;
+        }
+        boolean hasDot = false;
+        int i = (s.charAt(0) == '-' || s.charAt(0) == '+') ? 1 : 0;
+        for (; i < len; i++) {
+            char c = s.charAt(i);
+            if (c == '.') {
+                if (hasDot) {
+                    return false;
+                }
+                hasDot = true;
+            } else if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return hasDot;
+    }
+
+    private static boolean startsLikeDigits(String s) {
+        char c = s.charAt(0);
+        return (c >= '0' && c <= '9') || c == '-' || c == '+';
     }
 }

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/DurationConverterTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/DurationConverterTestCase.java
@@ -53,6 +53,9 @@ public class DurationConverterTestCase {
         Duration expectedDuration = Duration.ofDays(3);
         Duration actualDuration = durationConverter.convert("3d");
         assertEquals(expectedDuration, actualDuration);
+
+        actualDuration = durationConverter.convert("3D");
+        assertEquals(expectedDuration, actualDuration);
     }
 
     @Test
@@ -60,12 +63,38 @@ public class DurationConverterTestCase {
         Duration expectedDuration = Duration.ofMillis(25);
         Duration actualDuration = durationConverter.convert("25ms");
         assertEquals(expectedDuration, actualDuration);
+
+        actualDuration = durationConverter.convert("25MS");
+        assertEquals(expectedDuration, actualDuration);
     }
 
     @Test
     public void testValueIsInSec() {
         Duration expectedDuration = Duration.ofSeconds(2);
         Duration actualDuration = durationConverter.convert("2s");
+        assertEquals(expectedDuration, actualDuration);
+
+        actualDuration = durationConverter.convert("2S");
+        assertEquals(expectedDuration, actualDuration);
+    }
+
+    @Test
+    public void testValueIsInMinutes() {
+        Duration expectedDuration = Duration.ofMinutes(2);
+        Duration actualDuration = durationConverter.convert("2m");
+        assertEquals(expectedDuration, actualDuration);
+
+        actualDuration = durationConverter.convert("2M");
+        assertEquals(expectedDuration, actualDuration);
+    }
+
+    @Test
+    public void testValueIsInHours() {
+        Duration expectedDuration = Duration.ofHours(3);
+        Duration actualDuration = durationConverter.convert("3h");
+        assertEquals(expectedDuration, actualDuration);
+
+        actualDuration = durationConverter.convert("3H");
         assertEquals(expectedDuration, actualDuration);
     }
 

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
@@ -113,7 +113,7 @@ public interface ContainerImageOpenshiftConfig {
     /**
      * The build timeout.
      */
-    @WithDefault("PT5M")
+    @WithDefault("5M")
     Duration buildTimeout();
 
     /**

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -216,7 +216,7 @@ public interface MailerRuntimeConfig {
      * Sets the connection pool cleaner period.
      * Zero disables expiration checks and connections will remain in the pool until they are closed.
      */
-    @WithDefault("PT1S")
+    @WithDefault("1S")
     Duration poolCleanerPeriod();
 
     /**
@@ -224,7 +224,7 @@ public interface MailerRuntimeConfig {
      * This value determines how long a connection remains unused in the pool before being evicted and closed.
      * A timeout of 0 means there is no timeout.
      */
-    @WithDefault("PT300S")
+    @WithDefault("300S")
     Duration keepAliveTimeout();
 
     /**
@@ -272,6 +272,6 @@ public interface MailerRuntimeConfig {
      * <p>
      * Default is 60 seconds.
      */
-    @WithDefault("PT60S")
+    @WithDefault("60S")
     Duration timeout();
 }

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/GrafanaConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/GrafanaConfig.java
@@ -29,6 +29,6 @@ public interface GrafanaConfig extends ContainerConfig {
     /**
      * The timeout.
      */
-    @WithDefault("PT3M")
+    @WithDefault("3M")
     Duration timeout();
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
@@ -171,14 +172,16 @@ public class OpenTelemetryRecorder {
     private static class OTelDurationConverter implements Converter<String> {
         static OTelDurationConverter INSTANCE = new OTelDurationConverter();
 
+        private static final Pattern DIGITS = Pattern.compile("^[-+]?\\d+$");
+
         @Override
         public String convert(final String value) throws IllegalArgumentException, NullPointerException {
             if (value == null) {
                 throw new NullPointerException();
             }
 
-            if (DurationConverter.DIGITS.asPredicate().test(value)) {
-                // OTel regards values without a unit to me milliseconds instead of seconds
+            if (DIGITS.asPredicate().test(value)) {
+                // OTel regards values without a unit to be milliseconds instead of seconds
                 // that java.time.Duration assumes, so let's just not do any conversion and let OTel handle with it
                 return value;
             }

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -109,7 +109,7 @@ public interface DataSourceReactiveRuntimeConfig {
     /**
      * The interval between reconnection attempts when a pooled connection cannot be established on first try.
      */
-    @WithDefault("PT1S")
+    @WithDefault("1S")
     Duration reconnectInterval();
 
     /**

--- a/extensions/security-webauthn/deployment/src/test/java/io/quarkus/security/webauthn/test/WebAuthnAndBasicAuthnTest.java
+++ b/extensions/security-webauthn/deployment/src/test/java/io/quarkus/security/webauthn/test/WebAuthnAndBasicAuthnTest.java
@@ -67,6 +67,7 @@ public class WebAuthnAndBasicAuthnTest {
                 .filter(cookieFilter);
         WebAuthnEndpointHelper.addWebAuthnRegistrationFormParameters(request, registration);
         var config = new SmallRyeConfigBuilder()
+                .addDiscoveredConverters()
                 .withMapping(WebAuthnRunTimeConfig.class)
                 .build()
                 .getConfigMapping(WebAuthnRunTimeConfig.class);

--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRunTimeConfig.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRunTimeConfig.java
@@ -393,7 +393,7 @@ public interface WebAuthnRunTimeConfig {
      *
      * When inactivity timeout is reached, cookie is not renewed and a new login is enforced.
      */
-    @WithDefault("PT30M")
+    @WithDefault("30M")
     Duration sessionTimeout();
 
     /**
@@ -411,7 +411,7 @@ public interface WebAuthnRunTimeConfig {
      * That is, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
      * itself, and it is decrypted and parsed with each request.
      */
-    @WithDefault("PT1M")
+    @WithDefault("1M")
     Duration newCookieInterval();
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -96,7 +96,7 @@ public interface FormAuthConfig {
      * <p>
      * When inactivity timeout is reached, cookie is not renewed and a new login is enforced.
      */
-    @WithDefault("PT30M")
+    @WithDefault("30M")
     Duration timeout();
 
     /**
@@ -114,7 +114,7 @@ public interface FormAuthConfig {
      * That is, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
      * itself, and it is decrypted and parsed with each request.
      */
-    @WithDefault("PT1M")
+    @WithDefault("1M")
     Duration newCookieInterval();
 
     /**


### PR DESCRIPTION
It's good for both initialization and runtime.

Numbers from a JMH run:

```
DurationConverterBenchmark.optimizedManualConverter_durationComplex   avgt   10  149.635 ± 17.146  ns/op
DurationConverterBenchmark.optimizedManualConverter_durationWithUnit  avgt   10   14.357 ±  1.433  ns/op
DurationConverterBenchmark.optimizedManualConverter_emptyString       avgt   10    0.773 ±  0.034  ns/op
DurationConverterBenchmark.optimizedManualConverter_isoDuration       avgt   10  144.155 ±  9.086  ns/op
DurationConverterBenchmark.optimizedManualConverter_isoDurationFull   avgt   10  147.432 ± 10.191  ns/op
DurationConverterBenchmark.optimizedManualConverter_largeNumeric      avgt   10   23.352 ±  1.627  ns/op
DurationConverterBenchmark.optimizedManualConverter_numericNegative   avgt   10    5.481 ±  0.384  ns/op
DurationConverterBenchmark.optimizedManualConverter_numericOnly       avgt   10    6.149 ±  0.234  ns/op
DurationConverterBenchmark.optimizedManualConverter_numericPositive   avgt   10    7.034 ±  0.590  ns/op


DurationConverterBenchmark.regexConverter_durationComplex             avgt   10  319.064 ± 26.391  ns/op
DurationConverterBenchmark.regexConverter_durationWithUnit            avgt   10  326.141 ± 38.695  ns/op
DurationConverterBenchmark.regexConverter_emptyString                 avgt   10    0.618 ±  0.037  ns/op
DurationConverterBenchmark.regexConverter_isoDuration                 avgt   10  244.525 ± 21.900  ns/op
DurationConverterBenchmark.regexConverter_isoDurationFull             avgt   10  288.761 ± 22.641  ns/op
DurationConverterBenchmark.regexConverter_largeNumeric                avgt   10   44.164 ±  3.539  ns/op
DurationConverterBenchmark.regexConverter_numericNegative             avgt   10   22.343 ±  1.323  ns/op
DurationConverterBenchmark.regexConverter_numericOnly                 avgt   10   22.674 ±  1.730  ns/op
DurationConverterBenchmark.regexConverter_numericPositive             avgt   10   23.659 ±  1.865  ns/op
```

You'll notice that the all numeric case and the case with numeric + unit (such as the widely used `2s`) is a lot better.

And that's why the second commit that aligns all our default values in config to use this more readable and more optimized format.