### PR TITLE
Stop importing the Gizmo2 test JAR

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -87,7 +87,7 @@
         <!-- GraalVM sdk 23.1.2 has a minimum JDK requirement of 17+ at runtime -->
         <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.10.1</gizmo.version>
-        <gizmo2.version>2.1.0</gizmo2.version>
+        <gizmo2.version>2.1.1</gizmo2.version>
         <jackson-bom.version>2.21.0</jackson-bom.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -46,7 +46,7 @@
         <!-- main versions -->
         <version.gizmo>1.10.1</version.gizmo>
         <version.jandex>3.5.3</version.jandex>
-        <version.gizmo2>2.1.0</version.gizmo2>
+        <version.gizmo2>2.1.1</version.gizmo2>
         <version.jboss-logging>3.6.2.Final</version.jboss-logging>
         <version.mutiny>3.1.0</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
@@ -210,13 +210,6 @@
                 <groupId>io.quarkus.gizmo</groupId>
                 <artifactId>gizmo</artifactId>
                 <version>${version.gizmo}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus.gizmo</groupId>
-                <artifactId>gizmo2</artifactId>
-                <version>${version.gizmo2}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>

--- a/independent-projects/arc/processor/pom.xml
+++ b/independent-projects/arc/processor/pom.xml
@@ -74,11 +74,6 @@
             <artifactId>gizmo</artifactId>
             <type>test-jar</type>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus.gizmo</groupId>
-            <artifactId>gizmo2</artifactId>
-            <type>test-jar</type>
-        </dependency>
 
     </dependencies>
     <build>

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/AnnotationLiteralProcessorTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/AnnotationLiteralProcessorTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.arc.AbstractAnnotationLiteral;
 import io.quarkus.gizmo2.Gizmo;
-import io.quarkus.gizmo2.TestClassMaker;
+import io.quarkus.gizmo2.testing.TestClassMaker;
 
 public class AnnotationLiteralProcessorTest {
     public enum SimpleEnum {
@@ -298,8 +298,8 @@ public class AnnotationLiteralProcessorTest {
     public void test() throws ReflectiveOperationException {
         AnnotationLiteralProcessor literals = new AnnotationLiteralProcessor(index, ignored -> true);
 
-        TestClassMaker tcm = new TestClassMaker();
-        Gizmo gizmo = Gizmo.create(tcm);
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo gizmo = tcm.gizmo();
         ClassDesc desc = gizmo.class_(generatedClass, cc -> {
             cc.staticMethod("get", mc -> {
                 mc.public_();
@@ -314,13 +314,13 @@ public class AnnotationLiteralProcessorTest {
                 .generate(literals.getCache(), Collections.emptySet());
         for (ResourceOutput.Resource resource : resources) {
             if (resource.getType() == ResourceOutput.Resource.Type.JAVA_CLASS) {
-                tcm.write(ClassDesc.of(resource.getName().replace('/', '.')), resource.getData());
+                tcm.registerResource(resource.getName() + ".class", resource.getData());
             } else {
                 throw new IllegalStateException("Unexpected " + resource.getType() + " " + resource.getName());
             }
         }
 
-        ComplexAnnotation annotation = (ComplexAnnotation) tcm.forClass(desc).staticMethod("get", Supplier.class).get();
+        ComplexAnnotation annotation = (ComplexAnnotation) tcm.staticMethod(desc, "get", Supplier.class).get();
         verify(annotation);
 
         assertInstanceOf(AbstractAnnotationLiteral.class, annotation);
@@ -342,8 +342,8 @@ public class AnnotationLiteralProcessorTest {
     public void memberless() throws ReflectiveOperationException {
         AnnotationLiteralProcessor literals = new AnnotationLiteralProcessor(index, ignored -> true);
 
-        TestClassMaker tcm = new TestClassMaker();
-        Gizmo gizmo = Gizmo.create(tcm);
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo gizmo = tcm.gizmo();
         ClassDesc desc = gizmo.class_(generatedClass, cc -> {
             cc.staticMethod("get", mc -> {
                 mc.public_();
@@ -359,13 +359,13 @@ public class AnnotationLiteralProcessorTest {
                 .generate(literals.getCache(), Collections.emptySet());
         for (ResourceOutput.Resource resource : resources) {
             if (resource.getType() == ResourceOutput.Resource.Type.JAVA_CLASS) {
-                tcm.write(ClassDesc.of(resource.getName().replace('/', '.')), resource.getData());
+                tcm.registerResource(resource.getName() + ".class", resource.getData());
             } else {
                 throw new IllegalStateException("Unexpected " + resource.getType() + " " + resource.getName());
             }
         }
 
-        MemberlessAnnotation annotation = (MemberlessAnnotation) tcm.forClass(desc).staticMethod("get", Supplier.class).get();
+        MemberlessAnnotation annotation = (MemberlessAnnotation) tcm.staticMethod(desc, "get", Supplier.class).get();
 
         assertInstanceOf(AbstractAnnotationLiteral.class, annotation);
         AbstractAnnotationLiteral annotationLiteral = (AbstractAnnotationLiteral) annotation;
@@ -397,8 +397,8 @@ public class AnnotationLiteralProcessorTest {
     public void missingAnnotationClass() {
         AnnotationLiteralProcessor literals = new AnnotationLiteralProcessor(index, ignored -> true);
 
-        TestClassMaker tcm = new TestClassMaker();
-        Gizmo gizmo = Gizmo.create(tcm);
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo gizmo = tcm.gizmo();
         gizmo.class_(generatedClass, cc -> {
             cc.staticMethod("get", mc -> {
                 mc.public_();
@@ -416,8 +416,8 @@ public class AnnotationLiteralProcessorTest {
     public void classRetainedAnnotation() {
         AnnotationLiteralProcessor literals = new AnnotationLiteralProcessor(index, ignored -> true);
 
-        TestClassMaker tcm = new TestClassMaker();
-        Gizmo gizmo = Gizmo.create(tcm);
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo gizmo = tcm.gizmo();
         gizmo.class_(generatedClass, cc -> {
             cc.staticMethod("get", mc -> {
                 mc.public_();

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -41,7 +41,7 @@
         <version.junit>6.0.2</version.junit>
         <version.assertj>3.27.7</version.assertj>
         <version.jandex>3.5.3</version.jandex>
-        <version.gizmo2>2.1.0</version.gizmo2>
+        <version.gizmo2>2.1.1</version.gizmo2>
         <version.jboss-logging>3.6.2.Final</version.jboss-logging>
         <version.smallrye-common>2.15.0</version.smallrye-common>
         <version.smallrye-mutiny>3.1.0</version.smallrye-mutiny>


### PR DESCRIPTION
Now that we have Gizmo 2.1, we no longer should import the test JAR from that project because it will be removed in 2.2. Importing test JARs makes modularization very difficult.

The test utility `TestClassMaker` is now a part of the main Gizmo 2 API.

