### PR TITLE
Some cleanup related to QuarkusConsole

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsupportedOSBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsupportedOSBuildItem.java
@@ -1,9 +1,5 @@
 package io.quarkus.deployment.builditem.nativeimage;
 
-import static io.quarkus.dev.console.QuarkusConsole.IS_LINUX;
-import static io.quarkus.dev.console.QuarkusConsole.IS_MAC;
-import static io.quarkus.dev.console.QuarkusConsole.IS_WINDOWS;
-
 import io.quarkus.builder.item.MultiBuildItem;
 import io.smallrye.common.cpu.CPU;
 import io.smallrye.common.os.OS;
@@ -22,9 +18,9 @@ public final class UnsupportedOSBuildItem extends MultiBuildItem {
      */
     @Deprecated(forRemoval = true, since = "3.26.0")
     public enum Os {
-        WINDOWS(IS_WINDOWS),
-        MAC(IS_MAC),
-        LINUX(IS_LINUX),
+        WINDOWS(OS.WINDOWS.isCurrent()),
+        MAC(OS.MAC.isCurrent()),
+        LINUX(OS.LINUX.isCurrent()),
         NONE(false);
 
         public final boolean active;

--- a/core/devmode-spi/pom.xml
+++ b/core/devmode-spi/pom.xml
@@ -19,6 +19,10 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-os</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.PrintStream;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -18,31 +17,30 @@ public abstract class QuarkusConsole {
     public static final int TEST_RESULTS = 200;
     public static final int COMPILE_ERROR = 300;
 
+    /**
+     * @deprecated this should never have been public in the first place.
+     */
+    @Deprecated(forRemoval = true, since = "3.32")
     public static final String FORCE_COLOR_SUPPORT = "io.quarkus.force-color-support";
 
-    public static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows");
-    public static final boolean IS_MAC = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("mac");
-    public static final boolean IS_LINUX = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("linux");
+    /**
+     * @deprecated this should never have been public in the first place.
+     */
+    @Deprecated(forRemoval = true, since = "3.32")
+    public static final boolean IS_CON_EMU_ANSI = TerminalUtils.IS_CON_EMU_ANSI;
 
     /**
-     * <a href="https://conemu.github.io">ConEmu</a> ANSI X3.64 support enabled,
-     * used by <a href="https://cmder.net/">cmder</a>
+     * @deprecated this should never have been public in the first place.
      */
-    public static final boolean IS_CON_EMU_ANSI = IS_WINDOWS && "ON".equals(System.getenv("ConEmuANSI"));
+    @Deprecated(forRemoval = true, since = "3.32")
+    public static final boolean IS_CYGWIN = TerminalUtils.IS_CYGWIN;
 
     /**
-     * These tests are same as used in jansi
-     * Source: https://github.com/fusesource/jansi/commit/bb3d538315c44f799d34fd3426f6c91c8e8dfc55
+     * @deprecated this should never have been public in the first place.
      */
-    public static final boolean IS_CYGWIN = IS_WINDOWS
-            && System.getenv("PWD") != null
-            && System.getenv("PWD").startsWith("/")
-            && !"cygwin".equals(System.getenv("TERM"));
+    @Deprecated(forRemoval = true, since = "3.32")
+    public static final boolean IS_MINGW_XTERM = TerminalUtils.IS_MINGW_XTERM;
 
-    public static final boolean IS_MINGW_XTERM = IS_WINDOWS
-            && System.getenv("MSYSTEM") != null
-            && System.getenv("MSYSTEM").startsWith("MINGW")
-            && "xterm".equals(System.getenv("TERM"));
     protected volatile Consumer<int[]> inputHandler;
 
     public static volatile QuarkusConsole INSTANCE = new BasicConsole(hasColorSupport(), false, System.out::print);
@@ -104,34 +102,12 @@ public abstract class QuarkusConsole {
         redirectsInstalled = false;
     }
 
-    private static void checkAndSetJdkConsole() {
-        // the JLine console in JDK 23+ causes significant startup slowdown,
-        // so we avoid it unless the user opted into it
-        String res = System.getProperty("jdk.console");
-        if (res == null) {
-            System.setProperty("jdk.console", "java.base");
-        }
-    }
-
+    /**
+     * @deprecated
+     */
+    @Deprecated(forRemoval = true, since = "3.32")
     public static boolean hasColorSupport() {
-        checkAndSetJdkConsole();
-        if (Boolean.getBoolean(FORCE_COLOR_SUPPORT)) {
-            return true; //assume the IDE run window has color support
-        }
-        if (IS_WINDOWS) {
-            // On Windows without a known good emulator
-            // TODO: optimally we would check if Win32 getConsoleMode has
-            // ENABLE_VIRTUAL_TERMINAL_PROCESSING enabled or enable it via
-            // setConsoleMode.
-            // For now we turn it off to not generate noisy output for most
-            // users.
-            // Must be on some Unix variant or ANSI-enabled windows terminal...
-            return IS_CON_EMU_ANSI || IS_CYGWIN || IS_MINGW_XTERM;
-        } else {
-            // on sane operating systems having a console is a good indicator
-            // you are attached to a TTY with colors.
-            return TerminalUtils.isTerminal(System.console());
-        }
+        return TerminalUtils.hasColorSupport();
     }
 
     public static void start() {

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/TerminalUtils.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/TerminalUtils.java
@@ -4,9 +4,57 @@ import java.io.Console;
 
 import org.jboss.logging.Logger;
 
+import io.smallrye.common.os.OS;
+
 public class TerminalUtils {
 
-    private static final Logger LOGGER = Logger.getLogger(TerminalUtils.class.getName());
+    // Make fully private as soon as we drop the constants in QuarkusConsole
+    static final String FORCE_COLOR_SUPPORT = "io.quarkus.force-color-support";
+
+    /**
+     * <a href="https://conemu.github.io">ConEmu</a> ANSI X3.64 support enabled,
+     * used by <a href="https://cmder.net/">cmder</a>
+     */
+    // Make fully private as soon as we drop the constants in QuarkusConsole
+    static final boolean IS_CON_EMU_ANSI = OS.WINDOWS.isCurrent() && "ON".equals(System.getenv("ConEmuANSI"));
+
+    /**
+     * These tests are same as used in jansi
+     * Source: https://github.com/fusesource/jansi/commit/bb3d538315c44f799d34fd3426f6c91c8e8dfc55
+     */
+    // Make fully private as soon as we drop the constants in QuarkusConsole
+    static final boolean IS_CYGWIN = OS.WINDOWS.isCurrent()
+            && System.getenv("PWD") != null
+            && System.getenv("PWD").startsWith("/")
+            && !"cygwin".equals(System.getenv("TERM"));
+
+    // Make fully private as soon as we drop the constants in QuarkusConsole
+    static final boolean IS_MINGW_XTERM = OS.WINDOWS.isCurrent()
+            && System.getenv("MSYSTEM") != null
+            && System.getenv("MSYSTEM").startsWith("MINGW")
+            && "xterm".equals(System.getenv("TERM"));
+
+    public static boolean hasColorSupport() {
+        checkAndSetJdkConsole();
+        if (Boolean.getBoolean(FORCE_COLOR_SUPPORT)) {
+            return true; //assume the IDE run window has color support
+        }
+        if (OS.WINDOWS.isCurrent()) {
+            // On Windows without a known good emulator
+            // TODO: optimally we would check if Win32 getConsoleMode has
+            // ENABLE_VIRTUAL_TERMINAL_PROCESSING enabled or enable it via
+            // setConsoleMode.
+            // For now we turn it off to not generate noisy output for most
+            // users.
+            // Must be on some Unix variant or ANSI-enabled windows terminal...
+            return IS_CON_EMU_ANSI || IS_CYGWIN || IS_MINGW_XTERM;
+        } else {
+            // on sane operating systems having a console is a good indicator
+            // you are attached to a TTY with colors.
+
+            return TerminalUtils.isTerminal(System.console());
+        }
+    }
 
     public static boolean isTerminal(Console console) {
         if (console == null) {
@@ -20,8 +68,19 @@ public class TerminalUtils {
         try {
             return (boolean) Console.class.getMethod("isTerminal").invoke(console);
         } catch (Exception e) {
-            LOGGER.error("Failed to invoke System.console().isTerminal() via Reflection API", e);
+            // we don't make it a static as it's only used for an error case
+            Logger.getLogger(TerminalUtils.class.getName())
+                    .error("Failed to invoke System.console().isTerminal() via Reflection API", e);
             return false;
+        }
+    }
+
+    private static void checkAndSetJdkConsole() {
+        // the JLine console in JDK 23+ causes significant startup slowdown,
+        // so we avoid it unless the user opted into it
+        String res = System.getProperty("jdk.console");
+        if (res == null) {
+            System.setProperty("jdk.console", "java.base");
         }
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -53,7 +53,7 @@ import org.jboss.logmanager.handlers.SyslogHandler;
 
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.dev.console.CurrentAppExceptionHighlighter;
-import io.quarkus.dev.console.QuarkusConsole;
+import io.quarkus.dev.console.TerminalUtils;
 import io.quarkus.dev.testing.ExceptionReporting;
 import io.quarkus.runtime.ImageMode;
 import io.quarkus.runtime.LaunchMode;
@@ -875,7 +875,7 @@ public class LoggingSetupRecorder {
         if (consoleConfig.color().isPresent()) {
             return consoleConfig.color().get();
         }
-        return QuarkusConsole.hasColorSupport();
+        return TerminalUtils.hasColorSupport();
     }
 
     private static class AdditionalNamedHandlersConsumer implements BiConsumer<String, Handler> {


### PR DESCRIPTION
- Use SmallRye Common to determine the OS rather than custom code
- Avoid initializing QuarkusConsole when setting up the logging layer, as all we need in prod mode is to determine the color status, QuarkusConsole has some additional static fields that are only useful in dev mode

Franky, I don't think we should use dev mode SPI code in prod code, but I'm not sure where we could move this terminal detection API, maybe to something in SmallRye Common?

Noticed while having a look at some fast-jar startup profiling.