### PR TITLE
[Docs]: Review Deploy to Openshift guide and update for Java 25

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -90,14 +90,17 @@
 :create-app-group-id: org.acme
 :create-cli-group-id: {create-app-group-id}
 // Attributes required for single-sourcing to downstream.
-:jdk-version-other: 17
-:jdk-version-latest: 21
-:jdk-version-all: 17 or 21
+:jdk-version-earliest: 17
+:jdk-version-other: 21
+:jdk-version-latest: 25
+:jdk-version-all: 17, 21, or 25
 :openshift-long: OpenShift
 :openshift: OpenShift
 :name-image-ubi9-open-jdk-17: registry.access.redhat.com/ubi9/openjdk-17
 :name-image-ubi9-open-jdk-17-short: ubi9/openjdk-17
 :name-image-ubi9-open-jdk-21: registry.access.redhat.com/ubi9/openjdk-21
 :name-image-ubi9-open-jdk-21-short: ubi9/openjdk-21
+:name-image-ubi9-open-jdk-25: registry.access.redhat.com/ubi9/openjdk-25
+:name-image-ubi9-open-jdk-25-short: ubi9/openjdk-25
 // .
 include::_attributes-local.adoc[]

--- a/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
@@ -24,31 +24,26 @@ To deploy {project-name} applications compiled to native executables, use the Do
 ====
 endif::no-S2I-support[]
 
-The deployment procedure differs based on the Java version your {project-name} application uses.
+You can deploy project-name} applications to {openshift} with Java {jdk-version-all} versions.
 
-[[using-the-S2I-Java-17]]
-== Deploying {project-name} applications to {openshift} with Java {jdk-version-other}
+== Prerequisites
 
-You can deploy {project-name} applications that run Java {jdk-version-other} to {openshift} by using the S2I method.
-
-=== Prerequisites
-
-* You have a Quarkus application built with Java {jdk-ver-other}.
+* You have a Quarkus application built with either Java {jdk-version-all}.
 * Optional: You have a Quarkus project that includes the `quarkus-openshift` extension.
 * You are working in the correct OpenShift project namespace.
 * Your project is hosted in a Git repository.
 
-=== Procedure
+== Procedure
 
-. Open the `pom.xml` file, and set the Java version to {jdk-version-other}:
+. Open the `pom.xml` file, and set the Java version, where the Java version is {jdk-version-all}.
 +
 [source,xml,subs=attributes+]
 ----
-<maven.compiler.source>{jdk-version-other}</maven.compiler.source>
-<maven.compiler.target>{jdk-version-other}</maven.compiler.target>
+<maven.compiler.source><java-version></maven.compiler.source>
+<maven.compiler.target><java-version></maven.compiler.target>
 ----
 +
-. Package your Java {jdk-version-other} application, by entering the following command:
+. Package your Java {jdk-version-all} application, by entering the following command:
 +
 [source,shell]
 ----
@@ -68,136 +63,69 @@ JAVA_APP_JAR=/deployments/quarkus-run.jar
 +
 . Commit and push your changes to the remote Git repository.
 
-. Import the supported {openshift} image by entering the following command:
+. Import the supported {openshift} image.
++
+Java {jdk-version-earliest}:
 +
 [source,subs="attributes+,+quotes"]
 ----
 oc import-image {name-image-ubi9-open-jdk-17-short} --from={name-image-ubi9-open-jdk-17} --confirm
 ----
