### PR TITLE
Rework order of addition of application content to jars

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -75,7 +75,7 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
                     mainClass.getClassName(),
                     applicationInfo);
 
-            copyCommonContent(archiveCreator, services, ignoredEntriesPredicate);
+            copyApplicationContent(archiveCreator, services, ignoredEntriesPredicate);
         }
         runnerJar.toFile().setReadable(true, false);
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -208,7 +208,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                 }
             }
 
-            copyCommonContent(archiveCreator, concatenatedEntries, allIgnoredEntriesPredicate);
+            copyApplicationContent(archiveCreator, concatenatedEntries, allIgnoredEntriesPredicate);
             // now that all entries have been added, check if there's a META-INF/versions/ entry. If present,
             // mark this jar as multi-release jar. Strictly speaking, the jar spec expects META-INF/versions/N
             // directory where N is an integer greater than 8, but we don't do that level of checks here but that


### PR DESCRIPTION
We need to be extremely careful about the order and while it was more or less working, the previous order wasn't right.

The discussion in:
https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Pass.20quarkus.2Eclass-loading.2Eremoved-resources.20to.20Maven.20plugin/with/573711435 is an example of the problem but I'm pretty sure we could find others.
