### PR TITLE
Fix TLS registry plugin declaration

### DIFF
--- a/extensions/tls-registry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/tls-registry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,4 @@ metadata:
   config:
   - "quarkus.tls."
   cli-plugins:
-  - "tls: ${project.groupId}:quarkus-tls-registry-cli:${project.version}@jbang"
+  - "tls: ${project.groupId}:quarkus-tls-registry-cli:${project.version}@fatjar"


### PR DESCRIPTION
I had to test it with a local
.quarkus/cli/plugins/quarkus-cli-catalog.json and apparently had a brainfreeze when I copy/pasted the config...

Follow-up of https://github.com/quarkusio/quarkus/pull/52392, thanks to @rsvoboda for spotting it!
