### PR TITLE
Use ${quarkus.version} instead of ${project.version} in CallbackDevModeIT

### DIFF
--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>integration-test-extension-that-defines-junit-test-extensions</artifactId>
-      <version>\${project.version}</version>
+      <version>${quarkus.version}</version>
        <scope>test</scope> 
     </dependency>
 


### PR DESCRIPTION
This was failing in back branches as ${quarkus.version} is not 999-SNAPSHOT in back branches.

