### PR TITLE
Do not use a two-layer stack of JUnit test orderers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -49,7 +49,6 @@ public interface TestConfig {
      * @see <a href=https://docs.junit.org/current/user-guide/#writing-tests-test-execution-order-classes>JUnit Class
      *      Order<a/>
      */
-    @WithDefault("io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer")
     Optional<String> classOrderer();
 
     /**

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -472,9 +472,13 @@ To reduce the amount of times Quarkus needs to restart, `io.quarkus.test.junit.u
 is registered as a global `ClassOrderer` as described in the
 link:https://docs.junit.org/current/user-guide/#writing-tests-test-execution-order-classes[JUnit User Guide].
 The behavior of this `ClassOrderer` is configurable via `application.properties` using the property
-`quarkus.test.class-orderer`. The property accepts the FQCN of the `ClassOrderer` to use. If the class cannot be found,
-it fallbacks to JUnit default behaviour which does not set a `ClassOrderer` at all. It can also be disabled entirely by
-setting another `ClassOrderer` that is provided by JUnit or even your own custom one.
+`quarkus.test.class-orderer`. The Quarkus orderer will attempt to sort according to the secondary orderer, with the constraint that tests which require the same application instance are grouped.
+The property accepts the FQCN of the `ClassOrderer` to use as a secondary orderer. It can be set to an orderer that is provided by JUnit or even your own custom one.
+If the class cannot be found,
+it fallbacks to JUnit default behaviour which does not set a `ClassOrderer` at all.
+
+The Quarkus orderer can also be disabled entirely by
+setting another `ClassOrderer` using the JUnit configuration. This is only permitted in cases where all Quarkus tests would run on the same application (that is, the use of test profiles and test resources is limited).
 
 === Writing a Profile
 

--- a/test-framework/junit-config/src/main/java/io/quarkus/test/config/QuarkusClassOrderer.java
+++ b/test-framework/junit-config/src/main/java/io/quarkus/test/config/QuarkusClassOrderer.java
@@ -4,25 +4,26 @@ import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;
 import org.junit.platform.commons.util.ReflectionUtils;
 
-import io.quarkus.deployment.dev.testing.TestConfig;
-import io.smallrye.config.Config;
-
 /**
  * A JUnit {@link ClassOrderer}, used to delegate to a custom implementations of {@link ClassOrderer} set by Quarkus
  * config.
+ *
+ * @deprecated This no longer does anything except delegate to the QuarkusTestProfileAwareClassOrderer. In most cases it will
+ *             not be active, unless explicitly configured in.
  */
+@Deprecated(forRemoval = true, since = "3.34")
 public class QuarkusClassOrderer implements ClassOrderer {
     private final ClassOrderer delegate;
 
     public QuarkusClassOrderer() {
-        TestConfig testConfig = Config.get(ClassLoader.getSystemClassLoader()).getConfigMapping(TestConfig.class);
-        delegate = testConfig.classOrderer()
-                .map(klass -> ReflectionUtils.tryToLoadClass(klass)
-                        .andThenTry(ReflectionUtils::newInstance)
-                        .andThenTry(instance -> (ClassOrderer) instance)
-                        .toOptional()
-                        .orElse(EMPTY))
+
+        String klass = "io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer";
+        delegate = ReflectionUtils.tryToLoadClass(klass)
+                .andThenTry(ReflectionUtils::newInstance)
+                .andThenTry(instance -> (ClassOrderer) instance)
+                .toOptional()
                 .orElse(EMPTY);
+
     }
 
     @Override

--- a/test-framework/junit-config/src/main/resources/junit-platform.properties
+++ b/test-framework/junit-config/src/main/resources/junit-platform.properties
@@ -1,2 +1,0 @@
-junit.jupiter.extensions.autodetection.enabled=true
-junit.jupiter.testclass.order.default=io.quarkus.test.config.QuarkusClassOrderer

--- a/test-framework/junit/src/main/resources/junit-platform.properties
+++ b/test-framework/junit/src/main/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testclass.order.default=io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer


### PR DESCRIPTION
With #52404, we can now bypass the orderer which set up config, and go straight to the orderer which makes sure different applications are grouped. 

Instead of having a different config property for each level of delegation, I've made `quarkus.test.class-orderer` set the secondary orderer used by the profile-aware orderer. This is kind of what the docs implied it did anyway, so I've aligned reality and the docs. I've also updated the docs a bit for clarity.

Resolves #52354 