-+
-[NOTE]
-====
-* If you are using the OpenShift image registry and pulling from image streams in the same project, your pod service account must already have the correct permissions.
-* If you are pulling images across other {openshift} projects or from secured registries, additional configuration steps might be required.
-
-For more information, see the link:https://docs.openshift.com/container-platform/[Red Hat Openshift Container Platform] documentation.
-====
-
-. Build the project, create the application, and deploy the {openshift} service:
-+
-[source,xml,subs="attributes+,+quotes"]
-----
-oc new-app registry.access.redhat.com/ubi9/openjdk-17~<git_path> --name=<project_name>
-----
-+
-* Replace `<git_path>` with the path of the Git repository that hosts your Quarkus project.
-For example, `oc new-app registry.access.redhat.com/ubi9/openjdk-17~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus`.
-+
-If you do not have SSH keys configured for the Git repository, when specifying the Git path, use the HTTPS URL instead of the SSH URL.
-
-* Replace `<project_name>` with the name of your application.
-
-. To deploy an updated version of the project, push changes to the Git repository, and then run:
-+
-[source,xml,subs="attributes+,+quotes"]
-----
-oc start-build <project_name>
-----
-+
-. To expose a route to the application, run the following command:
-+
-[source,shell,subs="attributes+,+quotes"]
-----
-oc expose svc <project_name>
-----
-
-
-=== Verification
-
-. List the pods associated with your current {openshift} project:
-+
-[source,shell,subs="attributes+,+quotes"]
-----
-oc get pods
-----
-. To get the log output for your application's pod, run the following command, replacing `<pod_name>` with the name of the latest pod prefixed by your application name:
-+
-[source,shell,subs="attributes+,+quotes"]
-----
-oc logs -f <pod_name>
-----
-
-== Deploying {project-name} applications to {openshift} with Java {jdk-version-latest}
-
-You can deploy {project-name} applications that run Java {jdk-version-latest} to {openshift} by using the S2I method.
-
-=== Prerequisites
-
-* Optional: You have a Quarkus Maven project that includes the `quarkus-openshift` extension.
-* You are working in the correct {openshift} project namespace.
-* Your project is hosted in a Git repository.
-
-=== Procedure
-
-. Open the `pom.xml` file, and set the Java version to {jdk-version-latest}:
-+
-[source,xml,subs=attributes+]
-----
-<maven.compiler.source>{jdk-version-latest}</maven.compiler.source>
-<maven.compiler.target>{jdk-version-latest}</maven.compiler.target>
-----
-+
-. Package your Java {jdk-ver-latest} application, by entering the following command:
-+
-[source,shell]
-----
-./mvnw clean package
-----
-. Create a directory called `.s2i` at the same level as the `pom.xml` file.
-. Create a file called `environment` in the `.s2i` directory and add the following content:
-+
-[source]
-----
-MAVEN_S2I_ARTIFACT_DIRS=target/quarkus-app
-S2I_SOURCE_DEPLOYMENTS_FILTER=app lib quarkus quarkus-run.jar
-JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
-AB_JOLOKIA_OFF=true
-JAVA_APP_JAR=/deployments/quarkus-run.jar
-----
-. Commit and push your changes to the remote Git repository.
-. Import the supported {openshift} image by entering the following command:
+Java {jdk-version-other}:
 +
 [source,subs="attributes+,+quotes"]
 ----
 oc import-image {name-image-ubi9-open-jdk-21-short} --from={name-image-ubi9-open-jdk-21} --confirm
 ----
 +
+Java {jdk-version-latest}:
++
+[source,subs="attributes+,+quotes"]
+----
+oc import-image {name-image-ubi9-open-jdk-25-short} --from={name-image-ubi9-open-jdk-25} --confirm
+----
++
 [NOTE]
 ====
 * If you are using the OpenShift image registry and pulling from image streams in the same project, your pod service account must already have the correct permissions.
 
 * If you are pulling images across other {openshift} projects or from secured registries, additional configuration steps might be required.
++
 For more information, see the link:https://docs.openshift.com/container-platform/[Red Hat Openshift Container Platform] documentation.
 
 * If you are deploying on IBM Z infrastructure, enter `oc import-image {name-image-ubi9-open-jdk-21-short} --from=registry.redhat.io/{name-image-ubi9-open-jdk-21-short} --confirm` instead.
-For information about this image, see link:https://catalog.redhat.com/software/containers/ubi9/openjdk-21/653fb7e21b2ec10f7dfc10d0[{runtimes-openjdk-long} 21].
+For information about this image, see link:https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f[OpenJDK 21 runtime image on UBI9].
 ====
 
-. Build the project, create the application, and deploy the {openshift} service:
+. Build the project, create the application, and deploy the {openshift} service.
++
+Java {jdk-version-earliest}:
 +
 [source,xml,subs="attributes+,+quotes"]
 ----
-oc new-app registry.access.redhat.com/ubi8/openjdk-21~<git_path> --name=<project_name>
+oc new-app registry.access.redhat.com/ubi9/openjdk-17~<git_path> --name=<project_name>
+----
+Java {jdk-version-other}:
++
+[source,xml,subs="attributes+,+quotes"]
+----
+oc new-app registry.access.redhat.com/ubi9/openjdk-21~<git_path> --name=<project_name>
+----
++
+Java {jdk-version-latest}:
++
+[source,xml,subs="attributes+,+quotes"]
+----
+oc new-app registry.access.redhat.com/ubi9/openjdk-25~<git_path> --name=<project_name>
 ----
 +
 * Replace `<git_path>` with the path of the Git repository that hosts your Quarkus project.
