### PR TITLE
Panache next doc cleanup

### DIFF
--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedEntityOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedEntityOperations.java
@@ -1,8 +1,5 @@
 package io.quarkus.hibernate.panache.managed;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
 import jakarta.json.bind.annotation.JsonbTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -14,9 +11,6 @@ public interface PanacheManagedEntityOperations<Completion, Confirmation> extend
      * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
      *
      * @see #isPersistent()
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
      */
     public Completion persist();
 
@@ -25,9 +19,6 @@ public interface PanacheManagedEntityOperations<Completion, Confirmation> extend
      * Then flushes all pending changes to the database.
      *
      * @see #isPersistent()
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
      */
     public Completion persistAndFlush();
 
@@ -35,9 +26,6 @@ public interface PanacheManagedEntityOperations<Completion, Confirmation> extend
      * Delete this entity from the database, if it is already persisted.
      *
      * @see #isPersistent()
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
      */
     public Completion delete();
 

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.managed;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 public interface PanacheManagedRepositoryOperations<Entity, Session, Completion, Confirmation, Id> {
@@ -42,9 +41,6 @@ public interface PanacheManagedRepositoryOperations<Entity, Session, Completion,
      *
      * @param entity the entity to delete.
      * @see #isPersistent(Object)
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
      */
     Completion delete(Entity entity);
 

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingEntity.java
@@ -1,8 +1,5 @@
 package io.quarkus.hibernate.panache.managed.blocking;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
 import jakarta.json.bind.annotation.JsonbTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -17,53 +14,21 @@ public interface PanacheManagedBlockingEntity extends PanacheManagedEntityOperat
         return PanacheOperations.getBlockingManaged();
     }
 
-    /**
-     * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
-     *
-     * @see #isPersistent()
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
     @Override
     public default Void persist() {
         return operations().persist(this);
     }
 
-    /**
-     * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
-     * Then flushes all pending changes to the database.
-     *
-     * @see #isPersistent()
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
     @Override
     public default Void persistAndFlush() {
         return operations().persistAndFlush(this);
     }
 
-    /**
-     * Delete this entity from the database, if it is already persisted.
-     *
-     * @see #isPersistent()
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
-     */
     @Override
     public default Void delete() {
         return operations().delete(this);
     }
 
-    /**
-     * Returns true if this entity is persistent in the database. If yes, all modifications to
-     * its persistent fields will be automatically committed to the database at transaction
-     * commit time.
-     *
-     * @return true if this entity is persistent in the database.
-     */
     @JsonbTransient
     // @JsonIgnore is here to avoid serialization of this property with jackson
     @JsonIgnore

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.managed.blocking;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.hibernate.Session;
@@ -23,106 +22,47 @@ public interface PanacheManagedBlockingRepositoryOperations<Entity, Id>
 
     // Operations
 
-    /**
-     * Returns the {@link Session} for the <Entity> entity class for extra operations (eg. CriteriaQueries)
-     *
-     * @return the {@link Session} for the <Entity> entity class
-     */
+    @Override
     default Session getSession() {
         return operations().getSession(getEntityClass());
     }
 
-    /**
-     * Persist the given entity in the database, if not already persisted.
-     *
-     * @param entity the entity to persist.
-     * @see #isPersistent(Object)
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
+    @Override
     default Void persist(Entity entity) {
         return operations().persist(entity);
     }
 
-    /**
-     * Persist the given entity in the database, if not already persisted.
-     * Then flushes all pending changes to the database.
-     *
-     * @param entity the entity to persist.
-     * @see #isPersistent(Object)
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
+    @Override
     default Void persistAndFlush(Entity entity) {
         return operations().persistAndFlush(entity);
     }
 
-    /**
-     * Delete the given entity from the database, if it is already persisted.
-     *
-     * @param entity the entity to delete.
-     * @see #isPersistent(Object)
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
-     */
+    @Override
     default Void delete(Entity entity) {
         return operations().delete(entity);
     }
 
-    /**
-     * Returns true if the given entity is persistent in the database. If yes, all modifications to
-     * its persistent fields will be automatically committed to the database at transaction
-     * commit time.
-     *
-     * @param entity the entity to check
-     * @return true if the entity is persistent in the database.
-     */
+    @Override
     default Boolean isPersistent(Entity entity) {
         return operations().isPersistent(entity);
     }
 
-    /**
-     * Flushes all pending changes to the database using the Session for the <Entity> entity class.
-     */
+    @Override
     default Void flush() {
         return operations().flush(getEntityClass());
     }
 
-    /**
-     * Persist all given entities.
-     *
-     * @param entities the entities to persist
-     * @see #persist(Object)
-     * @see #persist(Stream)
-     * @see #persist(Object,Object...)
-     */
+    @Override
     default Void persist(Iterable<Entity> entities) {
         return operations().persist(entities);
     }
 
