### PR TITLE
Metric reader must use Quarkus classloader - part II

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -307,7 +307,9 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
                         public MetricReader apply(MetricReader metricReader, ConfigProperties configProperties) {
                             // Replace the provided metric reader because it uses an unmanaged executor
                             // with a null classloader
-                            if (metricExporter.isResolvable() && managedExecutor.isResolvable()) {
+                            if (metricReader instanceof PeriodicMetricReader &&
+                                    metricExporter.isResolvable() &&
+                                    managedExecutor.isResolvable()) {
                                 return PeriodicMetricReader.builder(metricExporter.get())
                                         .setInterval(oTelRuntimeConfig.metric().exportInterval())
                                         .setExecutor(managedExecutor.get())


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/52585

Make sure changes only apply to `PeriodicMetricReader` objects