-For example, `oc new-app registry.access.redhat.com/ubi9/openjdk-21~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus`.
+For example, for Java {jdk-version-other}: `oc new-app registry.access.redhat.com/ubi9/openjdk-21~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus`.
 +
 If you do not have SSH keys configured for the Git repository, when specifying the Git path, use the HTTPS URL instead of the SSH URL.
 
 * Replace `<project_name>` with the name of your application.
 +
-
 [NOTE]
 ====
 If you are deploying on IBM Z infrastructure, enter `oc new-app ubi9/openjdk-21~<git_path> --name=<project_name>` instead.
@@ -209,7 +137,7 @@ If you are deploying on IBM Z infrastructure, enter `oc new-app ubi9/openjdk-21~
 ----
 oc start-build <project_name>
 ----
-
++
 . To expose a route to the application, run the following command:
 +
 [source,shell,subs="attributes+,+quotes"]
@@ -217,7 +145,7 @@ oc start-build <project_name>
 oc expose svc <project_name>
 ----
 
-=== Verification
+== Verification
 
 . List the pods associated with your current {openshift} project:
 +
@@ -225,7 +153,6 @@ oc expose svc <project_name>
 ----
 oc get pods
 ----
-+
 . To get the log output for your application's pod, run the following command, replacing `<pod_name>` with the name of the latest pod prefixed by your application name:
 +
 [source,shell,subs="attributes+,+quotes"]

--- a/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
@@ -24,26 +24,27 @@ To deploy {project-name} applications compiled to native executables, use the Do
 ====
 endif::no-S2I-support[]
 
-You can deploy project-name} applications to {openshift} with Java {jdk-version-all} versions.
+You can deploy {project-name} applications to {openshift} with Java {jdk-version-all} versions.
 
 == Prerequisites
 
-* You have a Quarkus application built with either Java {jdk-version-all}.
+* You have a Quarkus application built with Java {jdk-version-all}.
 * Optional: You have a Quarkus project that includes the `quarkus-openshift` extension.
 * You are working in the correct OpenShift project namespace.
 * Your project is hosted in a Git repository.
 
 == Procedure
 
-. Open the `pom.xml` file, and set the Java version, where the Java version is {jdk-version-all}.
+. Open the `pom.xml` file, and set the Java version.
 +
 [source,xml,subs=attributes+]
 ----
-<maven.compiler.source><java-version></maven.compiler.source>
-<maven.compiler.target><java-version></maven.compiler.target>
+<maven.compiler.source>${java.version}</maven.compiler.source>
+<maven.compiler.target>${java.version}</maven.compiler.target>
 ----
+where ${java.version} is {jdk-version-all}.
 +
-. Package your Java {jdk-version-all} application, by entering the following command:
+. Package your application, by entering the following command:
 +
 [source,shell]
 ----

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -18,7 +18,7 @@ include::_attributes.adoc[]
 Quarkus offers the ability to automatically generate {openshift} resources based on sane defaults and user-supplied configuration.
 
 As an application developer, you can deploy your {project-name} applications to {openshift-long}.
-This functionality is provided by the `quarkus-openshift` extension, which supports multiple deployment options:
+The `quarkus-openshift` extension provides this functionality, which supports multiple deployment options:
 
 * xref:deploying-to-openshift-howto.adoc[With a single step]
 * xref:deploying-to-openshift-docker-howto.adoc[By using a Docker build strategy]
@@ -43,7 +43,7 @@ Source to Image (S2I):: The build process is performed inside the {openshift} cl
 
 Binary S2I:: This strategy uses a JAR file as input to the S2I build process, which speeds up the building and deploying of your application.
 
-=== Build strategies supported by Quarkus
+=== Supported build strategies
 
 The following table outlines the build strategies that {project-name} supports:
 


### PR DESCRIPTION
This PR covers edits to update the Deploy to Openshift guide to incorporate Java 25 references and minor lift and shift review edits relevant for RHBQ 3.33. 
