### PR TITLE
Improve error message for unexpected VertxWebSocketRestHandler restart

### DIFF
--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketRestHandler.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/websocket/VertxWebSocketRestHandler.java
@@ -17,7 +17,10 @@ public class VertxWebSocketRestHandler implements HandlerChainCustomizer {
                 @Override
                 public void handle(ResteasyReactiveRequestContext requestContext)
                         throws Exception {
-                    throw new IllegalStateException("FAILURE: should never be restarted");
+                    throw new IllegalStateException("VertxWebSocketRestHandler was restarted unexpectedly. " +
+                               "WebSocket REST handlers are not designed to be restarted once initialized. " +
+                               "This indicates an invalid lifecycle state.");
+
                 }
             }
     };


### PR DESCRIPTION
This PR improves the IllegalStateException message thrown when
VertxWebSocketRestHandler is unexpectedly restarted.

The previous message ("FAILURE: should never be restarted")
was not descriptive and did not provide useful debugging context.

The updated message clarifies that the handler is not expected
to be restarted and indicates a potential invalid lifecycle state.

No functional changes were introduced.