### PR TITLE
quarkus:dependency-list goal

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencyListMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencyListMojo.java
@@ -1,0 +1,255 @@
+package io.quarkus.maven;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.maven.components.QuarkusWorkspaceProvider;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * Lists dependencies of a Quarkus application as resolved by the Quarkus bootstrap dependency resolver.
+ */
+@Mojo(name = "dependency-list", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true)
+public class DependencyListMojo extends AbstractMojo {
+
+    @Inject
+    QuarkusWorkspaceProvider workspaceProvider;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    MavenSession session;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    List<RemoteRepository> repos;
+
+    /**
+     * Target launch mode corresponding to {@link io.quarkus.runtime.LaunchMode} for which the dependencies should be listed.
+     * {@code io.quarkus.runtime.LaunchMode.NORMAL} is the default.
+     */
+    @Parameter(property = "mode", defaultValue = "prod")
+    String mode;
+
+    /**
+     * Comma-separated list of dependency flag names from {@link DependencyFlags} indicating which dependencies should be
+     * listed.
+     * Only dependencies that have all the specified flags set will be included.
+     * <p>
+     * Accepted flag names (case-insensitive, both constant names and text names are supported):
+     * {@code OPTIONAL}, {@code DIRECT}, {@code RUNTIME_CP} (or {@code runtime-cp}),
+     * {@code DEPLOYMENT_CP} (or {@code deployment-cp}), {@code RUNTIME_EXTENSION_ARTIFACT} (or
+     * {@code runtime-extension-artifact}),
+     * {@code WORKSPACE_MODULE} (or {@code workspace-module}), {@code RELOADABLE},
+     * {@code TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT} (or {@code top-level-runtime-extension-artifact}),
+     * {@code CLASSLOADER_PARENT_FIRST} (or {@code classloader-parent-first}),
+     * {@code CLASSLOADER_RUNNER_PARENT_FIRST} (or {@code classloader-runner-parent-first}),
+     * {@code CLASSLOADER_LESSER_PRIORITY} (or {@code classloader-lesser-priority}),
+     * {@code COMPILE_ONLY} (or {@code compile-only}).
+     * <p>
+     * If not specified, all dependencies returned by {@link ApplicationModel#getDependencies()} are listed.
+     */
+    @Parameter(property = "flags")
+    String flags;
+
+    /**
+     * If specified, this parameter will cause the dependency list to be written to the path specified, instead of writing to
+     * the console.
+     */
+    @Parameter(property = "outputFile", required = false)
+    File outputFile;
+
+    /**
+     * Whether to append outputs into the output file or overwrite it.
+     */
+    @Parameter(property = "appendOutput", required = false, defaultValue = "false")
+    boolean appendOutput;
+
+    /**
+     * Whether to include dependency scope and flag names in the output for each dependency.
+     */
+    @Parameter(property = "verbose")
+    boolean verbose;
+
+    // Maps both Java constant names (upper-case with underscores) and text names (lower-case with hyphens) to flag values
+    private static final Map<String, Integer> FLAG_NAMES = Map.ofEntries(
+            Map.entry("optional", DependencyFlags.OPTIONAL),
+            Map.entry("direct", DependencyFlags.DIRECT),
+            Map.entry("runtime_cp", DependencyFlags.RUNTIME_CP),
+            Map.entry("runtime-cp", DependencyFlags.RUNTIME_CP),
+            Map.entry("deployment_cp", DependencyFlags.DEPLOYMENT_CP),
+            Map.entry("deployment-cp", DependencyFlags.DEPLOYMENT_CP),
+            Map.entry("runtime_extension_artifact", DependencyFlags.RUNTIME_EXTENSION_ARTIFACT),
+            Map.entry("runtime-extension-artifact", DependencyFlags.RUNTIME_EXTENSION_ARTIFACT),
+            Map.entry("workspace_module", DependencyFlags.WORKSPACE_MODULE),
+            Map.entry("workspace-module", DependencyFlags.WORKSPACE_MODULE),
+            Map.entry("reloadable", DependencyFlags.RELOADABLE),
+            Map.entry("top_level_runtime_extension_artifact", DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT),
+            Map.entry("top-level-runtime-extension-artifact", DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT),
+            Map.entry("classloader_parent_first", DependencyFlags.CLASSLOADER_PARENT_FIRST),
+            Map.entry("classloader-parent-first", DependencyFlags.CLASSLOADER_PARENT_FIRST),
+            Map.entry("classloader_runner_parent_first", DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST),
+            Map.entry("classloader-runner-parent-first", DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST),
+            Map.entry("classloader_lesser_priority", DependencyFlags.CLASSLOADER_LESSER_PRIORITY),
+            Map.entry("classloader-lesser-priority", DependencyFlags.CLASSLOADER_LESSER_PRIORITY),
+            Map.entry("compile_only", DependencyFlags.COMPILE_ONLY),
+            Map.entry("compile-only", DependencyFlags.COMPILE_ONLY));
+
+    protected MavenArtifactResolver resolver;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        BufferedWriter writer = null;
+        final Consumer<String> log;
+        if (outputFile == null) {
+            log = s -> getLog().info(s);
+        } else {
+            final BufferedWriter bw;
+            try {
+                Files.createDirectories(outputFile.toPath().getParent());
+                final OpenOption[] openOptions = appendOutput && outputFile.exists()
+                        ? new OpenOption[] { StandardOpenOption.APPEND }
+                        : new OpenOption[0];
+                bw = writer = Files.newBufferedWriter(outputFile.toPath(), openOptions);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to initialize file output writer", e);
+            }
+            log = s -> {
+                try {
+                    bw.write(s);
+                    bw.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to log the dependency list to a file", e);
+                }
+            };
+        }
+        try {
+            logDependencies(log);
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                    getLog().debug("Failed to close the output file", e);
+                }
+            }
+        }
+    }
+
+    private void logDependencies(final Consumer<String> log) throws MojoExecutionException {
+        final int parsedFlags = parseFlags();
+        final ApplicationModel appModel = resolveApplicationModel(parsedFlags);
+        final StringBuilder heading = new StringBuilder()
+                .append("Quarkus application ").append(mode.toUpperCase()).append(" mode dependencies");
+        if (flags != null && !flags.isBlank()) {
+            heading.append(" with flags ").append(flags);
+        }
+        heading.append(":");
+        log.accept(heading.toString());
+        final Iterable<ResolvedDependency> deps = parsedFlags == 0
+                ? appModel.getDependencies()
+                : appModel.getDependencies(parsedFlags);
+        final List<String> lines = new ArrayList<>();
+        for (ResolvedDependency dep : deps) {
+            if (verbose) {
+                final StringBuilder sb = new StringBuilder().append(dep.toCompactCoords());
+                sb.append(" [").append(dep.getScope()).append("] ")
+                        .append(DependencyFlags.toNames(dep.getFlags()));
+                lines.add(sb.toString());
+            } else {
+                lines.add(dep.toCompactCoords());
+            }
+        }
+        lines.sort(null);
+        for (String line : lines) {
+            log.accept(line);
+        }
+    }
+
+    private int parseFlags() throws MojoExecutionException {
+        if (flags == null || flags.isBlank()) {
+            return 0;
+        }
+        int result = 0;
+        for (String name : flags.split(",")) {
+            final String trimmed = name.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            final Integer flagValue = FLAG_NAMES.get(trimmed.toLowerCase(Locale.ROOT));
+            if (flagValue == null) {
+                throw new MojoExecutionException(
+                        "Unrecognized dependency flag '" + trimmed + "'. Supported flags: " + String.join(", ",
+                                "OPTIONAL", "DIRECT", "RUNTIME_CP", "DEPLOYMENT_CP",
+                                "RUNTIME_EXTENSION_ARTIFACT", "WORKSPACE_MODULE", "RELOADABLE",
+                                "TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT", "CLASSLOADER_PARENT_FIRST",
+                                "CLASSLOADER_RUNNER_PARENT_FIRST", "CLASSLOADER_LESSER_PRIORITY",
+                                "COMPILE_ONLY"));
+            }
+            result |= flagValue;
+        }
+        return result;
+    }
+
+    private ApplicationModel resolveApplicationModel(int flags) throws MojoExecutionException {
+        final ArtifactCoords appArtifact = ArtifactCoords.pom(project.getGroupId(), project.getArtifactId(),
+                project.getVersion());
+        final BootstrapAppModelResolver modelResolver;
+        try {
+            modelResolver = new BootstrapAppModelResolver(resolver())
+                    .setRuntimeModelOnly(((flags & DependencyFlags.RUNTIME_CP) > 0));
+            if (mode.equalsIgnoreCase("test")) {
+                modelResolver.setTest(true);
+            } else if (mode.equalsIgnoreCase("dev") || mode.equalsIgnoreCase("development")) {
+                modelResolver.setDevMode(true);
+            } else if (mode.equalsIgnoreCase("prod") || mode.isEmpty()) {
+                // ignore, that's the default
+            } else {
+                throw new MojoExecutionException(
+                        "Parameter 'mode' was set to '" + mode + "' while expected one of 'dev', 'test' or 'prod'");
+            }
+            modelResolver.setLegacyModelResolver(BootstrapAppModelResolver.isLegacyModelResolver(project.getProperties()));
+            return modelResolver.resolveModel(appArtifact);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to resolve application model " + appArtifact + " dependencies", e);
+        }
+    }
+
+    protected MavenArtifactResolver resolver() {
+        return resolver == null
+                ? resolver = workspaceProvider.createArtifactResolver(BootstrapMavenContext.config()
+                        .setUserSettings(session.getRequest().getUserSettingsFile())
+                        .setRemoteRepositories(repos)
+                        .setPreferPomsFromWorkspace(true))
+                : resolver;
+    }
+}

