### PR TITLE
Redis Client: add `setAndChanged()` that returns whether the command changed the key

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveTransactionalValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveTransactionalValueCommands.java
@@ -253,6 +253,36 @@ public interface ReactiveTransactionalValueCommands<K, V> extends ReactiveTransa
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> setAndChanged(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object, SetArgs) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> setAndChanged(K key, V value, SetArgs setArgs);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
      * Summary: Set the string value of a key, and return the previous value
      * Group: string
      * Requires Redis 1.0.0

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveValueCommands.java
@@ -251,6 +251,34 @@ public interface ReactiveValueCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     * @return {@code true} the key was set {@code false} the key was not set
+     **/
+    Uni<Boolean> setAndChanged(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object, SetArgs) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     * @return {@code true} the key was set {@code false} the key was not set
+     **/
+    Uni<Boolean> setAndChanged(K key, V value, SetArgs setArgs);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
      * Summary: Set the string value of a key, and return the previous value
      * Group: string
      * Requires Redis 1.0.0

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/TransactionalValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/TransactionalValueCommands.java
@@ -214,6 +214,33 @@ public interface TransactionalValueCommands<K, V> extends TransactionalRedisComm
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     **/
+    void setAndChanged(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object, SetArgs) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     * @param setArgs the set command extra-arguments
+     **/
+    void setAndChanged(K key, V value, SetArgs setArgs);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
      * Summary: Set the string value of a key, and return the previous value
      * Group: string
      * Requires Redis 1.0.0

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
@@ -223,6 +223,8 @@ public interface ValueCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * If you need to know whether the key was set, use {@link #setAndChanged(Object, Object) setAndChanged()}.
+     * If you need to know the previous value of the key, use {@link #setGet(Object, Object, SetArgs) setGet()}.
      * Summary: Set the string value of a key
      * Group: string
      * Requires Redis 1.0.0
@@ -234,6 +236,8 @@ public interface ValueCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * If you need to know whether the key was set, use {@link #setAndChanged(Object, Object, SetArgs) setAndChanged()}.
+     * If you need to know the previous value of the key, use {@link #setGet(Object, Object, SetArgs) setGet()}.
      * Summary: Set the string value of a key
      * Group: string
      * Requires Redis 1.0.0
@@ -246,6 +250,35 @@ public interface ValueCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     * @return {@code true} the key was set {@code false} the key was not set
+     **/
+    boolean setAndChanged(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Returns whether the key was set. If you need to know the previous value
+     * of the key, use {@link #setGet(Object, Object, SetArgs) setGet()}.
+     * Summary: Set the string value of a key
+     * Group: string
+     * Requires Redis 1.0.0
+     *
+     * @param key the key
+     * @param value the value
+     * @param setArgs the set command extra-arguments
+     * @return {@code true} the key was set {@code false} the key was not set
+     **/
+    boolean setAndChanged(K key, V value, SetArgs setArgs);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/set">SET</a> with the {@code GET} argument.
      * Summary: Set the string value of a key, and return the previous value
      * Group: string
      * Requires Redis 1.0.0
@@ -257,7 +290,7 @@ public interface ValueCommands<K, V> extends RedisCommands {
     V setGet(K key, V value);
 
     /**
-     * Execute the command <a href="https://redis.io/commands/set">SET</a>.
+     * Execute the command <a href="https://redis.io/commands/set">SET</a> with the {@code GET} argument.
      * Summary: Set the string value of a key, and return the previous value
      * Group: string
      * Requires Redis 1.0.0

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
@@ -9,8 +9,6 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
 import java.lang.reflect.Type;
 import java.util.Map;
 
-import io.quarkus.redis.datasource.string.GetExArgs;
-import io.quarkus.redis.datasource.string.SetArgs;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Response;
@@ -33,7 +31,7 @@ class AbstractStringCommands<K, V> extends AbstractRedisCommands {
         return execute(cmd);
     }
 
-    Uni<Response> _set(K key, V value, SetArgs setArgs) {
+    Uni<Response> _set(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         nonNull(key, "key");
         nonNull(value, "value");
         nonNull(setArgs, "setArgs");
@@ -61,7 +59,7 @@ class AbstractStringCommands<K, V> extends AbstractRedisCommands {
         RedisCommand cmd = RedisCommand.of(Command.SET);
         cmd.put(marshaller.encode(key));
         cmd.put(marshaller.encode(value));
-        cmd.putArgs(new SetArgs().get());
+        cmd.putArgs(new io.quarkus.redis.datasource.string.SetArgs().get());
         return execute(cmd);
     }
 
@@ -69,7 +67,7 @@ class AbstractStringCommands<K, V> extends AbstractRedisCommands {
         return marshaller.decode(typeOfValue, r);
     }
 
-    Uni<Response> _setGet(K key, V value, SetArgs setArgs) {
+    Uni<Response> _setGet(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         nonNull(key, "key");
         nonNull(value, "value");
         nonNull(setArgs, "setArgs");
@@ -160,7 +158,7 @@ class AbstractStringCommands<K, V> extends AbstractRedisCommands {
                 .put(marshaller.encode(key)));
     }
 
-    Uni<Response> _getex(K key, GetExArgs args) {
+    Uni<Response> _getex(K key, io.quarkus.redis.datasource.string.GetExArgs args) {
         nonNull(key, "key");
         nonNull(args, "args");
         RedisCommand cmd = RedisCommand.of(Command.GETEX);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingStringCommandsImpl.java
@@ -4,8 +4,6 @@ import java.time.Duration;
 import java.util.Map;
 
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.GetExArgs;
-import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.string.StringCommands;
 import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.quarkus.redis.datasource.value.ValueCommands;
@@ -47,7 +45,7 @@ public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup
     }
 
     @Override
-    public V getex(K key, GetExArgs args) {
+    public V getex(K key, io.quarkus.redis.datasource.string.GetExArgs args) {
         return reactive.getex(key, args)
                 .await().atMost(timeout);
     }
@@ -122,7 +120,7 @@ public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup
     }
 
     @Override
-    public void set(K key, V value, SetArgs setArgs) {
+    public void set(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         reactive.set(key, value, setArgs)
                 .await().atMost(timeout);
     }
@@ -134,13 +132,25 @@ public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup
     }
 
     @Override
+    public boolean setAndChanged(K key, V value) {
+        return reactive.setAndChanged(key, value)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public boolean setAndChanged(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        return reactive.setAndChanged(key, value, setArgs)
+                .await().atMost(timeout);
+    }
+
+    @Override
     public V setGet(K key, V value) {
         return reactive.setGet(key, value)
                 .await().atMost(timeout);
     }
 
     @Override
-    public V setGet(K key, V value, SetArgs setArgs) {
+    public V setGet(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         return reactive.setGet(key, value, setArgs)
                 .await().atMost(timeout);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalStringCommandsImpl.java
@@ -3,8 +3,6 @@ package io.quarkus.redis.runtime.datasource;
 import java.time.Duration;
 import java.util.Map;
 
-import io.quarkus.redis.datasource.string.GetExArgs;
-import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
@@ -47,7 +45,7 @@ public class BlockingTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
-    public void getex(K key, GetExArgs args) {
+    public void getex(K key, io.quarkus.redis.datasource.string.GetExArgs args) {
         this.reactive.getex(key, args).await().atMost(this.timeout);
     }
 
@@ -117,7 +115,7 @@ public class BlockingTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
-    public void set(K key, V value, SetArgs setArgs) {
+    public void set(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         this.reactive.set(key, value, setArgs).await().atMost(this.timeout);
     }
 
@@ -127,12 +125,22 @@ public class BlockingTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
+    public void setAndChanged(K key, V value) {
+        this.reactive.setAndChanged(key, value).await().atMost(this.timeout);
+    }
+
+    @Override
+    public void setAndChanged(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        this.reactive.setAndChanged(key, value, setArgs).await().atMost(this.timeout);
+    }
+
+    @Override
     public void setGet(K key, V value) {
         this.reactive.setGet(key, value).await().atMost(this.timeout);
     }
 
     @Override
-    public void setGet(K key, V value, SetArgs setArgs) {
+    public void setGet(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         this.reactive.setGet(key, value, setArgs).await().atMost(this.timeout);
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
@@ -2,11 +2,10 @@ package io.quarkus.redis.runtime.datasource;
 
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Objects;
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
-import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
-import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
@@ -33,7 +32,7 @@ public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, 
     }
 
     @Override
-    public Uni<Void> set(K key, V value, SetArgs setArgs) {
+    public Uni<Void> set(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         return super._set(key, value, setArgs)
                 .replaceWithVoid();
     }
@@ -45,13 +44,25 @@ public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, 
     }
 
     @Override
+    public Uni<Boolean> setAndChanged(K key, V value) {
+        return super._set(key, value)
+                .map(Objects::nonNull);
+    }
+
+    @Override
+    public Uni<Boolean> setAndChanged(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        return super._set(key, value, setArgs)
+                .map(Objects::nonNull);
+    }
+
+    @Override
     public Uni<V> setGet(K key, V value) {
         return super._setGet(key, value)
                 .map(this::decodeV);
     }
 
     @Override
-    public Uni<V> setGet(K key, V value, SetArgs setArgs) {
+    public Uni<V> setGet(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         return super._setGet(key, value, setArgs)
                 .map(this::decodeV);
     }
@@ -117,7 +128,7 @@ public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, 
     }
 
     @Override
-    public Uni<V> getex(K key, GetExArgs args) {
+    public Uni<V> getex(K key, io.quarkus.redis.datasource.string.GetExArgs args) {
         return super._getex(key, args)
                 .map(this::decodeV);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
@@ -1,10 +1,9 @@
 package io.quarkus.redis.runtime.datasource;
 
 import java.util.Map;
+import java.util.Objects;
 
-import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
-import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
@@ -52,7 +51,7 @@ public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
-    public Uni<Void> getex(K key, GetExArgs args) {
+    public Uni<Void> getex(K key, io.quarkus.redis.datasource.string.GetExArgs args) {
         this.tx.enqueue(this.reactive::decodeV);
         return this.reactive._getex(key, args).invoke(this::queuedOrDiscard).replaceWithVoid();
     }
@@ -136,7 +135,7 @@ public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
-    public Uni<Void> set(K key, V value, SetArgs setArgs) {
+    public Uni<Void> set(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         this.tx.enqueue(resp -> null);
         return this.reactive._set(key, value, setArgs).invoke(this::queuedOrDiscard).replaceWithVoid();
     }
@@ -148,13 +147,25 @@ public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
+    public Uni<Void> setAndChanged(K key, V value) {
+        this.tx.enqueue(Objects::nonNull);
+        return this.reactive._set(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> setAndChanged(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        this.tx.enqueue(Objects::nonNull);
+        return this.reactive._set(key, value, setArgs).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
     public Uni<Void> setGet(K key, V value) {
         this.tx.enqueue(this.reactive::decodeV);
         return this.reactive._setGet(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
     }
 
     @Override
-    public Uni<Void> setGet(K key, V value, SetArgs setArgs) {
+    public Uni<Void> setGet(K key, V value, io.quarkus.redis.datasource.string.SetArgs setArgs) {
         this.tx.enqueue(this.reactive::decodeV);
         return this.reactive._setGet(key, value, setArgs).invoke(this::queuedOrDiscard).replaceWithVoid();
     }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
@@ -215,6 +215,28 @@ public class ValueCommandsTest extends DatasourceTestBase {
 
     @Test
     @RequiresRedis7OrHigher
+    void setAndChanged() {
+        assertThat(values.setAndChanged(key, value)).isTrue();
+        assertThat(values.setAndChanged(key, "value2")).isTrue();
+        assertThat(values.get(key)).isEqualTo("value2");
+    }
+
+    @Test
+    @RequiresRedis7OrHigher
+    void setAndChangedWithArgs() {
+        KeyCommands<String> keys = ds.key(String.class);
+
+        assertThat(values.setAndChanged(key, value)).isTrue();
+        assertThat(values.setAndChanged(key, "value2", new SetArgs().nx())).isFalse();
+        assertThat(values.get(key)).isEqualTo(value);
+        assertThat(keys.del(key)).isEqualTo(1);
+
+        assertThat(values.setAndChanged(key, value, new SetArgs().xx())).isFalse();
+        assertThat(values.get(key)).isNull();
+    }
+
+    @Test
+    @RequiresRedis7OrHigher
     void setGet() {
         assertThat(values.setGet(key, value)).isNull();
         assertThat(values.setGet(key, "value2")).isEqualTo(value);


### PR DESCRIPTION
The `ValueCommands.set()` method returns `void`, discarding the information whether the key was changed (which is readily available from the response).

This commit adds a method `setAndChanged()` that returns `boolean`, carrying the information to the user if they need it. Other variants of `ValueCommands` are also modified, but the deprecated `StringCommands` and variants are not.

Fixes #49000