### PR TITLE
Panache Next: generate codestarts

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/base/README.tpl.qute.md
@@ -1,5 +1,9 @@
 {#include readme-header /}
 
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
+[Related Hibernate with Panache Next section...](https://quarkus.io/guides/hibernate-panache-next)
+{/if}
+
 {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-orm-panache')}
 [Related Hibernate with Panache section...](https://quarkus.io/guides/hibernate-orm-panache)
 {/if}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/java/src/main/java/org/acme/MyEntity.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/java/src/main/java/org/acme/MyEntity.tpl.qute.java
@@ -1,6 +1,61 @@
 package org.acme;
 
-{#if !input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-orm-panache')}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
+import io.quarkus.hibernate.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+
+
+/**
+ * Example JPA entity defined as a Panache Entity.
+ * An ID field of Long type is provided, if you want to define your own ID field extends <code>WithId</code> instead.
+ *
+ * Documentation: \{@see https://quarkus.io/guides/hibernate-panache-next}
+ *
+ * Usage:
+ *
+ * \{@code
+ *     public void doSomething() {
+ *         MyEntity entity1 = new MyEntity();
+ *         entity1.field = "field-1";
+ *         entity1.persist();
+ *
+ *         List<MyEntity> entities = MyEntity_.managedBlocking().listAll();
+ *     }
+ * }
+ */
+@Entity
+public class MyEntity extends PanacheEntity {
+    public String field;
+}
+{#else if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-orm-panache')}
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+
+
+/**
+ * Example JPA entity defined as a Panache Entity.
+ * An ID field of Long type is provided, if you want to define your own ID field extends <code>PanacheEntityBase</code> instead.
+ *
+ * This uses the active record pattern, you can also use the repository pattern instead:
+ * \{@see https://quarkus.io/guides/hibernate-orm-panache#solution-2-using-the-repository-pattern}.
+ *
+ * Usage:
+ *
+ * \{@code
+ *     public void doSomething() {
+ *         MyEntity entity1 = new MyEntity();
+ *         entity1.field = "field-1";
+ *         entity1.persist();
+ *
+ *         List<MyEntity> entities = MyEntity.listAll();
+ *     }
+ * }
+ */
+@Entity
+public class MyEntity extends PanacheEntity {
+    public String field;
+}
+{#else}
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -29,34 +84,6 @@ public class MyEntity {
     @GeneratedValue
     public Long id;
 
-    public String field;
-}
-{#else}
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
-import jakarta.persistence.Entity;
-
-
-/**
- * Example JPA entity defined as a Panache Entity.
- * An ID field of Long type is provided, if you want to define your own ID field extends <code>PanacheEntityBase</code> instead.
- *
- * This uses the active record pattern, you can also use the repository pattern instead:
- * {@see https://quarkus.io/guides/hibernate-orm-panache#solution-2-using-the-repository-pattern}.
- *
- * Usage (more example on the documentation)
- *
- * \{@code
- *     public void doSomething() {
- *         MyEntity entity1 = new MyEntity();
- *         entity1.field = "field-1";
- *         entity1.persist();
- *
- *         List<MyEntity> entities = MyEntity.listAll();
- *     }
- * }
- */
-@Entity
-public class MyEntity extends PanacheEntity {
     public String field;
 }
 {/if}

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,3 +17,7 @@ metadata:
   config:
   - "quarkus.datasource."
   - "quarkus.hibernate-orm."
+  codestart:
+    name: "hibernate-orm"
+    languages: ["java"]
+    artifact: "io.quarkus:quarkus-project-core-extension-codestarts"

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
@@ -33,9 +33,15 @@ dependencies {
     implementation(enforcedPlatform("{it.groupId}:{it.artifactId}:{it.version}"))
     {/if}
 {/each}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
+    annotationProcessor(enforcedPlatform("$\{quarkusPlatformGroupId}:$\{quarkusPlatformArtifactId}:$\{quarkusPlatformVersion}"))
+{/if}
 {#for dep in dependencies}
     implementation("{dep}")
 {/for}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
+    annotationProcessor("org.hibernate.orm:hibernate-processor")
+{/if}
     testImplementation("io.quarkus:quarkus-junit")
 {#for dep in test-dependencies}
     testImplementation("{dep}")

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
@@ -29,9 +29,15 @@ dependencies {
     implementation enforcedPlatform('{it.groupId}:{it.artifactId}:{it.version}')
     {/if}
 {/each}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
+    annotationProcessor enforcedPlatform("$\{quarkusPlatformGroupId}:$\{quarkusPlatformArtifactId}:$\{quarkusPlatformVersion}")
+{/if}
 {#for dep in dependencies}
     implementation '{dep}'
 {/for}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
+    annotationProcessor 'org.hibernate.orm:hibernate-processor'
+{/if}
     testImplementation 'io.quarkus:quarkus-junit'
 {#for dep in test-dependencies}
     testImplementation '{dep}'

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -163,6 +163,22 @@
                 <configuration>
                     <parameters>true</parameters>
                 </configuration>
+                {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+                            <annotationProcessorPaths>
+                                <annotationProcessorPath>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-processor</artifactId>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                {/if}
             </plugin>
             <!-- Run the tests in JVM mode -->
             <plugin>

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/WrapperRunner.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/WrapperRunner.java
@@ -79,6 +79,8 @@ public final class WrapperRunner {
         var holder = new Object() {
             int exitCode;
         };
+        var out = new ArrayList<String>();
+        var err = new ArrayList<String>();
         System.out.printf("Running command: %s %s%n", command, args);
         ProcessBuilder.newBuilder(command)
                 .arguments(args)
@@ -87,9 +89,19 @@ public final class WrapperRunner {
                     holder.exitCode = ec;
                     return true;
                 })
-                .output().inherited()
-                .error().inherited()
+                .output().consumeLinesWith(Integer.MAX_VALUE, line -> out.add(line))
+                .error().consumeLinesWith(Integer.MAX_VALUE, line -> err.add(line))
                 .run();
+        if (holder.exitCode != 0) {
+            for (String line : out) {
+                System.out.print("[Codestart stdout] ");
+                System.out.println(line);
+            }
+            for (String line : err) {
+                System.out.print("[Codestart stderr] ");
+                System.out.println(line);
+            }
+        }
         return holder.exitCode;
     }
 

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
@@ -290,11 +290,15 @@ public class QuarkusCodestartTest implements BeforeAllCallback, AfterAllCallback
     }
 
     private AbstractPathAssert<?> checkGeneratedSource(String sourceDir, Language language, String className) throws Throwable {
-        final String modifiedClassName = className.replace(DEFAULT_PACKAGE_DIR, packageName).replace('.', '/');
+        final String modifiedClassName = repackagedClassName(className).replace('.', '/');
         final String fileRelativePath = "src/" + sourceDir + "/" + language.key() + "/" + modifiedClassName
                 + getSourceFileExtension(language);
         return assertThatGeneratedFileMatchSnapshot(language, fileRelativePath)
                 .satisfies(checkContains("package " + packageName));
+    }
+
+    public String repackagedClassName(String className) {
+        return className.replace(DEFAULT_PACKAGE_DIR, packageName);
     }
 
     private String getTestId() {
@@ -335,7 +339,7 @@ public class QuarkusCodestartTest implements BeforeAllCallback, AfterAllCallback
         getQuarkusCodestartCatalog().createProject(input).generate(projectDir);
     }
 
-    private Path getProjectWithRealDataDir(Language language) throws IOException {
+    public Path getProjectWithRealDataDir(Language language) throws IOException {
         final Path dir = targetDir.resolve("real-data").resolve(language.key());
         generateRealDataProjectIfNeeded(dir, language);
         return dir;

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/HibernatePanacheNextCodestartIT.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/HibernatePanacheNextCodestartIT.java
@@ -1,0 +1,75 @@
+package io.quarkus.devtools.codestarts.quarkus;
+
+import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog.Language.JAVA;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.testing.codestarts.QuarkusCodestartTest;
+import io.quarkus.maven.ArtifactKey;
+
+public class HibernatePanacheNextCodestartIT {
+
+    @RegisterExtension
+    public static QuarkusCodestartTest codestartMavenTest = QuarkusCodestartTest.builder()
+            .codestarts("hibernate-orm")
+            .extension(new ArtifactKey("io.quarkus", "quarkus-jdbc-h2"))
+            .extension(new ArtifactKey("io.quarkus", "quarkus-hibernate-panache-next"))
+            .languages(JAVA)
+            .build();
+
+    @RegisterExtension
+    public static QuarkusCodestartTest codestartGradleTest = QuarkusCodestartTest.builder()
+            .codestarts("hibernate-orm")
+            .extension(new ArtifactKey("io.quarkus", "quarkus-jdbc-h2"))
+            .extension(new ArtifactKey("io.quarkus", "quarkus-hibernate-panache-next"))
+            .buildTool(BuildTool.GRADLE)
+            .languages(JAVA)
+            .build();
+
+    @RegisterExtension
+    public static QuarkusCodestartTest codestartGradleKotlinTest = QuarkusCodestartTest.builder()
+            .codestarts("hibernate-orm")
+            .extension(new ArtifactKey("io.quarkus", "quarkus-jdbc-h2"))
+            .extension(new ArtifactKey("io.quarkus", "quarkus-hibernate-panache-next"))
+            .buildTool(BuildTool.GRADLE_KOTLIN_DSL)
+            .languages(JAVA)
+            .build();
+
+    @Test
+    void testMavenContent() throws Throwable {
+        codestartMavenTest.checkGeneratedSource("org.acme.MyEntity");
+        codestartMavenTest.assertThatGeneratedFileMatchSnapshot(JAVA, "src/main/resources/import.sql");
+    }
+
+    @Test
+    void testMavenBuild() throws Throwable {
+        codestartMavenTest.buildAllProjects();
+        Path metamodelPath = codestartMavenTest.getProjectWithRealDataDir(JAVA).resolve("target/generated-sources/annotations/"
+                + codestartMavenTest.repackagedClassName("org.acme.MyEntity_").replace('.', '/') + ".java");
+        Assertions.assertTrue(Files.exists(metamodelPath));
+    }
+
+    @Test
+    void testGradleBuild() throws Throwable {
+        codestartGradleTest.buildAllProjects();
+        Path metamodelPath = codestartGradleTest.getProjectWithRealDataDir(JAVA)
+                .resolve("build/generated/sources/annotationProcessor/java/main/"
+                        + codestartGradleTest.repackagedClassName("org.acme.MyEntity_").replace('.', '/') + ".java");
+        Assertions.assertTrue(Files.exists(metamodelPath));
+    }
+
+    @Test
+    void testGradleKotlinBuild() throws Throwable {
+        codestartGradleKotlinTest.buildAllProjects();
+        Path metamodelPath = codestartGradleKotlinTest.getProjectWithRealDataDir(JAVA)
+                .resolve("build/generated/sources/annotationProcessor/java/main/"
+                        + codestartGradleKotlinTest.repackagedClassName("org.acme.MyEntity_").replace('.', '/') + ".java");
+        Assertions.assertTrue(Files.exists(metamodelPath));
+    }
+}

--- a/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmPanacheCodestartIT/testContent/src_main_java_ilove_quark_us_MyEntity.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmPanacheCodestartIT/testContent/src_main_java_ilove_quark_us_MyEntity.java
@@ -9,9 +9,9 @@ import jakarta.persistence.Entity;
  * An ID field of Long type is provided, if you want to define your own ID field extends <code>PanacheEntityBase</code> instead.
  *
  * This uses the active record pattern, you can also use the repository pattern instead:
- * .
+ * {@see https://quarkus.io/guides/hibernate-orm-panache#solution-2-using-the-repository-pattern}.
  *
- * Usage (more example on the documentation)
+ * Usage:
  *
  * {@code
  *     public void doSomething() {

--- a/integration-tests/devtools/src/test/resources/__snapshots__/HibernatePanacheNextCodestartIT/testMavenContent/src_main_java_ilove_quark_us_MyEntity.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/HibernatePanacheNextCodestartIT/testMavenContent/src_main_java_ilove_quark_us_MyEntity.java
@@ -1,0 +1,28 @@
+package ilove.quark.us;
+
+import io.quarkus.hibernate.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+
+
+/**
+ * Example JPA entity defined as a Panache Entity.
+ * An ID field of Long type is provided, if you want to define your own ID field extends <code>WithId</code> instead.
+ *
+ * Documentation: {@see https://quarkus.io/guides/hibernate-panache-next}
+ *
+ * Usage:
+ *
+ * {@code
+ *     public void doSomething() {
+ *         MyEntity entity1 = new MyEntity();
+ *         entity1.field = "field-1";
+ *         entity1.persist();
+ *
+ *         List<MyEntity> entities = MyEntity_.managedBlocking().listAll();
+ *     }
+ * }
+ */
+@Entity
+public class MyEntity extends PanacheEntity {
+    public String field;
+}

--- a/integration-tests/devtools/src/test/resources/__snapshots__/HibernatePanacheNextCodestartIT/testMavenContent/src_main_resources_import.sql
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/HibernatePanacheNextCodestartIT/testMavenContent/src_main_resources_import.sql
@@ -1,0 +1,6 @@
+-- This file allow to write SQL commands that will be emitted in test and dev.
+-- The commands are commented as their support depends of the database
+-- insert into myentity (id, field) values(1, 'field-1');
+-- insert into myentity (id, field) values(2, 'field-2');
+-- insert into myentity (id, field) values(3, 'field-3');
+-- alter sequence myentity_seq restart with 4;


### PR DESCRIPTION
Generate an entity for Panache Next, and include the ORM APT processor for Maven, Gradle, Gradle/Kotlin-DSL.

No support for Kotlin entities yet, as that will come later.

Fixes #51565