### PR TITLE
Fix test to work even if there is module name or CL name

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UnhandledExceptionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UnhandledExceptionTest.java
@@ -234,7 +234,7 @@ public class UnhandledExceptionTest {
         return allOf(
                 containsString("\"details\":\"Error id"),
                 containsString("\"stack\":\"java.lang.RuntimeException: Simulated failure"),
-                containsString("at " + BeanRegisteringRouteThatThrowsException.class.getName() + "$1.handle"));
+                containsString(BeanRegisteringRouteThatThrowsException.class.getName() + "$1.handle"));
     }
 
     private Matcher<String> htmlBodyMatcher() {


### PR DESCRIPTION
Don't assume that there is nothing between `at` and the class name.

- Fixes #52876


