### PR TITLE
AOT - Provide a config property to pass additional args to recording

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -278,6 +278,16 @@ public interface PackageConfig {
             Optional<AotType> type();
 
             /**
+             * Comma-separated list of additional recording arguments passed to the recording command line.
+             * <p>
+             * For instance, may be used to enable advanced logging with:
+             * {@code -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot-analysis.map:none:filesize=0 -Xlog:aot+resolve*=trace,aot+codecache+exit=debug:file=training.log:level,tags}
+             * <p>
+             * If an argument includes the {@code ,} symbol, it needs to be escaped, e.g. {@code \\,}
+             */
+            Optional<List<String>> additionalRecordingArgs();
+
+            /**
              * The phase in which the AOT file should be generated.
              * <p>
              * For Leyden AOT, {@code auto} means {@code integration-tests}.

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
@@ -169,7 +169,8 @@ public class JvmStartupOptimizerArchiveBuildStep {
             archivePath = createAppCDSFromExit(jarResult, outputTarget, javaBinPath, containerImage,
                     isFastJar);
         } else if (archiveType == JvmStartupOptimizerArchiveType.AOT) {
-            archivePath = createAot(jarResult, outputTarget, javaBinPath, containerImage, isFastJar);
+            archivePath = createAot(jarResult, outputTarget, javaBinPath, containerImage, isFastJar,
+                    packageConfig.jar().aot().additionalRecordingArgs().orElse(List.of()));
         } else {
             throw new IllegalStateException("Unsupported archive type: " + archiveType);
         }
@@ -303,22 +304,24 @@ public class JvmStartupOptimizerArchiveBuildStep {
      */
     private Path createAot(JarBuildItem jarResult,
             OutputTargetBuildItem outputTarget, String javaBinPath, String containerImage,
-            boolean isFastJar) {
+            boolean isFastJar, List<String> additionalRecordingArgs) {
         if (Runtime.version().feature() < 25) {
             throw new IllegalStateException(
                     "AOT cache generation requires building with JDK 25 or newer (see JEP 514). ");
         }
         ArchivePathsContainer aotPathContainers = ArchivePathsContainer.aotFromQuarkusJar(jarResult.getPath());
         return launchArchiveCreateCommand(aotPathContainers.workingDirectory, aotPathContainers.resultingFile,
-                createAotCommand(jarResult, outputTarget, javaBinPath, containerImage, isFastJar, aotPathContainers));
+                createAotCommand(jarResult, outputTarget, javaBinPath, containerImage, isFastJar, additionalRecordingArgs,
+                        aotPathContainers));
 
     }
 
     private List<String> createAotCommand(JarBuildItem jarResult, OutputTargetBuildItem outputTarget, String javaBinPath,
-            String containerImage, boolean isFastJar,
+            String containerImage, boolean isFastJar, List<String> additionalRecordingArgs,
             ArchivePathsContainer aotPathContainers) {
         List<String> javaArgs = new ArrayList<>();
         javaArgs.add("-XX:AOTCacheOutput=" + aotPathContainers.resultingFile.getFileName().toString());
+        javaArgs.addAll(additionalRecordingArgs);
         javaArgs.add(String.format("-D%s=true", MainClassBuildStep.GENERATE_APP_CDS_SYSTEM_PROPERTY));
         javaArgs.add("-jar");
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -54,6 +54,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     private String containerImage;
     private boolean pullRequired;
     private boolean generateAotFile;
+    private List<String> additionalRecordingArgs;
     private Map<Integer, Integer> additionalExposedPorts;
 
     private Map<String, String> volumeMounts;
@@ -87,6 +88,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         this.containerWorkingDirectory = initContext.containerWorkingDirectory();
         this.programArgs = initContext.programArgs();
         this.generateAotFile = initContext.generateAotFile();
+        this.additionalRecordingArgs = initContext.additionalRecordingArgs();
         this.outputTargetDirectory = initContext.outputTargetDirectory();
     }
 
@@ -327,6 +329,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
             if (containerWorkingDirectory.isPresent()) {
                 args.addAll(toEnvVar("JAVA_TOOL_OPTIONS",
                         "-XX:AOTMode=record -XX:AOTConfiguration=%s/%s".formatted(AOT_DIR, AOT_CONF_FILE_NAME)));
+                args.addAll(additionalRecordingArgs);
                 Path containerAotDir = Path.of(outputTargetDirectory).resolve(AOT_DIR);
                 Files.createDirectories(containerAotDir);
                 containerAotDir.toFile().setReadable(true, false);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -55,6 +55,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     private Map<String, String> env;
     private Path jarPath;
     private boolean generateAotFile;
+    private List<String> additionalRecordingArgs;
 
     private final Map<String, String> systemProps = new HashMap<>();
     private Process quarkusProcess;
@@ -73,6 +74,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         this.env = initContext.env();
         this.jarPath = initContext.jarPath();
         this.generateAotFile = initContext.generateAotFile();
+        this.additionalRecordingArgs = initContext.additionalRecordingArgs();
     }
 
     @Override
