### PR TITLE
Metric reader must use Quarkus classloader - Part III - Handle all exporters

### DIFF
--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -60,6 +60,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/GaugeCdiTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/GaugeCdiTest.java
@@ -45,10 +45,11 @@ public class GaugeCdiTest {
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
                             .add(new StringAsset(
                                     "quarkus.otel.metrics.enabled=true\n" +
+                                            "quarkus.otel.logs.enabled=true\n" +
                                             "quarkus.datasource.db-kind=h2\n" +
                                             "quarkus.datasource.jdbc.telemetry=true\n" +
                                             "quarkus.otel.traces.exporter=test-span-exporter\n" +
-                                            "quarkus.otel.metrics.exporter=in-memory\n" +
+                                            "quarkus.otel.metrics.exporter=in-memory,logging\n" +
                                             "quarkus.otel.metric.export.interval=300ms\n" +
                                             "quarkus.otel.bsp.export.timeout=1s\n" +
                                             "quarkus.otel.bsp.schedule.delay=50\n"),

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -96,18 +97,15 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
     final class ResourceCustomizer implements AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
 
         private final ApplicationConfig appConfig;
-        private final OTelBuildConfig oTelBuildConfig;
         private final OTelRuntimeConfig oTelRuntimeConfig;
         private final Instance<DelayedAttributes> delayedAttributes;
         private final List<Resource> resources;
 
         public ResourceCustomizer(ApplicationConfig appConfig,
-                OTelBuildConfig oTelBuildConfig,
                 OTelRuntimeConfig oTelRuntimeConfig,
                 @Any Instance<DelayedAttributes> delayedAttributes,
                 @All List<Resource> resources) {
             this.appConfig = appConfig;
-            this.oTelBuildConfig = oTelBuildConfig;
             this.oTelRuntimeConfig = oTelRuntimeConfig;
             this.delayedAttributes = delayedAttributes;
             this.resources = resources;
@@ -257,23 +255,21 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
         private final OTelBuildConfig oTelBuildConfig;
         private final OTelRuntimeConfig oTelRuntimeConfig;
         private final Instance<Clock> clock;
-        private final Instance<MetricExporter> metricExporter;
         private final Instance<ScheduledExecutorService> managedExecutor;
 
         public MetricProviderCustomizer(OTelBuildConfig oTelBuildConfig,
                 OTelRuntimeConfig runtimeConfig,
                 final Instance<Clock> clock,
-                final Instance<MetricExporter> metricExporter,
                 final Instance<ScheduledExecutorService> managedExecutor) {
             this.oTelBuildConfig = oTelBuildConfig;
             this.clock = clock;
-            this.metricExporter = metricExporter;
             this.managedExecutor = managedExecutor;
             this.oTelRuntimeConfig = runtimeConfig;
         }
 
         @Override
         public void customize(AutoConfiguredOpenTelemetrySdkBuilder builder) {
+            AtomicReference<MetricExporter> metricExporterRef = new AtomicReference<>();
             builder.addMeterProviderCustomizer(
                     new BiFunction<SdkMeterProviderBuilder, ConfigProperties, SdkMeterProviderBuilder>() {
                         @Override
@@ -303,15 +299,20 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
                             return meterProviderBuilder;
                         }
                     })
+                    .addMetricExporterCustomizer(new BiFunction<MetricExporter, ConfigProperties, MetricExporter>() {
+                        @Override
+                        public MetricExporter apply(MetricExporter metricExporter, ConfigProperties configProperties) {
+                            metricExporterRef.set(metricExporter);
+                            return metricExporter;
+                        }
+                    })
                     .addMetricReaderCustomizer(new BiFunction<MetricReader, ConfigProperties, MetricReader>() {
                         @Override
                         public MetricReader apply(MetricReader metricReader, ConfigProperties configProperties) {
                             // Replace the provided metric reader because it uses an unmanaged executor
                             // with a null classloader
-                            if (metricReader instanceof PeriodicMetricReader &&
-                                    metricExporter.isResolvable() &&
-                                    managedExecutor.isResolvable()) {
-                                return PeriodicMetricReader.builder(metricExporter.get())
+                            if (metricReader instanceof PeriodicMetricReader && managedExecutor.isResolvable()) {
+                                return PeriodicMetricReader.builder(metricExporterRef.get())
                                         .setInterval(oTelRuntimeConfig.metric().exportInterval())
                                         .setExecutor(managedExecutor.get())
                                         .build();

--- a/tcks/microprofile-opentelemetry/pom.xml
+++ b/tcks/microprofile-opentelemetry/pom.xml
@@ -77,7 +77,7 @@
                                 <quarkus.otel.traces.exporter>none</quarkus.otel.traces.exporter>
                                 <quarkus.otel.metrics.enabled>true</quarkus.otel.metrics.enabled>
                                 <quarkus.otel.metrics.exporter>logging</quarkus.otel.metrics.exporter>
-                                <quarkus.otel.metric.export.interval>1000</quarkus.otel.metric.export.interval>
+                                <quarkus.otel.metric.export.interval>PT1S</quarkus.otel.metric.export.interval>
                                 <quarkus.log.file.enable>true</quarkus.log.file.enable>
                                 <quarkus.log.file.path>${project.build.directory}/out.log</quarkus.log.file.path>
                                 <mptelemetry.tck.log.file.path>${project.build.directory}/out.log</mptelemetry.tck.log.file.path>


### PR DESCRIPTION
This way we handle all exporters, not just the one controlled by CDI.
Users can list multiple exporters to be used.
This adds on top of #52633, part III.
