### PR TITLE
Remove `jboss-parent` from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
     labels:
       - area/dependencies
     allow:
-      - dependency-name: org.jboss:jboss-parent
       - dependency-name: org.jboss.resteasy:*
       - dependency-name: org.jboss.resteasy.microprofile:*
       - dependency-name: org.jboss.resteasy.spring:*


### PR DESCRIPTION
JBoss Parent POM was replaced by quarkus-parent in https://github.com/quarkusio/quarkus/pull/33268
