### PR TITLE
Catch StreamConstraintsException in Jackson message body readers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FullyFeaturedStreamConstraintsExceptionTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FullyFeaturedStreamConstraintsExceptionTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class FullyFeaturedStreamConstraintsExceptionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FroMage.class, Views.class, Resource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        String bigNumber = "9".repeat(1001);
+        RestAssured.with()
+                .contentType("application/json")
+                .body("{\"price\": " + bigNumber + "}")
+                .put("/fromage")
+                .then().statusCode(400);
+    }
+
+    @Path("fromage")
+    public static class Resource {
+
+        @PUT
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public FroMage put(@JsonView(Views.Public.class) FroMage fromage) {
+            return fromage;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/StreamConstraintsExceptionTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/StreamConstraintsExceptionTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class StreamConstraintsExceptionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FroMage.class, FroMageEndpoint.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        String bigNumber = "9".repeat(1001);
+        RestAssured.with()
+                .contentType("application/json")
+                .body("{\"price\": " + bigNumber + "}")
+                .put("/fromage")
+                .then().statusCode(400);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
@@ -27,6 +27,7 @@ import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,12 +79,16 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends AbstractServerJ
              * communicate potential Jackson integration issues, and potential solutions for resolving them.
              */
             throw e;
-        } catch (StreamReadException | DatabindException e) {
+        } catch (StreamReadException | DatabindException | StreamConstraintsException e) {
             /*
-             * As JSON is evaluated, it can be invalid due to one of two reasons:
-             * 1) Malformed JSON. Un-parsable JSON results in a StreamReadException
-             * 2) Valid JSON that violates some binding constraint, i.e., a required property, mismatched data types, etc.
-             * Violations of these types are captured via a DatabindException.
+             * StreamReadException and DatabindException both represent client errors, covering malformed and
+             * semantically invalid JSON respectively. Note that MismatchedInputException and
+             * InvalidDefinitionException are DatabindException subtypes that are handled separately above
+             * and are not wrapped as client errors here.
+             *
+             * StreamConstraintsException must be listed explicitly because it extends JsonProcessingException
+             * directly rather than StreamReadException, and covers constraint violations such as a number
+             * value exceeding the default limit of 1000 digits.
              */
             throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
         }


### PR DESCRIPTION
StreamConstraintsException (Jackson >= 2.15) extends JsonProcessingException directly, not StreamReadException, so the existing catch blocks in ServerJacksonMessageBodyReader and FullyFeaturedServerJacksonMessageBodyReader missed it. JSON input violating stream constraints (e.g. a number exceeding the default maximum of 1000 digits) therefore propagated as an unhandled exception and resulted in a 500 instead of a 400 Bad Request.

- Fixes: #52693