### PR TITLE
Preserve buildtool packaging type during codestart POM merge

### DIFF
--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandler.java
@@ -38,10 +38,12 @@ final class SmartPomMergeCodestartFileStrategyHandler implements CodestartFileSt
 
         final SmartModelMerger merger = new SmartModelMerger();
         final Model targetModel = Maven.readModel(new StringReader(codestartFiles.get(0).getContent()));
+        final String originalPackaging = targetModel.getPackaging();
         final ListIterator<TargetFile> iterator = codestartFiles.listIterator(1);
         while (iterator.hasNext()) {
             merger.merge(targetModel, Maven.readModel(new StringReader(iterator.next().getContent())), true, null);
         }
+        targetModel.setPackaging(originalPackaging);
         Maven.writeModel(targetModel, targetPath,
                 XMLFormat.builder().indent("    ").insertLineBreakBetweenMajorSections().build());
     }

--- a/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandlerTest.java
+++ b/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandlerTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.devtools.codestarts.core.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.devtools.codestarts.core.reader.TargetFile;
+
+class SmartPomMergeCodestartFileStrategyHandlerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void mergeShouldPreserveTargetPackaging() throws Exception {
+        String basePom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.acme</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <packaging>quarkus</packaging>
+                </project>
+                """;
+
+        String extensionPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <properties>
+                        <property-from-extension>value</property-from-extension>
+                    </properties>
+                </project>
+                """;
+
+        List<TargetFile> codestartFiles = List.of(
+                new TargetFile("pom.xml", basePom),
+                new TargetFile("pom.xml", extensionPom));
+
+        Map<String, Object> data = Map.of("input", Map.of("base-codestart", Map.of("buildtool", "maven")));
+
+        SmartPomMergeCodestartFileStrategyHandler handler = new SmartPomMergeCodestartFileStrategyHandler();
+        handler.process(tempDir, "pom.xml", codestartFiles, data);
+
+        String result = Files.readString(tempDir.resolve("pom.xml"));
+        assertThat(result).contains("<packaging>quarkus</packaging>");
+    }
+}


### PR DESCRIPTION
When extension codestarts provide a `pom.xml.tpl.qute` template without an explicit `<packaging>` element, Maven defaults it to `jar`. The `SmartModelMerger` then overwrites the buildtool codestart's `quarkus` packaging with this implicit `jar` value.
This change fixes the issue by saving and restoring the original packaging from the buildtool POM around the merge loop.

Fixes #52679