### PR TITLE
[3.27] Update Hibernate Search to 8.1.3.Final / Update Apache Avro to 1.12.1 / Update Hibernate ORM to 7.1.16.Final  / Update Hibernate Reactive to 3.1.13.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -194,7 +194,7 @@
         <log4j2-jboss-logmanager.version>2.0.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.25.1</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.3.1.Final</log4j-jboss-logmanager.version>
-        <avro.version>1.12.0</avro.version>
+        <avro.version>1.12.1</avro.version>
         <apicurio-registry.version>2.6.13.Final</apicurio-registry.version>
         <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <testcontainers.version>1.21.4</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.6</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>3.1.12.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.1.13.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.0.1.Final</hibernate-validator.version>
         <hibernate-search.version>8.1.3.Final</hibernate-search.version>
         <hibernate-tools.version>7.1.12.Final</hibernate-tools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>3.1.12.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.0.1.Final</hibernate-validator.version>
-        <hibernate-search.version>8.1.2.Final</hibernate-search.version>
+        <hibernate-search.version>8.1.3.Final</hibernate-search.version>
         <hibernate-tools.version>7.1.12.Final</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jacoco.version>0.8.13</jacoco.version>
         <kubernetes-client.version>7.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.1.14.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.1.16.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.6</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
Since this update of Hibernate Search comes in pair with Apache Avro update, I thought I'll open a PR and let you decide how you want to manage the updates 🙂 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

