### PR TITLE
In dev-mode, we need to apply JVM module configuration to both base and runtime classloaders

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -108,7 +108,11 @@ public class StartupActionImpl implements StartupAction {
         runtimeClassLoader.setStartupAction(this);
         // Adjust JVM module requirements for this app
         jvmRequirements = buildResult.consume(ResolvedJVMRequirements.class);
-        applyModuleConfigurationToClassloader(runtimeClassLoader);
+        // Apply to both base and runtime classloaders, as classes may be loaded from either
+        applyModuleConfigurationToClassloader(baseClassLoader);
+        if (runtimeClassLoader != baseClassLoader) {
+            applyModuleConfigurationToClassloader(runtimeClassLoader);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #52343 

This need is made clear in the reproduced attached to #52335 