### PR TITLE
Make ClassPathElement cache static in CuratedApplication

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -45,11 +45,11 @@ public class CuratedApplication implements Serializable, AutoCloseable {
 
     /**
      * The class path elements for the various artifacts. These can be used in multiple class loaders
-     * so this map allows them to be shared.
+     * so this static map allows them to be shared, both across class loaders and across multiple CuratedApplications.
      *
      * This should not be used for hot reloadable elements
      */
-    private final Map<ArtifactKey, ClassPathElement> augmentationElements = new HashMap<>();
+    private static final Map<String, ClassPathElement> DEPENDENCY_CLASSPATH_ELEMENTS = new HashMap<>();
 
     /**
      * The augmentation class loader.
@@ -196,7 +196,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                 }
             };
         }
-        ClassPathElement cpe = useCpeCache ? augmentationElements.get(artifact.getKey()) : null;
+        ClassPathElement cpe = useCpeCache ? DEPENDENCY_CLASSPATH_ELEMENTS.get(artifact.toGACTVString()) : null;
         if (cpe != null) {
             consumer.accept(cpe);
             return;
@@ -209,7 +209,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         cpe = ClassPathElement.fromDependency(contentTree, artifact);
         consumer.accept(cpe);
         if (useCpeCache) {
-            augmentationElements.put(artifact.getKey(), cpe);
+            DEPENDENCY_CLASSPATH_ELEMENTS.put(artifact.toGACTVString(), cpe);
         }
     }
 
@@ -475,7 +475,10 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             baseRuntimeClassLoader.close();
             baseRuntimeClassLoader = null;
         }
-        augmentationElements.clear();
+        // we clear the elements when CuratedApplication is closed.
+        // in the case of tests with multiple profiles, we keep the CuratedApplications around until the end of the test run
+        // so all the ClassPathElements are shared
+        DEPENDENCY_CLASSPATH_ELEMENTS.clear();
     }
 
     public boolean isEligibleForReuse() {


### PR DESCRIPTION
@aloubyansky @holly-cummins this is not something I want to get merged as is, as it's plain ugly, but I think we should discuss how we can reuse the ClassPathElements when they point to something that is not reloadable (typically a jar). We are opening and keeping in memory a lot more than really necessary.

====

We were sharing the ClassPathElement for the dependencies across multiple class loaders of CuratedApplication, but not across multiple CuratedApplications.
I think it is safe to do, given they are tied to the dependency itself.

The only case, where it might be a problem is if a dependency is changed: we would keep the ClassPathElement around, but I don't think it will be a big problem in practice, compared to how much we gain by caching them.

Just to give an idea of the scale, with 9 test profiles, I ended up with 3000+ ClassPathElements.

Related to my investigations for #38774 but it's not solving the issue as it only affects heap space, not meta space.


