### PR TITLE
Fix conflict between the Messaging and Quarkus Flow quickstarts

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/messaging-codestart/java/src/main/java/org/acme/MyMessagingApplication.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/messaging-codestart/java/src/main/java/org/acme/MyMessagingApplication.java
@@ -1,17 +1,21 @@
 package org.acme;
 
 import io.quarkus.runtime.StartupEvent;
-import org.eclipse.microprofile.reactive.messaging.*;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import jakarta.inject.Inject;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
 import java.util.stream.Stream;
 
 @ApplicationScoped
 public class MyMessagingApplication {
 
-    @Inject
+    /**
+     * Injects an emitter to send messages to the "words-out" channel.
+     */
     @Channel("words-out")
     Emitter<String> emitter;
 
@@ -25,16 +29,16 @@ public class MyMessagingApplication {
 
     /**
      * Consume the message from the "words-in" channel, uppercase it and send it to the uppercase channel.
-     * Messages come from the broker.
+     * This method is called by the framework when a message is received on the "words-in" channel (from the broker).
      **/
     @Incoming("words-in")
     @Outgoing("uppercase")
-    public Message<String> toUpperCase(Message<String> message) {
-        return message.withPayload(message.getPayload().toUpperCase());
+    public String toUpperCase(String message) {
+        return message.toUpperCase();
     }
 
     /**
-     * Consume the uppercase channel (in-memory) and print the messages.
+     * Consume the uppercase channel (coming from within the application) and print the messages to the console.
      **/
     @Incoming("uppercase")
     public void sink(String word) {

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/messaging-codestart/java/src/test/java/org/acme/MyMessagingApplicationTest.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/messaging-codestart/java/src/test/java/org/acme/MyMessagingApplicationTest.java
@@ -1,10 +1,7 @@
 package org.acme;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 
-import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
 
 import jakarta.inject.Inject;
@@ -19,7 +16,7 @@ class MyMessagingApplicationTest {
 
     @Test
     void test() {
-        assertEquals("HELLO", application.toUpperCase(Message.of("Hello")).getPayload());
-        assertEquals("BONJOUR", application.toUpperCase(Message.of("bonjour")).getPayload());
+        assertEquals("HELLO", application.toUpperCase("Hello"));
+        assertEquals("BONJOUR", application.toUpperCase("bonjour"));
     }
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_main_java_ilove_quark_us_MyMessagingApplication.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_main_java_ilove_quark_us_MyMessagingApplication.java
@@ -1,17 +1,21 @@
 package ilove.quark.us;
 
 import io.quarkus.runtime.StartupEvent;
-import org.eclipse.microprofile.reactive.messaging.*;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import jakarta.inject.Inject;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
 import java.util.stream.Stream;
 
 @ApplicationScoped
 public class MyMessagingApplication {
 
-    @Inject
+    /**
+     * Injects an emitter to send messages to the "words-out" channel.
+     */
     @Channel("words-out")
     Emitter<String> emitter;
 
@@ -25,16 +29,16 @@ public class MyMessagingApplication {
 
     /**
      * Consume the message from the "words-in" channel, uppercase it and send it to the uppercase channel.
-     * Messages come from the broker.
+     * This method is called by the framework when a message is received on the "words-in" channel (from the broker).
      **/
     @Incoming("words-in")
     @Outgoing("uppercase")
-    public Message<String> toUpperCase(Message<String> message) {
-        return message.withPayload(message.getPayload().toUpperCase());
+    public String toUpperCase(String message) {
+        return message.toUpperCase();
     }
 
     /**
-     * Consume the uppercase channel (in-memory) and print the messages.
+     * Consume the uppercase channel (coming from within the application) and print the messages to the console.
      **/
     @Incoming("uppercase")
     public void sink(String word) {

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
@@ -1,10 +1,7 @@
 package ilove.quark.us;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 
-import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
 
 import jakarta.inject.Inject;
@@ -19,7 +16,7 @@ class MyMessagingApplicationTest {
 
     @Test
     void test() {
-        assertEquals("HELLO", application.toUpperCase(Message.of("Hello")).getPayload());
-        assertEquals("BONJOUR", application.toUpperCase(Message.of("bonjour")).getPayload());
+        assertEquals("HELLO", application.toUpperCase("Hello"));
+        assertEquals("BONJOUR", application.toUpperCase("bonjour"));
     }
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_main_java_ilove_quark_us_MyMessagingApplication.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_main_java_ilove_quark_us_MyMessagingApplication.java
@@ -1,17 +1,21 @@
 package ilove.quark.us;
 
 import io.quarkus.runtime.StartupEvent;
-import org.eclipse.microprofile.reactive.messaging.*;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import jakarta.inject.Inject;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
 import java.util.stream.Stream;
 
 @ApplicationScoped
 public class MyMessagingApplication {
 
-    @Inject
+    /**
+     * Injects an emitter to send messages to the "words-out" channel.
+     */
     @Channel("words-out")
     Emitter<String> emitter;
 
@@ -25,16 +29,16 @@ public class MyMessagingApplication {
 
     /**
      * Consume the message from the "words-in" channel, uppercase it and send it to the uppercase channel.
-     * Messages come from the broker.
+     * This method is called by the framework when a message is received on the "words-in" channel (from the broker).
      **/
     @Incoming("words-in")
     @Outgoing("uppercase")
-    public Message<String> toUpperCase(Message<String> message) {
-        return message.withPayload(message.getPayload().toUpperCase());
+    public String toUpperCase(String message) {
+        return message.toUpperCase();
     }
 
     /**
-     * Consume the uppercase channel (in-memory) and print the messages.
+     * Consume the uppercase channel (coming from within the application) and print the messages to the console.
      **/
     @Incoming("uppercase")
     public void sink(String word) {

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
@@ -1,10 +1,7 @@
 package ilove.quark.us;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 
-import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
 
 import jakarta.inject.Inject;
@@ -19,7 +16,7 @@ class MyMessagingApplicationTest {
 
     @Test
     void test() {
-        assertEquals("HELLO", application.toUpperCase(Message.of("Hello")).getPayload());
-        assertEquals("BONJOUR", application.toUpperCase(Message.of("bonjour")).getPayload());
+        assertEquals("HELLO", application.toUpperCase("Hello"));
+        assertEquals("BONJOUR", application.toUpperCase("bonjour"));
     }
 }


### PR DESCRIPTION
Fix #52578

- Remove the usage of `Message`, which is a very advanced use case, and should only be used in applications that need to handle metadata and acknowledgment manually. This fix the conflict between the Quarkus Flow quickstart and the Messaging one.
- Remove unused imports in the test
