### PR TITLE
Fail at build time when @QuarkusMain is on an abstract class

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -456,13 +456,13 @@ public class MainClassBuildStep {
             Collection<ClassInfo> impls = index
                     .getAllKnownImplementors(QUARKUS_APPLICATION);
             ClassInfo classByName = index.getClassByName(DotName.createSimple(mainClassName));
-            if (classByName != null && Modifier.isAbstract(classByName.flags())) {
-                throw new RuntimeException(
-                        "The selected @QuarkusMain class '" + mainClassName
-                                + "' is abstract and cannot be instantiated. "
-                                + "Use a concrete class or set 'quarkus.package.main-class' to specify a different entry point.");
-            }
             if (classByName != null) {
+                if (Modifier.isAbstract(classByName.flags())) {
+                    throw new RuntimeException(
+                            "The selected @QuarkusMain class '" + mainClassName
+                                    + "' is abstract and cannot be instantiated. "
+                                    + "Use a concrete class or set 'quarkus.package.main-class' to specify a different entry point.");
+                }
                 mainClassMethod = classByName
                         .method("main", STRING_ARRAY);
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -456,6 +456,12 @@ public class MainClassBuildStep {
             Collection<ClassInfo> impls = index
                     .getAllKnownImplementors(QUARKUS_APPLICATION);
             ClassInfo classByName = index.getClassByName(DotName.createSimple(mainClassName));
+            if (classByName != null && Modifier.isAbstract(classByName.flags())) {
+                throw new RuntimeException(
+                        "The selected @QuarkusMain class '" + mainClassName
+                                + "' is abstract and cannot be instantiated. "
+                                + "Use a concrete class or set 'quarkus.package.main-class' to specify a different entry point.");
+            }
             if (classByName != null) {
                 mainClassMethod = classByName
                         .method("main", STRING_ARRAY);

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/AbstractQuarkusMain.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/AbstractQuarkusMain.java
@@ -1,0 +1,13 @@
+package io.quarkus.commandmode;
+
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public abstract class AbstractQuarkusMain implements QuarkusApplication {
+
+    @Override
+    public int run(String... args) throws Exception {
+        return 0;
+    }
+}

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/AbstractQuarkusMainTestCase.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/AbstractQuarkusMainTestCase.java
@@ -1,0 +1,25 @@
+package io.quarkus.commandmode;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class AbstractQuarkusMainTestCase {
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsManifestResource("application.properties", "microprofile-config.properties")
+                    .addClasses(AbstractQuarkusMain.class))
+            .setApplicationName("run-exit")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectedException(RuntimeException.class);
+
+    @Test
+    public void shouldNotBeInvoked() {
+        fail("This method should not be invoked because @QuarkusMain on abstract class should fail at build time");
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds an `isAbstract()` check in `MainClassBuildStep` when scanning `@QuarkusMain` annotations
- Throws a clear `RuntimeException` at build time instead of a confusing `InstantiationException` at runtime
- Adds test case to verify the build-time failure

Fixes #52915

## Test plan

- [x] `AbstractQuarkusMainTestCase` verifies build fails with `RuntimeException` when `@QuarkusMain` is on an abstract class
- [x] Existing command mode tests still pass