### PR TITLE
Adjust normal shutdown wait time on IT JVM to be greater when generating AOT

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
@@ -27,6 +27,8 @@ public interface ArtifactLauncher<T extends ArtifactLauncher.InitContext> extend
 
         Duration waitTime();
 
+        Duration shutdownTimeout();
+
         String testProfile();
 
         List<String> argLine();

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -10,6 +10,7 @@ import java.net.ServerSocket;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,6 +46,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     private int httpPort;
     private int httpsPort;
     private long waitTimeSeconds;
+    private Duration shutdownTimeout;
     private String testProfile;
     private List<String> argLine;
     private Map<String, String> env;
@@ -71,6 +73,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         this.httpPort = initContext.httpPort();
         this.httpsPort = initContext.httpsPort();
         this.waitTimeSeconds = initContext.waitTime().getSeconds();
+        this.shutdownTimeout = initContext.shutdownTimeout();
         this.testProfile = initContext.testProfile();
         this.argLine = initContext.argLine();
         this.env = initContext.env();
@@ -380,7 +383,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
 
         if (containerProcess != null) {
             try {
-                containerProcess.waitFor(20, TimeUnit.SECONDS);
+                containerProcess.waitFor(getAdjustedShutdownTimeout().getSeconds(), TimeUnit.SECONDS);
             } catch (InterruptedException ignored) {
 
             }
@@ -402,6 +405,10 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         executorService.shutdown();
 
         recordMetadata();
+    }
+
+    private Duration getAdjustedShutdownTimeout() {
+        return shutdownTimeout.plus(generateAotFile ? Duration.ofMinutes(1) : Duration.ofSeconds(10));
     }
 
     private void createAotFileFromAotConfFile(Path aotConfigFile) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -12,6 +12,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.CodeSource;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
     private int httpPort;
     private int httpsPort;
     private long waitTimeSeconds;
+    private Duration shutdownTimeout;
     private String testProfile;
     private List<String> argLine;
     private Map<String, String> env;
@@ -53,6 +55,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
         this.httpPort = initContext.httpPort();
         this.httpsPort = initContext.httpsPort();
         this.waitTimeSeconds = initContext.waitTime().getSeconds();