-    /**
-     * Persist all given entities.
-     *
-     * @param entities the entities to persist
-     * @see #persist(Object)
-     * @see #persist(Iterable)
-     * @see #persist(Object,Object...)
-     */
+    @Override
     default Void persist(Stream<Entity> entities) {
         return operations().persist(entities);
     }
 
-    /**
-     * Persist all given entities.
-     *
-     * @param entities the entities to persist
-     * @see #persist(Object)
-     * @see #persist(Stream)
-     * @see #persist(Iterable)
-     */
+    @Override
     default Void persist(Entity firstEntity, @SuppressWarnings("unchecked") Entity... entities) {
         return operations().persist(firstEntity, entities);
     }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveEntity.java
@@ -1,8 +1,5 @@
 package io.quarkus.hibernate.panache.managed.reactive;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
 import jakarta.json.bind.annotation.JsonbTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -18,53 +15,21 @@ public interface PanacheManagedReactiveEntity extends PanacheManagedEntityOperat
         return PanacheOperations.getReactiveManaged();
     }
 
-    /**
-     * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
-     *
-     * @see #isPersistent()
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
     @Override
     public default Uni<Void> persist() {
         return operations().persist(this);
     }
 
-    /**
-     * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
-     * Then flushes all pending changes to the database.
-     *
-     * @see #isPersistent()
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
     @Override
     public default Uni<Void> persistAndFlush() {
         return operations().persistAndFlush(this);
     }
 
-    /**
-     * Delete this entity from the database, if it is already persisted.
-     *
-     * @see #isPersistent()
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
-     */
     @Override
     public default Uni<Void> delete() {
         return operations().delete(this);
     }
 
-    /**
-     * Returns true if this entity is persistent in the database. If yes, all modifications to
-     * its persistent fields will be automatically committed to the database at transaction
-     * commit time.
-     *
-     * @return true if this entity is persistent in the database.
-     */
     @JsonbTransient
     // @JsonIgnore is here to avoid serialization of this property with jackson
     @JsonIgnore

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.managed.reactive;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.hibernate.reactive.mutiny.Mutiny;
@@ -24,106 +23,47 @@ public interface PanacheManagedReactiveRepositoryOperations<Entity, Id>
 
     // Operations
 
-    /**
-     * Returns the {@link Mutiny.Session} for the <Entity> entity class for extra operations (eg. CriteriaQueries)
-     *
-     * @return the {@link Mutiny.Session} for the <Entity> entity class
-     */
+    @Override
     default Uni<Mutiny.Session> getSession() {
         return operations().getSession(getEntityClass());
     }
 
-    /**
-     * Persist the given entity in the database, if not already persisted.
-     *
-     * @param entity the entity to persist.
-     * @see #isPersistent(Object)
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
+    @Override
     default Uni<Void> persist(Entity entity) {
         return operations().persist(entity);
     }
 
-    /**
-     * Persist the given entity in the database, if not already persisted.
-     * Then flushes all pending changes to the database.
-     *
-     * @param entity the entity to persist.
-     * @see #isPersistent(Object)
-     * @see #persist(Iterable)
-     * @see #persist(Stream)
-     * @see #persist(Object, Object...)
-     */
+    @Override
     default Uni<Void> persistAndFlush(Entity entity) {
         return operations().persistAndFlush(entity);
     }
 
-    /**
-     * Delete the given entity from the database, if it is already persisted.
-     *
-     * @param entity the entity to delete.
-     * @see #isPersistent(Object)
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
-     */
+    @Override
     default Uni<Void> delete(Entity entity) {
         return operations().delete(entity);
     }
 
-    /**
-     * Returns true if the given entity is persistent in the database. If yes, all modifications to
-     * its persistent fields will be automatically committed to the database at transaction
-     * commit time.
-     *
-     * @param entity the entity to check
-     * @return true if the entity is persistent in the database.
-     */
+    @Override
     default Uni<Boolean> isPersistent(Entity entity) {
         return operations().isPersistent(entity);
     }
 
-    /**
-     * Flushes all pending changes to the database using the Session for the <Entity> entity class.
-     */
+    @Override
     default Uni<Void> flush() {
         return operations().flush(getEntityClass());
     }
 
-    /**
-     * Persist all given entities.
-     *
-     * @param entities the entities to persist
-     * @see #persist(Object)
-     * @see #persist(Stream)
-     * @see #persist(Object,Object...)
-     */
+    @Override
     default Uni<Void> persist(Iterable<Entity> entities) {
         return operations().persist(entities);
     }
 
-    /**
-     * Persist all given entities.
-     *
-     * @param entities the entities to persist
-     * @see #persist(Object)
-     * @see #persist(Iterable)
-     * @see #persist(Object,Object...)
-     */
+    @Override
     default Uni<Void> persist(Stream<Entity> entities) {
         return operations().persist(entities);
     }
 
