### PR TITLE
Throw exception on Prometheus meter registration failure

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusRegistrationFailureTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusRegistrationFailureTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.micrometer.deployment.export;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that the Prometheus registry throws an exception when meters with the same name
+ * but different tag keys are registered, instead of silently ignoring the duplicate.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/52410">GitHub issue #52410</a>
+ */
+public class PrometheusRegistrationFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setFlatClassPath(true)
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
+            .withEmptyApplication();
+
+    @Inject
+    PrometheusMeterRegistry promRegistry;
+
+    @Test
+    public void testDuplicateMeterWithDifferentTagsThrowsException() {
+        // Register a counter with tag key "env"
+        Counter.builder("my_counter")
+                .tag("env", "prod")
+                .register(promRegistry);
+
+        // Attempting to register a counter with the same name but a different tag key
+        // should throw an IllegalArgumentException instead of being silently ignored
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Counter.builder("my_counter")
+                    .tag("region", "us-east")
+                    .register(promRegistry);
+        }, "Registering a meter with the same name but different tag keys should throw an exception");
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/PrometheusMeterRegistryProducer.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/PrometheusMeterRegistryProducer.java
@@ -25,7 +25,8 @@ public class PrometheusMeterRegistryProducer {
     @Priority(Interceptor.Priority.APPLICATION + 100)
     public PrometheusMeterRegistry registry(PrometheusConfig config, CollectorRegistry collectorRegistry,
             Optional<ExemplarSampler> exemplarSampler, Clock clock) {
-        return new PrometheusMeterRegistry(config, collectorRegistry, clock, exemplarSampler.orElse(null));
+        return new PrometheusMeterRegistry(config, collectorRegistry, clock, exemplarSampler.orElse(null))
+                .throwExceptionOnRegistrationFailure();
     }
 
 }


### PR DESCRIPTION
## Summary
- `PrometheusMeterRegistry` silently ignores meters with the same name but different tag keys, making configuration errors hard to detect
- Call `throwExceptionOnRegistrationFailure()` on the produced registry so duplicate meters with conflicting tag sets cause an immediate `IllegalArgumentException`
- Added a test verifying the exception is thrown for conflicting meter registrations

**Before:** Duplicate meter registration silently ignored — no warning, no error
**After:** `IllegalArgumentException` thrown immediately, making the problem visible

## Changes
- `PrometheusMeterRegistryProducer.java`: Chain `.throwExceptionOnRegistrationFailure()` on the registry constructor (1 line)
- `PrometheusRegistrationFailureTest.java`: New test verifying the behavior

## References
- [Micrometer Prometheus limitation docs](https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html#_limitation_on_same_name_with_different_set_of_tag_keys)

Closes #52410