### PR TITLE
Fixes issues related to JvmModulesReconfigurer

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -460,7 +460,7 @@
                         <!-- the add-opens java.base/java.lang=ALL-UNNAMED is here for
                              org.jboss.JDKSpecific.ThreadAccess.clearThreadLocals() -->
                         <!-- set -XX:+HeapDumpOnOutOfMemoryError to provide some useful debugging info, should this happen -->
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/JvmModulesReconfigurer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/JvmModulesReconfigurer.java
@@ -34,6 +34,10 @@ public interface JvmModulesReconfigurer {
     }
 
     private static JvmModulesReconfigurer create() {
+        if (Runtime.version().feature() < 25) {
+            return NoopJvmModulesReconfigurer.INSTANCE;
+        }
+
         final Logger logger = JVMDeploymentLogger.logger;
 
         //First thing to check, is if we have our agent connected; that would make things really simple and avoid any need

--- a/core/deployment/src/main/java/io/quarkus/deployment/jvm/NoopJvmModulesReconfigurer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jvm/NoopJvmModulesReconfigurer.java
@@ -1,0 +1,15 @@
+package io.quarkus.deployment.jvm;
+
+import java.util.List;
+
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+
+class NoopJvmModulesReconfigurer implements JvmModulesReconfigurer {
+
+    static final NoopJvmModulesReconfigurer INSTANCE = new NoopJvmModulesReconfigurer();
+
+    @Override
+    public void openJavaModules(List<ModuleOpenBuildItem> addOpens, ModulesClassloaderContext referenceClassloader) {
+        // noop
+    }
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ModulesOpenedTestCase.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ModulesOpenedTestCase.java
@@ -4,12 +4,16 @@ import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class ModulesOpenedTestCase {
+
     @Test
+    @DisabledForJreRange(max = JRE.JAVA_24)
     public void test() {
         when().get("/core/modulesOpen").then()
                 .body(is("OK"));


### PR DESCRIPTION
It's causing some issues in tests as demonstrated in: https://github.com/quarkusio/quarkus/pull/52574 .

Unfortunately, in our own build, we cannot use our nice extension... and it wouldn't be usable for deployment tests anyway, so we pass the appropriate option to Surefire.

Also only execute this machinery for JDK >= 25.