### PR TITLE
Use Keycloak Devservice in all OIDC integration tests

### DIFF
--- a/integration-tests/oidc-client/pom.xml
+++ b/integration-tests/oidc-client/pom.xml
@@ -14,17 +14,18 @@
     <name>Quarkus - Integration Tests - OpenID Connect Client</name>
     <description>Module that contains OpenID Connect Client tests</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180</keycloak.url>
-        <keycloak.ssl.url>https://localhost:8543</keycloak.ssl.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-activation</artifactId>
         </dependency>
         <!-- test dependencies -->
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-keycloak-server</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-client-common-synced</artifactId>
@@ -147,18 +148,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -176,89 +171,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>docker-keycloak</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${keycloak.docker.image}</name>
-                                    <alias>quarkus-test-keycloak</alias>
-                                    <run>
-                                        <ports>
-                                            <port>8180:8080</port>
-                                            <port>8543:8443</port>
-                                        </ports>
-                                        <env>
-                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
-                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
-                                        </env>
-                                        <cmd>
-                                            <arg>start-dev</arg>
-                                        </cmd>
-                                        <log>
-                                            <prefix>Keycloak:</prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <http>
-                                                <url>http://localhost:8180</url>
-                                            </http>
-                                            <time>100000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/oidc-client/src/main/resources/application.properties
+++ b/integration-tests/oidc-client/src/main/resources/application.properties
@@ -1,6 +1,4 @@
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
-quarkus.oidc.client-id=quarkus-app
-quarkus.oidc.credentials.secret=secret
+quarkus.keycloak.devservices.create-realm=false
 
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=${quarkus.oidc.client-id}

--- a/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -1,32 +1,27 @@
 package io.quarkus.it.keycloak;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.util.JsonSerialization;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.restassured.RestAssured;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 
-public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
+public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180");
     private static final String KEYCLOAK_REALM = "quarkus";
 
