### PR TITLE
OIDC: extract client assertion provider interface

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -1,5 +1,7 @@
 package io.quarkus.oidc.client.runtime;
 
+import static io.quarkus.oidc.common.runtime.OidcCommonUtils.getClientAssertionProvider;
+
 import java.io.IOException;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
@@ -94,16 +96,8 @@ public class OidcClientImpl implements OidcClient {
         this.jwtBearerAuthentication = oidcClientConfig.credentials().jwt().source() == Source.BEARER;
         this.clientJwtKey = jwtBearerAuthentication ? null : clientCredentials.clientJwtKey;
         this.clientSecret = clientCredentials.clientSecret;
-        if (jwtBearerAuthentication && oidcClientConfig.credentials().jwt().tokenPath().isPresent()) {
-            this.clientAssertionProvider = new ClientAssertionProvider(vertx,
-                    oidcClientConfig.credentials().jwt().tokenPath().get());
-            if (this.clientAssertionProvider.getClientAssertion() == null) {
-                throw new OidcClientException("Cannot find a valid JWT bearer token at path: "
-                        + oidcClientConfig.credentials().jwt().tokenPath().get());
-            }
-        } else {
-            this.clientAssertionProvider = null;
-        }
+        this.clientAssertionProvider = getClientAssertionProvider(vertx, oidcClientConfig.credentials(),
+                OidcClientException::new);
     }
 
     @Override

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/ClientAssertionProvider.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/ClientAssertionProvider.java
@@ -1,114 +1,21 @@
 package io.quarkus.oidc.common.runtime;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+/**
+ * Client assertion provider.
+ */
+public sealed interface ClientAssertionProvider permits KubernetesServiceClientAssertionProvider {
 
-import org.eclipse.microprofile.jwt.Claims;
-import org.jboss.logging.Logger;
+    /**
+     * Gets current client assertion. This method should not block. If the client assertion is retrieved with blocking
+     * IO operation, we recommend to keep the assertion up to date using a periodic scheduled task.
+     *
+     * @return client assertion
+     */
+    String getClientAssertion();
 
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
+    /**
+     * Closes this provider. Use this method to cancel the periodic scheduled task.
+     */
+    void close();
 
-public final class ClientAssertionProvider implements Closeable {
-
-    private record ClientAssertion(String bearerToken, long expiresAt, long timerId) {
-        private boolean isInvalid() {
-            final long nowSecs = System.currentTimeMillis() / 1000;
-            return nowSecs > expiresAt;
-        }
-    }
-
-    private static final Logger LOG = Logger.getLogger(ClientAssertionProvider.class);
-    private final Vertx vertx;
-    private final Path bearerTokenPath;
-    private volatile ClientAssertion clientAssertion;
-
-    public ClientAssertionProvider(Vertx vertx, Path bearerTokenPath) {
-        this.vertx = vertx;
-        this.bearerTokenPath = bearerTokenPath;
-        this.clientAssertion = loadFromFileSystem();
-    }
-
-    public String getClientAssertion() {
-        ClientAssertion clientAssertion = this.clientAssertion;
-        if (isInvalid(clientAssertion)) {
-            clientAssertion = loadClientAssertion();
-        }
-        return clientAssertion == null ? null : clientAssertion.bearerToken;
-    }
-
-    @Override
-    public void close() {
-        cancelRefresh();
-        clientAssertion = null;
-    }
-
-    private synchronized ClientAssertion loadClientAssertion() {
-        if (isInvalid(clientAssertion)) {
-            cancelRefresh();
-            clientAssertion = loadFromFileSystem();
-        }
-        return clientAssertion;
-    }
-
-    private long scheduleRefresh(long expiresAt) {
-        // in K8 and OCP, tokens are proactively rotated at 80 % of their TTL
-        long delay = (long) (expiresAt * 0.85);
-        return vertx.setTimer(delay, new Handler<Long>() {
-            @Override
-            public void handle(Long ignored) {
-                ClientAssertionProvider.this.clientAssertion = loadFromFileSystem();
-            }
-        });
-    }
-
-    private void cancelRefresh() {
-        if (clientAssertion != null) {
-            vertx.cancelTimer(clientAssertion.timerId);
-        }
-    }
-
-    private ClientAssertion loadFromFileSystem() {
-        if (Files.exists(bearerTokenPath)) {
-            try {
-                String bearerToken = Files.readString(bearerTokenPath).trim();
-                if (bearerToken.isEmpty()) {
-                    LOG.error(String.format("Bearer token file at path %s is empty or contains only whitespace",
-                            bearerTokenPath));
-                    return null;
-                }
-                Long expiresAt = getExpiresAtFromExpClaim(bearerToken);
-                if (expiresAt != null) {
-                    return new ClientAssertion(bearerToken, expiresAt, scheduleRefresh(expiresAt));
-                } else {
-                    LOG.error("Bearer token or its expiry claim is invalid");
-                }
-            } catch (IOException e) {
-                LOG.error("Failed to read file with a bearer token at path: " + bearerTokenPath, e);
-            }
-        } else {
-            LOG.warn("Cannot find a file with a bearer token at path: " + bearerTokenPath);
-        }
-        return null;
-    }
-
-    private static boolean isInvalid(ClientAssertion clientAssertion) {
-        return clientAssertion == null || clientAssertion.isInvalid();
-    }
-
-    private static Long getExpiresAtFromExpClaim(String bearerToken) {
-        JsonObject claims = OidcCommonUtils.decodeJwtContent(bearerToken);
-        if (claims == null || !claims.containsKey(Claims.exp.name())) {
-            return null;
-        }
-        try {
-            return claims.getLong(Claims.exp.name());
-        } catch (IllegalArgumentException ex) {
-            LOG.debug("Bearer token expiry claim can not be converted to Long");
-            return null;
-        }
-    }
 }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProvider.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProvider.java
@@ -1,0 +1,115 @@
+package io.quarkus.oidc.common.runtime;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+final class KubernetesServiceClientAssertionProvider implements ClientAssertionProvider, Closeable {
+
+    private record ClientAssertion(String bearerToken, long expiresAt, long timerId) {
+        private boolean isInvalid() {
+            final long nowSecs = System.currentTimeMillis() / 1000;
+            return nowSecs > expiresAt;
+        }
+    }
+
+    private static final Logger LOG = Logger.getLogger(KubernetesServiceClientAssertionProvider.class);
+    private final Vertx vertx;
+    private final Path bearerTokenPath;
+    private volatile ClientAssertion clientAssertion;
+
+    KubernetesServiceClientAssertionProvider(Vertx vertx, Path bearerTokenPath) {
+        this.vertx = vertx;
+        this.bearerTokenPath = bearerTokenPath;
+        this.clientAssertion = loadFromFileSystem();
+    }
+
+    @Override
+    public String getClientAssertion() {
+        ClientAssertion clientAssertion = this.clientAssertion;
+        if (isInvalid(clientAssertion)) {
+            clientAssertion = loadClientAssertion();
+        }
+        return clientAssertion == null ? null : clientAssertion.bearerToken;
+    }
+
+    @Override
+    public void close() {
+        cancelRefresh();
+        clientAssertion = null;
+    }
+
+    private synchronized ClientAssertion loadClientAssertion() {
+        if (isInvalid(clientAssertion)) {
+            cancelRefresh();
+            clientAssertion = loadFromFileSystem();
+        }
+        return clientAssertion;
+    }
+
+    private long scheduleRefresh(long expiresAt) {
+        // in K8 and OCP, tokens are proactively rotated at 80 % of their TTL
+        long delay = (long) (expiresAt * 0.85);
+        return vertx.setTimer(delay, new Handler<Long>() {
+            @Override
+            public void handle(Long ignored) {
+                KubernetesServiceClientAssertionProvider.this.clientAssertion = loadFromFileSystem();
+            }
+        });
+    }
+
+    private void cancelRefresh() {
+        if (clientAssertion != null) {
+            vertx.cancelTimer(clientAssertion.timerId);
+        }
+    }
+
+    private ClientAssertion loadFromFileSystem() {
+        if (Files.exists(bearerTokenPath)) {
+            try {
+                String bearerToken = Files.readString(bearerTokenPath).trim();
+                if (bearerToken.isEmpty()) {
+                    LOG.error(String.format("Bearer token file at path %s is empty or contains only whitespace",
+                            bearerTokenPath));
+                    return null;
+                }
+                Long expiresAt = getExpiresAtFromExpClaim(bearerToken);
+                if (expiresAt != null) {
+                    return new ClientAssertion(bearerToken, expiresAt, scheduleRefresh(expiresAt));
+                } else {
+                    LOG.error("Bearer token or its expiry claim is invalid");
+                }
+            } catch (IOException e) {
+                LOG.error("Failed to read file with a bearer token at path: " + bearerTokenPath, e);
+            }
+        } else {
+            LOG.warn("Cannot find a file with a bearer token at path: " + bearerTokenPath);
+        }
+        return null;
+    }
+
+    private static boolean isInvalid(ClientAssertion clientAssertion) {
+        return clientAssertion == null || clientAssertion.isInvalid();
+    }
+
+    private static Long getExpiresAtFromExpClaim(String bearerToken) {
+        JsonObject claims = OidcCommonUtils.decodeJwtContent(bearerToken);
+        if (claims == null || !claims.containsKey(Claims.exp.name())) {
+            return null;
+        }
+        try {
+            return claims.getLong(Claims.exp.name());
+        } catch (IllegalArgumentException ex) {
+            LOG.debug("Bearer token expiry claim can not be converted to Long");
+            return null;
+        }
+    }
+}

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProviderTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProviderTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import io.smallrye.jwt.build.Jwt;
 import io.vertx.core.Vertx;
 
-public class ClientAssertionProviderTest {
+public class KubernetesServiceClientAssertionProviderTest {
 
     @Test
     public void testJwtBearerTokenRefresh() {
@@ -26,7 +26,7 @@ public class ClientAssertionProviderTest {
         Path jwtBearerTokenPath = Path.of("target").resolve("jwt-bearer-token.json");
         String jwtBearerToken = createJwtBearerToken();
         storeNewJwtBearerToken(jwtBearerTokenPath, jwtBearerToken);
-        try (var clientAssertionProvider = new ClientAssertionProvider(vertx, jwtBearerTokenPath)) {
+        try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, jwtBearerTokenPath)) {
             // assert first token is loaded
             assertEquals(jwtBearerToken, clientAssertionProvider.getClientAssertion());
 
@@ -47,7 +47,7 @@ public class ClientAssertionProviderTest {
         Path emptyTokenPath = Path.of("target").resolve("empty-jwt-bearer-token.json");
 
         storeNewJwtBearerToken(emptyTokenPath, "");
-        try (var clientAssertionProvider = new ClientAssertionProvider(vertx, emptyTokenPath)) {
+        try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, emptyTokenPath)) {
             assertNull(clientAssertionProvider.getClientAssertion());
 
             String validToken = createJwtBearerToken();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.runtime;
 
 import static io.quarkus.oidc.common.OidcEndpoint.Type.PUSHED_AUTHORIZATION_REQUEST;
+import static io.quarkus.oidc.common.runtime.OidcCommonUtils.getClientAssertionProvider;
 
 import java.io.Closeable;
 import java.net.SocketException;
@@ -98,7 +99,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         this.clientSecretBasicAuthScheme = clientCredentials.clientSecretBasicAuthScheme;
         this.jwtBearerAuthentication = oidcConfig.credentials().jwt()
                 .source() == OidcClientCommonConfig.Credentials.Jwt.Source.BEARER;
-        this.clientAssertionProvider = this.jwtBearerAuthentication ? createClientAssertionProvider(vertx, oidcConfig) : null;
+        this.clientAssertionProvider = getClientAssertionProvider(vertx, oidcConfig.credentials(), OIDCException::new);
         this.clientJwtKey = jwtBearerAuthentication ? null : clientCredentials.clientJwtKey;
         this.introspectionBasicAuthScheme = initIntrospectionBasicAuthScheme(oidcConfig);
         this.requestFilters = requestFilters;
@@ -106,16 +107,6 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         this.clientSecretQueryAuthentication = oidcConfig.credentials().clientSecret().method().orElse(null) == Method.QUERY;
         this.clientSecret = clientCredentials.clientSecret;
         this.jwtSecret = clientCredentials.jwtSecret;
-    }
-
-    private static ClientAssertionProvider createClientAssertionProvider(Vertx vertx, OidcTenantConfig oidcConfig) {
-        var clientAssertionProvider = new ClientAssertionProvider(vertx,
-                oidcConfig.credentials().jwt().tokenPath().get());
-        if (clientAssertionProvider.getClientAssertion() == null) {
-            throw new OIDCException("Cannot find a valid JWT bearer token at path: "
-                    + oidcConfig.credentials().jwt().tokenPath().get());
-        }
-        return clientAssertionProvider;
     }
 
     void setOidcProvider(OidcProvider oidcProvider) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -1378,15 +1378,15 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
 
         /**
          * Configures the `authorization_details` request parameter string fields of the authorization request.
-         * Please note that the `type` field is required. If the `type` is not configured, validation will fail.
-         * For example, if you configure the `quarkus.oidc.authentication.rar.simple.type=openid_credential`
+         * For example, if you configure the
+         * `quarkus.oidc.authentication.rar.simple.credential_configuration_id=vc-scope-mapping`
          * property, following `authorization_details` request parameter will be added to the authorization request:
          *
          * <pre>
          * {@code
          * [
          *    {
-         *       "type": "openid_credential"
+         *       "credential_configuration_id": "vc-scope-mapping"
          *    }
          * ]
          * }


### PR DESCRIPTION
As a pre-step for https://github.com/quarkusio/quarkus/issues/52232, we agreed to extract `ClientAssertionProvider` from Kubernetes implementation, so that later, we can introduce SPIFFE one.