### PR TITLE
Documentation: Use alphabetic `quarkus.security.ldap.identity-mapping.attribute-mappings."attribute-mappings".*` configuration property

### DIFF
--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -166,9 +166,9 @@ quarkus.security.ldap.dir-context.password=secret
 quarkus.security.ldap.identity-mapping.rdn-identifier=uid
 quarkus.security.ldap.identity-mapping.search-base-dn=ou=Users,dc=quarkus,dc=io
 
-quarkus.security.ldap.identity-mapping.attribute-mappings."0".from=cn
-quarkus.security.ldap.identity-mapping.attribute-mappings."0".filter=(member=uid={0},ou=Users,dc=quarkus,dc=io) <3>
-quarkus.security.ldap.identity-mapping.attribute-mappings."0".filter-base-dn=ou=Roles,dc=quarkus,dc=io
+quarkus.security.ldap.identity-mapping.attribute-mappings."cn".from=cn
+quarkus.security.ldap.identity-mapping.attribute-mappings."cn".filter=(member=uid={0},ou=Users,dc=quarkus,dc=io) <3>
+quarkus.security.ldap.identity-mapping.attribute-mappings."cn".filter-base-dn=ou=Roles,dc=quarkus,dc=io
 ----
 <1> You need to provide the URL to an LDAP server. This example requires the LDAP server to have imported link:{quarkus-blob-url}/test-framework/ldap/src/main/resources/quarkus-io.ldif[this LDIF file].
 <2> The URL used by our test resource. Tests may leverage `LdapServerTestResource` provided by Quarkus as link:{quickstarts-blob-url}/security-ldap-quickstart/src/test/java/org/acme/elytron/security/ldap/ElytronLdapExtensionTestResources.java[we do] in the test coverage of the example application.


### PR DESCRIPTION
Users that leverage YAML rather than `application.properties` can be confused by the fact that we use zero for a map key. Apparently when SR Config https://smallrye.io/smallrye-config/Main/config/mappings/#collections writes list like `server.environments[0].name=dev`, users not experienced with `application.properties` can confuse it with `server.environments.0.name=dev`. It is not really a bug, but we can avoid such a confusion.

I am opening this PR due to this discussion where user created a list instead of a map: https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Basic.20auth.20JDBC.20role.20mapping.20not.20working/with/562316770

Related Quarkus Quickstarts PR: https://github.com/quarkusio/quarkus-quickstarts/pull/1613