### PR TITLE
Native: Enable Netty JCTools' MpscUnboundedArrayQueue

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -21,9 +21,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.BooleanSupplier;
 
 import javax.crypto.NoSuchPaddingException;
@@ -395,15 +393,6 @@ final class Target_io_netty_bootstrap_AbstractBootstrap {
 
         return regFuture;
 
-    }
-}
-
-@TargetClass(className = "io.netty.channel.nio.NioEventLoop")
-final class Target_io_netty_channel_nio_NioEventLoop {
-
-    @Substitute
-    private static Queue<Runnable> newTaskQueue0(int maxPendingTasks) {
-        return new LinkedBlockingDeque<>();
     }
 }
 


### PR DESCRIPTION
I suggest we remove this substitution introduced in 2019 when it was the only way to make things work. With the current native-image and our Unsafe access I propose it's no longer necessary and it might be holding some performance back.

```java
  @TargetClass(className = "io.netty.channel.nio.NioEventLoop")
  final class Target_io_netty_channel_nio_NioEventLoop {

  @Substitute
  private static Queue<Runnable> newTaskQueue0(int maxPendingTasks) {
  return new LinkedBlockingDeque<>();
  }
  }
```

Netty, added traces
-------------------

I wasn't entirely sure about the trace logging as it's also affected by the substitutions, so I bluntly hardcoded these to make it super easy to check what I am really running:

```bash
karm@laptop:~/workspaceRH/netty ((netty-4.1.130.Final) *%)$ git status | grep "java\|\.c"
        modified:   buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
        modified:   common/src/main/java/io/netty/util/internal/PlatformDependent.java
        modified:   common/src/main/java/io/netty/util/internal/PlatformDependent0.java
        modified:   transport-classes-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
        modified:   transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
```

