### PR TITLE
Introduce `enableKeepAlive()` and `readTimeout()` in JDBC Runtime config

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalConnectionConfigurer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalConnectionConfigurer.java
@@ -1,5 +1,6 @@
 package io.quarkus.agroal.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.jboss.logging.Logger;
@@ -26,6 +27,16 @@ public interface AgroalConnectionConfigurer {
     default void setExceptionSorter(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
         log.warnv("Agroal does not support detecting if a connection is still usable after an exception for database kind: {0}",
                 databaseKind);
+    }
+
+    default void setKeepAlive(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, boolean keepAlive) {
+        log.warnv("Agroal does not support KeepAlive for database kind: {0}", databaseKind);
+    }
+
+    default void setReadTimeout(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, Duration timeout) {
+        log.warnv("Agroal does not support setting the read timeout for database kind: {0}", databaseKind);
     }
 
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -188,6 +188,19 @@ public interface DataSourceJdbcRuntimeConfig {
      */
     DataSourceJdbcTelemetryConfig telemetry();
 
+    /**
+     * Enable KeepAlive for this datasource. When enabled, the datasource will attempt to keep connections alive by sending
+     * periodic keep-alive messages to the database. Each JDBC driver has its own implementation of keep-alive, and the actual
+     * behavior may vary depending on the driver and database being used.
+     */
+    Optional<Boolean> enableKeepAlive();
+
+    /**
+     * The timeout value used for socket read operations. If reading from the server takes longer than this value, the
+     * connection is closed.
+     */
+    Optional<Duration> readTimeout();
+
     enum MultipleAcquisition {
 
         /**

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -198,6 +198,18 @@ public class DataSources {
             agroalConnectionConfigurer.disableSslSupport(resolvedDbKind, dataSourceConfiguration,
                     dataSourceJdbcRuntimeConfig.additionalJdbcProperties());
         }
+
+        if (dataSourceJdbcRuntimeConfig.enableKeepAlive().isPresent()) {
+            agroalConnectionConfigurer.setKeepAlive(resolvedDbKind, dataSourceConfiguration,
+                    dataSourceJdbcRuntimeConfig.additionalJdbcProperties(),
+                    dataSourceJdbcRuntimeConfig.enableKeepAlive().get());
+        }
+
+        if (dataSourceJdbcRuntimeConfig.readTimeout().isPresent()) {
+            agroalConnectionConfigurer.setReadTimeout(resolvedDbKind, dataSourceConfiguration,
+                    dataSourceJdbcRuntimeConfig.additionalJdbcProperties(), dataSourceJdbcRuntimeConfig.readTimeout().get());
+        }
+
         //we use a custom cache for two reasons:
         //fast thread local cache should be faster
         //and it prevents a thread local leak

--- a/extensions/jdbc/jdbc-mariadb/deployment/src/test/java/io/quarkus/jdbc/mariadb/deployment/DevServicesMariaDBKeepAliveTestCase.java
+++ b/extensions/jdbc/jdbc-mariadb/deployment/src/test/java/io/quarkus/jdbc/mariadb/deployment/DevServicesMariaDBKeepAliveTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.jdbc.mariadb.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DevServicesMariaDBKeepAliveTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.jdbc.enable-keep-alive", "true")
+            .overrideConfigKey("quarkus.datasource.jdbc.read-timeout", "30S");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testKeepAliveEnabled() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("tcpKeepAlive")).isEqualTo("true");
+    }
+
+    @Test
+    public void testReadTimeoutSet() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("socketTimeout")).isEqualTo("30000");
+    }
+}

--- a/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/MariaDBAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/MariaDBAgroalConnectionConfigurer.java
@@ -1,5 +1,6 @@
 package io.quarkus.jdbc.mariadb.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
@@ -23,4 +24,21 @@ public class MariaDBAgroalConnectionConfigurer implements AgroalConnectionConfig
         dataSourceConfiguration.connectionPoolConfiguration().exceptionSorter(new MySQLExceptionSorter());
     }
 
+    @Override
+    public void setKeepAlive(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, boolean keepAlive) {
+        // MariaDB JDBC driver uses "tcpKeepAlive" property to enable keep-alive. Default is true.
+        // See https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("tcpKeepAlive",
+                Boolean.toString(keepAlive));
+    }
+
+    @Override
+    public void setReadTimeout(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, Duration timeout) {
+        // MariaDB JDBC driver uses "socketTimeout" property to configure socket timeout.
+        // See https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("socketTimeout",
+                Long.toString(timeout.toMillis()));
+    }
 }

--- a/extensions/jdbc/jdbc-mssql/deployment/src/test/java/io/quarkus/jdbc/mssql/deployment/DevServicesMsSQLReadTimeoutTestCase.java
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/test/java/io/quarkus/jdbc/mssql/deployment/DevServicesMsSQLReadTimeoutTestCase.java
@@ -1,0 +1,34 @@
+package io.quarkus.jdbc.mssql.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DevServicesMsSQLReadTimeoutTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.datasource.jdbc.read-timeout", "30S");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testReadTimeoutSet() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("socketTimeout")).isEqualTo("30000");
+    }
+}

--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLAgroalConnectionConfigurer.java
@@ -1,5 +1,6 @@
 package io.quarkus.jdbc.mssql.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
@@ -22,4 +23,13 @@ public class MsSQLAgroalConnectionConfigurer implements AgroalConnectionConfigur
         dataSourceConfiguration.connectionPoolConfiguration().exceptionSorter(new MSSQLExceptionSorter());
     }
 
+    @Override
+    public void setReadTimeout(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, Duration timeout) {
+        // MSSQL socket timeout is configured using the "socketTimeout" property, which is in milliseconds
+        // See https://learn.microsoft.com/en-us/sql/connect/jdbc/understand-timeouts
+        // https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration()
+                .jdbcProperty("socketTimeout", Long.toString(timeout.toMillis()));
+    }
 }

--- a/extensions/jdbc/jdbc-mysql/deployment/src/test/java/io/quarkus/jdbc/mysql/deployment/DevServicesMySQLKeepAliveTestCase.java
+++ b/extensions/jdbc/jdbc-mysql/deployment/src/test/java/io/quarkus/jdbc/mysql/deployment/DevServicesMySQLKeepAliveTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.jdbc.mysql.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DevServicesMySQLKeepAliveTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.jdbc.enable-keep-alive", "true")
+            .overrideConfigKey("quarkus.datasource.jdbc.read-timeout", "30S");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testKeepAliveEnabled() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("tcpKeepAlive")).isEqualTo("true");
+    }
+
+    @Test
+    public void testReadTimeoutSet() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("socketTimeout")).isEqualTo("30000");
+    }
+}

--- a/extensions/jdbc/jdbc-mysql/runtime/src/main/java/io/quarkus/jdbc/mysql/runtime/MySQLAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-mysql/runtime/src/main/java/io/quarkus/jdbc/mysql/runtime/MySQLAgroalConnectionConfigurer.java
@@ -1,5 +1,6 @@
 package io.quarkus.jdbc.mysql.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
@@ -22,4 +23,20 @@ public class MySQLAgroalConnectionConfigurer implements AgroalConnectionConfigur
         dataSourceConfiguration.connectionPoolConfiguration().exceptionSorter(new MySQLExceptionSorter());
     }
 
+    @Override
+    public void setKeepAlive(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, boolean keepAlive) {
+        // The MySQL JDBC driver has its own keep-alive mechanism that can be enabled via a JDBC property
+        // https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-networking.html
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration()
+                .jdbcProperty("tcpKeepAlive", Boolean.toString(keepAlive));
+    }
+
+    @Override
+    public void setReadTimeout(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, Duration timeout) {
+        // https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-networking.html
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration()
+                .jdbcProperty("socketTimeout", Long.toString(timeout.toMillis()));
+    }
 }

--- a/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/DevServicesOracleKeepAliveTestCase.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/DevServicesOracleKeepAliveTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.jdbc.oracle.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DevServicesOracleKeepAliveTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.jdbc.enable-keep-alive", "true")
+            .overrideConfigKey("quarkus.datasource.jdbc.read-timeout", "30S");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testKeepAliveEnabled() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("oracle.net.keepAlive")).isEqualTo("true");
+    }
+
+    @Test
+    public void testReadTimeoutSet() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("oracle.jdbc.ReadTimeout")).isEqualTo("30000");
+    }
+}

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleAgroalConnectionConfigurer.java
@@ -1,5 +1,6 @@
 package io.quarkus.jdbc.oracle.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
@@ -14,7 +15,7 @@ public class OracleAgroalConnectionConfigurer implements AgroalConnectionConfigu
     /**
      * Oracle connection properties are documented here:
      * https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#Transport_Layer_Security__TLS_SSL_
-     *
+     * <p>
      * SSL seems to be disabled by default, so rather than disabling it explicitly we check that the user didn't attempt to
      * enable it.
      */
@@ -33,4 +34,21 @@ public class OracleAgroalConnectionConfigurer implements AgroalConnectionConfigu
         dataSourceConfiguration.connectionPoolConfiguration().exceptionSorter(new OracleExceptionSorter());
     }
 
+    @Override
+    public void setKeepAlive(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, boolean keepAlive) {
+        // Oracle keep-alive is configured via the "oracle.net.keepAlive" property. Defaults to false.
+        // https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration()
+                .jdbcProperty("oracle.net.keepAlive", Boolean.toString(keepAlive));
+    }
+
+    @Override
+    public void setReadTimeout(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, Duration timeout) {
+        // Oracle socket timeout is configured via the "oracle.jdbc.ReadTimeout" property, which is in milliseconds
+        // https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration()
+                .jdbcProperty("oracle.jdbc.ReadTimeout", Long.toString(timeout.toMillis()));
+    }
 }

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlKeepAliveTestCase.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlKeepAliveTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.jdbc.postgresql.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DevServicesPostgresqlKeepAliveTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.jdbc.enable-keep-alive", "true")
+            .overrideConfigKey("quarkus.datasource.jdbc.read-timeout", "30S");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testKeepAliveEnabled() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("tcpKeepAlive")).isEqualTo("true");
+    }
+
+    @Test
+    public void testReadTimeoutSet() {
+        AgroalConnectionFactoryConfiguration connectionFactoryConfig = dataSource.getConfiguration()
+                .connectionPoolConfiguration()
+                .connectionFactoryConfiguration();
+        Properties jdbcProperties = connectionFactoryConfig.jdbcProperties();
+        assertThat(jdbcProperties.getProperty("socketTimeout")).isEqualTo("30");
+    }
+}

