### PR TITLE
Adjust since version of openapi runstage deprecations

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -649,7 +649,7 @@ public class SmallRyeOpenApiProcessor {
      *         {@link io.quarkus.smallrye.openapi.OpenApiFilter.RunStage#RUN}
      * @deprecated This will be removed once {@link OpenApiFilter#value()} is also removed.
      */
-    @Deprecated(since = "3.34", forRemoval = true)
+    @Deprecated(since = "3.32", forRemoval = true)
     @SuppressWarnings("removal")
     private Set<OpenApiFilter.RunStage> resolveStages(AnnotationInstance ai, IndexView index) {
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunStageAlwaysRunConfigFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunStageAlwaysRunConfigFilterTest.java
@@ -34,7 +34,7 @@ import io.quarkus.test.QuarkusUnitTest;
  *             io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService#prepareDocument for a reference of the expected effect
  *             of always-run-filter
  */
-@Deprecated(since = "3.34", forRemoval = true)
+@Deprecated(since = "3.32", forRemoval = true)
 class OpenApiRunStageAlwaysRunConfigFilterTest {
 
     private static final String STORE_SCHEMA_DIRECTORY = "target/generated/OpenApiRunStageAlwaysRunConfigFilterTest/";

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/OpenApiFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/OpenApiFilter.java
@@ -45,7 +45,7 @@ public @interface OpenApiFilter {
      *
      * @deprecated Use {@link #stages()} instead.
      */
-    @Deprecated(since = "3.34", forRemoval = true)
+    @Deprecated(since = "3.32", forRemoval = true)
     RunStage value() default RunStage.RUN;
 
     /**
@@ -72,7 +72,7 @@ public @interface OpenApiFilter {
          * @deprecated Consider replacing with either {@link RunStage#RUNTIME_STARTUP} or {@link RunStage#RUNTIME_PER_REQUEST},
          *             depending on the value of the now also deprecated quarkus.smallrye-openapi.always-run-filter.
          */
-        @Deprecated(since = "3.34", forRemoval = true)
+        @Deprecated(since = "3.32", forRemoval = true)
         RUN,
 
         /**
@@ -81,7 +81,7 @@ public @interface OpenApiFilter {
          *             OpenApiFilter.RunStage.RUNTIME_PER_REQUEST}}, depending on the value of the now also deprecated
          *             quarkus.smallrye-openapi.always-run-filter.
          */
-        @Deprecated(since = "3.34", forRemoval = true)
+        @Deprecated(since = "3.32", forRemoval = true)
         BOTH,
 
         /**


### PR DESCRIPTION
Will be backported to 3.32, change the since to reflect that.

Related to #52669