### PR TITLE
BuildContext.consumeMulti() returns immutable list contrary to javadoc

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
@@ -3,7 +3,7 @@ package io.quarkus.builder;
 import static io.quarkus.builder.Execution.log;
 
 import java.time.LocalTime;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -135,7 +135,7 @@ public final class BuildContext {
         if (!stepInfo.getConsumes().contains(id)) {
             throw Messages.msg.undeclaredItem(id);
         }
-        return Collections.unmodifiableList(execution.getMultis().get(id));
+        return new ArrayList<>(execution.getMultis().get(id));
     }
 
     /**

--- a/core/builder/src/main/java/io/quarkus/builder/MultiBuildItems.java
+++ b/core/builder/src/main/java/io/quarkus/builder/MultiBuildItems.java
@@ -86,7 +86,7 @@ class MultiBuildItems {
     <T extends MultiBuildItem> List<T> get(ItemId id) {
         final List<MultiBuildItem>[] list = multis.get(id);
         if (list == null) {
-            return List.of();
+            return new ArrayList<>();
         }
         final ArrayList<MultiBuildItem> result = new ArrayList<MultiBuildItem>();
         synchronized (list) {


### PR DESCRIPTION
Closes: #52462

Prevents UnsupportedOperationException after the list manipulation.



