### PR TITLE
Add PathTree.getResourceNames()

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -71,6 +72,7 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
 
     protected final Path archive;
     private final PathFilter pathFilter;
+    private transient volatile Set<String> resourceNames;
 
     ArchivePathTree(Path archive) {
         this(archive, null);
@@ -135,7 +137,12 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
     }
 
     private void ensureResourcePath(String path) {
-        DirectoryPathTree.ensureResourcePath(archive.getFileSystem(), path);
+        OpenContainerPathTree.ensureResourcePath(archive.getFileSystem(), path);
+    }
+
+    @Override
+    public Set<String> getResourceNames() {
+        return resourceNames == null ? resourceNames = super.getResourceNames() : resourceNames;
     }
 
     @Override
@@ -371,6 +378,11 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
             } finally {
                 lock.readLock().unlock();
             }
+        }
+
+        @Override
+        public Set<String> getResourceNames() {
+            return resourceNames == null ? resourceNames = super.getResourceNames() : resourceNames;
         }
 
         @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
@@ -7,6 +7,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class DirectoryPathTree extends OpenContainerPathTree implements Serializable {
@@ -14,6 +15,7 @@ public class DirectoryPathTree extends OpenContainerPathTree implements Serializ
     private static final long serialVersionUID = 2255956884896445059L;
 
     private Path dir;
+    private transient volatile Set<String> resourceNames;
 
     /**
      * For deserialization
@@ -79,6 +81,11 @@ public class DirectoryPathTree extends OpenContainerPathTree implements Serializ
     @Override
     public PathTree getOriginalTree() {
         return this;
+    }
+
+    @Override
+    public Set<String> getResourceNames() {
+        return resourceNames == null ? resourceNames = super.getResourceNames() : resourceNames;
     }
 
     @Serial

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -40,6 +41,11 @@ public class EmptyPathTree implements OpenPathTree {
 
     @Override
     public void walkIfContains(String relativePath, PathVisitor visitor) {
+    }
+
+    @Override
+    public Set<String> getResourceNames() {
+        return Set.of();
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -29,7 +30,7 @@ class FilePathTree implements OpenPathTree {
 
     @Override
     public Collection<Path> getRoots() {
-        return Collections.singletonList(file);
+        return Collections.singletonList(file.getParent());
     }
 
     @Override
@@ -51,7 +52,7 @@ class FilePathTree implements OpenPathTree {
 
             @Override
             public Path getRoot() {
-                return file;
+                return file.getParent();
             }
 
             @Override
@@ -65,7 +66,7 @@ class FilePathTree implements OpenPathTree {
 
             @Override
             public String getRelativePath(String separator) {
-                return "";
+                return file.getFileName().toString();
             }
         });
     }
@@ -81,9 +82,15 @@ class FilePathTree implements OpenPathTree {
     }
 
     @Override
+    public Set<String> getResourceNames() {
+        return Set.of(file.getFileName().toString());
+    }
+
+    @Override
     public <T> T apply(String relativePath, Function<PathVisit, T> func) {
         if (relativePath.isEmpty()) {
-            return PathTreeVisit.process(file, file, file, pathFilter, func);
+            Path parent = file.getParent();
+            return PathTreeVisit.process(parent, parent, file, pathFilter, func);
         }
         return func.apply(null);
     }
@@ -91,7 +98,8 @@ class FilePathTree implements OpenPathTree {
     @Override
     public void accept(String relativePath, Consumer<PathVisit> func) {
         if (relativePath.isEmpty()) {
-            PathTreeVisit.consume(file, file, file, pathFilter, func);
+            Path parent = file.getParent();
+            PathTreeVisit.consume(parent, parent, file, pathFilter, func);
             return;
         }
         func.accept(null);

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
@@ -5,7 +5,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -15,6 +17,7 @@ public class MultiRootPathTree implements OpenPathTree {
 
     private final PathTree[] trees;
     private final List<Path> roots;
+    private transient volatile Set<String> resourceNames;
 
     public MultiRootPathTree(PathTree... trees) {
         this.trees = trees;
@@ -84,6 +87,22 @@ public class MultiRootPathTree implements OpenPathTree {
         for (PathTree t : trees) {
             t.walkIfContains(relativePath, visitor);
         }
+    }
+
+    @Override
+    public Set<String> getResourceNames() {
+        return resourceNames == null ? resourceNames = collectResourceNames() : resourceNames;
+    }
+
+    private Set<String> collectResourceNames() {
+        if (trees.length > 0) {
+            Set<String> result = new HashSet<>();
+            for (PathTree t : trees) {
+                t.walk(visit -> result.add(visit.getRelativePath()));
+            }
+            return result;
+        }
+        return Set.of();
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -5,6 +5,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -112,6 +114,18 @@ public interface PathTree {
      * @return parsed {@code META-INF/MANIFEST.MF} if it's found, otherwise {@code null}
      */
     ManifestAttributes getManifestAttributes();
+
+    /**
+     * Returns a set of resource names provided by this path tree.
+     * The set may include both directories and files.
+     *
+     * @return a set of resource names provided by this path tree
+     */
+    default Set<String> getResourceNames() {
+        Set<String> names = new HashSet<>();
+        walk(visit -> names.add(visit.getRelativePath()));
+        return names;
+    }
 
     /**
      * Walks the tree.

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -5,6 +5,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -186,6 +187,11 @@ class SharedArchivePathTree extends ArchivePathTree {
         @Override
         public void walkIfContains(String relativePath, PathVisitor visitor) {
             delegate.walkIfContains(relativePath, visitor);
+        }
+
+        @Override
+        public Set<String> getResourceNames() {
+            return delegate.getResourceNames();
         }
 
         @Override

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/DirectoryPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/DirectoryPathTreeTest.java
@@ -169,6 +169,30 @@ public class DirectoryPathTreeTest {
     }
 
     @Test
+    public void getResourceNames() {
+        final Path root = resolveTreeRoot("root");
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        assertThat(tree.getResourceNames()).containsExactlyInAnyOrderElementsOf(getRawPaths().keySet());
+    }
+
+    @Test
+    public void getResourceNamesMultiReleaseEnabled() {
+        final Path root = resolveTreeRoot("root");
+        final PathTree tree = new DirectoryPathTree(root, null, true);
+        assertThat(tree.getResourceNames())
+                .containsExactlyInAnyOrderElementsOf(getMultiReleaseMappedPaths().keySet());
+    }
+
+    @Test
+    public void getResourceNamesIsCached() {
+        final Path root = resolveTreeRoot("root");
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        var first = tree.getResourceNames();
+        var second = tree.getResourceNames();
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
     public void walk() throws Exception {
         final Path root = resolveTreeRoot("root");
         final PathTree tree = PathTree.ofDirectoryOrArchive(root);

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/FilteredPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/FilteredPathTreeTest.java
@@ -71,6 +71,40 @@ public class FilteredPathTreeTest {
     }
 
     @Test
+    public void getResourceNamesDirIncludeToolbox() {
+        var pathTree = PathTree.ofDirectoryOrArchive(testDir, PathFilter.forIncludes(List.of("*/toolbox/**")));
+        assertThat(pathTree.getResourceNames()).containsExactlyInAnyOrder(
+                "org/toolbox/Axe.class",
+                "org/toolbox/Hammer.class",
+                "org/toolbox/Saw.class");
+    }
+
+    @Test
+    public void getResourceNamesJarIncludeToolbox() {
+        var pathTree = PathTree.ofDirectoryOrArchive(testJar, PathFilter.forIncludes(List.of("*/toolbox/**")));
+        assertThat(pathTree.getResourceNames()).containsExactlyInAnyOrder(
+                "org/toolbox/Axe.class",
+                "org/toolbox/Hammer.class",
+                "org/toolbox/Saw.class");
+    }
+
+    @Test
+    public void getResourceNamesFilteredPathTree() {
+        var originalFilter = new PathFilter(
+                List.of("*/toolbox/**"),
+                List.of("**/Hammer.class"));
+        var outerFilter = new PathFilter(
+                List.of("**/Axe.class"),
+                List.of("**/Saw.class"));
+
+        var pathTree = new FilteredPathTree(PathTree.ofDirectoryOrArchive(testDir, originalFilter), outerFilter);
+        assertThat(pathTree.getResourceNames()).containsExactlyInAnyOrder("org/toolbox/Axe.class");
+
+        pathTree = new FilteredPathTree(PathTree.ofDirectoryOrArchive(testJar, originalFilter), outerFilter);
+        assertThat(pathTree.getResourceNames()).containsExactlyInAnyOrder("org/toolbox/Axe.class");
+    }
+
+    @Test
     public void dirIncludeToolbox() {
         var pathTree = PathTree.ofDirectoryOrArchive(testDir, PathFilter.forIncludes(List.of("*/toolbox/**")));
         assertThat(getAllPaths(pathTree)).containsExactlyInAnyOrder(

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/GetResourceNamesTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/GetResourceNamesTest.java
@@ -1,0 +1,112 @@
+package io.quarkus.paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.fs.util.ZipUtils;
+
+public class GetResourceNamesTest {
+
+    @TempDir
+    static Path testDir;
+    static Path dir1;
+    static Path dir2;
+    static Path testJar;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        dir1 = testDir.resolve("dir1");
+        createFile(dir1, "org/acme/Foo.class");
+        createFile(dir1, "org/acme/Bar.class");
+
+        dir2 = testDir.resolve("dir2");
+        createFile(dir2, "org/acme/Baz.class");
+        createFile(dir2, "META-INF/services/org.acme.Service");
+
+        testJar = testDir.resolve("test.jar");
+        ZipUtils.zip(dir1, testJar);
+    }
+
+    private static void createFile(Path root, String path) throws Exception {
+        var file = root.resolve(path);
+        Files.createDirectories(file.getParent());
+        Files.createFile(file);
+    }
+
+    @Test
+    public void emptyPathTree() {
+        assertThat(EmptyPathTree.getInstance().getResourceNames()).isEmpty();
+    }
+
+    @Test
+    public void filePathTree() {
+        var file = dir1.resolve("org/acme/Foo.class");
+        var tree = PathTree.ofDirectoryOrFile(file);
+        assertThat(tree.getResourceNames()).containsExactly("Foo.class");
+    }
+
+    @Test
+    public void multiRootPathTree() {
+        var tree1 = PathTree.ofDirectoryOrArchive(dir1);
+        var tree2 = PathTree.ofDirectoryOrArchive(dir2);
+        var multi = new MultiRootPathTree(tree1, tree2);
+        assertThat(multi.getResourceNames()).containsExactlyInAnyOrder(
+                "",
+                "org",
+                "org/acme",
+                "org/acme/Foo.class",
+                "org/acme/Bar.class",
+                "org/acme/Baz.class",
+                "META-INF",
+                "META-INF/services",
+                "META-INF/services/org.acme.Service");
+    }
+
+    @Test
+    public void multiRootPathTreeIsCached() {
+        var tree1 = PathTree.ofDirectoryOrArchive(dir1);
+        var tree2 = PathTree.ofDirectoryOrArchive(dir2);
+        var multi = new MultiRootPathTree(tree1, tree2);
+        var first = multi.getResourceNames();
+        var second = multi.getResourceNames();
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    public void multiRootPathTreeEmpty() {
+        var multi = new MultiRootPathTree();
+        assertThat(multi.getResourceNames()).isEmpty();
+    }
+
+    @Test
+    public void multiRootPathTreeDirAndJar() {
+        var tree1 = PathTree.ofDirectoryOrArchive(dir2);
+        var tree2 = PathTree.ofDirectoryOrArchive(testJar);
+        var multi = new MultiRootPathTree(tree1, tree2);
+        assertThat(multi.getResourceNames()).containsExactlyInAnyOrder(
+                "",
+                "org",
+                "org/acme",
+                "org/acme/Foo.class",
+                "org/acme/Bar.class",
+                "org/acme/Baz.class",
+                "META-INF",
+                "META-INF/services",
+                "META-INF/services/org.acme.Service");
+    }
+
+    @Test
+    public void getResourceNamesMatchesWalk() {
+        var tree = PathTree.ofDirectoryOrArchive(dir1);
+        var resourceNames = tree.getResourceNames();
+        var walkNames = new java.util.HashSet<String>();
+        tree.walk(visit -> walkNames.add(visit.getRelativePath()));
+        assertThat(resourceNames).containsExactlyInAnyOrderElementsOf(walkNames);
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/JarPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/JarPathTreeTest.java
@@ -135,6 +135,21 @@ public class JarPathTreeTest {
     }
 
     @Test
+    public void getResourceNames() {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        assertThat(tree.getResourceNames())
+                .containsExactlyInAnyOrderElementsOf(DirectoryPathTreeTest.getMultiReleaseMappedPaths().keySet());
+    }
+
+    @Test
+    public void getResourceNamesIsCached() {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        var first = tree.getResourceNames();
+        var second = tree.getResourceNames();
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
     public void walk() throws Exception {
         final PathTree tree = PathTree.ofDirectoryOrArchive(root);
         var visitor = new PathCollectingVisitor();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/AbstractClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/AbstractClassPathElement.java
@@ -1,45 +1,11 @@
 package io.quarkus.bootstrap.classloading;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.jar.Manifest;
-
-import org.jboss.logging.Logger;
-
 import io.quarkus.paths.ManifestAttributes;
 
 public abstract class AbstractClassPathElement implements ClassPathElement {
 
-    private static final Logger log = Logger.getLogger(AbstractClassPathElement.class);
-
-    private volatile ManifestAttributes manifestAttributes;
-    private volatile boolean manifestInitialized = false;
-
     @Override
     public ManifestAttributes getManifestAttributes() {
-        if (manifestInitialized) {
-            return manifestAttributes;
-        }
-        synchronized (this) {
-            if (manifestInitialized) {
-                return manifestAttributes;
-            }
-            manifestAttributes = readManifest();
-            manifestInitialized = true;
-        }
-        return manifestAttributes;
-    }
-
-    protected ManifestAttributes readManifest() {
-        final ClassPathResource mf = getResource("META-INF/MANIFEST.MF");
-        if (mf != null) {
-            try (InputStream manifestIs = new ByteArrayInputStream(mf.getData())) {
-                return ManifestAttributes.of(new Manifest(manifestIs));
-            } catch (IOException e) {
-                log.warnf("Failed to parse manifest for %s", toString(), e);
-            }
-        }
         return null;
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
@@ -13,7 +13,7 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -37,7 +37,6 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
     private final OpenPathTree pathTree;
     private final boolean runtime;
     private final ResolvedDependency resolvedDependency;
-    private volatile Set<String> resources;
 
     public PathTreeClassPathElement(PathTree pathTree, boolean runtime) {
         this(pathTree, runtime, null);
@@ -99,7 +98,7 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
     @Override
     public ClassPathResource getResource(String name) {
         final String sanitized = sanitize(name);
-        final Set<String> resources = this.resources;
+        final Collection<String> resources = pathTree.getResourceNames();
         if (resources != null && !resources.contains(sanitized)) {
             return null;
         }
@@ -113,7 +112,7 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
     @Override
     public List<ClassPathResource> getResources(String name) {
         final String sanitized = sanitize(name);
-        final Set<String> resources = this.resources;
+        final Collection<String> resources = pathTree.getResourceNames();
         if (resources != null && !resources.contains(sanitized)) {
             return List.of();
         }
@@ -154,23 +153,7 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
 
     @Override
     public Set<String> getProvidedResources() {
-        Set<String> resources = this.resources;
-        if (resources == null) {
-            resources = apply(PathTreeClassPathElement::collectResources);
-            this.resources = resources;
-        }
-        return resources;
-    }
-
-    private static Set<String> collectResources(OpenPathTree tree) {
-        final Set<String> relativePaths = new HashSet<>();
-        tree.walk(visit -> {
-            final String relativePath = visit.getRelativePath();
-            if (!relativePath.isEmpty()) {
-                relativePaths.add(relativePath);
-            }
-        });
-        return relativePaths;
+        return pathTree.getResourceNames();
     }
 
     @Override
@@ -179,7 +162,7 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
     }
 
     @Override
-    protected ManifestAttributes readManifest() {
+    public ManifestAttributes getManifestAttributes() {
         return apply(OpenPathTree::getManifestAttributes);
     }
 
@@ -199,7 +182,6 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
     @Override
     public void close() throws IOException {
         lock.writeLock().lock();
-        resources = null;
         try {
             pathTree.close();
         } finally {
@@ -216,7 +198,7 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
         }
         sb.append(pathTree.getOriginalTree().toString());
         sb.append(" runtime=").append(isRuntime());
-        final Set<String> resources = this.resources;
+        final Set<String> resources = pathTree.getResourceNames();
         sb.append(" resources=").append(resources == null ? "null" : resources.size());
         return sb.append(']').toString();
     }


### PR DESCRIPTION
This change adds a method `PathThree.getResourceNames()` and makes `PathTreeClassPathElement` call that instead of creating its own set of resource names.
This is more efficient when there are multiple `QuarkusClassLoader` instances, since `ArchivePathTree` are cached and shared between their users by default.

Supersedes https://github.com/quarkusio/quarkus/pull/52813