### PR TITLE
Extend `ReflectiveHierarchyStep`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -269,7 +269,7 @@ public class ReflectiveHierarchyStep {
             }
             final Type fieldType = getFieldType(combinedIndexBuildItem, initialName, info, field);
             visits.addLast(
-                    () -> addReflectiveHierarchyRecursively(nativeConfig, combinedIndexBuildItem, capabilities,
+                    () -> addReflectiveHierarchy(nativeConfig, combinedIndexBuildItem, capabilities,
                             reflectiveHierarchyBuildItem, source,
                             fieldType,
                             processedReflectiveHierarchies,
@@ -283,7 +283,7 @@ public class ReflectiveHierarchyStep {
                     method.returnType().kind() == Kind.VOID) {
                 continue;
             }
-            visits.addLast(() -> addReflectiveHierarchyRecursively(nativeConfig, combinedIndexBuildItem, capabilities,
+            visits.addLast(() -> addReflectiveHierarchy(nativeConfig, combinedIndexBuildItem, capabilities,
                     reflectiveHierarchyBuildItem, source,
                     method.returnType(),
                     processedReflectiveHierarchies,


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/51620 limited the types being registered when using `ReflectiveHierarchyStep` by not registering any subclasses or interface implementations of types being registered due to being transitively reachable though the explicitly registered type passed to `ReflectiveHierarchyStep`.

This commit relaxes this by treating field types and getter-methods return-types as explicitly marked for hierarchical reflective registration, allowing the registration of their subclasses and implementers (in case of interfaces).

Fixes #52312
