### PR TITLE
Allow to control Same-Site attribute for OIDC state cookie

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -552,7 +552,8 @@ The common cookie properties impact both the authorization code flow session and
 |quarkus.oidc.authentication.cookie-path |'/'| The cookie path
 |quarkus.oidc.authentication.cookie-domain || The cookie domain
 |quarkus.oidc.authentication.cookie-path-header || The cookie path header
-|quarkus.oidc.authentication.cookie-same-site |lax| The cookie SameSite status
+|quarkus.oidc.authentication.cookie-same-site |lax| The session cookie SameSite status
+|quarkus.oidc.authentication.state-cookie-same-site |lax| The state cookie SameSite status
 |quarkus.oidc.authentication.cookie-suffix || The cookie suffix
 |quarkus.oidc.authentication.cookie-force-secure |false| The cookie force secure
 |====
@@ -562,7 +563,11 @@ You may also want to restrict it when the specific endpoint paths should only be
 
 `quarkus.oidc.authentication.cookie-path-header` can be used to dynamically set the required cookie path - this property should be used with care and only when it fits your deployment requirements.
 
-`quarkus.oidc.authentication.cookie-same-site` defines a `Same-Site` attribute as `lax` by default, since setting it to `strict` proved to be breaking some deployments. However, setting it to `strict` is RECOMMENDED when it is known to work in your deployment, for example, when the OIDC provider is hosted in the same domain as the application, etc.
+`quarkus.oidc.authentication.cookie-same-site` defines a `Same-Site` attribute for a session cookie as `lax` by default, since setting it to `strict` proved to be breaking some deployments. However, setting it to `strict` is RECOMMENDED when it is known to work in your deployment, for example, when the OIDC provider is hosted in the same domain as the application, etc.
+
+Similarly, `quarkus.oidc.authentication.state-cookie-same-site` defines a `Same-Site` attribute for a state cookie as `lax` by default, but setting it to `strict` is RECOMMENDED when it is known to work in your deployment.
+
+Ideally both the session and state cookies have the same `Same-Site` attribute value, however having the same `Same-Site` `strict` value for both cookies also proved to be problematic in some cases.
 
 `quarkus.oidc.authentication.cookie-suffix` can be used to customize the state and session cookie names. For example, by setting `%test.quarkus.oidc.authentication.cookie-suffix=test` you can have the session cookie name qualified with the `_test` suffix in the test profile only.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1432,6 +1432,13 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         }
 
         @Override
+        public io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.CookieSameSite stateCookieSameSite() {
+            return stateCookieSameSite == null ? null
+                    : io.quarkus.oidc.runtime.OidcTenantConfig.Authentication.CookieSameSite
+                            .valueOf(stateCookieSameSite.toString());
+        }
+
+        @Override
         public boolean allowMultipleCodeFlows() {
             return allowMultipleCodeFlows;
         }
@@ -1712,6 +1719,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
          * SameSite attribute for the session cookie.
          */
         public CookieSameSite cookieSameSite = CookieSameSite.LAX;