```diff
diff --git a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
index 836ea16914..a2d821a547 100644
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -182,6 +182,13 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements
             logger.debug("-Dio.netty.allocator.disableCacheFinalizersForFastThreadLocalThreads: {}",
                          DEFAULT_DISABLE_CACHE_FINALIZERS_FOR_FAST_THREAD_LOCAL_THREADS);
         }
+        System.out.println("[KARM DEBUG] PooledByteBufAllocator init:");
+        System.out.println("  > DEFAULT_MAX_ORDER: " + DEFAULT_MAX_ORDER);
+        System.out.println("  > DEFAULT_PAGE_SIZE: " + DEFAULT_PAGE_SIZE);
+        System.out.println("  > DEFAULT_SMALL_CACHE_SIZE: " + DEFAULT_SMALL_CACHE_SIZE);
+        System.out.println("  > DEFAULT_NORMAL_CACHE_SIZE: " + DEFAULT_NORMAL_CACHE_SIZE);
+        System.out.println("  > DEFAULT_USE_CACHE_FOR_ALL_THREADS: " + DEFAULT_USE_CACHE_FOR_ALL_THREADS);
+        System.out.println("  > PlatformDependent.directBufferPreferred(): " + PlatformDependent.directBufferPreferred());
     }
 
     public static final PooledByteBufAllocator DEFAULT =
diff --git a/common/src/main/java/io/netty/util/internal/PlatformDependent.java b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
index 4f51ce4376..7cef50f7bd 100644
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -228,6 +228,17 @@ public final class PlatformDependent {
             addFilesystemOsClassifiers(allowedClassifiers, availableClassifiers);
         }
         LINUX_OS_CLASSIFIERS = Collections.unmodifiableSet(availableClassifiers);
+        System.out.println("\n[KARM DEBUG] ---------------- PlatformDependent -----------------");
+        System.out.println("[KARM DEBUG] USE_DIRECT_BUFFER_NO_CLEANER (Zero-Copy): " + USE_DIRECT_BUFFER_NO_CLEANER);
+        System.out.println("[KARM DEBUG] DIRECT_BUFFER_PREFERRED: " + DIRECT_BUFFER_PREFERRED);
+        System.out.println("[KARM DEBUG] MAX_DIRECT_MEMORY: " + MAX_DIRECT_MEMORY);
+        System.out.println("[KARM DEBUG] DIRECT_MEMORY_COUNTER: " + DIRECT_MEMORY_COUNTER);
+        System.out.println("[KARM DEBUG] DIRECT_MEMORY_LIMIT: " + DIRECT_MEMORY_LIMIT);
+        System.out.println("[KARM DEBUG] LINUX_OS_CLASSIFIERS: " + LINUX_OS_CLASSIFIERS);
+        System.out.println("[KARM DEBUG] RANDOM_PROVIDER: " + RANDOM_PROVIDER.getClass().getSimpleName());
+        System.out.println("[KARM DEBUG] UNINITIALIZED_ARRAY_ALLOCATION_THRESHOLD: " + UNINITIALIZED_ARRAY_ALLOCATION_THRESHOLD);
+        System.out.println("[KARM DEBUG] Cleaner Implementation: " + CLEANER.getClass().getSimpleName());
+        System.out.println("[KARM DEBUG] ------------------------------------------------------");
     }
 
     static void addFilesystemOsClassifiers(final Set<String> allowedClassifiers,
diff --git a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
index 950b93bc95..212af2184a 100644
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -31,6 +31,8 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static sun.misc.Unsafe.ADDRESS_SIZE;
+
 /**
  * The {@link PlatformDependent} operations which requires access to {@code sun.misc.*}.
  */
@@ -193,6 +195,7 @@ final class PlatformDependent0 {
                                 finalUnsafe.putLong(address, 42);
                                 finalUnsafe.freeMemory(address);
                             }
+                            System.out.println("KARM DEBUG: All unsafe methods OK.");
                             return null;
                         } catch (UnsupportedOperationException e) {
                             return e;
@@ -544,6 +547,34 @@ final class PlatformDependent0 {
 
         logger.debug("java.nio.DirectByteBuffer.<init>(long, {int,long}): {}",
                 DIRECT_BUFFER_CONSTRUCTOR != null ? "available" : "unavailable");
+        System.out.println("\n[KARM DEBUG] ---------------- PlatformDependent0 ----------------");
+        System.out.println("[KARM DEBUG] Platform: " + (RUNNING_IN_NATIVE_IMAGE ? "Native Image" : "Standard JVM"));
+        System.out.println("[KARM DEBUG] Java Version: " + JAVA_VERSION);
+        System.out.println("[KARM DEBUG] io.netty.noUnsafe: " + isExplicitNoUnsafe());
+        System.out.println("[KARM DEBUG] io.netty.tryReflectionSetAccessible: " + IS_EXPLICIT_TRY_REFLECTION_SET_ACCESSIBLE);
+        System.out.println("[KARM DEBUG] UNSAFE: " + (UNSAFE != null));
+        if (UNSAFE == null) {
+            System.out.println("[KARM DEBUG]    UNSAFE_UNAVAILABILITY_CAUSE: " + UNSAFE_UNAVAILABILITY_CAUSE);
+        }
+        System.out.println("[KARM DEBUG] DIRECT_BUFFER_CONSTRUCTOR (zero-copy alloc?): " + (DIRECT_BUFFER_CONSTRUCTOR != null));
+        System.out.println("[KARM DEBUG] java.nio.Bits (UNALIGNED access): " + UNALIGNED);
+        System.out.println("[KARM DEBUG] java.nio.Bits (BITS_MAX_DIRECT_MEMORY: " + BITS_MAX_DIRECT_MEMORY);
+        System.out.println(
+                "[KARM DEBUG] jdk.internal.misc.Unsafe, ALLOCATE_ARRAY_METHOD (Uninitialized arrays): " + (ALLOCATE_ARRAY_METHOD != null));
+        System.out.println("[KARM DEBUG] ByteBuffer.alignedSlice, ALIGN_SLICE: " + (ALIGN_SLICE != null));
+        System.out.println("[KARM DEBUG] Unsafe details:");
+        System.out.println("   ADDRESS_SIZE: " + ADDRESS_SIZE);
+        System.out.println("   UNSAFE.pageSize(): " + (UNSAFE != null ? UNSAFE.pageSize() : "null"));
+        System.out.println("   Unaligned access allowed, UNALIGNED: " + UNALIGNED);
+        System.out.println("   BYTE_ARRAY_BASE_OFFSET: " + BYTE_ARRAY_BASE_OFFSET);
+        try {
+            if (UNSAFE != null) {
+                final long addr = UNSAFE.allocateMemory(8);
+                UNSAFE.putLong(addr, 0xCAFECAFEL);
+                final long cafe = UNSAFE.getLong(addr);
+                UNSAFE.freeMemory(addr);
+                System.out.println("   Memory R/W Test: " + (cafe == 0xCAFECAFEL
+                        ? "PASS"
+                        : "FAIL, it's " + cafe));
+            }
+        } catch (Throwable t) {
+            System.out.println("   Memory R/W Test: FAIL (" + t.getMessage() + ")");
+        }
+        System.out.println("[KARM DEBUG] -----------------------------------------------------------\n");
     }
 
     private static Method getIsVirtualThreadMethod() {
diff --git a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Epoll.java b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
index 69620b12a4..1d2c62beed 100644
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
@@ -60,6 +60,13 @@ public final class Epoll {
         }
 
         UNAVAILABILITY_CAUSE = cause;
+        System.out.println("[KARM DEBUG] Epoll Transport:");
+        System.out.println("   isAvailable: " + isAvailable());
+        if (!isAvailable()) {
+            System.out.println("   unavailabilityCause: " + unavailabilityCause());
+        } else {
+            System.out.println("   Native.KERNEL_VERSION: " + Native.KERNEL_VERSION);
+        }
     }
 
     /**
diff --git a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
index cd1e6abfb1..574eb01561 100644
--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -871,6 +871,8 @@ error:
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
 //            Native to reflect that.
 jint netty_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    printf("KARM DEBUG: netty_epoll_linuxsocket_JNI_OnLoad called.\n");
+    fflush(stdout);
     int ret = JNI_ERR;
     char* nettyClassName = NULL;
     jclass fileRegionCls = NULL;
```


