### PR TITLE
Detect JUnit misconfiguration caused by too many properties files and fail faster, to avoid running tests in the wrong order

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -324,6 +324,13 @@ public class StartupActionImpl implements StartupAction {
      * Runs the application, and returns a handle that can be used to shut it down.
      */
     public RunningQuarkusApplication run(String... args) throws Exception {
+
+        if (runtimeClassLoader.isClosed()) {
+            throw new RuntimeException(
+                    "Internal error: An attempt was made to start an application which had already been started and closed. The affected ClassLoader is "
+                            + runtimeClassLoader);
+
+        }
         // Start dev services that weren't started in the augmentation phase
         ensureDevServicesStarted();
         InitialConfigurator.DELAYED_HANDLER.buildTimeComplete();

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -113,10 +113,6 @@ public class ConfigRecorder {
         // it actually does not because it operates on a different instance
         // of QuarkusConfigFactory from a different classloader.
 
-        if (shutdownContext == null) {
-            throw new RuntimeException(
-                    "Internal error: shutdownContext is null. This probably happened because Quarkus failed to start properly in an earlier step, or because tests were run on a Quarkus instance that had already been shut down.");
-        }
         shutdownContext.addLastShutdownTask(QuarkusConfigFactory::releaseTCCLConfig);
     }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -625,9 +625,10 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             ClearCache.clearCaches();
         }
 
-        // TODO if classes are misordered, say because someone overrode the ordering, and there are profiles or resources,
-        // we could try to start and application which has already been started, and fail with a mysterious error about
-        // null shutdown contexts; we should try and detect that case, and give a friendlier error message
+        if (cl.isClosed()) {
+            throw new IllegalStateException(
+                    "Internal error. Attempting to run tests using an application which has already been closed. Is a non-default test order being used?");
+        }
 
         // We want to start if the profile changed (or there are new test resources),
         // or if we don't have an app and that's not because the previous attempt to start it failed

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
@@ -641,6 +641,14 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
         return isServiceLoaderMechanism;
     }
 
+    /**
+     * Returns true if, after test discovery, multiple classloaders have been created. This would mean multiple Quarkus
+     * applications will be started to run the tests.
+     */
+    public boolean hasMultipleClassLoaders() {
+        return runtimeClassLoaders != null && runtimeClassLoaders.size() > 1;
+    }
+
     @Override
     public String getName() {
         return NAME;
@@ -659,5 +667,4 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
         runtimeClassLoaders.clear();
 
     }
-
 }


### PR DESCRIPTION
Fixes #50661 
Fixes #50740 
Fixes https://github.com/quarkusio/quarkus/issues/48125

This was a classic case where I spent a while debugging a problem, and then once I'd worked it out, found a TODO describing the exact problem, with the exact symptom, written by me. Doh!

See also related discussion in https://github.com/quarkusio/quarkus/pull/22172. This is fixing the same problem (again), but in a different way. 

The root cause of the `shutdownContext is null` and null Arc container problems we've been seeing is tests running in the wrong order. When that happens, we try and re-start an application which has been closed, and bad things happen.

I would *love* to be able to avoid the junit-platform.properties file altogether, but I can't find a way to do that without creating our own discovery requests, or having something set in surefire configuration (risky and brittle). (We can do it in continuous testing mode, but that doesn't help much.)

Since we can't fix the problem (without a JUnit change), all we can do is fail fast, with a less baffling error. A warning isn’t good enough, because there already is a warning in the logs:

```
2026-02-03 16:37:02,966 WARNING [org.junit.platform.launcher.core.LauncherConfigurationParameters] (Test worker) Discovered 2 'junit-platform.properties' configuration files on the classpath (see below); only the first (*) will be used.
- file:/Users/holly/Code/quarkus/OpenQuarterMaster/software/core/oqm-core-api/build/resources/test/junit-platform.properties (*)
- jar:file:/Users/holly/.m2/repository/io/quarkus/quarkus-junit-config/999-SNAPSHOT/quarkus-junit-config-999-SNAPSHOT.jar!/junit-platform.properties
```

### Normal-mode testing

We can’t fix bad config, but we can detect the situation and fail early. We suggest different workarounds in the case where the user wants their own orderer and the case where they just have a properties file. I’ve checked that setting junit.jupiter.testclass.order.default=io.quarkus.test.config.QuarkusClassOrderer in the project’s properties file gets everything working again. 

This is what the error looks like, in the case where a user tried to set their own orderer:

<img width="2214" height="556" alt="image" src="https://github.com/user-attachments/assets/565549a3-784e-4bdd-b9e8-e76edd3eb66f" />

### Continuous testing 

In this case, we have the right hook to actually set an orderer. However, I didn’t want to override a user-set orderer, because that could cause other failures in the user code. Sadly, I couldn’t find a way to check for existing values before setting my own. I also didn’t want to create behaviour differences between continuous testing and normal mode, so in the end I left  things as they were.

I’m also hoping to do a JUnit PR to allow properties to merge, but that might take a while to filter through. Once/if that lands in the Quarkus class path, the current guard should stop throwing exceptions.

I removed the guard from the `ConfigRecorder`, since I’m hoping the situation is now detected in `QuarkusTestExtension` instead. If we do want to keep the guard, there needs to be one in `JacksonRecorder` too, but I think chasing every usage of shutdownContext is not scalable.

We do have a bit of a mess about class orderers and config, but I’ve raised https://github.com/quarkusio/quarkus/issues/52354 to discuss it. 