### PR TITLE
Use deployment classloader instead of augmentation CL for starting dev services

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildResult.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildResult.java
@@ -23,15 +23,17 @@ public final class BuildResult {
     private final List<Diagnostic> diagnostics;
     private final long nanos;
     private final BuildMetrics metrics;
+    private final ClassLoader deploymentClassLoader;
 
     BuildResult(final ConcurrentHashMap<ItemId, BuildItem> simpleItems,
             final MultiBuildItems multiItems, final Set<ItemId> finalIds,
-            final List<Diagnostic> diagnostics, final long nanos, BuildMetrics metrics) {
+            final List<Diagnostic> diagnostics, final long nanos, BuildMetrics metrics, ClassLoader classLoader) {
         this.simpleItems = simpleItems;
         this.multiItems = multiItems;
         this.diagnostics = diagnostics;
         this.nanos = nanos;
         this.metrics = metrics;
+        this.deploymentClassLoader = classLoader;
     }
 
     /**
@@ -125,4 +127,9 @@ public final class BuildResult {
         }
         multiItems.closeAll();
     }
+
+    public ClassLoader getDeploymentClassLoader() {
+        return deploymentClassLoader;
+    }
+
 }

--- a/core/builder/src/main/java/io/quarkus/builder/Execution.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Execution.java
@@ -151,7 +151,7 @@ final class Execution {
         long duration = max(0, System.nanoTime() - start);
         metrics.buildFinished(TimeUnit.NANOSECONDS.toMillis(duration));
         return new BuildResult(singles, multis, finalIds, Collections.unmodifiableList(diagnostics),
-                duration, metrics);
+                duration, metrics, chain.getClassLoader());
     }
 
     EnhancedQueueExecutor getExecutor() {

--- a/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleContainer.java
+++ b/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleContainer.java
@@ -11,6 +11,8 @@ public class SimpleContainer extends GenericContainer<io.quarkus.tests.simpleext
     private static final DockerImageName dockerImageName = DockerImageName.parse("httpd");
     public static final int HTTPD_PORT = 80;
 
+    private String classLoaderNameOnStart;
+
     public SimpleContainer() {
         super(dockerImageName);
         this //.waitingFor(Wait.forLogMessage(".*" + "resuming normal operations" + ".*", 1))
@@ -20,6 +22,8 @@ public class SimpleContainer extends GenericContainer<io.quarkus.tests.simpleext
 
     @Override
     public void start() {
+        // At start, the classloader should be the deployment classloader; in normal mode the augmentation classloader also works, but in dev mode the augmentation classloader cannot see application resources
+        this.classLoaderNameOnStart = Thread.currentThread().getContextClassLoader().getName();
         super.start();
     }
 
@@ -31,5 +35,9 @@ public class SimpleContainer extends GenericContainer<io.quarkus.tests.simpleext
     @Override
     public void close() {
         super.close();
+    }
+
+    public String getClassLoaderNameOnStart() {
+        return classLoaderNameOnStart;
     }
 }

--- a/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleDevServicesProcessor.java
+++ b/integration-tests/devservices/simple-extension/deployment/src/main/java/io/quarkus/tests/simpleextension/deployment/SimpleDevServicesProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.tests.simpleextension.deployment;
 
 import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_BASE_URL;
 import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_STATIC_THING;
+import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START;
 
 import java.util.Map;
 
@@ -29,7 +30,8 @@ public class SimpleDevServicesProcessor {
                 .startable(SimpleContainer::new) // Builds could be speeded up a bit by using an in-process service, but coverage is probably better with a container
                 .config(Map.of(QUARKUS_SIMPLE_EXTENSION_STATIC_THING, "some value"))
                 .configProvider(Map.of(QUARKUS_SIMPLE_EXTENSION_BASE_URL,
-                        c -> c.getConnectionInfo()))
+                        c -> c.getConnectionInfo(), SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START,
+                        c -> c.getClassLoaderNameOnStart()))
                 .build();
 
     }

--- a/integration-tests/devservices/simple-extension/runtime/src/main/java/io/quarkus/tests/simpleextension/Constants.java
+++ b/integration-tests/devservices/simple-extension/runtime/src/main/java/io/quarkus/tests/simpleextension/Constants.java
@@ -3,5 +3,6 @@ package io.quarkus.tests.simpleextension;
 public class Constants {
     public static final String QUARKUS_SIMPLE_EXTENSION_BASE_URL = "acme.simpleextension.base-url";
     public static final String QUARKUS_SIMPLE_EXTENSION_STATIC_THING = "acme.simpleextension.static-thing";
+    public static final String SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START = "acme.simpleextension.classloader-on-start";
 
 }

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
@@ -9,6 +9,7 @@ import static io.quarkus.tests.dependentextension.Constants.QUARKUS_UNSATISFIED_
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_UNSATISFIED_OPTIONAL_DEPENDENT_EXTENSION_SEES_DEPENDENCY;
 import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_BASE_URL;
 import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_STATIC_THING;
+import static io.quarkus.tests.simpleextension.Constants.SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -25,6 +26,7 @@ import io.quarkus.test.junit.QuarkusTest;
 public class DevServicesTest {
     private static final String UNSET = "unset";
 
+    // All these config properties are ways for the dev service to communicate back to the test
     @ConfigProperty(name = QUARKUS_SIMPLE_EXTENSION_BASE_URL, defaultValue = UNSET)
     String simpleExtensionBaseUrl;
 
@@ -51,6 +53,9 @@ public class DevServicesTest {
 
     @ConfigProperty(name = QUARKUS_UNSATISFIED_OPTIONAL_DEPENDENT_EXTENSION_SEES_DEPENDENCY, defaultValue = "false")
     boolean unsatisfiedOptionalDependentExtensionSeesDependencyService;
+
+    @ConfigProperty(name = SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START, defaultValue = UNSET)
+    String classloaderOnServiceStart;
 
     @Test
     public void testTheLazyDevServicesConfigIsAvailable() {
@@ -108,6 +113,13 @@ public class DevServicesTest {
     public void testOptionalDependentServiceWithUnsatisfiedDependencyIsStarted() {
         assertIsSet(unsatisfiedOptionalDependentExtensionBaseUrl);
         assertFalse(unsatisfiedOptionalDependentExtensionSeesDependencyService);
+    }
+
+    @Test
+    public void testDeploymentClassLoaderIsSetAsTCCLOnStart() {
+        assertIsSet(classloaderOnServiceStart);
+        // In dev mode, the augmentation classloader cannot see application resources, so dev services should be started with a deployment classloader as the TCCL
+        assertTrue(classloaderOnServiceStart.contains("Deployment"));
     }
 
     private void assertIsSet(String value) {


### PR DESCRIPTION
A follow-on to https://github.com/quarkusio/quarkus/pull/52520. I did the "use the buildresult to store the classloader used for the build" option, as [discussed](https://github.com/quarkusio/quarkus/pull/52520#issuecomment-3876621484). 

As well as enabling me to undo the per-service fixes I'd put in for #52520, it also allowed me to undo a similar fix @michalvavrik had put in for Keycloak. @ozangunalp says Kubernetes will also have a similar issue, which makes me wonder if we actually should try and get this in before the LTS feature freeze. It's possible to work around the classloader issue (as done #52520), but it might be a source of headaches.

@michalvavrik, I'd welcome your advice on https://github.com/quarkusio/quarkus/pull/52529/changes#diff-3e03bcd7ecafec03e4c0ea1fcd4159a2bc37554574b4b04a233255cb0b91085bL693-L712. In most places, I could just remove the code that used the local copy of the classloader, but in that one the "TCCL works" and "TCCL doesn't work, use local copy" branches seemed quite different. I wasn't sure which to keep. 

@gsmet asked me to make sure not to leak classloaders. :) I'm fairly confident this doesn't, because it actually tidies up some classloaders that otherwise might get left on a thread pool, and the other places I store a reference to a classloader are all either fairly ephemeral classes, like `BuildResult`, or classes which are already storing classloaders, like `StartupActionImpl`. I null out the classloader when when closing the `StartupActionImpl`.

I've added a test, but the devservices tests are currently disabled, and they seemed to have some problems, so I can't check if the test is passing. 