+        this.shutdownTimeout = initContext.shutdownTimeout();
         this.testProfile = initContext.testProfile();
         this.nativeImagePath = initContext.nativeImagePath();
         this.configuredOutputDirectory = initContext.getConfiguredOutputDirectory();

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -136,9 +137,13 @@ public final class LauncherUtil {
      * and resort to forceful destruction if necessary
      */
     static void destroyProcess(Process quarkusProcess) {
+        destroyProcess(quarkusProcess, Duration.ofSeconds(10));
+    }
+
+    public static void destroyProcess(Process quarkusProcess, Duration waitTime) {
         quarkusProcess.destroy();
-        int i = 0;
-        while (i++ < 200) {
+        Instant max = Instant.now().plus(waitTime);
+        while (Instant.now().isBefore(max)) {
             try {
                 Thread.sleep(LOG_CHECK_INTERVAL);
             } catch (InterruptedException ignored) {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DefaultInitContextBase.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DefaultInitContextBase.java
@@ -10,19 +10,22 @@ class DefaultInitContextBase {
     private final int httpPort;
     private final int httpsPort;
     private final Duration waitTime;
+    private final Duration shutdownTimeout;
     private final String testProfile;
     private final List<String> argLine;
 
     private final Map<String, String> env;
     private final ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult;
 
-    DefaultInitContextBase(int httpPort, int httpsPort, Duration waitTime, String testProfile,
+    DefaultInitContextBase(int httpPort, int httpsPort, Duration waitTime, Duration shutdownTimeout,
+            String testProfile,
             List<String> argLine,
             Map<String, String> env,
             ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult) {
         this.httpPort = httpPort;
         this.httpsPort = httpsPort;
         this.waitTime = waitTime;
+        this.shutdownTimeout = shutdownTimeout;
         this.testProfile = testProfile;
         this.argLine = argLine;
         this.env = env;
@@ -39,6 +42,10 @@ class DefaultInitContextBase {
 
     public Duration waitTime() {
         return waitTime;
+    }
+
+    public Duration shutdownTimeout() {
+        return shutdownTimeout;
     }
 
     public String testProfile() {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -96,6 +96,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                 config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                 config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                 testConfig.waitTime(),
+                config.getOptionalValue("quarkus.shutdown.timeout", Duration.class).orElse(Duration.ZERO),
                 testConfig.integrationTestProfile(),
                 TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                 testConfig.env(),
@@ -176,7 +177,8 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
         private final Map<String, String> volumeMounts;
         private final String outputTargetDirectory;
 
-        public DefaultDockerInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
+        public DefaultDockerInitContext(int httpPort, int httpsPort, Duration waitTime, Duration shutdownTimeout,
+                String testProfile,
                 List<String> argLine, Map<String, String> env,
                 DevServicesLaunchResult devServicesLaunchResult,
                 String containerImage, boolean pullRequired,
@@ -187,7 +189,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                 Optional<String> entryPoint,
                 Optional<String> containerWorkingDirectory,
                 List<String> programArgs, String outputTargetDirectory) {
-            super(httpPort, httpsPort, waitTime, testProfile, argLine, env, devServicesLaunchResult);
+            super(httpPort, httpsPort, waitTime, shutdownTimeout, testProfile, argLine, env, devServicesLaunchResult);
             this.containerImage = containerImage;
             this.pullRequired = pullRequired;
             this.additionalExposedPorts = additionalExposedPorts;

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
@@ -47,6 +47,7 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                     testConfig.waitTime(),
+                    config.getOptionalValue("quarkus.shutdown.timeout", Duration.class).orElse(Duration.ZERO),
                     testConfig.integrationTestProfile(),
                     TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                     testConfig.env(),
@@ -68,11 +69,12 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
         private final Path jarPath;
         private final boolean generateAotFile;
 
-        DefaultJarInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
+        DefaultJarInitContext(int httpPort, int httpsPort, Duration waitTime, Duration shutdownTimeout,
+                String testProfile,
                 List<String> argLine, Map<String, String> env,
                 ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult, Path jarPath,
                 boolean generateAotFile) {
-            super(httpPort, httpsPort, waitTime, testProfile, argLine, env, devServicesLaunchResult);
+            super(httpPort, httpsPort, waitTime, shutdownTimeout, testProfile, argLine, env, devServicesLaunchResult);
             this.jarPath = jarPath;
             this.generateAotFile = generateAotFile;
         }
@@ -87,5 +89,4 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
             return generateAotFile;
         }
     }
-
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
@@ -45,6 +45,7 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                     testConfig.waitTime(),
+                    config.getOptionalValue("quarkus.shutdown.timeout", Duration.class).orElse(Duration.ZERO),
                     testConfig.integrationTestProfile(),
                     TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                     testConfig.env(),
@@ -65,11 +66,12 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
         private final Class<?> testClass;
         private final String configuredOutputDirectory;
 
-        public DefaultNativeImageInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
+        public DefaultNativeImageInitContext(int httpPort, int httpsPort, Duration waitTime, Duration shutdownTimeout,
+                String testProfile,
                 List<String> argLine, Map<String, String> env,
                 ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult,
                 String nativeImagePath, String configuredOutputDirectory, Class<?> testClass) {
-            super(httpPort, httpsPort, waitTime, testProfile, argLine, env, devServicesLaunchResult);
+            super(httpPort, httpsPort, waitTime, shutdownTimeout, testProfile, argLine, env, devServicesLaunchResult);
             this.nativeImagePath = nativeImagePath;
             this.configuredOutputDirectory = configuredOutputDirectory;
             this.testClass = testClass;


### PR DESCRIPTION
here is some context: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/aot-container-image/with/572784581 and https://github.com/quarkusio/quarkus/pull/52566
the appropriate approach is to give more time to the IT jvm to exit, specifically when we want to produce an aot file.
I kept the default as 10 secs, but made it configurable.
might need some polishing. for instance do we want to apply it to the other launchers?
and do we want to simplify `destroyProcess(Process)` to do something like this instead:
```
    static void destroyProcess(Process quarkusProcess) {
        destroyProcess(quarkusProcess, Duration.ofSeconds(10));
    }
```
cc @gsmet 