### PR TITLE
Undeprecate `quarkus.otel.exporter.otlp.enabled`

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -123,9 +123,9 @@ Once you add the dependency, the extension will generate tracing data by default
 | All output
 |`quarkus.otel.exporter.otlp.enabled`
 |true
-|Deprecated for removal.
+| If false, will disable Quarkus default OTLP exporters at *build* time.
 
-If false will disable the default OTLP exporter at *build* time.
+Telemetry will be generated, contexts will be propagated but no telemetry will be sent out.
 
 | Traces
 |`quarkus.otel.traces.enabled`

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/exporter/OtlpExporterBuildConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/exporter/OtlpExporterBuildConfig.java
@@ -9,11 +9,8 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public interface OtlpExporterBuildConfig {
     /**
-     * Legacy property kept for compatibility reasons. Just the defining the right exporter is enough.
-     * <p>
-     * Maps to quarkus.opentelemetry.tracer.exporter.otlp.enabled and will be removed in the future
+     * Will disable the Quarkus managed OpenTelemetry exporters. No telemetry will be sent output if set to `false`.
      */
-    @Deprecated
     @WithDefault("true")
     boolean enabled();
 }


### PR DESCRIPTION
It was deprecated a long time ago but always kept. There is no alternative and due to the interest of many users, we are un-deprecating the `quarkus.otel.exporter.otlp.enabled` build time configuration.

