### PR TITLE
Deprecate `ObjectLoader`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeRecorderObjectLoaderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeRecorderObjectLoaderBuildItem.java
@@ -3,6 +3,10 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.recording.ObjectLoader;
 
+/**
+ * @deprecated This class is intended only for internal use.
+ */
+@Deprecated(forRemoval = true)
 public final class BytecodeRecorderObjectLoaderBuildItem extends MultiBuildItem {
     private final ObjectLoader objectLoader;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/ObjectLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/ObjectLoader.java
@@ -6,7 +6,11 @@ import io.quarkus.gizmo.ResultHandle;
 /**
  * A segment of code generation which produces the necessary instructions to load the given object. The result handle
  * is cached for reuse.
+ *
+ * @deprecated This interface is for internal use only, and is tightly coupled to Gizmo 1 which is being replaced
+ *             by Gizmo 2.
  */
+@Deprecated(forRemoval = true)
 public interface ObjectLoader {
     /**
      * Load the given object if possible.

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
@@ -37,7 +37,12 @@ public interface RecorderContext {
      * Register an object loader.
      *
      * @param loader the object loader (must not be {@code null})
+     *
+     * @deprecated This method is only used internally and is tightly bound to Gizmo 1, which is being replaced
+     *             by Gizmo 2. To control serialization, use {@link #registerSubstitution(Class, Class, Class)}
+     *             instead.
      */
+    @Deprecated(forRemoval = true)
     void registerObjectLoader(ObjectLoader loader);
 
     /**


### PR DESCRIPTION
This should be converted into an internal-only API. I think we only use it in one place.
