### PR TITLE
Encode in base64 the value of SERIALIZED_TEST_APP_MODEL when using Maven to avoid escaping issues

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -2,7 +2,9 @@ package io.quarkus.maven;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -121,9 +123,11 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                             //so it doesn't have to do a workspace search to find it. Same as we do for Gradle.
                             Properties properties = mavenProject().getProperties();
                             String argLine = properties.getProperty("argLine", "");
+                            // Base64 encode the path to avoid issues with spaces and special characters on Windows
+                            String encodedPath = Base64.getEncoder().encodeToString(
+                                    serializedTestAppModelPath.toString().getBytes(StandardCharsets.UTF_8));
                             properties.setProperty("argLine", argLine +
-                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=\"" + serializedTestAppModelPath
-                                    + "\"");
+                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=" + encodedPath);
                         } catch (IOException e) {
                             getLog().warn("Failed to serialize application model", e);
                         }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
@@ -267,6 +267,23 @@ class BuildIT extends MojoTestBase {
         assertThat(result.getProcess().waitFor()).isZero();
     }
 
+    /**
+     * Tests that running tests works correctly when the project path contains spaces.
+     * This is a regression test for Windows where paths with spaces in the serialized
+     * test app model path could cause double-quoting issues in argLine.
+     *
+     * @see io.quarkus.maven.GenerateCodeMojo
+     */
+    @Test
+    void testProjectPathWithSpaces() throws MavenInvocationException, InterruptedException, IOException {
+        // Use a destination path with spaces to simulate Windows-style paths like "Program Files"
+        testDir = initProject("projects/classic", "projects/path with spaces/classic build");
+        running = new RunningInvoker(testDir, false);
+        MavenProcessInvocationResult result = running.execute(List.of("clean", "test", "-Dquarkus.analytics.disabled=true"),
+                Map.of());
+        assertThat(result.getProcess().waitFor()).isZero();
+    }
+
     private void launch() throws IOException {
         launch(TestContext.FAST_NO_PREFIX, "", "hello, from foo");
     }


### PR DESCRIPTION

* Fixes #52314

This seems to work. It's not my favourite approach, as the name of the property is now a little misleading, but it might to do for now to keep the changes small. 