### PR TITLE
Use Maven properties for non-platform extension versions

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -31,6 +31,16 @@
         {#if uberjar}
         <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
         {/if}
+        {#each dependencies}
+        {#if it.versionProperty}
+        <{it.versionProperty}>{it.version}</{it.versionProperty}>
+        {/if}
+        {/each}
+        {#each test-dependencies}
+        {#if it.versionProperty}
+        <{it.versionProperty}>{it.version}</{it.versionProperty}>
+        {/if}
+        {/each}
     </properties>
 
     <dependencyManagement>
@@ -97,8 +107,8 @@
         <dependency>
             <groupId>{it.groupId}</groupId>
             <artifactId>{it.artifactId}</artifactId>
-            {#if it.version}
-            <version>{it.version}</version>
+            {#if it.versionProperty}
+            <version>$\{{it.versionProperty}}</version>
             {/if}
         </dependency>
         {/each}
@@ -117,8 +127,8 @@
         <dependency>
             <groupId>{it.groupId}</groupId>
             <artifactId>{it.artifactId}</artifactId>
-            {#if it.version}
-            <version>{it.version}</version>
+            {#if it.versionProperty}
+            <version>$\{{it.versionProperty}}</version>
             {/if}
             <scope>test</scope>
         </dependency>

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartSpec.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartSpec.java
@@ -130,6 +130,7 @@ public final class CodestartSpec {
         private static final String VERSION = "version";
         private static final String FORMATTED_GAV = "formatted-gav";
         private static final String FORMATTED_GA = "formatted-ga";
+        private static final String VERSION_PROPERTY = "versionProperty";
 
         public CodestartDep() {
         }
@@ -145,6 +146,7 @@ public final class CodestartSpec {
 
             if (split.length == 3) {
                 this.put(VERSION, split[2]);
+                this.put(VERSION_PROPERTY, split[1] + ".version");
                 this.put(FORMATTED_GA, split[0] + ":" + split[1]);
             } else {
                 this.put(FORMATTED_GA, expression);
@@ -163,6 +165,10 @@ public final class CodestartSpec {
 
         public String getVersion() {
             return this.get(VERSION);
+        }
+
+        public String getVersionProperty() {
+            return this.get(VERSION_PROPERTY);
         }
 
         @Override

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -124,15 +124,17 @@ class QuarkusCodestartGenerationTest {
 
         checkMaven(projectDir);
         assertThatMatchSnapshot(testInfo, projectDir, "pom.xml")
+                .satisfies(checkContains("<quarkus-resteasy.version>1.8</quarkus-resteasy.version>"))
+                .satisfies(checkContains("<commons-io.version>2.5</commons-io.version>"))
                 .satisfies(checkContains("<dependency>\n" +
                         "            <groupId>io.quarkus</groupId>\n" +
                         "            <artifactId>quarkus-resteasy</artifactId>\n" +
-                        "            <version>1.8</version>\n" +
+                        "            <version>${quarkus-resteasy.version}</version>\n" +
                         "        </dependency>"))
                 .satisfies(checkContains("<dependency>\n" +
-                        "            <groupId>io.quarkus</groupId>\n" +
-                        "            <artifactId>quarkus-resteasy</artifactId>\n" +
-                        "            <version>1.8</version>\n" +
+                        "            <groupId>commons-io</groupId>\n" +
+                        "            <artifactId>commons-io</artifactId>\n" +
+                        "            <version>${commons-io.version}</version>\n" +
                         "        </dependency>"));
     }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
@@ -52,7 +52,7 @@ public class CreateProjectWithNonPlatformExtensionTest extends MultiplePlatformB
 
         assertModel(projectDir,
                 List.of(mainPlatformBom()),
-                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "${bla-magic.version}")),
+                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "5.5.5")),
                 Map.of("quarkus.platform.version", "1.1.1",
                         "bla-magic.version", "5.5.5"));
     }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
@@ -52,7 +52,7 @@ public class CreateProjectWithNonPlatformExtensionTest extends MultiplePlatformB
 
         assertModel(projectDir,
                 List.of(mainPlatformBom()),
-                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "5.5.5")),
+                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "${bla-magic.version}")),
                 Map.of("quarkus.platform.version", "1.1.1",
                         "bla-magic.version", "5.5.5"));
     }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
@@ -2,6 +2,7 @@ package io.quarkus.devtools.project.create;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,8 @@ public class CreateProjectWithNonPlatformExtensionTest extends MultiplePlatformB
 
         assertModel(projectDir,
                 List.of(mainPlatformBom()),
-                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "5.5.5")),
-                "1.1.1");
+                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "${bla-magic.version}")),
+                Map.of("quarkus.platform.version", "1.1.1",
+                        "bla-magic.version", "5.5.5"));
     }
 }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.apache.maven.model.Model;
