### PR TITLE
Allow to customize OIDC discovery path

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -77,6 +77,7 @@ See the <<multi-tenancy>> section for more details.
 |Property name |Default |Description
 
 |quarkus.oidc.auth-server-url ||OIDC base URL
+|quarkus.oidc.discovery-path |.well-known/openid-configuration|Discovery path
 |quarkus.oidc.discovery-enabled |true|Enable discovery
 |quarkus.oidc.authorization-path ||Authorization path
 |quarkus.oidc.token-path ||Token path
@@ -88,7 +89,10 @@ See the <<multi-tenancy>> section for more details.
 |quarkus.oidc.registration-path ||OIDC client registration path
 |====
 
-`quarkus.oidc.auth-server-url` is a key base OIDC URL property. By default, Quarkus OIDC adds a `.well-known/openid-configuration` path segment to this URL and discovers the OIDC provider metadata.
+`quarkus.oidc.auth-server-url` is a key base OIDC URL property.
+
+By default, Quarkus OIDC adds a `.well-known/openid-configuration` path segment to this URL and discovers the OIDC provider metadata.
+The discovery path can be customized with `quarkus.oidc.discovery-path`, for example, it can be set to `.well-known/oauth-authorization-server`.
 
 You can disable metadata discovery with `quarkus.oidc.discovery-enabled=false` when the provider does not support it (most OAuth2 providers do not), when you would like to optimize start up time by skipping a remote discovery call and configure individual OIDC provider endpoint URLs instead.
 

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
@@ -238,9 +238,10 @@ public class OidcClientRegistrationRecorder {
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters,
             String authServerUrl, io.vertx.mutiny.core.Vertx vertx, OidcClientRegistrationConfig oidcConfig) {
         final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
+        final String discoveryUri = OidcCommonUtils.getDiscoveryUri(authServerUrl, oidcConfig.discoveryPath());
         return OidcCommonUtils
                 .discoverMetadata(client, oidcRequestFilters, new OidcRequestContextProperties(),
-                        oidcResponseFilters, authServerUrl,
+                        oidcResponseFilters, discoveryUri,
                         connectionDelayInMillisecs, vertx,
                         oidcConfig.useBlockingDnsLookup())
                 .onItem().transform(json -> new OidcConfigurationMetadata(json.getString("registration_endpoint")));

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientHealthCheck.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientHealthCheck.java
@@ -80,7 +80,7 @@ public class OidcClientHealthCheck implements HealthCheck {
             } else if (oidcClientConfig.discoveryEnabled().orElse(true) && oidcClientConfig.authServerUrl().isPresent()) {
                 try {
                     String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcClientConfig);
-                    String discoveryUri = getDiscoveryUri(authServerUriString);
+                    String discoveryUri = getDiscoveryUri(authServerUriString, oidcClientConfig.discoveryPath());
                     status = checkHealth(oidcClientImpl, discoveryUri).await().indefinitely();
                 } catch (Exception e) {
                     status = ERROR_STATUS + ": " + e.getMessage();

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -232,8 +232,9 @@ public class OidcClientRecorder {
         final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
         OidcRequestContextProperties contextProps = new OidcRequestContextProperties(
                 Map.of(CLIENT_ID_ATTRIBUTE, oidcConfig.id().orElse(DEFAULT_OIDC_CLIENT_ID)));
+        final String discoveryUrl = OidcCommonUtils.getDiscoveryUri(authServerUrl, oidcConfig.discoveryPath());
         return OidcCommonUtils.discoverMetadata(client, oidcRequestFilters, contextProps, oidcResponseFilters,
-                authServerUrl, connectionDelayInMillisecs, vertx, oidcConfig.useBlockingDnsLookup())
+                discoveryUrl, connectionDelayInMillisecs, vertx, oidcConfig.useBlockingDnsLookup())
                 .onItem().transform(json -> new OidcConfigurationMetadata(json.getString("token_endpoint"),
                         json.getString("revocation_endpoint")));
     }

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
@@ -15,6 +15,7 @@ final class OidcClientConfigImpl implements OidcClientConfig {
     enum ConfigMappingMethods {
         ID,
         AUTH_SERVER_URL,
+        DISCOVERY_PATH,
         DISCOVERY_ENABLED,
         REGISTRATION_PATH,
         CONNECTION_DELAY,
@@ -431,6 +432,12 @@ final class OidcClientConfigImpl implements OidcClientConfig {
     public Optional<String> authServerUrl() {
         invocationsRecorder.put(ConfigMappingMethods.AUTH_SERVER_URL, true);
         return Optional.empty();
+    }
+
+    @Override
+    public String discoveryPath() {
+        invocationsRecorder.put(ConfigMappingMethods.DISCOVERY_PATH, true);
+        return null;
     }
 
     @Override

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -13,6 +13,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
 
     protected OidcCommonConfig(io.quarkus.oidc.common.runtime.config.OidcCommonConfig mapping) {
         this.authServerUrl = mapping.authServerUrl();
+        this.discoveryPath = mapping.discoveryPath();
         this.discoveryEnabled = mapping.discoveryEnabled();
         this.registrationPath = mapping.registrationPath();
         this.connectionDelay = mapping.connectionDelay();
@@ -45,6 +46,11 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      */
     @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Boolean> discoveryEnabled = Optional.empty();
+
+    /**
+     * The relative path of the OIDC discovery endpoint.
+     */
+    private String discoveryPath;
 
     /**
      * The relative path or absolute URL of the OIDC dynamic client registration endpoint.
@@ -131,6 +137,11 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     @Override
     public Optional<String> authServerUrl() {
         return authServerUrl;
+    }
+
+    @Override
+    public String discoveryPath() {
+        return discoveryPath;
     }
 
     @Override

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -576,9 +576,9 @@ public class OidcCommonUtils {
     public static Uni<JsonObject> discoverMetadata(WebClient client,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             OidcRequestContextProperties contextProperties, Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters,
-            String authServerUrl,
+            String discoveryUrl,
             long connectionDelayInMillisecs, Vertx vertx, boolean blockingDnsLookup) {
-        final String discoveryUrl = getDiscoveryUri(authServerUrl);
+
         final OidcRequestContextProperties requestProps = requestFilters.isEmpty() ? null
                 : getDiscoveryRequestProps(contextProperties, discoveryUrl);
 
@@ -695,8 +695,8 @@ public class OidcCommonUtils {
         return updatedResponseBody == null ? buffer : updatedResponseBody;
     }
 
-    public static String getDiscoveryUri(String authServerUrl) {
-        return authServerUrl + OidcConstants.WELL_KNOWN_CONFIGURATION;
+    public static String getDiscoveryUri(String authServerUrl, String discoveryPath) {
+        return authServerUrl + (discoveryPath != null ? prependSlash(discoveryPath) : OidcConstants.WELL_KNOWN_CONFIGURATION);
     }
 
     private static byte[] getFileContent(Path path) throws IOException {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfig.java
@@ -13,20 +13,30 @@ import io.smallrye.config.WithDefault;
 @ConfigGroup
 public interface OidcCommonConfig {
     /**
-     * The base URL of the OpenID Connect (OIDC) server, for example, `https://host:port/auth`.
-     * Do not set this property if you use 'quarkus-oidc' and the public key verification ({@link #publicKey})
-     * or certificate chain verification only ({@link #certificateChain}) is required.
-     * The OIDC discovery endpoint is called by default by appending a `.well-known/openid-configuration` path to this URL.
+     * The base URL of an OpenID Connect (OIDC) server, for example, `https://host:port/auth`.
+     * Do not set this property if you use the public key verification ({@link #publicKey})
+     * or certificate chain verification only ({@link #certificateChain}).
+     * <p>
+     * By default, when an OIDC configuration metadata discovery is enabled with the {@link #discoveryEnabled()} property,
+     * it is retrieved from a well known provider endpoint with its URL calculated by appending a value
+     * of the {@link #discoveryPath()} path such as `.well-known/openid-configuration` to this URL.
+     * <p>
      * For Keycloak, use `https://host:port/realms/{realm}`, replacing `{realm}` with the Keycloak realm name.
      */
     Optional<String> authServerUrl();
 
     /**
-     * Discovery of the OIDC endpoints.
+     * Enable discovery of the OIDC endpoints.
      * If not enabled, you must configure the OIDC endpoint URLs individually.
      */
     @ConfigDocDefault("true")
     Optional<Boolean> discoveryEnabled();
+
+    /**
+     * The relative path of the OIDC discovery endpoint.
+     */
+    @WithDefault(".well-known/openid-configuration")
+    String discoveryPath();
 
     /**
      * The relative path or absolute URL of the OIDC dynamic client registration endpoint.

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfigBuilder.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfigBuilder.java
@@ -26,6 +26,7 @@ public abstract class OidcCommonConfigBuilder<T> {
     protected static class OidcCommonConfigImpl implements OidcCommonConfig {
 
         private final Optional<String> authServerUrl;
+        private final String discoveryPath;
         private final Optional<Boolean> discoveryEnabled;
         private final Optional<String> registrationPath;
         private final Optional<Duration> connectionDelay;
@@ -39,6 +40,7 @@ public abstract class OidcCommonConfigBuilder<T> {
 
         protected OidcCommonConfigImpl(OidcCommonConfigBuilder<?> builder) {
             this.authServerUrl = builder.authServerUrl;
+            this.discoveryPath = builder.discoveryPath;
             this.discoveryEnabled = builder.discoveryEnabled;
             this.registrationPath = builder.registrationPath;
             this.connectionDelay = builder.connectionDelay;
@@ -55,6 +57,11 @@ public abstract class OidcCommonConfigBuilder<T> {
         @Override
         public Optional<String> authServerUrl() {
             return authServerUrl;
+        }
+
+        @Override
+        public String discoveryPath() {
+            return discoveryPath;
         }
 
         @Override
@@ -109,6 +116,7 @@ public abstract class OidcCommonConfigBuilder<T> {
     }
 
     private Optional<String> authServerUrl;
+    private String discoveryPath;
     private Optional<Boolean> discoveryEnabled;
     private Optional<String> registrationPath;
     private Optional<Duration> connectionDelay;
@@ -126,6 +134,7 @@ public abstract class OidcCommonConfigBuilder<T> {
 
     protected OidcCommonConfigBuilder(OidcCommonConfig oidcCommonConfig) {
         this.authServerUrl = oidcCommonConfig.authServerUrl();
+        this.discoveryPath = oidcCommonConfig.discoveryPath();
         this.discoveryEnabled = oidcCommonConfig.discoveryEnabled();
         this.registrationPath = oidcCommonConfig.registrationPath();
         this.connectionDelay = oidcCommonConfig.connectionDelay();
@@ -150,6 +159,15 @@ public abstract class OidcCommonConfigBuilder<T> {
      */
     public T authServerUrl(String authServerUrl) {
         this.authServerUrl = Optional.ofNullable(authServerUrl);
+        return getBuilder();
+    }
+
+    /**
+     * @param discoveryPath {@link OidcCommonConfig#discoveryPath()}
+     * @return T builder
+     */
+    public T discoveryPath(String discoveryPath) {
+        this.discoveryPath = discoveryPath;
         return getBuilder();
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
@@ -467,10 +467,11 @@ final class TenantContextFactory {
             metadataUni = Uni.createFrom().item(createLocalMetadata(oidcConfig, authServerUriString));
         } else {
             final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
+            final String discoveryUri = OidcCommonUtils.getDiscoveryUri(authServerUriString, oidcConfig.discoveryPath());
             OidcRequestContextProperties contextProps = new OidcRequestContextProperties(
                     Map.of(OidcUtils.TENANT_ID_ATTRIBUTE, oidcConfig.tenantId().orElse(OidcUtils.DEFAULT_TENANT_ID)));
             metadataUni = OidcCommonUtils
-                    .discoverMetadata(client, oidcRequestFilters, contextProps, oidcResponseFilters, authServerUriString,
+                    .discoverMetadata(client, oidcRequestFilters, contextProps, oidcResponseFilters, discoveryUri,
                             connectionDelayInMillisecs,
                             mutinyVertx,
                             oidcConfig.useBlockingDnsLookup())
@@ -479,7 +480,7 @@ final class TenantContextFactory {
                         @Override
                         public OidcConfigurationMetadata apply(JsonObject json) {
                             return new OidcConfigurationMetadata(json, createLocalMetadata(oidcConfig, authServerUriString),
-                                    OidcCommonUtils.getDiscoveryUri(authServerUriString));
+                                    discoveryUri);
                         }
                     });
         }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -26,6 +26,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
 
     enum ConfigMappingMethods {
         AUTH_SERVER_URL,
+        DISCOVERY_PATH,
         DISCOVERY_ENABLED,
         REGISTRATION_PATH,
         CONNECTION_DELAY,
@@ -1242,6 +1243,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
     public Optional<String> authServerUrl() {
         invocationsRecorder.put(ConfigMappingMethods.AUTH_SERVER_URL, true);
         return Optional.empty();
+    }
+
+    @Override
+    public String discoveryPath() {
+        invocationsRecorder.put(ConfigMappingMethods.DISCOVERY_PATH, true);
+        return null;
     }
 
     @Override

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcDiscoveryJwksRequestCustomizer.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcDiscoveryJwksRequestCustomizer.java
@@ -18,7 +18,10 @@ public class OidcDiscoveryJwksRequestCustomizer implements OidcRequestFilter {
 
     @Override
     public void filter(OidcRequestContext rc) {
-        if (!rc.request().uri().endsWith(".well-known/openid-configuration")
+        String discoveryPath = !rc.request().uri().contains("quarkus2") ? ".well-known/openid-configuration"
+                : ".well-known/oauth-authorization-server";
+
+        if (!rc.request().uri().endsWith(discoveryPath)
                 && !isJwksRequest(rc.request())) {
             throw new OIDCException("Filter is applied to the wrong endpoint: " + rc.request().uri());
         }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -2,6 +2,7 @@ quarkus.oidc.health.enabled=true
 
 # Configuration file
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus2/
+quarkus.oidc.discovery-path=.well-known/oauth-authorization-server
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.authentication.scopes=profile,email,phone
@@ -322,18 +323,21 @@ quarkus.grpc.clients.saluter.port=8081
 quarkus.grpc.server.use-separate-server=false
 
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.auth-server-url=http://localhost:8185/auth/realms/quarkus2
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.discovery-path=.well-known/oauth-authorization-server
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.client-id=quarkus-app
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.token.required-claims.client-name=a
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.credentials.secret=secret
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.token.audience=https://correct-issuer.edu
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-a.token.allow-jwt-introspection=false
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-b.auth-server-url=http://localhost:8185/auth/realms/quarkus2
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-b.discovery-path=/.well-known/oauth-authorization-server
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-b.client-id=quarkus-app
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-b.token.required-claims.client-name=b
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-b.credentials.secret=secret
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-b.token.audience=https://correct-issuer.edu
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-b.token.allow-jwt-introspection=false
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-abc.auth-server-url=http://localhost:8185/auth/realms/quarkus2
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-abc.discovery-path=.well-known/oauth-authorization-server
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-abc.client-id=quarkus-app
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-abc.token.required-claims.client-name=a,b,c
 %issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver-abc.credentials.secret=secret

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
@@ -53,6 +53,7 @@ public class AnnotationBasedTenantTest {
             return Map.ofEntries(Map.entry("quarkus.http.auth.proactive", "false"),
                     Map.entry("quarkus.oidc.hr.authentication.user-info-required", "false"),
                     Map.entry("quarkus.oidc.hr.auth-server-url", "http://localhost:8180/auth/realms/quarkus2/"),
+                    Map.entry("quarkus.oidc.hr.discovery-path", "/.well-known/oauth-authorization-server"),
                     Map.entry("quarkus.oidc.hr.client-id", "quarkus-app"),
                     Map.entry("quarkus.oidc.hr.credentials.secret", "secret"),
                     Map.entry("quarkus.oidc.hr.tenant-paths", "/api/tenant-echo/http-security-policy-applies-all-same"),

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
@@ -40,21 +40,21 @@ public class WiremockTestResource {
         server.start();
 
         server.stubFor(
-                head(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
+                head(urlEqualTo("/auth/realms/quarkus2/.well-known/oauth-authorization-server"))
                         .willReturn(aResponse().withStatus(200)));
 
         server.stubFor(
-                get(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
+                get(urlEqualTo("/auth/realms/quarkus2/.well-known/oauth-authorization-server"))
                         .withHeader("Filter", equalTo("OK"))
                         .withHeader("Cookie", absent())
                         .willReturn(aResponse()
                                 .withStatus(302)
                                 .withHeader("Location", "http://localhost:" + port
-                                        + "/auth/realms/quarkus2/.well-known/openid-configuration")
+                                        + "/auth/realms/quarkus2/.well-known/oauth-authorization-server")
                                 .withHeader("Set-Cookie", "redirect=true; Path=/; Domain=some.domain.com")));
 
         server.stubFor(
-                get(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
+                get(urlEqualTo("/auth/realms/quarkus2/.well-known/oauth-authorization-server"))
                         .withHeader("Cookie", equalTo("redirect=true"))
                         .withHeader("Filter", equalTo("OK"))
                         .withHeader("tenant-id", not(absent()))


### PR DESCRIPTION
Fixes #49668
(After a squash error in #52667)

With MCP Authorization highlighting that not only `.well-known/openid-configuration` well known address for finding the provider metadata is possible it is time to let users customize it.

For ex, a GitHub OAuth2 provider associated with the GitHub MCP Server has its metadata available at `.well-known/oauth-authorization-server/login/oauth`