### PR TITLE
Really bring back stdout+stderr output from int-test

### DIFF
--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
@@ -1,6 +1,9 @@
 package io.quarkus.test.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayOutputStream;
+import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -59,6 +62,41 @@ public class TestLauncherUtil {
         soft.assertThat(errCapture.toString()).isEqualTo("""
                 oops
                 """);
+    }
+
+    @Test
+    public void lotsOfChars() throws Exception {
+        var longString = "a".repeat(10_000);
+        var proc = new ProcessBuilder("/bin/bash", "-c",
+                "echo hello; echo " + longString + "; echo oops > /dev/stderr; echo " + longString + " > /dev/stderr")
+                .start();
+
+        var outCapture = new ByteArrayOutputStream();
+        var errCapture = new ByteArrayOutputStream();
+
+        var captureThread = new Thread(new LauncherUtil.ProcessReader(proc, outCapture, errCapture) {
+            // This override ensures that ProcessReader.flush() receive the "long strings" that
+            // exceed the read buffer size.
+            @Override
+            int checkExited(int exited) {
+                try {
+                    assertThat(proc.waitFor(120_000L, TimeUnit.MILLISECONDS));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return super.checkExited(exited);
+            }
+        });
+        captureThread.start();
+        captureThread.join(120_000L);
+
+        soft.assertThatCode(proc::exitValue).doesNotThrowAnyException();
+        soft.assertThat(outCapture.toString()).isEqualTo("""
+                hello
+                """ + longString + "\n");
+        soft.assertThat(errCapture.toString()).isEqualTo("""
+                oops
+                """ + longString + "\n");
     }
 
     @Test


### PR DESCRIPTION
... and fix an AIOB, if `available > readBuffer.length`

While #52382 added the necessary thread, stdout+stderr were still discarded.
