### PR TITLE
Make the Dev MCP Resource URI parsing safer

### DIFF
--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
@@ -260,4 +260,33 @@ public class DevMcpTest {
 
     }
 
+    @Test
+    public void testResourcesReadWithInvalidUri() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 7,
+                      "method": "resources/read",
+                      "params": {
+                           "uri": "quarkus://"
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(7))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("error.code", CoreMatchers.equalTo(-32603))
+                .body("error.message", CoreMatchers.containsString("Invalid resource URI"));
+
+    }
+
 }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
@@ -85,6 +85,10 @@ public class McpResourcesService {
     public Map<String, List<Content>> read(
             @JsonRpcDescription("The uri of the resources as defined in resources/list") String uri) {
         if (mcpDevUIJsonRpcService.getMcpServerConfiguration().isEnabled()) {
+            if (uri == null || !uri.startsWith(URI_SCHEME)) {
+                throw new IllegalArgumentException(
+                        "Invalid resource URI: " + uri + ". Expected URI starting with: " + URI_SCHEME);
+            }
             String subUri = uri.substring(URI_SCHEME.length());
             if (subUri.startsWith(SUB_SCHEME_BUILD_TIME)) {
                 return readBuildTimeData(uri);
@@ -102,6 +106,11 @@ public class McpResourcesService {
 
         String method = uri.substring((URI_SCHEME + SUB_SCHEME_BUILD_TIME).length());
         String[] split = method.split(UNDERSCORE);
+        if (split.length < 2) {
+            throw new IllegalArgumentException(
+                    "Invalid build-time resource URI: " + uri + ". Expected format: " + URI_SCHEME + SUB_SCHEME_BUILD_TIME
+                            + "<namespace>_<name>");
+        }
         String ns = split[0];
         String constt = split[1];
         String filename = ns + DASH_DATA_DOT_JS;


### PR DESCRIPTION
Fix #52238

I am not sure why windsurf send these uri, but this will make sure we do not fail, but send an error response