### PR TITLE
Avoid reading System Properties during configuration phase with  `disableCreatingBuildConfigDuringConfiguration` property

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -15,6 +15,7 @@ import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.testing.Test;
@@ -37,12 +38,15 @@ public class BeforeTestAction implements Action<Task> {
     private final MapProperty<String, Object> manifestAttributes;
     private final MapProperty<String, Attributes> manifestSections;
 
+    private final ListProperty<String> ignoredEntries;
+
     public BeforeTestAction(File projectDir, FileCollection combinedOutputSourceDirs,
             Provider<RegularFile> applicationModelPath, Provider<File> nativeRunnerPath,
             FileCollection mainSourceSetClassesDir,
             QuarkusPluginExtensionView extensionView,
             MapProperty<String, Object> manifestAttributes,
-            MapProperty<String, Attributes> manifestSections) {
+            MapProperty<String, Attributes> manifestSections,
+            ListProperty<String> ignoredEntries) {
         this.projectDir = projectDir;
         this.combinedOutputSourceDirs = combinedOutputSourceDirs;
         this.applicationModelPath = applicationModelPath;
@@ -51,6 +55,7 @@ public class BeforeTestAction implements Action<Task> {
         this.extensionView = extensionView;
         this.manifestAttributes = manifestAttributes;
         this.manifestSections = manifestSections;
+        this.ignoredEntries = ignoredEntries;
 
     }
 
@@ -100,7 +105,7 @@ public class BeforeTestAction implements Action<Task> {
 
     private EffectiveConfigProvider effectiveProvider() {
         return new EffectiveConfigProvider(
-                extensionView.getIgnoredEntries(),
+                ignoredEntries,
                 extensionView.getMainResources(),
                 extensionView.getForcedProperties(),
                 extensionView.getProjectProperties(),

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -46,6 +46,8 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
     private final ListProperty<String> codeGenerationProviders;
     private final ListProperty<String> codeGenerationInputs;
 
+    private final Property<Boolean> disableCreatingBuildConfigDuringConfiguration;
+
     public QuarkusPluginExtension(Project project) {
         super(project);
 
@@ -59,6 +61,7 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
                 .convention(List.of(CODE_GENERATION_INPUT));
 
         this.sourceSetExtension = new SourceSetExtension();
+        this.disableCreatingBuildConfigDuringConfiguration = project.getObjects().property(Boolean.class).convention(false);
     }
 
     public Manifest getManifest() {
@@ -264,5 +267,13 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
 
     private String addQuarkusBuildPropertyPrefix(String name) {
         return String.format("quarkus.%s", name);
+    }
+
+    public void setDisableCreatingBuildConfigDuringConfiguration(Boolean disableCreatingBuildConfigDuringConfiguration) {
+        this.disableCreatingBuildConfigDuringConfiguration.set(disableCreatingBuildConfigDuringConfiguration);
+    }
+
+    public Property<Boolean> getDisableCreatingBuildConfigDuringConfiguration() {
+        return disableCreatingBuildConfigDuringConfiguration;
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfigProvider.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfigProvider.java
@@ -1,0 +1,151 @@
+package io.quarkus.gradle.tasks;
+
+import static io.quarkus.gradle.tasks.QuarkusPropertiesResolver.*;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.gradle.api.Project;
+import org.gradle.api.java.archives.Attributes;
+
+import io.quarkus.deployment.pkg.PackageConfig;
+import io.quarkus.gradle.QuarkusPlugin;
+import io.quarkus.gradle.extension.QuarkusPluginExtension;
+
+/**
+ * BaseConfigProvider is used to provide configuration values to the tasks during the configuration phase.
+ * By default it provides the BaseConfig values from the plugin extension, but when
+ * {@link io.quarkus.gradle.extension.QuarkusPluginExtension#getDisableCreatingBuildConfigDuringConfiguration()}
+ * is enabled, it resolves the properties from system properties and the
+ * {@code application.properties} file in the resources directory.
+ */
+public class BaseConfigProvider {
+
+    private final Boolean disableCreatingBuildConfigDuringConfiguration;
+    private final QuarkusPluginExtension extension;
+
+    private final Map<String, String> properties;
+
+    private final Project project;
+
+    public BaseConfigProvider(Boolean disableCreatingBuildConfigDuringConfiguration,
+            Project project,
+            QuarkusPluginExtension extension) {
+        this.disableCreatingBuildConfigDuringConfiguration = disableCreatingBuildConfigDuringConfiguration;
+        this.extension = extension;
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            properties = QuarkusPropertiesResolver.resolve(project, extension);
+        } else {
+            properties = Map.of();
+        }
+        this.project = project;
+    }
+
+    public Boolean getJarEnabled() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return Boolean.parseBoolean(properties.get(KEY_JAR_ENABLED));
+        } else {
+            return extension.packageConfig().jar().enabled();
+        }
+    }
+
+    public Boolean getNativeEnabled() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return Boolean.parseBoolean(properties.get(KEY_NATIVE_ENABLED));
+        } else {
+            return extension.nativeConfig().enabled();
+        }
+    }
+
+    public Path getOutputDirectory() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return Path.of(properties.get(KEY_OUTPUT_DIRECTORY));
+        } else {
+            return Path.of(extension.packageConfig().outputDirectory().map(Path::toString)
+                    .orElse(QuarkusPlugin.DEFAULT_OUTPUT_DIRECTORY));
+        }
+    }
+
+    public String getOutputName() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return properties.get(KEY_OUTPUT_NAME);
+        } else {
+            return extension.packageConfig().outputName().orElseGet(extension::finalName);
+        }
+    }
+
+    public Boolean getNativeSourcesOnly() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return Boolean.parseBoolean(properties.get(KEY_NATIVE_SOURCES_ONLY));
+        } else {
+            return extension.nativeConfig().sourcesOnly();
+        }
+    }
+
+    public PackageConfig.JarConfig.JarType getJarType() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return PackageConfig.JarConfig.JarType.fromString(properties.get(KEY_JAR_TYPE));
+        } else {
+            return extension.packageConfig().jar().type();
+        }
+    }
+
+    public String getRunnerSuffix() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            if (Boolean.parseBoolean(properties.get(KEY_ADD_RUNNER_SUFFIX))) {
+                return properties.get(KEY_RUNNER_SUFFIX);
+            } else {
+                return "";
+            }
+        } else {
+            return extension.packageConfig().computedRunnerSuffix();
+        }
+    }
+
+    public Map<String, String> getCachingRelevantProperties(List<String> cachingRelevantProperties) {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return cachingRelevantProperties.stream()
+                    .filter(s -> !s.matches("quarkus\\..*") && !s.matches("platform\\.quarkus\\..*"))
+                    .map(s -> Map.entry(s, project.getProviders().environmentVariable(s)))
+                    .filter(e -> e.getValue().isPresent())
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.getValue().get()));
+
+        } else {
+            return extension.cachingRelevantProperties(extension.getCachingRelevantProperties().get());
+        }
+
+    }
+
+    public Map<String, Object> getManifestAttributes() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return Map.of();
+        } else {
+            return extension.manifest().getAttributes();
+        }
+    }
+
+    public Map<String, Attributes> getManifestSections() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            return Map.of();
+        } else {
+            return extension.manifest().getSections();
+        }
+    }
+
+    public List<String> getIgnoredEntries() {
+        if (disableCreatingBuildConfigDuringConfiguration) {
+            String userIgnoredEntries = properties.get(KEY_IGNORED_ENTRIES);
+            if (userIgnoredEntries != null && !userIgnoredEntries.isEmpty()) {
+                return List.of(userIgnoredEntries.split(","));
+            } else {
+                return List.of();
+            }
+        } else {
+            return extension.ignoredEntriesProperty().get();
+        }
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
@@ -235,7 +235,7 @@ public final class EffectiveConfig {
      * @param sourceDirectories a Set of source directories specified by the Gradle build.
      * @return a {@link ClassLoader} with the source paths
      */
-    private static ClassLoader toUrlClassloader(Set<File> sourceDirectories) {
+    public static ClassLoader toUrlClassloader(Set<File> sourceDirectories) {
         List<URL> urls = new ArrayList<>();
         for (File sourceDirectory : sourceDirectories) {
             try {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -16,7 +16,6 @@ import javax.inject.Inject;
 
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -53,15 +52,10 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
         return this;
     }
 
-    @Internal
-    public ListProperty<String> getIgnoredEntries() {
-        return extension().ignoredEntriesProperty();
-    }
-
     @Option(description = "When using the uber-jar option, this option can be used to "
             + "specify one or more entries that should be excluded from the final jar", option = "ignored-entry")
     public void setIgnoredEntries(List<String> ignoredEntries) {
-        getIgnoredEntries().addAll(ignoredEntries);
+        getIgnoredListEntries().addAll(ignoredEntries);
     }
 
     @Internal

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -49,14 +49,14 @@ public abstract class QuarkusPluginExtensionView {
         getFinalName().set(extension.getFinalName());
         getCodeGenForkOptions().set(getProviderFactory().provider(() -> extension.codeGenForkOptions));
         getBuildForkOptions().set(getProviderFactory().provider(() -> extension.buildForkOptions));
-        getIgnoredEntries().set(extension.ignoredEntriesProperty());
         getMainResources().setFrom(project.getExtensions().getByType(SourceSetContainer.class).getByName(MAIN_SOURCE_SET_NAME)
                 .getResources().getSourceDirectories());
         getQuarkusBuildProperties().set(extension.getQuarkusBuildProperties());
+        getQuarkusSystemProperties().set(getProviderFactory().systemPropertiesPrefixedBy("quarkus").get());
         getQuarkusRelevantProjectProperties().set(getQuarkusRelevantProjectProperties(project));
         getQuarkusProfileSystemVariable().set(getProviderFactory().systemProperty(QUARKUS_PROFILE));
         getQuarkusProfileEnvVariable().set(getProviderFactory().environmentVariable("QUARKUS_PROFILE"));
-        getCachingRelevantProperties().set(extension.getCachingRelevantProperties());
+        getCachingRelevantProperties().set(extension.getCachingRelevantProperties().get());
         getForcedProperties().set(extension.forcedPropertiesProperty());
         Map<String, Object> projectProperties = new HashMap<>();
         for (Map.Entry<String, ?> entry : project.getProperties().entrySet()) {
@@ -108,10 +108,10 @@ public abstract class QuarkusPluginExtensionView {
     public abstract ListProperty<Action<? super JavaForkOptions>> getBuildForkOptions();
 
     @Input
-    public abstract ListProperty<String> getIgnoredEntries();
+    public abstract MapProperty<String, String> getQuarkusBuildProperties();
 
     @Input
-    public abstract MapProperty<String, String> getQuarkusBuildProperties();
+    public abstract MapProperty<String, String> getQuarkusSystemProperties();
 
     @Input
     public abstract MapProperty<String, String> getQuarkusRelevantProjectProperties();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPropertiesResolver.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPropertiesResolver.java
@@ -1,0 +1,90 @@
+package io.quarkus.gradle.tasks;
+
+import static io.quarkus.gradle.tasks.EffectiveConfig.toUrlClassloader;
+import static io.quarkus.gradle.tasks.QuarkusGradleUtils.getSourceSet;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+
+import io.quarkus.gradle.QuarkusPlugin;
+import io.quarkus.gradle.extension.QuarkusPluginExtension;
+import io.smallrye.config.PropertiesConfigSourceLoader;
+
+/**
+ * Properties resolver used when
+ * {@link io.quarkus.gradle.extension.QuarkusPluginExtension#getDisableCreatingBuildConfigDuringConfiguration()}
+ * is enabled.
+ * It resolves properties from system properties and the {@code application.properties} file in the resources directory,
+ * following the same order as https://quarkus.io/guides/config-reference#configuration-sources.
+ */
+public class QuarkusPropertiesResolver {
+    private static final String QUARKUS_PREFIX = "quarkus.";
+    private static final String APPLICATION_PROPERTIES = "application.properties";
+    private static final int APPLICATION_PROPERTIES_ORDINAL = 250;
+    private static final String DEFAULT_JAR_TYPE = "fast-jar";
+    private static final String DEFAULT_RUNNER_SUFFIX = "-runner";
+    protected static final String KEY_NATIVE_ENABLED = "quarkus.native.enabled";
+    protected static final String KEY_JAR_ENABLED = "quarkus.package.jar.enabled";
+    protected static final String KEY_OUTPUT_DIRECTORY = "quarkus.package.output-directory";
+    protected static final String KEY_OUTPUT_NAME = "quarkus.package.output-name";
+    protected static final String KEY_ADD_RUNNER_SUFFIX = "quarkus.package.jar.add-runner-suffix";
+    protected static final String KEY_NATIVE_SOURCES_ONLY = "quarkus.native.sources-only";
+    protected static final String KEY_JAR_TYPE = "quarkus.package.jar.type";
+    protected static final String KEY_RUNNER_SUFFIX = "quarkus.package.jar.runner-suffix";
+    protected static final String KEY_IGNORED_ENTRIES = "quarkus.package.ignored-entries";
+
+    private QuarkusPropertiesResolver() {
+    }
+
+    public static Map<String, String> resolve(Project project, QuarkusPluginExtension extension) {
+        Map<String, String> defaults = new LinkedHashMap<>();
+        defaults.put(KEY_NATIVE_ENABLED, "false");
+        defaults.put(KEY_JAR_ENABLED, "true");
+        defaults.put(KEY_OUTPUT_DIRECTORY, QuarkusPlugin.DEFAULT_OUTPUT_DIRECTORY);
+        defaults.put(KEY_OUTPUT_NAME, extension.finalName());
+        defaults.put(KEY_ADD_RUNNER_SUFFIX, "true");
+        defaults.put(KEY_NATIVE_SOURCES_ONLY, "false");
+        defaults.put(KEY_JAR_TYPE, DEFAULT_JAR_TYPE);
+        defaults.put(KEY_RUNNER_SUFFIX, DEFAULT_RUNNER_SUFFIX);
+        defaults.put(KEY_IGNORED_ENTRIES, "");
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : defaults.entrySet()) {
+            properties.put(entry.getKey(), systemPropertyOrDefault(project, entry.getKey(), entry.getValue()));
+        }
+        addApplicationProperties(project, properties);
+
+        return properties;
+    }
+
+    private static String systemPropertyOrDefault(Project project, String key, String defaultValue) {
+        Provider<String> provider = project.getProviders().systemProperty(key);
+        return provider.getOrElse(defaultValue);
+    }
+
+    private static void addApplicationProperties(Project project, Map<String, String> properties) {
+        Set<File> resourceDirs = getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME)
+                .getResources()
+                .getSourceDirectories()
+                .getFiles();
+        List<ConfigSource> sources = PropertiesConfigSourceLoader.inClassPath(
+                APPLICATION_PROPERTIES,
+                APPLICATION_PROPERTIES_ORDINAL,
+                toUrlClassloader(resourceDirs));
+        for (ConfigSource configSource : sources) {
+            for (String name : configSource.getPropertyNames()) {
+                if (name.startsWith(QUARKUS_PREFIX)) {
+                    properties.putIfAbsent(name, configSource.getValue(name));
+                }
+            }
+        }
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTaskWithExtensionView.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle.tasks;
 
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
@@ -33,6 +34,9 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
     @Input
     public abstract MapProperty<String, String> getCachingRelevantInput();
 
+    @Input
+    public abstract ListProperty<String> getIgnoredListEntries();
+
     public QuarkusTaskWithExtensionView(String description, boolean compatible) {
         super(description, compatible);
         this.extensionView = getProject().getObjects().newInstance(QuarkusPluginExtensionView.class, extension());
@@ -40,7 +44,7 @@ public abstract class QuarkusTaskWithExtensionView extends QuarkusTask {
 
     public EffectiveConfigProvider effectiveProvider() {
         return new EffectiveConfigProvider(
-                getExtensionView().getIgnoredEntries(),
+                getIgnoredListEntries(),
                 getExtensionView().getMainResources(),
                 getExtensionView().getForcedProperties(),
                 getExtensionView().getProjectProperties(),

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/DisableCreatingBuildConfigDuringConfigurationTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/DisableCreatingBuildConfigDuringConfigurationTest.java
@@ -1,0 +1,268 @@
+package io.quarkus.gradle.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class DisableCreatingBuildConfigDuringConfigurationTest {
+    private static final Map<String, TaskOutcome> ALL_SUCCESS = Map.of(
+            ":quarkusGenerateCode", TaskOutcome.SUCCESS,
+            ":quarkusGenerateCodeTests", TaskOutcome.SUCCESS,
+            ":quarkusAppPartsBuild", TaskOutcome.SUCCESS,
+            ":quarkusDependenciesBuild", TaskOutcome.SUCCESS,
+            ":quarkusBuild", TaskOutcome.SUCCESS,
+            ":build", TaskOutcome.SUCCESS);
+    private static final Map<String, TaskOutcome> ALL_UP_TO_DATE = Map.of(
+            ":quarkusGenerateCode", TaskOutcome.UP_TO_DATE,
+            // intentionally omit ":quarkusGenerateCodeDev", it can be UP_TO_DATE or SUCCESS
+            ":quarkusGenerateCodeTests", TaskOutcome.UP_TO_DATE,
+            ":quarkusAppPartsBuild", TaskOutcome.UP_TO_DATE,
+            ":quarkusDependenciesBuild", TaskOutcome.UP_TO_DATE,
+            ":quarkusBuild", TaskOutcome.UP_TO_DATE,
+            ":build", TaskOutcome.UP_TO_DATE);
+    public static final Map<String, TaskOutcome> FROM_CACHE = Map.of(
+            ":quarkusGenerateCode", TaskOutcome.FROM_CACHE,
+            ":quarkusGenerateCodeTests", TaskOutcome.FROM_CACHE,
+            ":quarkusAppPartsBuild", TaskOutcome.FROM_CACHE,
+            ":quarkusDependenciesBuild", TaskOutcome.SUCCESS,
+            ":quarkusBuild", TaskOutcome.SUCCESS,
+            ":build", TaskOutcome.SUCCESS);
+
+    @InjectSoftAssertions
+    SoftAssertions soft;
+
+    @TempDir
+    Path testProjectDir;
+
+    @Test
+    void envChangeInvalidatesBuildWithExperimentalMode() throws Exception {
+        // Declare the environment variables FOO_ENV_VAR and FROM_DOT_ENV_FILE as relevant for the build.
+        prepareGradleBuildProject(String.join("\n",
+                "cachingRelevantProperties.add(\"FOO_ENV_VAR\")",
+                "cachingRelevantProperties.add(\"FROM_DOT_ENV_FILE\")",
+                "setDisableCreatingBuildConfigDuringConfiguration(true)"));
+
+        String[] arguments = List.of("build", "--info", "--stacktrace", "--build-cache",
+                "-Dquarkus.package.jar.type=fast-jar",
+                "-Dquarkus.randomized.value=" + UUID.randomUUID())
+                .toArray(new String[0]);
+
+        Map<String, String> env = Map.of();
+        assertBuildResult("initial", gradleBuild(rerunTasks(arguments), env), ALL_SUCCESS);
+        assertBuildResult("initial rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+
+        // Change the relevant environment, must rebuild
+        env = Map.of("FOO_ENV_VAR", "some-value");
+        assertBuildResult("set FOO_ENV_VAR", gradleBuild(arguments, env), ALL_SUCCESS);
+        assertBuildResult("set FOO_ENV_VAR rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+
+        // Change the environment file again, must rebuild
+        env = Map.of("FOO_ENV_VAR", "some-other-value");
+        assertBuildResult("change FOO_ENV_VAR", gradleBuild(arguments, env), ALL_SUCCESS);
+        assertBuildResult("change FOO_ENV_VAR rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+
+        // Change an unrelated environment variable, all up-to-date
+        env = Map.of("FOO_ENV_VAR", "some-other-value", "SOME_UNRELATED", "meep");
+        assertBuildResult("SOME_UNRELATED", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+    }
+
+    @Test
+    void systemPropertyChangeHitsConfigurationCache() throws Exception {
+        // Declare the environment variables FOO_ENV_VAR and FROM_DOT_ENV_FILE as relevant for the build.
+        prepareGradleBuildProject(String.join("\n",
+                "cachingRelevantProperties.add(\"FOO_ENV_VAR\")",
+                "cachingRelevantProperties.add(\"FROM_DOT_ENV_FILE\")",
+                "setDisableCreatingBuildConfigDuringConfiguration(true)"));
+
+        String[] argumentsFirstBuild = List.of("build", "--info", "--stacktrace", "--build-cache", "--configuration-cache",
+                "-Dquarkus.package.jar.type=fast-jar",
+                "-Da=1")
+                .toArray(new String[0]);
+        String[] argumentsSecondBuild = List.of("build", "--info", "--stacktrace", "--build-cache", "--configuration-cache",
+                "-Dquarkus.package.jar.type=fast-jar",
+                "-Da=2")
+                .toArray(new String[0]);
+
+        Map<String, String> env = Map.of();
+        BuildResult buildResult = gradleBuild(argumentsFirstBuild, env);
+        BuildResult buildResult2 = gradleBuild(argumentsSecondBuild, env);
+        assertBuildResult("initial", buildResult, ALL_SUCCESS);
+        assertBuildResult("initial rebuild", buildResult2, ALL_UP_TO_DATE);
+        buildResult2.getOutput().contains("Configuration cache entry reused.");
+    }
+
+    static Stream<Arguments> gradleCachingWithExperimentalMode() {
+        return Stream.of("fast-jar", "uber-jar", "mutable-jar", "legacy-jar", "native-sources")
+                .flatMap(packageType -> Stream.of(arguments(packageType, true), arguments(packageType, false)))
+                .flatMap(args -> Stream.of(arguments(args.get()[0], args.get()[1], null),
+                        arguments(args.get()[0], args.get()[1], "some-output-dir")));
+    }
+
+    @Test
+    public void systemPropertyIsOverrideInExperimentalMode() throws Exception {
+        final File projectDir = testProjectDir.toFile();
+        prepareGradleBuildProject(String.join("\n",
+                "setDisableCreatingBuildConfigDuringConfiguration(true)"));
+        // First build asserts that the output-directory is the one set in application properties
+        String[] argumentsFirstBuild = List
+                .of("clean", "build", "--info", "--stacktrace", "--build-cache", "--configuration-cache")
+                .toArray(new String[0]);
+        gradleBuild(argumentsFirstBuild, Map.of());
+        assertTrue(projectDir.toPath().resolve("build/customDirectory").toFile().exists());
+
+        // Second build overrides the output-directory with System Property
+        String[] argumentsSecondBuild = List
+                .of("clean", "build", "--info", "--stacktrace", "--build-cache", "--configuration-cache",
+                        "-Dquarkus.package.output-directory=some-other-dir")
+                .toArray(new String[0]);
+        gradleBuild(argumentsSecondBuild, Map.of());
+
+        assertTrue(projectDir.toPath().resolve("build/some-other-dir").toFile().exists());
+        assertFalse(projectDir.toPath().resolve("build/customDirectory").toFile().exists());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void gradleCachingWithExperimentalMode(String packageType, boolean simulateCI, String outputDir, @TempDir Path saveDir)
+            throws Exception {
+        prepareGradleBuildProject("setDisableCreatingBuildConfigDuringConfiguration(true)");
+
+        Map<String, String> env = simulateCI ? Map.of("CI", "yes") : Map.of();
+
+        List<String> args = new ArrayList<>();
+        Collections.addAll(args, "build", "--info", "--stacktrace", "--build-cache", "--no-configuration-cache");
+        if (packageType.equals("native-sources")) {
+            args.add("-Dquarkus.native.enabled=true");
+            args.add("-Dquarkus.native.sources-only=true");
+            args.add("-Dquarkus.package.jar.enabled=false");
+        } else {
+            args.add("-Dquarkus.package.jar.type=" + packageType);
+        }
+        if (outputDir != null) {
+            args.add("-Dquarkus.package.output-directory=" + outputDir);
+        } else {
+            args.add("-Dquarkus.package.output-directory=customDirectory");
+        }
+        String[] arguments = args.toArray(new String[0]);
+
+        assertBuildResult("initial", gradleBuild(rerunTasks(arguments), env), ALL_SUCCESS);
+        assertBuildResult("initial rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
+
+        // Purge the whole build/ directory
+
+        Path buildDir = testProjectDir.resolve("build");
+
+        Path saveBuildDir = saveDir.resolve("build");
+        FileUtils.moveDirectory(buildDir.toFile(), saveBuildDir.toFile());
+
+        soft.assertThat(buildDir).doesNotExist();
+
+        // A follow-up 'build', without a build/ directory should fetch everything from the cache / pull the dependencies
+
+        BuildResult result = gradleBuild(arguments, env);
+        Map<String, TaskOutcome> taskResults = taskResults(result);
+
+        Path quarkusBuildGen = Paths.get("quarkus-build", "gen");
+        boolean isFastJar = "fast-jar".equals(packageType);
+        boolean isFastOrLegacyJar = isFastJar || "legacy-jar".equals(packageType);
+        Predicate<Path> filter = isFastOrLegacyJar ? p -> !p.startsWith(quarkusBuildGen) : p -> true;
+        soft.assertThat(directoryContents(buildDir))
+                .describedAs("output: %s", result.getOutput())
+                .containsExactlyElementsOf(directoryContents(saveBuildDir, filter));
+
+        soft.assertThat(taskResults)
+                .describedAs("output: %s", result.getOutput())
+                .containsEntry(":compileJava", TaskOutcome.FROM_CACHE)
+                .containsEntry(":quarkusGenerateCode", TaskOutcome.FROM_CACHE)
+                .doesNotContainKey(":quarkusGenerateCodeDev")
+                .containsEntry(":quarkusAppPartsBuild", isFastOrLegacyJar ? TaskOutcome.FROM_CACHE : TaskOutcome.UP_TO_DATE)
+                .containsEntry(":quarkusDependenciesBuild", isFastOrLegacyJar ? TaskOutcome.SUCCESS : TaskOutcome.UP_TO_DATE)
+                .containsEntry(":quarkusBuild", simulateCI || isFastJar ? TaskOutcome.SUCCESS : TaskOutcome.FROM_CACHE);
+
+        // A follow-up 'build' does nothing, everything's up-to-date
+
+        result = gradleBuild(arguments, env);
+        assertBuildResult("follow-up", result, ALL_UP_TO_DATE);
+    }
+
+    private static String[] rerunTasks(String[] arguments) {
+        String[] args = Arrays.copyOf(arguments, arguments.length + 1);
+        args[arguments.length] = "--rerun-tasks";
+        return args;
+    }
+
+    private BuildResult gradleBuild(String[] arguments, Map<String, String> env) {
+        return GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(arguments)
+                .withEnvironment(env)
+                .build();
+    }
+
+    private void assertBuildResult(String step, BuildResult result,
+            Map<String, TaskOutcome> expected) {
+        Map<String, TaskOutcome> taskResults = taskResults(result);
+        soft.assertThat(taskResults)
+                .describedAs("output: %s\n\nSTEP: %s", result.getOutput(), step)
+                .containsAllEntriesOf(expected);
+    }
+
+    private void prepareGradleBuildProject(String additionalQuarkusConfig) throws IOException, URISyntaxException {
+        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/experimentalmode/main");
+
+        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
+
+        // Randomize the build script
+        String buildScript = Files.readString(testProjectDir.resolve("build.gradle.kts"));
+        buildScript = buildScript.replace("// ADDITIONAL_CONFIG", additionalQuarkusConfig);
+        Files.writeString(testProjectDir.resolve("build.gradle.kts"), buildScript);
+
+        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+    }
+
+    static Map<String, TaskOutcome> taskResults(BuildResult result) {
+        return result.getTasks().stream().collect(Collectors.toMap(BuildTask::getPath, BuildTask::getOutcome));
+    }
+
+    static List<Path> directoryContents(Path dir) throws IOException {
+        return directoryContents(dir, p -> true);
+    }
+
+    static List<Path> directoryContents(Path dir, Predicate<Path> include) throws IOException {
+        try (Stream<Path> saved = Files.walk(dir)) {
+            return saved.map(dir::relativize).filter(include).sorted(Comparator.comparing(Path::toString))
+                    .filter(p -> !p.toString().startsWith("reports" + File.separator + "configuration-cache" + File.separator))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/QuarkusBuildPropertiesResolverTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/QuarkusBuildPropertiesResolverTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.gradle.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.gradle.QuarkusPlugin;
+import io.quarkus.gradle.extension.QuarkusPluginExtension;
+
+class QuarkusBuildPropertiesResolverTest {
+
+    @TempDir
+    Path projectDir;
+
+    @Test
+    void resolvesDefaultsAndAddsApplicationProperties() throws IOException {
+        Project project = buildProject(projectDir);
+        QuarkusPluginExtension extension = project.getExtensions().getByType(QuarkusPluginExtension.class);
+        extension.getFinalName().set("app-final-name");
+        writeApplicationProperties("""
+                quarkus.http.port=9090
+                quarkus.package.jar.type=uber-jar
+                quarkus.package.jar.runner-suffix=-custom
+                foo=bar
+                """);
+
+        Map<String, String> properties = QuarkusPropertiesResolver.resolve(project, extension);
+
+        assertThat(properties)
+                .containsEntry("quarkus.native.enabled", "false")
+                .containsEntry("quarkus.package.jar.enabled", "true")
+                .containsEntry("quarkus.package.output-directory", QuarkusPlugin.DEFAULT_OUTPUT_DIRECTORY)
+                .containsEntry("quarkus.package.output-name", "app-final-name")
+                .containsEntry("quarkus.package.jar.add-runner-suffix", "true")
+                .containsEntry("quarkus.native.sources-only", "false")
+                .containsEntry("quarkus.package.jar.type", "fast-jar")
+                .containsEntry("quarkus.package.jar.runner-suffix", "-runner")
+                .containsEntry("quarkus.http.port", "9090");
+        assertThat(properties).doesNotContainKey("foo");
+    }
+
+    @Test
+    void systemPropertiesOverrideDefaults() throws IOException {
+        Project project = buildProject(projectDir);
+        QuarkusPluginExtension extension = project.getExtensions().getByType(QuarkusPluginExtension.class);
+        extension.getFinalName().set("default-name");
+        writeApplicationProperties("quarkus.http.host=0.0.0.0");
+
+        setSystemProperty("quarkus.native.enabled", "true");
+        setSystemProperty("quarkus.package.output-name", "from-system");
+        setSystemProperty("quarkus.package.jar.type", "legacy-jar");
+        setSystemProperty("quarkus.package.jar.runner-suffix", "-sys");
+
+        try {
+            Map<String, String> properties = QuarkusPropertiesResolver.resolve(project, extension);
+
+            assertThat(properties)
+                    .containsEntry("quarkus.native.enabled", "true")
+                    .containsEntry("quarkus.package.output-name", "from-system")
+                    .containsEntry("quarkus.package.jar.type", "legacy-jar")
+                    .containsEntry("quarkus.package.jar.runner-suffix", "-sys")
+                    .containsEntry("quarkus.http.host", "0.0.0.0");
+        } finally {
+            clearSystemProperty("quarkus.native.enabled");
+            clearSystemProperty("quarkus.package.output-name");
+            clearSystemProperty("quarkus.package.jar.type");
+            clearSystemProperty("quarkus.package.jar.runner-suffix");
+        }
+    }
+
+    private Project buildProject(Path projectDir) throws IOException {
+        Files.createDirectories(projectDir.resolve("src/main/resources"));
+        Project project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build();
+        project.setVersion("1.0.0");
+        project.getPluginManager().apply("java");
+        project.getPluginManager().apply(QuarkusPlugin.ID);
+        return project;
+    }
+
+    private void writeApplicationProperties(String contents) throws IOException {
+        Path propertiesPath = projectDir.resolve("src/main/resources/application.properties");
+        Files.createDirectories(propertiesPath.getParent());
+        Files.writeString(propertiesPath, contents);
+    }
+
+    private static void setSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    private static void clearSystemProperty(String key) {
+        System.clearProperty(key);
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/build.gradle.kts
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    java
+    id("io.quarkus")
+}
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(enforcedPlatform("io.quarkus:quarkus-bom:${project.property("version")}"))
+    implementation("jakarta.inject:jakarta.inject-api:2.0.1")
+}
+
+quarkus {
+    quarkusBuildProperties.put("quarkus.foo", "bar")
+    // The following line is replaced by the tests in `TasksConfigurationCacheCompatibilityTest`
+    // ADDITIONAL_CONFIG
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/settings.gradle.kts
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "experimental-mode"

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/src/main/java/org/acme/Foo.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/src/main/java/org/acme/Foo.java
@@ -1,0 +1,4 @@
+package org.acme;
+
+public class Foo {
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/src/main/resources/application.properties
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/experimentalmode/main/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.package.output-directory=customDirectory


### PR DESCRIPTION
This PR covers the issue described in [#52464 ](https://github.com/quarkusio/quarkus/issues/52464) and expanded on in discussion [#52506](https://github.com/quarkusio/quarkus/discussions/52506).

The Quarkus Gradle plugin extension introduces a new property, `disableCreatingBuildConfigDuringConfiguration`, which disables EffectConfig initialization during configuration. This avoids reading system properties at configuration time, which can cause configuration cache misses. The `EffectConfig` still happens during task execution.

To opt out of the EffectConfig / BaseConfig configuration, we still need to provide the required properties used as inputs for `GetBuildFiles` (`QuarkuBuild`). To do that, and only when `disableCreatingBuildConfigDuringConfiguration` is enabled, we provide a Provider that supplies the required system properties.

At the moment, we support two levels of properties:
*  System property arguments
* Application properties

For this experimental phase, this is sufficient. If we continue with this approach, we will likely need to replicate the other ConfigSource providers as well.

From the client perspective, the user only needs to enable the flag:
```
quarkus {
  setDisableCreatingBuildConfigDuringConfiguration(true)
  // ...
}
```
With this property enabled, a sequence of builds like:
```
./gradlew build -Da=1
./gradlew build -Da=2
```
will reuse the configuration cache on the second build.

- Closes: #52464
