### PR TITLE
Avoid sorting list of build items

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
@@ -113,12 +113,10 @@ public final class BuildContext {
     }
 
     /**
-     * Consume all the values produced for the named item. If the
-     * item type implements {@link Comparable}, it will be sorted by natural order before return. The returned list
-     * is a mutable copy.
+     * Consume all the values produced for the named item.
      *
      * @param type the item element type (must not be {@code null})
-     * @return the produced items (may be empty, will not be {@code null})
+     * @return the produced items as an immutable list (may be empty, will not be {@code null})
      * @throws IllegalArgumentException if this deployer was not declared to consume {@code type}, or if {@code type} is
      *         {@code null}
      */
@@ -148,10 +146,10 @@ public final class BuildContext {
      * @throws IllegalArgumentException if this deployer was not declared to consume {@code type}, or if {@code type} is
      *         {@code null}
      */
+    @Deprecated(since = "3.32", forRemoval = true)
     public <T extends MultiBuildItem> List<T> consumeMulti(Class<T> type, Comparator<? super T> comparator) {
-        final List<T> result = consumeMulti(type);
-        result.sort(comparator);
-        return result;
+        // you need to make a copy before sorting as the result of consumeMulti(type) is immutable
+        return consumeMulti(type).stream().sorted(comparator).toList();
     }
 
     /**

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1604,9 +1604,9 @@ public class ResteasyReactiveProcessor {
         if (preExceptionMapperHandlerBuildItems.size() == 1) {
             return preExceptionMapperHandlerBuildItems.get(0).getHandler();
         }
-        Collections.sort(preExceptionMapperHandlerBuildItems);
         return new DelegatingServerRestHandler(preExceptionMapperHandlerBuildItems.stream()
-                .map(PreExceptionMapperHandlerBuildItem::getHandler).collect(toList()));
+                .sorted()
+                .map(PreExceptionMapperHandlerBuildItem::getHandler).toList());
     }
 
     private static boolean notFoundCustomExMapper(String builtInExSignature, String builtInMapperSignature,


### PR DESCRIPTION
During the work on build step ordering, we decided to go with an immutable list for the build items, rather than always copying to a new list for a few corner cases.
This makes the contract clearer but... there was one Collections.sort() remaining.

Also remove some misleading javadoc and a method we decided not to support.

It would probably be a good idea to add a test for this feature to make sure we don't regress anymore.

This is a follow-up of https://github.com/quarkusio/quarkus/pull/52129.

It supersedes https://github.com/quarkusio/quarkus/pull/52463 and is a fix for https://github.com/quarkusio/quarkus/issues/52462.

Fixes #52462