-    /**
-     * Persist all given entities.
-     *
-     * @param entities the entities to persist
-     * @see #persist(Object)
-     * @see #persist(Stream)
-     * @see #persist(Iterable)
-     */
+    @Override
     default Uni<Void> persist(Entity firstEntity, @SuppressWarnings("unchecked") Entity... entities) {
         return operations().persist(firstEntity, entities);
     }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.stateless;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 public interface PanacheStatelessRepositoryOperations<Entity, Session, Completion, Confirmation, Id> {
@@ -28,9 +27,6 @@ public interface PanacheStatelessRepositoryOperations<Entity, Session, Completio
      * Delete the given entity from the database.
      *
      * @param entity the entity to delete.
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
      */
     Completion delete(Entity entity);
 

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessRepositoryOperations.java
@@ -38,6 +38,15 @@ public interface PanacheStatelessRepositoryOperations<Entity, Session, Completio
     Completion update(Entity entity);
 
     /**
+     * Insert or update this entity in the database. An insert will be performed if the entity does not already exist
+     * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
+     *
+     * @param entity the entity to insert or update.
+     * @return the entity passed as parameter
+     */
+    Completion upsert(Entity entity);
+
+    /**
      * Insert all given entities.
      *
      * @param entities the entities to insert

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingEntity.java
@@ -1,8 +1,5 @@
 package io.quarkus.hibernate.panache.stateless.blocking;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
 import io.quarkus.hibernate.panache.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheOperations;
 import io.quarkus.hibernate.panache.stateless.PanacheStatelessEntityOperations;
@@ -13,42 +10,21 @@ public interface PanacheStatelessBlockingEntity extends PanacheStatelessEntityOp
         return PanacheOperations.getBlockingStateless();
     }
 
-    /**
-     * Insert this entity in the database. This will set your ID field if it is not already set.
-     *
-     * @see #insert(Iterable)
-     * @see #insert(Stream)
-     * @see #insert(Object, Object...)
-     */
     @Override
     public default Void insert() {
         return operations().insert(this);
     }
 
-    /**
-     * Delete this entity from the database.
-     *
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
-     */
     @Override
     public default Void delete() {
         return operations().delete(this);
     }
 
-    /**
-     * Update this entity in the database.
-     */
     @Override
     public default Void update() {
         return operations().update(this);
     }
 
-    /**
-     * Insert or update this entity in the database. An insert will be performed if the entity does not already exist
-     * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
-     */
     @Override
     public default Void upsert() {
         return operations().upsert(this);

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.stateless.blocking;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.hibernate.StatelessSession;
@@ -23,91 +22,41 @@ public interface PanacheStatelessBlockingRepositoryOperations<Entity, Id>
 
     // Operations
 
-    /**
-     * Returns the {@link StatelessSession} for the <Entity> entity class for extra operations (eg. CriteriaQueries)
-     *
-     * @return the {@link StatelessSession} for the <Entity> entity class
-     */
+    @Override
     default StatelessSession getSession() {
         return operations().getStatelessSession(getEntityClass());
     }
 
-    /**
-     * Insert the given entity in the database, if not already inserted.
-     *
-     * @param entity the entity to insert.
-     * @see #insert(Iterable)
-     * @see #insert(Stream)
-     * @see #insert(Object, Object...)
-     */
+    @Override
     default Void insert(Entity entity) {
         return operations().insert(entity);
     }
 
-    /**
-     * Delete the given entity from the database, if it is already inserted.
-     *
-     * @param entity the entity to delete.
-     * @see #isInsertent(Object)
-     * @see #delete(String, Object...)
-     * @see #delete(String, Map)
-     * @see #deleteAll()
-     */
+    @Override
     default Void delete(Entity entity) {
         return operations().delete(entity);
     }
 
-    /**
-     * Update the given entity in the database.
-     *
-     * @param entity the entity to update.
-     */
+    @Override
     default Void update(Entity entity) {
         return operations().update(entity);
     }
 
-    /**
-     * Insert or update this entity in the database. An insert will be performed if the entity does not already exist
-     * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
-     *
-     * @param entity the entity to insert or update.
-     */
     default Void upsert(Entity entity) {
         return operations().upsert(entity);
     }
 
-    /**
-     * Insert all given entities.
-     *
-     * @param entities the entities to insert
-     * @see #insert(Object)
-     * @see #insert(Stream)
-     * @see #insert(Object,Object...)
-     */
+    @Override
     default Void insert(Iterable<Entity> entities) {
         return operations().insert(entities);
     }
 
-    /**
-     * Insert all given entities.
-     *
-     * @param entities the entities to insert
-     * @see #insert(Object)
-     * @see #insert(Iterable)
-     * @see #insert(Object,Object...)
-     */
+    @Override
     default Void insert(Stream<Entity> entities) {
         return operations().insert(entities);
     }
 
-    /**
-     * Insert all given entities.
-     *
-     * @param entities the entities to insert
-     * @see #insert(Object)
-     * @see #insert(Stream)
-     * @see #insert(Iterable)
-     */
+    @Override
     default Void insert(Entity firstEntity, @SuppressWarnings("unchecked") Entity... entities) {
         return operations().insert(firstEntity, entities);
     }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryOperations.java
@@ -42,6 +42,7 @@ public interface PanacheStatelessBlockingRepositoryOperations<Entity, Id>
         return operations().update(entity);
     }
 
+    @Override
     default Void upsert(Entity entity) {
         return operations().upsert(entity);
     }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveEntity.java
@@ -11,34 +11,21 @@ public interface PanacheStatelessReactiveEntity extends PanacheStatelessEntityOp
         return PanacheOperations.getReactiveManaged();
     }
 
