### PR TITLE
OIDC: Add basic support for rich authorization requests

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -942,6 +942,80 @@ quarkus.oidc.authentication.par.enabled=true
 quarkus.oidc.authentication.par.path=/as/par
 ----
 
+=== Rich Authorization Requests
+
+The link:https://datatracker.ietf.org/doc/html/rfc9396[OAuth 2.0 Rich Authorization Requests] (RAR) specification allows OAuth2 client applications to specify fine-grained authorization requirements in the authorization code flow request.
+Instead of relying solely on traditional OAuth 2.0 scopes, RAR allows to represent required permissions as JSON that must be URL-encoded and passed as an `authorization_details` query parameter.
+
+You can configure authorization details using the properties in the `quarkus.oidc.authentication.rar` configuration namespace:
+
+[source, properties]
+----
+quarkus.oidc.authentication.rar.type=openid_credential  <1>
+quarkus.oidc.authentication.rar.simple.credential_configuration_id=vc-scope-mapping <2>
+quarkus.oidc.authentication.rar.array.locations=${quarkus.oidc.auth-server-url} <3>
+----
+<1> The `type` field is required.
+<2> The `credential_configuration_id` field value `vc-scope-mapping` is added to the `authorization_details` as a string.
+<3> The link:https://datatracker.ietf.org/doc/html/rfc9396#name-common-data-fields[common data field] `locations` is added as an array of strings.
+
+With this configuration, the following JSON is created:
+
+[source, json]
+----
+[
+    {
+        "type": "openid_credential",
+        "credential_configuration_id": "vc-scope-mapping",
+        "locations": [ "http://localhost:34187/realms/quarkus" ]
+    }
+]
+----
+
+Next, this JSON is URL-encoded and added as an `authorization_details` query parameter to the authorization code flow redirect URL.
+
+==== Add an `authorization_details` query parameter with `OidcRedirectFilter`
+
+A complex JSON structure that cannot be expressed with configuration properties in the `quarkus.oidc.authentication.rar` configuration namespace can be added with the `OidcRedirectFilter`.
+For example:
+
+[source, java]
+----
+package io.quarkus.it.keycloak;
+
+import static io.quarkus.oidc.Redirect.Location.OIDC_AUTHORIZATION;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.OidcRedirectFilter;
+import io.quarkus.oidc.Redirect;
+
+@Redirect(OIDC_AUTHORIZATION)
+@ApplicationScoped
+@Unremovable
+class AuthorizationDetailsOidcRedirectFilter implements OidcRedirectFilter {
+
+    @Override
+    public void filter(OidcRedirectContext redirectContext) {
+        redirectContext.additionalQueryParams().add("authorization_details", """
+                [
+                    {
+                        "type": "openid_credential",
+                        "credential_configuration_id": "vc-scope-mapping-1",
+                        "locations": [ "http://localhost:34187/realms/quarkus" ]
+                    },
+                    {
+                        "type": "openid_credential",
+                        "credential_configuration_id": "vc-scope-mapping-2",
+                        "locations": [ "http://localhost:34187/realms/quarkus" ]
+                    }
+                ]
+                """);
+    }
+}
+----
+
 === Handling and controlling the lifetime of authentication
 
 Another important requirement for authentication is to ensure that the data the session is based on is up-to-date without requiring the user to authenticate for every single request.

--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -406,6 +406,31 @@ By setting `quarkus.oidc.authentication.force-redirect-https-scheme=true`, you t
 
 `quarkus.oidc.authentication.allow-multiple-code-flows` allows multi-tab authentication by default. For example, a user starts an authorization code flow in one tab, is about to enter the requested credentials, does not complete it because of some interruption, later opens another tab and starts and completes another authorization code flow, with the original one still pending in the first tab. Now, the already authenticated user returns to the first tab and completes it as well. If this kind of authentication flow flexibility is considered too much for the stricter authentication policies you may have, set `quarkus.oidc.authentication.allow-multiple-code-flows=false`. See also the `quarkus.oidc.authentication.fail-on-missing-kid` property description below.
 
