### PR TITLE
[Docs]: Minor editing fix to Cross-Origin Resource Sharing (CORS) guide per lift and shift review 

### DIFF
--- a/docs/src/main/asciidoc/security-cors.adoc
+++ b/docs/src/main/asciidoc/security-cors.adoc
@@ -36,10 +36,10 @@ For regular CORS requests, the filter denies access with an HTTP 403 status if t
 
 [NOTE]
 ====
-Despite its name the CORS filter may also prevent CSRF attacks based on link:https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#using-standard-headers-to-verify-origin[Origin verification].
-Therefore, since an [Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin) header is expected to be set by the browser for cross-origin JavaScript and HTML form requests, you may want to consider using it instead of the xref:security-csrf-prevention.adoc[REST CSRF filter].
+Despite its name, the CORS filter can also prevent CSRF attacks based on link:https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#using-standard-headers-to-verify-origin[Origin verification].
+Therefore, since the browser is expected to set an link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin[Origin header] for cross-origin JavaScript and HTML form requests, you might want to consider using the CORS filter instead of the link:{quarkusio-guides}/security-csrf-prevention[REST CSRF filter].
 
-You must confirm that the browser does set an `Origin` header for cross-origin requests when accessing your application, especially with HTML forms, before using the CORS filter to prevent CSRF  with the link:https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#using-standard-headers-to-verify-origin[Origin verification].
+You must confirm that the browser sets an `Origin` header for cross-origin requests when accessing your application, especially with HTML forms, before using the CORS filter to prevent CSRF through link:https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#using-standard-headers-to-verify-origin[Origin verification].
 ====
 
 For detailed configuration options, see the following Configuration Properties section.


### PR DESCRIPTION
This PR covers edits to fix a link typo and minor style fixes to the https://quarkus.io/guides/security-cors#cors-filter-programmatic-set-up guide (to be single sourced to RHBQ 3.33)

   
