### PR TITLE
Mark REST CSRF as stable, OIDC GraphQL Client as preview and unlisted OIDC Common and Security as stable

### DIFF
--- a/extensions/oidc-client-graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/oidc-client-graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,6 @@ metadata:
   guide: "https://quarkus.io/guides/security-openid-connect-client"
   categories:
   - "security"
-  status: "experimental"
+  status: "preview"
   config:
   - "quarkus.oidc-client."

--- a/extensions/oidc-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/oidc-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,5 +8,5 @@ metadata:
   - "oidc"
   categories:
   - "security"
-  status: "preview"
+  status: "stable"
   unlisted: true

--- a/extensions/resteasy-reactive/rest-csrf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-csrf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "csrf"
   categories:
   - "security"
-  status: "preview"
+  status: "stable"
   config:
   - "quarkus.rest-csrf."
   - "quarkus.csrf-reactive."

--- a/extensions/security/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/security/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,4 +7,4 @@ metadata:
   - "security"
   categories:
     - "security"
-  status: "preview"
+  status: "stable"


### PR DESCRIPTION
- REST CSRF after almost 4 years around should be considered stable as we don't have alternative for users (apart of bending CORS) and we don't serious issues reported
- OIDC GraphQL Client is around less than 3 years, we don't have many issues reported (more precisely, there are no open for what I know), so I think it is safe to mark it as a preview
- OIDC Common is unlisted, but it is still wrong to make it "preview", because it is not https://quarkus.io/extensions/?search-regex=oidc
- Security is unlisted (I suppose the idea is that users should rely on some builtin identity provider or mechanism that brings it in) but it still appears in https://quarkus.io/extensions/?search-regex=security as **preview** :grinning: 