### PR TITLE
[3.20] 3.20.6 backports 2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.21.4</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.21.5</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.28.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.3</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.6.3.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.2.Final</jboss-marshalling.version>
         <jboss-threads.version>3.8.0.Final</jboss-threads.version>
-        <vertx.version>4.5.24</vertx.version>
+        <vertx.version>4.5.25</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -103,7 +103,7 @@
 
         <unboundid-ldap.version>7.0.2</unboundid-ldap.version>
 
-        <assertj.version>3.27.4</assertj.version>
+        <assertj.version>3.27.5</assertj.version>
 
         <wiremock.version>3.11.0</wiremock.version>
         <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -103,7 +103,7 @@
 
         <unboundid-ldap.version>7.0.2</unboundid-ldap.version>
 
-        <assertj.version>3.27.5</assertj.version>
+        <assertj.version>3.27.6</assertj.version>
 
         <wiremock.version>3.11.0</wiremock.version>
         <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -103,7 +103,7 @@
 
         <unboundid-ldap.version>7.0.2</unboundid-ldap.version>
 
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.4</assertj.version>
 
         <wiremock.version>3.11.0</wiremock.version>
         <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -103,7 +103,7 @@
 
         <unboundid-ldap.version>7.0.2</unboundid-ldap.version>
 
-        <assertj.version>3.27.6</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
 
         <wiremock.version>3.11.0</wiremock.version>
         <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlin = "2.0.21"
 smallrye-config = "3.11.3"
 
 junit5 = "5.12.2"
-assertj = "3.27.4"
+assertj = "3.27.5"
 
 [plugins]
 plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlin = "2.0.21"
 smallrye-config = "3.11.3"
 
 junit5 = "5.12.2"
-assertj = "3.27.3"
+assertj = "3.27.4"
 
 [plugins]
 plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlin = "2.0.21"
 smallrye-config = "3.11.3"
 
 junit5 = "5.12.2"
-assertj = "3.27.6"
+assertj = "3.27.7"
 
 [plugins]
 plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlin = "2.0.21"
 smallrye-config = "3.11.3"
 
 junit5 = "5.12.2"
-assertj = "3.27.5"
+assertj = "3.27.6"
 
 [plugins]
 plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -51,7 +51,7 @@
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.12.2</version.smallrye-common>
         <!-- test versions -->
-        <version.assertj>3.27.5</version.assertj>
+        <version.assertj>3.27.6</version.assertj>
         <version.junit5>5.12.2</version.junit5>
         <version.kotlin>2.0.21</version.kotlin>
         <version.kotlin-coroutines>1.9.0</version.kotlin-coroutines>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -51,7 +51,7 @@
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.12.2</version.smallrye-common>
         <!-- test versions -->
-        <version.assertj>3.27.4</version.assertj>
+        <version.assertj>3.27.5</version.assertj>
         <version.junit5>5.12.2</version.junit5>
         <version.kotlin>2.0.21</version.kotlin>
         <version.kotlin-coroutines>1.9.0</version.kotlin-coroutines>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -51,7 +51,7 @@
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.12.2</version.smallrye-common>
         <!-- test versions -->
-        <version.assertj>3.27.3</version.assertj>
+        <version.assertj>3.27.4</version.assertj>
         <version.junit5>5.12.2</version.junit5>
         <version.kotlin>2.0.21</version.kotlin>
         <version.kotlin-coroutines>1.9.0</version.kotlin-coroutines>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -51,7 +51,7 @@
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.12.2</version.smallrye-common>
         <!-- test versions -->
-        <version.assertj>3.27.6</version.assertj>
+        <version.assertj>3.27.7</version.assertj>
         <version.junit5>5.12.2</version.junit5>
         <version.kotlin>2.0.21</version.kotlin>
         <version.kotlin-coroutines>1.9.0</version.kotlin-coroutines>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -38,7 +38,7 @@
         <jmh.version>1.37</jmh.version>
 
         <!-- Dependency versions -->
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.4</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -38,7 +38,7 @@
         <jmh.version>1.37</jmh.version>
 
         <!-- Dependency versions -->
-        <assertj.version>3.27.4</assertj.version>
+        <assertj.version>3.27.5</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -38,7 +38,7 @@
         <jmh.version>1.37</jmh.version>
 
         <!-- Dependency versions -->
-        <assertj.version>3.27.6</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -38,7 +38,7 @@
         <jmh.version>1.37</jmh.version>
 
         <!-- Dependency versions -->
-        <assertj.version>3.27.5</assertj.version>
+        <assertj.version>3.27.6</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -45,7 +45,7 @@
 
         <junit5.version>5.12.2</junit5.version>
         <junit.testkit.version>1.10.3</junit.testkit.version>
