### PR TITLE
Exclude quarkus.test.arg-line from additional system properties for integration tests

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -251,7 +251,11 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                 if (name.startsWith("quarkus.")
                         // don't include 'quarkus.profile' as that has already been taken into account when determining the launch profile
                         // so we don't want this to end up in multiple launch arguments
-                        && !name.equals("quarkus.profile")) {
+                        && !name.equals("quarkus.profile")
+                        // 'quarkus.test.arg-line' is provided directly to DefaultInitContextBase as a list of properties to add,
+                        // if it's not excluded here, it will be added to the command line (unquoted) resulting in
+                        // many duplicate system property arguments
+                        && !name.equals("quarkus.test.arg-line")) {
                     additionalProperties.put(name, existingSysProps.getProperty(name));
                 }
             }


### PR DESCRIPTION
Noticed when investigating https://github.com/quarkusio/quarkus/issues/52689

If integration tests are enabled and `quarkus.test.arg-line` is configured for the `failsafe` plugin, such as
```
                        <quarkus.test.arg-line>-Dprop1=value1 -Dprop2=value2</quarkus.test.arg-line>
```
The launcher will end up with the following arguments
```
Executing "java -Dprop1=value1 -Dprop2=value2 -Dquarkus.http.port=8081 -Dquarkus.http.ssl-port=8444 -Dtest.url=http://localhost:${quarkus.http.test-port:8081} -Dquarkus.log.file.path=/home/aloubyansky/playground/code-with-quarkus/target/quarkus.log -Dquarkus.log.file.enabled=true -Dquarkus.log.category."io.quarkus".level=INFO -Dquarkus.profile=prod -Dquarkus.test.arg-line=-Dprop1=value1 -Dprop2=value2 -jar /home/aloubyansky/playground/code-with-quarkus/target/quarkus-app/quarkus-run.jar"
```

Note, there is `-Dprop1=value1 -Dprop2=value2` and `-Dquarkus.test.arg-line=-Dprop1=value1 -Dprop2=value2` which isn't looking right. Either the whole value of `quarkus.test.arg-line` needs to be quoted or it simply has to be removed from the command line.

Given that the value of `quarkus.test.arg-line` is passed to launchers with API directly, this whole property should be safe to remove.