+[[rich-authorization-requests]]
+=== Rich Authorization Requests
+
+The link:https://datatracker.ietf.org/doc/html/rfc9396[OAuth 2.0 Rich Authorization Requests] (RAR) specification enables OAuth2 client applications to specify fine-grained authorization requirements during the authorization code flow.
+Instead of relying solely on traditional OAuth 2.0 scopes, RAR represents required permissions as JSON that is URL-encoded and passed as an `authorization_details` query parameter.
+
+.Rich Authorization Requests
+[options="header"]
+|====
+|Property | Default |Description
+
+|quarkus.oidc.authentication.rar.type || Authorization details type (required)
+|quarkus.oidc.authentication.rar.simple || Simple string field values
+|quarkus.oidc.authentication.rar.array || Array field values
+|====
+
+`quarkus.oidc.authentication.rar.type` is a required property that specifies the authorization details type.
+This type identifies the kind of authorization being requested, such as `openid_credential` for verifiable credentials.
+
+`quarkus.oidc.authentication.rar.simple` property can be used to add simple string fields to the authorization details JSON.
+
+`quarkus.oidc.authentication.rar.array` property can be used to add array fields to the authorization details JSON.
+
+For more complex JSON structures that cannot be expressed with configuration properties, use the xref:security-oidc-code-flow-authentication.adoc#oidc-redirect-filters[io.quarkus.oidc.OidcRedirectFilter].
+
 [[authorization-code-flow-completion]]
 === Authorization code flow completion
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1506,6 +1506,29 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             };
         }
 
+        @Override
+        public Optional<RichAuthorizationRequests> rar() {
+            if (rarTypeField == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new RichAuthorizationRequests() {
+                @Override
+                public Map<String, String> simple() {
+                    return rarStringTypeFields;
+                }
+
+                @Override
+                public Map<String, List<String>> array() {
+                    return rarArrayTypeFields;
+                }
+
+                @Override
+                public String type() {
+                    return rarTypeField;
+                }
+            });
+        }
+
         /**
          * SameSite attribute values for the session cookie.
          */
@@ -1840,6 +1863,12 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
 
         private Optional<String> parEndpoint = Optional.empty();
 
+        private Map<String, String> rarStringTypeFields = Map.of();
+
+        private Map<String, List<String>> rarArrayTypeFields = Map.of();
+
+        private String rarTypeField = null;
+
         public Optional<Duration> getInternalIdTokenLifespan() {
             return internalIdTokenLifespan;
         }
@@ -2123,6 +2152,12 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             cacheControl = mapping.cacheControl();
             parEnabled = mapping.par().enabled();
             parEndpoint = mapping.par().path();
+            var rar = mapping.rar().orElse(null);
+            if (rar != null) {
+                rarStringTypeFields = rar.simple();
+                rarArrayTypeFields = rar.array();
+                rarTypeField = rar.type();
+            }
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -1015,6 +1015,13 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
          */
         @ConfigDocSection
         PushedAuthorizationRequest par();
+
+        /**
+         * Configuration for the rich authorization requests (RAR)
+         * as defined by the <a href="https://datatracker.ietf.org/doc/html/rfc9396">RFC 9396</a>.
+         */
+        @ConfigDocSection
+        Optional<RichAuthorizationRequests> rar();
     }
 
     /**
@@ -1362,5 +1369,55 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
          * using the `pushed_authorization_request_endpoint` parameter.
          */
         Optional<String> path();
+    }
+
+    /**
+     * Rich Authorization Requests (RAR) configuration.
+     */
+    interface RichAuthorizationRequests {
+
+        /**
+         * Configures the `authorization_details` request parameter string fields of the authorization request.
+         * Please note that the `type` field is required. If the `type` is not configured, validation will fail.
+         * For example, if you configure the `quarkus.oidc.authentication.rar.simple.type=openid_credential`
+         * property, following `authorization_details` request parameter will be added to the authorization request:
+         *
+         * <pre>
+         * {@code
+         * [
+         *    {
+         *       "type": "openid_credential"
+         *    }
+         * ]
+         * }
+         * </pre>
+         */
+        @ConfigDocMapKey("field")
+        Map<String, String> simple();
+
+        /**
+         * Configures the `authorization_details` request parameter array fields of the authorization request.
+         * For example, if you configure the `quarkus.oidc.authentication.rar.array.locations=https://...`
+         * property, following `authorization_details` request parameter will be added to the authorization request:
+         *
+         * <pre>
+         * {@code
+         * [
+         *    {
+         *       "locations": [ "https://..." ]
+         *    }
+         * ]
+         * }
+         * </pre>
+         */
+        @ConfigDocMapKey("field")
+        Map<String, List<@WithConverter(TrimmedStringConverter.class) String>> array();
+
+        /**
+         * The `authorization_details` type field. Please see the RFC 9396
+         * <a href="https://datatracker.ietf.org/doc/html/rfc9396#name-request-parameter-authoriza">Request Parameter
+         * `authorization_details`</a> for more information.
+         */
+        String type();
     }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
