### PR TITLE
Register for reflection classes loaded with class loader parameter

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -248,6 +248,7 @@ public final class AmazonLambdaProcessor {
             AmazonLambdaRecorder recorder,
             List<ServiceStartBuildItem> orderServicesFirst, // try to order this after service recorders
             RecorderContext context,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchies) {
         // Have to set lambda class at runtime if there is not a provided lambda or there is more than one lambda in
@@ -260,6 +261,8 @@ public final class AmazonLambdaProcessor {
             Map<String, Class<? extends RequestStreamHandler>> namedStreamHandler = new HashMap<>();
 
             for (AmazonLambdaBuildItem i : lambdas) {
+                reflectiveClassBuildItemBuildProducer
+                        .produce(ReflectiveClassBuildItem.builder(i.getHandlerClass()).constructors(false).build());
                 if (i.isStreamHandler()) {
                     if (i.getName() == null) {
                         unnamedStreamHandler

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -60,6 +60,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo2.Const;
@@ -383,6 +384,7 @@ public class GrpcClientProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     SyntheticBeanBuildItem clientInterceptorStorage(GrpcClientRecorder recorder, RecorderContext recorderContext,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer,
             BeanArchiveIndexBuildItem beanArchiveIndex) {
 
         IndexView index = beanArchiveIndex.getIndex();
@@ -411,10 +413,14 @@ public class GrpcClientProcessor {
 
         Set<Class<?>> perClientInterceptors = new HashSet<>();
         for (String perClientInterceptor : interceptors.nonGlobalInterceptors) {
+            reflectiveClassBuildItemBuildProducer
+                    .produce(ReflectiveClassBuildItem.builder(perClientInterceptor).constructors(false).build());
             perClientInterceptors.add(recorderContext.classProxy(perClientInterceptor));
         }
         Set<Class<?>> globalInterceptors = new HashSet<>();
         for (String globalInterceptor : interceptors.globalInterceptors) {
+            reflectiveClassBuildItemBuildProducer
+                    .produce(ReflectiveClassBuildItem.builder(globalInterceptor).constructors(false).build());
             globalInterceptors.add(recorderContext.classProxy(globalInterceptor));
         }
 

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -72,6 +72,7 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.grpc.GrpcService;
 import io.quarkus.grpc.auth.DefaultAuthExceptionHandlerProvider;
@@ -612,7 +613,7 @@ public class GrpcServerProcessor {
             List<AdditionalGlobalInterceptorBuildItem> additionalGlobalInterceptors,
             List<DelegatingGrpcBeanBuildItem> delegatingGrpcBeans,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer,
             RecorderContext recorderContext,
             GrpcServerRecorder recorder) {
 
@@ -664,6 +665,8 @@ public class GrpcServerProcessor {
 
         Set<Class<?>> globalInterceptors = new HashSet<>();
         for (String interceptor : interceptors.globalInterceptors) {
+            reflectiveClassBuildItemBuildProducer
+                    .produce(ReflectiveClassBuildItem.builder(interceptor).constructors(false).build());
             globalInterceptors.add(recorderContext.classProxy(interceptor));
         }
         for (AdditionalGlobalInterceptorBuildItem globalInterceptorBuildItem : additionalGlobalInterceptors) {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
@@ -61,6 +61,7 @@ import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.gizmo.ClassTransformer;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.hibernate.orm.PersistenceUnit;
@@ -155,7 +156,8 @@ public class HibernateOrmCdiProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateJpaConfigBean(HibernateOrmRecorder recorder,
-            BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItem) {
         ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
                 .configure(JPAConfig.class)
                 .addType(JPAConfig.class)
@@ -163,6 +165,8 @@ public class HibernateOrmCdiProcessor {
                 .unremovable()
                 .setRuntimeInit()
                 .supplier(recorder.jpaConfigSupplier());
+
+        reflectiveClassBuildItem.produce(ReflectiveClassBuildItem.builder(JPAConfig.class).constructors(false).build());
 
         syntheticBeanBuildItemBuildProducer.produce(configurator.done());
     }

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
@@ -12,6 +12,7 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
@@ -55,6 +56,7 @@ public class PrometheusRegistryProcessor {
 
     @BuildStep
     MicrometerRegistryProviderBuildItem createPrometheusRegistry(MicrometerConfig config,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
 
         // Add the Prometheus Registry beans
@@ -65,6 +67,9 @@ public class PrometheusRegistryProcessor {
             builder.addBeanClass("io.quarkus.micrometer.runtime.export.PrometheusMeterRegistryProducer");
         }
         additionalBeans.produce(builder.build());
+
+        reflectiveClassBuildItemBuildProducer
+                .produce(ReflectiveClassBuildItem.builder(REGISTRY_CLASS).constructors(false).build());
 
         // Include the PrometheusMeterRegistry in a possible CompositeMeterRegistry
         return new MicrometerRegistryProviderBuildItem(REGISTRY_CLASS);

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -306,6 +306,9 @@ public class JaxrsClientReactiveProcessor {
             List<ParameterContainersBuildItem> parameterContainersBuildItems,
             List<EndpointValidationPredicatesBuildItem> validationPredicatesBuildItems) {
 
+        reflectiveClassBuildItemBuildProducer
+                .produce(ReflectiveClassBuildItem.builder(UniInvoker.class, MultiInvoker.class).constructors(false).build());
+
         String defaultConsumesType = defaultMediaType(defaultConsumes, MediaType.APPLICATION_OCTET_STREAM);
         String defaultProducesType = defaultMediaType(defaultProduces, MediaType.TEXT_PLAIN);
 

--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -430,7 +430,7 @@ class RestClientReactiveProcessor {
                         for (ProviderToRegister provider : providers) {
                             Expr clazz;
                             if (provider.fromTCCL()) {
-                                clazz = loadClassFromTCCL(bc, provider.className());
+                                clazz = loadClassFromTCCL(bc, provider.className(), reflectiveClassesProducer);
                             } else {
                                 clazz = Const.of(ClassDesc.of(provider.className()));
                             }
@@ -449,7 +449,7 @@ class RestClientReactiveProcessor {
 
                     // Register global providers
                     for (ProviderToRegister provider : globalProviders) {
-                        Expr clazz = loadClassFromTCCL(bc, provider.className());
+                        Expr clazz = loadClassFromTCCL(bc, provider.className(), reflectiveClassesProducer);
                         bc.invokeVirtual(ADD_GLOBAL_PROVIDER_METHOD, cc.this_(), clazz, Const.of(provider.priority()));
                     }
 
@@ -480,7 +480,9 @@ class RestClientReactiveProcessor {
         unremovableBeansProducer.produce(UnremovableBeanBuildItem.beanClassNames(annotationRegisteredProvidersImpl));
     }
 
-    private Expr loadClassFromTCCL(BlockCreator bc, String className) {
+    private Expr loadClassFromTCCL(BlockCreator bc, String className,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassesProducer) {
+        reflectiveClassesProducer.produce(ReflectiveClassBuildItem.builder(className).constructors(false).build());
         Expr currentThread = bc.currentThread();
         Expr tccl = bc.invokeVirtual(GET_CONTEXT_CLASS_LOADER, currentThread);
         return bc.classForName(Const.of(className), Const.of(false), tccl);

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -415,6 +415,9 @@ public class SchedulerProcessor {
             for (AnnotationInstance scheduled : scheduledMethod.getSchedules()) {
                 schedules.add(annotationProxy.builder(scheduled, Scheduled.class).build(classOutput));
             }
+            if (!schedules.isEmpty()) {
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(Scheduled.Never.class).constructors(false).build());
+            }
             metadata.setSchedules(schedules);
             metadata.setDeclaringClassName(scheduledMethod.getMethod().declaringClass().toString());
             metadata.setMethodName(scheduledMethod.getMethod().name());

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -335,6 +335,13 @@ public class SecurityProcessor {
                     "org.bouncycastle.jcajce.provider.asymmetric.rsa.PSSSignatureSpi$SHA256withRSA").methods().fields()
                     .build());
         }
+
+        if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
+                x -> x.getGroupId().equals("org.bouncycastle") && x.getArtifactId().startsWith("bcpkix-"))) {
+            reflection.produce(
+                    ReflectiveClassBuildItem.builder("org.bouncycastle.openssl.PEMParser").constructors(false).build());
+        }
+
         runtimeReInitialized
                 .produce(new RuntimeInitializedClassBuildItem("org.bouncycastle.crypto.CryptoServicesRegistrar"));
         if (!isFipsMode) {

--- a/extensions/spring-web/core/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/core/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -229,6 +229,8 @@ public class SpringWebProcessor {
             // we need to generate one JAX-RS ExceptionMapper per Exception type
             Type[] handledExceptionTypes = exceptionHandlerInstance.value().asClassArray();
             for (Type handledExceptionType : handledExceptionTypes) {
+                reflectiveClassProducer.produce(
+                        ReflectiveClassBuildItem.builder(method.declaringClass().toString()).constructors(false).build());
                 String name = new ControllerAdviceExceptionMapperGenerator(method, handledExceptionType.name(),
                         classOutput, typesUtil, isResteasyClassic).generate();
                 providersProducer.produce(new ResteasyJaxrsProviderBuildItem(name));

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -118,6 +118,7 @@ class VertxProcessor {
             BuildProducer<GeneratedResourceBuildItem> generatedResource,
             AnnotationProxyBuildItem annotationProxy, LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown,
             BuildProducer<ServiceStartBuildItem> serviceStart,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer,
             List<MessageCodecBuildItem> codecs, LocalCodecSelectorTypesBuildItem localCodecSelectorTypes,
             RecorderContext recorderContext) {
         List<EventConsumerInfo> messageConsumerConfigurations = new ArrayList<>();
@@ -135,6 +136,8 @@ class VertxProcessor {
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         Map<Class<?>, Class<?>> codecByClass = new HashMap<>();
         for (MessageCodecBuildItem messageCodecItem : codecs) {
+            reflectiveClassBuildItemBuildProducer
+                    .produce(ReflectiveClassBuildItem.builder(messageCodecItem.getType()).constructors(false).build());
             codecByClass.put(tryLoad(messageCodecItem.getType(), tccl), tryLoad(messageCodecItem.getCodec(), tccl));
         }
 

--- a/integration-tests/oidc-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-reactive/src/main/resources/application.properties
@@ -45,4 +45,3 @@ quarkus.log.category."io.quarkus.it.keycloak.TokenEndpointResponseFilter".level=
 quarkus.log.category."io.quarkus.it.keycloak.RestClientContentTypeRequestFilter".min-level=TRACE
 quarkus.log.category."io.quarkus.it.keycloak.RestClientContentTypeRequestFilter".level=TRACE
 quarkus.log.file.enabled=true
-quarkus.log.file.format=%C - %s%n


### PR DESCRIPTION
A new future default in GraalVM master called `class-for-name-respects-class-loader` is causing CI failures. In this PR we register for reflection classes that will be loaded at runtime using a class loader parameter.

I've kept the solution as simple as possible by just registering them without checking for a future default. The cases where this is necessary are just a handful.

I've also made a change to one of the ITs log format configuration which was hiding crucial information in debugging this issue.

With all these changes CI with GraalVM master goes from [these failures](https://github.com/oracle/graal/actions/runs/21576752582) to [all passing](https://github.com/graalvm/mandrel/actions/runs/21745480088).

- Fixes: #52368
