### PR TITLE
Discontinue support for log4j 1.x

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -191,7 +191,6 @@
         <gson.version>2.13.2</gson.version>
         <log4j2-jboss-logmanager.version>2.0.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.25.3</log4j2-api.version>
-        <log4j-jboss-logmanager.version>1.3.1.Final</log4j-jboss-logmanager.version>
         <avro.version>1.12.1</avro.version>
         <apicurio-registry.version>3.1.7</apicurio-registry.version>
         <testcontainers.version>2.0.3</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
@@ -3811,11 +3810,6 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j2-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logmanager</groupId>
-                <artifactId>log4j-jboss-logmanager</artifactId>
-                <version>${log4j-jboss-logmanager.version}</version>
             </dependency>
 
             <dependency>

--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -63,10 +63,6 @@
             <artifactId>netty-codec-http2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-process</artifactId>
         </dependency>

--- a/devtools/project-core-extension-codestarts/pom.xml
+++ b/devtools/project-core-extension-codestarts/pom.xml
@@ -20,11 +20,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -866,22 +866,7 @@ Do not include any Log4j dependencies, as the `log4j2-jboss-logmanager` library 
 [[logging-adapters-log4j]]
 ==== Log4j
 
-The Log4j adapter is provided by the following dependency:
-
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
-.pom.xml
-----
-<dependency>
-    <groupId>org.jboss.logmanager</groupId>
-    <artifactId>log4j-jboss-logmanager</artifactId>
-</dependency>
-----
-
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-implementation("org.jboss.logmanager:log4j-jboss-logmanager")
-----
+Log4j 1.x is no longer supported by Quarkus.
 
 === Use MDC to add contextual log information
 

--- a/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
+++ b/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
@@ -56,8 +56,9 @@
                 <exclude>org.eclipse.parsson:jakarta.json</exclude>
                 <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
                 <exclude>io.netty:netty-all</exclude>
-                <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->
+                <!-- Ban Log4J 1.x -->
                 <exclude>log4j:log4j</exclude>
+                <!-- Ban Log4J2 (use org.jboss.logmanager:log4j2-jboss-logmanager instead) -->
                 <exclude>org.apache.logging.log4j:log4j-core</exclude>
                 <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
                 <!-- Ban commons-logging (use org.jboss.logging:commons-logging-jboss-logging instead) -->


### PR DESCRIPTION
Libraries should no longer directly depend on Log4j 1.x due to CVEs and lack of ongoing maintenance. WildFly has already discontinued support.

/cc @jamezp 