### PR TITLE
Adding storage-engine properties into hibernate-orm.adoc

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -962,7 +962,11 @@ You can also fine-tune dialect behavior for specific databases using additional 
 ----
 quarkus.hibernate-orm."offline".dialect.mariadb.bytes-per-character=1
 quarkus.hibernate-orm."offline".dialect.mariadb.no-backslash-escapes=true
+quarkus.hibernate-orm."offline".dialect.mariadb.storage-engine=InnoDB <1>
+quarkus.hibernate-orm."inventory".dialect.mysql.storage-engine=MyISAM <2>
 ----
+<1> Set the storage engine for the MariaDB dialect of the `offline` persistence unit.
+<2> Different persistence units can use different storage engines.
 
 Refer to the <<configuration-reference>> section for more details on the available properties.
 


### PR DESCRIPTION
Adding properties to configure MariaDB/MySQL storage engines per persistence unit into [hibernate-orm.adoc](https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/hibernate-orm.adoc).

Related to #49273 

