### PR TITLE
Bump module-services-plugin to 1.3

### DIFF
--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -235,7 +235,7 @@
             <plugin>
                 <groupId>io.github.dmlloyd.maven</groupId>
                 <artifactId>module-services-plugin</artifactId>
-                <version>1.2</version>
+                <version>1.3</version>
                 <executions>
                     <execution>
                         <id>generate-services</id>


### PR DESCRIPTION
- This enables the plugin to execute in parallel
- Release notes: https://github.com/dmlloyd/module-services-plugin/releases/tag/1.3
