### PR TITLE
Add runtime config to enable default exporter alongside external exporter

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -143,10 +143,8 @@ public class OtlpExporterProcessor {
             CoreVertxBuildItem vertxBuildItem,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
-        if (!externalOtelExporterBuildItem.isEmpty()) {
-            // if there is an external exporter, we don't want to create the default one
-            return;
-        }
+
+        boolean hasExternalExporter = !externalOtelExporterBuildItem.isEmpty();
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem
                 .configure(LateBoundSpanProcessor.class)
                 .types(SpanProcessor.class)
@@ -156,7 +154,7 @@ public class OtlpExporterProcessor {
                 .addInjectionPoint(ParameterizedType.create(DotName.createSimple(Instance.class),
                         new Type[] { ClassType.create(DotName.createSimple(SpanExporter.class.getName())) }, null))
                 .addInjectionPoint(ClassType.create(DotName.createSimple(TlsConfigurationRegistry.class)))
-                .createWith(recorder.spanProcessorForOtlp(vertxBuildItem.getVertx()))
+                .createWith(recorder.spanProcessorForOtlp(vertxBuildItem.getVertx(), hasExternalExporter))
                 .done());
     }
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
@@ -19,6 +19,7 @@ public class OtlpExporterConfigTest {
             .overrideConfigKey("quarkus.otel.exporter.otlp.protocol", "wrong")
             .overrideConfigKey("quarkus.otel.exporter.otlp.traces.protocol", "http/protobuf")
             .overrideConfigKey("quarkus.otel.exporter.otlp.traces.endpoint", "http://localhost ")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.traces.experimental.dependent.default.enable", "true")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50")
             .overrideConfigKey("quarkus.otel.bsp.export.timeout", "PT1S");
