### PR TITLE
Add directories in ParallelCommonsCompressArchiveCreator

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -194,7 +194,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             // make sure we write the elements in order
             for (GeneratedResourceBuildItem i : generatedResources.stream()
                     .sorted(Comparator.comparing(GeneratedResourceBuildItem::getName)).toList()) {
-                archiveCreator.addFile(i.getData(), i.getName());
+                archiveCreator.addFileIfNotExists(i.getData(), i.getName());
             }
         }
         if (decompiler != null) {


### PR DESCRIPTION
We used to add the directories to the files as a side-effect of using a ZipFileSystem to create the jars.
We lost this property when we switched to the
ParallelCommonsCompressArchiveCreator.

While not important in most cases (jars don't need a directory structure), it's actually important for META-INF/resources because the Vert.x static handler relies on it.

Also made things a bit more consistent.

Fixes https://github.com/quarkiverse/quarkus-quinoa/issues/960