### PR TITLE
 Set version to main as dev and fallback to refname when branching 

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/antora.tpl.qute.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/antora.tpl.qute.yml
@@ -1,5 +1,6 @@
 name: {namespace.id}{extension.id}
 title: {extension.name}
-version: dev
+version:
+  main: dev # fallback to using the matched refname as the value for other branches
 nav:
   - modules/ROOT/nav.adoc

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_antora.yml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_antora.yml
@@ -1,5 +1,6 @@
 name: quarkus-my-quarkiverse-ext
 title: My Quarkiverse extension
-version: dev
+version:
+  main: dev # fallback to using the matched refname as the value for other branches
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
- This avoids any manual changes when branching
- See https://docs.antora.org/antora/latest/playbook/content-source-version/#refname-as-version