@@ -414,6 +414,7 @@ public class OidcTenantConfigBuilderTest {
                 .pkceRequired()
                 .stateSecret("state-secret-auth-whatever")
                 .par("/as/par")
+                .rar("openid_credential", Map.of("credentials", "mine"), Map.of("locations", List.of("something")))
                 .end()
                 // OidcCommonConfig methods
                 .authServerUrl("we")
@@ -567,6 +568,15 @@ public class OidcTenantConfigBuilderTest {
         var par = authentication.par();
         assertTrue(par.enabled().orElse(false));
         assertEquals("/as/par", par.path().orElse(null));
+        var rar = authentication.rar().orElse(null);
+        assertNotNull(rar);
+        assertEquals("openid_credential", rar.type());
+        assertNotNull(rar.array());
+        assertEquals(1, rar.array().size());
+        assertEquals(List.of("something"), rar.array().get("locations"));
+        assertNotNull(rar.simple());
+        assertEquals(1, rar.simple().size());
+        assertEquals("mine", rar.simple().get("credentials"));
 
         var codeGrant = config.codeGrant();
         assertNotNull(codeGrant);

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -216,6 +216,10 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         JWT_BEARER_TOKEN_PATH,
         PAR,
         PAR_ENABLED,
+        RAR,
+        RAR_SIMPLE,
+        RAR_ARRAY,
+        RAR_TYPE,
         PAR_PATH
     }
 
@@ -866,6 +870,30 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
                         return Optional.empty();
                     }
                 };
+            }
+
+            @Override
+            public Optional<RichAuthorizationRequests> rar() {
+                invocationsRecorder.put(ConfigMappingMethods.RAR, true);
+                return Optional.of(new RichAuthorizationRequests() {
+                    @Override
+                    public Map<String, String> simple() {
+                        invocationsRecorder.put(ConfigMappingMethods.RAR_SIMPLE, true);
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, List<String>> array() {
+                        invocationsRecorder.put(ConfigMappingMethods.RAR_ARRAY, true);
+                        return Map.of();
+                    }
+
+                    @Override
+                    public String type() {
+                        invocationsRecorder.put(ConfigMappingMethods.RAR_TYPE, true);
+                        return "";
+                    }
+                });
             }
         };
     }

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/OidcTokenResponseFilter.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/OidcTokenResponseFilter.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.oidc.TenantFeature;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.smallrye.mutiny.Uni;
+
+@TenantFeature("rar")
+@OidcEndpoint(value = OidcEndpoint.Type.TOKEN)
+@ApplicationScoped
+class OidcTokenResponseFilter implements OidcResponseFilter {
+
+    private volatile String authorizationDetails = null;
+
+    @Override
+    public Uni<Void> filter(OidcResponseFilterContext responseContext) {
+        authorizationDetails = responseContext.responseBody()
+                .toJsonObject()
+                .getString("authorization_details");
+        return Uni.createFrom().voidItem();
+    }
+
+    String getAuthorizationDetails() {
+        return authorizationDetails;
+    }
+}

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/RarResource.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/RarResource.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+
+@Authenticated
+@Path("/rar")
+public class RarResource {
+
+    @Any
+    @Inject
+    OidcTokenResponseFilter oidcTokenResponseFilter;
+
+    @Path("/token-response/authorization-details")
+    @GET
+    public String getAuthorizationDetails() {
+        return oidcTokenResponseFilter.getAuthorizationDetails();
+    }
+
+}

--- a/integration-tests/oidc-client-registration/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-registration/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 quarkus.keycloak.devservices.start-with-disabled-tenant=true
 quarkus.keycloak.devservices.show-logs=true
+quarkus.keycloak.devservices.features=oid4vc-vci
 
 quarkus.oidc.tenant-enabled=false
 quarkus.oidc-client-registration.auth-server-url=${quarkus.oidc.auth-server-url}
@@ -24,3 +25,11 @@ quarkus.log.category."io.quarkus.it.keycloak.RegisteredClientResponseFilter".min
 quarkus.log.category."io.quarkus.it.keycloak.RegisteredClientResponseFilter".level=TRACE
 quarkus.log.file.enabled=true
 quarkus.log.file.format=%C - %s%n
