### PR TITLE
Add --debug option to quarkus run CLI command

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Run.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Run.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.cli.common.BuildToolDelegatingCommand;
+import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
@@ -16,11 +17,28 @@ public class Run extends BuildToolDelegatingCommand {
     @CommandLine.Option(names = { "--target" }, description = "Run target.")
     String target;
 
+    @CommandLine.ArgGroup(order = 3, exclusive = false, validate = true, heading = "%nDebug options:%n")
+    DebugOptions debugOptions = new DebugOptions();
+
+    // Debug is off by default for run mode (unlike dev mode)
+    {
+        debugOptions.debug = false;
+    }
+
     @Override
     public void populateContext(BuildToolContext context) {
         super.populateContext(context);
         if (target != null)
             context.getPropertiesOptions().properties.put("quarkus.run.target", target);
+        if (debugOptions.debug) {
+            String jdwpArg = debugOptions.getJvmDebugParameter();
+            BuildTool buildTool = context.getBuildTool();
+            if (buildTool == BuildTool.GRADLE || buildTool == BuildTool.GRADLE_KOTLIN_DSL) {
+                context.getParams().add("--jvm-args=" + jdwpArg);
+            } else {
+                context.getPropertiesOptions().properties.put("jvmArgs", jdwpArg);
+            }
+        }
     }
 
     @Override
@@ -30,6 +48,6 @@ public class Run extends BuildToolDelegatingCommand {
 
     @Override
     public String toString() {
-        return "Run {}";
+        return "Run [debugOptions=" + debugOptions + "]";
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
@@ -55,6 +55,13 @@ public class RunMojo extends QuarkusBootstrapMojo {
     @Parameter(defaultValue = "${args}")
     String programArguments;
 
+    /**
+     * Additional JVM arguments to pass to the launched process, e.g. a JDWP debug agent string.
+     * To be specified as {@code -DjvmArgs=-agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n}
+     */
+    @Parameter(defaultValue = "${jvmArgs}")
+    String jvmArgs;
+
     @Override
     protected boolean beforeExecute() throws MojoExecutionException, MojoFailureException {
         return true;
@@ -116,6 +123,13 @@ public class RunMojo extends QuarkusBootstrapMojo {
                         throw new RuntimeException("Should never reach this!");
                     }
                     List<String> args = (List<String>) cmd.get(0);
+                    if (jvmArgs != null && !jvmArgs.isBlank()) {
+                        // Insert JVM args right after the java command (index 1)
+                        String[] jvmArgParts = jvmArgs.split("\\s+");
+                        for (int i = jvmArgParts.length - 1; i >= 0; i--) {
+                            args.add(1, jvmArgParts[i]);
+                        }
+                    }
                     if (additionalSystemProperties != null) {
                         String[] props = additionalSystemProperties.split(",");
                         for (int i = props.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Summary

Adds debug support to `quarkus run` by reusing the existing `DebugOptions` from `quarkus dev`, as suggested by @ebullient.

- Debug is **disabled by default** for `run` mode (unlike `dev` where it's enabled)
- Users enable it explicitly: `quarkus run --debug`
- All existing debug options work: `--debug-host`, `--debug-port`, `--debug-mode`, `--suspend`

### Changes

- **`Run.java`** — Added `DebugOptions` arg group with `debug=false` default. When enabled, passes the JDWP agent string to the build tool (Maven property for Maven, `--jvm-args` for Gradle)
- **`RunMojo.java`** — Added `jvmArgs` parameter that inserts JVM arguments into the launched process command

### Usage

```bash
# Run with debug (listen on localhost:5005)
quarkus run --debug

# Run with debug, suspend until debugger attaches
quarkus run --debug --suspend

# Run with custom debug port
quarkus run --debug --debug-port=8000

# Run with debug on all interfaces
quarkus run --debug --debug-host=0.0.0.0
```

### Design decisions

- Debug defaults to **off** for `run` (production mode should not expose a debug port by default)
- Gradle path uses the existing `--jvm-args` option on `QuarkusRun` task (no Gradle plugin changes needed)
- Maven path adds a new `jvmArgs` parameter to `RunMojo`, following the same pattern as `additionalSystemProperties`

Fixes #52490