### PR TITLE
Do not check AppCDS in AotClassLoadingEnabled

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/AotClassLoadingEnabled.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/AotClassLoadingEnabled.java
@@ -13,7 +13,6 @@ public class AotClassLoadingEnabled implements BooleanSupplier {
     @Override
     public boolean getAsBoolean() {
         return packageConfig.jar().enabled() &&
-                packageConfig.jar().appcds().enabled() &&
                 packageConfig.jar().appcds().useAot();
     }
 }


### PR DESCRIPTION
We might not enable it when using AOT.

The whole ergonomics of this will change soon but we need this to be enabled even if we don't generate the cache file at build.

@geoand the empty package-info optimization for Hibernate ORM was disabled since you updated the scripts :).