### PR TITLE
Adjust TCCL before trying to start containers that might look for a license in resources

### DIFF
--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -153,6 +153,7 @@ public class DB2DevServicesProcessor {
         private final boolean podman;
 
         private final String hostName;
+        private ClassLoader creationClassloader;
 
         public QuarkusDb2Container(Optional<String> imageName, OptionalInt fixedExposedPort,
                 String defaultNetworkId, boolean useSharedNetwork, boolean podman) {
@@ -162,6 +163,23 @@ public class DB2DevServicesProcessor {
             this.useSharedNetwork = useSharedNetwork;
             this.podman = podman;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "db2");
+            creationClassloader = Thread.currentThread().getContextClassLoader();
+        }
+
+        @Override
+        public void start() {
+            // Ideally StartupActionImpl would set the deployment classloader as the TCCL, but it sets the augmentation classloader as the TCCL
+            // In normal mode this doesn't matter because the augmentation classloader can see application classes, but in continuous testing/dev mode, it can't
+            // As a tactical workaround, stash away the deployment classloader and use it for the start, so that test containers classes can find application resources
+            ClassLoader orig = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(creationClassloader);
+                super.start();
+            } finally {
+                Thread.currentThread().setContextClassLoader(orig);
+                // Assume the same container instance won't start() twice, and null out the CL to be cautious about CL leaks
+                creationClassloader = null;
+            }
         }
 
         @Override

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -102,6 +102,7 @@ public class MSSQLDevServicesProcessor {
         private final boolean useSharedNetwork;
 
         private final String hostName;
+        private ClassLoader creationClassloader;
 
         public QuarkusMSSQLServerContainer(Optional<String> imageName, OptionalInt fixedExposedPort,
                 String defaultNetworkId, boolean useSharedNetwork) {
@@ -111,6 +112,23 @@ public class MSSQLDevServicesProcessor {
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "mssql");
+            creationClassloader = Thread.currentThread().getContextClassLoader();
+        }
+
+        @Override
+        public void start() {
+            // Ideally StartupActionImpl would set the deployment classloader as the TCCL, but it sets the augmentation classloader as the TCCL
+            // In normal mode this doesn't matter because the augmentation classloader can see application classes, but in continuous testing/dev mode, it can't
+            // As a tactical workaround, stash away the deployment classloader and use it for the start, so that test containers classes can find application resources
+            ClassLoader orig = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(creationClassloader);
+                super.start();
+            } finally {
+                Thread.currentThread().setContextClassLoader(orig);
+                // Assume the same container instance won't start() twice, and null out the CL to be cautious about CL leaks
+                creationClassloader = null;
+            }
         }
 
         @Override


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/52443

https://github.com/quarkusio/quarkus/issues/52443 happens because the testcontainers code uses a `Resources.getResource()` call to look for a license file, and in the new dev services model, this fails in dev mode. There are two reasons it fails:
- During the augmentation phase, when the `start()` call used to happen, the TCCL is the deployment classloader. For the new dev services start, we carefully set the TCCL to be the augmentation classloader before calling `start()` (_not_ the deployment one). 
- In normal mode, the augmentation classloader can see all application resources. In dev mode, it cannot. 

Unpicking all of that is too much to attempt the day before a feature freeze, so I've done a tactical fix. 

But I think we should come back to this. 
- Some other services might need to do resources lookups, so ideally the TCCL that's [set by the dev service registry](https://github.com/quarkusio/quarkus/blob/41a2c5aa5669e46b69ffe372dcf7e3c663503cfc/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java#L111-L118) would be the 'right' one
- I noticed that we don't reset the TCCL to what it was before when setting it before starting services; we should probably fix that
- The behaviour difference between dev mode and normal mode troubles me. According to my reading of [the classloader reference](https://quarkus.io/guides/class-loading-reference#classloader-implementations), the augmentation classloader can see application code, but not hot-deployable application code, so I guess maybe it's completely expected that in dev mode, where hot deploy is a thing, the behaviour would be different. 