@@ -32,5 +33,6 @@ public class OtlpExporterConfigTest {
         assertEquals("http/protobuf", config.traces().protocol().get().trim());
         assertTrue(config.traces().endpoint().isPresent());
         assertEquals("http://localhost", config.traces().endpoint().get().trim());
+        assertTrue(config.traces().activateDefaultExporter());
     }
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryDefaultExporterEnabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryDefaultExporterEnabledTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.opentelemetry.deployment.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.LateBoundSpanProcessor;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.VertxGrpcSpanExporter;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default span exporter is active when explicitly enabled.
+ */
+public class OpenTelemetryDefaultExporterEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.trace.enabled", "true")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.traces.experimental.dependent.default.enable", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("azure"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<LateBoundSpanProcessor> spanProcessorInstance;
+
+    @Test
+    void defaultExporterResolvable() throws Exception {
+        assertThat(spanProcessorInstance.isResolvable()).isTrue();
+
+        Field delegateField = LateBoundSpanProcessor.class.getDeclaredField("delegate");
+        delegateField.setAccessible(true);
+
+        Object obj = delegateField.get(spanProcessorInstance.get());
+        assertThat(obj).isInstanceOf(BatchSpanProcessor.class);
+        assertThat(((BatchSpanProcessor) obj).getSpanExporter()).isInstanceOf(VertxGrpcSpanExporter.class);
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryExternalExporterTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryExternalExporterTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.opentelemetry.deployment.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.opentelemetry.deployment.exporter.otlp.ExternalOtelExporterBuildItem;
+import io.quarkus.opentelemetry.runtime.exporter.otlp.tracing.LateBoundSpanProcessor;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that the default span exporter is not active when an external exporter is present.
+ */
+public class OpenTelemetryExternalExporterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.otel.traces.enabled", "true")
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep().produces(ExternalOtelExporterBuildItem.class)
+                            .setBuildStep(new BuildStep() {
+                                @Override
+                                public void execute(BuildContext context) {
+                                    context.produce(new ExternalOtelExporterBuildItem("azure"));
+                                }
+                            }).build();
+                }
+            });
+
+    @Inject
+    InjectableInstance<LateBoundSpanProcessor> spanProcessorInstance;
+
+    @Test
+    void defaultExporterNotResolvable() throws Exception {
+        assertThat(spanProcessorInstance.isResolvable()).isTrue();
+
+        Field delegateField = LateBoundSpanProcessor.class.getDeclaredField("delegate");
+        delegateField.setAccessible(true);
+
+        Object obj = delegateField.get(spanProcessorInstance.get());
+        assertThat(obj).isNull();
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterTracesConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterTracesConfig.java
@@ -1,7 +1,20 @@
 package io.quarkus.opentelemetry.runtime.config.runtime.exporter;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 @ConfigGroup
 public interface OtlpExporterTracesConfig extends OtlpExporterConfig {
+
+    /**
+     * If true, the Quarkus default OpenTelemetry exporter will always be instantiated, even when other exporters are present.
+     * This will allow OTel data to be sent simultaneously to multiple destinations, including the default one. If false, the
+     * Quarkus default OpenTelemetry exporter will not be instantiated if other exporters are present.
+     * <p>
+     * Defaults to <code>false</code>.
+     */
+    @WithName("experimental.dependent.default.enable")
+    @WithDefault("false")
+    boolean activateDefaultExporter();
 }

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/HttpClientOptionsConsumerTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/HttpClientOptionsConsumerTest.java
@@ -52,6 +52,11 @@ class HttpClientOptionsConsumerTest {
     private OtlpExporterTracesConfig createExporterConfig(final boolean isEnabled) {
         return new OtlpExporterTracesConfig() {
             @Override
+            public boolean activateDefaultExporter() {
+                return false;
+            }
+
+            @Override
             public Optional<String> endpoint() {
                 return Optional.of("http://localhost:4317");
             }

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
@@ -185,6 +185,11 @@ class OtlpExporterProviderTest {
             public OtlpExporterTracesConfig traces() {
                 return new OtlpExporterTracesConfig() {
                     @Override
+                    public boolean activateDefaultExporter() {
+                        return false;
+                    }
+
+                    @Override
                     public Optional<String> endpoint() {
                         return Optional.ofNullable(newTrace);
                     }

--- a/integration-tests/opentelemetry-external-exporter/pom.xml
+++ b/integration-tests/opentelemetry-external-exporter/pom.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-opentelemetry-external-exporter</artifactId>
+    <name>Quarkus - Integration Tests - OpenTelemetry external exporter</name>
+
+    <properties>
+        <!-- azure exporter has runtime config in build steps
+         https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383 -->
+        <quarkus.extension-loader.report-runtime-config-at-deployment>warn</quarkus.extension-loader.report-runtime-config-at-deployment>
+        <quarkus-opentelemetry-exporter-azure.version>3.20.0.0</quarkus-opentelemetry-exporter-azure.version>
+        <quarkus-azure-services-bom.version>1.1.1</quarkus-azure-services-bom.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- external quarkiverse exporter BOMs -->
+            <dependency>
+                <groupId>io.quarkiverse.azureservices</groupId>
+                <artifactId>quarkus-azure-services-bom</artifactId>
+                <type>pom</type>
+                <version>${quarkus-azure-services-bom.version}</version>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <!-- required for azure exporter -->
+                <!-- https://github.com/quarkiverse/quarkus-opentelemetry-exporter/issues/382 -->
+                <groupId>io.opentelemetry.semconv</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>1.29.0-alpha</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.opentelemetry.exporter</groupId>
+            <artifactId>quarkus-opentelemetry-exporter-azure</artifactId>
+            <version>${quarkus-opentelemetry-exporter-azure.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <vertx.disableWebsockets>false</vertx.disableWebsockets>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/opentelemetry-external-exporter/src/main/java/io/quarkus/it/external/exporter/HelloResource.java
+++ b/integration-tests/opentelemetry-external-exporter/src/main/java/io/quarkus/it/external/exporter/HelloResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.external.exporter;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("hello")
+@Produces(MediaType.APPLICATION_JSON)
+public class HelloResource {
+    private static final Logger LOG = LoggerFactory.getLogger(HelloResource.class);
+
+    @GET
+    public String get() {
+        LOG.info("Hello World");
+        return "get";
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-external-exporter/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+# Setting these for tests explicitly. Not required in normal application
+quarkus.application.name=opentelemetry-external-exporter-integration-test
+quarkus.application.version=999-SNAPSHOT
+
+applicationinsights.connection.string=InstrumentationKey=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;IngestionEndpoint=http://127.0.0.1:53602/export
+
+quarkus.otel.logs.enabled=true
+quarkus.otel.metrics.enabled=true
+quarkus.otel.metric.export.interval=1000ms
+quarkus.otel.instrument.jvm-metrics=false

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/AzureExporterTelemetry.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/AzureExporterTelemetry.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.external.exporter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+public class AzureExporterTelemetry {
+
+    private final WireMockServer wireMockServer;
+
+    public AzureExporterTelemetry(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
+    }
+
+    public Callable<Boolean> telemetryDataContainExport() {
+        return () -> !getTelemetryHttpRequests().isEmpty();
+    }
+
+    public void verifyExportedTraces() {
+        assertThat(getTelemetryHttpRequests()
+                .stream()
+                .map(request -> new String(request.getBody()))
+                .anyMatch(body -> body.contains("\"message\":\"opentelemetry-external-exporter-integration-test")
+                        && body.contains("(powered by Quarkus ")
+                        && body.contains("started in") && body.contains(
+                                "{\"LoggerName\":\"io.quarkus.opentelemetry\",\"LoggingLevel\":\"INFO\",\"log.logger.namespace\":\"org.jboss.logging.Logger\"")))
+                .as("Should contain OTel log.").isTrue();
+    }
+
+    private List<LoggedRequest> getTelemetryHttpRequests() {
+        return wireMockServer.findAll(postRequestedFor(urlEqualTo("/export/v2.1/track")));
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/DefaultExporterTelemetry.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/DefaultExporterTelemetry.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.external.exporter;
+
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+
+public class DefaultExporterTelemetry {
+
+    private final Traces traces;
+
+    public DefaultExporterTelemetry(Traces traces) {
+        this.traces = traces;
+    }
+
+    public void verifyExportedTraces() {
+        await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(traces.getTraceRequests()).hasSize(1));
+
+        ExportTraceServiceRequest request = traces.getTraceRequests().get(0);
+        assertThat(request.getResourceSpansCount()).isEqualTo(1);
+
+        ResourceSpans resourceSpans = request.getResourceSpans(0);
+        assertThat(resourceSpans.getResource().getAttributesList())
+                .contains(KeyValue.newBuilder()
+                        .setKey(SERVICE_NAME.getKey())
+                        .setValue(AnyValue.newBuilder()
+                                .setStringValue("opentelemetry-external-exporter-integration-test").build())
+                        .build());
+        assertThat(resourceSpans.getScopeSpansCount()).isEqualTo(1);
+
+        ScopeSpans scopeSpans = resourceSpans.getScopeSpans(0);
+        assertThat(scopeSpans.getSpansCount()).isEqualTo(1);
+
+        Span span = scopeSpans.getSpans(0);
+        assertThat(span.getName()).isEqualTo("GET /hello");
+        assertThat(span.getAttributesList())
+                .contains(KeyValue.newBuilder()
+                        .setKey("http.request.method")
+                        .setValue(AnyValue.newBuilder()
+                                .setStringValue("GET").build())
+                        .build());
+    }
+
+    public void verifyNoExportedTraces() {
+        assertThat(traces.getTraceRequests()).isEmpty();
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/ExporterTestBase.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/ExporterTestBase.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.external.exporter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
+public class ExporterTestBase {
+
+    // Azure Monitor endpoint port, see application.properties
+    public static final int HTTP_PORT_NUMBER = 53602;
+    protected DefaultExporterTelemetry defaultExporterTelemetry;
+    protected AzureExporterTelemetry azureExporterTelemetry;
+    private WireMockServer wireMockServer;
+    private Traces traces;
+
+    @BeforeEach
+    public void startWireMock() {
+        WireMockConfiguration wireMockConfiguration = new WireMockConfiguration().port(HTTP_PORT_NUMBER);
+        wireMockServer = new WireMockServer(wireMockConfiguration);
+        wireMockServer.start();
+        wireMockServer.stubFor(
+                any(urlMatching(".*"))
+                        .withPort(HTTP_PORT_NUMBER)
+                        .willReturn(aResponse().withStatus(200)));
+        defaultExporterTelemetry = new DefaultExporterTelemetry(traces);
+        azureExporterTelemetry = new AzureExporterTelemetry(wireMockServer);
+    }
+
+    @AfterEach
+    public void stopWireMock() {
+        wireMockServer.stop();
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/OtelCollectorLifecycleManager.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/OtelCollectorLifecycleManager.java
@@ -1,0 +1,146 @@
+package io.quarkus.it.external.exporter;
+
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
+import static org.testcontainers.Testcontainers.exposeHostPorts;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.DockerImageName;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.server.GrpcServer;
+
+public class OtelCollectorLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+    // from https://github.com/open-telemetry/opentelemetry-java/pkgs/container/opentelemetry-java%2Fotel-collector/versions
+    // otel collector v0.114.0. The last with OpenTelemetry proto 1.3.x
+    private static final String COLLECTOR_IMAGE = "ghcr.io/open-telemetry/opentelemetry-java/otel-collector" +
+            "@sha256:37fa87091cfaaec7234a27e4e395a40c31c2bfaea97a349a4afef6d9e9681197";
+    private static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
+    private static final Integer COLLECTOR_OTLP_HTTP_PORT = 4318;
+    private static final Integer COLLECTOR_HEALTH_CHECK_PORT = 13133;
+    private static final ServiceName TRACE_SERVICE_NAME = ServiceName
+            .create("opentelemetry.proto.collector.trace.v1.TraceService");
+    private static final ServiceName METRIC_SERVICE_NAME = ServiceName
+            .create("opentelemetry.proto.collector.metrics.v1.MetricsService");
+    private static final ServiceName LOG_SERVICE_NAME = ServiceName
+            .create("opentelemetry.proto.collector.logs.v1.LogsService");
+    private static final String EXPORT_METHOD_NAME = "Export";
+
+    private String protocol = GRPC;
+    private Vertx vertx;
+    private HttpServer server;
+    private GenericContainer<?> collector;
+    private Traces collectedTraces;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        if (initArgs.containsKey("protocol")) {
+            protocol = initArgs.get("protocol");
+        }
+    }
+
+    @Override
+    public Map<String, String> start() {
+        setupVertxGrpcServer();
+        int vertxGrpcServerPort = server.actualPort();
+
+        // Expose the port the in-process OTLP gRPC server will run on before the collector is
+        // initialized so the collector can connect to it.
+        exposeHostPorts(vertxGrpcServerPort);
+
+        collector = new GenericContainer<>(DockerImageName.parse(COLLECTOR_IMAGE))
+                .withImagePullPolicy(PullPolicy.alwaysPull())
+                .withEnv("LOGGING_EXPORTER_VERBOSITY_LEVEL", "basic") // basic, normal, detailed
+                .withEnv("OTLP_EXPORTER_ENDPOINT", "host.testcontainers.internal:" + vertxGrpcServerPort)
+                .withClasspathResourceMapping(
+                        "otel-config.yaml", "/otel-config.yaml", BindMode.READ_ONLY)
+                .withCommand("--config", "/otel-config.yaml")
+                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("otel-collector")))
+                .withExposedPorts(
+                        COLLECTOR_OTLP_GRPC_PORT,
+                        COLLECTOR_OTLP_HTTP_PORT,
+                        COLLECTOR_HEALTH_CHECK_PORT)
+                .waitingFor(Wait.forHttp("/").forPort(COLLECTOR_HEALTH_CHECK_PORT));
+        collector.start();
+
+        Map<String, String> result = new HashMap<>();
+        result.put("quarkus.otel.exporter.otlp.traces.protocol", protocol);
+
+        int inSecureEndpointPort = GRPC.equals(protocol) ? COLLECTOR_OTLP_GRPC_PORT : COLLECTOR_OTLP_HTTP_PORT;
+        result.put("quarkus.otel.exporter.otlp.traces.endpoint",
+                "http://" + collector.getHost() + ":" + collector.getMappedPort(inSecureEndpointPort));
+        return result;
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(collectedTraces, f -> f.getType().equals(Traces.class));
+    }
+
+    private void setupVertxGrpcServer() {
+        vertx = Vertx.vertx(new VertxOptions().setWorkerPoolSize(1).setEventLoopPoolSize(1));
+        GrpcServer grpcServer = GrpcServer.server(vertx);
+        collectedTraces = new Traces();
+        grpcServer.callHandler(request -> {
+
+            if (request.serviceName().equals(TRACE_SERVICE_NAME) && request.methodName().equals(EXPORT_METHOD_NAME)) {
+
+                request.handler(message -> {
+                    try {
+                        collectedTraces.getTraceRequests().add(ExportTraceServiceRequest.parseFrom(message.getBytes()));
+                        request.response().end(Buffer.buffer(ExportTraceServiceResponse.getDefaultInstance().toByteArray()));
+                    } catch (InvalidProtocolBufferException e) {
+                        request.response()
+                                .status(GrpcStatus.INVALID_ARGUMENT)
+                                .end();
+                    }
+                });
+            } else {
+                request.response()
+                        .status(GrpcStatus.NOT_FOUND)
+                        .end();
+            }
+        });
+
+        server = vertx.createHttpServer(new HttpServerOptions().setPort(0));
+        try {
+            server.requestHandler(grpcServer).listen().toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            server.close().andThen(ar -> {
+                if (vertx != null) {
+                    vertx.close();
+                }
+            });
+        }
+        if (collector != null) {
+            collector.stop();
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Traces.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/Traces.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.external.exporter;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+
+public final class Traces {
+
+    private final List<ExportTraceServiceRequest> traceRequests = new CopyOnWriteArrayList<>();
+
+    public List<ExportTraceServiceRequest> getTraceRequests() {
+        return traceRequests;
+    }
+
+    public void reset() {
+        traceRequests.clear();
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterDisabledIT.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterDisabledIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.external.exporter.azure;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DefaultExporterDisabledIT extends DefaultExporterDisabledTest {
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterDisabledTest.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterDisabledTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.external.exporter.azure;
+
+import static io.restassured.RestAssured.when;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.external.exporter.ExporterTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verify that the default traces exporter is disabled when an external exporter is configured.
+ */
+@QuarkusTest
+@TestProfile(DefaultExporterDisabledTest.DefaultExporterDisabledProfile.class)
+public class DefaultExporterDisabledTest extends ExporterTestBase {
+
+    @Test
+    void defaultExporterDisabled() throws InterruptedException {
+
+        when()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+
+        // wait for telemetry to be sent to Application Insights via the /v2.1/track API endpoint
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .until(azureExporterTelemetry.telemetryDataContainExport());
+
+        // wait a bit more to ensure all telemetry data has arrived
+        Thread.sleep(10_000);
+
+        // verify that telemetry was sent via the Azure exporter
+        azureExporterTelemetry.verifyExportedTraces();
+
+        // verify nothing sent via the default exporter
+        defaultExporterTelemetry.verifyNoExportedTraces();
+    }
+
+    public static class DefaultExporterDisabledProfile implements QuarkusTestProfile {
+        // azure exporter has runtime config in build steps
+        // https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.extension-loader.report-runtime-config-at-deployment", "warn");
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterEnabledIT.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterEnabledIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.external.exporter.azure;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DefaultExporterEnabledIT extends DefaultExporterEnabledTest {
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterEnabledTest.java
+++ b/integration-tests/opentelemetry-external-exporter/src/test/java/io/quarkus/it/external/exporter/azure/DefaultExporterEnabledTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.external.exporter.azure;
+
+import static io.restassured.RestAssured.when;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.external.exporter.ExporterTestBase;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verify that OpenTelemetry traces are sent using CDI and external exporters when the default traces exporter
+ * is enabled.
+ */
+@QuarkusTest
+@TestProfile(DefaultExporterEnabledTest.DefaultTracesExportersEnabledProfile.class)
+public class DefaultExporterEnabledTest extends ExporterTestBase {
+
+    @Test
+    void defaultExporterEnabled() throws InterruptedException {
+        when()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+
+        // wait for telemetry to be sent to Application Insights via the /v2.1/track API endpoint
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .until(azureExporterTelemetry.telemetryDataContainExport());
+
+        // wait a bit more to ensure all telemetry data has arrived
+        Thread.sleep(10_000);
+
+        // verify that telemetry was sent via the Azure exporter
+        azureExporterTelemetry.verifyExportedTraces();
+
+        // verify that traces were sent via the default exporter
+        defaultExporterTelemetry.verifyExportedTraces();
+    }
+
+    public static class DefaultTracesExportersEnabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    // azure exporter has runtime config in build steps
+                    // https://github.com/quarkiverse/quarkus-opentelemetry-exporter/pull/383
+                    "quarkus.extension-loader.report-runtime-config-at-deployment", "warn",
+                    "quarkus.otel.exporter.otlp.traces.experimental.dependent.default.enable", "true");
+        }
+    }
+}

--- a/integration-tests/opentelemetry-external-exporter/src/test/resources/otel-config.yaml
+++ b/integration-tests/opentelemetry-external-exporter/src/test/resources/otel-config.yaml
@@ -1,0 +1,30 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  debug:
+    verbosity: ${env:LOGGING_EXPORTER_VERBOSITY_LEVEL}
+  otlp:
+    endpoint: ${env:OTLP_EXPORTER_ENDPOINT}
+    tls:
+      insecure: true
+    compression: none
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug, otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [debug, otlp]
+    logs:
+      receivers: [otlp]
+      exporters: [debug, otlp]

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -389,6 +389,7 @@
                 <module>opentelemetry-reactive-messaging</module>
                 <module>opentelemetry-redis-instrumentation</module>
                 <module>opentelemetry-exporter-logging</module>
+                <module>opentelemetry-external-exporter</module>
                 <module>logging-json</module>
                 <module>jaxb</module>
                 <module>jaxp</module>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

For https://github.com/quarkusio/quarkus/issues/36500

We are unable to use runtime config in buildsteps to control the creation of synthetic-beans, so in order create an 'span-processor' for the default trace exporter we allow the build step the create the synthetic-bean and pass an argument to the 'Recorder' indicating whether an external exporter is present.   Depending on whether the new config is enabled, the recorder will create a `LateBoundSpanProcessor` or a `RemovableLateBoundSpanProcessor` instance, and any 'removable' instance is dropped in the `AutoConfiguredOpenTelemetrySdkBuilderCustomizer` allowing just the external exporter to remain.

When the default exporter is enabled two span processors will be added via 'builder-customizers'.  For instance,  a `BatchSpanProcessor` for the `AzureMonitorTraceExporter` (when using the Azure monitor), and a `LateBoundSpanProcessor` for the `VertxGrpxSpanExporter`.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

