### PR TITLE
Add CORSFilter option to fail the same origin check unless Host header is localhost name

### DIFF
--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
@@ -131,6 +131,11 @@ public class DevUICORSFilter implements Handler<RoutingContext> {
             }
 
             @Override
+            public boolean sameOriginLocalHost() {
+                return baseCorsconfig.sameOriginLocalHost();
+            }
+
+            @Override
             public Optional<List<String>> origins() {
                 return origins;
             }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFluentApiSameOriginAnyHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFluentApiSameOriginAnyHostTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.CORS;
+import io.quarkus.vertx.http.security.HttpSecurity;
+
+public class CORSFluentApiSameOriginAnyHostTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanRegisteringRoute.class, CorsProgrammaticConfig.class));
+
+    @Test
+    void corsSameOriginRequest() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsSameOriginRequestFails() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8080")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsSameOriginPublicHostRequest() {
+        String origin = "http://externalhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "externalhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsSameOriginPublicHostRequestFails() {
+        String origin = "http://externalhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "externalhost:8080")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    public static class CorsProgrammaticConfig {
+        void configure(@Observes HttpSecurity httpSecurity) {
+            httpSecurity.cors(CORS.builder().origin("someorigin").build());
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFluentApiSameOriginLocalHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFluentApiSameOriginLocalHostTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.CORS;
+import io.quarkus.vertx.http.security.HttpSecurity;
+
+public class CORSFluentApiSameOriginLocalHostTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanRegisteringRoute.class, CorsProgrammaticConfig.class));
+
+    @Test
+    void corsSameOriginRequest() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsSameOriginRequestFails() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8080")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsSameOriginPublicHostRequestFails() {
+        String origin = "http://externalhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "externalhost:8081")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    public static class CorsProgrammaticConfig {
+        void configure(@Observes HttpSecurity httpSecurity) {
+            httpSecurity.cors(CORS.builder().origin("someorigin").sameOriginLocalHost(true).build());
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSameOriginAnyHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSameOriginAnyHostTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class CORSSameOriginAnyHostTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.http.cors.enabled=true
+                            quarkus.http.cors.origins=someorigin
+                            """), "application.properties"));
+
+    @Test
+    void corsSameOriginRequest() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsSameOriginRequestFails() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8080")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsSameOriginPublicHostRequest() {
+        String origin = "http://externalhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "externalhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsSameOriginPublicHostRequestFails() {
+        String origin = "http://externalhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "externalhost:8080")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+
+            router.get("/test").handler(handler);
+            router.patch("/test").handler(handler);
+            router.options("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSameOriginLocalHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSameOriginLocalHostTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class CORSSameOriginLocalHostTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.http.cors.enabled=true
+                            quarkus.http.cors.same-origin-local-host=true
+                            quarkus.http.cors.origins=someorigin
+                            """), "application.properties"));
+
+    @Test
+    void corsSameOriginRequest() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsSameOriginRequestFails() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "localhost:8080")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsSameOriginPublicHostRequestFails() {
+        String origin = "http://externalhost:8081";
+        given().header("Origin", origin)
+                .header("Host", "externalhost:8081")
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+
+            router.get("/test").handler(handler);
+            router.patch("/test").handler(handler);
+            router.options("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -17,6 +17,13 @@ public interface CORSConfig {
     boolean enabled();
 
     /**
+     * Request that the same origin check passes only if HTTP Host header
+     * is one of the localhost representations: "localhost", "127.0.0.1", "[::1]" or "::1".
+     */
+    @WithDefault("false")
+    boolean sameOriginLocalHost();
+
+    /**
      * The origins allowed for CORS.
      * <p>
      * A comma-separated list of valid URLs, such as `http://www.quarkus.io,http://localhost:3000`.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -21,6 +21,7 @@ import io.vertx.ext.web.RoutingContext;
 public class CORSFilter implements Handler<RoutingContext> {
 
     private static final Logger LOG = Logger.getLogger(CORSFilter.class);
+    private static final Set<String> LOCAL_HOSTNAMES = Set.of("localhost", "127.0.0.1", "[::1]", "::1");
 
     private final CORSConfig corsConfig;
 
@@ -148,9 +149,9 @@ public class CORSFilter implements Handler<RoutingContext> {
                     (corsConfig.origins().get().contains(origin) || isOriginAllowedByRegex(allowedOriginsRegex, origin));
             if (!allowsOrigin) {
                 if (corsConfig.origins().isPresent()) {
-                    allowsOrigin = originMatches || isSameOrigin(request, origin);
+                    allowsOrigin = originMatches || isSameOrigin(request, origin, corsConfig.sameOriginLocalHost());
                 } else {
-                    allowsOrigin = isSameOrigin(request, origin);
+                    allowsOrigin = isSameOrigin(request, origin, corsConfig.sameOriginLocalHost());
                 }
             }
             if (!allowsOrigin) {
@@ -228,7 +229,21 @@ public class CORSFilter implements Handler<RoutingContext> {
 
     }
 
-    static boolean isSameOrigin(HttpServerRequest request, String origin) {
+    static boolean isSameOrigin(HttpServerRequest request, String origin, boolean sameOriginLocaHost) {
+        final boolean sameOrigin = verifySameOrigin(request, origin);
+        if (sameOrigin && sameOriginLocaHost) {
+            if (!LOCAL_HOSTNAMES.contains(request.authority().host())) {
+                LOG.debugf(
+                        "Same origin check has failed, HTTP Host header is not a local hostname: %s",
+                        request.authority().host());
+                return false;
+            }
+        }
+        return sameOrigin;
+    }
+
+    static boolean verifySameOrigin(HttpServerRequest request, String origin) {
+
         //fast path check, when everything is the same
         if (origin.startsWith(request.scheme())) {
             if (!substringMatch(origin, request.scheme().length(), "://", false)) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
@@ -41,6 +41,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
      */
     final class Builder {
 
+        private boolean sameOriginLocalHost;
         private Optional<Boolean> accessControlAllowCredentials;
         private Optional<Duration> accessControlMaxAge;
         private Optional<List<String>> exposedHeaders;
@@ -53,12 +54,22 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
         }
 
         public Builder(CORSConfig corsConfig) {
+            this.sameOriginLocalHost = corsConfig.sameOriginLocalHost();
             this.accessControlAllowCredentials = corsConfig.accessControlAllowCredentials();
             this.accessControlMaxAge = corsConfig.accessControlMaxAge();
             this.exposedHeaders = corsConfig.exposedHeaders();
             this.headers = corsConfig.headers();
             this.methods = corsConfig.methods();
             this.origins = corsConfig.origins();
+        }
+
+        /**
+         * @param sameOriginLocalHost {@link CORSConfig#sameOriginLocalHost()}
+         * @return this builder
+         */
+        public Builder sameOriginLocalHost(boolean sameOriginLocalHost) {
+            this.sameOriginLocalHost = sameOriginLocalHost;
+            return this;
         }
 
         /**
@@ -179,7 +190,8 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
          * @return CORS instance, which should be passed to the {@link HttpSecurity} event
          */
         public CORS build() {
-            return new CORSImpl(accessControlAllowCredentials, accessControlMaxAge, exposedHeaders, headers, methods, origins);
+            return new CORSImpl(sameOriginLocalHost, accessControlAllowCredentials, accessControlMaxAge, exposedHeaders,
+                    headers, methods, origins);
         }
 
         private static Optional<List<String>> merge(Optional<List<String>> optionalOriginalList, Set<String> newSet,
@@ -199,7 +211,8 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
             return Optional.of(result);
         }
 
-        record CORSImpl(Optional<Boolean> accessControlAllowCredentials, Optional<Duration> accessControlMaxAge,
+        record CORSImpl(boolean sameOriginLocalHost, Optional<Boolean> accessControlAllowCredentials,
+                Optional<Duration> accessControlMaxAge,
                 Optional<List<String>> exposedHeaders, Optional<List<String>> headers,
                 Optional<List<String>> methods, Optional<List<String>> origins) implements CORS, CORSConfig {
             @Override

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 
 import io.quarkus.vertx.http.security.CORS;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.HostAndPort;
 
 public class CORSFilterTest {
 
@@ -53,31 +54,66 @@ public class CORSFilterTest {
         Mockito.when(request.scheme()).thenReturn("http");
         Mockito.when(request.host()).thenReturn("localhost");
         Mockito.when(request.absoluteURI()).thenReturn("http://localhost");
-        Assertions.assertTrue(isSameOrigin(request, "http://localhost"));
-        Assertions.assertTrue(isSameOrigin(request, "http://localhost:80"));
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost:8080"));
-        Assertions.assertFalse(isSameOrigin(request, "https://localhost"));
+        Assertions.assertTrue(isSameOrigin(request, "http://localhost", false));
+        Assertions.assertTrue(isSameOrigin(request, "http://localhost:80", false));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:8080", false));
+        Assertions.assertFalse(isSameOrigin(request, "https://localhost", false));
         Mockito.when(request.host()).thenReturn("localhost:8080");
         Mockito.when(request.absoluteURI()).thenReturn("http://localhost:8080");
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost:80"));
-        Assertions.assertTrue(isSameOrigin(request, "http://localhost:8080"));
-        Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080"));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", false));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:80", false));
+        Assertions.assertTrue(isSameOrigin(request, "http://localhost:8080", false));
+        Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080", false));
         Mockito.when(request.scheme()).thenReturn("https");
         Mockito.when(request.host()).thenReturn("localhost");
         Mockito.when(request.absoluteURI()).thenReturn("http://localhost");
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost:443"));
-        Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080"));
-        Assertions.assertTrue(isSameOrigin(request, "https://localhost"));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", false));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:443", false));
+        Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080", false));
+        Assertions.assertTrue(isSameOrigin(request, "https://localhost", false));
         Mockito.when(request.host()).thenReturn("localhost:8443");
         Mockito.when(request.absoluteURI()).thenReturn("https://localhost:8443");
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost:80"));
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost:8443"));
-        Assertions.assertTrue(isSameOrigin(request, "https://localhost:8443"));
-        Assertions.assertFalse(isSameOrigin(request, "http://%s"));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", false));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:80", false));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:8443", false));
+        Assertions.assertTrue(isSameOrigin(request, "https://localhost:8443", false));
+        Assertions.assertFalse(isSameOrigin(request, "http://%s", false));
+    }
 
