### PR TITLE
Upgrade to Google Cloud Function framework 2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -185,7 +185,7 @@
         <google-http-client.version>1.47.1</google-http-client.version>
         <scram-client.version>3.2</scram-client.version>
         <picocli.version>4.7.7</picocli.version>
-        <google-cloud-functions.version>1.1.4</google-cloud-functions.version>
+        <google-cloud-functions.version>2.0.0</google-cloud-functions.version>
         <commons-compress.version>1.28.0</commons-compress.version> <!-- Please check with Java Operator SDK / Fabric8 team before updating -->
         <commons-text.version>1.15.0</commons-text.version>
         <gson.version>2.13.2</gson.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -156,7 +156,7 @@
         <failsafe.argLine.additional>${surefire.argLine.additional}</failsafe.argLine.additional>
 
         <!-- google cloud functions invoker-->
-        <gcf-invoker.version>1.4.1</gcf-invoker.version>
+        <gcf-invoker.version>2.0.0</gcf-invoker.version>
         <!-- Jakarta JMS API -->
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
 

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -185,14 +185,14 @@ This means that Cloud Build is not activated yet. To overcome this error, open t
 ====
 
 
-This command will give you as output a `httpsTrigger.url` that points to your function.
+This command will give you as output a `url` that points to your function.
 
 You can then call your endpoints via:
 
-- For Jakarta REST: {httpsTrigger.url}/hello
-- For servlet: {httpsTrigger.url}/servlet/hello
-- For Reactive Routes: {httpsTrigger.url}/vertx/hello
-- For Funqy: {httpsTrigger.url}/funqy
+- For Jakarta REST: `{url}/hello`
+- For servlet: `{url}/servlet/hello`
+- For Reactive Routes: `{url}/vertx/hello`
+- For Funqy: `{url}/funqy`
 
 == Testing locally
 

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -266,7 +266,7 @@ gcloud functions deploy quarkus-example-http \
 The entry point must always be set to `io.quarkus.gcp.functions.QuarkusHttpFunction` as this is the class that integrates Cloud Functions with Quarkus.
 ====
 
-This command will give you as output a `httpsTrigger.url` that points to your function.
+This command will give you as output a `url` that points to your function.
 
 === The BackgroundFunction
 


### PR DESCRIPTION
Closes #50904

I manually tested that you can still deploy and run a function in Google Cloud.

