### PR TITLE
Dev UI: Show file location for application.properties config sources

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
@@ -167,14 +167,29 @@ export class QwcConfiguration extends observeState(LitElement) {
     }
 
     _createConfigSourceObject(configSourceName,configValue){
-        
+
         let displayName = configSourceName;
-        
-        if(configSourceName.startsWith("PropertiesConfigSource[source")
+
+        if(configSourceName.startsWith("PropertiesConfigSource[source=")
                     && configSourceName.endsWith("/application.properties]")){
-            displayName = msg('My properties', { id: 'configuration-my-properties' });
+            // Extract the source path: everything between "source=" and the closing "]"
+            let sourcePath = configSourceName.substring(30, configSourceName.length - 1);
+            if(sourcePath.startsWith("jar:") || sourcePath.includes("!")){
+                // JAR-embedded source: extract the JAR filename
+                // Format: jar:file:/path/to/some-lib-1.0.jar!/application.properties
+                let jarPath = sourcePath;
+                let bangIndex = jarPath.indexOf("!");
+                if(bangIndex > 0){
+                    jarPath = jarPath.substring(0, bangIndex);
+                }
+                let lastSlash = jarPath.lastIndexOf("/");
+                let jarName = lastSlash >= 0 ? jarPath.substring(lastSlash + 1) : jarPath;
+                displayName = "application.properties (" + jarName + ")";
+            }else{
+                displayName = msg('My properties', { id: 'configuration-my-properties' });
+            }
         }
-        
+
         let configSourceObject = {name:configSourceName, display: displayName, position:configValue.configSourcePosition, ordinal:configValue.configSourceOrdinal};
         return configSourceObject;
     }


### PR DESCRIPTION
## Summary

When multiple `application.properties` files exist (e.g. from JAR dependencies), the Dev UI config source dropdown previously showed all of them as "My properties", making it impossible to distinguish between them.

This PR updates the `_createConfigSourceObject()` method in `qwc-configuration.js` to:
- **JAR-embedded sources**: Extract the JAR filename and display it, e.g. `application.properties (some-lib-1.0.jar)`
- **Local file**: Continue showing "My properties" for the user's own `application.properties`

The full file path is already visible in the row detail expansion (Config source field), so the dropdown now provides a quick visual distinction.

### Before
All `application.properties` sources show as "My properties" in the dropdown — no way to tell them apart.

### After
- Local file → "My properties"
- JAR sources → "application.properties (jar-name.jar)"

Fixes #51949