+    @Test
+    public void sameOriginLocalHostTest() {
+        var request = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(request.scheme()).thenReturn("http");
+        Mockito.when(request.host()).thenReturn("localhost");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.authority("localhost"));
+        Mockito.when(request.absoluteURI()).thenReturn("http://localhost");
+        Assertions.assertTrue(isSameOrigin(request, "http://localhost", true));
+        Assertions.assertTrue(isSameOrigin(request, "http://localhost:80", true));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:8080", true));
+        Assertions.assertFalse(isSameOrigin(request, "https://localhost", true));
+        Mockito.when(request.host()).thenReturn("localhost:8080");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.authority("localhost", 8080));
+        Mockito.when(request.absoluteURI()).thenReturn("http://localhost:8080");
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", true));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:80", true));
+        Assertions.assertTrue(isSameOrigin(request, "http://localhost:8080", false));
+        Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080", true));
+        Mockito.when(request.scheme()).thenReturn("https");
+        Mockito.when(request.host()).thenReturn("localhost");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.authority("localhost"));
+        Mockito.when(request.absoluteURI()).thenReturn("http://localhost");
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", true));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:443", true));
+        Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080", true));
+        Assertions.assertTrue(isSameOrigin(request, "https://localhost", true));
+        Mockito.when(request.host()).thenReturn("localhost:8443");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.authority("localhost", 8443));
+        Mockito.when(request.absoluteURI()).thenReturn("https://localhost:8443");
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", true));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:80", true));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost:8443", true));
+        Assertions.assertTrue(isSameOrigin(request, "https://localhost:8443", true));
+        Assertions.assertFalse(isSameOrigin(request, "http://%s", true));
     }
 
     @Test
