### PR TITLE
Add manifest information to application jar

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
@@ -202,43 +202,16 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
         }
     }
 
-    /**
-     * Manifest generation is quite simple : we just have to push some attributes in manifest.
-     * However, it gets a little more complex if the manifest preexists.
-     * So we first try to see if a manifest exists, and otherwise create a new one.
-     *
-     * <b>BEWARE</b> this method should be invoked after file copy from target/classes and so on.
-     * Otherwise, this manifest manipulation will be useless.
-     */
-    protected static void generateManifest(ArchiveCreator archiveCreator, final String classPath, PackageConfig config,
-            ResolvedDependency appArtifact,
-            ResolvedJVMRequirements jvmRequirements,
-            String mainClassName,
-            ApplicationInfoBuildItem applicationInfo)
-            throws IOException {
+    protected static Manifest createManifest(PackageConfig config, ResolvedDependency appArtifact,
+            ApplicationInfoBuildItem applicationInfo) {
         final Manifest manifest = new Manifest();
 
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
 
-        jvmRequirements.renderAddOpensElementToJarManifest(attributes);
-
         for (Map.Entry<String, String> attribute : config.jar().manifest().attributes().entrySet()) {
             attributes.putValue(attribute.getKey(), attribute.getValue());
         }
-        if (attributes.containsKey(Attributes.Name.CLASS_PATH)) {
-            LOG.warn(
-                    "A CLASS_PATH entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Class-Path\". Quarkus has overwritten this existing entry.");
-        }
-        attributes.put(Attributes.Name.CLASS_PATH, classPath);
-        if (attributes.containsKey(Attributes.Name.MAIN_CLASS)) {
-            String existingMainClass = attributes.getValue(Attributes.Name.MAIN_CLASS);
-            if (!mainClassName.equals(existingMainClass)) {
-                LOG.warn(
-                        "A MAIN_CLASS entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Main-Class\". Quarkus has overwritten your existing entry.");
-            }
-        }
-        attributes.put(Attributes.Name.MAIN_CLASS, mainClassName);
         if (config.jar().manifest().addImplementationEntries()
                 && !attributes.containsKey(Attributes.Name.IMPLEMENTATION_TITLE)) {
             String name = ApplicationInfoBuildItem.UNSET_VALUE.equals(applicationInfo.getName())
@@ -260,7 +233,30 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
             }
         }
 
-        archiveCreator.addManifest(manifest);
+        return manifest;
+    }
+
+    protected static Manifest attachRunnerMetadata(Manifest manifest, String mainClassName, String classPath,
+            ResolvedJVMRequirements jvmRequirements) {
+        Attributes attributes = manifest.getMainAttributes();
+
+        jvmRequirements.renderAddOpensElementToJarManifest(attributes);
+
+        if (attributes.containsKey(Attributes.Name.CLASS_PATH)) {
+            LOG.warn(
+                    "A CLASS_PATH entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Class-Path\". Quarkus has overwritten this existing entry.");
+        }
+        attributes.put(Attributes.Name.CLASS_PATH, classPath);
+        if (attributes.containsKey(Attributes.Name.MAIN_CLASS)) {
+            String existingMainClass = attributes.getValue(Attributes.Name.MAIN_CLASS);
+            if (!mainClassName.equals(existingMainClass)) {
+                LOG.warn(
+                        "A MAIN_CLASS entry was already defined in your MANIFEST.MF or using the property quarkus.package.jar.manifest.attributes.\"Main-Class\". Quarkus has overwritten your existing entry.");
+            }
+        }
+        attributes.put(Attributes.Name.MAIN_CLASS, mainClassName);
+
+        return manifest;
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
+import java.util.jar.Manifest;
 
 import io.quarkus.builder.item.BuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
@@ -71,9 +72,10 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
             ResolvedDependency appArtifact = curateOutcome.getApplicationModel().getAppArtifact();
             // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
             // see https://bugs.openjdk.java.net/browse/JDK-8031748
-            generateManifest(archiveCreator, classPath.toString(), packageConfig, appArtifact, jvmRequirements,
-                    mainClass.getClassName(),
-                    applicationInfo);
+            // the ArchiveCreator now makes sure it's the case, keeping the comment in case we change the implementation at some point
+            Manifest manifest = createManifest(packageConfig, appArtifact, applicationInfo);
+            attachRunnerMetadata(manifest, mainClass.getClassName(), classPath.toString(), jvmRequirements);
+            archiveCreator.addManifest(manifest);
 
             copyCommonContent(archiveCreator, services, ignoredEntriesPredicate);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
@@ -160,8 +161,10 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
             // the manifest needs to be the first entry in the jar, otherwise JarInputStream does not work properly
             // see https://bugs.openjdk.java.net/browse/JDK-8031748
-            generateManifest(archiveCreator, "", packageConfig, appArtifact, jvmRequirements, mainClass.getClassName(),
-                    applicationInfo);
+            // the ArchiveCreator now makes sure it's the case, keeping the comment in case we change the implementation at some point
+            Manifest manifest = createManifest(packageConfig, appArtifact, applicationInfo);
+            attachRunnerMetadata(manifest, mainClass.getClassName(), "", jvmRequirements);
+            archiveCreator.addManifest(manifest);
 
             final Set<String> existingEntries = new HashSet<>();
             generatedResources.stream()


### PR DESCRIPTION
The information added to the manifest by the package config should be accessible from the application code.
It was already the case for uberjars and legacy jars as the application code is in this case embedded in the runner, but it wasn't the case for fast jars.