@@ -121,6 +123,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         if (generateAotFile) {
             args.add("-XX:AOTMode=record");
             args.add("-XX:AOTConfiguration=%s".formatted(jarPath.resolveSibling(AOT_CONF_FILE_NAME)));
+            args.addAll(additionalRecordingArgs);
         }
         if (HTTP_PRESENT) {
             args.add("-Dquarkus.http.port=" + httpPort);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DockerContainerArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DockerContainerArtifactLauncher.java
@@ -26,6 +26,8 @@ public interface DockerContainerArtifactLauncher extends ArtifactLauncher<Docker
 
         boolean generateAotFile();
 
+        List<String> additionalRecordingArgs();
+
         String outputTargetDirectory();
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/JarArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/JarArtifactLauncher.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.common;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * If an implementation of this class is found using the ServiceLoader mechanism, then it is used.
@@ -13,5 +14,7 @@ public interface JarArtifactLauncher extends ArtifactLauncher<JarArtifactLaunche
         Path jarPath();
 
         boolean generateAotFile();
+
+        List<String> additionalRecordingArgs();
     }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -111,6 +111,8 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                         .orElse(Boolean.FALSE)
                         // only record AOT file for the default profile
                         && (context.profile() == null),
+                config.getOptionalValues("quarkus.package.jar.aot.additional-recording-args", String.class)
+                        .orElse(List.of()),
                 entryPoint,
                 containerWorkingDirectory,
                 programArgs,
@@ -170,6 +172,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
         private final boolean pullRequired;
         private final Map<Integer, Integer> additionalExposedPorts;
         private final Boolean generateAotFile;
+        private final List<String> additionalRecordingArgs;
         private final Optional<String> entryPoint;
         private final Optional<String> containerWorkingDirectory;
         private final List<String> programArgs;
@@ -186,6 +189,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                 Map<String, String> labels,
                 Map<String, String> volumeMounts,
                 Boolean generateAotFile,
+                List<String> additionalRecordingArgs,
                 Optional<String> entryPoint,
                 Optional<String> containerWorkingDirectory,
                 List<String> programArgs, String outputTargetDirectory) {
@@ -197,6 +201,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
             this.labels = labels;
             this.volumeMounts = volumeMounts;
             this.generateAotFile = generateAotFile;
+            this.additionalRecordingArgs = additionalRecordingArgs;
             this.entryPoint = entryPoint;
             this.programArgs = programArgs;
             this.outputTargetDirectory = outputTargetDirectory;
@@ -245,6 +250,11 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
         @Override
         public boolean generateAotFile() {
             return generateAotFile;
+        }
+
+        @Override
+        public List<String> additionalRecordingArgs() {
+            return additionalRecordingArgs;
         }
 
         @Override

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
@@ -57,7 +57,9 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
                             .or(() -> config.getOptionalValue("quarkus.package.jar.appcds.use-aot", Boolean.class))
                             .orElse(Boolean.FALSE)
                             // only record AOT file for the default profile
-                            && (context.profile() == null)));
+                            && (context.profile() == null),
+                    config.getOptionalValues("quarkus.package.jar.aot.additional-recording-args", String.class)
+                            .orElse(List.of())));
             return launcher;
         } else {
             throw new IllegalStateException("The path of the native binary could not be determined");
@@ -68,15 +70,17 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
 
         private final Path jarPath;
         private final boolean generateAotFile;
+        private final List<String> additionalRecordingArgs;
 
         DefaultJarInitContext(int httpPort, int httpsPort, Duration waitTime, Duration shutdownTimeout,
                 String testProfile,
                 List<String> argLine, Map<String, String> env,
                 ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult, Path jarPath,
-                boolean generateAotFile) {
+                boolean generateAotFile, List<String> additionalRecordingArgs) {
             super(httpPort, httpsPort, waitTime, shutdownTimeout, testProfile, argLine, env, devServicesLaunchResult);
             this.jarPath = jarPath;
             this.generateAotFile = generateAotFile;
+            this.additionalRecordingArgs = additionalRecordingArgs;
         }
 
         @Override
@@ -87,6 +91,11 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
         @Override
         public boolean generateAotFile() {
             return generateAotFile;
+        }
+
+        @Override
+        public List<String> additionalRecordingArgs() {
+            return additionalRecordingArgs;
         }
     }
 }


### PR DESCRIPTION
This is extremely useful when we want to add additional logging to the recording.

For instance, some more advanced logging such as:

> -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot-analysis.map:none:filesize=0 -Xlog:aot+resolve*=trace,aot+codecache+exit=debug:file=training.log:level,tags
