### PR TITLE
Dev UI/MCP: shorten method names

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/OperationName.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/OperationName.java
@@ -1,0 +1,46 @@
+package io.quarkus.runtime.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies an alternative name for the method part of a JsonRPC method name.
+ * The full method name is composed as {@code namespace_methodName}, and this
+ * annotation only overrides the {@code methodName} part while preserving the namespace.
+ *
+ * <p>
+ * This is useful for both Dev UI and MCP (Model Context Protocol) clients.
+ * Some MCP clients may introduce a name size limit,
+ * so method names should ideally be under 60 characters.
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>
+ * // If the namespace is "devui-continuous-testing" and the Java method is "getContinuousTestingResults",
+ * // the default full name would be "devui-continuous-testing_getContinuousTestingResults" (52 chars).
+ * // Using this annotation to shorten the method part:
+ * &#64;OperationName("getResults")
+ * &#64;JsonRpcDescription("Get the results of a Continuous testing test run")
+ * public TestStatus getContinuousTestingResults() {
+ *     // The effective name becomes "devui-continuous-testing_getResults" (35 chars)
+ * }
+ * </pre>
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+@Documented
+public @interface OperationName {
+
+    /**
+     * @return the alternative name for this method
+     */
+    String value();
+
+}

--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -161,7 +161,46 @@ The code in the `function` runs on the deployment classpath. The function can re
 
 By default this tool will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFuctionByDefault()` in the builder method.
 
+=== Method naming
+
+MCP tool names are constructed as `namespace_methodName`, where the namespace is typically derived from the extension's artifact ID (e.g., `quarkus-smallrye-health_getHealth`).
+
+Some MCP clients may introduce a name size limit. Since the client may also prepend its own server identifier prefix, it's recommended to keep method names under 60 characters.
+
+==== Shortening runtime method names
+
+For runtime classpath methods, use the `@OperationName` annotation to provide a shorter method name:
+
+[source,java]
+----
+public class MyExtensionRPCService {
+
+    @OperationName("getHealth")  // <1>
+    @JsonRpcDescription("Get the current health status")
+    public SmallRyeHealth getDetailedHealthCheckResults() { // <2>
+        // implementation…
+    }
+}
+----
+<1> The `@OperationName` annotation overrides the method name part. The full MCP name becomes `namespace_getHealth` instead of `namespace_getDetailedHealthCheckResults`.
+<2> The Java method name can remain descriptive for code readability.
+
+==== Shortening deployment method names
+
+For deployment classpath methods, simply use a shorter name in the `.methodName()` builder call:
+
+[source,java]
+----
+actions.actionBuilder()
+        .methodName("getResults")  // <1>
+        .description("Get the test results")
+        .enableMcpFuctionByDefault()
+        .function(ignored -> getTestResults())
+        .build();
+----
+<1> Use a concise method name directly. The full MCP name becomes `namespace_getResults`.
+
 === JSON‑RPC usage
 
-By default all JSON‑RPC methods are visible in the Dev UI. Only methods with descriptions are exposed via Dev MCP. 
+By default all JSON‑RPC methods are visible in the Dev UI. Only methods with descriptions are exposed via Dev MCP.
 You can override this behaviour with the `@JsonRpcUsage` annotation. Pass one or both of the `Usage` enums (`DEV_UI`, `DEV_MCP`) to control where a method is exposed.

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/AbstractDevUIBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/AbstractDevUIBuildItem.java
@@ -62,13 +62,22 @@ public abstract class AbstractDevUIBuildItem extends MultiBuildItem {
         return this.artifactKey;
     }
 
+    private String cachedExtensionPathName = null;
+
     public String getExtensionPathName(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        if (this.cachedExtensionPathName != null) {
+            return this.cachedExtensionPathName;
+        }
+
         if (this.extensionIdentifier == null) {
             ArtifactKey ak = getArtifactKey(curateOutcomeBuildItem);
             this.extensionIdentifier = ak.getArtifactId();
         }
 
-        return this.extensionIdentifier;
+        // Return full identifier without stripping prefixes
+        // Use @OperationName annotation for shorter names
+        this.cachedExtensionPathName = this.extensionIdentifier;
+        return this.cachedExtensionPathName;
     }
 
     public boolean isInternal() {

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
@@ -184,7 +184,8 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
                 parameters = null;
             if (function != null) {
                 return addAction(
-                        new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                        new DeploymentJsonRpcMethod(methodName, description, parameters,
+                                autoUsage(usage, description),
                                 mcpEnabledByDefault,
                                 function));
             } else if (runtimeValue != null) {
@@ -194,7 +195,8 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
                                 runtimeValue));
             } else if (assistantFunction != null) {
                 return addAction(
-                        new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                        new DeploymentJsonRpcMethod(methodName, description, parameters,
+                                autoUsage(usage, description),
                                 mcpEnabledByDefault,
                                 assistantFunction));
             } else {
@@ -266,12 +268,14 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
             if (parameters.isEmpty())
                 parameters = null;
             if (function != null) {
-                addSubscription(new DeploymentJsonRpcMethod(methodName, description, parameters, autoUsage(usage, description),
+                addSubscription(new DeploymentJsonRpcMethod(methodName, description, parameters,
+                        autoUsage(usage, description),
                         mcpEnabledByDefault,
                         function));
             } else if (runtimeValue != null) {
                 addSubscription(
-                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description), mcpEnabledByDefault,
+                        new RecordedJsonRpcMethod(methodName, description, autoUsage(usage, description),
+                                mcpEnabledByDefault,
                                 runtimeValue));
             } else {
                 throw new IllegalStateException("Either function or runtimeValue must be provided");

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/AbstractJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/AbstractJsonRpcMethod.java
@@ -12,6 +12,8 @@ import io.quarkus.runtime.annotations.Usage;
 public abstract class AbstractJsonRpcMethod {
 
     private String methodName;
+    private String jsonRpcName;
+    private String effectiveJsonRpcNameCache;
     private String description;
     private Map<String, Parameter> parameters;
     private EnumSet<Usage> usage;
@@ -28,9 +30,28 @@ public abstract class AbstractJsonRpcMethod {
         this.mcpEnabledByDefault = mcpEnabledByDefault;
     }
 
+    public AbstractJsonRpcMethod(String methodName, String jsonRpcName, String description,
+            EnumSet<Usage> usage, boolean mcpEnabledByDefault) {
+        this.methodName = methodName;
+        this.jsonRpcName = jsonRpcName;
+        this.description = description;
+        this.usage = usage;
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
+    }
+
     public AbstractJsonRpcMethod(String methodName, String description, Map<String, Parameter> parameters,
             EnumSet<Usage> usage, boolean mcpEnabledByDefault) {
         this.methodName = methodName;
+        this.description = description;
+        this.parameters = parameters;
+        this.usage = usage;
+        this.mcpEnabledByDefault = mcpEnabledByDefault;
+    }
+
+    public AbstractJsonRpcMethod(String methodName, String jsonRpcName, String description, Map<String, Parameter> parameters,
+            EnumSet<Usage> usage, boolean mcpEnabledByDefault) {
+        this.methodName = methodName;
+        this.jsonRpcName = jsonRpcName;
         this.description = description;
         this.parameters = parameters;
         this.usage = usage;
@@ -43,7 +64,45 @@ public abstract class AbstractJsonRpcMethod {
 
     public void setMethodName(String methodName) {
         this.methodName = methodName;
+        this.effectiveJsonRpcNameCache = null; // Invalidate cache
     }
+
+    public String getJsonRpcName() {
+        return jsonRpcName;
+    }
+
+    public void setJsonRpcName(String jsonRpcName) {
+        this.jsonRpcName = jsonRpcName;
+        this.effectiveJsonRpcNameCache = null; // Invalidate cache
+    }
+
+    /**
+     * Returns the effective JsonRPC name by combining the namespace (extracted from methodName)
+     * with the jsonRpcName if set, otherwise returns the full methodName.
+     * <p>
+     * The jsonRpcName only overrides the method name part, not the namespace.
+     * For example, if methodName is "devui-continuous-testing_getContinuousTestingResults"
+     * and jsonRpcName is "getResults", the effective name would be "devui-continuous-testing_getResults".
+     *
+     * @return the effective name to use
+     */
+    public String getEffectiveJsonRpcName() {
+        if (effectiveJsonRpcNameCache != null) {
+            return effectiveJsonRpcNameCache;
+        }
+        if (jsonRpcName != null && methodName != null) {
+            int underscoreIndex = methodName.indexOf(UNDERSCORE);
+            if (underscoreIndex > 0) {
+                String namespace = methodName.substring(0, underscoreIndex);
+                effectiveJsonRpcNameCache = namespace + UNDERSCORE + jsonRpcName;
+                return effectiveJsonRpcNameCache;
+            }
+        }
+        effectiveJsonRpcNameCache = methodName;
+        return effectiveJsonRpcNameCache;
+    }
+
+    private static final String UNDERSCORE = "_";
 
     public String getDescription() {
         return description;

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RuntimeJsonRpcMethod.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/jsonrpc/RuntimeJsonRpcMethod.java
@@ -32,6 +32,21 @@ public final class RuntimeJsonRpcMethod extends AbstractJsonRpcMethod {
         this.nonBlocking = nonBlocking;
     }
 
+    public RuntimeJsonRpcMethod(String methodName,
+            String jsonRpcName,
+            String description,
+            Map<String, Parameter> parameters,
+            EnumSet<Usage> usage,
+            boolean mcpEnabledByDefault,
+            Class<?> bean,
+            boolean blocking,
+            boolean nonBlocking) {
+        super(methodName, jsonRpcName, description, parameters, usage, mcpEnabledByDefault);
+        this.bean = bean;
+        this.blocking = blocking;
+        this.nonBlocking = nonBlocking;
+    }
+
     public Class<?> getBean() {
         return bean;
     }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -270,6 +270,7 @@ public class BuildTimeContentProcessor {
             // Build time methods
             for (DeploymentJsonRpcMethod deploymentJsonRpcMethod : actions.getDeploymentActions()) {
                 String fullName = extensionPathName + UNDERSCORE + deploymentJsonRpcMethod.getMethodName();
+                warnIfJsonRpcNameTooLong(deploymentJsonRpcMethod.getEffectiveJsonRpcName(), fullName);
                 if (deploymentJsonRpcMethod.hasAction()) {
                     DevConsoleManager.register(fullName, deploymentJsonRpcMethod.getAction());
                 } else if (deploymentJsonRpcMethod.hasAssistantAction()) {
@@ -282,6 +283,7 @@ public class BuildTimeContentProcessor {
             // Build time recorded values
             for (RecordedJsonRpcMethod recordedJsonRpcMethod : actions.getRecordedActions()) {
                 String fullName = extensionPathName + UNDERSCORE + recordedJsonRpcMethod.getMethodName();
+                warnIfJsonRpcNameTooLong(recordedJsonRpcMethod.getEffectiveJsonRpcName(), fullName);
                 recordedJsonRpcMethod.setMethodName(fullName);
                 recordedMethods.put(fullName, recordedJsonRpcMethod);
             }
@@ -289,6 +291,7 @@ public class BuildTimeContentProcessor {
             // Build time subscriptions
             for (DeploymentJsonRpcMethod deploymentJsonRpcSubscription : actions.getDeploymentSubscriptions()) {
                 String fullName = extensionPathName + UNDERSCORE + deploymentJsonRpcSubscription.getMethodName();
+                warnIfJsonRpcNameTooLong(deploymentJsonRpcSubscription.getEffectiveJsonRpcName(), fullName);
                 if (deploymentJsonRpcSubscription.hasAction()) {
                     DevConsoleManager.register(fullName, deploymentJsonRpcSubscription.getAction());
                 } else if (deploymentJsonRpcSubscription.hasAssistantAction()) {
@@ -300,6 +303,7 @@ public class BuildTimeContentProcessor {
             // Build time recorded subscription
             for (RecordedJsonRpcMethod recordedJsonRpcSubscription : actions.getRecordedSubscriptions()) {
                 String fullName = extensionPathName + UNDERSCORE + recordedJsonRpcSubscription.getMethodName();
+                warnIfJsonRpcNameTooLong(recordedJsonRpcSubscription.getEffectiveJsonRpcName(), fullName);
                 recordedJsonRpcSubscription.setMethodName(fullName);
                 recordedSubscriptions.put(fullName, recordedJsonRpcSubscription);
             }
@@ -1366,6 +1370,30 @@ public class BuildTimeContentProcessor {
 
         static Color from(int hue, int saturation, int lightness, double alpha) {
             return new Color(hue, saturation, lightness, alpha);
+        }
+    }
+
+    private static final int MAX_MCP_NAME_LENGTH = 60;
+
+    private void warnIfJsonRpcNameTooLong(String jsonRpcName, String fullName) {
+        // The jsonRpcName only overrides the method part, namespace is preserved
+        String effectiveName;
+        if (jsonRpcName != null) {
+            int underscoreIndex = fullName.indexOf(UNDERSCORE);
+            if (underscoreIndex > 0) {
+                String namespace = fullName.substring(0, underscoreIndex);
+                effectiveName = namespace + UNDERSCORE + jsonRpcName;
+            } else {
+                effectiveName = fullName;
+            }
+        } else {
+            effectiveName = fullName;
+        }
+        if (effectiveName.length() > MAX_MCP_NAME_LENGTH) {
+            log.warnf("JsonRPC method name '%s' exceeds %d characters (length: %d). " +
+                    "Consider using a shorter .methodName() on the builder. " +
+                    "MCP clients may introduce a name size limit.",
+                    effectiveName, MAX_MCP_NAME_LENGTH, effectiveName.length());
         }
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -105,6 +105,7 @@ import io.quarkus.qute.Qute;
 import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 import io.quarkus.runtime.annotations.JsonRpcUsage;
+import io.quarkus.runtime.annotations.OperationName;
 import io.quarkus.runtime.annotations.Usage;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
@@ -483,6 +484,7 @@ public class DevUIProcessor {
 
         DotName descriptionAnnotation = DotName.createSimple(JsonRpcDescription.class);
         DotName devMCPEnableByDefaultAnnotation = DotName.createSimple(DevMCPEnableByDefault.class);
+        DotName operationNameAnnotation = DotName.createSimple(OperationName.class);
 
         // Let's use the Jandex index to find all methods
         for (JsonRPCProvidersBuildItem jsonRPCProvidersBuildItem : jsonRPCProvidersBuildItems) {
@@ -498,6 +500,16 @@ public class DevUIProcessor {
                             && method.returnType().kind() != Type.Kind.VOID) {
 
                         String methodName = extension + UNDERSCORE + method.name();
+
+                        // Look for @OperationName annotation
+                        String operationName = null;
+                        AnnotationInstance operationNameAnnotationInstance = method.annotation(operationNameAnnotation);
+                        if (operationNameAnnotationInstance != null) {
+                            AnnotationValue operationNameValue = operationNameAnnotationInstance.value();
+                            if (operationNameValue != null && !operationNameValue.asString().isBlank()) {
+                                operationName = operationNameValue.asString();
+                            }
+                        }
 
                         Map<String, AbstractJsonRpcMethod.Parameter> parameters = new LinkedHashMap<>(); // Keep the order
                         for (int i = 0; i < method.parametersCount(); i++) {
@@ -555,7 +567,20 @@ public class DevUIProcessor {
                             usage = Usage.onlyDevUI();
                         }
 
-                        RuntimeJsonRpcMethod runtimeJsonRpcMethod = new RuntimeJsonRpcMethod(methodName, description,
+                        // Warn if effective JsonRPC name exceeds 60 characters
+                        // The operationName only overrides the method part, namespace is preserved
+                        String effectiveJsonRpcName = operationName != null
+                                ? (extension + UNDERSCORE + operationName)
+                                : methodName;
+                        if (effectiveJsonRpcName.length() > 60) {
+                            log.warnf("JsonRPC method name '%s' exceeds 60 characters (length: %d). " +
+                                    "Consider adding @OperationName annotation with a shorter name. " +
+                                    "MCP clients may introduce a name size limit.",
+                                    effectiveJsonRpcName, effectiveJsonRpcName.length());
+                        }
+
+                        RuntimeJsonRpcMethod runtimeJsonRpcMethod = new RuntimeJsonRpcMethod(methodName, operationName,
+                                description,
                                 parameters,
                                 usage,
                                 mcpEnabledByDefault,
@@ -663,6 +688,7 @@ public class DevUIProcessor {
         JsonRpcMethod o = new JsonRpcMethod();
 
         o.setMethodName(i.getMethodName());
+        o.setJsonRpcName(i.getJsonRpcName());
         o.setDescription(i.getDescription());
         o.setUsage(List.copyOf(i.getUsage()));
         o.setMcpEnabledByDefault(i.isMcpEnabledByDefault());

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -266,6 +266,9 @@ public class ContinuousTestingProcessor {
                 .build();
     }
 
+    /**
+     * Internal method used by ContinuousTestingJsonRPCService.
+     */
     private void registerGetResultsMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
         actions.actionBuilder()
                 .methodName("getResults")
@@ -276,11 +279,11 @@ public class ContinuousTestingProcessor {
     }
 
     /**
-     * Duplicate of getResults but using a MCP friendly version of TestRunResults.
+     * MCP method returning trimmed TestRunResults.
      */
     private void registerGetResultsMCPMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
         actions.actionBuilder()
-                .methodName("getContinuousTestingResults")
+                .methodName("getTestResults")
                 .description("Get the results of a Continuous testing test run")
                 .enableMcpFuctionByDefault()
                 .function(ignored -> {

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-resources.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-resources.js
@@ -155,11 +155,11 @@ export class QwcDevMCPResources extends observeState(LitElement) {
     }
 
     _namespaceRenderer(prop) {
-        return html`${prop.name.split('_')[0]}`;
+        return html`<span title="${prop.name}">${prop.name.split('_')[0]}</span>`;
     }
-    
+
     _nameRenderer(prop) {
-        return html`${prop.name.split('_')[1]}`;
+        return html`<span title="${prop.name}">${prop.name.split('_')[1]}</span>`;
     }
 
     _stateRenderer(prop) {

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-setting.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-setting.js
@@ -303,6 +303,13 @@ export class QwcDevMCPSetting extends QwcHotReloadElement {
         }
       },
       {
+        name: 'Claude Code',
+        icon: 'font-awesome-solid:terminal',
+        file: 'Run in terminal',
+        docsUrl: 'https://docs.anthropic.com/en/docs/claude-code',
+        configString: `claude mcp add --transport http devmcp ${this._mcpPath}`
+      },
+      {
         name: 'Cline',
         icon: 'font-awesome-solid:terminal',
         file: 'Cline MCP Settings (via UI)',

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-tools.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-dev-mcp-tools.js
@@ -265,11 +265,11 @@ export class QwcDevMCPTools extends QwcHotReloadElement {
     }
 
     _namespaceRenderer(prop) {
-        return html`${prop.name.split('_')[0]}`;
+        return html`<span title="${prop.name}">${prop.name.split('_')[0]}</span>`;
     }
-    
+
     _nameRenderer(prop) {
-        return html`${prop.name.split('_')[1]}`;
+        return html`<span title="${prop.name}">${prop.name.split('_')[1]}</span>`;
     }
 
     _noOfParameterRenderer(prop) {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
@@ -15,6 +15,8 @@ import io.smallrye.mutiny.Uni;
 public final class JsonRpcMethod {
     private Class bean;
     private String methodName;
+    private String jsonRpcName;
+    private String effectiveJsonRpcNameCache;
     private String description;
     private Method javaMethod;
     private Map<String, Parameter> parameters;
@@ -51,6 +53,42 @@ public final class JsonRpcMethod {
 
     public void setMethodName(String methodName) {
         this.methodName = methodName;
+        this.effectiveJsonRpcNameCache = null; // Invalidate cache
+    }
+
+    public String getJsonRpcName() {
+        return jsonRpcName;
+    }
+
+    public void setJsonRpcName(String jsonRpcName) {
+        this.jsonRpcName = jsonRpcName;
+        this.effectiveJsonRpcNameCache = null; // Invalidate cache
+    }
+
+    /**
+     * Returns the effective JsonRPC name by combining the namespace (extracted from methodName)
+     * with the jsonRpcName if set, otherwise returns the full methodName.
+     * <p>
+     * The jsonRpcName only overrides the method name part, not the namespace.
+     * For example, if methodName is "devui-continuous-testing_getContinuousTestingResults"
+     * and jsonRpcName is "getResults", the effective name would be "devui-continuous-testing_getResults".
+     *
+     * @return the effective name to use
+     */
+    public String getEffectiveJsonRpcName() {
+        if (effectiveJsonRpcNameCache != null) {
+            return effectiveJsonRpcNameCache;
+        }
+        if (jsonRpcName != null && methodName != null) {
+            int underscoreIndex = methodName.indexOf(UNDERSCORE);
+            if (underscoreIndex > 0) {
+                String namespace = methodName.substring(0, underscoreIndex);
+                effectiveJsonRpcNameCache = namespace + UNDERSCORE + jsonRpcName;
+                return effectiveJsonRpcNameCache;
+            }
+        }
+        effectiveJsonRpcNameCache = methodName;
+        return effectiveJsonRpcNameCache;
     }
 
     public String getDescription() {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
@@ -1,5 +1,6 @@
 package io.quarkus.devui.runtime.mcp;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.enterprise.inject.spi.CDI;
@@ -7,6 +8,7 @@ import jakarta.enterprise.inject.spi.CDI;
 import io.quarkus.devui.runtime.comms.JsonRpcRouter;
 import io.quarkus.devui.runtime.comms.MessageType;
 import io.quarkus.devui.runtime.jsonrpc.JsonRpcCodec;
+import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
 import io.quarkus.devui.runtime.jsonrpc.JsonRpcRequest;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.runtime.mcp.model.InitializeResponse;
@@ -22,6 +24,9 @@ public class McpHttpHandler implements Handler<RoutingContext> {
     private final String quarkusVersion;
     private final JsonMapper jsonMapper;
     private final JsonRpcCodec codec;
+
+    // Lazily built mapping from mcpName -> jsonRpcMethodName
+    private volatile Map<String, String> mcpNameToJsonRpcName;
 
     public McpHttpHandler(String quarkusVersion, JsonMapper jsonMapper) {
         this.quarkusVersion = quarkusVersion;
@@ -120,6 +125,12 @@ public class McpHttpHandler implements Handler<RoutingContext> {
                 jsonRpcRequest.setParams(Map.of("uri", uri));
                 jsonRpcRouter.route(jsonRpcRequest, writer);
             } else {
+                // Translate MCP name to JsonRPC name if needed
+                String jsonRpcMethodName = translateMcpNameToJsonRpcName(jsonRpcRouter, methodName);
+                if (!jsonRpcMethodName.equals(methodName)) {
+                    jsonRpcRequest.setMethod(jsonRpcMethodName);
+                }
+
                 if (jsonRpcRouter.isEnabled(jsonRpcRequest)) {
                     jsonRpcRouter.route(jsonRpcRequest, writer);
                 } else {
@@ -146,6 +157,57 @@ public class McpHttpHandler implements Handler<RoutingContext> {
         // TODO: Do something with the notification ?
 
         writer.getResponse().setStatusCode(202).end();
+    }
+
+    private String translateMcpNameToJsonRpcName(JsonRpcRouter jsonRpcRouter, String mcpName) {
+        // Check if mcpName is already a valid JsonRPC method
+        if (isKnownJsonRpcMethod(jsonRpcRouter, mcpName)) {
+            return mcpName;
+        }
+
+        // Lazily build the mapping
+        if (mcpNameToJsonRpcName == null) {
+            synchronized (this) {
+                if (mcpNameToJsonRpcName == null) {
+                    mcpNameToJsonRpcName = buildMcpNameMapping(jsonRpcRouter);
+                }
+            }
+        }
+
+        return mcpNameToJsonRpcName.getOrDefault(mcpName, mcpName);
+    }
+
+    private boolean isKnownJsonRpcMethod(JsonRpcRouter router, String name) {
+        return router.getRuntimeMethodsMap().containsKey(name)
+                || router.getRuntimeSubscriptionMap().containsKey(name)
+                || router.getDeploymentMethodsMap().containsKey(name)
+                || router.getDeploymentSubscriptionsMap().containsKey(name)
+                || router.getRecordedMethodsMap().containsKey(name)
+                || router.getRecordedSubscriptionsMap().containsKey(name);
+    }
+
+    private Map<String, String> buildMcpNameMapping(JsonRpcRouter router) {
+        Map<String, String> mapping = new HashMap<>();
+
+        addMappings(mapping, router.getRuntimeMethodsMap());
+        addMappings(mapping, router.getRuntimeSubscriptionMap());
+        addMappings(mapping, router.getDeploymentMethodsMap());
+        addMappings(mapping, router.getDeploymentSubscriptionsMap());
+        addMappings(mapping, router.getRecordedMethodsMap());
+        addMappings(mapping, router.getRecordedSubscriptionsMap());
+
+        return mapping;
+    }
+
+    private void addMappings(Map<String, String> mapping, Map<String, JsonRpcMethod> methods) {
+        for (JsonRpcMethod method : methods.values()) {
+            if (method.getJsonRpcName() != null) {
+                String effectiveName = method.getEffectiveJsonRpcName();
+                if (!effectiveName.equals(method.getMethodName())) {
+                    mapping.put(effectiveName, method.getMethodName());
+                }
+            }
+        }
     }
 
     private static final String SLASH = "/";

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
@@ -181,8 +181,10 @@ public class McpResourcesService {
         for (JsonRpcMethod recordedJsonRpcMethod : recordedMethodsMap.values()) {
             if (isEnabled(recordedJsonRpcMethod, filter)) {
                 Resource resource = new Resource();
+                // Keep URI using methodName for internal routing
                 resource.uri = URI_SCHEME + SUB_SCHEME_RECORDED + recordedJsonRpcMethod.getMethodName();
-                resource.name = recordedJsonRpcMethod.getMethodName();
+                // Use effective MCP name for display
+                resource.name = recordedJsonRpcMethod.getEffectiveJsonRpcName();
 
                 if (recordedJsonRpcMethod.getDescription() != null && !recordedJsonRpcMethod.getDescription().isBlank()) {
                     resource.description = recordedJsonRpcMethod.getDescription();

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
@@ -82,7 +82,8 @@ public class McpToolsService {
 
     private Tool toTool(JsonRpcMethod jsonRpcMethod) {
         Tool tool = new Tool();
-        tool.name = jsonRpcMethod.getMethodName();
+        // Use effective JsonRPC name (jsonRpcName if set, otherwise methodName)
+        tool.name = jsonRpcMethod.getEffectiveJsonRpcName();
         if (jsonRpcMethod.getDescription() != null && !jsonRpcMethod.getDescription().isBlank()) {
             tool.description = jsonRpcMethod.getDescription();
         }


### PR DESCRIPTION
Fixes #52701

Allows a way to shortern JsonRPC Method names. Useful when using it with Dev MCP.

I also added a tooltip to the Dev MCP tools and resources page to see the actual method name