### PR TITLE
Improve test orderer logic to honour type prefixes and secondary orderer across profiles

### DIFF
--- a/integration-tests/reactive-messaging-kafka/src/test/resources/junit-platform.properties
+++ b/integration-tests/reactive-messaging-kafka/src/test/resources/junit-platform.properties
@@ -1,1 +1,0 @@
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -1,12 +1,10 @@
 package io.quarkus.test.junit.util;
 
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -15,8 +13,8 @@ import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;
 import org.junit.jupiter.api.Nested;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.TestResourceScope;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
@@ -29,13 +27,9 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
  * restarts by grouping them by their {@link TestProfile}, {@link WithTestResource}, and {@link QuarkusTestResource}
  * annotation(s).
  * <p/>
- * By default, Quarkus*Tests not using any profile come first, then classes using a profile (in groups) and then all other
+ * By default, QuarkusTests not using any profile come first, then QuarkusMainTests, then QuarkusIntegrationTests, then all
+ * other
  * non-Quarkus tests (e.g. plain unit tests).<br/>
- * Quarkus*Tests with {@linkplain WithTestResource#scope() matching resources} or
- * {@linkplain QuarkusTestResource#restrictToAnnotatedClass() restricted} {@code QuarkusTestResource} come
- * after tests with profiles and Quarkus*Tests with only unrestricted resources are handled like tests without a profile (come
- * first).
- * <p/>
  * Internally, ordering is based on prefixes that are prepended to a secondary order suffix (by default the fully qualified
  * name of the respective test class), with the fully qualified class name of the
  * {@link io.quarkus.test.junit.QuarkusTestProfile QuarkusTestProfile} as an infix (if present).
@@ -46,6 +40,8 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
  * The secondary order suffix can be changed via {@value #CFGKEY_SECONDARY_ORDERER}, e.g. a value of
  * {@link org.junit.jupiter.api.ClassOrderer.Random org.junit.jupiter.api.ClassOrderer$Random} will order the test classes
  * within one group randomly instead by class name.
+ * That order will also generally be maintained across groups, with each group running according to the position of its earliest
+ * entry.
  * <p/>
  * Limitations:
  * <ul>
@@ -56,27 +52,23 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
 public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST = "20_";
-    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES = "30_";
-    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE = "40_";
-    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES = "45_";
+    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_MAIN_TEST = "30_";
+    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_INTEGRATION_TEST = "40_";
     protected static final String DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST = "60_";
 
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST = "junit.quarkus.orderer.prefix.quarkus-test";
 
-    static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES = "junit.quarkus.orderer.prefix.quarkus-test-with-matching-resource";
+    static final String CFGKEY_ORDER_PREFIX_QUARKUS_INTEGRATION_TEST = "junit.quarkus.orderer.prefix.quarkus-integration-test";
 
-    static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE = "junit.quarkus.orderer.prefix.quarkus-test-with-profile";
-
-    static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES = "junit.quarkus.orderer.prefix.quarkus-test-with-restricted-resource";
+    static final String CFGKEY_ORDER_PREFIX_QUARKUS_MAIN_TEST = "junit.quarkus.orderer.prefix.quarkus-main-test";
 
     static final String CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST = "junit.quarkus.orderer.prefix.non-quarkus-test";
 
     static final String CFGKEY_SECONDARY_ORDERER = "junit.quarkus.orderer.secondary-orderer";
 
     private final String prefixQuarkusTest;
-    private final String prefixQuarkusTestWithProfile;
-    private final String prefixQuarkusTestWithRestrictedResource;
-    private final String prefixQuarkusTestWithMatchingResource;
+    private final String prefixQuarkusMainTest;
+    private final String prefixQuarkusIntegrationTest;
     private final String prefixNonQuarkusTest;
     private final Optional<String> secondaryOrderer;
 
@@ -84,14 +76,11 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
         Config config = ConfigProvider.getConfig();
         this.prefixQuarkusTest = config.getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_TEST, String.class)
                 .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST);
-        this.prefixQuarkusTestWithMatchingResource = config
-                .getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES, String.class)
-                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES);
-        this.prefixQuarkusTestWithProfile = config.getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE, String.class)
-                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE);
-        this.prefixQuarkusTestWithRestrictedResource = config
-                .getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES, String.class)
-                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES);
+        this.prefixQuarkusMainTest = config
+                .getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_MAIN_TEST, String.class)
+                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_MAIN_TEST);
+        this.prefixQuarkusIntegrationTest = config.getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_INTEGRATION_TEST, String.class)
+                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_INTEGRATION_TEST);
         this.prefixNonQuarkusTest = config.getOptionalValue(CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST, String.class)
                 .orElse(DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST);
         this.secondaryOrderer = config.getOptionalValue(CFGKEY_SECONDARY_ORDERER, String.class);
