### PR TITLE
Adjust filter of log messages to capture the listening port

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ValueRegistryImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ValueRegistryImpl.java
@@ -6,14 +6,11 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-
 import io.quarkus.value.registry.RuntimeInfoProvider;
 import io.quarkus.value.registry.RuntimeInfoProvider.RuntimeSource;
 import io.quarkus.value.registry.ValueRegistry;
 import io.quarkus.value.registry.ValueRegistry.RuntimeInfo.SimpleRuntimeInfo;
-import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.Config;
 
 /**
  * Implementation of {@link ValueRegistry}.
@@ -96,7 +93,7 @@ public class ValueRegistryImpl implements ValueRegistry {
             return this;
         }
 
-        public Builder withRuntimeSource(final SmallRyeConfig config) {
+        public Builder withRuntimeSource(final Config config) {
             this.sources.add(new ConfigRuntimeSource(config));
             return this;
         }
@@ -142,7 +139,7 @@ public class ValueRegistryImpl implements ValueRegistry {
         }
 
         public static RuntimeSource runtimeSource() {
-            return new ConfigRuntimeSource(ConfigProvider.getConfig());
+            return new ConfigRuntimeSource(Config.get());
         }
     }
 }

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.test;
 
+import static io.quarkus.test.config.TestValueRegistryConfigSource.CONFIG;
+import static org.junit.jupiter.api.extension.ExtensionContext.StoreScope.LAUNCHER_SESSION;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -241,22 +244,22 @@ public class QuarkusDevModeTest
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) {
+    public void beforeEach(ExtensionContext context) {
         if (archiveProducer == null) {
             throw new RuntimeException("QuarkusDevModeTest does not have archive producer set");
         }
-        ExclusivityChecker.checkTestType(extensionContext, QuarkusDevModeTest.class);
-        ExtensionContext.Store store = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
+        ExclusivityChecker.checkTestType(context, QuarkusDevModeTest.class);
+        ExtensionContext.Store store = context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
         if (store.get(TestResourceManager.class.getName()) == null) {
-            TestResourceManager testResourceManager = new TestResourceManager(extensionContext.getRequiredTestClass());
+            TestResourceManager testResourceManager = new TestResourceManager(context.getRequiredTestClass());
             testResourceManager.init(null);
-            Map<String, String> properties = testResourceManager.start();
-            TestResourceManager tm = testResourceManager;
-
+            testResourceManager.start();
             store.put(TestResourceManager.class.getName(), testResourceManager);
-            store.put(TestResourceManager.CLOSEABLE_NAME, tm);
+            store.put(TestResourceManager.CLOSEABLE_NAME, testResourceManager);
         }
         TestResourceManager tm = (TestResourceManager) store.get(TestResourceManager.class.getName());
+        assert tm != null;
+
         //dev mode tests just use system properties
         //we set them here and clear them in afterAll
         //so they don't interfere with other tests
@@ -268,7 +271,8 @@ public class QuarkusDevModeTest
                 System.setProperty(i.getKey(), i.getValue());
             }
         }
-        Class<?> testClass = extensionContext.getRequiredTestClass();
+        Class<?> testClass = context.getRequiredTestClass();
+        Object testInstance = context.getRequiredTestInstance();
         try {
             deploymentDir = Files.createTempDirectory("quarkus-dev-mode-test");
             testLocation = PathTestHelper.getTestClassesLocation(testClass);
@@ -284,25 +288,23 @@ public class QuarkusDevModeTest
             }
 
             InMemoryLogHandler startupLogHandler = new InMemoryLogHandler(
-                    logRecord -> logRecord.getMessage().contains("started in"));
+                    logRecord -> logRecord.getMessage().contains("powered by Quarkus"));
             rootLogger.addHandler(startupLogHandler);
-
-            devModeMain = newDevModeMain(extensionContext, deploymentDir, projectSourceRoot);
+            devModeMain = newDevModeMain(context, deploymentDir, projectSourceRoot);
             devModeMain.start();
             ApplicationStateNotification.waitForApplicationStart();
-
             rootLogger.removeHandler(startupLogHandler);
+
             Optional<ListeningAddress> listeningAddress = listeningAddress(startupLogHandler.getRecords());
-            if (listeningAddress.isPresent()) {
-                ValueRegistry valueRegistry = ValueRegistryImpl.builder().addDiscoveredInfos().build();
-                listeningAddress.get().register(valueRegistry, Config.get());
-                extensionContext.getTestInstance().ifPresent(
-                        testInstance -> {
-                            ValueRegistryInjector.inject(testInstance, valueRegistry);
-                            TestHTTPResourceManager.inject(testInstance, valueRegistry);
-                        });
-                extensionContext.getStore(Namespace.GLOBAL).put(ValueRegistry.class.getName(), valueRegistry);
-            }
+            ValueRegistry valueRegistry = ValueRegistryImpl.builder().addDiscoveredInfos()
+                    .withRuntimeSource(Config.get())
+                    .build();
+            listeningAddress.ifPresent(address -> address.register(valueRegistry, Config.get()));
+            context.getStore(LAUNCHER_SESSION, CONFIG).put(ValueRegistry.class.getName(), valueRegistry);
+            context.getStore(Namespace.GLOBAL).put(ValueRegistry.class.getName(), valueRegistry);
+
+            ValueRegistryInjector.inject(testInstance, valueRegistry);
+            TestHTTPResourceManager.inject(testInstance, valueRegistry);
 
         } catch (Exception e) {
             if (allowFailedStart) {


### PR DESCRIPTION
Following https://github.com/quarkusio/quarkus/pull/52845, it relied on a log filter to retrieve the listening address `started in`, but this can clash with other log messages that contain the same string (testcontainers). It now filters with `powered by Quarkus`, which should be unique.

Also adjusted to always create a `ValueRegistry`, even when Quarkus is not running with http in test dev mode, to avoid NPEs.

For https://github.com/quarkiverse/quarkiverse/issues/195#issuecomment-3995565389