### PR TITLE
Document how to mock beans during startup

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -712,6 +712,7 @@ However, note that it is not possible to assign different test profiles or resou
 Quarkus supports the use of mock objects using two different approaches. You can either use CDI alternatives to
 mock out a bean for all test classes, or use `QuarkusMock` to mock out beans on a per test basis.
 
+[[mock-cdi-alternative]]
 === CDI `@Alternative` mechanism.
 
 To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean.
@@ -1066,6 +1067,13 @@ public class GreetingResourceTest {
 }
 ----
 <1> Indicate that this injection point is meant to use an instance of `RestClient`.
+
+=== Mocking on Startup
+
+Beans accessed and used during startup are not subject to automatic mocking, even if the test declares injection points
+with the same bean types annotated with @InjectMock or @InjectSpy. Mocking is a local operation within a test, whereas
+startup is a global operation for executing many tests. In such cases, the recommendation is to use the
+<<mock-cdi-alternative>>.
 
 === Mocking with Panache
 

--- a/integration-tests/injectmock/pom.xml
+++ b/integration-tests/injectmock/pom.xml
@@ -20,6 +20,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
@@ -33,6 +37,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/GreetingRestClient.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/GreetingRestClient.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.mockbean;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+public interface GreetingRestClient {
+    @GET
+    @Path("/hello")
+    @Produces(MediaType.TEXT_PLAIN)
+    String greeting();
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/StartupService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/StartupService.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.mockbean;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.runtime.Startup;
+
+@Startup
+@ApplicationScoped
+public class StartupService {
+    @Inject
+    @RestClient
+    GreetingRestClient greetingRestClient;
+
+    String greetingStartup = null;
+
+    @PostConstruct
+    void onStart() {
+        greetingStartup = greetingRestClient.greeting();
+    }
+
+    public String greetingStartup() {
+        return greetingStartup;
+    }
+
+    public String greeting() {
+        return greetingRestClient.greeting();
+    }
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/StartupTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/StartupTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.mockbean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class StartupTest {
+    @InjectMock
+    @RestClient
+    GreetingRestClient greetingRestClient;
+    @Inject
+    StartupService startupService;
+
+    @Test
+    void startup() {
+        Mockito.when(greetingRestClient.greeting()).thenReturn("Hello from Mocked REST Client");
+        assertEquals("Hello from Startup Mocked REST Client", startupService.greetingStartup());
+        assertEquals("Hello from Mocked REST Client", startupService.greeting());
+    }
+
+    @Produces
+    @ApplicationScoped
+    @RestClient
+    @Alternative
+    @Priority(1)
+    public GreetingRestClient restClient() {
+        GreetingRestClient mock = Mockito.mock(GreetingRestClient.class);
+        Mockito.when(mock.greeting()).thenReturn("Hello from Startup Mocked REST Client");
+        return mock;
+    }
+}


### PR DESCRIPTION
- Closes: #51784  

After tentatively fixing it with:
- #51830
- #52670

We concluded that this is a corner case and that there is no good fix, as explained in #52670. Our recommendation is to use https://quarkus.io/guides/getting-started-testing#cdi-alternative-mechanism.