### PR TITLE
Panache Next: return Entity from operation methods

### DIFF
--- a/docs/src/main/asciidoc/hibernate-panache-next.adoc
+++ b/docs/src/main/asciidoc/hibernate-panache-next.adoc
@@ -117,7 +117,7 @@ import jakarta.persistence.Entity;
 import java.time.LocalDate;
 
 @Entity
-public class Cat extends PanacheEntity {
+public class Cat extends PanacheEntity<Cat> {
     public String name;
     public LocalDate birth;
     public Breed breed;
@@ -132,7 +132,7 @@ In order to map a Java class to a Database table, just:
 
 - Write a class
 - Annotate it with link:{jakarta-persistence-javadocs-url}/jakarta/persistence/entity[`@Entity`]
-- Make it extend `PanacheEntity`
+- Make it extend `PanacheEntity<your-entity>`
 - Make its fields `public`
 
 And that's it, now you can start creating instances of your entity, persist it to your database, after which point
@@ -189,7 +189,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-public class Cat extends PanacheEntity {
+public class Cat extends PanacheEntity<Cat> {
     public String name;
     public LocalDate birth;
     public Breed breed;
@@ -450,7 +450,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-public class CatWithId implements PanacheEntity.Managed {
+public class CatWithId implements PanacheEntity.Managed<CatWithId> {
     @Id
     public String id;
     public String name;
@@ -486,7 +486,7 @@ extend any of these types if you define you own ID:
 
 |`Long`
 |`WithId.AutoLong`
-|`PanacheEntity`
+|`PanacheEntity<Entity>`
 
 |`UUID`
 |`WithId.AutoUUID`
@@ -526,7 +526,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-public class Cat extends WithId.AutoLong implements PanacheEntity.Stateless {
+public class Cat extends WithId.AutoLong implements PanacheEntity.Stateless<Cat> {
     public String name;
     public LocalDate birth;
     public Breed breed;
@@ -677,7 +677,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-public class Cat extends WithId.AutoLong implements PanacheEntity.Reactive {
+public class Cat extends WithId.AutoLong implements PanacheEntity.Reactive<Cat> {
     public String name;
     public LocalDate birth;
     public Breed breed;
@@ -765,7 +765,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-public class Cat extends WithId.AutoLong implements PanacheEntity.Reactive.Stateless {
+public class Cat extends WithId.AutoLong implements PanacheEntity.Reactive.Stateless<Cat> {
     public String name;
     public LocalDate birth;
     public Breed breed;
@@ -895,19 +895,19 @@ All the alternative entity operations are available from these methods:
 
 |`Session`
 |`.managedBlocking()`
-|`PanacheEntity.Managed`
+|`PanacheEntity.Managed<Cat>`
 
 |`StatelessSession`
 |`.statelessBlocking()`
-|`PanacheEntity.Stateless`
+|`PanacheEntity.Stateless<Cat>`
 
 |`Mutiny.Session`
 |`.managedReactive()`
-|`PanacheEntity.Reactive`
+|`PanacheEntity.Reactive<Cat>`
 
 |`Mutiny.StatelessSession`
 |`.statelessReactive()`
-|`PanacheEntity.Reactive.Stateless`
+|`PanacheEntity.Reactive.Stateless<Cat>`
 
 |===
 
@@ -951,7 +951,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-public class Cat extends PanacheEntity {
+public class Cat extends PanacheEntity<Cat> {
     public String name;
     public LocalDate birth;
     public Breed breed;
@@ -1018,33 +1018,33 @@ define your own ID entity field:
 
 |`Session` (managed, blocking)
 |`Long`
-|`PanacheEntity`
+|`PanacheEntity<Entity>`
 |
 |`PanacheRepository<Entity>`
 
 |`Session` (managed, blocking)
 |`Id`
 |`WithId<Id>`
-|`PanacheEntity.Managed`
+|`PanacheEntity.Managed<Entity>`
 |`PanacheRepository.Managed<Entity, Id>`
 
 |`StatelessSession` (stateless, blocking)
 |`Id`
 |`WithId<Id>`
-|`PanacheEntity.Stateless`
+|`PanacheEntity.Stateless<Entity>`
 |`PanacheRepository.Stateless<Entity, Id>`
 
 |`Mutiny.Session` (managed, reactive)
 |`Id`
 |`WithId<Id>`
-|`PanacheEntity.Reactive`
+|`PanacheEntity.Reactive<Entity>`
 |`PanacheRepository.Reactive<Entity, Id>`
 
 
 |`Mutiny.StatelessSession` (stateless, reactive)
 |`Id`
 |`WithId<Id>`
-|`PanacheEntity.Reactive.Stateless`
+|`PanacheEntity.Reactive.Stateless<Entity>`
 |`PanacheRepository.Reactive.Stateless<Entity, Id>`
 
 |===

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/MyEntity.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/MyEntity.java
@@ -11,7 +11,7 @@ import io.quarkus.hibernate.panache.PanacheEntity;
 import io.quarkus.hibernate.panache.PanacheRepository;
 
 @Entity
-public class MyEntity extends PanacheEntity {
+public class MyEntity extends PanacheEntity<MyEntity> {
     public String foo;
     public String bar;
 

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/MyReactiveEntity.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/MyReactiveEntity.java
@@ -13,7 +13,7 @@ import io.quarkus.hibernate.panache.WithId;
 import io.smallrye.mutiny.Uni;
 
 @Entity
-public class MyReactiveEntity extends WithId.AutoLong implements PanacheEntity.Reactive {
+public class MyReactiveEntity extends WithId.AutoLong implements PanacheEntity.Reactive<MyReactiveEntity> {
 
     public String foo;
     public String bar;

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/hr/Panache2Book.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/hr/Panache2Book.java
@@ -17,7 +17,7 @@ import io.quarkus.hibernate.panache.WithId;
 import io.smallrye.mutiny.Uni;
 
 @Entity
-public class Panache2Book extends WithId.AutoLong implements PanacheEntity.Reactive {
+public class Panache2Book extends WithId.AutoLong implements PanacheEntity.Reactive<Panache2Book> {
     public @NaturalId String isbn;
     public @NaturalId String title;
     public @NaturalId String author;

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/hr/Panache2BookCustomId.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/hr/Panache2BookCustomId.java
@@ -18,7 +18,7 @@ import io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveR
 import io.smallrye.mutiny.Uni;
 
 @Entity
-public class Panache2BookCustomId implements PanacheEntity.Reactive {
+public class Panache2BookCustomId implements PanacheEntity.Reactive<Panache2BookCustomId> {
     public @NaturalId String isbn;
     public @NaturalId String title;
     public @NaturalId String author;

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/orm/Panache2Book.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/orm/Panache2Book.java
@@ -15,7 +15,7 @@ import org.hibernate.annotations.processing.HQL;
 import io.quarkus.hibernate.panache.PanacheEntity;
 
 @Entity
-public class Panache2Book extends PanacheEntity {
+public class Panache2Book extends PanacheEntity<Panache2Book> {
     public @NaturalId String isbn;
     public @NaturalId String title;
     public @NaturalId String author;

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/orm/Panache2BookCustomId.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/processor/orm/Panache2BookCustomId.java
@@ -17,7 +17,7 @@ import io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingRepos
 import io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingRepositoryBase;
 
 @Entity
-public class Panache2BookCustomId implements PanacheEntity.Managed {
+public class Panache2BookCustomId implements PanacheEntity.Managed<Panache2BookCustomId> {
     public @NaturalId String isbn;
     public @NaturalId String title;
     public @NaturalId String author;

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheEntity.java
@@ -9,28 +9,29 @@ import io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveE
  * This is just an alias for {@link PanacheManagedBlockingEntity} and {@link WithId.AutoLong}
  * for people coming from Panache 1
  */
-public abstract class PanacheEntity extends WithId.AutoLong implements PanacheManagedBlockingEntity {
+public abstract class PanacheEntity<Entity extends PanacheEntityMarker<Entity>> extends WithId.AutoLong
+        implements PanacheManagedBlockingEntity<Entity> {
 
     /**
      * Represents an entity with managed blocking operations.
      */
-    public interface Managed extends PanacheManagedBlockingEntity {
+    public interface Managed<Entity extends PanacheEntityMarker<Entity>> extends PanacheManagedBlockingEntity<Entity> {
     }
 
     /**
      * Represents an entity with stateless blocking operations.
      */
-    public interface Stateless extends PanacheStatelessBlockingEntity {
+    public interface Stateless<Entity extends PanacheEntityMarker<Entity>> extends PanacheStatelessBlockingEntity<Entity> {
     }
 
     /**
      * Represents an entity with managed reactive operations.
      */
-    public interface Reactive extends PanacheManagedReactiveEntity {
+    public interface Reactive<Entity extends PanacheEntityMarker<Entity>> extends PanacheManagedReactiveEntity<Entity> {
         /**
          * Represents an entity with stateless reactive operations.
          */
-        public interface Stateless extends PanacheStatelessReactiveEntity {
+        public interface Stateless<Entity extends PanacheEntityMarker<Entity>> extends PanacheStatelessReactiveEntity<Entity> {
         }
     }
 }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheEntityBase.java
@@ -5,5 +5,5 @@ import io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingEntit
 /**
  * This is just an alias for {@link PanacheManagedBlockingEntity} for people coming from Panache 1
  */
-public class PanacheEntityBase implements PanacheManagedBlockingEntity {
+public class PanacheEntityBase<Entity extends PanacheEntityMarker<Entity>> implements PanacheManagedBlockingEntity<Entity> {
 }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheEntityMarker.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheEntityMarker.java
@@ -9,8 +9,8 @@ import io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingE
 import io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveEntity;
 import io.smallrye.mutiny.Uni;
 
-public interface PanacheEntityMarker {
-    default PanacheManagedBlockingEntity managedBlocking() {
+public interface PanacheEntityMarker<Entity extends PanacheEntityMarker<Entity>> {
+    default PanacheManagedBlockingEntity<Entity> managedBlocking() {
         if (this instanceof PanacheManagedBlockingEntity) {
             return (PanacheManagedBlockingEntity) this;
         } else {
@@ -18,7 +18,7 @@ public interface PanacheEntityMarker {
         }
     }
 
-    default PanacheManagedReactiveEntity managedReactive() {
+    default PanacheManagedReactiveEntity<Entity> managedReactive() {
         if (this instanceof PanacheManagedReactiveEntity) {
             return (PanacheManagedReactiveEntity) this;
         } else {
@@ -26,7 +26,7 @@ public interface PanacheEntityMarker {
         }
     }
 
-    default PanacheStatelessReactiveEntity statelessReactive() {
+    default PanacheStatelessReactiveEntity<Entity> statelessReactive() {
         if (this instanceof PanacheStatelessReactiveEntity) {
             return (PanacheStatelessReactiveEntity) this;
         } else {
@@ -34,7 +34,7 @@ public interface PanacheEntityMarker {
         }
     }
 
-    default PanacheStatelessBlockingEntity statelessBlocking() {
+    default PanacheStatelessBlockingEntity<Entity> statelessBlocking() {
         if (this instanceof PanacheStatelessBlockingEntity) {
             return (PanacheStatelessBlockingEntity) this;
         } else {
@@ -43,11 +43,12 @@ public interface PanacheEntityMarker {
     }
 
     // FIXME: move to runtime
-    static class PanacheManagedBlockingEntityOperationsImpl implements PanacheManagedBlockingEntity {
+    static class PanacheManagedBlockingEntityOperationsImpl<Entity extends PanacheEntityMarker<Entity>>
+            implements PanacheManagedBlockingEntity<Entity> {
 
-        private Object entity;
+        private Entity entity;
 
-        public PanacheManagedBlockingEntityOperationsImpl(Object entity) {
+        public PanacheManagedBlockingEntityOperationsImpl(Entity entity) {
             this.entity = entity;
         }
 
@@ -56,18 +57,21 @@ public interface PanacheEntityMarker {
         }
 
         @Override
-        public Void persist() {
-            return operations().persist(entity);
+        public Entity persist() {
+            operations().persist(entity);
+            return entity;
         }
 
         @Override
-        public Void persistAndFlush() {
-            return operations().persistAndFlush(entity);
+        public Entity persistAndFlush() {
+            operations().persistAndFlush(entity);
+            return entity;
         }
 
         @Override
-        public Void delete() {
-            return operations().delete(entity);
+        public Entity delete() {
+            operations().delete(entity);
+            return entity;
         }
 
         @Override
@@ -77,11 +81,12 @@ public interface PanacheEntityMarker {
     }
 
     // FIXME: move to runtime
-    static class PanacheManagedReactiveEntityOperationsImpl implements PanacheManagedReactiveEntity {
+    static class PanacheManagedReactiveEntityOperationsImpl<Entity extends PanacheEntityMarker<Entity>>
+            implements PanacheManagedReactiveEntity<Entity> {
 
-        private Object entity;
+        private Entity entity;
 
-        public PanacheManagedReactiveEntityOperationsImpl(Object entity) {
+        public PanacheManagedReactiveEntityOperationsImpl(Entity entity) {
             this.entity = entity;
         }
 
@@ -90,18 +95,18 @@ public interface PanacheEntityMarker {
         }
 
         @Override
-        public Uni<Void> persist() {
-            return operations().persist(entity);
+        public Uni<Entity> persist() {
+            return operations().persist(entity).replaceWith(entity);
         }
 
         @Override
-        public Uni<Void> persistAndFlush() {
-            return operations().persistAndFlush(entity);
+        public Uni<Entity> persistAndFlush() {
+            return operations().persistAndFlush(entity).replaceWith(entity);
         }
 
         @Override
-        public Uni<Void> delete() {
-            return operations().delete(entity);
+        public Uni<Entity> delete() {
+            return operations().delete(entity).replaceWith(entity);
         }
 
         @Override
@@ -111,11 +116,12 @@ public interface PanacheEntityMarker {
     }
 
     // FIXME: move to runtime
-    static class PanacheStatelessReactiveEntityOperationsImpl implements PanacheStatelessReactiveEntity {
+    static class PanacheStatelessReactiveEntityOperationsImpl<Entity extends PanacheEntityMarker<Entity>>
+            implements PanacheStatelessReactiveEntity<Entity> {
 
-        private Object entity;
+        private Entity entity;
 
-        public PanacheStatelessReactiveEntityOperationsImpl(Object entity) {
+        public PanacheStatelessReactiveEntityOperationsImpl(Entity entity) {
             this.entity = entity;
         }
 
@@ -124,32 +130,33 @@ public interface PanacheEntityMarker {
         }
 
         @Override
-        public Uni<Void> insert() {
-            return operations().insert(entity);
+        public Uni<Entity> insert() {
+            return operations().insert(entity).replaceWith(entity);
         }
 
         @Override
-        public Uni<Void> update() {
-            return operations().update(entity);
+        public Uni<Entity> update() {
+            return operations().update(entity).replaceWith(entity);
         }
 
         @Override
-        public Uni<Void> upsert() {
-            return operations().upsert(entity);
+        public Uni<Entity> upsert() {
+            return operations().upsert(entity).replaceWith(entity);
         }
 
         @Override
-        public Uni<Void> delete() {
-            return operations().delete(entity);
+        public Uni<Entity> delete() {
+            return operations().delete(entity).replaceWith(entity);
         }
     }
 
     // FIXME: move to runtime
-    static class PanacheStatelessBlockingEntityOperationsImpl implements PanacheStatelessBlockingEntity {
+    static class PanacheStatelessBlockingEntityOperationsImpl<Entity extends PanacheEntityMarker<Entity>>
+            implements PanacheStatelessBlockingEntity<Entity> {
 
-        private Object entity;
+        private Entity entity;
 
-        public PanacheStatelessBlockingEntityOperationsImpl(Object entity) {
+        public PanacheStatelessBlockingEntityOperationsImpl(Entity entity) {
             this.entity = entity;
         }
 
@@ -158,23 +165,27 @@ public interface PanacheEntityMarker {
         }
 
         @Override
-        public Void insert() {
-            return operations().insert(entity);
+        public Entity insert() {
+            operations().insert(entity);
+            return entity;
         }
 
         @Override
-        public Void update() {
-            return operations().update(entity);
+        public Entity update() {
+            operations().update(entity);
+            return entity;
         }
 
         @Override
-        public Void upsert() {
-            return operations().upsert(entity);
+        public Entity upsert() {
+            operations().upsert(entity);
+            return entity;
         }
 
         @Override
-        public Void delete() {
-            return operations().delete(entity);
+        public Entity delete() {
+            operations().delete(entity);
+            return entity;
         }
     }
 }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedEntityOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedEntityOperations.java
@@ -1,45 +1,46 @@
 package io.quarkus.hibernate.panache.managed;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
 import jakarta.json.bind.annotation.JsonbTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.quarkus.hibernate.panache.PanacheEntityMarker;
 
-public interface PanacheManagedEntityOperations<Completion, Confirmation> extends PanacheEntityMarker {
+public interface PanacheManagedEntityOperations<Entity extends PanacheEntityMarker<Entity>, CompletionEntity, Confirmation>
+        extends PanacheEntityMarker<Entity> {
     /**
      * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
      *
+     * @return this entity
      * @see #isPersistent()
      * @see #persist(Iterable)
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    public Completion persist();
+    public CompletionEntity persist();
 
     /**
      * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
      * Then flushes all pending changes to the database.
      *
+     * @return this entity
      * @see #isPersistent()
      * @see #persist(Iterable)
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    public Completion persistAndFlush();
+    public CompletionEntity persistAndFlush();
 
     /**
      * Delete this entity from the database, if it is already persisted.
      *
+     * @return this entity
      * @see #isPersistent()
      * @see #delete(String, Object...)
      * @see #delete(String, Map)
      * @see #deleteAll()
      */
-    public Completion delete();
+    public CompletionEntity delete();
 
     /**
      * Returns true if this entity is persistent in the database. If yes, all modifications to

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/PanacheManagedRepositoryOperations.java
@@ -1,9 +1,8 @@
 package io.quarkus.hibernate.panache.managed;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
-public interface PanacheManagedRepositoryOperations<Entity, Session, Completion, Confirmation, Id> {
+public interface PanacheManagedRepositoryOperations<Entity, Session, CompletionEntity, Completion, Confirmation, Id> {
 
     // Operations
 
@@ -18,35 +17,38 @@ public interface PanacheManagedRepositoryOperations<Entity, Session, Completion,
      * Persist the given entity in the database, if not already persisted.
      *
      * @param entity the entity to persist.
+     * @return the entity passed as parameter
      * @see #isPersistent(Object)
      * @see #persist(Iterable)
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    Completion persist(Entity entity);
+    CompletionEntity persist(Entity entity);
 
     /**
      * Persist the given entity in the database, if not already persisted.
      * Then flushes all pending changes to the database.
      *
      * @param entity the entity to persist.
+     * @return the entity passed as parameter
      * @see #isPersistent(Object)
      * @see #persist(Iterable)
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    Completion persistAndFlush(Entity entity);
+    CompletionEntity persistAndFlush(Entity entity);
 
     /**
      * Delete the given entity from the database, if it is already persisted.
      *
      * @param entity the entity to delete.
+     * @return the entity passed as parameter
      * @see #isPersistent(Object)
      * @see #delete(String, Object...)
      * @see #delete(String, Map)
      * @see #deleteAll()
      */
-    Completion delete(Entity entity);
+    CompletionEntity delete(Entity entity);
 
     /**
      * Returns true if the given entity is persistent in the database. If yes, all modifications to

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingEntity.java
@@ -1,17 +1,16 @@
 package io.quarkus.hibernate.panache.managed.blocking;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
 import jakarta.json.bind.annotation.JsonbTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import io.quarkus.hibernate.panache.PanacheEntityMarker;
 import io.quarkus.hibernate.panache.managed.PanacheManagedEntityOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheOperations;
 
-public interface PanacheManagedBlockingEntity extends PanacheManagedEntityOperations<Void, Boolean> {
+public interface PanacheManagedBlockingEntity<Entity extends PanacheEntityMarker<Entity>>
+        extends PanacheManagedEntityOperations<Entity, Entity, Boolean> {
 
     private PanacheBlockingOperations operations() {
         return PanacheOperations.getBlockingManaged();
@@ -26,8 +25,9 @@ public interface PanacheManagedBlockingEntity extends PanacheManagedEntityOperat
      * @see #persist(Object, Object...)
      */
     @Override
-    public default Void persist() {
-        return operations().persist(this);
+    public default Entity persist() {
+        operations().persist(this);
+        return (Entity) this;
     }
 
     /**
@@ -40,8 +40,9 @@ public interface PanacheManagedBlockingEntity extends PanacheManagedEntityOperat
      * @see #persist(Object, Object...)
      */
     @Override
-    public default Void persistAndFlush() {
-        return operations().persistAndFlush(this);
+    public default Entity persistAndFlush() {
+        operations().persistAndFlush(this);
+        return (Entity) this;
     }
 
     /**
@@ -53,8 +54,9 @@ public interface PanacheManagedBlockingEntity extends PanacheManagedEntityOperat
      * @see #deleteAll()
      */
     @Override
-    public default Void delete() {
-        return operations().delete(this);
+    public default Entity delete() {
+        operations().delete(this);
+        return (Entity) this;
     }
 
     /**

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.managed.blocking;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.hibernate.Session;
@@ -11,7 +10,7 @@ import io.quarkus.hibernate.panache.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheOperations;
 
 public interface PanacheManagedBlockingRepositoryOperations<Entity, Id>
-        extends PanacheManagedRepositoryOperations<Entity, Session, Void, Boolean, Id> {
+        extends PanacheManagedRepositoryOperations<Entity, Session, Entity, Void, Boolean, Id> {
 
     private Class<? extends Entity> getEntityClass() {
         return AbstractJpaOperations.getRepositoryEntityClass(getClass());
@@ -41,8 +40,9 @@ public interface PanacheManagedBlockingRepositoryOperations<Entity, Id>
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    default Void persist(Entity entity) {
-        return operations().persist(entity);
+    default Entity persist(Entity entity) {
+        operations().persist(entity);
+        return entity;
     }
 
     /**
@@ -55,8 +55,9 @@ public interface PanacheManagedBlockingRepositoryOperations<Entity, Id>
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    default Void persistAndFlush(Entity entity) {
-        return operations().persistAndFlush(entity);
+    default Entity persistAndFlush(Entity entity) {
+        operations().persistAndFlush(entity);
+        return entity;
     }
 
     /**
@@ -68,8 +69,9 @@ public interface PanacheManagedBlockingRepositoryOperations<Entity, Id>
      * @see #delete(String, Map)
      * @see #deleteAll()
      */
-    default Void delete(Entity entity) {
-        return operations().delete(entity);
+    default Entity delete(Entity entity) {
+        operations().delete(entity);
+        return entity;
     }
 
     /**

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveEntity.java
@@ -1,18 +1,17 @@
 package io.quarkus.hibernate.panache.managed.reactive;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
 import jakarta.json.bind.annotation.JsonbTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import io.quarkus.hibernate.panache.PanacheEntityMarker;
 import io.quarkus.hibernate.panache.managed.PanacheManagedEntityOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheReactiveOperations;
 import io.smallrye.mutiny.Uni;
 
-public interface PanacheManagedReactiveEntity extends PanacheManagedEntityOperations<Uni<Void>, Uni<Boolean>> {
+public interface PanacheManagedReactiveEntity<Entity extends PanacheEntityMarker<Entity>>
+        extends PanacheManagedEntityOperations<Entity, Uni<Entity>, Uni<Boolean>> {
 
     private PanacheReactiveOperations operations() {
         return PanacheOperations.getReactiveManaged();
@@ -27,8 +26,8 @@ public interface PanacheManagedReactiveEntity extends PanacheManagedEntityOperat
      * @see #persist(Object, Object...)
      */
     @Override
-    public default Uni<Void> persist() {
-        return operations().persist(this);
+    public default Uni<Entity> persist() {
+        return operations().persist(this).replaceWith((Entity) this);
     }
 
     /**
@@ -41,8 +40,8 @@ public interface PanacheManagedReactiveEntity extends PanacheManagedEntityOperat
      * @see #persist(Object, Object...)
      */
     @Override
-    public default Uni<Void> persistAndFlush() {
-        return operations().persistAndFlush(this);
+    public default Uni<Entity> persistAndFlush() {
+        return operations().persistAndFlush(this).replaceWith((Entity) this);
     }
 
     /**
@@ -54,8 +53,8 @@ public interface PanacheManagedReactiveEntity extends PanacheManagedEntityOperat
      * @see #deleteAll()
      */
     @Override
-    public default Uni<Void> delete() {
-        return operations().delete(this);
+    public default Uni<Entity> delete() {
+        return operations().delete(this).replaceWith((Entity) this);
     }
 
     /**

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.managed.reactive;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.hibernate.reactive.mutiny.Mutiny;
@@ -12,7 +11,7 @@ import io.quarkus.hibernate.panache.runtime.spi.PanacheReactiveOperations;
 import io.smallrye.mutiny.Uni;
 
 public interface PanacheManagedReactiveRepositoryOperations<Entity, Id>
-        extends PanacheManagedRepositoryOperations<Entity, Uni<Mutiny.Session>, Uni<Void>, Uni<Boolean>, Id> {
+        extends PanacheManagedRepositoryOperations<Entity, Uni<Mutiny.Session>, Uni<Entity>, Uni<Void>, Uni<Boolean>, Id> {
 
     private Class<? extends Entity> getEntityClass() {
         return AbstractJpaOperations.getRepositoryEntityClass(getClass());
@@ -42,8 +41,8 @@ public interface PanacheManagedReactiveRepositoryOperations<Entity, Id>
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    default Uni<Void> persist(Entity entity) {
-        return operations().persist(entity);
+    default Uni<Entity> persist(Entity entity) {
+        return operations().persist(entity).replaceWith(entity);
     }
 
     /**
@@ -56,8 +55,8 @@ public interface PanacheManagedReactiveRepositoryOperations<Entity, Id>
      * @see #persist(Stream)
      * @see #persist(Object, Object...)
      */
-    default Uni<Void> persistAndFlush(Entity entity) {
-        return operations().persistAndFlush(entity);
+    default Uni<Entity> persistAndFlush(Entity entity) {
+        return operations().persistAndFlush(entity).replaceWith(entity);
     }
 
     /**
@@ -69,8 +68,8 @@ public interface PanacheManagedReactiveRepositoryOperations<Entity, Id>
      * @see #delete(String, Map)
      * @see #deleteAll()
      */
-    default Uni<Void> delete(Entity entity) {
-        return operations().delete(entity);
+    default Uni<Entity> delete(Entity entity) {
+        return operations().delete(entity).replaceWith(entity);
     }
 
     /**

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessEntityOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessEntityOperations.java
@@ -2,25 +2,34 @@ package io.quarkus.hibernate.panache.stateless;
 
 import io.quarkus.hibernate.panache.PanacheEntityMarker;
 
-public interface PanacheStatelessEntityOperations<Completion, Confirmation> extends PanacheEntityMarker {
+public interface PanacheStatelessEntityOperations<Entity extends PanacheEntityMarker<Entity>, CompletionEntity, Confirmation>
+        extends PanacheEntityMarker<Entity> {
     /**
      * Insert this entity in the database. This will set your ID field if it is not already set.
+     *
+     * @return this entity
      */
-    public Completion insert();
+    public CompletionEntity insert();
 
     /**
      * Delete this entity from the database, if it is already persisted.
+     *
+     * @return this entity
      */
-    public Completion delete();
+    public CompletionEntity delete();
 
     /**
      * Update this entity to the database.
+     *
+     * @return this entity
      */
-    public Completion update();
+    public CompletionEntity update();
 
     /**
      * Insert or update this entity in the database. An insert will be performed if the entity does not already exist
      * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
+     *
+     * @return this entity
      */
-    public Completion upsert();
+    public CompletionEntity upsert();
 }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/PanacheStatelessRepositoryOperations.java
@@ -1,9 +1,8 @@
 package io.quarkus.hibernate.panache.stateless;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
-public interface PanacheStatelessRepositoryOperations<Entity, Session, Completion, Confirmation, Id> {
+public interface PanacheStatelessRepositoryOperations<Entity, Session, CompletionEntity, Completion, Confirmation, Id> {
 
     // Operations
 
@@ -18,11 +17,12 @@ public interface PanacheStatelessRepositoryOperations<Entity, Session, Completio
      * Insert the given entity in the database.
      *
      * @param entity the entity to insert.
+     * @return the entity passed as parameter
      * @see #insert(Iterable)
      * @see #insert(Stream)
      * @see #insert(Object, Object...)
      */
-    Completion insert(Entity entity);
+    CompletionEntity insert(Entity entity);
 
     /**
      * Delete the given entity from the database.
@@ -31,15 +31,17 @@ public interface PanacheStatelessRepositoryOperations<Entity, Session, Completio
      * @see #delete(String, Object...)
      * @see #delete(String, Map)
      * @see #deleteAll()
+     * @return the entity passed as parameter
      */
-    Completion delete(Entity entity);
+    CompletionEntity delete(Entity entity);
 
     /**
      * Update the given entity in the database.
      *
      * @param entity the entity to update.
+     * @return the entity passed as parameter
      */
-    Completion update(Entity entity);
+    CompletionEntity update(Entity entity);
 
     /**
      * Insert all given entities.

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingEntity.java
@@ -1,13 +1,12 @@
 package io.quarkus.hibernate.panache.stateless.blocking;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
+import io.quarkus.hibernate.panache.PanacheEntityMarker;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheBlockingOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheOperations;
 import io.quarkus.hibernate.panache.stateless.PanacheStatelessEntityOperations;
 
-public interface PanacheStatelessBlockingEntity extends PanacheStatelessEntityOperations<Void, Boolean> {
+public interface PanacheStatelessBlockingEntity<Entity extends PanacheEntityMarker<Entity>>
+        extends PanacheStatelessEntityOperations<Entity, Entity, Boolean> {
 
     private PanacheBlockingOperations operations() {
         return PanacheOperations.getBlockingStateless();
@@ -21,8 +20,9 @@ public interface PanacheStatelessBlockingEntity extends PanacheStatelessEntityOp
      * @see #insert(Object, Object...)
      */
     @Override
-    public default Void insert() {
-        return operations().insert(this);
+    public default Entity insert() {
+        operations().insert(this);
+        return (Entity) this;
     }
 
     /**
@@ -33,16 +33,18 @@ public interface PanacheStatelessBlockingEntity extends PanacheStatelessEntityOp
      * @see #deleteAll()
      */
     @Override
-    public default Void delete() {
-        return operations().delete(this);
+    public default Entity delete() {
+        operations().delete(this);
+        return (Entity) this;
     }
 
     /**
      * Update this entity in the database.
      */
     @Override
-    public default Void update() {
-        return operations().update(this);
+    public default Entity update() {
+        operations().update(this);
+        return (Entity) this;
     }
 
     /**
@@ -50,7 +52,8 @@ public interface PanacheStatelessBlockingEntity extends PanacheStatelessEntityOp
      * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
      */
     @Override
-    public default Void upsert() {
-        return operations().upsert(this);
+    public default Entity upsert() {
+        operations().upsert(this);
+        return (Entity) this;
     }
 }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryOperations.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.panache.stateless.blocking;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.hibernate.StatelessSession;
@@ -11,7 +10,7 @@ import io.quarkus.hibernate.panache.runtime.spi.PanacheOperations;
 import io.quarkus.hibernate.panache.stateless.PanacheStatelessRepositoryOperations;
 
 public interface PanacheStatelessBlockingRepositoryOperations<Entity, Id>
-        extends PanacheStatelessRepositoryOperations<Entity, StatelessSession, Void, Boolean, Id> {
+        extends PanacheStatelessRepositoryOperations<Entity, StatelessSession, Entity, Void, Boolean, Id> {
 
     private Class<? extends Entity> getEntityClass() {
         return AbstractJpaOperations.getRepositoryEntityClass(getClass());
@@ -40,8 +39,9 @@ public interface PanacheStatelessBlockingRepositoryOperations<Entity, Id>
      * @see #insert(Stream)
      * @see #insert(Object, Object...)
      */
-    default Void insert(Entity entity) {
-        return operations().insert(entity);
+    default Entity insert(Entity entity) {
+        operations().insert(entity);
+        return entity;
     }
 
     /**
@@ -53,8 +53,9 @@ public interface PanacheStatelessBlockingRepositoryOperations<Entity, Id>
      * @see #delete(String, Map)
      * @see #deleteAll()
      */
-    default Void delete(Entity entity) {
-        return operations().delete(entity);
+    default Entity delete(Entity entity) {
+        operations().delete(entity);
+        return entity;
     }
 
     /**
@@ -62,8 +63,9 @@ public interface PanacheStatelessBlockingRepositoryOperations<Entity, Id>
      *
      * @param entity the entity to update.
      */
-    default Void update(Entity entity) {
-        return operations().update(entity);
+    default Entity update(Entity entity) {
+        operations().update(entity);
+        return entity;
     }
 
     /**
@@ -72,8 +74,9 @@ public interface PanacheStatelessBlockingRepositoryOperations<Entity, Id>
      *
      * @param entity the entity to insert or update.
      */
-    default Void upsert(Entity entity) {
-        return operations().upsert(entity);
+    default Entity upsert(Entity entity) {
+        operations().upsert(entity);
+        return entity;
     }
 
     /**

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveEntity.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveEntity.java
@@ -1,11 +1,13 @@
 package io.quarkus.hibernate.panache.stateless.reactive;
 
+import io.quarkus.hibernate.panache.PanacheEntityMarker;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheOperations;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheReactiveOperations;
 import io.quarkus.hibernate.panache.stateless.PanacheStatelessEntityOperations;
 import io.smallrye.mutiny.Uni;
 
-public interface PanacheStatelessReactiveEntity extends PanacheStatelessEntityOperations<Uni<Void>, Uni<Boolean>> {
+public interface PanacheStatelessReactiveEntity<Entity extends PanacheEntityMarker<Entity>>
+        extends PanacheStatelessEntityOperations<Entity, Uni<Entity>, Uni<Boolean>> {
 
     private PanacheReactiveOperations operations() {
         return PanacheOperations.getReactiveManaged();
@@ -15,24 +17,24 @@ public interface PanacheStatelessReactiveEntity extends PanacheStatelessEntityOp
      * Insert this entity in the database. This will set your ID field if it is not already set.
      */
     @Override
-    public default Uni<Void> insert() {
-        return operations().insert(this);
+    public default Uni<Entity> insert() {
+        return operations().insert(this).replaceWith((Entity) this);
     }
 
     /**
      * Delete this entity from the database.
      */
     @Override
-    public default Uni<Void> delete() {
-        return operations().delete(this);
+    public default Uni<Entity> delete() {
+        return operations().delete(this).replaceWith((Entity) this);
     }
 
     /**
      * Update this entity in the database.
      */
     @Override
-    public default Uni<Void> update() {
-        return operations().update(this);
+    public default Uni<Entity> update() {
+        return operations().update(this).replaceWith((Entity) this);
     }
 
     /**
@@ -40,7 +42,7 @@ public interface PanacheStatelessReactiveEntity extends PanacheStatelessEntityOp
      * in the database, otherwise it will be updated. Note that you cannot upsert an entity with a null ID.
      */
     @Override
-    public default Uni<Void> upsert() {
-        return operations().upsert(this);
+    public default Uni<Entity> upsert() {
+        return operations().upsert(this).replaceWith((Entity) this);
     }
 }

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryOperations.java
@@ -11,7 +11,8 @@ import io.quarkus.hibernate.panache.stateless.PanacheStatelessRepositoryOperatio
 import io.smallrye.mutiny.Uni;
 
 public interface PanacheStatelessReactiveRepositoryOperations<Entity, Id>
-        extends PanacheStatelessRepositoryOperations<Entity, Uni<Mutiny.StatelessSession>, Uni<Void>, Uni<Boolean>, Id> {
+        extends
+        PanacheStatelessRepositoryOperations<Entity, Uni<Mutiny.StatelessSession>, Uni<Entity>, Uni<Void>, Uni<Boolean>, Id> {
 
     private Class<? extends Entity> getEntityClass() {
         return AbstractJpaOperations.getRepositoryEntityClass(getClass());
@@ -38,8 +39,8 @@ public interface PanacheStatelessReactiveRepositoryOperations<Entity, Id>
      *
      * @param entity the entity to insert.
      */
-    default Uni<Void> insert(Entity entity) {
-        return operations().insert(entity);
+    default Uni<Entity> insert(Entity entity) {
+        return operations().insert(entity).replaceWith(entity);
     }
 
     /**
@@ -47,8 +48,8 @@ public interface PanacheStatelessReactiveRepositoryOperations<Entity, Id>
      *
      * @param entity the entity to delete.
      */
-    default Uni<Void> delete(Entity entity) {
-        return operations().delete(entity);
+    default Uni<Entity> delete(Entity entity) {
+        return operations().delete(entity).replaceWith(entity);
     }
 
     /**
@@ -56,8 +57,8 @@ public interface PanacheStatelessReactiveRepositoryOperations<Entity, Id>
      *
      * @param entity the entity to update.
      */
-    default Uni<Void> update(Entity entity) {
-        return operations().update(entity);
+    default Uni<Entity> update(Entity entity) {
+        return operations().update(entity).replaceWith(entity);
     }
 
     /**
@@ -66,8 +67,8 @@ public interface PanacheStatelessReactiveRepositoryOperations<Entity, Id>
      *
      * @param entity the entity to insert or update.
      */
-    default Uni<Void> upsert(Entity entity) {
-        return operations().upsert(entity);
+    default Uni<Entity> upsert(Entity entity) {
+        return operations().upsert(entity).replaceWith(entity);
     }
 
     /**


### PR DESCRIPTION
This requires adding a self-type parameter to PanacheEntity, which is far from convincing.

This also has implications on entity inheritance.

I'm not sure if we want to merge this.

I guess I'd like opinions on this.

Fixes #52267

