### PR TITLE
More prominent AI Policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        When using AI tools (LLMs, agents, etc.) to help prepare this issue, please make sure you follow our [AI and LLM Usage Policy](https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md).
+  - type: markdown
+    attributes:
+      value: |
         To maximize the chance of your issue being handled in a timely manner, please ensure you have tested that the issue occurs on the absolute latest version of Quarkus, or latest LTS version. 
         Moreover, providing a minimal canonical sample project that makes it easy to reproduce the issue is a huge help to the community when it comes to understanding, debugging, fixing the problem and testing the fix.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report_native.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_native.yml
@@ -10,6 +10,10 @@ body:
         **To report a Quarkus security vulnerability, please [send an email to `security@quarkus.io`](mailto:security@quarkus.io) with all the details.**
 
         :warning: Do **NOT** create a public issue on GitHub for security vulnerabilities. See our [security policy](https://github.com/quarkusio/quarkus/security/policy) for more details. :warning:
+  - type: markdown
+    attributes:
+      value: |
+        When using AI tools (LLMs, agents, etc.) to help prepare this issue, please make sure you follow our [AI and LLM Usage Policy](https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md).
   - type: textarea
     id: description
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,10 @@ name: Feature request / Enhancement
 description: Request or propose a new feature/enhancement
 labels: kind/enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        When using AI tools (LLMs, agents, etc.) to help prepare this issue, please make sure you follow our [AI and LLM Usage Policy](https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md).
   - type: textarea
     id: description
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
 If this is your first time contributing to the project, 
 please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
+and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
 -->
 
 [Please describe here what your change is about]

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,30 @@
+# Artificial Intelligence (AI) Usage Policy
+
+At Quarkus, we welcome tools that help developers become more productive — including AI tools such as Large Language Models (LLMs) and agents like ChatGPT, GitHub Copilot, and others.
+
+However, recent patterns of use have led to increased moderation burden, low-value contributions, and reduced community signal. To ensure a healthy and productive community, the following expectations apply to all contributions (issues, pull requests, comments, discussions, and other project interactions).
+
+## Acceptable Use of LLMs
+
+- LLMs may be used to **assist your development** — for example drafting code, writing documentation, or proposing fixes — as long as **you understand, validate**, and **take responsibility for the results**.
+- You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an agent/LLM "spit out."
+- You may use agents/LLMs to help you **write better**, but not to **post more**.
+
+## Unacceptable Use
+
+- Submitting code, tests, comments, discussions or issues that appear to be **copied directly from an LLM with little or no human oversight** is **not acceptable**.
+- Posting **large volumes of low-effort suggestions, vague issues, or links with no context** — even if technically accurate — is considered spam.
+- Submitting **AI-generated tests that do not validate actual behavior** or meaningfully cover functionality is not helpful and will be rejected.
+- Using bots, agents, or automated tools to open PRs, file issues, or post content **without human authorship and responsibility** is not allowed.
+
+## Consequences
+
+- We may close issues, PRs, or discussions that violate this policy without detailed explanation.
+- Repeated violations may result in temporary or permanent restrictions from participating in the project.
+
+## If in Doubt
+
+If you're unsure whether your use of agents/LLMs is acceptable — ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
+
+> This isn’t about banning AI — it’s about keeping Quarkus collaborative, human-driven, and focused on quality.
+

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,21 +1,27 @@
 # Artificial Intelligence (AI) Usage Policy
 
-At Quarkus, we welcome tools that help developers become more productive — including AI tools such as Large Language Models (LLMs) and agents like ChatGPT, GitHub Copilot, and others.
+At Quarkus, we welcome tools that help developers become more productive — including AI tools such as Large Language Models (LLMs) and agents like Claude Code, Codex, ChatGPT, GitHub Copilot, and others.
 
 However, recent patterns of use have led to increased moderation burden, low-value contributions, and reduced community signal. To ensure a healthy and productive community, the following expectations apply to all contributions (issues, pull requests, comments, discussions, and other project interactions).
 
-## Acceptable Use of LLMs
+## Acceptable Use of AI
 
-- LLMs may be used to **assist your development** — for example drafting code, writing documentation, or proposing fixes — as long as **you understand, validate**, and **take responsibility for the results**.
-- You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an agent/LLM "spit out."
 - You may use agents/LLMs to help you **write better**, but not to **post more**.
+- AI may be used to **assist your development** — for example drafting code, writing documentation, or proposing fixes — as long as **you understand, validate**, and **take responsibility for the results**.
+- You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an agent/LLM "spit out."
 
-## Unacceptable Use
+## Unacceptable Use of AI
 
-- Submitting code, tests, comments, discussions or issues that appear to be **copied directly from an LLM with little or no human oversight** is **not acceptable**.
+- Submitting code, tests, comments, discussions or issues that appear to be **copied directly from an AI with little or no human oversight** is **not acceptable**.  
 - Posting **large volumes of low-effort suggestions, vague issues, or links with no context** — even if technically accurate — is considered spam.
 - Submitting **AI-generated tests that do not validate actual behavior** or meaningfully cover functionality is not helpful and will be rejected.
 - Using bots, agents, or automated tools to open PRs, file issues, or post content **without human authorship and responsibility** is not allowed.
+
+## Signal-to-Noise Ratio
+
+As a general rule, the actual PR and its metadata should be similar to what the developer would have come up with had they not been using AI tools.
+For example, when writing PR descriptions, developers tend to make it clear what the PR does and don't pack the description with useless details or superfluous formatting and emojis.
+Furthermore, developers usually try to introduce focused tests that follow the project's existing test philosophy instead of dumping a bunch of new tests for everything that could conceivably be tested concerning the updated code.
 
 ## Consequences
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -963,34 +963,9 @@ When a dependency relies on an external repository that is not Maven Central, we
 
 ## LLM Usage Policy
 
-At Quarkus, we welcome tools that help developers become more productive — including Large Language Models (LLMs) and Agents like ChatGPT, GitHub Copilot, and others.
+The Quarkus project has a dedicated AI and LLM usage policy that applies to all contributions (issues, pull requests, comments, discussions, and other project interactions).
 
-However, recent patterns of use have led to increased moderation burden, low-value contributions, and reduced community signal. To ensure a healthy and productive community, the following expectations apply:
-
-### Acceptable Use of LLMs
-
-- LLMs may be used to **assist your development** — e.g. drafting code, writing documentation, proposing fixes — as long as **you understand, validate**, and **take responsibility for the results.**
-- You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an Agent/LLM "spit out."
-- You may use Agents/LLMs to help you **write better**, but not to **post more**.
-
-### Unacceptable Use
-
-- Submitting code, tests, comments, or issues that appear to be **copied directly from an LLM with little or no human oversight** is **not acceptable**.
-- Posting **large volumes of low-effort suggestions, vague issues, or links with no context** — even if technically accurate — is considered spam.
-- Submitting **AI-generated tests that do not validate actual behavior** or meaningfully cover functionality is not helpful and will be rejected.
-- Using bots, agents, or automated tools to open PRs, file issues, or post content **without human authorship and responsibility** is not allowed.
-
-### Consequences
-
-- We may close issues, PRs, or discussions that violate this policy without detailed explanation.
-- Repeated violations may result in temporary or permanent restrictions from participating in the project.
-
-### If in Doubt
-
-If you're unsure whether your use of Agent/LLMs is acceptable — ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
-
-> This isn’t about banning AI — it’s about keeping Quarkus collaborative, human-driven, and focused on quality.
-
+Please read the [AI and LLM Usage Policy](AI_POLICY.md) before opening issues or pull requests.
 
 
 ## The small print


### PR DESCRIPTION
As AI slop is showing up more and more this PR is pulling out in clear sight the already existing LLM Policy that allow using AI for making good contributions but disallow use of AI to make slop/noise/waste.

Explicit inclusion of discussions, AI_POLICY.md now in root + contribution guide still mentions but links and issue/pr templates has mention of the policy.