### PR TITLE
Make sure static init logging is initialized early

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
@@ -40,7 +40,7 @@ public final class BuildChainBuilder {
     private final Map<BuildStepBuilder, StackTraceElement[]> steps = new LinkedHashMap<BuildStepBuilder, StackTraceElement[]>();
     private final Set<ItemId> initialIds = new HashSet<>();
     private final Set<ItemId> finalIds = new LinkedHashSet<>();
-    private final Set<ItemId> prioritizedItemIds = new HashSet<>();
+    private final Set<ItemId> prioritizedItemIds = new LinkedHashSet<>();
     private ClassLoader classLoader = BuildChainBuilder.class.getClassLoader();
 
     BuildChainBuilder() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -35,6 +35,7 @@ import io.quarkus.deployment.builditem.RawCommandLineArgumentsBuildItem;
 import io.quarkus.deployment.builditem.RuntimeApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.deployment.logging.StaticInitLoggingSetupBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.paths.PathCollection;
@@ -119,6 +120,7 @@ public class QuarkusAugmentor {
             chainBuilder.loadProviders(classLoader);
 
             chainBuilder.addPriorityItem(LoggingSetupBuildItem.class);
+            chainBuilder.addPriorityItem(StaticInitLoggingSetupBuildItem.class);
 
             chainBuilder
                     .addInitial(QuarkusBuildCloseablesBuildItem.class)

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -504,10 +504,13 @@ public final class LoggingResourceProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    void setupLoggingStaticInit(LoggingSetupRecorder recorder, LaunchModeBuildItem launchModeBuildItem) {
+    StaticInitLoggingSetupBuildItem setupLoggingStaticInit(LoggingSetupRecorder recorder,
+            LaunchModeBuildItem launchModeBuildItem) {
         if (!launchModeBuildItem.isAuxiliaryApplication()) {
             recorder.initializeLoggingForImageBuild();
         }
+
+        return new StaticInitLoggingSetupBuildItem();
     }
 
     // This is specifically to help out with presentations, to allow an env var to always override this value

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/StaticInitLoggingSetupBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/StaticInitLoggingSetupBuildItem.java
@@ -1,0 +1,12 @@
+package io.quarkus.deployment.logging;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Indicates that the static init logging setup has been done.
+ * <p>
+ * See {@link LoggingSetupBuildItem} when you want the full logging subsystem to be properly initialized with runtime
+ * configuration.
+ */
+public final class StaticInitLoggingSetupBuildItem extends SimpleBuildItem {
+}


### PR DESCRIPTION
Same as for runtime logging.

By doing that, when in JVM, the static init phase was logging at trace level, and only when we get to the runtime phase, the logging levels would be applied and the messages discarded.

Also make sure prioritized items are always applied in the same order.

<img width="1559" height="579" alt="Screenshot From 2026-03-03 15-20-41" src="https://github.com/user-attachments/assets/9a9466fb-ab92-4d46-9df4-4f006117690c" />


