### PR TITLE
Enhance documentation of AdditionalApplicationArchiveBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalApplicationArchiveBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalApplicationArchiveBuildItem.java
@@ -5,19 +5,37 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.paths.PathCollection;
 
 /**
- * An additional application archive. This build item can only be consumed, it should not be produced by build steps.
+ * Represents an additional application archive that must be considered part of the
+ * application during the augmentation phase.
+ *
+ * <p>
+ * This build item is produced internally by the Quarkus bootstrap process when
+ * extra archives need to be indexed and treated as application code.
+ * </p>
+ *
+ * <p>
+ * It is intended to be consumed by build steps that analyze or process
+ * application archives. Extensions must not produce this build item directly.
+ * </p>
+ *
  */
 public final class AdditionalApplicationArchiveBuildItem extends MultiBuildItem {
-
+    /**
+     * The resolved paths that compose the additional application archive.
+     */
     private final PathCollection path;
 
+    /**
+     * Creates a new build item representing an additional application archive.
+     *
+     * @param path the resolved paths that form the archive
+     */
     public AdditionalApplicationArchiveBuildItem(PathCollection path) {
         this.path = path;
     }
 
     /**
-     * @deprecated in favor of {@link #getResolvedPaths()}
-     * @return
+     * @deprecated Use {@link #getResolvedPaths()} instead.
      */
     @Deprecated
     public PathsCollection getPaths() {


### PR DESCRIPTION
### Summary

This PR enhances the documentation of `AdditionalApplicationArchiveBuildItem` by adding detailed JavaDoc comments to improve clarity and maintainability.

### Details

The previous implementation lacked comprehensive documentation explaining its role during the augmentation phase.

No functional changes were made.

### Impact

Documentation-only change. No runtime or build behavior impact.

Fixes #47523

