### PR TITLE
Use absolute redirect path in all redirects to Quarkus

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -218,7 +218,6 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         .transformToUni(new Function<TenantConfigContext, Uni<? extends SecurityIdentity>>() {
                             @Override
                             public Uni<SecurityIdentity> apply(TenantConfigContext tenantContext) {
-                                URI absoluteUri = URI.create(context.request().absoluteURI());
 
                                 String userQuery = null;
 
@@ -233,12 +232,11 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                     }
                                 }
 
-                                StringBuilder errorUri = new StringBuilder(buildUri(context,
-                                        isForceHttps(oidcTenantConfig),
-                                        absoluteUri.getAuthority(),
-                                        oidcTenantConfig.authentication().errorPath().get()));
+                                StringBuilder errorUri = prepareRedirectPathBuilder(context, oidcTenantConfig,
+                                        oidcTenantConfig.authentication().errorPath().get());
+
                                 errorUri.append('?')
-                                        .append(getRequestParametersAsQuery(absoluteUri, requestParams, oidcTenantConfig));
+                                        .append(getRequestParametersAsQuery(context, requestParams, oidcTenantConfig));
                                 if (userQuery != null) {
                                     errorUri.append('&').append(userQuery);
                                 }
@@ -266,6 +264,17 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             return Uni.createFrom().failure(new AuthenticationCompletionException(error));
         }
 
+    }
+
+    protected StringBuilder prepareRedirectPathBuilder(RoutingContext context, OidcTenantConfig oidcTenantConfig, String path) {
+        StringBuilder sb = new StringBuilder();
+
+        if (path.startsWith(HTTP_SCHEME)) {
+            sb.append(path);
+        } else {
+            sb.append(buildUri(context, isForceHttps(oidcTenantConfig), context.request().authority().toString(), path));
+        }
+        return sb;
     }
 
     private static String filterRedirect(RoutingContext context,
@@ -332,11 +341,11 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
     }
 