--- a/devtools/maven/src/test/java/io/quarkus/maven/DependencyListMojoTest.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/DependencyListMojoTest.java
@@ -1,0 +1,161 @@
+package io.quarkus.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.bootstrap.resolver.TsRepoBuilder;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public class DependencyListMojoTest {
+
+    private Path workDir;
+    private MavenArtifactResolver mvnResolver;
+    private TsArtifact app;
+    private Model appModel;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        workDir = IoUtils.createRandomTmpDir();
+        final Path repoHome = IoUtils.mkdirs(workDir.resolve("repo"));
+
+        mvnResolver = MavenArtifactResolver.builder()
+                .setOffline(true)
+                .setLocalRepository(repoHome.toString())
+                .setRemoteRepositories(Collections.emptyList())
+                .build();
+
+        final TsRepoBuilder repoBuilder = TsRepoBuilder.getInstance(mvnResolver, workDir);
+        final TsQuarkusExt coreExt = new TsQuarkusExt("test-core-ext");
+        app = TsArtifact.jar("test-app")
+                .addDependency(new TsArtifact(TsArtifact.DEFAULT_GROUP_ID, "artifact-with-classifier", "classifier", "jar",
+                        TsArtifact.DEFAULT_VERSION))
+                .addDependency(new TsQuarkusExt("test-ext2")
+                        .addDependency(new TsQuarkusExt("test-ext1").addDependency(coreExt)))
+                .addDependency(new TsDependency(TsArtifact.jar("optional"), true))
+                .addDependency(new TsQuarkusExt("test-ext3").addDependency(coreExt))
+                .addDependency(new TsDependency(TsArtifact.jar("provided"), "provided"))
+                .addDependency(new TsDependency(TsArtifact.jar("runtime"), "runtime"))
+                .addDependency(new TsDependency(TsArtifact.jar("test"), "test"));
+        appModel = app.getPomModel();
+        app.install(repoBuilder);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        if (workDir != null) {
+            IoUtils.recursiveDelete(workDir);
+        }
+    }
+
+    private DependencyListMojo newMojo(String mode) {
+        final DependencyListMojo mojo = new DependencyListMojo();
+        mojo.project = new MavenProject();
+        mojo.project.setArtifact(new DefaultArtifact(app.getGroupId(), app.getArtifactId(), app.getVersion(),
+                JavaScopes.COMPILE, app.getType(), app.getClassifier(),
+                new DefaultArtifactHandler(ArtifactCoords.TYPE_JAR)));
+        mojo.project.setModel(appModel);
+        mojo.project.setOriginalModel(appModel);
+        mojo.resolver = mvnResolver;
+        mojo.mode = mode;
+        return mojo;
+    }
+
+    private List<String> execute(DependencyListMojo mojo) throws Exception {
+        final Path mojoLog = workDir.resolve("mojo.log");
+        final PrintStream defaultOut = System.out;
+        try (PrintStream logOut = new PrintStream(mojoLog.toFile(), StandardCharsets.UTF_8)) {
+            System.setOut(logOut);
+            mojo.execute();
+        } finally {
+            System.setOut(defaultOut);
+        }
+        return Files.readAllLines(mojoLog);
+    }
+
+    @Test
+    public void testProdMode() throws Exception {
+        final DependencyListMojo mojo = newMojo("prod");
+        final List<String> lines = execute(mojo);
+
+        assertThat(lines.get(0)).contains("Quarkus application PROD mode dependencies:");
+        // dependency lines follow the heading
+        final List<String> deps = lines.subList(1, lines.size());
+        assertThat(deps).isNotEmpty();
+
+        // the list should contain runtime and deployment dependencies
+        assertThat(deps).anyMatch(l -> l.contains("test-ext2:"));
+        assertThat(deps).anyMatch(l -> l.contains("test-ext2-deployment:"));
+        assertThat(deps).anyMatch(l -> l.contains("runtime:"));
+        // provided is excluded in prod mode
+        assertThat(deps).noneMatch(l -> l.contains("provided:"));
+
+        // verify alphabetical ordering
+        final List<String> sorted = new ArrayList<>(deps);
+        Collections.sort(sorted);
+        assertThat(deps).isEqualTo(sorted);
+    }
+
+    @Test
+    public void testTestMode() throws Exception {
+        final DependencyListMojo mojo = newMojo("test");
+        final List<String> lines = execute(mojo);
+
+        assertThat(lines.get(0)).contains("Quarkus application TEST mode dependencies:");
+        final List<String> deps = lines.subList(1, lines.size());
+        assertThat(deps).isNotEmpty();
+
+        // test mode includes test-scoped dependencies
+        assertThat(deps).anyMatch(l -> l.contains("test:"));
+    }
+
+    @Test
+    public void testFlagsFiltering() throws Exception {
+        final DependencyListMojo mojo = newMojo("prod");
+        mojo.flags = "RUNTIME_EXTENSION_ARTIFACT";
+        final List<String> lines = execute(mojo);
+
+        assertThat(lines.get(0)).contains("with flags RUNTIME_EXTENSION_ARTIFACT");
+        final List<String> deps = lines.subList(1, lines.size());
+        // only runtime extension artifacts should be listed
+        assertThat(deps).allMatch(l -> l.contains("test-ext") || l.contains("test-core-ext"));
+        // non-extension deps should not appear
+        assertThat(deps).noneMatch(l -> l.contains("artifact-with-classifier"));
+        assertThat(deps).noneMatch(l -> l.contains("optional:"));
+        assertThat(deps).noneMatch(l -> l.contains("runtime:"));
+    }
+
+    @Test
+    public void testVerbose() throws Exception {
+        final DependencyListMojo mojo = newMojo("prod");
+        mojo.verbose = true;
+        final List<String> lines = execute(mojo);
+
+        final List<String> deps = lines.subList(1, lines.size());
+        assertThat(deps).isNotEmpty();
+        // verbose output should include scope and flag names
+        for (String dep : deps) {
+            assertThat(dep).containsPattern("\\[\\w+\\]");
+        }
+    }
+}


