### PR TITLE
Fix NPE when preserving MDC entries in VertxMDC

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
@@ -268,8 +268,8 @@ public enum VertxMDC implements MDCProvider {
         return contextualDataMap(vertxContext).isEmpty();
     }
 
-    public Set<String> getKeys() {
-        return new HashSet<>(contextualDataMap(getContext()).keySet());
+    public Set<Map.Entry<String, Object>> getEntrySet() {
+        return new HashSet<>(contextualDataMap(getContext()).entrySet());
     }
 
     /**
@@ -349,9 +349,12 @@ public enum VertxMDC implements MDCProvider {
 
         final Map<String, Object> carryover = new HashMap<>();
         final boolean hasDiscardKeys = discardMdcKeys == null || discardMdcKeys.isEmpty();
-        for (String key : VertxMDC.INSTANCE.getKeys()) {
-            if (hasDiscardKeys || !discardMdcKeys.contains(key)) {
-                carryover.put(key, VertxMDC.INSTANCE.getObject(key));
+        for (Map.Entry<String, Object> entry : VertxMDC.INSTANCE.getEntrySet()) {
+            final String key = entry.getKey();
+            final Object value = entry.getValue();
+            // Not taking chances with null values
+            if (key != null && value != null && (hasDiscardKeys || !discardMdcKeys.contains(key))) {
+                carryover.put(key, value);
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/quarkusio/quarkus/issues/52634

Replacing `public Set<String> getKeys()` by getting the entry set. That method was only used in the data carryover and it's clearly not safe for that usage.

Couldn't find a deterministic way to test this because it either requires a null entry, which cannot happen if only the `VertxMDC` is used, or a race condition.