-    /**
-     * Insert this entity in the database. This will set your ID field if it is not already set.
-     */
     @Override
     public default Uni<Void> insert() {
         return operations().insert(this);
     }
 
-    /**
-     * Delete this entity from the database.
-     */
     @Override
     public default Uni<Void> delete() {
         return operations().delete(this);
     }
 
-    /**
-     * Update this entity in the database.
-     */
     @Override
     public default Uni<Void> update() {
         return operations().update(this);
     }
 
-    /**
-     * Insert or update this entity in the database. An insert will be performed if the entity does not already exist
-     * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
-     */
     @Override
     public default Uni<Void> upsert() {
         return operations().upsert(this);

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryOperations.java
@@ -43,6 +43,7 @@ public interface PanacheStatelessReactiveRepositoryOperations<Entity, Id>
         return operations().update(entity);
     }
 
+    @Override
     default Uni<Void> upsert(Entity entity) {
         return operations().upsert(entity);
     }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryOperations.java
@@ -23,85 +23,41 @@ public interface PanacheStatelessReactiveRepositoryOperations<Entity, Id>
 
     // Operations
 
-    /**
-     * Returns the {@link Mutiny.StatelessSession} for the <Entity> entity class for extra operations (eg. CriteriaQueries)
-     *
-     * @return the {@link Mutiny.StatelessSession} for the <Entity> entity class
-     */
+    @Override
     default Uni<Mutiny.StatelessSession> getSession() {
-        // FIXME: this is false
         return operations().getStatelessSession(getEntityClass());
     }
 
-    /**
-     * Insert the given entity in the database.
-     *
-     * @param entity the entity to insert.
-     */
+    @Override
     default Uni<Void> insert(Entity entity) {
         return operations().insert(entity);
     }
 
-    /**
-     * Delete the given entity from the database.
-     *
-     * @param entity the entity to delete.
-     */
+    @Override
     default Uni<Void> delete(Entity entity) {
         return operations().delete(entity);
     }
 
-    /**
-     * Update the given entity in the database.
-     *
-     * @param entity the entity to update.
-     */
+    @Override
     default Uni<Void> update(Entity entity) {
         return operations().update(entity);
     }
 
-    /**
-     * Insert or update this entity in the database. An insert will be performed if the entity does not already exist
-     * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
-     *
-     * @param entity the entity to insert or update.
-     */
     default Uni<Void> upsert(Entity entity) {
         return operations().upsert(entity);
     }
 
-    /**
-     * Insert all given entities.
-     *
-     * @param entities the entities to insert
-     * @see #insert(Object)
-     * @see #insert(Stream)
-     * @see #insert(Object,Object...)
-     */
+    @Override
     default Uni<Void> insert(Iterable<Entity> entities) {
         return operations().insert(entities);
     }
 
-    /**
-     * Insert all given entities.
-     *
-     * @param entities the entities to insert
-     * @see #insert(Object)
-     * @see #insert(Iterable)
-     * @see #insert(Object,Object...)
-     */
+    @Override
     default Uni<Void> insert(Stream<Entity> entities) {
         return operations().insert(entities);
     }
 
-    /**
-     * Insert all given entities.
-     *
-     * @param entities the entities to insert
-     * @see #insert(Object)
-     * @see #insert(Stream)
-     * @see #insert(Iterable)
-     */
+    @Override
     default Uni<Void> insert(Entity firstEntity, @SuppressWarnings("unchecked") Entity... entities) {
         return operations().insert(firstEntity, entities);
     }


### PR DESCRIPTION
Removed javadoc from middle interfaces in favour of top interfaces, added missing `@Override`, removed missind javadoc `@See` and fixed the location of `upsert` operation to the top _operations_ interface.