### PR TITLE
Prep changes for loading Maven POM 4.1

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BootstrapFromOriginalJarTestBase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BootstrapFromOriginalJarTestBase.java
@@ -193,7 +193,9 @@ public abstract class BootstrapFromOriginalJarTestBase extends PackageAppTestBas
                             break;
                         }
                     }
+                    boolean addProfileToParent = false;
                     if (profile == null) {
+                        addProfileToParent = true;
                         for (Profile p : appPom.getProfiles()) {
                             if (p.getId().equals(profileModules.getKey())) {
                                 profile = p;
@@ -205,13 +207,13 @@ public abstract class BootstrapFromOriginalJarTestBase extends PackageAppTestBas
                                     "Failed to locate profile " + profileModules.getKey() + " in the application POM");
                         }
                         final Profile tmp = new Profile();
+                        tmp.setId(profileModules.getKey());
                         tmp.setActivation(profile.getActivation());
                         profile = tmp;
-                        parentPom.getProfiles().add(profile);
                     }
 
                     for (TsArtifact a : profileModules.getValue()) {
-                        profile.getModules().add(a.getArtifactId());
+                        profile.addModule(a.getArtifactId());
                         Model modulePom = a.getPomModel();
                         modulePom.setParent(parent);
                         final Path moduleDir = IoUtils.mkdirs(ws.resolve(modulePom.getArtifactId()));
@@ -225,6 +227,10 @@ public abstract class BootstrapFromOriginalJarTestBase extends PackageAppTestBas
                         ZipUtils.unzip(resolvedJar, moduleTargetDir.resolve("classes"));
                         IoUtils.copy(resolvedJar,
                                 moduleTargetDir.resolve(modulePom.getArtifactId() + "-" + modulePom.getVersion() + ".jar"));
+                    }
+
+                    if (addProfileToParent) {
+                        parentPom.addProfile(profile);
                     }
                 }
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyInProfileActiveByDefaultRawModelBuilderTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyInProfileActiveByDefaultRawModelBuilderTest.java
@@ -72,8 +72,6 @@ public class DependencyInProfileActiveByDefaultRawModelBuilderTest extends Boots
 
         appJar.addProfile(profile);
 