@@ -99,65 +88,19 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     QuarkusTestProfileAwareClassOrderer(
             final String prefixQuarkusTest,
-            final String prefixQuarkusTestWithMatchingResource,
-            final String prefixQuarkusTestWithProfile,
-            final String prefixQuarkusTestWithRestrictedResource,
+            final String prefixQuarkusMainTest,
+            final String prefixQuarkusIntegrationTest,
             final String prefixNonQuarkusTest,
             final Optional<String> secondaryOrderer) {
         this.prefixQuarkusTest = prefixQuarkusTest;
-        this.prefixQuarkusTestWithMatchingResource = prefixQuarkusTestWithMatchingResource;
-        this.prefixQuarkusTestWithProfile = prefixQuarkusTestWithProfile;
-        this.prefixQuarkusTestWithRestrictedResource = prefixQuarkusTestWithRestrictedResource;
+        this.prefixQuarkusMainTest = prefixQuarkusMainTest;
+        this.prefixQuarkusIntegrationTest = prefixQuarkusIntegrationTest;
         this.prefixNonQuarkusTest = prefixNonQuarkusTest;
         this.secondaryOrderer = secondaryOrderer;
     }
 
     @Override
     public void orderClasses(ClassOrdererContext context) {
-        // don't do anything if there is just one test class or the current order request is for @Nested tests
-        if (context.getClassDescriptors()
-                .size() <= 1 || context.getClassDescriptors()
-                        .get(0)
-                        .isAnnotated(Nested.class)) {
-            return;
-        }
-
-        // In many cases (like QuarkusTest), the heavy lifting of understanding profiles and resources has been done elsewhere; we just need to group tests by classloader
-        // However, for integration tests and main tests, profiles will not have been read
-        long classloaderCount = context.getClassDescriptors()
-                .stream()
-                .map(d -> d.getTestClass()
-                        .getClassLoader())
-                .distinct()
-                .count();
-
-        // TODO this check probably isn't enough, because if there's a mix of QuarkusMain and other tests, we will have more than one classloader, but the others will still need sorting
-        // TODO a safer check will be to assume anything loaded with a QuarkusClassLoader is pre-sorted, but to sort anything else.
-        // TODO So sort by classloader, and then sort the pile which is in the system (or whatever) classloader
-        if (classloaderCount > 1) {
-
-            // If we sort first before applying the classloader sorting, the original order will be preserved within classloader groups
-            secondaryOrderer
-                    .map(fqcn -> {
-                        try {
-                            return (ClassOrderer) Class.forName(fqcn).getDeclaredConstructor().newInstance();
-                        } catch (ReflectiveOperationException e) {
-                            throw new IllegalArgumentException("Failed to instantiate " + fqcn, e);
-                        }
-                    })
-                    .orElseGet(ClassName::new).orderClasses(context);
-
-            context.getClassDescriptors().sort(Comparator.<ClassDescriptor, String> comparing(o -> o.getTestClass()
-                    .getClassLoader()
-                    .getName()));
-
-        } else {
-            orderByProfiles(context);
-        }
-    }
-
-    private void orderByProfiles(ClassOrdererContext context) {
-
         // don't do anything if there is just one test class or the current order request is for @Nested tests
         if (context.getClassDescriptors()
                 .size() <= 1 || context.getClassDescriptors()
@@ -178,111 +121,46 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
                 .orElseGet(ClassName::new).orderClasses(context);
 
         var classDescriptors = context.getClassDescriptors();
-        var firstPassIndexMap = IntStream.range(0, classDescriptors.size()).boxed()
-                .collect(Collectors.toMap(classDescriptors::get, i -> String.format("%06d", i)));
 
-        // second pass: apply the actual Quarkus aware ordering logic, using the first pass indices as order key suffixes
-        classDescriptors.sort(Comparator.comparing(classDescriptor -> {
-            var secondaryOrderSuffix = firstPassIndexMap.get(classDescriptor);
-            Optional<String> customOrderKey = getCustomOrderKey(classDescriptor, context, secondaryOrderSuffix);
-            if (customOrderKey.isPresent()) {
-                return customOrderKey.get();
-            }
-            if (classDescriptor.isAnnotated(QuarkusTest.class)
-                    || classDescriptor.isAnnotated(QuarkusIntegrationTest.class)
-                    || classDescriptor.isAnnotated(QuarkusMainTest.class)) {
-                return classDescriptor.findAnnotation(TestProfile.class)
-                        .map(TestProfile::value)
-                        .map(profileClass -> prefixQuarkusTestWithProfile + profileClass.getName() + "@" + secondaryOrderSuffix)
-                        .orElseGet(() -> {
-                            // TODO it should be possible to re-use the resource key here for (a) less code and (b) guaranteed consistency
-                            // TODO we should probably also extend the key logic to a profile key ?
-                            String prefix = prefixQuarkusTest;
-                            String suffix = "";
-                            TestResourceScope mostLimitedScope = mostLimitedScope(classDescriptor);
-                            if (mostLimitedScope != null) {
-                                if (mostLimitedScope == TestResourceScope.RESTRICTED_TO_CLASS) {
-                                    prefix = prefixQuarkusTestWithRestrictedResource;
-                                } else {
-                                    prefix = prefixQuarkusTestWithMatchingResource;
-                                    suffix = String.join(",",
-                                            lifecycleManagerClassNamesForNonRestricted(classDescriptor));
-                                }
-                            }
-                            return prefix + suffix + secondaryOrderSuffix;
-                        });
-            }
-            return prefixNonQuarkusTest + secondaryOrderSuffix;
-        }));
+        // make a map recording the positions of each class descriptor after the initial sort
+        Map<ClassDescriptor, Integer> firstPassIndex = new HashMap<>();
+        for (int i = 0; i < classDescriptors.size(); i++) {
+            firstPassIndex.put(classDescriptors.get(i), i);
+        }
+
+        // second pass: group by classloaders, and then assign an order to each classloader, based on the minimum secondary order within that group
+        // Why group by classloader? The heavy lifting of understanding profiles and resources has been done elsewhere for Quarkus tests
+        Map<ClassLoader, Integer> classLoaderOrder = classDescriptors.stream()
+                .collect(Collectors.groupingBy(
+                        cd -> cd.getTestClass().getClassLoader(),
+                        Collectors.collectingAndThen(
+                                Collectors.mapping(firstPassIndex::get,
+                                        Collectors.minBy(Integer::compare)),
+                                opt -> opt.orElse(Integer.MAX_VALUE))));
+
+        // third pass: apply the actual Quarkus aware ordering logic, using the first and second pass indices as order key suffixes
+        classDescriptors.sort(
+                Comparator
+                        .comparing((ClassDescriptor cd) -> getTypePrefix(cd))
+                        .thenComparing(cd -> classLoaderOrder.get(cd.getTestClass().getClassLoader()))
+                        .thenComparing(firstPassIndex::get));
     }
 
-    private TestResourceScope mostLimitedScope(ClassDescriptor classDescriptor) {
-        TestResourceScope result = null;
-        for (WithTestResource annotation : classDescriptor.findRepeatableAnnotations(WithTestResource.class)) {
-            if (isMetaTestResource(annotation, classDescriptor)) {
-                result = TestResourceScope.RESTRICTED_TO_CLASS;
+    private String getTypePrefix(ClassDescriptor classDescriptor) {
+        // There are lots of ways something can be declared as a Quarkus test, and only some of them are annotations
+        // Furthermore, isAnnotated only works for QuarkusTests if we reload the annotation class with the class's classloader
+        // But we do know any QuarkusTest, and only QuarkusTests, will be loaded with the QuarkusClassLoader
+        if (classDescriptor.getTestClass().getClassLoader() instanceof QuarkusClassLoader) {
+            return prefixQuarkusTest;
+        } else if (classDescriptor.isAnnotated(QuarkusIntegrationTest.class)) {
+            return prefixQuarkusIntegrationTest;
+        } else {
+            if (classDescriptor.isAnnotated(QuarkusMainTest.class)) {
+                return prefixQuarkusMainTest;
             } else {
-                TestResourceScope scope = annotation.scope();
-                if ((result == null) || (scope.compareTo(result) < 0)) {
-                    result = scope;
-                }
+                return prefixNonQuarkusTest;
             }
         }
 
-        for (QuarkusTestResource annotation : classDescriptor.findRepeatableAnnotations(QuarkusTestResource.class)) {
-            if (isMetaTestResource(annotation, classDescriptor) || annotation.restrictToAnnotatedClass()) {
-                result = TestResourceScope.RESTRICTED_TO_CLASS;
-            } else {
-                result = TestResourceScope.GLOBAL;
-            }
-        }
-
-        return result;
-    }
-
-    private Set<String> lifecycleManagerClassNamesForNonRestricted(ClassDescriptor classDescriptor) {
-        Set<String> result = new HashSet<>();
-        for (WithTestResource annotation : classDescriptor.findRepeatableAnnotations(WithTestResource.class)) {
-            TestResourceScope scope = annotation.scope();
-            if ((scope != TestResourceScope.RESTRICTED_TO_CLASS) && !isMetaTestResource(annotation, classDescriptor)) {
-                result.add(annotation.value().getSimpleName());
-            }
-        }
-
-        for (QuarkusTestResource annotation : classDescriptor.findRepeatableAnnotations(QuarkusTestResource.class)) {
-            if (!annotation.restrictToAnnotatedClass() && !isMetaTestResource(annotation, classDescriptor)) {
-                result.add(annotation.value().getSimpleName());
-            }
-        }
-
-        return result;
-    }
-
-    @Deprecated(forRemoval = true)
-    private boolean isMetaTestResource(QuarkusTestResource resource, ClassDescriptor classDescriptor) {
-        return Arrays.stream(classDescriptor.getTestClass()
-                .getAnnotationsByType(QuarkusTestResource.class))
-                .map(QuarkusTestResource::value)
-                .noneMatch(resource.value()::equals);
-    }
-
-    private boolean isMetaTestResource(WithTestResource resource, ClassDescriptor classDescriptor) {
-        return Arrays.stream(classDescriptor.getTestClass()
-                .getAnnotationsByType(WithTestResource.class))
-                .map(WithTestResource::value)
-                .noneMatch(resource.value()::equals);
-    }
-
-    /**
-     * Template method that provides an optional custom order key for the given {@code classDescriptor}.
-     *
-     * @param classDescriptor the respective test class
-     * @param context for config lookup
-     * @param secondaryOrderSuffix the secondary order suffix that was calculated by the secondary orderer
-     * @return optional custom order key for the given test class
-     */
-    protected Optional<String> getCustomOrderKey(ClassDescriptor classDescriptor, ClassOrdererContext context,
-            String secondaryOrderSuffix) {
-        return Optional.empty();
     }
 }

--- a/test-framework/junit/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
+++ b/test-framework/junit/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
@@ -2,6 +2,7 @@ package io.quarkus.test.junit.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,9 +31,9 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.common.TestResourceScope;
 import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 import io.quarkus.test.junit.util.dummyclasses.Test07;
 import io.quarkus.test.junit.util.dummyclasses.Test08;
 import io.quarkus.test.junit.util.dummyclasses.Test09;
@@ -56,18 +57,18 @@ class QuarkusTestProfileAwareClassOrdererTest {
     }
 
     @Test
-    void multipleClassloaders() throws IOException {
+    void multipleClassloaders() {
         ByteClassLoader a = new ByteClassLoader("a");
-        Class cla1 = a.cloneClass(Test08.class);
-        Class cla2 = a.cloneClass(Test09.class);
+        Class<?> cla1 = a.cloneClass(Test08.class);
+        Class<?> cla2 = a.cloneClass(Test09.class);
         ByteClassLoader b = new ByteClassLoader("b");
-        Class clb1 = b.cloneClass(Test07.class);
-        Class clb2 = b.cloneClass(Test10.class);
+        Class<?> clb1 = b.cloneClass(Test07.class);
+        Class<?> clb2 = b.cloneClass(Test10.class);
 
-        ClassDescriptor quarkusTesta1Desc = quarkusDescriptorMock(cla1, null);
-        ClassDescriptor quarkusTesta2Desc = quarkusDescriptorMock(cla2, null);
-        ClassDescriptor quarkusTestb1Desc = quarkusDescriptorMock(clb1, null);
-        ClassDescriptor quarkusTestb2Desc = quarkusDescriptorMock(clb2, null);
+        ClassDescriptor quarkusTesta1Desc = quarkusDescriptorMock(cla1);
+        ClassDescriptor quarkusTesta2Desc = quarkusDescriptorMock(cla2);
+        ClassDescriptor quarkusTestb1Desc = quarkusDescriptorMock(clb1);
+        ClassDescriptor quarkusTestb2Desc = quarkusDescriptorMock(clb2);
 
         List<ClassDescriptor> input = Arrays.asList(
                 quarkusTestb2Desc,
@@ -80,26 +81,29 @@ class QuarkusTestProfileAwareClassOrdererTest {
 
         new QuarkusTestProfileAwareClassOrderer().orderClasses(contextMock);
 
-        assertThat(input).containsExactly(
+        // We don't care which order the classloader groups are in, as long as they're grouped
+        assertThat(input).containsSequence(
                 quarkusTesta1Desc,
-                quarkusTesta2Desc,
+                quarkusTesta2Desc);
+
+        assertThat(input).containsSequence(
                 quarkusTestb1Desc,
                 quarkusTestb2Desc);
     }
 
     @Test
-    void multipleClassloadersAndSecondaryOrderer() throws IOException {
+    void multipleClassloadersAndSecondaryOrdererOrdersWithinClassloaderGroups() {
         ByteClassLoader a = new ByteClassLoader("a");
-        Class cla1 = a.cloneClass(Test07.class);
-        Class cla2 = a.cloneClass(Test08.class);
-        Class cla3 = a.cloneClass(Test09.class);
+        Class<?> cla1 = a.cloneClass(Test07.class);
+        Class<?> cla2 = a.cloneClass(Test08.class);
+        Class<?> cla3 = a.cloneClass(Test09.class);
         ByteClassLoader b = new ByteClassLoader("b");
-        Class clb1 = b.cloneClass(Test10.class);
+        Class<?> clb1 = b.cloneClass(Test10.class);
 
-        ClassDescriptor quarkusTesta1Desc = quarkusDescriptorMock(cla1, null, 4);
-        ClassDescriptor quarkusTesta2Desc = quarkusDescriptorMock(cla2, null, 6);
-        ClassDescriptor quarkusTesta3Desc = quarkusDescriptorMock(cla3, null, 2);
-        ClassDescriptor quarkusTestb1Desc = quarkusDescriptorMock(clb1, null, 1);
+        ClassDescriptor quarkusTesta1Desc = quarkusDescriptorMock(cla1, 4);
+        ClassDescriptor quarkusTesta2Desc = quarkusDescriptorMock(cla2, 6);
+        ClassDescriptor quarkusTesta3Desc = quarkusDescriptorMock(cla3, 2);
+        ClassDescriptor quarkusTestb1Desc = quarkusDescriptorMock(clb1, 1);
 
         List<ClassDescriptor> input = Arrays.asList(
                 quarkusTesta3Desc,
@@ -111,19 +115,111 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 .getClassDescriptors();
 
         // change secondary orderer from ClassName to OrderAnnotation
-        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "45_", "50_", "60_",
+        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "60_",
                 Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
 
-        assertThat(input).containsExactly(
+        assertThat(input).containsExactly(quarkusTestb1Desc,
+                quarkusTesta3Desc,
+                quarkusTesta1Desc,
+                quarkusTesta2Desc);
+    }
+
+    // In this test, there are multiple groups of 1, so the secondary orderer should just apply as if there were no classloaders
+    @Test
+    void multipleClassloadersAndSecondaryOrdererOrdersBetweenClassloaderGroups() {
+        ByteClassLoader a = new ByteClassLoader("a");
+        Class<?> cla1 = a.cloneClass(Test07.class);
+        ByteClassLoader b = new ByteClassLoader("b");
+        Class<?> clb1 = b.cloneClass(Test10.class);
+        ByteClassLoader c = new ByteClassLoader("c");
+        Class<?> clc1 = c.cloneClass(Test08.class);
+        ByteClassLoader d = new ByteClassLoader("d");
+        Class<?> cld1 = d.cloneClass(Test09.class);
+
+        ClassDescriptor quarkusTesta1Desc = quarkusDescriptorMock(cla1, 4);
+        ClassDescriptor quarkusTesta2Desc = quarkusDescriptorMock(clc1, 6);
+        ClassDescriptor quarkusTesta3Desc = quarkusDescriptorMock(cld1, 2);
+        ClassDescriptor quarkusTestb1Desc = quarkusDescriptorMock(clb1, 1);
+
+        List<ClassDescriptor> input = Arrays.asList(
                 quarkusTesta3Desc,
                 quarkusTesta1Desc,
                 quarkusTesta2Desc,
                 quarkusTestb1Desc);
+
+        doReturn(input).when(contextMock)
+                .getClassDescriptors();
+
+        // change secondary orderer from ClassName to OrderAnnotation
+        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "60_",
+                Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
+
+        assertThat(input).containsExactly(
+                quarkusTestb1Desc,
+                quarkusTesta3Desc,
+                quarkusTesta1Desc,
+                quarkusTesta2Desc);
+    }
+
+    @Test
+    void multipleClassloadersAndSecondaryOrdererOrdersBetweenAndWithinClassloaderGroups() {
+        ByteClassLoader a = new ByteClassLoader("a");
+        Class<?> cla1 = a.cloneClass(Test07.class);
+        Class<?> cla2 = a.cloneClass(Test08.class);
+        ByteClassLoader b = new ByteClassLoader("b");
+        Class<?> clb1 = b.cloneClass(Test07.class);
+        Class<?> clb2 = b.cloneClass(Test10.class);
+        ByteClassLoader c = new ByteClassLoader("c");
+        Class<?> clc1 = c.cloneClass(Test07.class);
+        Class<?> clc2 = c.cloneClass(Test08.class);
+        Class<?> clc3 = c.cloneClass(Test09.class);
+        ByteClassLoader d = new ByteClassLoader("d");
+        Class<?> cld1 = d.cloneClass(Test08.class);
+        Class<?> cld2 = d.cloneClass(Test09.class);
+
+        ClassDescriptor quarkusTesta1Desc = quarkusDescriptorMock(cla1, 20);
+        ClassDescriptor quarkusTesta2Desc = quarkusDescriptorMock(cla2, 1);
+        ClassDescriptor quarkusTestb1Desc = quarkusDescriptorMock(clb1, 10);
+        ClassDescriptor quarkusTestb2Desc = quarkusDescriptorMock(clb2, 3);
+        ClassDescriptor quarkusTestc1Desc = quarkusDescriptorMock(clc1, 5);
+        ClassDescriptor quarkusTestc2Desc = quarkusDescriptorMock(clc2, 15);
+        ClassDescriptor quarkusTestc3Desc = quarkusDescriptorMock(clc3, 7);
+        ClassDescriptor quarkusTestd1Desc = quarkusDescriptorMock(cld1, 2);
+        ClassDescriptor quarkusTestd2Desc = quarkusDescriptorMock(cld2, 8);
+
+        List<ClassDescriptor> input = Arrays.asList(
+                quarkusTesta2Desc,
+                quarkusTestb2Desc,
+                quarkusTestc2Desc,
+                quarkusTestc3Desc,
+                quarkusTesta1Desc,
+                quarkusTestd1Desc,
+                quarkusTestb1Desc,
+                quarkusTestc1Desc,
+                quarkusTestd2Desc);
+
+        doReturn(input).when(contextMock)
+                .getClassDescriptors();
+
+        // change secondary orderer from ClassName to OrderAnnotation
+        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "60_",
+                Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
+
+        assertThat(input).containsExactly(
+                quarkusTesta2Desc,
+                quarkusTesta1Desc,
+                quarkusTestd1Desc,
+                quarkusTestd2Desc,
+                quarkusTestb2Desc,
+                quarkusTestb1Desc,
+                quarkusTestc1Desc,
+                quarkusTestc3Desc,
+                quarkusTestc2Desc);
     }
 
     @Test
     void allVariants() {
-        ClassDescriptor quarkusTest1Desc = quarkusDescriptorMock(Test01.class, null);
+        ClassDescriptor quarkusTest1Desc = quarkusDescriptorMock(Test01.class, 0);
         ClassDescriptor quarkusTest2b = quarkusDescriptorMock(Test02b.class, Manager3.class, false,
                 WithTestResource.class);
         ClassDescriptor quarkusTest2a = quarkusDescriptorMock(Test02a.class,
@@ -134,10 +230,10 @@ class QuarkusTestProfileAwareClassOrdererTest {
         ClassDescriptor quarkusTest3aDesc = quarkusDescriptorMock(Test03a.class, Manager4.class, false, WithTestResource.class);
         ClassDescriptor quarkusTest3bDesc = quarkusDescriptorMock(Test03b.class, Manager4.class, false,
                 QuarkusTestResource.class);
-        ClassDescriptor quarkusTest1aDesc = quarkusDescriptorMock(Test01a.class, null);
-        ClassDescriptor quarkusTestWithProfile1Desc = quarkusDescriptorMock(Test04.class, Profile1.class);
-        ClassDescriptor quarkusTestWithProfile2Test4Desc = quarkusDescriptorMock(Test05.class, Profile2.class);
-        ClassDescriptor quarkusTestWithProfile2Test5Desc = quarkusDescriptorMock(Test06.class, Profile2.class);
+        ClassDescriptor quarkusTest1aDesc = quarkusDescriptorMock(Test01a.class);
+        ClassDescriptor quarkusTestWithProfile1Desc = quarkusDescriptorMock(Test04.class);
+        ClassDescriptor quarkusTestWithProfile2Test5Desc = quarkusDescriptorMock(Test05.class);
+        ClassDescriptor quarkusTestWithProfile2Test6Desc = quarkusDescriptorMock(Test06.class);
         ClassDescriptor quarkusTestWithRestrictedResourceDesc = quarkusDescriptorMock(Test07.class, Manager2.class, true,
                 WithTestResource.class);
         ClassDescriptor quarkusTestWithRestrictedResourceDesc2 = quarkusDescriptorMock(Test07.class, Manager2.class, true,
@@ -153,12 +249,12 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 nonQuarkusTest2Desc,
                 quarkusTest2Desc,
                 quarkusTestWithRestrictedResourceDesc2,
-                quarkusTestWithProfile2Test5Desc,
+                quarkusTestWithProfile2Test6Desc,
                 quarkusTest1aDesc,
                 nonQuarkusTest1Desc,
                 quarkusTestWithMetaResourceDesc,
                 quarkusTest1Desc,
-                quarkusTestWithProfile2Test4Desc,
+                quarkusTestWithProfile2Test5Desc,
                 quarkusTestWithMetaResourceDesc2,
                 quarkusTest3Desc,
                 quarkusTest2b,
@@ -180,8 +276,8 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 quarkusTest3aDesc,
                 quarkusTest3bDesc,
                 quarkusTestWithProfile1Desc,
-                quarkusTestWithProfile2Test4Desc,
                 quarkusTestWithProfile2Test5Desc,
+                quarkusTestWithProfile2Test6Desc,
                 quarkusTestWithRestrictedResourceDesc,
                 quarkusTestWithRestrictedResourceDesc2,
                 quarkusTestWithMetaResourceDesc,
@@ -192,20 +288,20 @@ class QuarkusTestProfileAwareClassOrdererTest {
 
     @Test
     void configuredPrefix() {
-        ClassDescriptor quarkusTestDesc = quarkusDescriptorMock(Test01.class, null);
+        ClassDescriptor quarkusTestDesc = quarkusDescriptorMock(Test01.class, 0, QuarkusMainTest.class);
         ClassDescriptor nonQuarkusTestDesc = descriptorMock(Test01a.class);
         List<ClassDescriptor> input = Arrays.asList(quarkusTestDesc, nonQuarkusTestDesc);
         doReturn(input).when(contextMock)
                 .getClassDescriptors();
 
-        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "45_", "01_", Optional.empty()).orderClasses(contextMock);
+        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "01_", Optional.empty()).orderClasses(contextMock);
 
         assertThat(input).containsExactly(nonQuarkusTestDesc, quarkusTestDesc);
     }
 
     @Test
     void secondaryOrderer() {
-        ClassDescriptor quarkusTest1Desc = quarkusDescriptorMock(Test01.class, null);
+        ClassDescriptor quarkusTest1Desc = quarkusDescriptorMock(Test01.class, 0, QuarkusIntegrationTest.class);
         ClassDescriptor nonQuarkusTest1Desc = descriptorMock(Test09.class);
         ClassDescriptor nonQuarkusTest2Desc = descriptorMock(Test10.class);
         var orderMock = Mockito.mock(Order.class);
@@ -218,32 +314,13 @@ class QuarkusTestProfileAwareClassOrdererTest {
         doReturn(input).when(contextMock)
                 .getClassDescriptors();
 
-        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "45_", "60_",
+        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "60_",
                 Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
 
         assertThat(input).containsExactly(
                 quarkusTest1Desc,
                 nonQuarkusTest2Desc,
                 nonQuarkusTest1Desc);
-    }
-
-    @Test
-    void customOrderKey() {
-        ClassDescriptor quarkusTest1Desc = quarkusDescriptorMock(Test01.class, null);
-        ClassDescriptor quarkusTest2Desc = quarkusDescriptorMock(Test01a.class, null);
-        List<ClassDescriptor> input = Arrays.asList(quarkusTest1Desc, quarkusTest2Desc);
-        doReturn(input).when(contextMock)
-                .getClassDescriptors();
-
-        new QuarkusTestProfileAwareClassOrderer() {
-            @Override
-            protected Optional<String> getCustomOrderKey(ClassDescriptor classDescriptor, ClassOrdererContext context,
-                    String secondaryOrderSuffix) {
-                return classDescriptor == quarkusTest2Desc ? Optional.of("00_first") : Optional.empty();
-            }
-        }.orderClasses(contextMock);
-
-        assertThat(input).containsExactly(quarkusTest2Desc, quarkusTest1Desc);
     }
 
     private ClassDescriptor descriptorMock(Class<?> testClass) {
@@ -255,26 +332,39 @@ class QuarkusTestProfileAwareClassOrdererTest {
         return mock;
     }
 
-    private ClassDescriptor quarkusDescriptorMock(Class<?> testClass, Class<? extends QuarkusTestProfile> profileClass) {
-        return quarkusDescriptorMock(testClass, profileClass, -1);
+    private ClassDescriptor quarkusDescriptorMock(Class<?> testClass) {
+        return quarkusDescriptorMock(testClass, -1);
     }
 
-    private ClassDescriptor quarkusDescriptorMock(Class<?> testClass, Class<? extends QuarkusTestProfile> profileClass,
-            int order) {
+    private ClassDescriptor quarkusDescriptorMock(Class<?> testClass, int i) {
+        return quarkusDescriptorMock(testClass, i, QuarkusTest.class);
+    }
+
+    // Note that this mock cannot properly represent QuarkusTests, because the implementation checks the type of the creating classloader
+    // In practice, that only affects the prefix sorting
+    private ClassDescriptor quarkusDescriptorMock(Class<?> testClass,
+            int order, Class<? extends Annotation> annotation) {
         ClassDescriptor mock = descriptorMock(testClass);
-        when(mock.isAnnotated(QuarkusTest.class)).thenReturn(true);
-        if (profileClass != null) {
-            TestProfile profileMock = Mockito.mock(TestProfile.class);
-            doReturn(profileClass).when(profileMock)
-                    .value();
-            when(mock.findAnnotation(TestProfile.class)).thenReturn(Optional.of(profileMock));
-        }
+
+        // This mock is an attempt to simulate the real behaviour of
+        // the JUnit `isAnnotated`; it has to match both class name and classloader,
+        // and in general the classloader would be the classloader of the test class
+        String annotationName = annotation != null ? annotation.getName() : "";
+
+        when(mock.isAnnotated(
+                argThat(c -> c.getName().equals(annotationName)
+                        && testClass.getClassLoader().equals(c.getClassLoader()))))
+                .thenReturn(true);
+
         if (order > 0) {
             Order orderMock = Mockito.mock(Order.class);
             doReturn(order).when(orderMock).value();
             when(mock.findAnnotation(Order.class)).thenReturn(Optional.of(orderMock));
 
         }
+        when(mock.toString())
+                .thenReturn(
+                        testClass.getSimpleName() + " - CL: " + testClass.getClassLoader().getName() + " - order: " + order);
         return mock;
     }
 
@@ -358,31 +448,31 @@ class QuarkusTestProfileAwareClassOrdererTest {
     private static class Test06 {
     }
 
-    private static class Profile1 implements QuarkusTestProfile {
+    private interface Manager1 extends QuarkusTestResourceLifecycleManager {
     }
 
-    private static class Profile2 implements QuarkusTestProfile {
+    private interface Manager2 extends QuarkusTestResourceLifecycleManager {
     }
 
-    private static interface Manager1 extends QuarkusTestResourceLifecycleManager {
+    private interface Manager3 extends QuarkusTestResourceLifecycleManager {
     }
 
-    private static interface Manager2 extends QuarkusTestResourceLifecycleManager {
-    }
-
-    private static interface Manager3 extends QuarkusTestResourceLifecycleManager {
-    }
-
-    private static interface Manager4 extends QuarkusTestResourceLifecycleManager {
+    private interface Manager4 extends QuarkusTestResourceLifecycleManager {
     }
 
     public static class ByteClassLoader extends ClassLoader {
 
-        public ByteClassLoader(String name) throws IOException {
+        public ByteClassLoader(String name) {
             super(name, null);
+
+            // Pre-load some annotations we will need
+            cloneClass(QuarkusTest.class);
+            cloneClass(QuarkusMainTest.class);
+            cloneClass(QuarkusIntegrationTest.class);
+
         }
 
-        protected Class<?> cloneClass(final Class clazz) {
+        protected Class<?> cloneClass(final Class<?> clazz) {
 
             try {
                 String resourceName = clazz.getName()


### PR DESCRIPTION
As part of the test classloading rewrite, I bypass the old test ordering logic in most cases, and use a quicker method based on the classloader – things in the same classloader should be grouped together. However, this means that the old (undocumented) config such as `junit.quarkus.orderer.prefix.quarkus-test-with-profile` which can be used to adjust whether plain tests run before or after quarkus tests no longer works. 

I tried switching back to use the old reasoning based on examining annotations and resources. This was *not* a good idea. (Pre classloading rewrite, running tests in the wrong order was a functional problem, but now it's a functional one.) 

So I've implemented a hybrid approach, which honours the old contract (sort of), but also keys off the classloader to make sure that we never try and run a QuarkusTest after closing its application. 

I've added a more powerful sorting capability, too. I noticed that the reactive-messaging-kafka tests don't pass with the current classloader-based orderer, because it only sorts within a profile group, rather than between them. 

I removed the support for CustomOrderKey, since it wasn’t used anywhere in the core codebase and added to the complexity. A secondary orderer should be used instead.

I also tidied up some compiler warnings in the test. 
 
- Fixes: #49755