### PR TITLE
Update images in catalog and use runtime images

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -4,6 +4,9 @@ import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
 import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem.JavaVersion.Status;
 
 /**
+ * IMPORTANT: when updating this file, please also update
+ * {@code devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json}
+ *
  * This class is used to define the container images that are used by Quarkus.
  * <p>
  * For each image, the image name and version are defined as constants:

--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -145,8 +145,8 @@
     "project": {
       "default-codestart": "rest",
       "codestart-data": {
-        "tooling-dockerfiles.dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.23",
-        "tooling-dockerfiles.dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.23",
+        "tooling-dockerfiles.dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}-runtime:1.24",
+        "tooling-dockerfiles.dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24",
         "tooling-dockerfiles.dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.7",
         "tooling-dockerfiles.dockerfile.native-micro.from": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
       },


### PR DESCRIPTION
We have been using the builder images for ages, which is clearly not the intent: these Dockerfiles are to create runtime images so we should use the OpenJDK runtime image.

Fixes #52384