### PR TITLE
AOT - Store config files in memory in the AotRunnerClassLoader

### DIFF
--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/java/org/acme/HelloResource.java
@@ -14,6 +14,9 @@ public class HelloResource {
     @ConfigProperty(name = "greeting")
     String greeting;
 
+    @ConfigProperty(name = "greeting-prod")
+    String greetingProd;
+
     @ConfigProperty(name = "quarkus.application.version")
     String applicationVersion;
 
@@ -37,6 +40,13 @@ public class HelloResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String greeting() {
         return greeting;
+    }
+
+    @GET
+    @Path("/greeting-prod")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String greetingProd() {
+        return greetingProd;
     }
 
     @GET

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/resources/application-prod.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/resources/application-prod.properties
@@ -1,0 +1,2 @@
+# Configuration file
+greeting-prod=bonjour prod


### PR DESCRIPTION
And provide an optimized path for SmallRye Config to read them.

@radcortez this is what we talked about, together with https://github.com/smallrye/smallrye-common/pull/518, it boots `ClassPathUtils` out of the profile.

Also it looks simple enough.

Note that this is only implemented for the AOT runner.