+
+        /**
+         * SameSite attribute for the state cookie.
+         */
+        public CookieSameSite stateCookieSameSite = CookieSameSite.LAX;
 
         /**
          * If a state cookie is present, a `state` query parameter must also be present and both the state
@@ -2137,6 +2149,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             cookiePathHeader = mapping.cookiePathHeader();
             cookieDomain = mapping.cookieDomain();
             cookieSameSite = CookieSameSite.valueOf(mapping.cookieSameSite().toString());
+            stateCookieSameSite = CookieSameSite.valueOf(mapping.stateCookieSameSite().toString());
             allowMultipleCodeFlows = mapping.allowMultipleCodeFlows();
             failOnMissingStateParam = mapping.failOnMissingStateParam();
             failOnUnresolvedKid = mapping.failOnUnresolvedKid();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -62,7 +62,9 @@ import io.smallrye.jwt.util.KeyUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.Cookie;
+import io.vertx.core.http.CookieSameSite;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.impl.ServerCookie;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -1299,9 +1301,12 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             cookieValue += (COOKIE_DELIM + encodeExtraStateValue(extraStateValue, configContext));
         }
         String stateCookieNameSuffix = configContext.oidcConfig().authentication().allowMultipleCodeFlows() ? "_" + uuid : "";
-        OidcUtils.createCookie(context, configContext.oidcConfig(),
+        ServerCookie stateCookie = OidcUtils.createCookie(context, configContext.oidcConfig(),
                 getStateCookieName(configContext.oidcConfig()) + stateCookieNameSuffix, cookieValue,
                 configContext.oidcConfig().authentication().stateCookieAge().toSeconds());
+        stateCookie
+                .setSameSite(CookieSameSite.valueOf(configContext.oidcConfig().authentication().stateCookieSameSite().name()));
+
         return uuid;
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -857,6 +857,12 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         CookieSameSite cookieSameSite();
 
         /**
+         * SameSite attribute for the state cookie.
+         */
+        @WithDefault("lax")
+        CookieSameSite stateCookieSameSite();
+
+        /**
          * If a state cookie is present, a `state` query parameter must also be present and both the state
          * cookie name suffix and state cookie value must match the value of the `state` query parameter when
          * the redirect path matches the current path.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -502,6 +502,18 @@ public final class OidcUtils {
             if (auth.cookieDomain().isPresent()) {
                 cookie.setDomain(auth.cookieDomain().get());
             }
+
+            CookieSameSite sameSite = null;
+            if (cookie.getName().startsWith(SESSION_COOKIE_NAME)) {
+                sameSite = CookieSameSite.valueOf(oidcConfig.authentication().cookieSameSite().name());
+            } else if (cookie.getName().startsWith(STATE_COOKIE_NAME)) {
+                sameSite = CookieSameSite.valueOf(oidcConfig.authentication().stateCookieSameSite().name());
+            }
+            if (CookieSameSite.NONE == sameSite) {
+                // browsers may want it if the same site is none
+                cookie.setSameSite(sameSite);
+                cookie.setSecure(oidcConfig.authentication().cookieForceSecure() || context.request().isSSL());
+            }
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
@@ -30,7 +30,8 @@ public final class AuthenticationConfigBuilder {
             Optional<List<String>> scopes, Optional<String> scopeSeparator, boolean nonceRequired,
             Optional<Boolean> addOpenidScope, Map<String, String> extraParams, Optional<List<String>> forwardParams,
             boolean cookieForceSecure, Optional<String> cookieSuffix, String cookiePath, Optional<String> cookiePathHeader,
-            Optional<String> cookieDomain, CookieSameSite cookieSameSite, Optional<Set<CacheControl>> cacheControl,
+            Optional<String> cookieDomain, CookieSameSite cookieSameSite, CookieSameSite stateCookieSameSite,
+            Optional<Set<CacheControl>> cacheControl,
             boolean allowMultipleCodeFlows, boolean failOnMissingStateParam, boolean failOnUnresolvedKid,
             Optional<Boolean> userInfoRequired, Optional<Duration> sessionAgeExtension,
             Duration stateCookieAge, boolean javaScriptAutoRedirect, Optional<Boolean> idTokenRequired,
@@ -60,6 +61,7 @@ public final class AuthenticationConfigBuilder {
     private Optional<String> cookiePathHeader;
     private Optional<String> cookieDomain;
     private CookieSameSite cookieSameSite;
+    private CookieSameSite stateCookieSameSite;
     private Set<CacheControl> cacheControl = new HashSet<>();
     private boolean allowMultipleCodeFlows;
     private boolean failOnMissingStateParam;
@@ -107,6 +109,7 @@ public final class AuthenticationConfigBuilder {
         this.cookiePathHeader = authentication.cookiePathHeader();
         this.cookieDomain = authentication.cookieDomain();
         this.cookieSameSite = authentication.cookieSameSite();
+        this.stateCookieSameSite = authentication.stateCookieSameSite();
         if (authentication.cacheControl().isPresent()) {
             this.cacheControl.addAll(authentication.cacheControl().get());
         }
@@ -396,6 +399,15 @@ public final class AuthenticationConfigBuilder {
     }
 
     /**
+     * @param stateCookieSameSite {@link Authentication#stateCookieSameSite()}
+     * @return this builder
+     */
+    public AuthenticationConfigBuilder stateCookieSameSite(CookieSameSite cookieSameSite) {
+        this.stateCookieSameSite = Objects.requireNonNull(stateCookieSameSite);
+        return this;
+    }
+
+    /**
      * Sets {@link Authentication#allowMultipleCodeFlows()} to true.
      *
      * @return this builder
@@ -657,7 +669,8 @@ public final class AuthenticationConfigBuilder {
         return new AuthenticationImpl(responseMode, redirectPath, restorePathAfterRedirect, removeRedirectParameters, errorPath,
                 sessionExpiredPath, verifyAccessToken, forceRedirectHttpsScheme, optionalScopes, scopeSeparator, nonceRequired,
                 addOpenidScope, Map.copyOf(extraParams), optionalForwardParams, cookieForceSecure, cookieSuffix, cookiePath,
-                cookiePathHeader, cookieDomain, cookieSameSite, optionalCacheControl, allowMultipleCodeFlows,
+                cookiePathHeader, cookieDomain, cookieSameSite, stateCookieSameSite, optionalCacheControl,
+                allowMultipleCodeFlows,
                 failOnMissingStateParam,
                 failOnUnresolvedKid,
                 userInfoRequired, sessionAgeExtension, stateCookieAge, javaScriptAutoRedirect, idTokenRequired,

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -143,6 +143,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         AUTHENTICATION_COOKIE_PATH_HEADER,
         AUTHENTICATION_COOKIE_DOMAIN,
         AUTHENTICATION_COOKIE_SAME_SITE,
+        AUTHENTICATION_STATE_COOKIE_SAME_SITE,
         AUTHENTICATION_CACHE_CONTROL,
         AUTHENTICATION_ALLOW_MULTIPLE_CODE_FLOWS,
         AUTHENTICATION_FAIL_ON_MISSING_STATE_PARAM,
@@ -773,6 +774,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             @Override
             public CookieSameSite cookieSameSite() {
                 invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_COOKIE_SAME_SITE, true);
+                return CookieSameSite.LAX;
+            }
+
+            @Override
+            public CookieSameSite stateCookieSameSite() {
+                invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_STATE_COOKIE_SAME_SITE, true);
                 return CookieSameSite.LAX;
             }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -137,6 +137,7 @@ quarkus.oidc.tenant-https.authentication.pkce-required=true
 quarkus.oidc.tenant-https.authentication.nonce-required=true
 quarkus.oidc.tenant-https.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-https.authentication.cookie-same-site=strict
+quarkus.oidc.tenant-https.authentication.state-cookie-same-site=none
 quarkus.oidc.tenant-https.authentication.fail-on-missing-state-param=true
 
 quarkus.oidc.tenant-nonce.auth-server-url=${quarkus.oidc.auth-server-url}

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -75,7 +75,7 @@ public class CodeFlowTest {
             Cookie stateCookie = getStateCookie(webClient, null);
             assertNotNull(stateCookie);
             assertEquals(stateCookie.getName(), "q_auth_Default_test_" + getStateCookieStateParam(stateCookie));
-            assertNull(stateCookie.getSameSite());
+            assertEquals("lax", stateCookie.getSameSite());
 
             webClient.getCookieManager().clearCookies();
 
@@ -294,7 +294,7 @@ public class CodeFlowTest {
             String endpointLocation = webResponse.getResponseHeaderValue("location");
 
             Cookie stateCookie = getStateCookie(webClient, "tenant-https_test");
-            assertNull(stateCookie.getSameSite());
+            assertEquals("none", stateCookie.getSameSite());
             verifyCodeVerifierAndNonce(stateCookie, keycloakUrl);
 
             assertTrue(endpointLocation.startsWith("https"));
@@ -369,7 +369,7 @@ public class CodeFlowTest {
 
             // State cookie is present
             Cookie stateCookie = getStateCookie(webClient, "tenant-https_test");
-            assertNull(stateCookie.getSameSite());
+            assertEquals("none", stateCookie.getSameSite());
             verifyCodeVerifierAndNonce(stateCookie, keycloakUrl);
 
             // Make a call without an extra state query param, status is 401


### PR DESCRIPTION
Fixes #52607 

Currently only the session cookie can have its same-site attribute controlled, the session cookie has its lax by default.
As per the links from the issue, originally, I started with both the session and state cookies sharing the same Same-site values that broke several applications once it is set to `Strict`, when the `session-cookie: strict`, `state-cookie: lax` typically works.

Other than that, in #52607, we found a workaround for the authentication to work by controlling the state cookie same site status at the Vert.x HTTP level - but it does require disabling the mullti-tab auth. Additionally the reporter discovered  that for same site none cookies this attribute has to be set when the cookie is removed

So having a dedicated property to control it for the state cookie works best.