### PR TITLE
Redis-client: optionally fail on aborted SET (NX/XX nil reply)

### DIFF
--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/FailOnAbortedSetConfigWiringTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/FailOnAbortedSetConfigWiringTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.redis.deployment.client.datasource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.RedisCommandAbortedException;
+import io.quarkus.redis.datasource.value.SetArgs;
+import io.quarkus.redis.deployment.client.RedisTestResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class FailOnAbortedSetConfigWiringTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(MyRedisApp.class))
+            .overrideConfigKey("quarkus.redis.hosts", "${quarkus.redis.tr}")
+            .overrideConfigKey("quarkus.redis.fail-on-aborted-set", "true");
+
+    @Inject
+    MyRedisApp app;
+
+    @Test
+    public void testFailOnAbortedSetIsWiredFromConfig() {
+        String key = "fail-on-aborted-set-wiring-" + UUID.randomUUID();
+        app.del(key);
+
+        app.setNx(key, "v1");
+
+        assertThatThrownBy(() -> app.setNx(key, "v2"))
+                .isInstanceOf(RedisCommandAbortedException.class);
+    }
+
+    @ApplicationScoped
+    public static class MyRedisApp {
+
+        @Inject
+        ReactiveRedisDataSource reactive;
+
+        void del(String key) {
+            reactive.key(String.class).del(key)
+                    .await().indefinitely();
+        }
+
+        void setNx(String key, String value) {
+            reactive.value(String.class)
+                    .set(key, value, new SetArgs().nx())
+                    .await().indefinitely();
+        }
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/FailOnAbortedSetDefaultConfigWiringTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/FailOnAbortedSetDefaultConfigWiringTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.redis.deployment.client.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.UUID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.value.SetArgs;
+import io.quarkus.redis.deployment.client.RedisTestResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class FailOnAbortedSetDefaultConfigWiringTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(MyRedisApp.class))
+            .overrideConfigKey("quarkus.redis.hosts", "${quarkus.redis.tr}");
+
+    @Inject
+    MyRedisApp app;
+
+    @Test
+    public void testFailOnAbortedSetDefaultsToFalse() {
+        String key = "fail-on-aborted-set-default-" + UUID.randomUUID();
+        app.del(key);
+
+        app.setNx(key, "v1");
+
+        assertThatCode(() -> app.setNx(key, "v2"))
+                .doesNotThrowAnyException();
+
+        assertThat(app.get(key)).isEqualTo("v1");
+    }
+
+    @ApplicationScoped
+    public static class MyRedisApp {
+
+        @Inject
+        ReactiveRedisDataSource reactive;
+
+        void del(String key) {
+            reactive.key(String.class).del(key)
+                    .await().indefinitely();
+        }
+
+        void setNx(String key, String value) {
+            reactive.value(String.class)
+                    .set(key, value, new SetArgs().nx())
+                    .await().indefinitely();
+        }
+
+        String get(String key) {
+            return reactive.value(String.class).get(key)
+                    .await().indefinitely();
+        }
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisCommandAbortedException.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisCommandAbortedException.java
@@ -1,0 +1,12 @@
+package io.quarkus.redis.datasource;
+
+/**
+ * Indicates a Redis command was aborted due to unmet preconditions (for example, a conditional {@code SET}
+ * using {@code NX}/{@code XX} returning a nil reply).
+ */
+public class RedisCommandAbortedException extends RuntimeException {
+
+    public RedisCommandAbortedException(String message) {
+        super(message);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/SetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/SetArgs.java
@@ -208,4 +208,16 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
         return args;
     }
 
+    public boolean isNx() {
+        return nx;
+    }
+
+    public boolean isXx() {
+        return xx;
+    }
+
+    public boolean isGet() {
+        return get;
+    }
+
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/SetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/SetArgs.java
@@ -205,4 +205,16 @@ public class SetArgs implements RedisCommandExtraArguments {
         return args;
     }
 
+    public boolean isNx() {
+        return nx;
+    }
+
+    public boolean isXx() {
+        return xx;
+    }
+
+    public boolean isGet() {
+        return get;
+    }
+
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
@@ -130,7 +130,8 @@ public class RedisClientRecorder {
                     RedisClientAndApi redisClientAndApi = clients.get(name);
                     Redis redis = redisClientAndApi.redis;
                     RedisAPI api = redisClientAndApi.api;
-                    return new ReactiveRedisDataSourceImpl(vertx, redis, api);
+                    boolean failOnAbortedSet = runtimeConfig.getValue().clients().get(name).failOnAbortedSet();
+                    return new ReactiveRedisDataSourceImpl(vertx, redis, api, failOnAbortedSet);
                 });
             }
         };

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -55,6 +55,20 @@ public interface RedisClientConfig {
     Duration timeout();
 
     /**
+     * Whether to fail when a Redis {@code SET} command is aborted because the condition specified by
+     * {@code NX}/{@code XX} is not satisfied (nil reply).
+     * <p>
+     * When enabled, datasource {@code set(...)} methods that do not return a value will fail with
+     * {@link io.quarkus.redis.datasource.RedisCommandAbortedException} when Redis returns a nil reply for a conditional
+     * {@code SET} (for example, with {@code NX}/{@code XX}).
+     * <p>
+     * This affects both reactive ({@code Uni<Void>}) and blocking ({@code void}) variants. When disabled (default),
+     * nil replies are treated as successful completion (legacy behavior).
+     */
+    @WithDefault("false")
+    boolean failOnAbortedSet();
+
+    /**
      * The Redis client type.
      * Accepted values are: {@code STANDALONE} (default), {@code CLUSTER}, {@code REPLICATION}, {@code SENTINEL}.
      */
@@ -277,6 +291,7 @@ public interface RedisClientConfig {
                 "hosts=" + hosts() +
                 ", hostsProviderName=" + hostsProviderName() +
                 ", timeout=" + timeout() +
+                ", failOnAbortedSet=" + failOnAbortedSet() +
                 ", clientType=" + clientType() +
                 ", masterName=" + masterName() +
                 ", role=" + role() +

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/FailOnAbortedSetTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/FailOnAbortedSetTest.java
@@ -1,0 +1,109 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
+import io.quarkus.redis.datasource.value.SetArgs;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+
+public class FailOnAbortedSetTest extends DatasourceTestBase {
+
+    @Test
+    void setWithNxEx_DefaultDoesNotFailOnAbort() {
+        ReactiveRedisDataSource ds = new ReactiveRedisDataSourceImpl(vertx, redis, api, false);
+        ReactiveValueCommands<String, String> values = ds.value(String.class);
+
+        String key = "reactive-set-abort-default-" + UUID.randomUUID();
+        ds.key(String.class).del(key).await().atMost(Duration.ofSeconds(5));
+
+        values.set(key, "v1", new SetArgs().nx().ex(10)).await().atMost(Duration.ofSeconds(5));
+        values.set(key, "v2", new SetArgs().nx().ex(10)).await().atMost(Duration.ofSeconds(5));
+
+        assertThat(values.get(key).await().atMost(Duration.ofSeconds(5))).isEqualTo("v1");
+    }
+
+    @Test
+    void setWithNxEx_FlagEnabledFailsOnAbort() {
+        ReactiveRedisDataSource ds = new ReactiveRedisDataSourceImpl(vertx, redis, api, true);
+        ReactiveValueCommands<String, String> values = ds.value(String.class);
+
+        String key = "reactive-set-abort-enabled-" + UUID.randomUUID();
+        ds.key(String.class).del(key).await().atMost(Duration.ofSeconds(5));
+
+        values.set(key, "v1", new SetArgs().nx().ex(10)).await().atMost(Duration.ofSeconds(5));
+
+        assertThatThrownBy(() -> values.set(key, "v2", new SetArgs().nx().ex(10)).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(RedisCommandAbortedException.class);
+
+        assertThat(values.get(key).await().atMost(Duration.ofSeconds(5))).isEqualTo("v1");
+    }
+
+    @Test
+    void setWithXxEx_FlagEnabledFailsOnAbort() {
+        ReactiveRedisDataSource ds = new ReactiveRedisDataSourceImpl(vertx, redis, api, true);
+        ReactiveValueCommands<String, String> values = ds.value(String.class);
+
+        String key = "reactive-set-abort-xx-enabled-" + UUID.randomUUID();
+        ds.key(String.class).del(key).await().atMost(Duration.ofSeconds(5));
+
+        assertThatThrownBy(() -> values.set(key, "v1", new SetArgs().xx().ex(10)).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(RedisCommandAbortedException.class);
+
+        assertThat(values.get(key).await().atMost(Duration.ofSeconds(5))).isNull();
+    }
+
+    @Test
+    void setWithNxEx_UsingStringSetArgs_FlagEnabledFailsOnAbort() {
+        ReactiveRedisDataSource ds = new ReactiveRedisDataSourceImpl(vertx, redis, api, true);
+        io.quarkus.redis.datasource.string.ReactiveStringCommands<String, String> strings = ds.string(String.class);
+
+        String key = "reactive-set-abort-stringargs-enabled-" + UUID.randomUUID();
+        ds.key(String.class).del(key).await().atMost(Duration.ofSeconds(5));
+
+        strings.set(key, "v1", new io.quarkus.redis.datasource.string.SetArgs().nx().ex(10)).await()
+                .atMost(Duration.ofSeconds(5));
+
+        assertThatThrownBy(() -> strings.set(key, "v2", new io.quarkus.redis.datasource.string.SetArgs().nx().ex(10)).await()
+                .atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(RedisCommandAbortedException.class);
+
+        assertThat(ds.value(String.class).get(key).await().atMost(Duration.ofSeconds(5))).isEqualTo("v1");
+    }
+
+    @Test
+    void setWithNxGet_DoesNotFailOnFlagEnabled() {
+        ReactiveRedisDataSource ds = new ReactiveRedisDataSourceImpl(vertx, redis, api, true);
+        io.quarkus.redis.datasource.string.ReactiveStringCommands<String, String> strings = ds.string(String.class);
+
+        String key = "reactive-set-abort-nx-get-enabled-" + UUID.randomUUID();
+        ds.key(String.class).del(key).await().atMost(Duration.ofSeconds(5));
+
+        strings.set(key, "v1", new io.quarkus.redis.datasource.string.SetArgs().nx().get()).await()
+                .atMost(Duration.ofSeconds(5));
+
+        assertThat(ds.value(String.class).get(key).await().atMost(Duration.ofSeconds(5))).isEqualTo("v1");
+    }
+
+    @Test
+    void blockingSetWithNxEx_FlagEnabledFailsOnAbort() {
+        ReactiveRedisDataSourceImpl reactive = new ReactiveRedisDataSourceImpl(vertx, redis, api, true);
+        BlockingRedisDataSourceImpl ds = new BlockingRedisDataSourceImpl(reactive, Duration.ofSeconds(5));
+
+        String key = "blocking-set-abort-enabled-" + UUID.randomUUID();
+        reactive.key(String.class).del(key).await().atMost(Duration.ofSeconds(5));
+
+        ds.value(String.class).set(key, "v1", new SetArgs().nx().ex(10));
+
+        assertThatThrownBy(() -> ds.value(String.class).set(key, "v2", new SetArgs().nx().ex(10)))
+                .isInstanceOf(RedisCommandAbortedException.class);
+
+        assertThat(ds.value(String.class).get(key)).isEqualTo("v1");
+    }
+}


### PR DESCRIPTION
Fixes #49000

Redis conditional SET (NX/XX without GET) returns a nil reply when the condition is not met. Previously, datasource set(...) methods returning void/Uni<Void> treated this as successful completion (null), making it impossible to distinguish “key was set” vs “operation was aborted”.

This PR introduces a new config flag: quarkus.redis.fail-on-aborted-set (default: false) to preserve existing behavior. When enabled, aborted conditional SET (NX/XX without GET) fails with RedisCommandAbortedException.

Tests:
- Unit-level/runtime tests for the SET behavior (flag disabled vs enabled)
- Integration/E2E wiring tests to verify the config is propagated into the datasource