### PR TITLE
Decrease log level for `NativeImageAgentMojo`

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageAgentMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageAgentMojo.java
@@ -93,7 +93,7 @@ public class NativeImageAgentMojo extends QuarkusBootstrapMojo {
                 throw new MojoExecutionException("Failed to transform native image agent configuration", e);
             }
         } else {
-            getLog().info("Missing " + dirName + " directory with native image agent configuration to transform");
+            getLog().debug("Missing " + dirName + " directory with native image agent configuration to transform");
         }
     }
 


### PR DESCRIPTION
This is done because there is no reason
to spam users every time about this opt-in
feature

P.S. This is especially prominent now that we have the `quarkus` Maven packaging