### PR TITLE
Mock ApplicationScoped beans at Startup

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/FieldMockBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/FieldMockBuildItem.java
@@ -1,0 +1,29 @@
+package io.quarkus.arc.deployment;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class FieldMockBuildItem extends MultiBuildItem {
+    private final DotName declaringClass;
+    private final String fieldName;
+    private final boolean deepMocks;
+
+    public FieldMockBuildItem(DotName declaringClass, String fieldName, boolean deepMocks) {
+        this.declaringClass = declaringClass;
+        this.fieldName = fieldName;
+        this.deepMocks = deepMocks;
+    }
+
+    public DotName getDeclaringClass() {
+        return declaringClass;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public boolean isDeepMocks() {
+        return deepMocks;
+    }
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/MockProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/MockProcessor.java
@@ -1,0 +1,26 @@
+package io.quarkus.arc.deployment;
+
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+
+import java.util.List;
+
+import io.quarkus.arc.runtime.MockRecorder;
+import io.quarkus.deployment.IsTest;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.Consume;
+import io.quarkus.deployment.annotations.Record;
+
+@BuildSteps(onlyIf = IsTest.class)
+class MockProcessor {
+    @BuildStep
+    @Record(STATIC_INIT)
+    @Consume(BeanContainerBuildItem.class)
+    void process(
+            MockRecorder mockRecorder,
+            List<FieldMockBuildItem> mocks) throws Exception {
+        for (FieldMockBuildItem mock : mocks) {
+            mockRecorder.registerMock(mock.getDeclaringClass().toString(), mock.getFieldName(), mock.isDeepMocks());
+        }
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/MockRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/MockRecorder.java
@@ -1,0 +1,80 @@
+package io.quarkus.arc.runtime;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.BeanManager;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.impl.EventBean;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class MockRecorder {
+    public static volatile Set<Mock> beansToMock = new HashSet<>();
+
+    public void registerMock(String declaringClass, String field, boolean deepMocks) throws Exception {
+        Class<?> klass = Thread.currentThread().getContextClassLoader().loadClass(declaringClass);
+        Field declaredField = klass.getDeclaredField(field);
+        InstanceHandle<?> beanHandle = getBeanHandle(declaredField, declaringClass, "@InjectMock");
+        if (beanHandle.getBean().getScope().equals(ApplicationScoped.class)) {
+            // TODO - Pass beans indirectly because we need the Mockito API, which is not a direct dependency of Arc
+            // We can probably move the mockito integration to be a full extension
+            beansToMock.add(new Mock(declaredField.getGenericType(), beanHandle, deepMocks));
+        }
+    }
+
+    static InstanceHandle<?> getBeanHandle(Field field, String declaringClass, String annotation) {
+        Type fieldType = field.getGenericType();
+        ArcContainer container = Arc.container();
+        BeanManager beanManager = container.beanManager();
+        Annotation[] qualifiers = getQualifiers(field, beanManager);
+
+        InstanceHandle<?> handle = container.instance(fieldType, qualifiers);
+        if (!handle.isAvailable()) {
+            throw new IllegalStateException(
+                    "Invalid use of " + annotation + " - could not resolve the bean of type: "
+                            + fieldType.getTypeName() + ". Offending field is " + field.getName() + " of test class "
+                            + declaringClass);
+        }
+        InjectableBean<?> bean = handle.getBean();
+        if (!(bean instanceof EventBean)
+                && !beanManager.isNormalScope(bean.getScope())) {
+            throw new IllegalStateException(
+                    "Invalid use of " + annotation
+                            + " - the injected bean does not declare a CDI normal scope but: "
+                            + handle.getBean().getScope().getName()
+                            + ". Offending field is " + field.getName() + " of test class "
+                            + declaringClass);
+        }
+        return handle;
+    }
+
+    static Annotation[] getQualifiers(Field fieldToMock, BeanManager beanManager) {
+        List<Annotation> qualifiers = new ArrayList<>();
+        Annotation[] fieldAnnotations = fieldToMock.getDeclaredAnnotations();
+        for (Annotation fieldAnnotation : fieldAnnotations) {
+            if (beanManager.isQualifier(fieldAnnotation.annotationType())) {
+                qualifiers.add(fieldAnnotation);
+            }
+        }
+        if (qualifiers.isEmpty()) {
+            // Add @Default as if @InjectMock was a normal @Inject
+            qualifiers.add(Default.Literal.INSTANCE);
+        }
+        return qualifiers.toArray(new Annotation[0]);
+    }
+
+    public record Mock(Type type, InstanceHandle<?> beanHandle, boolean deepMocks) {
+    }
+}

--- a/integration-tests/injectmock/pom.xml
+++ b/integration-tests/injectmock/pom.xml
@@ -20,6 +20,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
@@ -33,6 +37,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/GreetingRestClient.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/GreetingRestClient.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.mockbean;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+public interface GreetingRestClient {
+    @GET
+    @Path("/hello")
+    @Produces(MediaType.TEXT_PLAIN)
+    String greeting();
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/StartupService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/StartupService.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.mockbean;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.runtime.Startup;
+
+@Startup
+@ApplicationScoped
+public class StartupService {
+    @Inject
+    @RestClient
+    GreetingRestClient greetingRestClient;
+
+    @PostConstruct
+    void onStart() {
+        greetingRestClient.greeting();
+    }
+
+    public String greeting() {
+        return greetingRestClient.greeting();
+    }
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/StartupTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/StartupTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.mockbean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class StartupTest {
+    @InjectMock
+    @RestClient
+    GreetingRestClient greetingRestClient;
+    @Inject
+    StartupService startupService;
+
+    @Test
+    void startup() {
+        Mockito.when(greetingRestClient.greeting()).thenReturn("Hello from Mocked REST Client");
+        assertEquals("Hello from Mocked REST Client", startupService.greeting());
+    }
+}

--- a/test-framework/junit-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/StartupMocks.java
+++ b/test-framework/junit-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/StartupMocks.java
@@ -1,0 +1,27 @@
+package io.quarkus.test.junit.mockito.internal;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+
+import org.mockito.Mockito;
+
+import io.quarkus.arc.runtime.MockRecorder;
+import io.quarkus.arc.runtime.MockRecorder.Mock;
+import io.quarkus.runtime.Startup;
+import io.quarkus.test.junit.QuarkusMock;
+
+@Startup(value = 1)
+@Singleton
+public class StartupMocks {
+    @PostConstruct
+    void onStart() {
+        for (Mock mock : MockRecorder.beansToMock) {
+            Class<?> mockType = mock.beanHandle().getBean().getImplementationClass();
+            Object mockInstance = mock.deepMocks() ? Mockito.mock(mockType, RETURNS_DEEP_STUBS) : Mockito.mock(mockType);
+            Object beanInstance = mock.beanHandle().get();
+            QuarkusMock.installMockForInstance(mockInstance, beanInstance);
+        }
+    }
+}

--- a/test-framework/junit-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/UnremoveableMockTestBuildChainCustomizerProducer.java
+++ b/test-framework/junit-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/UnremoveableMockTestBuildChainCustomizerProducer.java
@@ -1,5 +1,8 @@
 package io.quarkus.test.junit.mockito.internal;
 
+import static io.quarkus.test.junit.mockito.internal.SingletonToApplicationScopedTestBuildChainCustomizerProducer.INJECT_MOCK;
+import static io.quarkus.test.junit.mockito.internal.SingletonToApplicationScopedTestBuildChainCustomizerProducer.MOCKITO_CONFIG;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -7,8 +10,12 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
 
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.FieldMockBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
@@ -26,18 +33,41 @@ public class UnremoveableMockTestBuildChainCustomizerProducer implements TestBui
                 buildChainBuilder.addBuildStep(new BuildStep() {
                     @Override
                     public void execute(BuildContext context) {
+                        context.produce(new AdditionalBeanBuildItem(StartupMocks.class));
+                    }
+                }).produces(AdditionalBeanBuildItem.class).build();
+
+                buildChainBuilder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
                         Set<String> mockTypes = new HashSet<>();
-                        List<AnnotationInstance> instances = new ArrayList<>(testClassesIndex
-                                .getAnnotations(
-                                        SingletonToApplicationScopedTestBuildChainCustomizerProducer.INJECT_MOCK));
+                        List<AnnotationInstance> instances = new ArrayList<>(testClassesIndex.getAnnotations(INJECT_MOCK));
                         for (AnnotationInstance instance : instances) {
                             mockTypes.add(instance.target().asField().type().name().toString());
                         }
                         context.produce(
                                 new UnremovableBeanBuildItem(new UnremovableBeanBuildItem.BeanClassNamesExclusion(mockTypes)));
                     }
-                }).produces(UnremovableBeanBuildItem.class)
-                        .build();
+                }).produces(UnremovableBeanBuildItem.class).build();
+
+                buildChainBuilder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        List<AnnotationInstance> instances = new ArrayList<>(testClassesIndex.getAnnotations(INJECT_MOCK));
+                        for (AnnotationInstance instance : instances) {
+                            FieldInfo field = instance.target().asField();
+                            AnnotationInstance mockitoConfig = field.annotation(MOCKITO_CONFIG);
+                            boolean deepMocks = false;
+                            if (mockitoConfig != null) {
+                                AnnotationValue returnsDeepMocks = mockitoConfig.value("returnsDeepMocks");
+                                if (returnsDeepMocks != null) {
+                                    deepMocks = returnsDeepMocks.asBoolean();
+                                }
+                            }
+                            context.produce(new FieldMockBuildItem(field.declaringClass().name(), field.name(), deepMocks));
+                        }
+                    }
+                }).produces(FieldMockBuildItem.class).build();
             }
         };
     }


### PR DESCRIPTION
- Fixes #51784 

This eagerly creates mocks for ApplicationScoped beans, so if beans are used during Startup and the test marks them for mocking, Startup does not fail. This can be observed when injecting a REST Client in a Startup bean and calling any methods before the test executes. Currently, mocks are created only when the test executes, but Startup beans run before, causing the issue.

I've experimented with different approaches, and this one seemed to be the least intrusive, including generating Alternative beans, creating the mocks used by the test before execution, and some other variations.

The downside is that when you run the test, you get a different mock from the one used in the StartupBean. I've looked into making this global and reusing the same mock, but ultimately, I ditched the idea because it would cause issues with parallel testing.

To achieve this, I require a build item to register the bean candidates and then create the mock in our own high-priority Startup bean.

Still missing:
- Support for `@InjectSpy`
- Maybe clear the mocks after Startup?
- Maybe move `junit-mockito` to a full-fledged extension?
