### PR TITLE
Do not use System Properties to set test profile configuration

### DIFF
--- a/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesOverrideConfigSource.java
+++ b/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesOverrideConfigSource.java
@@ -59,7 +59,6 @@ public class DevServicesOverrideConfigSource implements ConfigSource {
 
     @Override
     public int getOrdinal() {
-        // This is a dynamic override, so it needs a high priority to be able to override ephemeral port (0) with real values
-        return 410; // a bit more than system properties
+        return Integer.MAX_VALUE - 500;
     }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/PrepareResult.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/PrepareResult.java
@@ -3,6 +3,5 @@ package io.quarkus.test.junit;
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.CuratedApplication;
 
-record PrepareResult(AugmentAction augmentAction, QuarkusTestProfile profileInstance,
-        CuratedApplication curatedApplication) {
+public record PrepareResult(AugmentAction augmentAction, CuratedApplication curatedApplication) {
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -1,11 +1,11 @@
 package io.quarkus.test.junit;
 
+import static io.quarkus.runtime.LaunchMode.NORMAL;
 import static io.quarkus.test.config.TestValueRegistryConfigSource.CONFIG;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isContainer;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isJar;
 import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
 import static io.quarkus.test.junit.IntegrationTestUtil.determineBuildOutputDirectory;
-import static io.quarkus.test.junit.IntegrationTestUtil.determineTestProfileAndProperties;
 import static io.quarkus.test.junit.IntegrationTestUtil.doProcessTestInstance;
 import static io.quarkus.test.junit.IntegrationTestUtil.ensureNoInjectAnnotationIsUsed;
 import static io.quarkus.test.junit.IntegrationTestUtil.findProfile;
@@ -167,7 +167,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
         boolean reloadTestResources = false;
         if ((state == null && !failedBoot) || wrongProfile || (reloadTestResources = isNewTestClass
                 && TestResourceUtil.testResourcesRequireReload(state, extensionContext.getRequiredTestClass(),
-                        selectedProfile))) {
+                        Optional.ofNullable(selectedProfile)))) {
             if (wrongProfile || reloadTestResources) {
                 if (state != null) {
                     try {
@@ -219,7 +219,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
 
             Map<String, String> sysPropRestore = getSysPropsToRestore();
 
-            TestProfileAndProperties testProfileAndProperties = determineTestProfileAndProperties(profile);
+            TestProfileAndProperties testProfileAndProperties = TestProfileAndProperties.ofNullable(profile, NORMAL);
             // prepare dev services after profile and properties have been determined
             ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult = handleDevServices(context,
                     isDockerLaunch, testProfileAndProperties);
@@ -232,7 +232,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             testResourceManager = new TestResourceManager(
                     requiredTestClass,
                     quarkusTestProfile,
-                    copyEntriesFromProfile(testProfileAndProperties.testProfile().orElse(null),
+                    copyEntriesFromProfile(testProfileAndProperties.testProfile(),
                             context.getRequiredTestClass().getClassLoader()),
                     testProfileAndProperties.isDisabledGlobalTestResources(),
                     devServicesProps,

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -1,10 +1,10 @@
 package io.quarkus.test.junit;
 
+import static io.quarkus.runtime.LaunchMode.NORMAL;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isContainer;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isJar;
 import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
 import static io.quarkus.test.junit.IntegrationTestUtil.determineBuildOutputDirectory;
-import static io.quarkus.test.junit.IntegrationTestUtil.determineTestProfileAndProperties;
 import static io.quarkus.test.junit.IntegrationTestUtil.ensureNoInjectAnnotationIsUsed;
 import static io.quarkus.test.junit.IntegrationTestUtil.getEffectiveArtifactType;
 import static io.quarkus.test.junit.IntegrationTestUtil.getSysPropsToRestore;
@@ -120,7 +120,7 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                 Class<?> requiredTestClass = context.getRequiredTestClass();
 
                 Map<String, String> sysPropRestore = getSysPropsToRestore();
-                TestProfileAndProperties testProfileAndProperties = determineTestProfileAndProperties(profile);
+                TestProfileAndProperties testProfileAndProperties = TestProfileAndProperties.ofNullable(profile, NORMAL);
                 // prepare dev services after profile and properties have been determined
                 if (quarkusArtifactProperties == null) {
                     prepare(context, testProfileAndProperties);
@@ -130,7 +130,7 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                 testResourceManager = new TestResourceManager(
                         requiredTestClass,
                         profile,
-                        copyEntriesFromProfile(testProfileAndProperties.testProfile().orElse(null),
+                        copyEntriesFromProfile(testProfileAndProperties.testProfile(),
                                 context.getRequiredTestClass().getClassLoader()),
                         testProfileAndProperties.isDisabledGlobalTestResources());
                 testResourceManager.init(testProfileAndProperties.testProfileClassName().orElse(null));

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/TestProfileAndProperties.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/TestProfileAndProperties.java
@@ -1,10 +1,25 @@
 package io.quarkus.test.junit;
 
+import static org.eclipse.microprofile.config.spi.ConfigSource.CONFIG_ORDINAL;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-final class TestProfileAndProperties {
+import jakarta.enterprise.inject.Alternative;
+
+import io.quarkus.runtime.LaunchMode;
+
+public final class TestProfileAndProperties {
     private final QuarkusTestProfile testProfile;
     private final Map<String, String> properties;
 
@@ -17,19 +32,89 @@ final class TestProfileAndProperties {
         return Optional.ofNullable(testProfile);
     }
 
-    Map<String, String> properties() {
+    public Map<String, String> properties() {
         return Collections.unmodifiableMap(properties);
     }
 
-    Optional<String> configProfile() {
+    public Optional<String> configProfile() {
         return testProfile().map(QuarkusTestProfile::getConfigProfile);
     }
 
-    boolean isDisabledGlobalTestResources() {
+    public boolean isDisabledGlobalTestResources() {
         return testProfile().map(QuarkusTestProfile::disableGlobalTestResources).orElse(false);
     }
 
-    Optional<String> testProfileClassName() {
+    public Optional<String> testProfileClassName() {
         return testProfile().map(testProfile -> testProfile.getClass().getName());
+    }
+
+    public TestProfileConfigSource toTestProfileConfigSource() throws Exception {
+        Properties properties = new Properties();
+        properties.put(CONFIG_ORDINAL, String.valueOf(Integer.MAX_VALUE - 1000));
+        properties.putAll(this.properties);
+
+        Path tempDirectory = Files.createTempDirectory("quarkus-test");
+        Path propertiesFile = tempDirectory.resolve("application.properties");
+        File file = Files.createFile(propertiesFile).toFile();
+
+        file.deleteOnExit();
+        tempDirectory.toFile().deleteOnExit();
+
+        try (FileOutputStream outputStream = new FileOutputStream(file)) {
+            properties.store(outputStream, "");
+        }
+
+        return new TestProfileConfigSource(tempDirectory, propertiesFile);
+    }
+
+    public static TestProfileAndProperties of(Class<?> profileClass, LaunchMode launchMode) throws Exception {
+        ClassCoercingTestProfile profileInstance = new ClassCoercingTestProfile(profileClass.getConstructor().newInstance());
+        Map<String, String> properties = new HashMap<>(profileInstance.getConfigOverrides());
+        Set<Class<?>> enabledAlternatives = profileInstance.getEnabledAlternatives();
+
+        @SuppressWarnings("unchecked")
+        Class<? extends Annotation> alternative = (Class<? extends Annotation>) profileClass.getClassLoader()
+                .loadClass(Alternative.class.getName());
+        if (!enabledAlternatives.isEmpty()) {
+            properties.put("quarkus.arc.selected-alternatives", enabledAlternatives.stream()
+                    .peek(c -> {
+                        if (!c.isAnnotationPresent(alternative)) {
+                            throw new RuntimeException("Enabled alternative " + c + " is not annotated with @Alternative");
+                        }
+                    })
+                    .map(Class::getName).collect(Collectors.joining(",")));
+        }
+        String configProfile = profileInstance.getConfigProfile();
+        if (configProfile != null) {
+            properties.put(launchMode.getProfileKey(), configProfile);
+        }
+        properties.put("quarkus.config.build-time-mismatch-at-runtime", "fail");
+        return new TestProfileAndProperties(profileInstance, properties);
+    }
+
+    public static TestProfileAndProperties ofNullable(Class<?> profileClass, LaunchMode launchMode) throws Exception {
+        if (profileClass == null) {
+            return new TestProfileAndProperties(null, null);
+        } else {
+            return of(profileClass, launchMode);
+        }
+    }
+
+    public final static class TestProfileConfigSource {
+        private final Path propertiesLocation;
+        private final Path propertiesFile;
+
+        TestProfileConfigSource(Path propertiesLocation, Path propertiesFile) {
+            this.propertiesLocation = propertiesLocation;
+            this.propertiesFile = propertiesFile;
+        }
+
+        public Path getPropertiesLocation() {
+            return propertiesLocation;
+        }
+
+        public Path getPropertiesFile() {
+            return propertiesFile;
+        }
     }
 }


### PR DESCRIPTION
Changes `QuarkusTestProfile#getConfigOverrides` to not use System Properties to set the test profile configuration. Instead, it generates an `application.properties` file in the tmp folder and adds it as resource to the tested application. In this way, it is possible to expose and isolate the configuration to both the build and run of the test app. 

This `application.properties` is generated with a very high ordinal, just below `BuildTimeRunTimeFixedConfigSource`, and also changed to `DevServicesOverrideConfigSource`, to be in between. As we may have other sources above 400, what we really want is:

- `BuildTimeRunTimeFixedConfigSource`
- `DevServicesOverrideConfigSource`
- Test Profile Overrides

Also:
- Reduce the list of Exceptions throws in many methods 
- Reduce some code duplication around creating the Test Profile instance
- Express the Test Profile as an `Optional` in most cases

Finally:
- Fixes #27996 