### PR TITLE
Fix mvn quarkus:run environmentVariables parameter documentation and -DenvVars=... parsing

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
@@ -43,7 +43,7 @@ public class RunMojo extends QuarkusBootstrapMojo {
 
     /**
      * The list of environment variables with which the process will be launched. To be specified in a format like
-     * {@code -DsysProps=prop1=val1,prop2=val2}
+     * {@code -DenvVars=VAR1=val1,VAR2=val2}
      */
     @Parameter(defaultValue = "${envVars}")
     String environmentVariables;
@@ -153,7 +153,7 @@ public class RunMojo extends QuarkusBootstrapMojo {
                     String[] envVars = environmentVariables.split(",");
                     Map<String, String> env = new HashMap<>();
                     for (String envVar : envVars) {
-                        String[] parts = envVar.split("=");
+                        String[] parts = envVar.split("=", 2);
                         if (parts.length == 2) {
                             env.put(parts[0], parts[1]);
                         } else {


### PR DESCRIPTION
* Fixes #52630

Besides fixing documentation bug #52630, I also fixed parsing of environment variables containing "=" character in the values, for example:

```xml
<environmentVariables>JAVA_TOOL_OPTIONS=--enable-native-access=ALL-UNNAMED</environmentVariables>
```

This currently fails.