-    private String getRequestParametersAsQuery(URI requestUri, MultiMap requestParams, OidcTenantConfig oidcConfig) {
+    private String getRequestParametersAsQuery(RoutingContext context, MultiMap requestParams, OidcTenantConfig oidcConfig) {
         if (ResponseMode.FORM_POST == oidcConfig.authentication().responseMode().orElse(ResponseMode.QUERY)) {
             return OidcCommonUtils.encodeForm(new io.vertx.mutiny.core.MultiMap(requestParams)).toString();
         } else {
-            return requestUri.getRawQuery();
+            return context.request().query();
         }
     }
 
@@ -505,11 +514,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     }
 
     private Uni<SecurityIdentity> redirectToSessionExpiredPage(RoutingContext context, TenantConfigContext configContext) {
-        URI absoluteUri = URI.create(context.request().absoluteURI());
-        StringBuilder sessionExpired = new StringBuilder(buildUri(context,
-                isForceHttps(configContext.oidcConfig()),
-                absoluteUri.getAuthority(),
-                configContext.oidcConfig().authentication().sessionExpiredPath().get()));
+        StringBuilder sessionExpired = prepareRedirectPathBuilder(context, configContext.oidcConfig(),
+                configContext.oidcConfig().authentication().sessionExpiredPath().get());
+
         String sessionExpiredUri = sessionExpired.toString();
         LOG.debugf("Session Expired URI: %s", sessionExpiredUri);
         return removeSessionCookie(context, configContext.oidcConfig())
@@ -956,17 +963,32 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                         if (removeRedirectParams || finalUserPath != null
                                                 || finalUserQuery != null) {
 
-                                            URI absoluteUri = URI.create(context.request().absoluteURI());
+                                            StringBuilder finalUriWithoutQuery = new StringBuilder();
 
-                                            StringBuilder finalUriWithoutQuery = new StringBuilder(buildUri(context,
-                                                    isForceHttps(configContext.oidcConfig()),
-                                                    absoluteUri.getAuthority(),
-                                                    (finalUserPath != null ? finalUserPath
-                                                            : absoluteUri.getRawPath())));
+                                            String redirectPath = configContext.oidcConfig().authentication()
+                                                    .redirectPath().orElse(null);
+                                            if (redirectPath != null && redirectPath.startsWith(HTTP_SCHEME)) {
+                                                // This is the actual URI that OIDC provider used to redirect the user back to Quarkus
+                                                if (finalUserPath == null) {
+                                                    // No need to restore the original request path
+                                                    finalUriWithoutQuery.append(redirectPath);
+                                                } else {
+                                                    URI redirectUri = URI.create(redirectPath);
+                                                    finalUriWithoutQuery.append(
+                                                            buildUri(redirectUri.getScheme(), redirectUri.getAuthority(), "",
+                                                                    finalUserPath));
+                                                }
+                                            } else {
+                                                finalUriWithoutQuery.append(
+                                                        buildUri(context, isForceHttps(configContext.oidcConfig()),
+                                                                context.request().authority().toString(),
+                                                                (finalUserPath != null ? finalUserPath
+                                                                        : context.request().path())));
+                                            }
 
                                             if (!removeRedirectParams) {
                                                 finalUriWithoutQuery.append('?')
-                                                        .append(getRequestParametersAsQuery(absoluteUri, requestParams,
+                                                        .append(getRequestParametersAsQuery(context, requestParams,
                                                                 configContext.oidcConfig()));
                                             }
                                             if (finalUserQuery != null) {
@@ -1375,6 +1397,10 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 }
             }
         }
+        return buildUri(scheme, authority, forwardedPrefix, path);
+    }
+
+    private static String buildUri(String scheme, String authority, String forwardedPrefix, String path) {
         return new StringBuilder(scheme).append("://")
                 .append(authority)
                 .append(forwardedPrefix)

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -78,6 +78,15 @@ public class CustomTenantResolver implements TenantResolver {
             }
         }
 
+        if (path.endsWith("tenant-absolute-redirect") || path.endsWith("tenant-absolute-redirect/callback")) {
+            return "tenant-absolute-redirect";
+        }
+
+        if (path.endsWith("tenant-restore-path-absolute-redirect")
+                || path.endsWith("tenant-restore-path-absolute-redirect/callback")) {
+            return "tenant-restore-path-absolute-redirect";
+        }
+
         if (path.contains("tenant-xhr")) {
             return "tenant-xhr";
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantAbsoluteRedirect.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantAbsoluteRedirect.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriInfo;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/tenant-absolute-redirect")
+public class TenantAbsoluteRedirect {
+
+    @Context
+    UriInfo ui;
+
+    @GET
+    @Authenticated
+    public String getTenant() {
+        throw new RuntimeException("/tenant-absolute-redirect/callback is a callback method");
+    }
+
+    @GET
+    @Authenticated
+    @Path("/callback")
+    public String getTenantCallback() {
+        return ui.getAbsolutePath().toString();
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRestorePathAbsoluteRedirect.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRestorePathAbsoluteRedirect.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriInfo;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/tenant-restore-path-absolute-redirect")
+public class TenantRestorePathAbsoluteRedirect {
+
+    @Context
+    UriInfo ui;
+
+    @GET
+    @Authenticated
+    public String getTenant() {
+        return ui.getAbsolutePath().toString();
+    }
+
+    @GET
+    @Authenticated
+    @Path("/callback")
+    public String getTenantCallback() {
+        throw new RuntimeException("/tenant-restore-path-absolute-redirect must be restored");
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -156,6 +156,23 @@ quarkus.oidc.tenant-nonce.resource-metadata.resource=/metadata
 quarkus.oidc.tenant-nonce.resource-metadata.scopes=read
 quarkus.oidc.tenant-nonce.resource-metadata.authorization-server=http://localhost:8080/q/oidc
 
+quarkus.oidc.tenant-absolute-redirect.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc.tenant-absolute-redirect.client-id=quarkus-app
+quarkus.oidc.tenant-absolute-redirect.credentials.secret=secret
+quarkus.oidc.tenant-absolute-redirect.authentication.scopes=profile,email,phone
+quarkus.oidc.tenant-absolute-redirect.authentication.redirect-path=http://localhost:8081/tenant-absolute-redirect/callback
+quarkus.oidc.tenant-absolute-redirect.authentication.extra-params.max-age=60
+quarkus.oidc.tenant-absolute-redirect.application-type=web-app
+
+quarkus.oidc.tenant-restore-path-absolute-redirect.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc.tenant-restore-path-absolute-redirect.client-id=quarkus-app
+quarkus.oidc.tenant-restore-path-absolute-redirect.credentials.secret=secret
+quarkus.oidc.tenant-restore-path-absolute-redirect.authentication.scopes=profile,email,phone
+quarkus.oidc.tenant-restore-path-absolute-redirect.authentication.redirect-path=http://localhost:8081/tenant-restore-path-absolute-redirect/callback
+quarkus.oidc.tenant-restore-path-absolute-redirect.authentication.extra-params.max-age=60
+quarkus.oidc.tenant-restore-path-absolute-redirect.authentication.restore-path-after-redirect=true
+quarkus.oidc.tenant-restore-path-absolute-redirect.application-type=web-app
+
 quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-javascript.client-id=quarkus-app
 quarkus.oidc.tenant-javascript.credentials.secret=secret


### PR DESCRIPTION
It is a follow up to #51666.

In some setups, Quarkus OIDC uses a configured redirect path as a redirect URL to the OIDC provider, when this path is an absolute URL, to workaround various proxy related URI transformations.

But when the provider redirects the user back to this configured redirect URI, Quarkus OIDC does the final redirect to itself, it drops the technical query parameters such as `code` and `state` and then performs this final redirect - but it ignores  that very same configured absolute redirect path.

So this PR updates the code that calculates the final redirect URI to use the redirect path if it is configured and is an absolute url