### PR TITLE
Quote only the application model path value

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -122,7 +122,7 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                             Properties properties = mavenProject().getProperties();
                             String argLine = properties.getProperty("argLine", "");
                             properties.setProperty("argLine", argLine +
-                                    " \"-D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=" + serializedTestAppModelPath
+                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=\"" + serializedTestAppModelPath
                                     + "\"");
                         } catch (IOException e) {
                             getLog().warn("Failed to serialize application model", e);


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/52689

When integration tests are launched with the `ProcessBuilder`, the arguments aren't going through the shell evaluation, so they don't need to be quoted. Apparently, quoting the whole `"-Dprop=value"` argument results in a confusion in this case and the whole argument in quotes is interpreted as the main class to launch.