### PR TITLE
Provide a hashCode/equals implementation for PersistenceUnitKey

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitKey.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitKey.java
@@ -1,4 +1,30 @@
 package io.quarkus.hibernate.orm.runtime;
 
+import java.util.Objects;
+
+/**
+ * We implement equals/hashCode here as this element is used in a Map and the initialization
+ * of the hashCode method for the record is actually quite slow, even with Project Leyden
+ * (at least in its current version).
+ * <p>
+ * Hopefully, we will be able to simplify this in the future.
+ */
 public record PersistenceUnitKey(String name, boolean isReactive) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PersistenceUnitKey that = (PersistenceUnitKey) o;
+        return Objects.equals(name, that.name) && isReactive == that.isReactive;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(name);
+        result = 31 * result + Boolean.hashCode(isReactive);
+        return result;
+    }
 }


### PR DESCRIPTION
The generation of the record hashCode is actually quite costly, even with Project Leyden (I reported the issue), and for now implementing these methods is the best solution. I don't expect them to be hard to maintain and hopefully we will be able to drop them at some point in the future.

Note that the initialization of hashCode/equals was ~ 3.13% of the CPU samples (after some other optimizations), so this is not negligible.

<img width="2194" height="895" alt="Screenshot From 2026-03-03 11-27-36" src="https://github.com/user-attachments/assets/2896fd08-922b-4806-822a-79318e01a373" />
<img width="2194" height="875" alt="Screenshot From 2026-03-03 11-27-14" src="https://github.com/user-attachments/assets/165d6ded-27a5-432c-a80b-155df307a1d4" />