@@ -86,9 +122,21 @@ public class CORSFilterTest {
         Mockito.when(request.scheme()).thenReturn("https");
         Mockito.when(request.host()).thenReturn("stage.code.quarkus.io");
         Mockito.when(request.absoluteURI()).thenReturn("https://stage.code.quarkus.io/api/project");
-        Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
-        Assertions.assertFalse(isSameOrigin(request, "https://code.quarkus.io"));
-        Assertions.assertTrue(isSameOrigin(request, "https://stage.code.quarkus.io"));
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", false));
+        Assertions.assertFalse(isSameOrigin(request, "https://code.quarkus.io", false));
+        Assertions.assertTrue(isSameOrigin(request, "https://stage.code.quarkus.io", false));
+    }
+
+    @Test
+    public void sameOriginLocalHostPublicWebAddressTest() {
+        var request = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(request.scheme()).thenReturn("https");
+        Mockito.when(request.host()).thenReturn("stage.code.quarkus.io");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.authority("stage.code.quarkus.io"));
+        Mockito.when(request.absoluteURI()).thenReturn("https://stage.code.quarkus.io/api/project");
+        Assertions.assertFalse(isSameOrigin(request, "http://localhost", true));
+        Assertions.assertFalse(isSameOrigin(request, "https://code.quarkus.io", true));
+        Assertions.assertFalse(isSameOrigin(request, "https://stage.code.quarkus.io", true));
     }
 
     @Test
