### PR TITLE
JaCoCo - QuarkusUnitTest support: fixes

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2229,6 +2229,55 @@ public class PersistenceAndQuarkusConfigTest {
 <1> This tells JUnit that the Quarkus deployment should fail with a specific exception
 
 
+[TIP]
+Test coverage and `QuarkusUnitTest`
+====
+If you want to measure the test coverage of the runtime submodule, then a specific JaCoCo configuration is needed in the deployment module:
+
+[source,xml]
+----
+<profiles>
+    <profile>
+        <id>test-coverage</id>
+        <activation>
+            <property>
+                <name>jacoco</name> <1>
+            </property>
+        </activation>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-jacoco-deployment</artifactId> <2>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+        <build>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <quarkus.jacoco.instrument-artifacts.runtime.group-id>io.quarkus</quarkus.jacoco.instrument-artifacts.runtime.group-id> <3>
+                            <quarkus.jacoco.instrument-artifacts.runtime.artifact-id>quarkus-runtime-module-name</quarkus.jacoco.instrument-artifacts.runtime.artifact-id>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+</profiles>
+----
+<1> This profile is activated with the `jacoco` property.
+<2> Add the `quarkus-jacoco-deployment` dependency with the `test` scope.
+<3> Instruct the JaCoCo plugin to instrument the `io.quarkus:quarkus-runtime-module-name` artifact.
+
+By default, JaCoCo will save the collected data in `target/jacoco-quarkus.exec` and the generated report is located in `target/jacoco-report`.
+For multi-module projects, more config properties will be needed. 
+Typically, `quarkus.jacoco.data-file=/path/to/shared/data-file`, `quarkus.jacoco.reuse-data-file=true` and `quarkus.jacoco.aggregate-report-data=true`.
+See xref:tests-with-coverage.adoc[Measuring the coverage of your tests] for more information. 
+====
+
+
 === Testing hot reload
 
 It is also possible to write tests that verify an extension works correctly in development mode and can correctly

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportCreator.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportCreator.java
@@ -26,8 +26,12 @@ import org.jacoco.report.MultiSourceFileLocator;
 import org.jacoco.report.csv.CSVFormatter;
 import org.jacoco.report.html.HTMLFormatter;
 import org.jacoco.report.xml.XMLFormatter;
+import org.jboss.logging.Logger;
 
 public class ReportCreator implements Runnable {
+
+    private static final Logger LOG = Logger.getLogger(ReportCreator.class);
+
     private final ReportInfo reportInfo;
     private final JacocoConfig config;
     private final DataFileWatch dataFileWatch;
@@ -67,6 +71,7 @@ public class ReportCreator implements Runnable {
             for (String i : reportInfo.savedData) {
                 File file = new File(i);
                 if (file.exists()) {
+                    LOG.debugf("JaCoCo is loading data for report from: %s", file);
                     loader.load(file);
                 }
             }

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportInfo.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportInfo.java
@@ -21,8 +21,8 @@ public class ReportInfo {
     public String reportDir;
     public Path dataFile;
     public final List<String> savedData = new ArrayList<>();
-    public Set<String> sourceDirectories;
-    public Set<String> classFiles;
+    public Set<String> sourceDirectories = new HashSet<>();
+    public Set<String> classFiles = new HashSet<>();
     public String artifactId;
     public Path errorFile;
 


### PR DESCRIPTION
- this is a follow-up to #52153
- fix NPE when ApplicationArchive#getKey() returns null
- fix report generation when quarkus.jacoco.data-file is not set
- add basic docs to the "Writing Your Own Extension" guide

NOTE: I still expect more fixes/docs updates coming. Mainly because I'm still struggling to understand all supported use cases. We should also try to write some automated tests for this extension (I'm not sure if we have some).