### PR TITLE
Move build-time-initialization from beforeAnalysis to duringSetup

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -93,6 +93,14 @@ public class NativeImageFeatureStep {
                 mc.body(b0 -> b0.return_(Const.of("Auto-generated class by Quarkus from the existing extensions")));
             });
 
+            cc.method("duringSetup", mc -> {
+                mc.parameter("access", Feature.DuringSetupAccess.class);
+                mc.body(b0 -> {
+                    b0.invokeStatic(BUILD_TIME_INITIALIZATION, b0.newArray(String.class, Const.of("")));
+                    b0.return_();
+                });
+            });
+
             cc.method("beforeAnalysis", mc -> {
                 ParamVar access = mc.parameter("access", Feature.BeforeAnalysisAccess.class);
                 MethodDesc classForName3 = MethodDesc.of(Class.class, "forName", Class.class, String.class, boolean.class,
@@ -100,7 +108,6 @@ public class NativeImageFeatureStep {
                 mc.body(b0 -> {
                     b0.try_(t1 -> {
                         t1.body(b2 -> {
-                            b2.invokeStatic(BUILD_TIME_INITIALIZATION, b2.newArray(String.class, Const.of("")));
                             LocalVar cl = b2.localVar("cl", b2.invokeVirtual(MD_Class.getClassLoader, Const.of(cc.type())));
                             if (localesBuildTimeConfig.defaultLocale().isPresent()) {
                                 Locale defaultLocale = localesBuildTimeConfig.defaultLocale().get();

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/SerializationBuildTimeInitTestEndpoint.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/SerializationBuildTimeInitTestEndpoint.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.corestuff;
+
+import java.io.IOException;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import io.quarkus.it.corestuff.serialization.SerializationChildBuildTimeInit;
+import io.quarkus.it.corestuff.serialization.SerializationParentBuildTimeInit;
+
+/**
+ * Ensure that classes registered for serialization are build-time-initialized
+ */
+@WebServlet(name = "CoreSerializationBuildTimeInitTestEndpoint", urlPatterns = "/core/serialization-build-time-init")
+public class SerializationBuildTimeInitTestEndpoint extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().write(SerializationParentBuildTimeInit.value + "\t" + SerializationChildBuildTimeInit.value);
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationChildBuildTimeInit.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationChildBuildTimeInit.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.corestuff.serialization;
+
+import io.quarkus.bootstrap.graal.ImageInfo;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection(serialization = true)
+public class SerializationChildBuildTimeInit extends SerializationParentBuildTimeInit {
+
+    public final static String value = "Child: " + (ImageInfo.inImageBuildtimeCode() ? "BUILD_TIME" : "RUN_TIME");
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationParentBuildTimeInit.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationParentBuildTimeInit.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.corestuff.serialization;
+
+import java.io.Serializable;
+
+import io.quarkus.bootstrap.graal.ImageInfo;
+
+public class SerializationParentBuildTimeInit implements Serializable {
+
+    public final static String value = "Parent: " + (ImageInfo.inImageBuildtimeCode() ? "BUILD_TIME" : "RUN_TIME");
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/CoreSerializationBuildTimeInitInGraalITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/CoreSerializationBuildTimeInitInGraalITCase.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.main;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+
+@QuarkusIntegrationTest
+public class CoreSerializationBuildTimeInitInGraalITCase {
+
+    @Test
+    public void testBuildTimeInitOnRegisteredForSerializationClassServlet() throws Exception {
+        RestAssured.when().get("/core/serialization-build-time-init").then()
+                .body(is("Parent: BUILD_TIME\tChild: BUILD_TIME"));
+    }
+
+}


### PR DESCRIPTION
When setting up build-time initialization in the beforeAnalysis phase other GraalVM features (e.g. the SerializationFeature) end up runing before it, thus resulting in some classes being run-time initialized instead.

Moving the build-time initialization setting in duringSetup we ensure that it runs before any other Feature that might be trying to initialize (or set the initialization kind of) a class.

cc @yrodiere 