### PR TITLE
Config doc - Add a list index for config groups in lists

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
@@ -121,6 +121,8 @@ public class ConfigResolver {
                             .map(p -> p + ConfigNamingUtil.getMapKey(discoveryConfigProperty.getMapKey()))
                             .collect(Collectors.toCollection(ArrayList::new));
                 }
+            } else if (discoveryConfigProperty.getType().isList()) {
+                potentiallyMappedPath += ConfigNamingUtil.getListIndex();
             }
 
             ResolutionContext configGroupContext;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/ConfigNamingUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/ConfigNamingUtil.java
@@ -216,4 +216,8 @@ public final class ConfigNamingUtil {
     public static String getMapKey(String mapKey) {
         return String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, mapKey);
     }
+
+    public static String getListIndex() {
+        return "[i]";
+    }
 }

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/configProperty.qute.adoc
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/configProperty.qute.adoc
@@ -1,9 +1,9 @@
-a|{#if configProperty.phase.fixedAtBuildTime}icon:lock[title=Fixed at build time]{/if} [[{configProperty.toAnchor(extension, additionalAnchorPrefix)}]] [.property-path]##link:#{configProperty.toAnchor(extension, additionalAnchorPrefix)}[{#if configProperty.deprecated}[.line-through]#{/if}`{configProperty.path.property}`{#if configProperty.deprecated}#{/if}]##
+a|{#if configProperty.phase.fixedAtBuildTime}icon:lock[title=Fixed at build time]{/if} [[{configProperty.toAnchor(extension, additionalAnchorPrefix)}]] [.property-path]##link:#{configProperty.toAnchor(extension, additionalAnchorPrefix)}[{#if configProperty.deprecated}[.line-through]#{/if}`+++{configProperty.path.property}+++`{#if configProperty.deprecated}#{/if}]##
 {#propertyCopyButton configProperty.path.property /}
 
 {#for additionalPath in configProperty.additionalPaths}
 
-{#if configProperty.deprecated}[.line-through]#{/if}`{additionalPath.property}`{#if configProperty.deprecated}#{/if}
+{#if configProperty.deprecated}[.line-through]#{/if}`+++{additionalPath.property}+++`{#if configProperty.deprecated}#{/if}
 {#propertyCopyButton additionalPath.property /}
 {/for}
 


### PR DESCRIPTION
Similar to what we do for Maps.
I decided to keep the fact that properties were required as they are required as soon as a list item is present.
But I think having the [i] in the property makes it clear enough.

Fixes #52397