### PR TITLE
Open java.naming/com.sun.naming.internal

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -464,6 +464,8 @@ public class QuarkusPlugin implements Plugin<Project> {
                         t.jvmArgs(
                                 "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
                                 "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                                // we need to access com.sun.naming.internal.ResourceManager to reset a cache
+                                "--add-opens=java.naming/com.sun.naming.internal=ALL-UNNAMED",
                                 "--add-exports=java.base/jdk.internal.module=ALL-UNNAMED");
 
                         t.getInputs().files(quarkusGenerateTestAppModelTask);

--- a/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
@@ -26,6 +26,8 @@ public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant 
     private static final List<String> INJECTED_JVM_PROPS = List.of(
             "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
             "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            // this one is needed when running the tests, as we need to access com.sun.naming.internal.ResourceManager to reset a cache
+            "--add-opens=java.naming/com.sun.naming.internal=ALL-UNNAMED",
             "--add-exports=java.base/jdk.internal.module=ALL-UNNAMED");
 
     private final Logger logger;


### PR DESCRIPTION
In tests, we clear a static map in
com.sun.naming.internal.ResourceManager and we need the module to be open for that.

Related to my investigation in #38774 but it doesn't solve the problem one bit.

