### PR TITLE
Add property maxMailsPerConnection to quarkus-mailer

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.regex.Pattern;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -274,4 +275,11 @@ public interface MailerRuntimeConfig {
      */
     @WithDefault("60S")
     Duration timeout();
+
+    /**
+     * Sets the max emails count per connection before it gets closed.
+     * <p>
+     * Some SMTP servers have the requirement to allow only a number of emails sent per connection.
+     */
+    OptionalLong maxMailsPerConnection();
 }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
@@ -245,6 +245,10 @@ public class Mailers {
             cfg.addDKIMSignOption(toVertxDkimSignOptions(config.dkim()));
         }
 
+        if (config.maxMailsPerConnection().isPresent()) {
+            cfg.setMaxMailsPerConnection(config.maxMailsPerConnection().getAsLong());
+        }
+
         cfg.setStarttls(StartTLSOptions.valueOf(config.startTLS().toUpperCase()));
         cfg.setMultiPartOnly(config.multiPartOnly());
 

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -318,6 +319,10 @@ public class FakeSmtpTestBase {
             return Duration.ofSeconds(60);
         }
 
+        @Override
+        public OptionalLong maxMailsPerConnection() {
+            return OptionalLong.empty();
+        }
     }
 
 }


### PR DESCRIPTION
The PR makes the property maxMailsPerConnection, which is present in the Vert.x-MailConfig, also available in the configuration of the quarkus-mailer extension.
