### PR TITLE
Set quarkus-cyclonedx status to stable and add it to the security category

### DIFF
--- a/extensions/cyclonedx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cyclonedx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -4,5 +4,7 @@ metadata:
   keywords:
   - "cyclonedx"
   - "cdx"
-  status: "preview"
+  categories:
+  - "security"
+  status: "stable"
   guide: "https://quarkus.io/guides/cyclonedx"


### PR DESCRIPTION
Adding `quarkus-cyclonedx` to the `security` category and promoting it to `stable`