--- a/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/PostgreSQLAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/PostgreSQLAgroalConnectionConfigurer.java
@@ -1,5 +1,6 @@
 package io.quarkus.jdbc.postgresql.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
@@ -23,4 +24,21 @@ public class PostgreSQLAgroalConnectionConfigurer implements AgroalConnectionCon
         dataSourceConfiguration.connectionPoolConfiguration().exceptionSorter(new PostgreSQLExceptionSorter());
     }
 
+    @Override
+    public void setKeepAlive(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, boolean keepAlive) {
+        // The PostgreSQL JDBC driver has its own keep-alive mechanism that can be enabled via a JDBC property. Default is false.
+        // See https://jdbc.postgresql.org/documentation/use/#connection-parameters
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("tcpKeepAlive",
+                Boolean.toString(keepAlive));
+    }
+
+    @Override
+    public void setReadTimeout(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties, Duration timeout) {
+        // The PostgreSQL JDBC driver uses the "socketTimeout" property to specify the socket timeout in seconds.
+        // See https://jdbc.postgresql.org/documentation/use/#connection-parameters
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("socketTimeout",
+                Long.toString(timeout.getSeconds()));
+    }
 }


### PR DESCRIPTION
  ## Summary

  Introduce two new JDBC runtime configuration properties:

  - `quarkus.datasource.jdbc.enable-keep-alive` — enables TCP keep-alive on the JDBC socket, allowing the driver to detect dead connections via periodic keep-alive probes. Supported for PostgreSQL, MariaDB, MySQL, and Oracle.
  - `quarkus.datasource.jdbc.read-timeout` — sets a socket-level read timeout on the JDBC connection. If a read from the database takes longer than this value, the connection is closed. Supported for all five JDBC drivers (PostgreSQL,
  MariaDB, MySQL, Oracle, MS SQL).

  Each driver maps these to its native JDBC connection property (e.g., `tcpKeepAlive`, `socketTimeout`, `oracle.net.keepAlive`, `oracle.jdbc.ReadTimeout`).

  These properties give users more control over connection health detection and can serve as a workaround for scenarios where higher-level timeouts (like `validation-query-timeout`) are not reliably enforced by the JDBC driver.

- Related: #49976
