### PR TITLE
Fix `NarayanaLRARecovery` for Java 25

### DIFF
--- a/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
+++ b/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/NarayanaLRARecovery.java
@@ -59,6 +59,7 @@ public class NarayanaLRARecovery implements LRARecoveryService {
     @Override
     public void waitForCallbacks(URI lraId) {
         log.trace("waitForCallbacks for: " + lraId.toASCIIString());
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
         try (Client client = ClientBuilder.newClient()) {
             try {
                 await().atMost(Duration.ofMillis(WAIT_CALLBACK_TIMEOUT)).catchUncaughtExceptions()
@@ -66,6 +67,7 @@ public class NarayanaLRARecovery implements LRARecoveryService {
                             try {
                                 WebTarget target;
                                 try {
+                                    Thread.currentThread().setContextClassLoader(old);
                                     target = client.target(lraId);
                                 } catch (Exception | Error e) {
                                     // Some TCK tests don't start Quarkus application, so we can't create REST request


### PR DESCRIPTION
This is not a perfect solution (which might not even be possible for Java 25; we need to look into it more), but it's good enough to allow our CI to move to Java 25 as part of https://github.com/quarkusio/quarkus/pull/52555

- Fixes: #52573