### PR TITLE
Redis Client: fix NPE in optimistic locking transactions

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/TransactionHolder.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/TransactionHolder.java
@@ -39,11 +39,12 @@ public class TransactionHolder {
         List<Object> results = new ArrayList<>();
         for (int i = 0; i < mappers.size(); i++) {
             Response responsePart = response.get(i);
-            if (responsePart.type() == ResponseType.ERROR) {
+            if (responsePart == null || responsePart.type() != ResponseType.ERROR) {
+                // `null` is a valid result
+                results.add(mappers.get(i).apply(responsePart));
+            } else {
                 hasErrors = true;
                 results.add(responsePart.getDelegate()); // it's also an exception
-            } else {
-                results.add(mappers.get(i).apply(responsePart));
             }
         }
         return new OptimisticLockingTransactionResultImpl<>(discarded, hasErrors, input, results);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Validation.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Validation.java
@@ -127,13 +127,13 @@ public class Validation {
 
     public static void positiveOrZero(double amount, String name) {
         if (amount < 0) {
-            throw new IllegalArgumentException(String.format("`%s` must be greater or equal to zero`", name));
+            throw new IllegalArgumentException(String.format("`%s` must be greater or equal to zero", name));
         }
     }
 
     public static void isBit(int b, String name) {
         if (b != 0 && b != 1) {
-            throw new IllegalArgumentException(String.format("%s` must be either `0` or `1`", name));
+            throw new IllegalArgumentException(String.format("`%s` must be either `0` or `1`", name));
         }
     }
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/OptimisticLockingTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/OptimisticLockingTest.java
@@ -347,4 +347,27 @@ public class OptimisticLockingTest extends DatasourceTestBase {
         assertThat(res.getPreTransactionResult()).isEqualTo("a");
     }
 
+    @Test
+    public void nullInResult() {
+        OptimisticLockingTransactionResult<Object> result = blocking.withTransaction(
+                ds -> null,
+                (ignored, tx) -> tx.value(String.class).get(key),
+                key);
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.discarded()).isFalse();
+        assertThat((Object) result.get(0)).isNull();
+    }
+
+    @Test
+    public void nullInResultReactive() {
+        OptimisticLockingTransactionResult<Void> result = reactive.withTransaction(
+                ds -> Uni.createFrom().voidItem(),
+                (ignored, tx) -> tx.value(String.class).get(key),
+                key).await().indefinitely();
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.discarded()).isFalse();
+        assertThat((Object) result.get(0)).isNull();
+    }
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalValueCommandsTest.java
@@ -42,14 +42,16 @@ public class TransactionalValueCommandsTest extends DatasourceTestBase {
             string.append(key, "-1");
             string.get(key);
             string.strlen("k2");
+            string.get("nonexisting_key");
         });
-        assertThat(result.size()).isEqualTo(5);
+        assertThat(result.size()).isEqualTo(6);
         assertThat(result.discarded()).isFalse();
         assertThat(result.<Void> get(0)).isNull();
         assertThat((boolean) result.get(1)).isTrue();
         assertThat((long) result.get(2)).isEqualTo(7L);
         assertThat((String) result.get(3)).isEqualTo("hello-1");
         assertThat((long) result.get(4)).isEqualTo(7L);
+        assertThat((Object) result.get(5)).isNull();
     }
 
     @Test
@@ -60,15 +62,17 @@ public class TransactionalValueCommandsTest extends DatasourceTestBase {
                     .chain(() -> string.setnx("k2", "bonjour"))
                     .chain(() -> string.append(key, "-1"))
                     .chain(() -> string.get(key))
-                    .chain(() -> string.strlen("k2"));
+                    .chain(() -> string.strlen("k2"))
+                    .chain(() -> string.get("nonexisting_key"));
         }).await().atMost(Duration.ofSeconds(5));
-        assertThat(result.size()).isEqualTo(5);
+        assertThat(result.size()).isEqualTo(6);
         assertThat(result.discarded()).isFalse();
         assertThat(result.<Void> get(0)).isNull();
         assertThat((boolean) result.get(1)).isTrue();
         assertThat((long) result.get(2)).isEqualTo(7L);
         assertThat((String) result.get(3)).isEqualTo("hello-1");
         assertThat((long) result.get(4)).isEqualTo(7L);
+        assertThat((Object) result.get(5)).isNull();
     }
 
 }


### PR DESCRIPTION
The `TransactionHolder` class has methods to convert a `Response` into a `TransactionResult` or `OptimisticLockingTransactionResult`. For some reason, the first variant did consider `null` as a valid result, while the second did not. They are unified now.

Further, this commit adds input validation to transactional methods in `BlockingRedisDataSourceImpl`, similarly to how they are done in `ReactiveRedisDataSourceImpl`.

Fixes #52478