-        createWorkspace();
-
         return appJar;
     }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1536,7 +1536,7 @@ public class DevMojo extends AbstractMojo {
                     .setEffectiveModelBuilder(BootstrapMavenContextConfig.getEffectiveModelBuilderProperty(projectProperties))
                     .setRootProjectDir(rootProjectDir);
             // to support Maven plugins and extensions manipulating POM files
-            QuarkusBootstrapProvider.setProjectModels(mvnConfig, session.getAllProjects(), toFiles(reloadPoms));
+            QuarkusBootstrapProvider.setProvidedModules(mvnConfig, session, toFiles(reloadPoms));
 
             // There are a couple of reasons we don't want to use the original Maven session:
             // 1) a reload could be triggered by a change in a pom.xml, in which case the Maven session might not be in sync anymore with the effective POM;

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ModelResolutionTaskRunner.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ModelResolutionTaskRunner.java
@@ -6,43 +6,56 @@ package io.quarkus.bootstrap.resolver.maven;
 public interface ModelResolutionTaskRunner {
 
     /**
-     * Returns an instance of a non-blocking task runner with an error handler
-     * that collects all task execution errors and throws a single error when all the tasks
-     * have finished.
+     * @deprecated in favor of {@link ModelResolutionTaskRunnerFactory#getNonBlockingTaskRunner()}
+     *
+     *             Returns an instance of a non-blocking task runner with an error handler
+     *             that collects all task execution errors and throws a single error when all the tasks
+     *             have finished.
      *
      * @return an instance of a non-blocking task runner
      */
+    @Deprecated(forRemoval = true)
     static ModelResolutionTaskRunner getNonBlockingTaskRunner() {
-        return getNonBlockingTaskRunner(new FailAtCompletionErrorHandler());
+        return ModelResolutionTaskRunnerFactory.getNonBlockingTaskRunner();
     }
 
     /**
-     * Returns an instance of a non-blocking task runner with a custom error handler.
+     * @deprecated in favor of
+     *             {@link ModelResolutionTaskRunnerFactory#getNonBlockingTaskRunner(ModelResolutionTaskErrorHandler)}
+     *
+     *             Returns an instance of a non-blocking task runner with a custom error handler.
      *
      * @param errorHandler error handler
      * @return an instance of non-blocking task runner
      */
+    @Deprecated(forRemoval = true)
     static ModelResolutionTaskRunner getNonBlockingTaskRunner(ModelResolutionTaskErrorHandler errorHandler) {
-        return new NonBlockingModelResolutionTaskRunner(errorHandler);
+        return ModelResolutionTaskRunnerFactory.getNonBlockingTaskRunner(errorHandler);
     }
 
     /**
-     * Returns an instance of a blocking task runner with no error handler.
-     * Exceptions thrown from tasks will be immediately propagated to the caller.
+     * @deprecated in favor of {@link ModelResolutionTaskRunnerFactory#getBlockingTaskRunner()}
+     *
+     *             Returns an instance of a blocking task runner with no error handler.
+     *             Exceptions thrown from tasks will be immediately propagated to the caller.
      *
      * @return an instance of a blocking task runner
      */
+    @Deprecated(forRemoval = true)
     static ModelResolutionTaskRunner getBlockingTaskRunner() {
-        return BlockingModelResolutionTaskRunner.getInstance();
+        return ModelResolutionTaskRunnerFactory.getBlockingTaskRunner();
     }
 
     /**
-     * Returns an instance of a blocking task runner with a custom error handler.
+     * @deprecated in favor of {@link ModelResolutionTaskRunnerFactory#getBlockingTaskRunner(ModelResolutionTaskErrorHandler)}
+     *
+     *             Returns an instance of a blocking task runner with a custom error handler.
      *
      * @return an instance of a blocking task runner
      */
+    @Deprecated(forRemoval = true)
     static ModelResolutionTaskRunner getBlockingTaskRunner(ModelResolutionTaskErrorHandler errorHandler) {
-        return BlockingModelResolutionTaskRunner.getInstance(errorHandler);
+        return ModelResolutionTaskRunnerFactory.getBlockingTaskRunner(errorHandler);
     }
 
     /**

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ModelResolutionTaskRunnerFactory.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ModelResolutionTaskRunnerFactory.java
@@ -1,0 +1,63 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+public class ModelResolutionTaskRunnerFactory {
+
+    /**
+     * Whether to use a blocking or non-blocking dependency resolution and processing task runner
+     */
+    private static final boolean BLOCKING_TASK_RUNNER = Boolean.getBoolean("quarkus.bootstrap.blocking-task-runner");
+
+    public static boolean isDefaultRunnerBlocking() {
+        return BLOCKING_TASK_RUNNER;
+    }
+
+    /**
+     * New instance of {@link ModelResolutionTaskRunner}. Unless system property {@code quarkus.bootstrap.blocking-task-runner}
+     * is set to {@code true}, the returned runner will not be blocking.
+     *
+     * @return new task runner instance
+     */
+    public static ModelResolutionTaskRunner newTaskRunner() {
+        return BLOCKING_TASK_RUNNER ? getBlockingTaskRunner() : getNonBlockingTaskRunner();
+    }
+
+    /**
+     * Returns an instance of a non-blocking task runner with an error handler
+     * that collects all task execution errors and throws a single error when all the tasks
+     * have finished.
+     *
+     * @return an instance of a non-blocking task runner
+     */
+    public static ModelResolutionTaskRunner getNonBlockingTaskRunner() {
+        return getNonBlockingTaskRunner(new FailAtCompletionErrorHandler());
+    }
+
+    /**
+     * Returns an instance of a non-blocking task runner with a custom error handler.
+     *
+     * @param errorHandler error handler
+     * @return an instance of non-blocking task runner
+     */
+    public static ModelResolutionTaskRunner getNonBlockingTaskRunner(ModelResolutionTaskErrorHandler errorHandler) {
+        return new NonBlockingModelResolutionTaskRunner(errorHandler);
+    }
+
+    /**
+     * Returns an instance of a blocking task runner with no error handler.
+     * Exceptions thrown from tasks will be immediately propagated to the caller.
+     *
+     * @return an instance of a blocking task runner
+     */
+    public static ModelResolutionTaskRunner getBlockingTaskRunner() {
+        return BlockingModelResolutionTaskRunner.getInstance();
+    }
+
+    /**
+     * Returns an instance of a blocking task runner with a custom error handler.
+     *
+     * @return an instance of a blocking task runner
+     */
+    public static ModelResolutionTaskRunner getBlockingTaskRunner(ModelResolutionTaskErrorHandler errorHandler) {
+        return BlockingModelResolutionTaskRunner.getInstance(errorHandler);
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -176,21 +176,22 @@ public class LocalProject {
     }
 
     LocalProject(Model rawModel, LocalWorkspace workspace) {
-        this(rawModel, null, workspace);
+        this(ModelUtils.getGroupId(rawModel), ModelUtils.getVersion(rawModel), rawModel, null, workspace);
     }
 
-    LocalProject(Model rawModel, Model effectiveModel, LocalWorkspace workspace) {
+    LocalProject(String resolvedGroupId, String resolvedVersion, Model rawModel, Model effectiveModel,
+            LocalWorkspace workspace) {
         this.rawModel = rawModel;
         this.effectiveModel = effectiveModel;
         this.modelBuildingResult = null;
         // Maven does not guarantee the projectDirectory will be normalized
         this.dir = rawModel.getProjectDirectory().toPath().normalize().toAbsolutePath();
         this.workspace = workspace;
-        this.key = ArtifactKey.ga(ModelUtils.getGroupId(rawModel), rawModel.getArtifactId());
+        this.key = ArtifactKey.ga(resolvedGroupId, rawModel.getArtifactId());
 
-        final String rawVersion = ModelUtils.getRawVersion(rawModel);
-        final boolean rawVersionIsUnresolved = ModelUtils.isUnresolvedVersion(rawVersion);
-        version = rawVersionIsUnresolved ? ModelUtils.resolveVersion(rawVersion, rawModel) : rawVersion;
+        final String rawVersion = ModelUtils.getRawVersionOrNull(rawModel);
+        final boolean rawVersionIsUnresolved = rawVersion == null || ModelUtils.isUnresolvedVersion(rawVersion);
+        version = resolvedVersion;
 
         if (workspace != null) {
             workspace.addProject(this);

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
@@ -143,15 +143,32 @@ public class ModelUtils {
     }
 
     /**
+     * Returns the raw version of the model. This method returns the result of {@link #getRawVersionOrNull(Model)}
+     * except if it's null, it throws an exception.
+     *
+     * @param model POM
+     * @return raw model
+     */
+    public static String getRawVersion(Model model) {
+        String version = getRawVersionOrNull(model);
+        if (version != null) {
+            return version;
+        }
+        throw new IllegalStateException("Failed to determine version for project model");
+    }
+
+    /**
      * Returns the raw version of the model. If the model does not include
-     * the version directly, it will return the version of the parent.
+     * the version directly and the coordinates of the parent artifact are configured,
+     * the parent version will be returned.
+     * If the parent coordinates are not configured, the method will return null.
      * The version is raw in a sense if it's a property expression, the
      * expression will not be resolved.
      *
      * @param model POM
      * @return raw model
      */
-    public static String getRawVersion(Model model) {
+    public static String getRawVersionOrNull(Model model) {
         String version = model.getVersion();
         if (version != null) {
             return version;
@@ -163,7 +180,7 @@ public class ModelUtils {
                 return version;
             }
         }
-        throw new IllegalStateException("Failed to determine version for project model");
+        return null;
     }
 
     public static String getVersion(Model model) {
@@ -239,7 +256,7 @@ public class ModelUtils {
 
     public static Model readModel(InputStream stream) throws IOException {
         try (InputStream is = stream) {
-            return new MavenXpp3Reader().read(stream);
+            return new MavenXpp3Reader().read(is);
         } catch (XmlPullParserException e) {
             throw new IOException("Failed to parse POM", e);
         }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
@@ -8,7 +8,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +31,7 @@ import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.BootstrapModelBuilderFactory;
 import io.quarkus.bootstrap.resolver.maven.BootstrapModelResolver;
 import io.quarkus.bootstrap.resolver.maven.ModelResolutionTaskRunner;
+import io.quarkus.bootstrap.resolver.maven.ModelResolutionTaskRunnerFactory;
 import io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptions;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.GAV;
@@ -43,6 +43,13 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
     static final String POM_XML = "pom.xml";
 
     static final Model MISSING_MODEL = new Model();
+
+    private static ModelResolutionTaskRunner getTaskRunner() {
+        if (ModelResolutionTaskRunnerFactory.isDefaultRunnerBlocking()) {
+            return ModelResolutionTaskRunnerFactory.getBlockingTaskRunner();
+        }
+        return ModelResolutionTaskRunnerFactory.getNonBlockingTaskRunner();
+    }
 
     static Path getFsRootDir() {
         return Path.of("/");
@@ -76,9 +83,9 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
         throw new BootstrapMavenException("Failed to locate project pom.xml for " + path);
     }
 
-    private final Deque<WorkspaceModulePom> moduleQueue = new ConcurrentLinkedDeque<>();
+    private final Deque<WorkspaceModulePom> loadQueue = new ConcurrentLinkedDeque<>();
     // Map key is the normalized absolute Path to the module directory
-    private final Map<Path, Model> loadedPoms = new ConcurrentHashMap<>();
+    private final Map<Path, WorkspaceModulePom> knownModules = new ConcurrentHashMap<>();
     private final Map<GAV, Model> loadedModules = new ConcurrentHashMap<>();
     private final Consumer<WorkspaceModulePom> loadedModelProcessor;
 
@@ -98,51 +105,51 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
         boolean queueCurrentPom = true;
         if (providedModules != null) {
             // queue all the provided POMs
-            for (var e : providedModules) {
-                if (queueCurrentPom && this.currentProjectPom.equals(e.pom)) {
+            for (var module : providedModules) {
+                if (queueCurrentPom && this.currentProjectPom.equals(module.pom)) {
                     queueCurrentPom = false;
                 }
-                moduleQueue.push(e);
+                knownModules.put(module.getModuleDir(), module);
+                loadQueue.add(module);
             }
         }
 
         if (queueCurrentPom) {
-            moduleQueue.push(new WorkspaceModulePom(this.currentProjectPom));
+            WorkspaceModulePom module = new WorkspaceModulePom(this.currentProjectPom);
+            knownModules.put(module.getModuleDir(), module);
+            loadQueue.add(module);
         }
 
         loadedModelProcessor = getLoadedModelProcessor(ctx);
         workspace.setBootstrapMavenContext(ctx);
     }
 
-    private void addModulePom(Path pom) {
-        if (pom != null) {
-            moduleQueue.push(new WorkspaceModulePom(pom));
-        }
-    }
-
     void setWorkspaceRootPom(Path rootPom) {
-        addModulePom(rootPom);
+        WorkspaceModulePom rootModule = new WorkspaceModulePom(rootPom);
+        knownModules.put(rootModule.getModuleDir(), rootModule);
+        loadQueue.addLast(rootModule);
     }
 
     LocalProject load() throws BootstrapMavenException {
-        final ModelResolutionTaskRunner taskRunner = ModelResolutionTaskRunner.getNonBlockingTaskRunner();
-        while (!moduleQueue.isEmpty()) {
-            final ConcurrentLinkedDeque<WorkspaceModulePom> newModules = new ConcurrentLinkedDeque<>();
-            while (!moduleQueue.isEmpty()) {
-                while (!moduleQueue.isEmpty()) {
-                    final WorkspaceModulePom module = moduleQueue.removeLast();
-                    taskRunner.run(() -> loadModule(module, newModules));
+        final ModelResolutionTaskRunner taskRunner = getTaskRunner();
+        while (!loadQueue.isEmpty()) {
+            while (!loadQueue.isEmpty()) {
+                while (!loadQueue.isEmpty()) {
+                    final WorkspaceModulePom module = loadQueue.removeLast();
+                    taskRunner.run(() -> loadModule(module));
                 }
                 taskRunner.waitForCompletion();
             }
-            for (var newModule : newModules) {
-                newModule.process(loadedModelProcessor);
+            for (var module : knownModules.values()) {
+                if (module.isLoaded()) {
+                    module.process(loadedModelProcessor);
+                }
             }
         }
 
         if (currentProject == null) {
             log.errorf("Failed to locate %s among the following loaded modules:", currentProjectPom);
-            for (Path moduleDir : loadedPoms.keySet()) {
+            for (Path moduleDir : knownModules.keySet()) {
                 log.error("- " + moduleDir);
             }
             throw new BootstrapMavenException("Failed to locate " + currentProjectPom + " in the workspace");
@@ -192,18 +199,14 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
             }
             loadedModule(project);
             for (var module : project.getEffectiveModel().getModules()) {
-                Path modulePath = project.getDir().resolve(module);
-                if (Files.isDirectory(modulePath)) {
-                    addModulePom(modulePath.resolve(POM_XML));
-                } else {
-                    addModulePom(modulePath);
-                }
+                queueModule(project.getDir().resolve(module));
             }
         };
     }
 
-    private void processLoadedRawModel(WorkspaceModulePom rawModule) {
-        loadedModule(new LocalProject(rawModule.getModel(), rawModule.effectiveModel, workspace));
+    private void processLoadedRawModel(WorkspaceModulePom module) {
+        loadedModule(new LocalProject(module.getResolvedGroupId(), module.getResolvedVersion(), module.getModel(),
+                module.effectiveModel, workspace));
     }
 
     private void loadedModule(LocalProject project) {
@@ -213,54 +216,62 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
         }
     }
 
-    private void loadModule(WorkspaceModulePom rawModule, Collection<WorkspaceModulePom> newModules) {
-        final Path moduleDir = rawModule.getModuleDir();
-        if (loadedPoms.containsKey(moduleDir)) {
+    private void loadModule(WorkspaceModulePom module) {
+        if (!module.isNew()) {
             return;
         }
 
-        final Model model = rawModule.getModel();
-        loadedPoms.put(moduleDir, model);
+        final Model model = module.getModel();
         if (model == MISSING_MODEL) {
             return;
         }
 
-        final String rawVersion = ModelUtils.getRawVersion(model);
-        final String version = ModelUtils.isUnresolvedVersion(rawVersion)
-                ? ModelUtils.resolveVersion(rawVersion, model)
-                : rawVersion;
-        final Model existingModel = loadedModules.putIfAbsent(
-                new GAV(ModelUtils.getGroupId(model), model.getArtifactId(), version),
-                model);
-        if (existingModel != null) {
-            return;
-        }
-        newModules.add(rawModule);
-
-        if (!rawVersion.equals(version)) {
-            loadedModules.putIfAbsent(new GAV(ModelUtils.getGroupId(model), model.getArtifactId(), rawVersion), model);
-        }
-
-        for (var module : model.getModules()) {
-            queueModule(model.getProjectDirectory().toPath().resolve(module));
-        }
-        for (var profile : model.getProfiles()) {
-            for (var module : profile.getModules()) {
-                queueModule(model.getProjectDirectory().toPath().resolve(module));
-            }
-        }
-        if (rawModule.parent == null) {
-            final Path parentPom = rawModule.getParentPom();
+        if (module.parent == null) {
+            final Path parentPom = module.getParentPom();
             if (parentPom != null) {
                 var parentDir = parentPom.getParent();
                 if (parentDir == null) {
                     parentDir = getFsRootDir();
                 }
-                if (!loadedPoms.containsKey(parentDir)) {
-                    rawModule.parent = new WorkspaceModulePom(parentPom);
-                    moduleQueue.push(rawModule.parent);
+                module.parent = knownModules.computeIfAbsent(parentDir, dir -> queuePom(parentPom));
+                if (module.parent.isNew() && module.isParentConfigured()) {
+                    module.parent.thenLoad(module);
                 }
             }
+        }
+        if (module.parent != null && module.parent.isNew() && module.isParentConfigured()) {
+            // the parent still has not been loaded, once it's loaded, it will queue this module
+            return;
+        }
+
+        final String version = module.getResolvedVersion();
+        final Model existingModel = this.loadedModules.putIfAbsent(
+                new GAV(module.getResolvedGroupId(), model.getArtifactId(), version),
+                model);
+        if (existingModel != null) {
+            return;
+        }
+        final String rawVersion = ModelUtils.getRawVersionOrNull(model);
+        if (rawVersion != null && !rawVersion.equals(version)) {
+            this.loadedModules.putIfAbsent(new GAV(module.getResolvedGroupId(), model.getArtifactId(), rawVersion), model);
+        }
+
+        module.setLoaded();
+
+        for (String modulePath : model.getModules()) {
+            queueModule(model.getProjectDirectory().toPath().resolve(modulePath));
+        }
+        for (var profile : model.getProfiles()) {
+            for (String modulePath : profile.getModules()) {
+                queueModule(model.getProjectDirectory().toPath().resolve(modulePath));
+            }
+        }
+
+        // queue dependencies
+        // these may or may not be modules/subprojects of this POM
+        var thenLoad = module.getThenLoad();
+        while (!thenLoad.isEmpty()) {
+            loadQueue.add(thenLoad.removeLast());
         }
     }
 
@@ -274,10 +285,13 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
             pom = normalizedModuleDir;
             normalizedModuleDir = normalizedModuleDir.getParent() != null ? normalizedModuleDir.getParent() : getFsRootDir();
         }
+        knownModules.computeIfAbsent(normalizedModuleDir, dir -> queuePom(pom));
+    }
 
-        if (!loadedPoms.containsKey(normalizedModuleDir)) {
-            moduleQueue.push(new WorkspaceModulePom(pom));
-        }
+    private WorkspaceModulePom queuePom(Path pomFile) {
+        var module = new WorkspaceModulePom(pomFile);
+        loadQueue.add(module);
+        return module;
     }
 
     @Override

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceModulePom.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceModulePom.java
@@ -2,17 +2,29 @@ package io.quarkus.bootstrap.resolver.maven.workspace;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Consumer;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 
 public class WorkspaceModulePom {
+
+    // new, not yet loaded, state
+    private static int STATE_NEW = 0;
+    // model has been loaded but not yet processed (added to the workspace)
+    private static int STATE_LOADED = 1;
+    // module has been added to the workspace
+    private static int STATE_PROCESSED = 2;
+
     final Path pom;
     Model model;
     Model effectiveModel;
     WorkspaceModulePom parent;
-    boolean processed;
+    int state = STATE_NEW;
+    // a queue of modules that should be loaded after this one
+    final ConcurrentLinkedDeque<WorkspaceModulePom> thenLoad = new ConcurrentLinkedDeque<>();
 
     WorkspaceModulePom(Path pom) {
         this(pom, null, null);
@@ -33,12 +45,13 @@ public class WorkspaceModulePom {
         return model == null ? model = WorkspaceLoader.readModel(pom) : model;
     }
 
+    boolean isParentConfigured() {
+        return getModel().getParent() != null;
+    }
+
     Path getParentPom() {
-        if (model == null) {
-            return null;
-        }
         Path parentPom = null;
-        final Parent parent = model.getParent();
+        final Parent parent = getModel().getParent();
         if (parent != null && parent.getRelativePath() != null && !parent.getRelativePath().isEmpty()) {
             parentPom = pom.getParent().resolve(parent.getRelativePath()).normalize();
             if (Files.isDirectory(parentPom)) {
@@ -53,17 +66,103 @@ public class WorkspaceModulePom {
         return parentPom != null && Files.exists(parentPom) ? parentPom.normalize().toAbsolutePath() : null;
     }
 
-    void process(Consumer<WorkspaceModulePom> consumer) {
-        if (processed) {
+    boolean isNew() {
+        return state == STATE_NEW;
+    }
+
+    boolean isLoaded() {
+        return state == STATE_LOADED;
+    }
+
+    void setLoaded() {
+        state = STATE_LOADED;
+    }
+
+    void process(Consumer<WorkspaceModulePom> processor) {
+        if (state == STATE_PROCESSED) {
             return;
         }
-        processed = true;
+        state = STATE_PROCESSED;
         if (parent != null) {
-            parent.process(consumer);
+            parent.process(processor);
         }
         if (model != null && model != WorkspaceLoader.MISSING_MODEL) {
-            consumer.accept(this);
+            processor.accept(this);
         }
+    }
+
+    /**
+     * Group Ids aren't always configured in a pom.xml.
+     * Sometimes, they are inherited from a parent POM.
+     * This method returns resolved groupId value for this module.
+     *
+     * @return resolved groupId for this module
+     */
+    String getResolvedGroupId() {
+        if (effectiveModel != null) {
+            return effectiveModel.getGroupId();
+        }
+        final Model model = getModel();
+        if (model != null) {
+            String groupId = model.getGroupId();
+            if (groupId != null) {
+                return groupId;
+            }
+            Parent parent = model.getParent();
+            if (parent != null) {
+                groupId = parent.getGroupId();
+                if (groupId != null) {
+                    return groupId;
+                }
+            }
+        }
+        if (parent != null) {
+            return parent.getResolvedGroupId();
+        }
+        throw new RuntimeException("Failed to determine the groupId of module " + pom);
+    }
+
+    /**
+     * Returns a resolved version value for this module, which may be inherited from a parent POM.
+     *
+     * @return resolved version value for this module
+     */
+    String getResolvedVersion() {
+        if (effectiveModel != null) {
+            return effectiveModel.getVersion();
+        }
+        final Model model = getModel();
+        if (model != null) {
+            String version = ModelUtils.getRawVersionOrNull(model);
+            if (version != null && ModelUtils.isUnresolvedVersion(version)) {
+                version = ModelUtils.resolveVersion(version, model);
+            }
+            if (version != null) {
+                return version;
+            }
+        }
+        if (parent != null) {
+            return parent.getResolvedVersion();
+        }
+        throw new RuntimeException("Failed to determine the version of module " + pom);
+    }
+
+    /**
+     * Allows scheduling module loading after this module has been loaded.
+     *
+     * @param module module to load once this module has been loaded
+     */
+    void thenLoad(WorkspaceModulePom module) {
+        thenLoad.add(module);
+    }
+
+    /**
+     * Modules that should be loaded after this module.
+     *
+     * @return modules that should be loaded after this module
+     */
+    Deque<WorkspaceModulePom> getThenLoad() {
+        return thenLoad;
     }
 
     @Override


### PR DESCRIPTION
These code changes will be necessary to make the reproducer from https://github.com/quarkusio/quarkus/issues/52190 work once we upgrade to the Maven dependency versions supporting model 4.1 API in https://github.com/quarkusio/quarkus/pull/52491.

The reason we are not upgrading the dependency versions yet is because with the new dependency versions our CI times out. We'll need to make sure the new dependencies do not introduce memory-related issues.

I thought, given the code changes are relatively significant, it could be a good idea to merge them earlier to make sure they don't introduce regressions on their own.