### PR DESCRIPTION
The goal allows listing application dependencies for a specific launch mode and optionally with specific `DependencyFlags` set.

For example
```
quarkus-super-heroes$ mvn -Dquarkus.platform.group-id=io.quarkus -Dquarkus.platform.version=999-SNAPSHOT -f rest-fights quarkus:dependency-list -Dflags=direct,runtime-extension-artifact -Dmode=test
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< io.quarkus.sample.super-heroes:rest-fights >-------------
[INFO] Building Quarkus Sample :: Super-Heroes :: Fights Microservice 1.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- quarkus:999-SNAPSHOT:dependency-list (default-cli) @ rest-fights ---
[INFO] Quarkus application TEST mode dependencies with flags direct,runtime-extension-artifact:
[INFO] io.github.microcks.quarkus:quarkus-microcks:0.4.3
[INFO] io.quarkiverse.pact:quarkus-pact-consumer:1.6.0
[INFO] io.quarkiverse.pact:quarkus-pact-provider:1.6.0
[INFO] io.quarkus:quarkus-apicurio-registry-avro:999-SNAPSHOT
[INFO] io.quarkus:quarkus-arc:999-SNAPSHOT
[INFO] io.quarkus:quarkus-container-image-docker:999-SNAPSHOT
[INFO] io.quarkus:quarkus-grpc:999-SNAPSHOT
[INFO] io.quarkus:quarkus-hibernate-validator:999-SNAPSHOT
[INFO] io.quarkus:quarkus-info:999-SNAPSHOT
[INFO] io.quarkus:quarkus-jacoco:999-SNAPSHOT
[INFO] io.quarkus:quarkus-kubernetes-client:999-SNAPSHOT
[INFO] io.quarkus:quarkus-kubernetes:999-SNAPSHOT
[INFO] io.quarkus:quarkus-liquibase-mongodb:999-SNAPSHOT
[INFO] io.quarkus:quarkus-messaging-kafka:999-SNAPSHOT
[INFO] io.quarkus:quarkus-micrometer-registry-prometheus:999-SNAPSHOT
[INFO] io.quarkus:quarkus-minikube:999-SNAPSHOT
[INFO] io.quarkus:quarkus-mongodb-panache:999-SNAPSHOT
[INFO] io.quarkus:quarkus-openshift:999-SNAPSHOT
[INFO] io.quarkus:quarkus-opentelemetry:999-SNAPSHOT
[INFO] io.quarkus:quarkus-rest-client-jackson:999-SNAPSHOT
[INFO] io.quarkus:quarkus-rest-jackson:999-SNAPSHOT
[INFO] io.quarkus:quarkus-smallrye-fault-tolerance:999-SNAPSHOT
[INFO] io.quarkus:quarkus-smallrye-health:999-SNAPSHOT
[INFO] io.quarkus:quarkus-smallrye-openapi:999-SNAPSHOT
[INFO] io.quarkus:quarkus-smallrye-stork:999-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```