How I tested
------------

Fedora 41, dedicated desktop, 64GB DDR5, i9-13900K CPU, Quarkus specifically pinned to P-cores, Hyperfoil pinned to E-cores.

The test app is an artificially tailored REST Hello World, that both prints additional info about Netty on startup, [EventLoopProbe.java](https://github.com/Karm/dev-null/blob/main/MpscQueue/src/main/java/org/acme/EventLoopProbe.java) and tries to keep the endpoint busy [GreetingResource.java](https://github.com/Karm/dev-null/blob/main/MpscQueue/src/main/java/org/acme/GreetingResource.java).

I have `JVM-21-Hotspot` and `JVM-25-Hotspot` runs as a kind of sanity check. Then there are 
`Native-JDK21-Patched`, `Native-JDK21-Unpatched`, `Native-JDK25-Patched` and `Native-JDK25-Unpatched` runs.

The logs show the difference in used queue implementation, i.e.

Unpatched logs:

```
APP RUNTIME: Netty Transport: NIO
    eventLoop.getClass().getName(): io.netty.channel.nio.NioEventLoop
    Actual Queue Field: java.util.concurrent.LinkedBlockingDeque
```

Whereas the patched, this PR version logs:

```
APP RUNTIME: Netty Transport: NIO
    eventLoop.getClass().getName(): io.netty.channel.nio.NioEventLoop
    Actual Queue Field: io.netty.util.internal.shaded.org.jctools.queues.MpscUnboundedArrayQueue
```

* [quarkus_JVM-21-Hotspot.log](https://karms.biz/netty-mpsc-01/quarkus_JVM-21-Hotspot.log)
* [quarkus_JVM-25-Hotspot.log](https://karms.biz/netty-mpsc-01/quarkus_JVM-25-Hotspot.log)
* [quarkus_Native-JDK21-Patched.log](https://karms.biz/netty-mpsc-01/quarkus_Native-JDK21-Patched.log)
* [quarkus_Native-JDK21-Unpatched.log](https://karms.biz/netty-mpsc-01/quarkus_Native-JDK21-Unpatched.log)
* [quarkus_Native-JDK25-Patched.log](https://karms.biz/netty-mpsc-01/quarkus_Native-JDK25-Patched.log)
* [quarkus_Native-JDK25-Unpatched.log](https://karms.biz/netty-mpsc-01/quarkus_Native-JDK25-Unpatched.log)


The run has a ramp up, calibration and stress phase, Hyperfoil config, e.g. [Native-JDK21-Patched.hf.yaml](https://karms.biz/netty-mpsc-01/Native-JDK21-Patched.hf.yaml).

The results are here:

* [report_JVM-21-Hotspot.html](https://karms.biz/netty-mpsc-01/report_JVM-21-Hotspot.html)
* [report_JVM-25-Hotspot.html](https://karms.biz/netty-mpsc-01/report_JVM-25-Hotspot.html)
* [report_Native-JDK21-Patched.html](https://karms.biz/netty-mpsc-01/report_Native-JDK21-Patched.html)
* [report_Native-JDK21-Unpatched.html](https://karms.biz/netty-mpsc-01/report_Native-JDK21-Unpatched.html)
* [report_Native-JDK25-Patched.html](https://karms.biz/netty-mpsc-01/report_Native-JDK25-Patched.html)
* [report_Native-JDK25-Unpatched.html](https://karms.biz/netty-mpsc-01/report_Native-JDK25-Unpatched.html)

There is no magically interesting speedup, but there is a slight positive difference between Native unpatched and patched.
I did not measure memory impact and I did not measure any long-running soak test.

The JDK used is this (the setup pre-dates the recent CPU):
* HotSpot runs: `openjdk 21.0.9 2025-10-21 LTS` and `openjdk 25.0.1 2025-10-21 LTS`.
* Native runs: `GraalVM CE 25.1.0-dev+8.1 (build 25.0.1+8-jvmci-25.1-b14)` and `Mandrel-23.1.9.0-Final (build 21.0.9+10-LTS)`.

I propose that the substitution is at best not necessary these days. 

I summon @franz1981 for an opinion :) 