### PR TITLE
Reflect all of DescriptorProtos

### DIFF
--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
@@ -2,6 +2,7 @@ package io.quarkus.grpc.common.deployment;
 
 import org.jboss.jandex.DotName;
 
+import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.GeneratedMessage;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.ProtocolMessageEnum;
@@ -15,6 +16,7 @@ public class GrpcDotNames {
     static final DotName MESSAGE_BUILDER = DotName.createSimple(GeneratedMessage.Builder.class.getName());
     static final DotName MESSAGE_BUILDER_V3 = DotName.createSimple(GeneratedMessageV3.Builder.class.getName());
     static final DotName PROTOCOL_MESSAGE_ENUM = DotName.createSimple(ProtocolMessageEnum.class.getName());
+    static final DotName DESRIPTOR_PROTOS = DotName.createSimple(DescriptorProtos.class.getName());
     static final DotName NAME_RESOLVER_PROVIDER = DotName.createSimple(NameResolverProvider.class.getName());
     static final DotName LOAD_BALANCER_PROVIDER = DotName.createSimple(LoadBalancerProvider.class.getName());
 }

--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
@@ -16,7 +16,7 @@ public class GrpcDotNames {
     static final DotName MESSAGE_BUILDER = DotName.createSimple(GeneratedMessage.Builder.class.getName());
     static final DotName MESSAGE_BUILDER_V3 = DotName.createSimple(GeneratedMessageV3.Builder.class.getName());
     static final DotName PROTOCOL_MESSAGE_ENUM = DotName.createSimple(ProtocolMessageEnum.class.getName());
-    static final DotName DESRIPTOR_PROTOS = DotName.createSimple(DescriptorProtos.class.getName());
+    static final DotName DESCRIPTOR_PROTOS = DotName.createSimple(DescriptorProtos.class.getName());
     static final DotName NAME_RESOLVER_PROVIDER = DotName.createSimple(NameResolverProvider.class.getName());
     static final DotName LOAD_BALANCER_PROVIDER = DotName.createSimple(LoadBalancerProvider.class.getName());
 }


### PR DESCRIPTION
In native all info from protobuf DescriptorProtos is erased, but it looks like it is used / needed when accessing protobuf enums.

This fixes #52436 issue.