### PR TITLE
Add Official Apache Kafka dev services provider

### DIFF
--- a/extensions/kafka-client/deployment/pom.xml
+++ b/extensions/kafka-client/deployment/pom.xml
@@ -60,6 +60,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-kafka</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>strimzi-test-container</artifactId>
         </dependency>

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.deployment.Feature;
@@ -131,6 +132,17 @@ public class DevServicesKafkaProcessor {
                     useSharedNetwork)
                     .withEnv(config.containerEnv())
                     .withSharedServiceLabel(launchMode.getLaunchMode(), config.serviceName());
+            case OFFICIAL_KAFKA -> {
+                KafkaContainer kafka = new KafkaContainer(DockerImageName.parse(config.effectiveImageName()));
+                ConfigureUtil.configureNetwork(kafka,
+                        composeProjectBuildItem.getDefaultNetworkId(), useSharedNetwork, "kafka");
+                if (config.port().isPresent() && config.port().get() != 0) {
+                    kafka.setPortBindings(List.of(config.port().get() + ":" + KAFKA_PORT));
+                }
+                kafka.withEnv(config.containerEnv());
+                configureSharedServiceLabel(kafka, launchMode.getLaunchMode(), DEV_SERVICE_LABEL, config.serviceName());
+                yield new StartableContainer<>(kafka, KafkaContainer::getBootstrapServers);
+            }
         };
         return startable;
     }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -21,7 +21,6 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
-import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.deployment.Feature;
@@ -132,17 +131,12 @@ public class DevServicesKafkaProcessor {
                     useSharedNetwork)
                     .withEnv(config.containerEnv())
                     .withSharedServiceLabel(launchMode.getLaunchMode(), config.serviceName());
-            case OFFICIAL_KAFKA -> {
-                KafkaContainer kafka = new KafkaContainer(DockerImageName.parse(config.effectiveImageName()));
-                ConfigureUtil.configureNetwork(kafka,
-                        composeProjectBuildItem.getDefaultNetworkId(), useSharedNetwork, "kafka");
-                if (config.port().isPresent() && config.port().get() != 0) {
-                    kafka.setPortBindings(List.of(config.port().get() + ":" + KAFKA_PORT));
-                }
-                kafka.withEnv(config.containerEnv());
-                configureSharedServiceLabel(kafka, launchMode.getLaunchMode(), DEV_SERVICE_LABEL, config.serviceName());
-                yield new StartableContainer<>(kafka, KafkaContainer::getBootstrapServers);
-            }
+            case OFFICIAL_KAFKA -> new OfficialKafkaContainer(DockerImageName.parse(config.effectiveImageName()),
+                    config.port().orElse(0),
+                    composeProjectBuildItem.getDefaultNetworkId(),
+                    useSharedNetwork)
+                    .withEnv(config.containerEnv())
+                    .withSharedServiceLabel(launchMode.getLaunchMode(), config.serviceName());
         };
         return startable;
     }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -27,7 +27,7 @@ public interface KafkaDevServicesBuildTimeConfig {
     /**
      * Kafka dev service container type.
      * <p>
-     * Redpanda, Strimzi and kafka-native container providers are supported. Default is redpanda.
+     * Redpanda, Strimzi, kafka-native and official-kafka container providers are supported. Default is redpanda.
      * <p>
      * For Redpanda:
      * See https://docs.redpanda.com/current/get-started/quick-start/ and https://hub.docker.com/r/redpandadata/redpanda
@@ -38,7 +38,10 @@ public interface KafkaDevServicesBuildTimeConfig {
      * For Kafka Native:
      * See https://github.com/ozangunalp/kafka-native and https://quay.io/repository/ogunalp/kafka-native
      * <p>
-     * Note that Strimzi and Kafka Native images are launched in Kraft mode.
+     * For Official Kafka:
+     * See https://kafka.apache.org/ and https://hub.docker.com/r/apache/kafka
+     * <p>
+     * Note that Strimzi, Kafka Native, and Official Kafka images are launched in Kraft mode.
      */
     @WithDefault("redpanda")
     Provider provider();
@@ -46,7 +49,8 @@ public interface KafkaDevServicesBuildTimeConfig {
     enum Provider {
         REDPANDA("docker.io/redpandadata/redpanda:v24.1.2"),
         STRIMZI("quay.io/strimzi-test-container/test-container:0.114.0-kafka-4.1.1"),
-        KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
+        KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest"),
+        OFFICIAL_KAFKA("apache/kafka:4.2.0");
 
         private final String defaultImageName;
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/OfficialKafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/OfficialKafkaContainer.java
@@ -1,0 +1,87 @@
+package io.quarkus.kafka.client.deployment;
+
+import static io.quarkus.kafka.client.deployment.DevServicesKafkaProcessor.DEV_SERVICE_LABEL;
+
+import java.util.Map;
+
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.deployment.builditem.Startable;
+import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Container for official Apache Kafka images with support for shared networks.
+ */
+public class OfficialKafkaContainer extends KafkaContainer implements Startable {
+
+    private final Integer fixedExposedPort;
+    private final boolean useSharedNetwork;
+    private final String hostName;
+
+    public OfficialKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String defaultNetworkId,
+            boolean useSharedNetwork) {
+        super(dockerImageName);
+        this.fixedExposedPort = fixedExposedPort;
+        this.useSharedNetwork = useSharedNetwork;
+        this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "kafka");
+    }
+
+    public OfficialKafkaContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {
+        withLabel(DEV_SERVICE_LABEL, serviceName);
+        if (LaunchMode.DEVELOPMENT == launchMode) {
+            withLabel("quarkus-dev-service", serviceName);
+        }
+        return this;
+    }
+
+    @Override
+    public OfficialKafkaContainer withEnv(Map<String, String> env) {
+        super.withEnv(env);
+        return this;
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+
+        if (fixedExposedPort != null && fixedExposedPort != 0) {
+            addFixedExposedPort(fixedExposedPort, DevServicesKafkaProcessor.KAFKA_PORT);
+        }
+
+        // Configure advertised listeners for shared network
+        if (useSharedNetwork) {
+            // Override the default advertised listeners to use the container hostname
+            // This allows other containers in the shared network to connect
+            withEnv("KAFKA_LISTENERS",
+                    String.format("PLAINTEXT://0.0.0.0:%d,BROKER://localhost:9093",
+                            DevServicesKafkaProcessor.KAFKA_PORT));
+            withEnv("KAFKA_ADVERTISED_LISTENERS",
+                    String.format("PLAINTEXT://%s:%d,BROKER://localhost:9093",
+                            hostName, DevServicesKafkaProcessor.KAFKA_PORT));
+            withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "PLAINTEXT:PLAINTEXT,BROKER:PLAINTEXT");
+            withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER");
+        }
+    }
+
+    @Override
+    public String getBootstrapServers() {
+        if (useSharedNetwork) {
+            // In shared network mode, return the container hostname
+            return String.format("%s:%d", hostName, DevServicesKafkaProcessor.KAFKA_PORT);
+        }
+        // Otherwise, use the default behavior (docker host + mapped port)
+        return super.getBootstrapServers();
+    }
+
+    @Override
+    public String getConnectionInfo() {
+        return getBootstrapServers();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+    }
+}


### PR DESCRIPTION
  - Added OFFICIAL_KAFKA provider using apache/kafka images
  - Uses Testcontainers kafka module for production-ready infrastructure
  - Supports KRaft mode (no ZooKeeper required)
  - Configurable via quarkus.kafka.devservices.provider=official-kafka
  - Default image: apache/kafka:4.2.0

* Fixes #43272