@@ -195,11 +196,24 @@ public abstract class MultiplePlatformBomsTestBase {
         //assertThat(model.getDependencyManagement().getDependencies().size()).isEqualTo(expectedBoms.size());
 
         // TODO the order should be predictable
+        final Properties props = model.getProperties();
         assertThat(model.getDependencies().stream()
-                .map(d -> ArtifactCoords.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion()))
+                .map(d -> ArtifactCoords.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(),
+                        resolveProperty(d.getVersion(), props)))
                 .collect(Collectors.toSet())).containsAll(expectedExtensions);
 
         assertThat(model.getProperties()).containsAllEntriesOf(expectedProperties);
+    }
+
+    private static String resolveProperty(String value, Properties props) {
+        if (value != null && value.startsWith("${") && value.endsWith("}")) {
+            String propName = value.substring(2, value.length() - 1);
+            String resolved = props.getProperty(propName);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+        return value;
     }
 
     ArtifactCoords platformExtensionCoords(String artifactId) {

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MultiplePlatformBomsTestBase.java
@@ -196,24 +196,12 @@ public abstract class MultiplePlatformBomsTestBase {
         //assertThat(model.getDependencyManagement().getDependencies().size()).isEqualTo(expectedBoms.size());
 
         // TODO the order should be predictable
-        final Properties props = model.getProperties();
         assertThat(model.getDependencies().stream()
                 .map(d -> ArtifactCoords.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(),
-                        resolveProperty(d.getVersion(), props)))
+                        d.getVersion()))
                 .collect(Collectors.toSet())).containsAll(expectedExtensions);
 
         assertThat(model.getProperties()).containsAllEntriesOf(expectedProperties);
-    }
-
-    private static String resolveProperty(String value, Properties props) {
-        if (value != null && value.startsWith("${") && value.endsWith("}")) {
-            String propName = value.substring(2, value.length() - 1);
-            String resolved = props.getProperty(propName);
-            if (resolved != null) {
-                return resolved;
-            }
-        }
-        return value;
     }
 
     ArtifactCoords platformExtensionCoords(String artifactId) {

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -7,10 +7,12 @@
     <packaging>quarkus</packaging>
 
     <properties>
+        <commons-io.version>2.5</commons-io.version>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus-resteasy.version>1.8</quarkus-resteasy.version>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-MOCK</quarkus.platform.version>
@@ -34,12 +36,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
-            <version>1.8</version>
+            <version>${quarkus-resteasy.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -396,7 +396,8 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
                 .isTrue();
 
         assertThat(model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("jandex-test-data")
-                && d.getVersion().equalsIgnoreCase("3.4.0"))).isTrue();
+                && "${jandex-test-data.version}".equals(d.getVersion()))).isTrue();
+        assertThat(model.getProperties().getProperty("jandex-test-data.version")).isEqualTo("3.4.0");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- When creating a new project with a non-platform extension, the version was hardcoded in the `<dependency>` element
- This change extracts it into a Maven property in `<properties>` and references it via `${artifactId.version}`, following Maven best practices

**Before:**
```xml
<dependency>
    <groupId>org.bla</groupId>
    <artifactId>bla-magic</artifactId>
    <version>5.5.5</version>
</dependency>
```

**After:**
```xml
<properties>
    <bla-magic.version>5.5.5</bla-magic.version>
</properties>
...
<dependency>
    <groupId>org.bla</groupId>
    <artifactId>bla-magic</artifactId>
    <version>${bla-magic.version}</version>
</dependency>
```

## Changes
- `CodestartSpec.java` — added `versionProperty` field to `CodestartDep` (computed as `artifactId.version` when a version is present)
- `pom.tpl.qute.xml` — output version properties in `<properties>` and use `${...}` references in dependencies
- `CreateProjectWithNonPlatformExtensionTest.java` — updated assertion to verify property-based versioning

Fixes #39439

## Test plan
- [x] `CreateProjectWithNonPlatformExtensionTest` passes
- [x] All `io.quarkus.devtools.project.create.*` tests pass
- [x] Verified generated `pom.xml` contains property declaration and reference