### PR TITLE
Fix some ClassLoader leaks in QuarkusTests

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3519,6 +3519,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-junit-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-junit-component</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/test-framework/junit-common/pom.xml
+++ b/test-framework/junit-common/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-junit-common</artifactId>
+    <name>Quarkus - Test Framework - JUnit common elements</name>
+
+    <description>Elements shared with quarkus-junit-internal and quarkus-junit</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ClearCache.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/common/ClearCache.java
@@ -1,4 +1,4 @@
-package io.quarkus.test;
+package io.quarkus.test.junit.common;
 
 import java.beans.Introspector;
 import java.lang.reflect.Field;

--- a/test-framework/junit-internal/pom.xml
+++ b/test-framework/junit-internal/pom.xml
@@ -45,6 +45,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -67,6 +67,7 @@ import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.test.config.TestConfigProviderResolver;
+import io.quarkus.test.junit.common.ClearCache;
 import io.quarkus.value.registry.ValueRegistry;
 
 /**

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -75,6 +75,7 @@ import io.quarkus.test.common.RestAssuredStateManager;
 import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
+import io.quarkus.test.junit.common.ClearCache;
 import io.quarkus.value.registry.ValueRegistry;
 
 /**

--- a/test-framework/junit/pom.xml
+++ b/test-framework/junit/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>quarkus-junit-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -76,6 +76,7 @@ import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.test.junit.callback.QuarkusTestContext;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+import io.quarkus.test.junit.common.ClearCache;
 import io.quarkus.value.registry.ValueRegistry;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
@@ -618,6 +619,11 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     "Internal error: ClassLoader " + cl + " does not have a linked curated application.");
         }
         cl.getCuratedApplication().setEligibleForReuse(isSameCuratedApplication);
+
+        // Let's clear the class-based caches of JDK/libraries when we switch to another application
+        if (!isSameCuratedApplication) {
+            ClearCache.clearCaches();
+        }
 
         // TODO if classes are misordered, say because someone overrode the ordering, and there are profiles or resources,
         // we could try to start and application which has already been started, and fail with a mysterious error about

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/classloading/FacadeClassLoader.java
@@ -623,6 +623,18 @@ public final class FacadeClassLoader extends ClassLoader implements Closeable {
 
         configProviderResolverClass.getDeclaredMethod("setInstance", configProviderResolverClass)
                 .invoke(null, testConfigProviderResolver);
+
+        if (loader instanceof QuarkusClassLoader quarkusClassLoader) {
+            quarkusClassLoader.addCloseTask(() -> {
+                try {
+                    Method releaseMethod = testConfigProviderResolverClass.getMethod("releaseConfig",
+                            ClassLoader.class);
+                    releaseMethod.invoke(testConfigProviderResolver, quarkusClassLoader);
+                } catch (Exception e) {
+                    throw new IllegalStateException("Unable to release config of QuarkusTestConfigProviderResolver", e);
+                }
+            });
+        }
     }
 
     public boolean isServiceLoaderMechanism() {

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -19,6 +19,7 @@
         <module>h2</module>
         <module>grpc</module>
         <module>kubernetes-client</module>
+        <module>junit-common</module>
         <module>junit-config</module>
         <module>junit-internal</module>
         <module>junit</module>


### PR DESCRIPTION
Reproducer provided by @geoand: [test-test-profile.zip](https://github.com/user-attachments/files/25180924/test-test-profile.zip)

The CL leak could be observed by starting the app with `mvn quarkus:dev` and then doing multiple test executions with `r`.