### PR TITLE
Update default guide URLs to reference 'main' branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/extension_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/extension_proposal.yml
@@ -41,7 +41,7 @@ body:
       description: >-
         A URL with more information about the technology this extension promotes (defaults to the Quarkiverse Docs repository)
       value:
-        https://docs.quarkiverse.io/<REPOSITORY_NAME>/dev/
+        https://docs.quarkiverse.io/<REPOSITORY_NAME>/main/
 
   - type: textarea
     id: repository_topics

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-codestart/java/runtime/src/main/codestarts/quarkus/{extension.id}-codestart/codestart.tpl.qute.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-codestart/java/runtime/src/main/codestarts/quarkus/{extension.id}-codestart/codestart.tpl.qute.yml
@@ -7,7 +7,7 @@ metadata:
   description: {#if extension.description}{extension.description}{#else}Start coding with {extension.name}{/if}
 #  path: /some-path
 {#if input.extra-codestarts.contains("quarkiverse")}
-  related-guide-section: https://docs.quarkiverse.io/quarkus-{extension.id}/dev/index.html
+  related-guide-section: https://docs.quarkiverse.io/quarkus-{extension.id}/main/index.html
 {#else}
 #  related-guide-section: TBD
 {/if}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -89,7 +89,7 @@ public class CreateExtension {
     public static final String DEFAULT_QUARKIVERSE_PARENT_ARTIFACT_ID = "quarkiverse-parent";
     public static final String DEFAULT_QUARKIVERSE_PARENT_VERSION = "20";
     public static final String DEFAULT_QUARKIVERSE_NAMESPACE_ID = "quarkus-";
-    public static final String DEFAULT_QUARKIVERSE_GUIDE_URL = "https://docs.quarkiverse.io/%s/dev/";
+    public static final String DEFAULT_QUARKIVERSE_GUIDE_URL = "https://docs.quarkiverse.io/%s/main/";
 
     private static final String DEFAULT_SUREFIRE_PLUGIN_VERSION = "3.5.4";
     private static final String DEFAULT_COMPILER_PLUGIN_VERSION = "3.15.0";

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
@@ -3,7 +3,7 @@ name: My Quarkiverse extension
 metadata:
 #  keywords:
 #    - my-quarkiverse-ext
-#  guide: https://docs.quarkiverse.io/quarkus-my-quarkiverse-ext/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+#  guide: https://docs.quarkiverse.io/quarkus-my-quarkiverse-ext/main/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
 #  categories:
 #    - "miscellaneous"
 #  status: "preview"


### PR DESCRIPTION
- Standardize Quarkiverse guide URLs and repository homepage references to use the "main" branch for consistency.
- Update templates and integration test snapshots to reflect the new default URL structure.
