### PR TITLE
Update RESTEasy HAL IETF URL

### DIFF
--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -299,7 +299,7 @@ public class CustomJsonbConfig {
 [[links]]
 === JSON Hypertext Application Language (HAL) support
 
-The https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL] standard is a simple format to represent web links.
+The https://www.ietf.org/archive/id/draft-kelly-json-hal-11.html[HAL] standard is a simple format to represent web links.
 
 To enable the HAL support, add the `quarkus-hal` extension to your project. Also, as HAL needs JSON support, you need to add either the `quarkus-resteasy-jsonb` or the `quarkus-resteasy-jackson` extension.
 
@@ -308,7 +308,7 @@ To enable the HAL support, add the `quarkus-hal` extension to your project. Also
 |GAV|Usage
 
 |`io.quarkus:quarkus-hal`
-|https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL]
+|https://www.ietf.org/archive/id/draft-kelly-json-hal-11.html[HAL]
 
 |===
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

When I checked the documentation, I found a link referencing an IETF draft that is now bitrotten and shows a 404. I have replaced the URL with an archived (on the IETF website) link to the latest version instead of revision 1, too.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