@@ -110,11 +158,17 @@ public class CORSFilterTest {
             public boolean enabled() {
                 return true;
             }
+
+            @Override
+            public boolean sameOriginLocalHost() {
+                return false;
+            }
         }
         var config = new CORSConfigImpl(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty());
         var emptyConfig = (CORSConfig) new CORS.Builder(config).build();
         Assertions.assertTrue(emptyConfig.enabled());
+        Assertions.assertFalse(emptyConfig.sameOriginLocalHost());
         Assertions.assertTrue(emptyConfig.origins().isEmpty());
         Assertions.assertTrue(emptyConfig.headers().isEmpty());
         Assertions.assertTrue(emptyConfig.exposedHeaders().isEmpty());
@@ -125,8 +179,10 @@ public class CORSFilterTest {
                 .origin("origin-1")
                 .origins(Set.of("origin-2", "origin-3"))
                 .origins(Set.of("origin-4", "origin-5"))
+                .sameOriginLocalHost(true)
                 .build();
         Assertions.assertTrue(configWithOriginsOnly.enabled());
+        Assertions.assertTrue(configWithOriginsOnly.sameOriginLocalHost());
         Assertions.assertTrue(configWithOriginsOnly.origins().isPresent());
         List<String> origins = configWithOriginsOnly.origins().get();
         assertThat(origins)


### PR DESCRIPTION
When users need to enforce that the same origin check succeeds only if an HTTP Host header value is a localhost name, they have to create CORSFilter extensions or do some custom solutions which might not always be ideal.

This PR let's users add `quarkus.http.cors.same-origin-local-host=true` to their CORS filter configuration and the same origin check will fail unless an accompanying HTTP Host header contains a valid localhost name.

I thought of adding an option to list various host names that are known to represent the same origin host for a given deployment, but decided to start with making it straightforward for a localhost case; perhaps a more general support for such hosts can be added later as well.

CC @mkouba 