### PR TITLE
Enable default exporter when using Quarkiverse Exporters

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsExternalExporterDefaultEnabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsExternalExporterDefaultEnabledTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.opentelemetry.deployment.logs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.logs.VertxGrpcLogRecordExporter;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default log exporter is active when explicitly enabled.
+ */
+public class OtelLogsExternalExporterDefaultEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.logs.enabled", "true")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.logs.default-exporter-enabled", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("external-exporter"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<LogRecordExporter> logRecordExporter;
+
+    @Test
+    void testOpenTelemetryButNoSpanProcessor() {
+        assertThat(logRecordExporter.listActive().isEmpty()).isFalse();
+        assertThat(logRecordExporter.listActive().get(0)).isInstanceOf(VertxGrpcLogRecordExporter.class);
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsExternalExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLogsExternalExporterTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.opentelemetry.deployment.logs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default log exporter is not active when an external exporter is present.
+ */
+public class OtelLogsExternalExporterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.logs.enabled", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("external-log-exporter"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<LogRecordExporter> logRecordExporter;
+
+    @Test
+    void defaultExporterNotResolvable() {
+        assertThat(logRecordExporter.listActive().isEmpty()).isTrue();
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsExternalExporterDefaultEnabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsExternalExporterDefaultEnabledTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.opentelemetry.deployment.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.metrics.VertxGrpcMetricExporter;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default metrics exporter is active when explicitly enabled.
+ */
+public class MetricsExternalExporterDefaultEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "true")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.metrics.default-exporter-enabled", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("external-exporter"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<MetricExporter> metricExporterInstance;
+
+    @Test
+    void defaultExporterResolvable() {
+        assertThat(metricExporterInstance.listActive().isEmpty()).isFalse();
+        assertThat(metricExporterInstance.listActive().get(0)).isInstanceOf(VertxGrpcMetricExporter.class);
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsExternalExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/MetricsExternalExporterTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.opentelemetry.deployment.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default metrics exporter is not active when an external exporter is present.
+ */
+public class MetricsExternalExporterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.metrics.enabled", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("external-exporter"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<MetricExporter> metricExporterInstance;
+
+    @Test
+    void defaultExporterNotResolvable() {
+        assertThat(metricExporterInstance.listActive().isEmpty()).isTrue();
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryDefaultExporterEnabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryDefaultExporterEnabledTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.opentelemetry.deployment.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.LateBoundSpanProcessor;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.VertxGrpcSpanExporter;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default span exporter is active when explicitly enabled.
+ */
+public class OpenTelemetryDefaultExporterEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.trace.enabled", "true")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.traces.default-exporter-enabled", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("external-trace-exporter"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<LateBoundSpanProcessor> spanProcessorInstance;
+
+    @Test
+    void defaultExporterResolvable() throws Exception {
+        assertThat(spanProcessorInstance.isResolvable()).isTrue();
+
+        Field delegateField = LateBoundSpanProcessor.class.getDeclaredField("delegate");
+        delegateField.setAccessible(true);
+
+        Object obj = delegateField.get(spanProcessorInstance.get());
+        assertThat(obj).isInstanceOf(BatchSpanProcessor.class);
+        assertThat(((BatchSpanProcessor) obj).getSpanExporter()).isInstanceOf(VertxGrpcSpanExporter.class);
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryExternalExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryExternalExporterTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.opentelemetry.deployment.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.LateBoundSpanProcessor;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default span exporter is not active when an external exporter is present.
+ */
+public class OpenTelemetryExternalExporterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.traces.enabled", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("external-trace-exporter"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<LateBoundSpanProcessor> spanProcessorInstance;
+
+    @Test
+    void defaultExporterNotResolvable() throws Exception {
+        assertThat(spanProcessorInstance.isResolvable()).isTrue();
+
+        Field delegateField = LateBoundSpanProcessor.class.getDeclaredField("delegate");
+        delegateField.setAccessible(true);
+
+        Object obj = delegateField.get(spanProcessorInstance.get());
+        assertThat(obj).isNull();
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfig.java
@@ -8,6 +8,7 @@ import java.util.OptionalInt;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.configuration.DurationConverter;
 import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 public interface OtlpExporterConfig {
@@ -96,6 +97,22 @@ public interface OtlpExporterConfig {
      */
     @WithName("trust-cert")
     TrustCert trustCert();
+
+    /**
+     * Whether to use the default OpenTelemetry exporter in addition to any external exporters that may be present.
+     * <p>
+     * When `true`, the Quarkus default OpenTelemetry exporter will always be instantiated, even when other exporters
+     * are present. This will allow OTel data to be sent simultaneously to multiple destinations, including the default
+     * one. If `false`, the Quarkus default OpenTelemetry exporter will not be instantiated if external exporters are
+     * present.
+     * <p>
+     * There is a generic property, that will apply to all signals and a signal specific one, following the pattern:
+     * `quarkus.otel.exporter.otlp.<signal-type>.default-exporter-enabled` where <signal-type> is one of the
+     * supported signal types, like `traces`, `logs` or `metrics`.
+     */
+    @WithName("default-exporter-enabled")
+    @WithDefault("false")
+    boolean defaultExporterEnabled();
 
     /**
      * The name of the TLS configuration to use.

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfigBuilder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterConfigBuilder.java
@@ -45,6 +45,8 @@ public class OtlpExporterConfigBuilder implements ConfigBuilder {
         fallbacks.put("quarkus.otel.exporter.otlp.traces.key-cert.keys", "quarkus.otel.exporter.otlp.key-cert.keys");
         fallbacks.put("quarkus.otel.exporter.otlp.traces.key-cert.certs", "quarkus.otel.exporter.otlp.key-cert.certs");
         fallbacks.put("quarkus.otel.exporter.otlp.traces.trust-cert.certs", "quarkus.otel.exporter.otlp.trust-cert.certs");
+        fallbacks.put("quarkus.otel.exporter.otlp.traces.default-exporter-enabled",
+                "quarkus.otel.exporter.otlp.default-exporter-enabled");
         fallbacks.put("quarkus.otel.exporter.otlp.traces.tls-configuration-name",
                 "quarkus.otel.exporter.otlp.tls-configuration-name");
         fallbacks.put("quarkus.otel.exporter.otlp.traces.proxy-options.enabled",
@@ -65,6 +67,8 @@ public class OtlpExporterConfigBuilder implements ConfigBuilder {
         fallbacks.put("quarkus.otel.exporter.otlp.metrics.key-cert.keys", "quarkus.otel.exporter.otlp.key-cert.keys");
         fallbacks.put("quarkus.otel.exporter.otlp.metrics.key-cert.certs", "quarkus.otel.exporter.otlp.key-cert.certs");
         fallbacks.put("quarkus.otel.exporter.otlp.metrics.trust-cert.certs", "quarkus.otel.exporter.otlp.trust-cert.certs");
+        fallbacks.put("quarkus.otel.exporter.otlp.metrics.default-exporter-enabled",
+                "quarkus.otel.exporter.otlp.default-exporter-enabled");
         fallbacks.put("quarkus.otel.exporter.otlp.metrics.tls-configuration-name",
                 "quarkus.otel.exporter.otlp.tls-configuration-name");
         fallbacks.put("quarkus.otel.exporter.otlp.metrics.proxy-options.enabled",
@@ -85,6 +89,8 @@ public class OtlpExporterConfigBuilder implements ConfigBuilder {
         fallbacks.put("quarkus.otel.exporter.otlp.logs.key-cert.keys", "quarkus.otel.exporter.otlp.key-cert.keys");
         fallbacks.put("quarkus.otel.exporter.otlp.logs.key-cert.certs", "quarkus.otel.exporter.otlp.key-cert.certs");
         fallbacks.put("quarkus.otel.exporter.otlp.logs.trust-cert.certs", "quarkus.otel.exporter.otlp.trust-cert.certs");
+        fallbacks.put("quarkus.otel.exporter.otlp.logs.default-exporter-enabled",
+                "quarkus.otel.exporter.otlp.default-exporter-enabled");
         fallbacks.put("quarkus.otel.exporter.otlp.logs.tls-configuration-name",
                 "quarkus.otel.exporter.otlp.tls-configuration-name");
         fallbacks.put("quarkus.otel.exporter.otlp.logs.proxy-options.enabled",

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/spi/LogsExporterCDIProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/spi/LogsExporterCDIProvider.java
@@ -3,14 +3,14 @@ package io.quarkus.opentelemetry.runtime.logs.spi;
 import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constants.CDI_VALUE;
 
 import jakarta.enterprise.inject.Any;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
 
 import org.jboss.logging.Logger;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableInstance;
 import io.quarkus.opentelemetry.runtime.exporter.otlp.logs.NoopLogRecordExporter;
 
 public class LogsExporterCDIProvider implements ConfigurableLogRecordExporterProvider {
@@ -19,14 +19,14 @@ public class LogsExporterCDIProvider implements ConfigurableLogRecordExporterPro
 
     @Override
     public LogRecordExporter createExporter(ConfigProperties configProperties) {
-        Instance<LogRecordExporter> exporters = CDI.current().select(LogRecordExporter.class, Any.Literal.INSTANCE);
+        InjectableInstance<LogRecordExporter> exporters = Arc.container().select(LogRecordExporter.class, Any.Literal.INSTANCE);
         if (log.isDebugEnabled()) {
             log.debug("available exporters: " + exporters.stream()
                     .map(e -> e.getClass().getName())
                     .reduce((a, b) -> a + ", " + b)
                     .orElse("none"));
         }
-        if (exporters.isUnsatisfied()) {
+        if (exporters.isUnsatisfied() || exporters.listActive().isEmpty()) {
             return NoopLogRecordExporter.INSTANCE;
         } else {
             log.debugf("using exporter: %s", exporters.get().getClass().getName());

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/HttpClientOptionsConsumerTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/HttpClientOptionsConsumerTest.java
@@ -92,6 +92,11 @@ class HttpClientOptionsConsumerTest {
             }
 
             @Override
+            public boolean defaultExporterEnabled() {
+                return false;
+            }
+
+            @Override
             public TrustCert trustCert() {
                 return new TrustCert() {
                     @Override

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
@@ -182,6 +182,11 @@ class OtlpExporterProviderTest {
             }
 
             @Override
+            public boolean defaultExporterEnabled() {
+                return false;
+            }
+
+            @Override
             public OtlpExporterTracesConfig traces() {
                 return new OtlpExporterTracesConfig() {
                     @Override
@@ -232,6 +237,11 @@ class OtlpExporterProviderTest {
                                 return Optional.empty();
                             }
                         };
+                    }
+
+                    @Override
+                    public boolean defaultExporterEnabled() {
+                        return false;
                     }
 
                     @Override
@@ -310,6 +320,11 @@ class OtlpExporterProviderTest {
                     }
 
                     @Override
+                    public boolean defaultExporterEnabled() {
+                        return false;
+                    }
+
+                    @Override
                     public KeyCert keyCert() {
                         return new KeyCert() {
                             @Override
@@ -373,6 +388,11 @@ class OtlpExporterProviderTest {
                     @Override
                     public Optional<String> protocol() {
                         return Optional.empty();
+                    }
+
+                    @Override
+                    public boolean defaultExporterEnabled() {
+                        return false;
                     }
 
                     @Override

--- a/integration-tests/opentelemetry-external-exporter/pom.xml
+++ b/integration-tests/opentelemetry-external-exporter/pom.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-opentelemetry-external-exporter</artifactId>
+    <name>Quarkus - Integration Tests - OpenTelemetry external exporter</name>
+
+    <properties>
+        <!-- azure exporter has runtime config in build steps
+         https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383 -->
+        <quarkus.extension-loader.report-runtime-config-at-deployment>warn</quarkus.extension-loader.report-runtime-config-at-deployment>
+        <quarkus-opentelemetry-exporter-azure.version>3.20.0.0</quarkus-opentelemetry-exporter-azure.version>
+        <quarkus-azure-services-bom.version>1.1.1</quarkus-azure-services-bom.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- external quarkiverse exporter BOMs -->
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-services-bom</artifactId>
+                <type>pom</type>
+                <version>${quarkus-azure-services-bom.version}</version>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <!-- required for azure exporter -->
+                <!-- https://github.com/quarkiverse/quarkus-opentelemetry-exporter/issues/382 -->
+                <groupId>io.opentelemetry.semconv</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>1.29.0-alpha</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.opentelemetry.exporter</groupId>
+            <artifactId>quarkus-opentelemetry-exporter-azure</artifactId>
+            <version>${quarkus-opentelemetry-exporter-azure.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <vertx.disableWebsockets>false</vertx.disableWebsockets>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/opentelemetry-external-exporter/src/main/java/io/quarkus/it/external/exporter/HelloResource.java
+++ b/integration-tests/opentelemetry-external-exporter/src/main/java/io/quarkus/it/external/exporter/HelloResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.external.exporter;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+
+@Path("hello")
+@Produces(MediaType.APPLICATION_JSON)
+public class HelloResource {
+    private static final Logger LOG = LoggerFactory.getLogger(HelloResource.class);
+    public static final String HISTOGRAM_NAME = "example_histogram";
+
+    @Inject
+    Meter meter;
+
+    @GET
+    public String get() {
+        LongHistogram histogram = meter.histogramBuilder(HISTOGRAM_NAME).ofLongs().build();
+        histogram.record(10, Attributes.of(AttributeKey.stringKey("key"), "value"));
+        LOG.info("Hello World");
+        return "get";
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-external-exporter/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+# Setting these for tests explicitly. Not required in normal application
+quarkus.application.name=opentelemetry-external-exporter-integration-test
+quarkus.application.version=999-SNAPSHOT
+
+applicationinsights.connection.string=InstrumentationKey=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;IngestionEndpoint=http://127.0.0.1:53602/export
+
+quarkus.otel.logs.enabled=true
+quarkus.otel.metrics.enabled=true
+quarkus.otel.metric.export.interval=1000ms
+quarkus.otel.instrument.jvm-metrics=false

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/AzureExporterTelemetry.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/AzureExporterTelemetry.java
@@ -1,0 +1,59 @@
+package io.quarkus.it.external.exporter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.assertj.core.api.Assertions;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+public class AzureExporterTelemetry {
+
+    private final WireMockServer wireMockServer;
+
+    public AzureExporterTelemetry(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
+    }
+
+    public Callable<Boolean> telemetryDataContainExport() {
+        return () -> !getTelemetryHttpRequests().isEmpty();
+    }
+
+    public void verifyExportedLogs() {
+        assertThat(getTelemetryHttpRequests()
+                .stream()
+                .map(request -> new String(request.getBody()))
+                .anyMatch(
+                        body -> body.contains("Request") && body.contains("GET /hello")))
+                .as("Should contain OTel trace.").isTrue();
+    }
+
+    public void verifyExportedTraces() {
+        assertThat(getTelemetryHttpRequests()
+                .stream()
+                .map(request -> new String(request.getBody()))
+                .anyMatch(body -> body.contains("\"message\":\"opentelemetry-external-exporter-integration-test")
+                        && body.contains("(powered by Quarkus ")
+                        && body.contains("started in") && body.contains(
+                                "{\"LoggerName\":\"io.quarkus.opentelemetry\",\"LoggingLevel\":\"INFO\",\"log.logger.namespace\":\"org.jboss.logging.Logger\"")))
+                .as("Should contain OTel log.").isTrue();
+    }
+
+    public void verifyExportedMetrics() {
+        Assertions.assertThat(getTelemetryHttpRequests()
+                .stream()
+                .map(request -> new String(request.getBody()))
+                .anyMatch(body -> body.contains("MetricData") && body.contains("baseData\":{\"ver\":2,\"metrics\":[{\"name\":\""
+                        + HelloResource.HISTOGRAM_NAME + "\",\"value\":10.0,\"count\":1,\"min\":10.0,\"max\":10.0")))
+                .as("Should contain OTel metric.").isTrue();
+    }
+
+    private List<LoggedRequest> getTelemetryHttpRequests() {
+        return wireMockServer.findAll(postRequestedFor(urlEqualTo("/export/v2.1/track")));
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/DefaultExporterTelemetry.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/DefaultExporterTelemetry.java
@@ -1,0 +1,160 @@
+package io.quarkus.it.external.exporter;
+
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import io.opentelemetry.proto.logs.v1.SeverityNumber;
+import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+import io.opentelemetry.proto.metrics.v1.Histogram;
+import io.opentelemetry.proto.metrics.v1.HistogramDataPoint;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+
+public class DefaultExporterTelemetry {
+
+    private final Traces traces;
+    private final Metrics metrics;
+    private final Logs logs;
+
+    public DefaultExporterTelemetry(Traces traces, Metrics metrics, Logs logs) {
+        this.traces = traces;
+        this.metrics = metrics;
+        this.logs = logs;
+    }
+
+    public void verifyExportedTraces() {
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(traces.getTraceRequests()).hasSize(1));
+
+        ExportTraceServiceRequest request = traces.getTraceRequests().get(0);
+        assertThat(request.getResourceSpansCount()).isEqualTo(1);
+
+        ResourceSpans resourceSpans = request.getResourceSpans(0);
+        assertThat(resourceSpans.getResource().getAttributesList())
+                .contains(KeyValue.newBuilder()
+                        .setKey(SERVICE_NAME.getKey())
+                        .setValue(AnyValue.newBuilder()
+                                .setStringValue("opentelemetry-external-exporter-integration-test").build())
+                        .build());
+        assertThat(resourceSpans.getScopeSpansCount()).isEqualTo(1);
+
+        ScopeSpans scopeSpans = resourceSpans.getScopeSpans(0);
+        assertThat(scopeSpans.getSpansCount()).isEqualTo(1);
+
+        Span span = scopeSpans.getSpans(0);
+        assertThat(span.getName()).isEqualTo("GET /hello");
+        assertThat(span.getAttributesList())
+                .contains(KeyValue.newBuilder()
+                        .setKey("http.request.method")
+                        .setValue(AnyValue.newBuilder()
+                                .setStringValue("GET").build())
+                        .build());
+    }
+
+    public void verifyNoExportedTraces() {
+        assertThat(traces.getTraceRequests()).isEmpty();
+    }
+
+    public void verifyExportedMetrics() {
+        Metric customMetric = getMetric(HelloResource.HISTOGRAM_NAME);
+        assertThat(customMetric.getDataCase()).isEqualTo(Metric.DataCase.HISTOGRAM);
+
+        Histogram histogram = customMetric.getHistogram();
+        assertThat(histogram.getAggregationTemporality())
+                .isEqualTo(AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE);
+        assertThat(histogram.getDataPointsCount()).isEqualTo(1);
+
+        HistogramDataPoint dataPoint = histogram.getDataPoints(0);
+        assertThat(dataPoint.getCount()).isEqualTo(1);
+        assertThat(dataPoint.getSum()).isEqualTo(10);
+        assertThat(dataPoint.getAttributesList())
+                .isEqualTo(Collections.singletonList(KeyValue.newBuilder()
+                        .setKey("key")
+                        .setValue(AnyValue.newBuilder().setStringValue("value").build())
+                        .build()));
+
+        Metric requestDuration = getMetric("http.server.request.duration");
+        assertThat(requestDuration.getDataCase()).isEqualTo(Metric.DataCase.HISTOGRAM);
+        requestDuration.getHistogram().getDataPointsList().stream()
+                .forEach(point -> {
+                    assertThat(point.getCount()).isGreaterThan(0);
+                });
+    }
+
+    public void verifyNoExportedMetrics() {
+        List<ExportMetricsServiceRequest> reqs = metrics.getMetricRequests();
+        Optional<Metric> metric = getMetric(HelloResource.HISTOGRAM_NAME, reqs);
+        assertThat(metric).isNotPresent();
+    }
+
+    private Metric getMetric(final String metricName) {
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> {
+                    List<ExportMetricsServiceRequest> reqs = metrics.getMetricRequests();
+                    Optional<Metric> metric = getMetric(metricName, reqs);
+                    assertThat(metric).isPresent();
+                });
+        final List<ExportMetricsServiceRequest> metricRequests = metrics.getMetricRequests();
+        return getMetric(metricName, metricRequests).get();
+    }
+
+    private Optional<Metric> getMetric(String metricName, List<ExportMetricsServiceRequest> metricRequests) {
+        return metricRequests.stream()
+                .flatMap(reqs -> reqs.getResourceMetricsList().stream())
+                .flatMap(resourceMetrics -> resourceMetrics.getScopeMetricsList().stream())
+                .flatMap(libraryMetrics -> libraryMetrics.getMetricsList().stream())
+                .filter(metric -> metric.getName().equals(metricName))
+                .findFirst();
+    }
+
+    public void verifyExportedLogs() {
+        List<ExportLogsServiceRequest> logsRequests = logs.getLogsRequests();
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(logsRequests).hasSizeGreaterThan(2));
+        ExportLogsServiceRequest request = logsRequests.get(logsRequests.size() - 2);
+        assertEquals(1, request.getResourceLogsCount());
+
+        ResourceLogs resourceLogs = request.getResourceLogs(0);
+        assertThat(resourceLogs.getResource().getAttributesList())
+                .contains(KeyValue.newBuilder()
+                        .setKey(SERVICE_NAME.getKey())
+                        .setValue(AnyValue.newBuilder()
+                                .setStringValue("opentelemetry-external-exporter-integration-test").build())
+                        .build());
+        assertThat(resourceLogs.getScopeLogsCount()).isEqualTo(1);
+
+        List<LogRecord> list = logsRequests.stream()
+                .flatMap(req -> req.getResourceLogsList().stream().flatMap(res -> res.getScopeLogsList().stream()))
+                .flatMap(scopeLogs -> scopeLogs.getLogRecordsList().stream())
+                .toList();
+
+        Optional<LogRecord> helloLog = list.stream()
+                .filter(logRecord -> logRecord.getBody().getStringValue().contains("Hello World"))
+                .findFirst();
+        assertThat(helloLog).isPresent();
+        assertThat(helloLog.get().getBody().getStringValue()).isEqualTo("Hello World");
+        assertThat(helloLog.get().getSeverityNumber()).isEqualTo(SeverityNumber.SEVERITY_NUMBER_INFO);
+    }
+
+    public void verifyNoExportedLogs() {
+        List<ExportLogsServiceRequest> logsRequests = logs.getLogsRequests();
+        assertTrue(logsRequests.isEmpty());
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/ExporterTestBase.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/ExporterTestBase.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.external.exporter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
+public class ExporterTestBase {
+
+    // Azure Monitor endpoint port, see application.properties
+    public static final int HTTP_PORT_NUMBER = 53602;
+
+    protected DefaultExporterTelemetry defaultExporterTelemetry;
+    protected AzureExporterTelemetry azureExporterTelemetry;
+
+    private WireMockServer wireMockServer;
+    private Traces traces;
+    private Metrics metrics;
+    private Logs logs;
+
+    @BeforeEach
+    public void startWireMock() {
+        WireMockConfiguration wireMockConfiguration = new WireMockConfiguration().port(HTTP_PORT_NUMBER);
+        wireMockServer = new WireMockServer(wireMockConfiguration);
+        wireMockServer.start();
+        wireMockServer.stubFor(
+                any(urlMatching(".*"))
+                        .withPort(HTTP_PORT_NUMBER)
+                        .willReturn(aResponse().withStatus(200)));
+        defaultExporterTelemetry = new DefaultExporterTelemetry(traces, metrics, logs);
+        azureExporterTelemetry = new AzureExporterTelemetry(wireMockServer);
+    }
+
+    @AfterEach
+    public void stopWireMock() {
+        wireMockServer.stop();
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Logs.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Logs.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.external.exporter;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+
+public class Logs {
+    private final List<ExportLogsServiceRequest> logsRequests = new CopyOnWriteArrayList<>();
+
+    public List<ExportLogsServiceRequest> getLogsRequests() {
+        return logsRequests;
+    }
+
+    public void reset() {
+        logsRequests.clear();
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Metrics.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Metrics.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.external.exporter;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+
+public final class Metrics {
+
+    private final List<ExportMetricsServiceRequest> metricRequests = new CopyOnWriteArrayList<>();
+
+    public List<ExportMetricsServiceRequest> getMetricRequests() {
+        return metricRequests;
+    }
+
+    public void reset() {
+        metricRequests.clear();
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/OtelCollectorLifecycleManager.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/OtelCollectorLifecycleManager.java
@@ -1,0 +1,185 @@
+package io.quarkus.it.external.exporter;
+
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
+import static org.testcontainers.Testcontainers.exposeHostPorts;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.DockerImageName;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.server.GrpcServer;
+
+public class OtelCollectorLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+    // from https://github.com/open-telemetry/opentelemetry-java/pkgs/container/opentelemetry-java%2Fotel-collector/versions
+    // otel collector v0.114.0. The last with OpenTelemetry proto 1.3.x
+    private static final String COLLECTOR_IMAGE = "ghcr.io/open-telemetry/opentelemetry-java/otel-collector" +
+            "@sha256:37fa87091cfaaec7234a27e4e395a40c31c2bfaea97a349a4afef6d9e9681197";
+    private static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
+    private static final Integer COLLECTOR_OTLP_HTTP_PORT = 4318;
+    private static final Integer COLLECTOR_HEALTH_CHECK_PORT = 13133;
+    private static final ServiceName TRACE_SERVICE_NAME = ServiceName
+            .create("opentelemetry.proto.collector.trace.v1.TraceService");
+    private static final ServiceName METRIC_SERVICE_NAME = ServiceName
+            .create("opentelemetry.proto.collector.metrics.v1.MetricsService");
+    private static final ServiceName LOG_SERVICE_NAME = ServiceName
+            .create("opentelemetry.proto.collector.logs.v1.LogsService");
+    private static final String EXPORT_METHOD_NAME = "Export";
+
+    private String protocol = GRPC;
+    private Vertx vertx;
+    private HttpServer server;
+    private GenericContainer<?> collector;
+    private Traces collectedTraces;
+    private Metrics collectedMetrics;
+    private Logs collectedLogs;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        if (initArgs.containsKey("protocol")) {
+            protocol = initArgs.get("protocol");
+        }
+    }
+
+    @Override
+    public Map<String, String> start() {
+        setupVertxGrpcServer();
+        int vertxGrpcServerPort = server.actualPort();
+
+        // Expose the port the in-process OTLP gRPC server will run on before the collector is
+        // initialized so the collector can connect to it.
+        exposeHostPorts(vertxGrpcServerPort);
+
+        collector = new GenericContainer<>(DockerImageName.parse(COLLECTOR_IMAGE))
+                .withImagePullPolicy(PullPolicy.alwaysPull())
+                .withEnv("LOGGING_EXPORTER_VERBOSITY_LEVEL", "basic") // basic, normal, detailed
+                .withEnv("OTLP_EXPORTER_ENDPOINT", "host.testcontainers.internal:" + vertxGrpcServerPort)
+                .withClasspathResourceMapping(
+                        "otel-config.yaml", "/otel-config.yaml", BindMode.READ_ONLY)
+                .withCommand("--config", "/otel-config.yaml")
+                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("otel-collector")))
+                .withExposedPorts(
+                        COLLECTOR_OTLP_GRPC_PORT,
+                        COLLECTOR_OTLP_HTTP_PORT,
+                        COLLECTOR_HEALTH_CHECK_PORT)
+                .waitingFor(Wait.forHttp("/").forPort(COLLECTOR_HEALTH_CHECK_PORT));
+        collector.start();
+
+        Map<String, String> result = new HashMap<>();
+        result.put("quarkus.otel.exporter.otlp.traces.protocol", protocol);
+        result.put("quarkus.otel.exporter.otlp.metrics.protocol", protocol);
+        result.put("quarkus.otel.exporter.otlp.logs.protocol", protocol);
+
+        int inSecureEndpointPort = GRPC.equals(protocol) ? COLLECTOR_OTLP_GRPC_PORT : COLLECTOR_OTLP_HTTP_PORT;
+        result.put("quarkus.otel.exporter.otlp.traces.endpoint",
+                "http://" + collector.getHost() + ":" + collector.getMappedPort(inSecureEndpointPort));
+        result.put("quarkus.otel.exporter.otlp.metrics.endpoint",
+                "http://" + collector.getHost() + ":" + collector.getMappedPort(inSecureEndpointPort));
+        result.put("quarkus.otel.exporter.otlp.logs.endpoint",
+                "http://" + collector.getHost() + ":" + collector.getMappedPort(inSecureEndpointPort));
+
+        return result;
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(collectedTraces, f -> f.getType().equals(Traces.class));
+        testInjector.injectIntoFields(collectedMetrics, f -> f.getType().equals(Metrics.class));
+        testInjector.injectIntoFields(collectedLogs, f -> f.getType().equals(Logs.class));
+    }
+
+    private void setupVertxGrpcServer() {
+        vertx = Vertx.vertx(new VertxOptions().setWorkerPoolSize(1).setEventLoopPoolSize(1));
+        GrpcServer grpcServer = GrpcServer.server(vertx);
+        collectedTraces = new Traces();
+        collectedMetrics = new Metrics();
+        collectedLogs = new Logs();
+        grpcServer.callHandler(request -> {
+
+            if (request.serviceName().equals(TRACE_SERVICE_NAME) && request.methodName().equals(EXPORT_METHOD_NAME)) {
+
+                request.handler(message -> {
+                    try {
+                        collectedTraces.getTraceRequests().add(ExportTraceServiceRequest.parseFrom(message.getBytes()));
+                        request.response().end(Buffer.buffer(ExportTraceServiceResponse.getDefaultInstance().toByteArray()));
+                    } catch (InvalidProtocolBufferException e) {
+                        request.response()
+                                .status(GrpcStatus.INVALID_ARGUMENT)
+                                .end();
+                    }
+                });
+            } else if (request.serviceName().equals(METRIC_SERVICE_NAME) && request.methodName().equals(EXPORT_METHOD_NAME)) {
+
+                request.handler(message -> {
+                    try {
+                        collectedMetrics.getMetricRequests().add(ExportMetricsServiceRequest.parseFrom(message.getBytes()));
+                        request.response().end(Buffer.buffer(ExportMetricsServiceRequest.getDefaultInstance().toByteArray()));
+                    } catch (InvalidProtocolBufferException e) {
+                        request.response()
+                                .status(GrpcStatus.INVALID_ARGUMENT)
+                                .end();
+                    }
+                });
+            } else if (request.serviceName().equals(LOG_SERVICE_NAME) && request.methodName().equals(EXPORT_METHOD_NAME)) {
+
+                request.handler(message -> {
+                    try {
+                        collectedLogs.getLogsRequests().add(ExportLogsServiceRequest.parseFrom(message.getBytes()));
+                        request.response().end(Buffer.buffer(ExportLogsServiceRequest.getDefaultInstance().toByteArray()));
+                    } catch (InvalidProtocolBufferException e) {
+                        request.response()
+                                .status(GrpcStatus.INVALID_ARGUMENT)
+                                .end();
+                    }
+                });
+            } else {
+                request.response()
+                        .status(GrpcStatus.NOT_FOUND)
+                        .end();
+            }
+        });
+
+        server = vertx.createHttpServer(new HttpServerOptions().setPort(0));
+        try {
+            server.requestHandler(grpcServer).listen().toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            server.close().andThen(ar -> {
+                if (vertx != null) {
+                    vertx.close();
+                }
+            });
+        }
+        if (collector != null) {
+            collector.stop();
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Traces.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Traces.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.external.exporter;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+
+public final class Traces {
+
+    private final List<ExportTraceServiceRequest> traceRequests = new CopyOnWriteArrayList<>();
+
+    public List<ExportTraceServiceRequest> getTraceRequests() {
+        return traceRequests;
+    }
+
+    public void reset() {
+        traceRequests.clear();
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/AllDefaultExportersEnabledIT.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/AllDefaultExportersEnabledIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.external.exporter.azure;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class AllDefaultExportersEnabledIT extends AllDefaultExportersEnabledTest {
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/AllDefaultExportersEnabledTest.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/AllDefaultExportersEnabledTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.it.external.exporter.azure;
+
+import static io.restassured.RestAssured.when;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.external.exporter.ExporterTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verify that OpenTelemetry logs, traces and metrics are sent using CDI exporters when the default exporter
+ * is enabled, and that the Azure exporter continues to export telemetry as well.
+ */
+@QuarkusTest
+@TestProfile(AllDefaultExportersEnabledTest.DefaultExportersEnabledProfile.class)
+public class AllDefaultExportersEnabledTest extends ExporterTestBase {
+
+    @Test
+    void telemetrySentUsingDefaultExporters() throws InterruptedException {
+        when()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+
+        // wait for telemetry to be sent to Application Insights via the /v2.1/track API endpoint
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .until(azureExporterTelemetry.telemetryDataContainExport());
+
+        // wait a bit more to ensure all telemetry data has arrived
+        Thread.sleep(10_000);
+
+        // verify that telemetry was sent via the Azure exporter
+        azureExporterTelemetry.verifyExportedTraces();
+        azureExporterTelemetry.verifyExportedMetrics();
+        azureExporterTelemetry.verifyExportedLogs();
+
+        // verify that telemetry was sent via the default exporter
+        defaultExporterTelemetry.verifyExportedTraces();
+        defaultExporterTelemetry.verifyExportedMetrics();
+        defaultExporterTelemetry.verifyExportedLogs();
+    }
+
+    public static class DefaultExportersEnabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    // azure exporter has runtime config in build steps
+                    // https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383
+                    "quarkus.extension-loader.report-runtime-config-at-deployment", "warn",
+                    "quarkus.otel.exporter.otlp.default-exporter-enabled", "true");
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultLogsExporterEnabledIT.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultLogsExporterEnabledIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.external.exporter.azure;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DefaultLogsExporterEnabledIT extends DefaultLogsExporterEnabledTest {
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultLogsExporterEnabledTest.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultLogsExporterEnabledTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.it.external.exporter.azure;
+
+import static io.restassured.RestAssured.when;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.external.exporter.ExporterTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verify that OpenTelemetry logs are sent using the CDI exporter when the default logs exporter is enabled,
+ * and that the Azure exporter continues to export telemetry as well.
+ */
+@QuarkusTest
+@TestProfile(DefaultLogsExporterEnabledTest.DefaultLogsExporterEnabledProfile.class)
+public class DefaultLogsExporterEnabledTest extends ExporterTestBase {
+
+    @Test
+    void defaultLogsExporterEnabled() throws InterruptedException {
+
+        when()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+
+        // wait for telemetry to be sent to Application Insights via the /v2.1/track API endpoint
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .until(azureExporterTelemetry.telemetryDataContainExport());
+
+        // wait a bit more to ensure all telemetry data has arrived
+        Thread.sleep(10_000);
+
+        // verify that telemetry was sent via the Azure exporter
+        azureExporterTelemetry.verifyExportedTraces();
+        azureExporterTelemetry.verifyExportedMetrics();
+        azureExporterTelemetry.verifyExportedLogs();
+
+        // verify default exporter telemetry
+        defaultExporterTelemetry.verifyExportedLogs();
+        defaultExporterTelemetry.verifyNoExportedMetrics();
+        defaultExporterTelemetry.verifyNoExportedTraces();
+    }
+
+    public static class DefaultLogsExporterEnabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    // azure exporter has runtime config in build steps
+                    // https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383
+                    "quarkus.extension-loader.report-runtime-config-at-deployment", "warn",
+                    "quarkus.otel.exporter.otlp.logs.default-exporter-enabled", "true");
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultMetricsExporterEnabledIT.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultMetricsExporterEnabledIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.external.exporter.azure;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DefaultMetricsExporterEnabledIT extends DefaultMetricsExporterEnabledTest {
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultMetricsExporterEnabledTest.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultMetricsExporterEnabledTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.it.external.exporter.azure;
+
+import static io.restassured.RestAssured.when;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.external.exporter.ExporterTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verify that OpenTelemetry metrics are sent using CDI exporter when the default metrics exporter is enabled,
+ * and that the Azure exporter continues to export telemetry as well.
+ */
+@QuarkusTest
+@TestProfile(DefaultMetricsExporterEnabledTest.DefaultMetricsExporterEnabledProfile.class)
+public class DefaultMetricsExporterEnabledTest extends ExporterTestBase {
+
+    @Test
+    void defaultMetricsExporterEnabled() throws InterruptedException {
+
+        when()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+
+        // wait for telemetry to be sent to Application Insights via the /v2.1/track API endpoint
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .until(azureExporterTelemetry.telemetryDataContainExport());
+
+        // wait a bit more to ensure all telemetry data has arrived
+        Thread.sleep(10_000);
+
+        // verify that telemetry was sent via the Azure exporter
+        azureExporterTelemetry.verifyExportedTraces();
+        azureExporterTelemetry.verifyExportedMetrics();
+        azureExporterTelemetry.verifyExportedLogs();
+
+        // verify default exporter telemetry
+        defaultExporterTelemetry.verifyExportedMetrics();
+        defaultExporterTelemetry.verifyNoExportedLogs();
+        defaultExporterTelemetry.verifyNoExportedTraces();
+    }
+
+    public static class DefaultMetricsExporterEnabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    // azure exporter has runtime config in build steps
+                    // https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383
+                    "quarkus.extension-loader.report-runtime-config-at-deployment", "warn",
+                    "quarkus.otel.exporter.otlp.metrics.default-exporter-enabled", "true");
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultTracesExporterEnabledIT.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultTracesExporterEnabledIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.external.exporter.azure;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DefaultTracesExporterEnabledIT extends DefaultTracesExporterEnabledTest {
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultTracesExporterEnabledTest.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultTracesExporterEnabledTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.it.external.exporter.azure;
+
+import static io.restassured.RestAssured.when;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.external.exporter.ExporterTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verify that OpenTelemetry traces are sent using CDI exporter when the default traces exporter is enabled,
+ * and that the Azure exporter continues to export telemetry as well.
+ */
+@QuarkusTest
+@TestProfile(DefaultTracesExporterEnabledTest.DefaultTracesExporterEnabledProfile.class)
+public class DefaultTracesExporterEnabledTest extends ExporterTestBase {
+
+    @Test
+    void defaultTracesExporterEnabled() throws InterruptedException {
+
+        when()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+
+        // wait for telemetry to be sent to Application Insights via the /v2.1/track API endpoint
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .until(azureExporterTelemetry.telemetryDataContainExport());
+
+        // wait a bit more to ensure all telemetry data has arrived
+        Thread.sleep(10_000);
+
+        // verify that telemetry was sent via the Azure exporter
+        azureExporterTelemetry.verifyExportedTraces();
+        azureExporterTelemetry.verifyExportedMetrics();
+        azureExporterTelemetry.verifyExportedLogs();
+
+        // verify that telemetry was sent via the default exporter
+        defaultExporterTelemetry.verifyExportedTraces();
+        defaultExporterTelemetry.verifyNoExportedMetrics();
+        defaultExporterTelemetry.verifyNoExportedLogs();
+    }
+
+    public static class DefaultTracesExporterEnabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    // azure exporter has runtime config in build steps
+                    // https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383
+                    "quarkus.extension-loader.report-runtime-config-at-deployment", "warn",
+                    "quarkus.otel.exporter.otlp.traces.default-exporter-enabled", "true");
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/resources/otel-config.yaml
+++ b/integration-tests/opentelemetry-external-exporter/src/test/resources/otel-config.yaml
@@ -1,0 +1,30 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  debug:
+    verbosity: ${env:LOGGING_EXPORTER_VERBOSITY_LEVEL}
+  otlp:
+    endpoint: ${env:OTLP_EXPORTER_ENDPOINT}
+    tls:
+      insecure: true
+    compression: none
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug, otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [debug, otlp]
+    logs:
+      receivers: [otlp]
+      exporters: [debug, otlp]

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -389,6 +389,7 @@
                 <module>opentelemetry-reactive-messaging</module>
                 <module>opentelemetry-redis-instrumentation</module>
                 <module>opentelemetry-exporter-logging</module>
+                <module>opentelemetry-external-exporter</module>
                 <module>logging-json</module>
                 <module>jaxb</module>
                 <module>jaxp</module>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

For enhancement https://github.com/quarkusio/quarkus/issues/36500

Added configuration to enable the default OpenTelemetry exporter when an external exporter is present allowing simultaneous exporting to multiple destinations including the default one for logs, metrics and traces. For instance, if the quarkiverse Azure exporter is used to export to the Azure Monitor, the default OTel exporter can also be enabled by setting `quarkus.otel.exporter.otlp.[logs|metrics|traces].default-exporter-enabled` to `true`.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

