### PR TITLE
[3.27] backport bump avro 1.12.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -194,7 +194,7 @@
         <log4j2-jboss-logmanager.version>2.0.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.25.1</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.3.1.Final</log4j-jboss-logmanager.version>
-        <avro.version>1.12.0</avro.version>
+        <avro.version>1.12.1</avro.version>
         <apicurio-registry.version>2.6.13.Final</apicurio-registry.version>
         <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <testcontainers.version>1.21.4</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->


### PR DESCRIPTION
Backport of https://github.com/quarkusio/quarkus/pull/50587, which was merged on main in https://github.com/quarkusio/quarkus/pull/50519