### PR TITLE
Include component tests in orderer

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.junit.util;
 
+import java.lang.annotation.Annotation;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,6 +59,7 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST = "20_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_MAIN_TEST = "30_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_INTEGRATION_TEST = "40_";
+    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_COMPONENT_TEST = "70_";
     protected static final String DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST = "60_";
 
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST = "junit.quarkus.orderer.prefix.quarkus-test";
@@ -66,6 +68,8 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_MAIN_TEST = "junit.quarkus.orderer.prefix.quarkus-main-test";
 
+    static final String CFGKEY_ORDER_PREFIX_QUARKUS_COMPONENT_TEST = "junit.quarkus.orderer.prefix.quarkus-component-test";
+
     static final String CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST = "junit.quarkus.orderer.prefix.non-quarkus-test";
 
     static final String CFGKEY_UNDOCUMENTED_SECONDARY_ORDERER = "junit.quarkus.orderer.secondary-orderer";
@@ -73,9 +77,11 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     private final String prefixQuarkusTest;
     private final String prefixQuarkusMainTest;
+    private final String prefixQuarkusComponentTest;
     private final String prefixQuarkusIntegrationTest;
     private final String prefixNonQuarkusTest;
     private final Optional<String> secondaryOrderer;
+    private final Optional<Class<? extends Annotation>> componentTestAnnotation;
 
     public QuarkusTestProfileAwareClassOrderer() {
         Config config = ConfigProvider.getConfig();
@@ -86,6 +92,8 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
                 .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_MAIN_TEST);
         this.prefixQuarkusIntegrationTest = config.getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_INTEGRATION_TEST, String.class)
                 .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_INTEGRATION_TEST);
+        this.prefixQuarkusComponentTest = config.getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_COMPONENT_TEST, String.class)
+                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_COMPONENT_TEST);
         this.prefixNonQuarkusTest = config.getOptionalValue(CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST, String.class)
                 .orElse(DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST);
 
@@ -100,19 +108,38 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
             secondaryOrdererFromConfig = null;
         }
         this.secondaryOrderer = secondaryOrdererFromConfig != null ? Optional.of(secondaryOrdererFromConfig) : Optional.empty();
+        componentTestAnnotation = loadComponentTestAnnotation();
+
     }
 
     QuarkusTestProfileAwareClassOrderer(
             final String prefixQuarkusTest,
             final String prefixQuarkusMainTest,
             final String prefixQuarkusIntegrationTest,
+            final String prefixQuarkusComponentTest,
             final String prefixNonQuarkusTest,
             final Optional<String> secondaryOrderer) {
         this.prefixQuarkusTest = prefixQuarkusTest;
         this.prefixQuarkusMainTest = prefixQuarkusMainTest;
+        this.prefixQuarkusComponentTest = prefixQuarkusComponentTest;
         this.prefixQuarkusIntegrationTest = prefixQuarkusIntegrationTest;
         this.prefixNonQuarkusTest = prefixNonQuarkusTest;
         this.secondaryOrderer = secondaryOrderer;
+
+        componentTestAnnotation = loadComponentTestAnnotation();
+
+    }
+
+    private static Optional<Class<? extends Annotation>> loadComponentTestAnnotation() {
+        Optional<Class<? extends Annotation>> maybeComponentTestAnnotation;
+        try {
+            maybeComponentTestAnnotation = Optional
+                    .of((Class<? extends Annotation>) Class.forName("io.quarkus.test.component.QuarkusComponentTest"));
+        } catch (ClassNotFoundException e) {
+            // The dependency isn't there, so we definitely don't have to worry about it
+            maybeComponentTestAnnotation = Optional.empty();
+        }
+        return maybeComponentTestAnnotation;
     }
 
     @Override
@@ -173,6 +200,8 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
         } else {
             if (classDescriptor.isAnnotated(QuarkusMainTest.class)) {
                 return prefixQuarkusMainTest;
+            } else if (componentTestAnnotation.isPresent() && classDescriptor.isAnnotated(componentTestAnnotation.get())) {
+                return prefixQuarkusComponentTest;
             } else {
                 return prefixNonQuarkusTest;
             }

--- a/test-framework/junit/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
+++ b/test-framework/junit/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
@@ -115,7 +115,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 .getClassDescriptors();
 
         // change secondary orderer from ClassName to OrderAnnotation
-        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "60_",
+        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "10_", "_60",
                 Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
 
         assertThat(input).containsExactly(quarkusTestb1Desc,
@@ -151,7 +151,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 .getClassDescriptors();
 
         // change secondary orderer from ClassName to OrderAnnotation
-        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "60_",
+        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "_5", "60_",
                 Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
 
         assertThat(input).containsExactly(
@@ -202,7 +202,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 .getClassDescriptors();
 
         // change secondary orderer from ClassName to OrderAnnotation
-        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "60_",
+        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "50_", "70_", "60_",
                 Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
 
         assertThat(input).containsExactly(
@@ -294,7 +294,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
         doReturn(input).when(contextMock)
                 .getClassDescriptors();
 
-        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "01_", Optional.empty()).orderClasses(contextMock);
+        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "35_", "01_", Optional.empty()).orderClasses(contextMock);
 
         assertThat(input).containsExactly(nonQuarkusTestDesc, quarkusTestDesc);
     }
@@ -314,7 +314,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
         doReturn(input).when(contextMock)
                 .getClassDescriptors();
 
-        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "60_",
+        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "80_", "60_",
                 Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
 
         assertThat(input).containsExactly(


### PR DESCRIPTION
I couldn't easily add tests for this without adding a dependency on the component test project from the main junit project. I also couldn't reproduce the problem with the reproducer, probably because of a environment-sensitive difference in the underlying test order junit was using. So I'm *hoping* this fixes the problem! 

Resolves https://github.com/quarkusio/quarkus/issues/48289