### PR TITLE
ArC: avoid duplicates early on

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
@@ -206,6 +206,7 @@ public final class Annotations {
      * Returns a list of annotations created out of the given set such that the result does not have
      * annotations that are identical except of the {@linkplain AnnotationInstance#target() annotation target}.
      */
+    @Deprecated(forRemoval = true, since = "3.34")
     public static List<AnnotationInstance> uniqueAnnotations(Set<AnnotationInstance> annotations) {
         Set<AnnotationInstanceEquivalenceProxy> proxies = new HashSet<>();
         for (AnnotationInstance annotation : annotations) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1,7 +1,9 @@
 package io.quarkus.arc.processor;
 
-import static io.quarkus.arc.processor.Annotations.uniqueAnnotations;
 import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+import static io.quarkus.arc.processor.Reproducibility.orderedAnnotations;
+import static io.quarkus.arc.processor.Reproducibility.orderedStereotypes;
+import static io.quarkus.arc.processor.Reproducibility.orderedTypes;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.fieldDescOf;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.methodDescOf;
@@ -446,7 +448,7 @@ public class BeanGenerator extends AbstractGenerator {
 
                 // Bean types
                 RuntimeTypeCreator rttc = RuntimeTypeCreator.of(bc).withTCCL(tccl);
-                Expr typesSet = bc.setOf(bean.getTypes().stream().toList(), type -> {
+                Expr typesSet = bc.setOf(orderedTypes(bean.getTypes()), type -> {
                     try {
                         return rttc.create(type);
                     } catch (IllegalArgumentException e) {
@@ -457,7 +459,7 @@ public class BeanGenerator extends AbstractGenerator {
 
                 // Qualifiers
                 if (!bean.getQualifiers().isEmpty() && !bean.hasDefaultQualifiers()) {
-                    Expr qualifiersSet = bc.setOf(uniqueAnnotations(bean.getQualifiers()), qualifier -> {
+                    Expr qualifiersSet = bc.setOf(orderedAnnotations(bean.getQualifiers()), qualifier -> {
                         BuiltinQualifier builtinQualifier = BuiltinQualifier.of(qualifier);
                         if (builtinQualifier != null) {
                             return builtinQualifier.getLiteralInstance();
@@ -471,7 +473,7 @@ public class BeanGenerator extends AbstractGenerator {
 
                 // Stereotypes
                 if (!bean.getStereotypes().isEmpty()) {
-                    Expr stereotypesSet = bc.setOf(bean.getStereotypes(),
+                    Expr stereotypesSet = bc.setOf(orderedStereotypes(bean.getStereotypes()),
                             stereotype -> Const.of(classDescOf(stereotype.getTarget())));
                     bc.set(cc.this_().field(stereotypesField), stereotypesSet);
                 }
@@ -708,7 +710,7 @@ public class BeanGenerator extends AbstractGenerator {
             }));
 
             // Interceptor bindings
-            List<AnnotationInstance> bindings = uniqueAnnotations(aroundConstructInterception.bindings);
+            List<AnnotationInstance> bindings = orderedAnnotations(aroundConstructInterception.bindings);
             LocalVar bindingsSet = bc.localVar("bindings", bc.setOf(bindings, binding -> {
                 ClassInfo bindingClass = bean.getDeployment().getInterceptorBinding(binding.name());
                 return annotationLiterals.create(bc, bindingClass, binding);
@@ -908,7 +910,7 @@ public class BeanGenerator extends AbstractGenerator {
             }));
 
             // Interceptor bindings
-            List<AnnotationInstance> bindings = uniqueAnnotations(postConstructInterception.bindings);
+            List<AnnotationInstance> bindings = orderedAnnotations(postConstructInterception.bindings);
             LocalVar bindingsSet = bc.localVar("bindings", bc.setOf(bindings, binding -> {
                 ClassInfo bindingClass = bean.getDeployment().getInterceptorBinding(binding.name());
                 return annotationLiterals.create(bc, bindingClass, binding);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -139,12 +139,13 @@ public class BeanInfo implements InjectionTargetInfo {
         this.beanDeployment = beanDeployment;
         this.scope = scope != null ? scope : BuiltinScope.DEPENDENT.getInfo();
         types.add(ClassType.OBJECT_TYPE);
+        types = Unique.types(types);
         this.types = types;
         for (Type type : types) {
             Beans.analyzeType(type, beanDeployment);
         }
-        this.unrestrictedTypes = unrestrictedTypes != null ? unrestrictedTypes : types;
-        this.qualifiers = Beans.addImplicitQualifiers(qualifiers);
+        this.unrestrictedTypes = unrestrictedTypes != null ? Unique.types(unrestrictedTypes) : types;
+        this.qualifiers = Unique.annotations(Beans.addImplicitQualifiers(qualifiers));
         // we have a fast path for all beans which didn't have a qualifier and for which we added them, which is the most common case
         this.hasDefaultQualifiers = (this.qualifiers == BuiltinQualifier.DEFAULT_QUALIFIERS) ||
                 (this.qualifiers.size() == 2 && this.qualifiers.contains(BuiltinQualifier.DEFAULT.getInstance())
@@ -154,7 +155,7 @@ public class BeanInfo implements InjectionTargetInfo {
         this.disposer = disposer;
         this.alternative = alternative;
         this.priority = priority;
-        this.stereotypes = stereotypes;
+        this.stereotypes = Unique.stereotypes(stereotypes);
         this.name = name;
         this.defaultBean = isDefaultBean;
         this.creatorConsumer = creatorConsumer;
@@ -917,12 +918,10 @@ public class BeanInfo implements InjectionTargetInfo {
     }
 
     private void putLifecycleInterceptors(Map<InterceptionType, InterceptionInfo> lifecycleInterceptors,
-            Set<AnnotationInstance> classLevelBindings,
-            InterceptionType interceptionType) {
-        List<InterceptorInfo> interceptors = beanDeployment.getInterceptorResolver().resolve(interceptionType,
-                classLevelBindings);
+            Set<AnnotationInstance> bindings, InterceptionType interceptionType) {
+        List<InterceptorInfo> interceptors = beanDeployment.getInterceptorResolver().resolve(interceptionType, bindings);
         if (!interceptors.isEmpty()) {
-            lifecycleInterceptors.put(interceptionType, new InterceptionInfo(interceptors, classLevelBindings));
+            lifecycleInterceptors.put(interceptionType, new InterceptionInfo(interceptors, bindings));
         }
     }
 
@@ -1062,7 +1061,7 @@ public class BeanInfo implements InjectionTargetInfo {
 
         InterceptionInfo(List<InterceptorInfo> interceptors, Set<AnnotationInstance> bindings) {
             this.interceptors = interceptors;
-            this.bindings = bindings;
+            this.bindings = Unique.annotations(bindings);
         }
 
         boolean isEmpty() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.processor;
 
-import static io.quarkus.arc.processor.Annotations.uniqueAnnotations;
 import static io.quarkus.arc.processor.ClientProxyGenerator.MOCK_FIELD;
+import static io.quarkus.arc.processor.Reproducibility.orderedAnnotations;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.methodDescOf;
 
@@ -303,7 +303,7 @@ public class ObserverGenerator extends AbstractGenerator {
                 bc.set(cc.this_().field(observedTypeField), RuntimeTypeCreator.of(bc).create(observer.getObservedType()));
 
                 if (observedQualifiersField != null) {
-                    Expr set = bc.setOf(uniqueAnnotations(observer.getQualifiers()), qualifier -> {
+                    Expr set = bc.setOf(orderedAnnotations(observer.getQualifiers()), qualifier -> {
                         BuiltinQualifier builtin = BuiltinQualifier.of(qualifier);
                         if (builtin != null) {
                             return builtin.getLiteralInstance();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -206,7 +206,7 @@ public class ObserverInfo implements InjectionTargetInfo {
         this.reception = reception;
         this.transactionPhase = transactionPhase;
         this.observedType = observedType;
-        this.qualifiers = qualifiers;
+        this.qualifiers = Unique.annotations(qualifiers);
         this.notify = notify;
         this.params = params;
         this.forceApplicationClass = forceApplicationClass;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Reproducibility.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Reproducibility.java
@@ -5,9 +5,29 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationInstanceEquivalenceProxy;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+
+import io.smallrye.common.annotation.SuppressForbidden;
+
+@SuppressForbidden(reason = """
+        In `TYPE_COMPARATOR`, we first use `Type.name()`, which should distinguish most cases, but there are some
+        where it is not enough and we have to use `Type.toString()`. For example, class type `java.lang.Number`
+        and wildcard type `? extends java.lang.Number` have the same `name()`. We only use the `toString()` form
+        to establish some kind of deterministic ordering, nothing more.
+        """)
 public class Reproducibility {
     static final Comparator<BeanInfo> BEAN_COMPARATOR = Comparator.comparing(BeanInfo::getIdentifier);
     static final Comparator<ObserverInfo> OBSERVER_COMPARATOR = Comparator.comparing(ObserverInfo::getIdentifier);
+    static final Comparator<Type> TYPE_COMPARATOR = Comparator.comparing(Type::name).thenComparing(Type::toString);
+    static final Comparator<AnnotationInstance> ANNOTATION_COMPARATOR = Comparator.comparing(AnnotationInstance::name)
+            .thenComparing(it -> it.toString());
+    static final Comparator<AnnotationInstanceEquivalenceProxy> ANNOTATION_PROXY_COMPARATOR = Comparator
+            .<AnnotationInstanceEquivalenceProxy, DotName> comparing(it -> it.get().name())
+            .thenComparing(it -> it.get().toString());
+    static final Comparator<StereotypeInfo> STEREOTYPE_COMPARATOR = Comparator.comparing(StereotypeInfo::getName);
 
     static List<BeanInfo> orderedBeans(Collection<BeanInfo> beans) {
         List<BeanInfo> list = new ArrayList<>(beans);
@@ -30,6 +50,31 @@ public class Reproducibility {
     static List<ObserverInfo> orderedObservers(Collection<ObserverInfo> observers) {
         List<ObserverInfo> list = new ArrayList<>(observers);
         list.sort(OBSERVER_COMPARATOR);
+        return list;
+    }
+
+    static List<Type> orderedTypes(Collection<Type> types) {
+        List<Type> list = new ArrayList<>(types);
+        list.sort(TYPE_COMPARATOR);
+        return list;
+    }
+
+    static List<AnnotationInstance> orderedAnnotations(Collection<AnnotationInstance> annotations) {
+        List<AnnotationInstance> list = new ArrayList<>(annotations);
+        list.sort(ANNOTATION_COMPARATOR);
+        return list;
+    }
+
+    static List<AnnotationInstanceEquivalenceProxy> orderedAnnotationProxies(
+            Collection<AnnotationInstanceEquivalenceProxy> annotationProxies) {
+        List<AnnotationInstanceEquivalenceProxy> list = new ArrayList<>(annotationProxies);
+        list.sort(ANNOTATION_PROXY_COMPARATOR);
+        return list;
+    }
+
+    static List<StereotypeInfo> orderedStereotypes(Collection<StereotypeInfo> stereotypes) {
+        List<StereotypeInfo> list = new ArrayList<>(stereotypes);
+        list.sort(STEREOTYPE_COMPARATOR);
         return list;
     }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -1,6 +1,8 @@
 package io.quarkus.arc.processor;
 
 import static io.quarkus.arc.processor.KotlinUtils.isKotlinMethod;
+import static io.quarkus.arc.processor.Reproducibility.orderedAnnotationProxies;
+import static io.quarkus.arc.processor.Reproducibility.orderedAnnotations;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.methodDescOf;
 
@@ -337,7 +339,7 @@ public class SubclassGenerator extends AbstractGenerator {
                     mc.body(b0 -> {
                         b0.try_(tc -> {
                             tc.body(b1 -> {
-                                Expr bindings = b1.setOf(preDestroyInterception.bindings
+                                Expr bindings = b1.setOf(orderedAnnotations(preDestroyInterception.bindings)
                                         .stream()
                                         .map(binding -> {
                                             ClassInfo bindingClass = bean.getDeployment().getInterceptorBinding(binding.name());
@@ -537,7 +539,7 @@ public class SubclassGenerator extends AbstractGenerator {
 
         return bindings -> {
             String key = "b" + bindingIdx.i++;
-            Expr value = bc.setOf(bindings.stream().toList(),
+            Expr value = bc.setOf(orderedAnnotationProxies(bindings),
                     binding -> bindingsLiterals.computeIfAbsent(binding, bindingsLiteralFun));
             bc.withMap(bindingsMap).put(Const.of(key), value);
             return key;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Unique.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Unique.java
@@ -1,0 +1,73 @@
+package io.quarkus.arc.processor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationInstanceEquivalenceProxy;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.EquivalenceKey;
+import org.jboss.jandex.Type;
+
+final class Unique {
+    static Set<Type> types(Set<Type> types) {
+        return types(types, HashSet::new);
+    }
+
+    static List<Type> types(List<Type> types) {
+        return types(types, ArrayList::new);
+    }
+
+    private static <C extends Collection<Type>> C types(C types, Supplier<C> creator) {
+        C result = creator.get();
+        Set<EquivalenceKey> seen = new HashSet<>();
+        for (Type type : types) {
+            if (seen.add(EquivalenceKey.of(type))) {
+                result.add(type);
+            }
+        }
+        return result;
+    }
+
+    static Set<AnnotationInstance> annotations(Set<AnnotationInstance> annotations) {
+        return annotations(annotations, HashSet::new);
+    }
+
+    static List<AnnotationInstance> annotations(List<AnnotationInstance> annotations) {
+        return annotations(annotations, ArrayList::new);
+    }
+
+    private static <C extends Collection<AnnotationInstance>> C annotations(C annotations, Supplier<C> creator) {
+        C result = creator.get();
+        Set<AnnotationInstanceEquivalenceProxy> seen = new HashSet<>();
+        for (AnnotationInstance annotation : annotations) {
+            if (seen.add(annotation.createEquivalenceProxy())) {
+                result.add(annotation);
+            }
+        }
+        return result;
+    }
+
+    static Set<StereotypeInfo> stereotypes(Set<StereotypeInfo> stereotypes) {
+        return stereotypes(stereotypes, HashSet::new);
+    }
+
+    static List<StereotypeInfo> stereotypes(List<StereotypeInfo> stereotypes) {
+        return stereotypes(stereotypes, ArrayList::new);
+    }
+
+    private static <C extends Collection<StereotypeInfo>> C stereotypes(C stereotypes, Supplier<C> creator) {
+        C result = creator.get();
+        Set<DotName> seen = new HashSet<>();
+        for (StereotypeInfo stereotype : stereotypes) {
+            if (seen.add(stereotype.getName())) {
+                result.add(stereotype);
+            }
+        }
+        return result;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanQualifiersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanQualifiersTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.arc.test.duplicates;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DuplicateBeanQualifiersTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyQualifier.class)
+            .beanRegistrars(new MyBeanRegistrar())
+            .build();
+
+    @Test
+    public void test() {
+        assertNotNull(Arc.container().select(MyBean.class, new MyQualifier.Literal("foobar")).get());
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyQualifier {
+        String value();
+
+        final class Literal extends AnnotationLiteral<MyQualifier> implements MyQualifier {
+            private final String value;
+
+            public Literal(String value) {
+                this.value = value;
+            }
+
+            @Override
+            public String value() {
+                return value;
+            }
+        }
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            Index index = null;
+            try {
+                index = Index.of(MyBean.class, Object.class);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            context.configure(MyBean.class)
+                    .addType(MyBean.class)
+                    .addQualifier(AnnotationInstance.builder(MyQualifier.class).value("foobar")
+                            .buildWithTarget(index.getClassByName(Object.class)))
+                    .addQualifier(AnnotationInstance.builder(MyQualifier.class).value("foobar")
+                            .buildWithTarget(index.getClassByName(MyBean.class)))
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanStereotypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanStereotypesTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.arc.test.duplicates;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.arc.processor.StereotypeInfo;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DuplicateBeanStereotypesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyStereotype.class)
+            .beanRegistrars(new MyBeanRegistrar())
+            .build();
+
+    @Test
+    public void test() {
+        assertNotNull(Arc.container().select(MyBean.class).get());
+    }
+
+    @Stereotype
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyStereotype {
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            ClassInfo clazz;
+            try {
+                clazz = Index.singleClass(MyStereotype.class);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            Supplier<StereotypeInfo> stereotypeSupplier = () -> new StereotypeInfo(BuiltinScope.DEPENDENT.getInfo(),
+                    List.of(), false, null, false, false, clazz, false, List.of());
+
+            context.configure(MyBean.class)
+                    .addType(MyBean.class)
+                    .addStereotype(stereotypeSupplier.get())
+                    .addStereotype(stereotypeSupplier.get())
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanTypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanTypesTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.arc.test.duplicates;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DuplicateBeanTypesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new MyBeanRegistrar())
+            .build();
+
+    @Test
+    public void test() {
+        assertNotNull(Arc.container().select(MyBean.class).get());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyAnnotation {
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(MyBean.class)
+                    .addType(ClassType.create(MyBean.class))
+                    .addType(ClassType.builder(MyBean.class)
+                            .addAnnotation(AnnotationInstance.builder(MyAnnotation.class).build())
+                            .build())
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateObserverQualifiersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateObserverQualifiersTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.arc.test.duplicates;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.inject.Qualifier;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.processor.ObserverRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DuplicateObserverQualifiersTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyQualifier.class)
+            .observerRegistrars(new MyObserverRegistrar())
+            .build();
+
+    @Test
+    public void test() {
+        assertDoesNotThrow(() -> {
+            Arc.container().select(new TypeLiteral<Event<MyEvent>>() {
+            }).get().fire(new MyEvent());
+        });
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyQualifier {
+        String value();
+
+        final class Literal extends AnnotationLiteral<MyQualifier> implements MyQualifier {
+            private final String value;
+
+            public Literal(String value) {
+                this.value = value;
+            }
+
+            @Override
+            public String value() {
+                return value;
+            }
+        }
+    }
+
+    static class MyEvent {
+    }
+
+    static class MyObserverRegistrar implements ObserverRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            Index index = null;
+            try {
+                index = Index.of(MyEvent.class, Object.class);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            context.configure()
+                    .beanClass(DotName.createSimple(MyEvent.class))
+                    .observedType(MyEvent.class)
+                    .addQualifier(AnnotationInstance.builder(MyQualifier.class).value("foobar")
+                            .buildWithTarget(index.getClassByName(Object.class)))
+                    .addQualifier(AnnotationInstance.builder(MyQualifier.class).value("foobar")
+                            .buildWithTarget(index.getClassByName(MyEvent.class)))
+                    .notify(ng -> ng.notifyMethod().return_())
+                    .done();
+        }
+    }
+}


### PR DESCRIPTION
Previously (see [1]), we got rid of generating calls to `Sets.of()`, because it used to have relatively high overhead, and eliminated duplicates very late in the game. The generator classes (`BeanGenerator` and `ObserverGenerator`) turned annotation sets into unique sets and hoped for the best in case of other collections.

As it turned out, the other collections may contain duplicates as well, particularly in case of synthetic beans.

This commit reverses the approach: we now avoid duplicates early on, during creation of `BeanInfo` and `ObserverInfo`. The generators can now safely assume that the following collections do not contain duplicate elements:

- `BeanInfo.types` and `unrestrictedTypes`
- `BeanInfo.qualifiers`
- `BeanInfo.stereotypes`
- `BeanInfo.InterceptionInfo.bindings`
- `ObserverInfo.qualifiers`

[1] https://github.com/quarkusio/quarkus/pull/52333

Further, this commit makes sure that all calls to `setOf()` use deterministic ordering of passed items. This is to ensure build reproducibility. There might still be cases where the generated code builds sets in other ways, but we can handle those later on.

Fixes #52778
Fixes #52787