### PR TITLE
Use Podman exclusively in PodmanProcessor

### DIFF
--- a/extensions/container-image/container-image-podman/deployment/src/main/java/io/quarkus/container/image/podman/deployment/PodmanProcessor.java
+++ b/extensions/container-image/container-image-podman/deployment/src/main/java/io/quarkus/container/image/podman/deployment/PodmanProcessor.java
@@ -214,7 +214,7 @@ public class PodmanProcessor extends CommonProcessor<PodmanConfig> {
             throw new UnsupportedOperationException("Unable to save enhanced Dockerfile contents to disk", e);
         }
 
-        String executableName = getExecutableName(podmanConfig, ContainerRuntime.DOCKER, ContainerRuntime.PODMAN);
+        String executableName = getExecutableName(podmanConfig, ContainerRuntime.PODMAN);
         var dockerBuildArgs = getPodmanBuildArgs(enhancedImage, new DockerfilePaths() {
             @Override
             public Path dockerfilePath() {


### PR DESCRIPTION
PodmanProcessor is all about Podman, so we should use the podman command line (and definitely not the docker command line first).