### PR TITLE
Allow CORS origin header to return * when specifically configured

### DIFF
--- a/docs/src/main/asciidoc/security-cors.adoc
+++ b/docs/src/main/asciidoc/security-cors.adoc
@@ -81,23 +81,24 @@ Incorrectly escaped patterns can lead to unintended behavior or security vulnera
 Always verify regular expression syntax before deployment.
 ====
 
-== Allowing all origins in dev mode
+== When to accept all origins
 
-Configuring origins during development can be challenging.
-To simplify development, consider allowing all origins in development mode only:
+[WARNING]
+====
+Allowing unrestricted origins with `quarkus.http.cors.origins=*` in production environments poses severe security risks, such as unauthorized data access or resource abuse.
+For production, define explicit origins in the `quarkus.http.cors.origins` property.
+====
+
+The only exception where accepting all origins might be appropriate in production is for read-only public API applications that have no side effects of any kind, such as managing cookies, saving request data on the disk, or similar operations.
+In such cases, to improve the HTTP cache performance, you might want to return a literal `*` origin by setting `quarkus.http.cors.return-exact-origins=false` to avoid the `Vary: Origin` response header.
+
+Also, since configuring origins during development can be challenging, consider allowing all origins in development mode:
 
 [source, properties]
 ----
 quarkus.http.cors.enabled=true
 %dev.quarkus.http.cors.origins=/.*/
 ----
