### PR TITLE
Use standard tmp directory to create temp files for parallel jar

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -160,7 +160,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             fastJarJarsBuilder.setTransformedJar(transformedZip);
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(transformedZip,
                     packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                    outputTarget.getOutputDirectory(), executorService)) {
+                    executorService)) {
                 // we make sure the entries are added in a reproducible order
                 // we use Path#toString() to get a reproducible order on both Unix-based OSes and Windows
                 for (Entry<Path, Set<TransformedClass>> transformedClassEntry : transformedClasses
@@ -182,7 +182,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         Path generatedZip = quarkus.resolve(FastJarFormat.GENERATED_BYTECODE_JAR);
         fastJarJarsBuilder.setGeneratedJar(generatedZip);
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(generatedZip,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null), outputTarget.getOutputDirectory(),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
                 executorService)) {
             // make sure we write the elements in order
             for (GeneratedClassBuildItem i : generatedClasses.stream()
@@ -216,7 +216,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
                     packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                    outputTarget.getOutputDirectory(), executorService)) {
+                    executorService)) {
                 copyFiles(applicationArchives.getRootArchive(), archiveCreator, null, ignoredEntriesPredicate);
             }
         }
@@ -287,7 +287,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         if (!rebuild) {
             try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(initJar,
                     packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                    outputTarget.getOutputDirectory(), executorService)) {
+                    executorService)) {
                 ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
                 generateManifest(archiveCreator, getClassPath(fastJarJars), packageConfig, appArtifact,
                         jvmRequirements,
@@ -465,7 +465,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             OutputTargetBuildItem outputTargetBuildItem, ExecutorService executorService) throws IOException {
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(targetPath,
                 packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
-                outputTargetBuildItem.getOutputDirectory(), executorService)) {
+                executorService)) {
             Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
                     new SimpleFileVisitor<Path>() {
                         @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -54,7 +54,7 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
 
     protected void doBuild(Path runnerJar, Path libDir) throws IOException {
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null), outputTarget.getOutputDirectory(),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
                 executorService)) {
             final Map<String, String> seen = new HashMap<>();
             final StringBuilder classPath = new StringBuilder();

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ParallelCommonsCompressArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ParallelCommonsCompressArchiveCreator.java
@@ -61,7 +61,7 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
     private Manifest manifest;
     private final Map<String, String> addedFiles = new HashMap<>();
 
-    ParallelCommonsCompressArchiveCreator(Path archivePath, boolean compressed, Instant entryTimestamp, Path outputTarget,
+    ParallelCommonsCompressArchiveCreator(Path archivePath, boolean compressed, Instant entryTimestamp,
             ExecutorService executorService) throws IOException {
         int compressionLevel;
         if (compressed) {
@@ -81,14 +81,14 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
         this.entryTimestamp = entryTimestamp != null ? FileTime.from(entryTimestamp) : null;
         this.archive = new ZipArchiveOutputStream(archivePath);
         this.archive.setMethod(compressionMethod);
-        this.tempDirectory = Files.createTempDirectory(outputTarget, "zip-builder-files");
+        this.tempDirectory = Files.createTempDirectory("zip-builder-files");
 
         scatterZipCreator = new ParallelScatterZipCreator(
                 // we need to make sure our own executor won't be shut down by Commons Compress...
                 new DoNotShutdownDelegatingExecutorService(executorService),
                 new DefaultBackingStoreSupplier(this.tempDirectory),
                 compressionLevel);
-        directories = ScatterZipOutputStream.pathBased(Files.createTempFile(outputTarget, "zip-builder-dirs", ""),
+        directories = ScatterZipOutputStream.pathBased(Files.createTempFile("zip-builder-dirs", ""),
                 compressionLevel);
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -144,7 +144,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
     private void buildUberJar0(Path runnerJar) throws IOException {
 
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
-                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null), outputTarget.getOutputDirectory(),
+                packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
                 executorService)) {
             LOG.info("Building uber jar: " + runnerJar);
 


### PR DESCRIPTION
Fixes #52323
