### PR TITLE
Docs: Add Kotlin @JvmRecord tip for Qute type-safe templates

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -2055,6 +2055,21 @@ public class HelloResource {
 <1> Declares a type-safe template with the Java record. The template is located at `/src/main/resources/templates/HelloResource/Hello.html`.
 <2> Instantiate the record and use it as an ordinary `TemplateInstance`.
 
+[TIP]
+====
+**Kotlin users** can use a data class annotated with `@JvmRecord` to achieve the same result:
+
+[source,kotlin]
+----
+@CheckedTemplate(basePath = "HelloResource")
+@JvmRecord
+data class Hello(val name: String) : TemplateInstance
+----
+
+The `@JvmRecord` annotation instructs the Kotlin compiler to generate a Java record in the bytecode, which Quarkus then recognizes as a type-safe template.
+Note that `@JvmRecord` requires Kotlin 1.5+ and JVM target 16+.
+====
+
 
 ==== Customized Template Path
 


### PR DESCRIPTION
## Summary

Adds a tip box to the "Template Records" section of the Qute reference docs, documenting how Kotlin users can use `@JvmRecord` on a data class to make it work as a type-safe Qute template.

This was the recommended first step by @mkouba and @geoand in the issue discussion:

> I would start with a note about the `@JvmRecord` in the docs.

The tip includes:
- A Kotlin code example showing `@JvmRecord` + `@CheckedTemplate` on a data class
- A brief explanation of why it works (Kotlin compiler generates a Java record in bytecode)
- Version requirements (Kotlin 1.5+, JVM target 16+)

Fixes #38194