-
-[WARNING]
-====
-Only allow all origins in the development profile (`%dev`).
-Allowing unrestricted origins in production environments poses severe security risks, such as unauthorized data access or resource abuse.
-For production, define explicit origins in the `quarkus.http.cors.origins` property.
-====
 
 [[cors-filter-programmatic-set-up]]
 == Configuring the CORS filter programmatically

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
@@ -159,6 +159,11 @@ public class DevUICORSFilter implements Handler<RoutingContext> {
             public Optional<Boolean> accessControlAllowCredentials() {
                 return baseCorsConfig.accessControlAllowCredentials();
             }
+
+            @Override
+            public boolean returnExactOrigins() {
+                return true;
+            }
         };
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -158,10 +158,13 @@ class VertxHttpProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     FilterBuildItem cors(CORSRecorder recorder,
-            Optional<HttpSecurityConfigSetupCompleteBuildItem> httpSecurityConfigSetupCompleteBuildItem) {
+            Optional<HttpSecurityConfigSetupCompleteBuildItem> httpSecurityConfigSetupCompleteBuildItem,
+            Capabilities capabilities) {
         RuntimeValue<CORSConfig> programmaticCorsConfig = httpSecurityConfigSetupCompleteBuildItem
                 .map(i -> i.programmaticCorsConfig).orElse(null);
-        return new FilterBuildItem(recorder.corsHandler(programmaticCorsConfig), SecurityHandlerPriorities.CORS);
+        return new FilterBuildItem(
+                recorder.corsHandler(programmaticCorsConfig, capabilities.isPresent(Capability.SECURITY)),
+                SecurityHandlerPriorities.CORS);
     }
 
     @BuildStep

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardDefaultExactOriginTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardDefaultExactOriginTestCase.java
@@ -1,0 +1,62 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.Is.is;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies the default behavior ({@code return-exact-origins=true}) where the CORS
+ * filter echoes back the request origin even when {@code origins=*} is configured.
+ */
+public class CORSWildcardDefaultExactOriginTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.cors.enabled=true\n" +
+            "quarkus.http.cors.origins=*\n" +
+            "quarkus.http.cors.methods=GET,POST,OPTIONS\n";
+    // return-exact-origins defaults to true
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @Test
+    @DisplayName("Default behavior echoes request origin for simple request")
+    public void corsDefaultEchoesOrigin() {
+        String origin = "http://custom.origin.quarkus";
+        given().header("Origin", origin)
+                .when()
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", is(origin))
+                .body(is("test route"));
+    }
+
+    @Test
+    @DisplayName("Default behavior echoes request origin for preflight request")
+    public void corsDefaultPreflightEchoesOrigin() {
+        String origin = "http://custom.origin.quarkus";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", "POST")
+                .when()
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", is(origin));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardExactOriginCredentialsFailTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardExactOriginCredentialsFailTestCase.java
@@ -1,0 +1,52 @@
+package io.quarkus.vertx.http.cors;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that application startup fails with a {@link ConfigurationException} when
+ * {@code quarkus.http.cors.return-exact-origins=false} is combined with
+ * {@code quarkus.http.cors.access-control-allow-credentials=true}.
+ * The CORS specification does not allow credentials with a wildcard origin.
+ */
+public class CORSWildcardExactOriginCredentialsFailTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.cors.enabled=true\n" +
+            "quarkus.http.cors.origins=*\n" +
+            "quarkus.http.cors.return-exact-origins=false\n" +
+            "quarkus.http.cors.access-control-allow-credentials=true\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(BeanRegisteringRoute.class)
+                            .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+                }
+            })
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof ConfigurationException,
+                        "Expected ConfigurationException but got: " + t.getClass().getName());
+                Assertions.assertTrue(t.getMessage().contains("return-exact-origins"),
+                        "Exception message should mention return-exact-origins, got: " + t.getMessage());
+                Assertions.assertTrue(t.getMessage().contains("credentials"),
+                        "Exception message should mention credentials, got: " + t.getMessage());
+            });
+
+    @Test
+    public void shouldFailAtStartup() {
+        Assertions.fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardExactOriginNonWildcardFailTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardExactOriginNonWildcardFailTestCase.java
@@ -1,0 +1,49 @@
+package io.quarkus.vertx.http.cors;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that application startup fails with a {@link ConfigurationException} when
+ * {@code quarkus.http.cors.return-exact-origins=false} is set but the configured origins
+ * do not contain a wildcard. The {@code return-exact-origins} flag is only meaningful
+ * with wildcard origins.
+ */
+public class CORSWildcardExactOriginNonWildcardFailTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.cors.enabled=true\n" +
+            "quarkus.http.cors.origins=http://example.com\n" +
+            "quarkus.http.cors.return-exact-origins=false\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(BeanRegisteringRoute.class)
+                            .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+                }
+            })
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof ConfigurationException,
+                        "Expected ConfigurationException but got: " + t.getClass().getName());
+                Assertions.assertTrue(t.getMessage().contains("return-exact-origins"),
+                        "Exception message should mention return-exact-origins, got: " + t.getMessage());
+            });
+
+    @Test
+    public void shouldFailAtStartup() {
+        Assertions.fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardExactOriginSecurityFailTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardExactOriginSecurityFailTestCase.java
@@ -1,0 +1,55 @@
+package io.quarkus.vertx.http.cors;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.PathHandler;
+
+/**
+ * Verifies that application startup fails with a {@link ConfigurationException} when
+ * {@code quarkus.http.cors.return-exact-origins=false} is combined with a wildcard origin
+ * and a Quarkus security extension is present.
+ */
+public class CORSWildcardExactOriginSecurityFailTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.cors.enabled=true\n" +
+            "quarkus.http.cors.origins=*\n" +
+            "quarkus.http.cors.return-exact-origins=false\n" +
+            "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.policy.r1.roles-allowed=test\n" +
+            "quarkus.http.auth.permission.roles1.paths=/test\n" +
+            "quarkus.http.auth.permission.roles1.policy=r1\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(TestIdentityProvider.class, TestIdentityController.class, PathHandler.class)
+                            .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+                }
+            })
+            .assertException(t -> {
+                Assertions.assertTrue(t instanceof ConfigurationException,
+                        "Expected ConfigurationException but got: " + t.getClass().getName());
+                Assertions.assertTrue(t.getMessage().contains("return-exact-origins"),
+                        "Exception message should mention return-exact-origins, got: " + t.getMessage());
+            });
+
+    @Test
+    public void shouldFailAtStartup() {
+        Assertions.fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -72,4 +72,19 @@ public interface CORSConfig {
      * and matches the precise `Origin` header value.
      */
     Optional<Boolean> accessControlAllowCredentials();
+
+    /**
+     * Whether to return the exact request origin in the `Access-Control-Allow-Origin` response header.
+     * <p>
+     * When set to `true` (the default), the filter echoes back the request's `Origin` header value.
+     * When set to `false` and `origins` is configured as `*`, the response will contain the literal
+     * `Access-Control-Allow-Origin: *` instead of echoing the request origin. This is useful for public
+     * APIs where HTTP caching is important, as echoing the origin requires `Vary: Origin` and defeats
+     * shared caches.
+     * <p>
+     * Note: When `*` is returned as the origin, `Access-Control-Allow-Credentials` is forced to `false`
+     * per the CORS specification.
+     */
+    @WithDefault("true")
+    boolean returnExactOrigins();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -80,7 +80,7 @@ public class CORSFilter implements Handler<RoutingContext> {
         return list.isEmpty() || (list.size() == 1 && "*".equals(list.get(0)));
     }
 
-    private static boolean isOriginConfiguredWithWildcard(Optional<List<String>> origins) {
+    static boolean isOriginConfiguredWithWildcard(Optional<List<String>> origins) {
         if (origins.isEmpty() || origins.get().size() != 1) {
             return false;
         }
@@ -158,9 +158,19 @@ public class CORSFilter implements Handler<RoutingContext> {
                 response.setStatusCode(403);
                 response.setStatusMessage("CORS Rejected - Invalid origin");
             } else {
-                boolean allowCredentials = corsConfig.accessControlAllowCredentials().orElse(originMatches);
-                response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, String.valueOf(allowCredentials));
-                response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+                if (wildcardOrigin && !corsConfig.returnExactOrigins()) {
+                    // Return literal * for public APIs where caching matters.
+                    // Incompatible configurations (credentials=true, security extensions)
+                    // are rejected at startup by CORSRecorder; the browser CORS engine
+                    // enforces that credentials cannot be used with a wildcard origin.
+                    response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+                    response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "false");
+                } else {
+                    boolean allowCredentials = corsConfig.accessControlAllowCredentials().orElse(originMatches);
+                    response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                            String.valueOf(allowCredentials));
+                    response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+                }
             }
 
             if (request.method().equals(HttpMethod.OPTIONS)) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.cors;
 
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
@@ -14,7 +15,7 @@ public class CORSRecorder {
         this.httpConfig = httpConfig;
     }
 
-    public Handler<RoutingContext> corsHandler(RuntimeValue<CORSConfig> programmaticCorsConfig) {
+    public Handler<RoutingContext> corsHandler(RuntimeValue<CORSConfig> programmaticCorsConfig, boolean securityPresent) {
         final CORSConfig corsConfig;
         if (programmaticCorsConfig != null && programmaticCorsConfig.getValue() != null) {
             corsConfig = programmaticCorsConfig.getValue();
@@ -22,6 +23,25 @@ public class CORSRecorder {
             corsConfig = httpConfig.getValue().cors();
         }
         if (corsConfig.enabled()) {
+            if (!corsConfig.returnExactOrigins()) {
+                if (!CORSFilter.isOriginConfiguredWithWildcard(corsConfig.origins())) {
+                    throw new ConfigurationException(
+                            "'quarkus.http.cors.return-exact-origins=false' can only be used when "
+                                    + "'quarkus.http.cors.origins' is set to '*'.");
+                }
+                if (corsConfig.accessControlAllowCredentials().orElse(false)) {
+                    throw new ConfigurationException(
+                            "'quarkus.http.cors.return-exact-origins=false' is incompatible with "
+                                    + "'quarkus.http.cors.access-control-allow-credentials=true' because the CORS "
+                                    + "specification does not allow credentials when 'Access-Control-Allow-Origin' "
+                                    + "is '*'.");
+                }
+                if (securityPresent) {
+                    throw new ConfigurationException(
+                            "'quarkus.http.cors.return-exact-origins=false' can't be used when "
+                                    + "a Quarkus Security capability is detected.");
+                }
+            }
             return new CORSFilter(corsConfig);
         }
         return null;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
@@ -47,6 +47,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
         private Optional<List<String>> headers;
         private Optional<List<String>> methods;
         private Optional<List<String>> origins;
+        private boolean returnExactOrigins;
 
         public Builder() {
             this(HttpSecurityUtils.getDefaultAuthConfig().cors());
@@ -59,6 +60,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
             this.headers = corsConfig.headers();
             this.methods = corsConfig.methods();
             this.origins = corsConfig.origins();
+            this.returnExactOrigins = corsConfig.returnExactOrigins();
         }
 
         /**
@@ -174,12 +176,22 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
         }
 
         /**
+         * @param returnExactOrigins {@link CORSConfig#returnExactOrigins()}
+         * @return this builder
+         */
+        public Builder returnExactOrigins(boolean returnExactOrigins) {
+            this.returnExactOrigins = returnExactOrigins;
+            return this;
+        }
+
+        /**
          * Create a new CORS configuration.
          *
          * @return CORS instance, which should be passed to the {@link HttpSecurity} event
          */
         public CORS build() {
-            return new CORSImpl(accessControlAllowCredentials, accessControlMaxAge, exposedHeaders, headers, methods, origins);
+            return new CORSImpl(accessControlAllowCredentials, accessControlMaxAge, exposedHeaders, headers, methods, origins,
+                    returnExactOrigins);
         }
 
         private static Optional<List<String>> merge(Optional<List<String>> optionalOriginalList, Set<String> newSet,
@@ -201,7 +213,8 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
 
         record CORSImpl(Optional<Boolean> accessControlAllowCredentials, Optional<Duration> accessControlMaxAge,
                 Optional<List<String>> exposedHeaders, Optional<List<String>> headers,
-                Optional<List<String>> methods, Optional<List<String>> origins) implements CORS, CORSConfig {
+                Optional<List<String>> methods, Optional<List<String>> origins,
+                boolean returnExactOrigins) implements CORS, CORSConfig {
             @Override
             public boolean enabled() {
                 return true;

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
@@ -105,14 +105,15 @@ public class CORSFilterTest {
     void testCorsConfig() {
         record CORSConfigImpl(Optional<Boolean> accessControlAllowCredentials, Optional<Duration> accessControlMaxAge,
                 Optional<List<String>> exposedHeaders, Optional<List<String>> headers,
-                Optional<List<String>> methods, Optional<List<String>> origins) implements CORSConfig {
+                Optional<List<String>> methods, Optional<List<String>> origins,
+                boolean returnExactOrigins) implements CORSConfig {
             @Override
             public boolean enabled() {
                 return true;
             }
         }
         var config = new CORSConfigImpl(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty());
+                Optional.empty(), Optional.empty(), true);
         var emptyConfig = (CORSConfig) new CORS.Builder(config).build();
         Assertions.assertTrue(emptyConfig.enabled());
         Assertions.assertTrue(emptyConfig.origins().isEmpty());


### PR DESCRIPTION
## Summary

When `quarkus.http.cors.origins=*` is configured, the CORS filter currently echoes back the request's `Origin` header instead of returning the literal `*`. This forces `Vary: Origin` on responses, which defeats CDN/proxy caching for public APIs.

This PR adds a new config property `quarkus.http.cors.return-exact-origins` (default `true`) that controls this behavior:

- `true` (default): Current behavior — echoes back the request origin (backward compatible)
- `false`: Returns literal `Access-Control-Allow-Origin: *` and forces `Access-Control-Allow-Credentials: false` (per CORS spec, credentials and wildcard origin are incompatible)

### Changes

- **`CORSConfig.java`** — New `returnExactOrigins` property with `@WithDefault("true")`
- **`CORSFilter.java`** — Conditionally returns `*` instead of echoing origin when `wildcardOrigin && !returnExactOrigins`
- **`CORS.java`** — Updated Builder and CORSImpl record with the new field
- **`CORSFilterTest.java`** — Updated test's CORSConfigImpl record to include new field

### Usage

```properties
quarkus.http.cors.enabled=true
quarkus.http.cors.origins=*
quarkus.http.cors.return-exact-origins=false
```

### Spec compliance

When `Access-Control-Allow-Origin: *` is returned, `Access-Control-Allow-Credentials` is forced to `false` per the [Fetch specification](https://fetch.spec.whatwg.org/#http-cors-protocol), which prohibits credentials with wildcard origins.

Fixes #52792