-        <assertj.version>3.27.4</assertj.version>
+        <assertj.version>3.27.5</assertj.version>
     </properties>
 
     <dependencyManagement>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -45,7 +45,7 @@
 
         <junit5.version>5.12.2</junit5.version>
         <junit.testkit.version>1.10.3</junit.testkit.version>
-        <assertj.version>3.27.5</assertj.version>
+        <assertj.version>3.27.6</assertj.version>
     </properties>
 
     <dependencyManagement>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -45,7 +45,7 @@
 
         <junit5.version>5.12.2</junit5.version>
         <junit.testkit.version>1.10.3</junit.testkit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.4</assertj.version>
     </properties>
 
     <dependencyManagement>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -45,7 +45,7 @@
 
         <junit5.version>5.12.2</junit5.version>
         <junit.testkit.version>1.10.3</junit.testkit.version>
-        <assertj.version>3.27.6</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
     </properties>
 
     <dependencyManagement>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.junit>5.12.2</version.junit>
-        <version.assertj>3.27.4</version.assertj>
+        <version.assertj>3.27.5</version.assertj>
         <version.jandex>3.3.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.junit>5.12.2</version.junit>
-        <version.assertj>3.27.5</version.assertj>
+        <version.assertj>3.27.6</version.assertj>
         <version.jandex>3.3.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.junit>5.12.2</version.junit>
-        <version.assertj>3.27.3</version.assertj>
+        <version.assertj>3.27.4</version.assertj>
         <version.jandex>3.3.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.junit>5.12.2</version.junit>
-        <version.assertj>3.27.6</version.assertj>
+        <version.assertj>3.27.7</version.assertj>
         <version.jandex>3.3.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -49,7 +49,7 @@
         <bytebuddy.version>1.15.11</bytebuddy.version>
         <junit5.version>5.12.2</junit5.version>
         <maven.version>3.9.9</maven.version>
-        <assertj.version>3.27.6</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <jboss-logmanager.version>3.1.2.Final</jboss-logmanager.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -49,7 +49,7 @@
         <bytebuddy.version>1.15.11</bytebuddy.version>
         <junit5.version>5.12.2</junit5.version>
         <maven.version>3.9.9</maven.version>
-        <assertj.version>3.27.5</assertj.version>
+        <assertj.version>3.27.6</assertj.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <jboss-logmanager.version>3.1.2.Final</jboss-logmanager.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -49,7 +49,7 @@
         <bytebuddy.version>1.15.11</bytebuddy.version>
         <junit5.version>5.12.2</junit5.version>
         <maven.version>3.9.9</maven.version>
-        <assertj.version>3.27.4</assertj.version>
+        <assertj.version>3.27.5</assertj.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <jboss-logmanager.version>3.1.2.Final</jboss-logmanager.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -49,7 +49,7 @@
         <bytebuddy.version>1.15.11</bytebuddy.version>
         <junit5.version>5.12.2</junit5.version>
         <maven.version>3.9.9</maven.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.4</assertj.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <jboss-logmanager.version>3.1.2.Final</jboss-logmanager.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,9 +57,9 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>3.1.0</mutiny.version>
-        <smallrye-mutiny-vertx-core.version>3.21.4</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.21.5</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.12.2</smallrye-common.version>
-        <vertx.version>4.5.24</vertx.version>
+        <vertx.version>4.5.25</vertx.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.18.2</jackson-bom.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -48,7 +48,7 @@
         <scala-plugin.version>4.4.0</scala-plugin.version>
 
         <!-- Versions -->
-        <assertj.version>3.27.5</assertj.version>
+        <assertj.version>3.27.6</assertj.version>
         <jackson-bom.version>2.18.2</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -48,7 +48,7 @@
         <scala-plugin.version>4.4.0</scala-plugin.version>
 
         <!-- Versions -->
-        <assertj.version>3.27.4</assertj.version>
+        <assertj.version>3.27.5</assertj.version>
         <jackson-bom.version>2.18.2</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -48,7 +48,7 @@
         <scala-plugin.version>4.4.0</scala-plugin.version>
 
         <!-- Versions -->
-        <assertj.version>3.27.6</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <jackson-bom.version>2.18.2</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -48,7 +48,7 @@
         <scala-plugin.version>4.4.0</scala-plugin.version>
 
         <!-- Versions -->
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.4</assertj.version>
         <jackson-bom.version>2.18.2</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <junit5.version>5.12.2</junit5.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.24</vertx.version>
+        <vertx.version>4.5.25</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Note: when backporting https://github.com/quarkusio/quarkus/commit/3d06ac97b74d723a9a7260034207e2469c56f0df, I skipped the mutiny bump (3.20 is at mutiny 2.9)