### PR TITLE
Drop duplicate log output in ITs

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -184,7 +184,6 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
 
     @Override
     public void close() {
-        LauncherUtil.toStdOut(logFile);
         LauncherUtil.destroyProcess(quarkusProcess);
         if (generateAotFile) {
             Path aotConfFile = jarPath.resolveSibling(AOT_CONF_FILE_NAME);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -261,7 +261,6 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
 
     @Override
     public void close() {
-        LauncherUtil.toStdOut(logFile);
         LauncherUtil.destroyProcess(quarkusProcess);
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -9,7 +9,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -229,16 +228,6 @@ public final class LauncherUtil {
             throw new RuntimeException("Unable to start target quarkus application " + waitTimeSeconds + "s");
         }
         return result;
-    }
-
-    static void toStdOut(Path log) {
-        if (log != null) {
-            try (var r = Files.newBufferedReader(log, StandardCharsets.UTF_8)) {
-                r.lines().forEach(System.out::println);
-            } catch (IOException ignored) {
-                System.err.println("Unable to write process output");
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
It was introduced in #51081 as a workaround but we have now reinstated proper log output in the ITs, so we don't need that anymore.

Related to #52465 and #52403 and #52382.

/cc @geoand @snazy 