### PR TITLE
ArC - Make CurrentManagedContext a public API

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AbstractManagedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AbstractManagedContext.java
@@ -1,4 +1,4 @@
-package io.quarkus.arc.impl;
+package io.quarkus.arc;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -15,17 +15,20 @@ import jakarta.enterprise.context.spi.CreationalContext;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.arc.ContextInstanceHandle;
-import io.quarkus.arc.CurrentContext;
-import io.quarkus.arc.InjectableBean;
-import io.quarkus.arc.ManagedContext;
+import io.quarkus.arc.impl.ContextInstanceHandleImpl;
+import io.quarkus.arc.impl.ContextInstances;
+import io.quarkus.arc.impl.CreationalContextImpl;
+import io.quarkus.arc.impl.Scopes;
 
 /**
- * A managed context backed by the {@link CurrentContext}.
+ * An implementation of managed context based on {@link CurrentContext} which allows getting/setting
+ * the context state.
+ * <p>
+ * While primarily used by Quarkus request and session contexts, it can also be leveraged by custom context impls.
  */
-public abstract class CurrentManagedContext implements ManagedContext {
+public abstract class AbstractManagedContext implements ManagedContext {
 
-    private static final Logger LOG = Logger.getLogger(CurrentManagedContext.class);
+    private static final Logger LOG = Logger.getLogger(AbstractManagedContext.class);
 
     private final CurrentContext<CurrentContextState> currentContext;
 
@@ -35,7 +38,7 @@ public abstract class CurrentManagedContext implements ManagedContext {
     private final Consumer<Object> beforeDestroyedNotifier;
     private final Consumer<Object> destroyedNotifier;
 
-    protected CurrentManagedContext(CurrentContext<CurrentContextState> currentContext,
+    protected AbstractManagedContext(CurrentContext<CurrentContextState> currentContext,
             Supplier<ContextInstances> contextInstances, Consumer<Object> initializedNotifier,
             Consumer<Object> beforeDestroyedNotifier, Consumer<Object> destroyedNotifier) {
         this.currentContext = currentContext;
@@ -145,7 +148,7 @@ public abstract class CurrentManagedContext implements ManagedContext {
     @Override
     public boolean isActive() {
         CurrentContextState contextState = currentState();
-        return contextState == null ? false : contextState.isValid();
+        return contextState != null && contextState.isValid();
     }
 
     @Override
@@ -200,6 +203,7 @@ public abstract class CurrentManagedContext implements ManagedContext {
         return state;
     }
 
+    // Trace logging - by default no-op
     protected Logger traceLog() {
         return LOG;
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.RequestScoped;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.AbstractManagedContext;
 import io.quarkus.arc.CurrentContext;
 import io.quarkus.arc.impl.EventImpl.Notifier;
 
@@ -18,7 +19,7 @@ import io.quarkus.arc.impl.EventImpl.Notifier;
  *
  * @author Martin Kouba
  */
-class RequestContext extends CurrentManagedContext {
+class RequestContext extends AbstractManagedContext {
 
     private static final Logger LOG = Logger.getLogger("io.quarkus.arc.requestContext");
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Scopes.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Scopes.java
@@ -3,16 +3,16 @@ package io.quarkus.arc.impl;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
 
-class Scopes {
+public class Scopes {
 
     private Scopes() {
     }
 
-    static boolean scopeMatches(InjectableContext context, InjectableBean<?> bean) {
+    public static boolean scopeMatches(InjectableContext context, InjectableBean<?> bean) {
         return context.getScope().getName().equals(bean.getScope().getName());
     }
 
-    static IllegalArgumentException scopeDoesNotMatchException(InjectableContext context, InjectableBean<?> bean) {
+    public static IllegalArgumentException scopeDoesNotMatchException(InjectableContext context, InjectableBean<?> bean) {
         return new IllegalArgumentException(String.format(
                 "The scope of the bean [%s] does not match the scope of the context [%s]:\n\t- %s bean with bean class %s and identifier %s \n\t- context %s",
                 bean.getScope().getName(), context.getScope().getName(), bean.getKind(), bean.getBeanClass().getName(),

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/SessionContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/SessionContext.java
@@ -6,13 +6,14 @@ import java.util.function.Supplier;
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.context.SessionScoped;
 
+import io.quarkus.arc.AbstractManagedContext;
 import io.quarkus.arc.CurrentContext;
 import io.quarkus.arc.impl.EventImpl.Notifier;
 
 /**
  * The built-in context for {@link SessionScoped}.
  */
-public class SessionContext extends CurrentManagedContext {
+public class SessionContext extends AbstractManagedContext {
 
     public SessionContext(CurrentContext<CurrentContextState> currentContext, Notifier<Object> initializedNotifier,
             Notifier<Object> beforeDestroyedNotifier, Notifier<Object> destroyedNotifier,


### PR DESCRIPTION
Fixes #47856 

First and foremost, I do not recall the original case we had but the issue is still there and it popped up (again) in my lottery so I thought I might as well send this. Feel free to throw it out of the window :)

The PR renames the `CurrentManagedContext` class to `AbstractManagedContext` and moves it outside of the `impl` package.