### PR TITLE
Prefer the profile-aware test class orderer in error message

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
@@ -12,11 +12,13 @@ import org.junit.platform.launcher.TestPlan;
 
 import io.quarkus.test.config.QuarkusClassOrderer;
 import io.quarkus.test.junit.classloading.FacadeClassLoader;
+import io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer;
 
 public class CustomLauncherInterceptor
         implements LauncherDiscoveryListener, LauncherSessionListener, TestExecutionListener {
 
-    private static final Class<? extends ClassOrderer> DESIRED_CLASS_ORDERER = QuarkusClassOrderer.class;
+    private static final Class<? extends ClassOrderer> DESIRED_CLASS_ORDERER = QuarkusTestProfileAwareClassOrderer.class;
+    private static final Class<? extends ClassOrderer> CONFIG_SETTING_DESIRED_CLASS_ORDERER = QuarkusClassOrderer.class;
 
     private static FacadeClassLoader facadeLoader = null;
     // Also use a static variable to store a 'first' starting state that we can reset to
@@ -133,7 +135,9 @@ public class CustomLauncherInterceptor
 
             Optional<String> orderer = request.getConfigurationParameters().get("junit.jupiter.testclass.order.default");
 
-            if (orderer.isEmpty() || !orderer.get().equals(DESIRED_CLASS_ORDERER.getName())) {
+            if (orderer.isEmpty() || !(orderer.get()
+                    .equals(DESIRED_CLASS_ORDERER.getName())
+                    || orderer.get().equals(CONFIG_SETTING_DESIRED_CLASS_ORDERER.getName()))) {
                 if (facadeLoader.hasMultipleClassLoaders()) {
                     String message = getFailureMessageForJUnitMisconfiguration(orderer);
                     throw new IllegalStateException(message);


### PR DESCRIPTION
This is a small follow-on to https://github.com/quarkusio/quarkus/pull/52350. When #52404 merges, it will make it so that the `QuarkusTestClassOrderer` doesn't need to be the JUnit orderer. At some point in the near future, I think we'll want to do #52354 and the config half of https://github.com/quarkusio/quarkus/issues/52389. 
That would mean making `quarkus.test.class-orderer` and `junit.quarkus.orderer.secondary-orderer` synonyms of each other, and removing or deprecating `QuarkusClassOrderer` so that `QuarkusTestProfileAwareClassOrderer` is the first orderer JUnit 'sees'. 

I don't want to ship an error message saying "set the orderer to be QuarkusClassOrderer" and then on the next release that orderer disappears and we change the recommendation and people need to update their config. Instead, if `QuarkusTestProfileAwareClassOrderer` works (once #52404 merges), we should just recommend people to use that now. 

