### PR TITLE
Filter out package names before proxy generation to fix spurious warning

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -524,6 +524,11 @@ public final class HibernateOrmProcessor {
             managedClassAndPackageNames.add(additionalJpaModelBuildItem.getClassName());
         }
 
+        // Remove package names: only actual class names should be passed to generateProxies,
+        // because attempting to look up a package name via IndexWrapper.getClassByName()
+        // triggers a spurious "Failed to index" warning.
+        managedClassAndPackageNames.removeAll(jpaModel.getAllModelPackageNames());
+
         PreGeneratedProxies proxyDefinitions = generateProxies(managedClassAndPackageNames,
                 indexBuildItem.getIndex(), transformedClassesBuildItem,
                 generatedClassBuildItemBuildProducer, liveReloadBuildItem, buildExecutor);


### PR DESCRIPTION
## Summary
- Filter out known package names from `managedClassAndPackageNames` in `HibernateOrmProcessor.pregenProxies()` before passing the set to `generateProxies()`
- Prevents `IndexWrapper.getClassByName()` from logging a misleading WARN when it tries to look up a package name as a class resource

## Problem
When a `package-info.java` with Hibernate annotations (e.g. `@FilterDef`) exists, the package name ends up in the `managedClassAndPackageNames` set via `PersistenceUnitDescriptor.getManagedClassNames()`. When `generateProxies` calls `combinedIndex.getClassByName()` with a package name, `IndexWrapper` fails to load it as a class and logs:

```
WARN [io.qua.dep.ind.IndexWrapper] Failed to index org.acme: Class does not exist in ClassLoader ...
```

## Fix
`JpaModelBuildItem` already tracks package names separately via `getAllModelPackageNames()`. We simply call `removeAll()` to strip them from the set before proxy generation.

Fixes #50572

## Test plan
- [x] Existing Hibernate ORM tests should pass (proxy generation unaffected since `generateProxies` already skipped non-proxiable entries)
- [ ] Verify with a project containing `package-info.java` with `@FilterDef` that the WARN no longer appears