-    static {
-        RestAssured.useRelaxedHTTPSValidation();
-    }
+    final KeycloakTestClient client = new KeycloakTestClient();
 
     @Override
     public Map<String, String> start() {
@@ -41,31 +36,8 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.getUsers().add(createUser("alice", "user"));
         realm.getUsers().add(createUser("bob", "user"));
 
-        try {
-            RestAssured
-                    .given()
-                    .auth().oauth2(getAdminAccessToken())
-                    .contentType("application/json")
-                    .body(JsonSerialization.writeValueAsBytes(realm))
-                    .when()
-                    .post(KEYCLOAK_SERVER_URL + "/admin/realms").then()
-                    .statusCode(201);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        client.createRealm(realm);
         return Collections.emptyMap();
-    }
-
-    private static String getAdminAccessToken() {
-        return RestAssured
-                .given()
-                .param("grant_type", "password")
-                .param("username", "admin")
-                .param("password", "admin")
-                .param("client_id", "admin-cli")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/master/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
     }
 
     private static RealmRepresentation createRealm(String name) {
@@ -126,12 +98,11 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
     }
 
     @Override
-    public void stop() {
+    public void setIntegrationTestContext(DevServicesContext context) {
+        client.setIntegrationTestContext(context);
+    }
 
-        RestAssured
-                .given()
-                .auth().oauth2(getAdminAccessToken())
-                .when()
-                .delete(KEYCLOAK_SERVER_URL + "/admin/realms/" + KEYCLOAK_REALM).then().statusCode(204);
+    @Override
+    public void stop() {
     }
 }

--- a/integration-tests/smallrye-graphql-client-keycloak/pom.xml
+++ b/integration-tests/smallrye-graphql-client-keycloak/pom.xml
@@ -12,9 +12,6 @@
     <artifactId>quarkus-integration-test-smallrye-graphql-client-keycloak</artifactId>
     <name>Quarkus - Integration Tests - SmallRye GraphQL Client with Keycloak</name>
 
-    <properties>
-        <keycloak.url>http://localhost:8180</keycloak.url>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -170,18 +167,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -195,92 +186,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-keycloak</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180</keycloak.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${keycloak.docker.image}</name>
-                                    <alias>quarkus-test-keycloak</alias>
-                                    <run>
-                                        <ports>
-                                            <port>8180:8080</port>
-                                        </ports>
-                                        <env>
-                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
-                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
-                                        </env>
-                                        <cmd>
-                                            <arg>start-dev</arg>
-                                        </cmd>
-                                        <log>
-                                            <prefix>Keycloak:</prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <http>
-                                                <url>http://localhost:8180</url>
-                                            </http>
-                                            <time>100000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!--<plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>-->
                 </plugins>
             </build>
         </profile>

--- a/integration-tests/smallrye-graphql-client-keycloak/src/main/resources/application.properties
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/main/resources/application.properties
@@ -1,7 +1,4 @@
-# Disable Dev Services, Keycloak is started by a Maven plugin
-quarkus.keycloak.devservices.enabled=false
+quarkus.keycloak.devservices.create-realm=false
 
-quarkus.oidc.client-id=quarkus-app
-quarkus.oidc.credentials.secret=secret
 quarkus.smallrye-graphql.log-payload=queryAndVariables
 quarkus.smallrye-graphql.authorization-client-init-payload-name=Authorization

--- a/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryTest.java
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
 
 /**
@@ -24,6 +25,8 @@ public class GraphQLAuthExpiryTest {
     @TestHTTPResource
     URL url;
 
+    final KeycloakTestClient client = new KeycloakTestClient();
+
     private static Stream<Arguments> clientOptions() {
         Boolean[] clientInitValues = new Boolean[] { true, false };
         WebsocketSubprotocol[] subprotocolsValues = WebsocketSubprotocol.values();
@@ -35,7 +38,7 @@ public class GraphQLAuthExpiryTest {
     @ParameterizedTest
     @MethodSource("clientOptions")
     public void testDynamicClientWebSocketAuthenticationExpiry(boolean clientInit, String subprotocol) {
-        String token = KeycloakRealmResourceManager.getAccessToken();
+        String token = client.getAccessToken("alice");
         when()
                 .get("/dynamic-subscription-auth-expiry/" + clientInit + "/" + subprotocol + "/" + token + "/" + url.toString())
                 .then()

--- a/integration-tests/smallrye-jwt-token-propagation/pom.xml
+++ b/integration-tests/smallrye-jwt-token-propagation/pom.xml
@@ -14,10 +14,6 @@
     <name>Quarkus - Integration Tests - Smallrye JWT Token Propagation</name>
     <description>Module that contains Smallrye JWT Token Propagation tests</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180</keycloak.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.eclipse.angus</groupId>
@@ -36,6 +32,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-security-jwt</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-keycloak-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -181,18 +182,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -204,92 +199,6 @@
                                     <goal>generate-code</goal>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-keycloak</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180</keycloak.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${keycloak.docker.image}</name>
-                                    <alias>quarkus-test-keycloak</alias>
-                                    <run>
-                                        <ports>
-                                            <port>8180:8080</port>
-                                        </ports>
-                                        <env>
-                                            <KC_BOOTSTRAP_ADMIN_USERNAME>admin</KC_BOOTSTRAP_ADMIN_USERNAME>
-                                            <KC_BOOTSTRAP_ADMIN_PASSWORD>admin</KC_BOOTSTRAP_ADMIN_PASSWORD>
-                                        </env>
-                                        <cmd>
-                                            <arg>start-dev</arg>
-                                        </cmd>
-                                        <log>
-                                            <prefix>Keycloak:</prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <http>
-                                                <url>http://localhost:8180</url>
-                                            </http>
-                                            <time>100000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.keycloak.devservices.enabled=false
+quarkus.keycloak.devservices.create-realm=false
 
 mp.jwt.verify.publickey.location=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 mp.jwt.verify.issuer=${keycloak.url}/realms/quarkus

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
@@ -14,9 +15,11 @@ import io.restassured.http.ContentType;
 @QuarkusTestResource(KeycloakRealmResourceManager.class)
 public class OidcTokenPropagationTest {
 
+    final KeycloakTestClient client = new KeycloakTestClient();
+
     @Test
     public void testGetUserNameWithJwtTokenPropagation() {
-        RestAssured.given().auth().oauth2(KeycloakRealmResourceManager.getAccessToken("alice"))
+        RestAssured.given().auth().oauth2(client.getAccessToken("alice"))
                 .when().get("/frontend/jwt-token-propagation")
                 .then()
                 .statusCode(200)
@@ -25,7 +28,7 @@ public class OidcTokenPropagationTest {
 
     @Test
     public void testGetUserNameWithJwtTokenPropagationAndAugmentedIdentity() {
-        RestAssured.given().auth().oauth2(KeycloakRealmResourceManager.getAccessToken("alice"))
+        RestAssured.given().auth().oauth2(client.getAccessToken("alice"))
                 .header(USE_SEC_IDENTITY_AUGMENTOR, Boolean.TRUE)
                 .when().get("/frontend/jwt-token-propagation-with-augmentation")
                 .then()
@@ -35,7 +38,7 @@ public class OidcTokenPropagationTest {
 
     @Test
     public void testGetUserNameWithAccessTokenPropagation() {
-        RestAssured.given().auth().oauth2(KeycloakRealmResourceManager.getAccessToken("alice"))
+        RestAssured.given().auth().oauth2(client.getAccessToken("alice"))
                 .when().get("/frontend/access-token-propagation")
                 .then()
                 .statusCode(200)
@@ -44,7 +47,7 @@ public class OidcTokenPropagationTest {
 
     @Test
     public void testEchoUserNameWithAccessTokenPropagation() {
-        RestAssured.given().contentType(ContentType.JSON).auth().oauth2(KeycloakRealmResourceManager.getAccessToken("alice"))
+        RestAssured.given().contentType(ContentType.JSON).auth().oauth2(client.getAccessToken("alice"))
                 .when().body("{\"name\":\"alice\"}").post("/frontend/access-token-propagation")
                 .then()
                 .statusCode(200)
@@ -53,7 +56,7 @@ public class OidcTokenPropagationTest {
 
     @Test
     public void testEchoUserNameWithAccessTokenPropagationForbidden() {
-        RestAssured.given().contentType(ContentType.JSON).auth().oauth2(KeycloakRealmResourceManager.getAccessToken("john"))
+        RestAssured.given().contentType(ContentType.JSON).auth().oauth2(client.getAccessToken("john"))
                 .when().body("{\"name\":\"alice\"}").post("/frontend/access-token-propagation")
                 .then()
                 .statusCode(403);

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtGrpcAuthorizationTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtGrpcAuthorizationTest.java
@@ -5,19 +5,22 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(KeycloakRealmResourceManager.class)
 public class SmallRyeJwtGrpcAuthorizationTest {
 
+    final KeycloakTestClient client = new KeycloakTestClient();
+
     @Test
     public void test() {
-        RestAssured.given().auth().oauth2(KeycloakRealmResourceManager.getAccessToken("john"))
+        RestAssured.given().auth().oauth2(client.getAccessToken("john"))
                 .when().get("/hello/admin")
                 .then()
                 .statusCode(500);
-        RestAssured.given().auth().oauth2(KeycloakRealmResourceManager.getAccessToken("john"))
+        RestAssured.given().auth().oauth2(client.getAccessToken("john"))
                 .when().get("/hello/tester")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
This PR updates the integration OIDC/Keycloak related tests that use a Fabric maven plugin to load Keycloak to use Keycloak Dev Service instead

Holly, please rebase #51829 to pick up this one.

FYI, the `extensions/oidc-client/deployment` tests still use a Fabric maven plugin to load Keycloak but I might change it later