+
+quarkus.oidc.rar.application-type=web-app
+quarkus.oidc.rar.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc.rar.client-id=oid4vc-rest-api
+quarkus.oidc.rar.credentials.client-secret.value=secret
+quarkus.oidc.rar.authentication.rar.type=openid_credential
+quarkus.oidc.rar.authentication.rar.simple.credential_configuration_id=vc-scope-mapping
+quarkus.oidc.rar.authentication.rar.array.locations=${quarkus.oidc.auth-server-url}

--- a/integration-tests/oidc-client-registration/src/main/resources/quarkus-realm.json
+++ b/integration-tests/oidc-client-registration/src/main/resources/quarkus-realm.json
@@ -682,6 +682,23 @@
         "offline_access",
         "microprofile-jwt"
       ]
+    },
+    {
+      "clientId": "oid4vc-rest-api",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "secret",
+      "redirectUris": ["*"],
+      "directAccessGrantsEnabled": true,
+      "defaultClientScopes": ["profile"],
+      "optionalClientScopes": ["vc-scope-mapping"],
+      "attributes": {
+        "oid4vci.enabled": "true",
+        "oid4vc.client.enabled": "true"
+      }
     }
   ],
   "clientScopes": [
@@ -1167,6 +1184,29 @@
           "config": {}
         }
       ]
+    },
+    {
+      "id": "12345-vc-scope-mapping",
+      "name": "vc-scope-mapping",
+      "protocol": "oid4vc",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "vc.issuer_did": "did:web:vc.example.com",
+        "vc.credential_configuration_id": "vc-scope-mapping",
+        "vc.credential_identifier": "my-credential-identifier",
+        "vc.format": "jwt_vc",
+        "vc.expiry_in_seconds": 31536000,
+        "vc.verifiable_credential_type": "my-vct",
+        "vc.supported_credential_types": "credential-type-1,credential-type-2",
+        "vc.credential_contexts": "context-1,context-2",
+        "vc.credential_signing_alg": "ES256",
+        "vc.cryptographic_binding_methods_supported": "jwk",
+        "vc.sd_jwt.number_of_decoys": "2",
+        "vc.credential_build_config.sd_jwt.visible_claims": "iat,jti,nbf,exp,given_name",
+        "vc.credential_build_config.hash_algorithm": "SHA-256",
+        "vc.credential_build_config.token_jws_type": "JWS",
+        "vc.include_in_metadata": "true"
+      }
     }
   ],
   "defaultDefaultClientScopes": [
@@ -1317,6 +1357,20 @@
           "secret" : [ "qBFGKdUGf6xDgKphnRfoFzIzaFHJW4bYnZ9MinPFzN38X5_ctq-2u1q5RdZzeJukXvk2biHB8_s3DxWmmLZFsA" ],
           "priority": [ "100" ],
           "algorithm": [ "HS256" ]
+        }
+      },
+      {
+        "id": "generated-ecdsa-key-provider",
+        "name": "es256-generated",
+        "providerId": "ecdsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "ES256"
+          ]
         }
       }
     ]

--- a/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcRichAuthorizationRequestsTest.java
+++ b/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcRichAuthorizationRequestsTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.it.keycloak;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class OidcRichAuthorizationRequestsTest {
+
+    @Test
+    void testAuthorizationDetails() throws IOException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/rar/token-response/authorization-details");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            TextPage textPage = loginForm.getButtonByName("login").click();
+
+            String authorizationDetailsFromTokenResponse = textPage.getContent().trim();
+            assertNotNull(authorizationDetailsFromTokenResponse);
+            assertTrue(authorizationDetailsFromTokenResponse.contains("type=openid_credential"),
+                    authorizationDetailsFromTokenResponse);
+            assertTrue(authorizationDetailsFromTokenResponse.contains("credential_configuration_id=vc-scope-mapping"),
+                    authorizationDetailsFromTokenResponse);
+            assertTrue(authorizationDetailsFromTokenResponse.contains("credential_identifiers"),
+                    authorizationDetailsFromTokenResponse);
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private static WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}


### PR DESCRIPTION
Adds basic support for RAR. Only string and array fields are supported, as bare minimum required for OpenID4VC.

* Closes: https://github.com/quarkusio/quarkus/issues/52286
