### PR TITLE
Bring back stdout+stderr output from int-test

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -4,9 +4,11 @@ import static io.quarkus.test.common.http.TestHTTPResourceManager.host;
 import static io.quarkus.test.common.http.TestHTTPResourceManager.rootPath;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,6 +27,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import io.smallrye.common.os.OS;
 import io.smallrye.config.SmallRyeConfig;
@@ -70,7 +74,9 @@ public final class LauncherUtil {
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .redirectInput(ProcessBuilder.Redirect.INHERIT);
         pb.environment().putAll(env);
-        return pb.start();
+        var process = pb.start();
+        new Thread(new ProcessReader(process)).start();
+        return process;
     }
 
     /**
@@ -355,27 +361,84 @@ public final class LauncherUtil {
     }
 
     /**
-     * Used to drain the input of a launched process
+     * Captures stdout + stderr of the given process to {@code System.out} and {@code System.err}
+     * respectively.
+     *
+     * <p>
+     * The {@link #run()} method runs as long as the given {@link #process} is alive.
+     *
      */
-    private static class ProcessReader implements Runnable {
+    static final class ProcessReader implements Runnable {
+        private final Process process;
 
-        private final InputStream inputStream;
+        private final ByteArrayOutputStream stdoutBuffer = new ByteArrayOutputStream();
+        private final ByteArrayOutputStream stderrBuffer = new ByteArrayOutputStream();
+        private final byte[] readBuffer = new byte[100];
 
-        private ProcessReader(InputStream inputStream) {
-            this.inputStream = inputStream;
+        private final OutputStream outTo;
+        private final OutputStream errTo;
+
+        ProcessReader(Process process) {
+            this(process, System.out, System.err);
         }
 
+        @VisibleForTesting
+        ProcessReader(Process process, OutputStream outTo, OutputStream errTo) {
+            this.process = process;
+            this.outTo = outTo;
+            this.errTo = errTo;
+        }
+
+        @SuppressWarnings("BusyWait")
         @Override
         public void run() {
-            byte[] b = new byte[100];
-            int i;
-            try {
-                while ((i = inputStream.read(b)) > 0) {
-                    System.out.print(new String(b, 0, i, StandardCharsets.UTF_8));
+            try (var stdout = process.getInputStream(); var stderr = process.getErrorStream()) {
+                var exited = -1;
+                while (true) {
+                    if (exited == -1) {
+                        try {
+                            exited = process.exitValue();
+                        } catch (IllegalThreadStateException e) {
+                            // still running
+                        }
+                    }
+
+                    var anyData = flush(stderr, stderrBuffer, errTo);
+                    anyData |= flush(stdout, stdoutBuffer, outTo);
+
+                    if (exited != -1 && !anyData) {
+                        if (exited != 0) {
+                            System.err.println("Process exited with non-zero status: " + exited);
+                        }
+                        break;
+                    }
+
+                    Thread.sleep(1L);
                 }
-            } catch (IOException e) {
+                stderrBuffer.writeTo(errTo);
+                stdoutBuffer.writeTo(outTo);
+            } catch (IOException | InterruptedException e) {
                 //ignore
             }
+        }
+
+        private boolean flush(InputStream processStream, ByteArrayOutputStream buffer, OutputStream to)
+                throws IOException {
+            var available = processStream.available();
+            if (available > 0) {
+                var read = processStream.read(readBuffer, 0, available);
+                for (int i = 0; i < read; i++) {
+                    var b = readBuffer[i];
+                    buffer.write(b);
+                    if (b == 10) {
+                        // Flush line to stderr
+                        buffer.writeTo(to);
+                        buffer.reset();
+                    }
+                }
+                return available > read;
+            }
+            return false;
         }
     }
 

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
@@ -1,0 +1,80 @@
+package io.quarkus.test.common;
+
+import java.io.ByteArrayOutputStream;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@EnabledOnOs({ OS.LINUX, OS.MAC })
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestLauncherUtil {
+    @InjectSoftAssertions
+    protected SoftAssertions soft;
+
+    @Test
+    public void lastLineNoEOL() throws Exception {
+        var proc = new ProcessBuilder("/bin/bash", "-c",
+                "echo hello; echo world; echo oops > /dev/stderr; echo -n dogs; echo -n \" are great!\"").start();
+
+        var outCapture = new ByteArrayOutputStream();
+        var errCapture = new ByteArrayOutputStream();
+
+        var captureThread = new Thread(new LauncherUtil.ProcessReader(proc, outCapture, errCapture));
+        captureThread.start();
+        captureThread.join(120_000L);
+
+        soft.assertThatCode(proc::exitValue).doesNotThrowAnyException();
+        soft.assertThat(outCapture.toString()).isEqualTo("""
+                hello
+                world
+                dogs are great!""");
+        soft.assertThat(errCapture.toString()).isEqualTo("""
+                oops
+                """);
+    }
+
+    @Test
+    public void exitNon0() throws Exception {
+        var proc = new ProcessBuilder("/bin/bash", "-c", "echo hello; echo world; echo oops > /dev/stderr; echo dogs; exit 1")
+                .start();
+
+        var outCapture = new ByteArrayOutputStream();
+        var errCapture = new ByteArrayOutputStream();
+
+        var captureThread = new Thread(new LauncherUtil.ProcessReader(proc, outCapture, errCapture));
+        captureThread.start();
+        captureThread.join(120_000L);
+
+        soft.assertThatCode(proc::exitValue).doesNotThrowAnyException();
+        soft.assertThat(outCapture.toString()).isEqualTo("""
+                hello
+                world
+                dogs
+                """);
+        soft.assertThat(errCapture.toString()).isEqualTo("""
+                oops
+                """);
+    }
+
+    @Test
+    public void exitImmediately() throws Exception {
+        var proc = new ProcessBuilder("/bin/bash", "-c", "exit 1")
+                .start();
+
+        var outCapture = new ByteArrayOutputStream();
+        var errCapture = new ByteArrayOutputStream();
+
+        var captureThread = new Thread(new LauncherUtil.ProcessReader(proc, outCapture, errCapture));
+        captureThread.start();
+        captureThread.join(120_000L);
+
+        soft.assertThatCode(proc::exitValue).doesNotThrowAnyException();
+        soft.assertThat(outCapture.toString()).isEmpty();
+        soft.assertThat(errCapture.toString()).isEmpty();
+    }
+}


### PR DESCRIPTION
stdout and stderr are currently discarded for Quarkus integration tests (`@QuarkusIntegrationTest`). This makes it very difficult to debug issues when the launched Quarkus process exits early.

This change brings back the original, thread-based "piping" of the laucned Quarkus process' stdout and stderr to `System.out` and `System.err` respectively.

The original two-threads approach has been replaced with a single thread polling both stderr and stdout, buffering full lines for each of those.

Related PRs and issues: #33062 (reverted by #33432), #50952, #33229
