### PR TITLE
Support for loading Maven POM 4.1

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -187,6 +187,7 @@
                         <parentFirstArtifact>org.jboss.logmanager:jboss-logmanager</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logging:jboss-logging</parentFirstArtifact>
                         <parentFirstArtifact>org.apache.maven:maven-model</parentFirstArtifact>
+                        <parentFirstArtifact>org.apache.maven:maven-xml</parentFirstArtifact>
                         <parentFirstArtifact>org.apache.maven.resolver:maven-resolver-api</parentFirstArtifact>
                         <parentFirstArtifact>org.apache.maven.resolver:maven-resolver-impl</parentFirstArtifact>
                         <parentFirstArtifact>org.codehaus.plexus:plexus-utils</parentFirstArtifact>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -151,6 +151,11 @@
             <artifactId>maven-model-builder</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-xml</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -170,6 +170,11 @@
             <artifactId>maven-model-builder</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-xml</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -105,12 +105,12 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model</artifactId>
-                <version>${maven-core.version}</version>
+                <version>${maven-model.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model-builder</artifactId>
-                <version>${maven-core.version}</version>
+                <version>${maven-model.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.inject</groupId>
@@ -120,13 +120,18 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
+                <artifactId>maven-xml</artifactId>
+                <version>${maven-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>
                 <version>${maven-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-builder-support</artifactId>
-                <version>${maven-core.version}</version>
+                <version>${maven-model.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -433,6 +438,11 @@
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>${plexus-utils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-xml</artifactId>
+                <version>${plexus-xml.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -105,12 +105,12 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model</artifactId>
-                <version>${maven-core.version}</version>
+                <version>${maven-model.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model-builder</artifactId>
-                <version>${maven-core.version}</version>
+                <version>${maven-model.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.inject</groupId>
@@ -120,13 +120,18 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
+                <artifactId>maven-xml</artifactId>
+                <version>${maven-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>
                 <version>${maven-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-builder-support</artifactId>
-                <version>${maven-core.version}</version>
+                <version>${maven-model.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -172,6 +177,11 @@
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>${plexus-utils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-xml</artifactId>
+                <version>${plexus-xml.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
@@ -11,16 +11,20 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Consumer;
 
+import org.apache.maven.api.xml.XmlService;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Profile;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelCache;
 import org.apache.maven.model.resolution.WorkspaceModelResolver;
+import org.apache.maven.model.v4.MavenStaxReader;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.repository.WorkspaceRepository;
@@ -44,10 +48,29 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
 
     static final Model MISSING_MODEL = new Model();
 
+    /**
+     * Preloads a few classes related to POM parsing. This is to avoid classloading deadlocks when called
+     * in the context of the FacadeClassLoader, which isn't parallel capable atm.
+     */
+    private static void preloadMavenXmlReaders() {
+        new MavenStaxReader().getXMLInputFactory();
+        try {
+            // maven-xml was added as parent-first in quarkus-core, which helps with initializing the resolver in a test process,
+            // here we use TCCL to make sure quarkus:dev boots
+            //final Class<?> cls = Thread.currentThread().getContextClassLoader().loadClass(XmlService.class.getName());
+            final Class<?> cls = RepositorySystem.class.getClassLoader().loadClass(XmlService.class.getName());
+            ServiceLoader.load(cls).findFirst();
+        } catch (ClassNotFoundException e) {
+            // it's expected to load the class. If it doesn't, there is no reason to fail at this point though, since
+            // this preload is a kind of hacky workaround anyway
+        }
+    }
+
     private static ModelResolutionTaskRunner getTaskRunner() {
         if (ModelResolutionTaskRunnerFactory.isDefaultRunnerBlocking()) {
             return ModelResolutionTaskRunnerFactory.getBlockingTaskRunner();
         }
+        preloadMavenXmlReaders();
         return ModelResolutionTaskRunnerFactory.getNonBlockingTaskRunner();
     }
 

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -161,13 +161,21 @@ public class DependencyUtils {
     }
 
     public static ResolvedDependencyBuilder toAppArtifact(Artifact artifact, WorkspaceModule module) {
+        String version = artifact.getVersion();
+        // Hopefully, this version check won't be necessary once we move to the Maven resolver 2.x.
+        // For now, when we resolve an artifact descriptor for a local project that has a dependency
+        // on another local project but doesn't configure a version for that dependency (and it's not managed),
+        // we will get an empty version for that dependency, which will also appear in the corresponding DependencyNode.
+        if (version.isEmpty() && module != null) {
+            version = module.getId().getVersion();
+        }
         return ResolvedDependencyBuilder.newInstance()
                 .setWorkspaceModule(module)
                 .setGroupId(artifact.getGroupId())
                 .setArtifactId(artifact.getArtifactId())
                 .setClassifier(artifact.getClassifier())
                 .setType(artifact.getExtension())
-                .setVersion(artifact.getVersion())
+                .setVersion(version)
                 .setResolvedPaths(artifact.getFile() == null ? PathList.empty() : PathList.of(artifact.getFile().toPath()));
     }
 

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -211,13 +211,21 @@ public class DependencyUtils {
     }
 
     public static ResolvedDependencyBuilder toAppArtifact(Artifact artifact, WorkspaceModule module) {
+        String version = artifact.getVersion();
+        // Hopefully, this version check won't be necessary once we move to the Maven resolver 2.x.
+        // For now, when we resolve an artifact descriptor for a local project that has a dependency
+        // on another local project but doesn't configure a version for that dependency (and it's not managed),
+        // we will get an empty version for that dependency, which will also appear in the corresponding DependencyNode.
+        if (version.isEmpty() && module != null) {
+            version = module.getId().getVersion();
+        }
         return ResolvedDependencyBuilder.newInstance()
                 .setWorkspaceModule(module)
                 .setGroupId(artifact.getGroupId())
                 .setArtifactId(artifact.getArtifactId())
                 .setClassifier(artifact.getClassifier())
                 .setType(artifact.getExtension())
-                .setVersion(artifact.getVersion())
+                .setVersion(version)
                 .setResolvedPaths(artifact.getFile() == null ? PathList.empty() : PathList.of(artifact.getFile().toPath()));
     }
 

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -733,6 +733,21 @@ public class LocalWorkspaceDiscoveryTest {
         assertEquals(2, ws.getProjects().size());
     }
 
+    @Test
+    public void mavenModel401() throws Exception {
+        final Path moduleDir = getModuleDir("maven-model-4.1/integration-test/java/quarkus-app");
+
+        final LocalWorkspace ws = new BootstrapMavenContext(BootstrapMavenContext.config()
+                .setOffline(true)
+                .setCurrentProject(moduleDir.toString()))
+                .getWorkspace();
+
+        assertThat(ws.getProject("org.acme.integration", "integration-test-java-quarkus-app")).isNotNull();
+        assertThat(ws.getProject("org.acme.integration", "integration-test-parent")).isNotNull();
+        assertThat(ws.getProject("org.acme", "acme-parent")).isNotNull();
+        assertThat(ws.getProjects().size()).isEqualTo(3);
+    }
+
     private void testMavenCiFriendlyVersion(String placeholder, String testResourceDirName, String expectedResolvedVersion,
             boolean resolvesFromWorkspace) throws Exception {
         final Path module1Dir = getModuleDir(testResourceDirName + "/root/module1");

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/maven-model-4.1/integration-test/java/quarkus-app/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/maven-model-4.1/integration-test/java/quarkus-app/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <parent>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>integration-test-java-quarkus-app</artifactId>
+    <name>Integration Test Java Quarkus-App</name>
+
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/maven-model-4.1/integration-test/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/maven-model-4.1/integration-test/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>acme-parent</artifactId>
+    </parent>
+
+    <groupId>org.acme.integration</groupId>
+    <artifactId>integration-test-parent</artifactId>
+    <name>Integration Test Parent</name>
+    <packaging>pom</packaging>
+
+    <subprojects>
+        <subproject>java/quarkus-app</subproject>
+    </subprojects>
+
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/maven-model-4.1/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/maven-model-4.1/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>acme-parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Acme Project POM</name>
+    <description>Parent POM for Acme project</description>
+
+    <subprojects>
+        <subproject>integration-test</subproject>
+    </subprojects>
+
+</project>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -43,6 +43,7 @@
         <junit.version>6.0.3</junit.version>
         <maven-core.version>3.9.12</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.9.0.M4</sisu.version><!-- Keep in sync with maven-core.version -->
+        <maven-model.version>4.0.0-rc-5</maven-model.version>
         <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <maven-resolver.version>1.9.25</maven-resolver.version>
         <maven-shared-utils.version>3.4.2</maven-shared-utils.version> <!-- Keep in sync with maven-core.version (force this version on maven-invoker) -->
@@ -69,7 +70,8 @@
         <plexus-cipher.version>2.0</plexus-cipher.version>
         <plexus-interpolation.version>1.26</plexus-interpolation.version>
         <plexus-sec-dispatcher.version>2.0</plexus-sec-dispatcher.version>
-        <plexus-utils.version>3.5.1</plexus-utils.version>
+        <plexus-utils.version>4.0.2</plexus-utils.version>
+        <plexus-xml.version>4.1.0</plexus-xml.version>
         <smallrye-common.version>2.16.0</smallrye-common.version>
         <smallrye-beanbag.version>1.6.1</smallrye-beanbag.version>
         <gradle-tooling.version>9.3.1</gradle-tooling.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -43,6 +43,7 @@
         <junit.version>6.1.3</junit.version>
         <maven-core.version>3.9.16</maven-core.version><!-- Keep in sync with sisu.version: https://central.sonatype.com/artifact/org.apache.maven/maven -->
         <sisu.version>1.0.1</sisu.version><!-- Keep in sync with maven-core.version -->
+        <maven-model.version>4.0.0-rc-6</maven-model.version>
         <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <maven-resolver.version>1.9.27</maven-resolver.version>
         <maven-shared-utils.version>3.4.2</maven-shared-utils.version> <!-- Keep in sync with maven-core.version (force this version on maven-invoker) -->
@@ -69,9 +70,10 @@
         <plexus-cipher.version>2.0</plexus-cipher.version>
         <plexus-interpolation.version>1.26</plexus-interpolation.version>
         <plexus-sec-dispatcher.version>2.0</plexus-sec-dispatcher.version>
-        <plexus-utils.version>3.6.1</plexus-utils.version>
         <smallrye-common.version>2.20.0</smallrye-common.version>
         <smallrye-classfile.version>26</smallrye-classfile.version>
+        <plexus-utils.version>4.0.2</plexus-utils.version>
+        <plexus-xml.version>4.1.0</plexus-xml.version>
         <smallrye-beanbag.version>1.6.1</smallrye-beanbag.version>
         <gradle-tooling.version>9.7.0</gradle-tooling.version>
         <quarkus-fs-util.version>1.4.2</quarkus-fs-util.version>

--- a/independent-projects/tools/codestarts/src/test/resources/expected-pom-maven-merge.xml
+++ b/independent-projects/tools/codestarts/src/test/resources/expected-pom-maven-merge.xml
@@ -6,11 +6,11 @@
     <version>1.2.3</version>
 
     <properties>
+        <zebra>starts-with-z</zebra>
+        <prop2>prop-2-namespaced</prop2>
+        <prop1>proppp</prop1>
         <abc>123</abc>
         <fruit>pineapple</fruit>
-        <prop1>proppp</prop1>
-        <prop2>prop-2-namespaced</prop2>
-        <zebra>starts-with-z</zebra>
     </properties>
 
     <dependencies>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
@@ -7,13 +7,13 @@
     <packaging>quarkus</packaging>
 
     <properties>
-        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
+        <maven.compiler.release>17</maven.compiler.release>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>999-MOCK</quarkus.platform.version>
+        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-MOCK</surefire-plugin.version>
     </properties>
@@ -100,9 +100,9 @@
                 </property>
             </activation>
             <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
                 <skipITs>false</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefaultWithWrapper/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefaultWithWrapper/pom.xml
@@ -7,13 +7,13 @@
     <packaging>quarkus</packaging>
 
     <properties>
-        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
+        <maven.compiler.release>17</maven.compiler.release>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>999-MOCK</quarkus.platform.version>
+        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-MOCK</surefire-plugin.version>
     </properties>
@@ -100,9 +100,9 @@
                 </property>
             </activation>
             <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
                 <skipITs>false</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -7,13 +7,13 @@
     <packaging>quarkus</packaging>
 
     <properties>
-        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
+        <maven.compiler.release>17</maven.compiler.release>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>999-MOCK</quarkus.platform.version>
+        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-MOCK</surefire-plugin.version>
     </properties>
@@ -115,9 +115,9 @@
                 </property>
             </activation>
             <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
                 <skipITs>false</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>

--- a/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
@@ -6,16 +6,16 @@
     <version>1.0.0-codestart</version>
 
     <properties>
-        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <kotlin.version>1.4.28-MOCK</kotlin.version>
         <maven.compiler.release>17</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-MOCK</quarkus.platform.version>
-        <skipITs>true</skipITs>
+        <kotlin.version>1.4.28-MOCK</kotlin.version>
+        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-MOCK</surefire-plugin.version>
+        <skipITs>true</skipITs>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     </properties>
 
     <dependencyManagement>
@@ -173,9 +173,9 @@
                 </property>
             </activation>
             <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
                 <skipITs>false</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>

--- a/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
@@ -7,16 +7,16 @@
     <packaging>quarkus</packaging>
 
     <properties>
-        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <kotlin.version>1.4.28-MOCK</kotlin.version>
         <maven.compiler.release>17</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-MOCK</quarkus.platform.version>
-        <skipITs>true</skipITs>
+        <kotlin.version>1.4.28-MOCK</kotlin.version>
+        <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-MOCK</surefire-plugin.version>
+        <skipITs>true</skipITs>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     </properties>
 
     <dependencyManagement>
@@ -174,9 +174,9 @@
                 </property>
             </activation>
             <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
                 <skipITs>false</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/52190

I'm opening this PR, however, I noticed that with upgraded the Maven model dependencies the integration tests timed out in my fork for all JDKs but they would get to different tests in the runs. If I rollback the dependency upgrades and leave the code changes, the CI passes. Let's see whether the same happens in this CI run.
