### PR TITLE
AOT - Allow to run some pre-init steps

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/PreInitBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/PreInitBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Indicates the pre-init should be executed in GeneratedMain.
+ */
+public final class PreInitBuildItem extends SimpleBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/PreInitRunnableBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/PreInitRunnableBuildItem.java
@@ -1,0 +1,106 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Objects;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.runtime.init.InitializeClassPreInitRunnable;
+
+/**
+ * A build item that can be used to register pre-init tasks that will be executed early in GeneratedMain.
+ * <p>
+ * For now, these tasks are only executed when using the AOT runner.
+ * <p>
+ * Pre-init is run at the very beginning of the GeneratedMain, and all tasks are submitted to a thread pool
+ * that will execute the tasks in parallel so don't expect any execution ordering.
+ * <p>
+ * The tasks are submitted to the thread pool in the priority order: a lower value for priority will be submitted first.
+ */
+public final class PreInitRunnableBuildItem extends MultiBuildItem implements Comparable<PreInitRunnableBuildItem> {
+
+    public static final int DEFAULT_PRIORITY = 100;
+
+    // the model here is extremely naive and, if we need more parameters, we will need to make it more clever
+    // let's keep it simple for now
+    private final String runnableClassName;
+    private final String parameter;
+    private final int priority;
+
+    private PreInitRunnableBuildItem(String runnableClassName, String parameter, int priority) {
+        this.runnableClassName = runnableClassName;
+        this.parameter = parameter;
+        this.priority = priority;
+    }
+
+    public static PreInitRunnableBuildItem runnable(String runnableClassName) {
+        return new PreInitRunnableBuildItem(runnableClassName, null, DEFAULT_PRIORITY);
+    }
+
+    public static PreInitRunnableBuildItem runnable(String runnableClassName, int priority) {
+        return new PreInitRunnableBuildItem(runnableClassName, null, priority);
+    }
+
+    public static PreInitRunnableBuildItem initializeClass(String className) {
+        return new PreInitRunnableBuildItem(InitializeClassPreInitRunnable.class.getName(), className, DEFAULT_PRIORITY);
+    }
+
+    public static PreInitRunnableBuildItem initializeClass(String className, int priority) {
+        return new PreInitRunnableBuildItem(InitializeClassPreInitRunnable.class.getName(), className, priority);
+    }
+
+    public String getRunnableClassName() {
+        return runnableClassName;
+    }
+
+    public String getParameter() {
+        return parameter;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public int compareTo(PreInitRunnableBuildItem o) {
+        int compare = Integer.compare(priority, o.priority);
+
+        if (compare != 0) {
+            return compare;
+        }
+
+        compare = runnableClassName.compareTo(o.runnableClassName);
+
+        if (compare != 0) {
+            return compare;
+        }
+
+        if (parameter == null && o.parameter == null) {
+            return 0;
+        }
+        if (parameter == null) {
+            return 1; // nulls last
+        }
+        if (o.parameter == null) {
+            return -1;
+        }
+        return parameter.compareTo(o.parameter);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PreInitRunnableBuildItem other = (PreInitRunnableBuildItem) o;
+        return runnableClassName.equals(other.runnableClassName)
+                && Objects.equals(parameter, other.parameter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(runnableClassName, parameter);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/AotJarEnabled.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/AotJarEnabled.java
@@ -2,17 +2,19 @@ package io.quarkus.deployment.pkg;
 
 import java.util.function.BooleanSupplier;
 
-public class AotClassLoadingEnabled implements BooleanSupplier {
+import io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType;
+
+public class AotJarEnabled implements BooleanSupplier {
 
     private final PackageConfig packageConfig;
 
-    AotClassLoadingEnabled(PackageConfig packageConfig) {
+    AotJarEnabled(PackageConfig packageConfig) {
         this.packageConfig = packageConfig;
     }
 
     @Override
     public boolean getAsBoolean() {
         return packageConfig.jar().enabled() &&
-                packageConfig.jar().appcds().useAot();
+                packageConfig.jar().type() == JarType.AOT_JAR;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/PreInitBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/PreInitBuildStep.java
@@ -1,0 +1,103 @@
+package io.quarkus.deployment.steps;
+
+import java.lang.constant.ClassDesc;
+import java.net.InetAddress;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.PreInitBuildItem;
+import io.quarkus.deployment.builditem.PreInitRunnableBuildItem;
+import io.quarkus.deployment.pkg.AotJarEnabled;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo2.ClassOutput;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.desc.ClassMethodDesc;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+import io.quarkus.runtime.init.AbstractPreInitRunner;
+import io.quarkus.runtime.init.TimeZonePreInitRunnable;
+
+public class PreInitBuildStep {
+
+    private static final String PRE_INIT_RUNNER_CLASS_NAME = "io.quarkus.runtime.generated.PreInitRunner";
+    private static final MethodDesc PRE_INIT_RUNNER_EXECUTE_PRE_INIT_TASKS_METHOD = ClassMethodDesc
+            .of(ClassDesc.of(PRE_INIT_RUNNER_CLASS_NAME), "executePreInitTasks", void.class);
+    public static final MethodDescriptor PRE_INIT_RUNNER_EXECUTE_PRE_INIT_TASKS_GIZMO1_METHOD = MethodDescriptor
+            .ofMethod(PRE_INIT_RUNNER_CLASS_NAME, "executePreInitTasks", void.class);
+
+    /**
+     * For now, this is only used when using the AOT runner.
+     * We might want to also use it for fast-jar at some point but let's be safe for now.
+     */
+    @BuildStep(onlyIf = AotJarEnabled.class)
+    PreInitBuildItem executePreInitTasks(List<PreInitRunnableBuildItem> preInitRunnables,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources) {
+        ClassOutput output = new GeneratedClassGizmo2Adaptor(generatedClasses, generatedResources, false);
+        Gizmo gizmo = Gizmo.create(output)
+                .withDebugInfo(false)
+                .withParameters(false);
+
+        // we deduplicate the list, keeping the element with the lower priority in case of duplicate
+        List<PreInitRunnableBuildItem> deduplicatedPreInitRunnables = preInitRunnables.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        Function.identity(),
+                        (a, b) -> a.getPriority() <= b.getPriority() ? a : b))
+                .values().stream().sorted().toList();
+
+        gizmo.class_(PRE_INIT_RUNNER_CLASS_NAME, cc -> {
+            cc.extends_(AbstractPreInitRunner.class);
+
+            cc.staticMethod(PRE_INIT_RUNNER_EXECUTE_PRE_INIT_TASKS_METHOD, mc -> {
+                mc.public_();
+                mc.body(b0 -> {
+                    Expr preinitRunnableArray = b0.newArray(Runnable.class, deduplicatedPreInitRunnables, pir -> {
+                        ClassDesc runnableClassDesc = ClassDesc.of(pir.getRunnableClassName());
+                        Expr runnableInstance;
+
+                        // the model here is extremely naive and, if we need more parameters, we will need to make it more clever
+                        // let's keep it simple for now
+                        if (pir.getParameter() != null) {
+                            runnableInstance = b0.new_(ConstructorDesc.of(runnableClassDesc, String.class),
+                                    Const.of(pir.getParameter()));
+                        } else {
+                            runnableInstance = b0.new_(ConstructorDesc.of(runnableClassDesc));
+                        }
+
+                        return runnableInstance;
+                    });
+
+                    b0.invokeStatic(
+                            MethodDesc.of(AbstractPreInitRunner.class, "doExecutePreInitTasks", void.class, Runnable[].class),
+                            preinitRunnableArray);
+
+                    b0.return_();
+                });
+            });
+        });
+
+        return new PreInitBuildItem();
+    }
+
+    @BuildStep
+    void corePreInitTasks(BuildProducer<PreInitRunnableBuildItem> preInitTasks) {
+        // DO NOT go berserk here: we should limit ourselves to very low level elements,
+        // and element we cannot optimize by ourselves.
+        // we also need to be careful to avoid circular reference, thus why we don't initialize LoggingProviders here
+
+        // this is required by JBoss Logging and is rather costly
+        preInitTasks.produce(PreInitRunnableBuildItem.runnable(TimeZonePreInitRunnable.class.getName()));
+
+        // InetAddress is used in config and other places
+        preInitTasks.produce(PreInitRunnableBuildItem.initializeClass(InetAddress.class.getName()));
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/init/AbstractPreInitRunner.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/init/AbstractPreInitRunner.java
@@ -1,0 +1,63 @@
+package io.quarkus.runtime.init;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class AbstractPreInitRunner {
+
+    private static final AtomicInteger THREAD_ID = new AtomicInteger();
+
+    protected static void doExecutePreInitTasks(Runnable[] preInitTasks) {
+        // 5 came empirically: it is both fast enough and low overhead
+        int threadCount = Math.min(5, Runtime.getRuntime().availableProcessors());
+
+        ExecutorService executor = Executors.newFixedThreadPool(
+                threadCount,
+                new ThreadFactory() {
+
+                    @Override
+                    public Thread newThread(Runnable runnable) {
+                        Thread t = new Thread(runnable, "pre-init-" + THREAD_ID.getAndIncrement());
+                        t.setDaemon(true);
+                        return t;
+                    }
+                });
+
+        CountDownLatch latch = new CountDownLatch(preInitTasks.length);
+
+        for (Runnable preInitTask : preInitTasks) {
+            submit(executor, latch, preInitTask);
+        }
+
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    executor.shutdown();
+                }
+            }
+        });
+    }
+
+    private static void submit(ExecutorService executor,
+            CountDownLatch latch,
+            Runnable task) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    task.run();
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/init/InitializeClassPreInitRunnable.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/init/InitializeClassPreInitRunnable.java
@@ -1,0 +1,27 @@
+package io.quarkus.runtime.init;
+
+public class InitializeClassPreInitRunnable implements Runnable {
+
+    private static final boolean PRE_INIT_RAISE_ERRORS = Boolean.getBoolean("quarkus-pre-init-raise-errors");
+
+    private final String className;
+
+    public InitializeClassPreInitRunnable(String className) {
+        this.className = className;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Class.forName(className, true, Thread.currentThread().getContextClassLoader());
+        } catch (Throwable e) {
+            // when testing Quarkus itself, we raise the errors, so that we can catch them
+            if (PRE_INIT_RAISE_ERRORS) {
+                throw new IllegalStateException(
+                        "Unable to preload class: " + className + ". Pre-init instructions need to be adjusted.", e);
+            }
+
+            // otherwise we simply ignore the errors
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/init/TimeZonePreInitRunnable.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/init/TimeZonePreInitRunnable.java
@@ -1,0 +1,11 @@
+package io.quarkus.runtime.init;
+
+import java.util.TimeZone;
+
+public class TimeZonePreInitRunnable implements Runnable {
+
+    @Override
+    public void run() {
+        TimeZone.getDefault().toZoneId();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -120,7 +120,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.index.IndexingUtil;
-import io.quarkus.deployment.pkg.AotClassLoadingEnabled;
+import io.quarkus.deployment.pkg.AotJarEnabled;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.deployment.util.IoUtil;
@@ -894,7 +894,7 @@ public final class HibernateOrmProcessor {
      * So point of this method is to generate an empty package-info in packages where we have a mapped class,
      * if there isn't a package-info already.
      */
-    @BuildStep(onlyIf = AotClassLoadingEnabled.class, onlyIfNot = NativeOrNativeSourcesBuild.class)
+    @BuildStep(onlyIf = AotJarEnabled.class, onlyIfNot = NativeOrNativeSourcesBuild.class)
     void generateMissingPackageInfos(CombinedIndexBuildItem combinedIndex,
             JpaModelBuildItem jpaModel,
             List<ApplicationClassPredicateBuildItem> predicates,

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/PackageInfoGenerationTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packageinfo/PackageInfoGenerationTest.java
@@ -24,8 +24,7 @@ public class PackageInfoGenerationTest {
                     .addPackage(EntityWithoutPackageInfo.class.getPackage()))
             .withConfigurationResource("application.properties")
             .overrideConfigKey("quarkus.package.jar.enabled", "true")
-            .overrideConfigKey("quarkus.package.jar.appcds.enabled", "true")
-            .overrideConfigKey("quarkus.package.jar.appcds.use-aot", "true");
+            .overrideConfigKey("quarkus.package.jar.type", "aot-jar");
 
     @Test
     public void testExistingPackageInfoNotOverwritten() throws Exception {

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -39,6 +39,7 @@ import io.quarkus.deployment.builditem.GeneratedRuntimeSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.ModuleEnableNativeAccessBuildItem;
 import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+import io.quarkus.deployment.builditem.PreInitRunnableBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -50,7 +51,6 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildI
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
-import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem.JavaVersion.Status;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
@@ -108,6 +108,13 @@ class NettyProcessor {
     @BuildStep
     public SystemPropertyBuildItem disableFinalizers() {
         return new SystemPropertyBuildItem("io.netty.allocator.disableCacheFinalizersForFastThreadLocalThreads", "true");
+    }
+
+    @BuildStep
+    public PreInitRunnableBuildItem preInitPlatformDependent() {
+        // initialize PlatformDependent as a pre-init task as it's quite slow
+        return PreInitRunnableBuildItem.initializeClass(PlatformDependent.class.getName(),
+                PreInitRunnableBuildItem.DEFAULT_PRIORITY - 50);
     }
 
     /**

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -58,6 +58,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.PreInitRunnableBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
@@ -75,6 +76,7 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.vertx.ConsumeEvent;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
+import io.quarkus.vertx.core.runtime.init.UUIDRandomPreInitRunnable;
 import io.quarkus.vertx.deployment.spi.EventConsumerInvokerCustomizerBuildItem;
 import io.quarkus.vertx.runtime.EventConsumerInfo;
 import io.quarkus.vertx.runtime.VertxEventBusConsumerRecorder;
@@ -92,6 +94,15 @@ class VertxProcessor {
     @BuildStep
     void featureAndCapability(BuildProducer<FeatureBuildItem> feature, BuildProducer<CapabilityBuildItem> capability) {
         feature.produce(new FeatureBuildItem(Feature.VERTX));
+    }
+
+    /**
+     * Hopefully, we will be able to get rid of this once we find a solution for
+     * https://github.com/eclipse-vertx/vert.x/pull/5450.
+     */
+    @BuildStep
+    public PreInitRunnableBuildItem preInitPlatformDependent() {
+        return PreInitRunnableBuildItem.runnable(UUIDRandomPreInitRunnable.class.getName());
     }
 
     @BuildStep

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/init/UUIDRandomPreInitRunnable.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/init/UUIDRandomPreInitRunnable.java
@@ -1,0 +1,12 @@
+package io.quarkus.vertx.core.runtime.init;
+
+import java.util.UUID;
+
+public class UUIDRandomPreInitRunnable implements Runnable {
+
+    @Override
+    public void run() {
+        // initialize the SecureRandom in UUID as a pre-init task as it's quite slow
+        UUID.randomUUID();
+    }
+}

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -851,7 +851,8 @@ public class JarRunnerIT extends MojoTestBase {
         Assertions.assertTrue(properties.get("path").toString().startsWith(outputDir == null ? "quarkus-app" : outputDir));
         Assertions.assertTrue(properties.get("path").toString().endsWith("quarkus-run.jar"));
 
-        Process process = doLaunch(jar, output).start();
+        // quarkus-pre-init-raise-errors is used to catch errors related to pre-init execution when running the Quarkus tests
+        Process process = doLaunch(jar, output, List.of("-Dquarkus-pre-init-raise-errors=true")).start();
         try {
             // Wait until server up
             dumpFileContentOnFailure(() -> {
@@ -865,6 +866,8 @@ public class JarRunnerIT extends MojoTestBase {
             String logs = FileUtils.readFileToString(output, "UTF-8");
 
             assertThat(logs).isNotEmpty().contains("rest");
+            assertThat(logs).doesNotContain("Exception in thread").describedAs(
+                    "An exception occurred during the pre-init phase:\n\n" + logs);
 
             // test that the application name and version are properly set
             assertApplicationPropertiesSetCorrectly();


### PR DESCRIPTION
Some low-level class initializations are very slow and there's nothing we can do about it (JUL backend detection, time zone database reading, ...).
This mechanism allows to initialize them early in threads so that we don't block the initialization.

The approach is relatively similar to what was done in: https://github.com/quarkusio/quarkus/commit/61e145f0ef64174e789ae59e013dcadd9daa5eba

Except we need these to be executed before the Config initialization, which is done outside of the build step infrastructure, thus why the specific infrastructure.

We really need to limit ourselves to very low-level elements, let's not go crazy and reinvent GraalVM static init.
