### PR TITLE
Programmatic way to ignore specific JAXB annotated classes when registering for reflection and adding to default JAXB context

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/IgnoreJaxbAnnotatedClassesBuildItem.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/IgnoreJaxbAnnotatedClassesBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.jaxb.deployment;
+
+import java.util.function.Predicate;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Selects class names to ignore when registering for reflection and binding in the default JAXB context even though
+ * annotated with some of the JAXB root annotations.
+ */
+public final class IgnoreJaxbAnnotatedClassesBuildItem extends MultiBuildItem {
+
+    private final Predicate<String> predicate;
+
+    /**
+     * @param predicate whose {@link Predicate#test(Object)} method returns {@code true} for class names which should
+     *        be ignored when registering for reflection and binding in the default JAXB context
+     */
+    public IgnoreJaxbAnnotatedClassesBuildItem(Predicate<String> predicate) {
+        this.predicate = predicate;
+    }
+
+    public Predicate<String> getPredicate() {
+        return predicate;
+    }
+
+}


### PR DESCRIPTION
fix #52484

The idea is that Camel Quarkus will produce IgnoreJaxbAnnotatedClassesBuildItem for all `org.apache.camel.model.*` classes and possible pass its own custom ReflectiveHierarchyBuildItems that won't cause issues mentioned in https://github.com/apache/camel-quarkus/issues/8245