### PR TITLE
ArC - Reduce allocations for injection points

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -2152,29 +2153,60 @@ public class BeanGenerator extends AbstractGenerator {
 
     public static Var collectInjectionPointQualifiers(BeanDeployment beanDeployment, BlockCreator bc,
             InjectionPointInfo injectionPoint, AnnotationLiteralProcessor annotationLiterals) {
+        return collectInjectionPointQualifiers(beanDeployment, bc, injectionPoint, annotationLiterals, Set.of());
+    }
+
+    public static Var collectInjectionPointQualifiers(BeanDeployment beanDeployment, BlockCreator bc,
+            InjectionPointInfo injectionPoint, AnnotationLiteralProcessor annotationLiterals, Set<DotName> excludeQualifiers) {
         return collectQualifiers(beanDeployment, bc, annotationLiterals,
-                injectionPoint.hasDefaultedQualifier() ? Collections.emptySet() : injectionPoint.getRequiredQualifiers());
+                injectionPoint.hasDefaultedQualifier() ? Set.of() : injectionPoint.getRequiredQualifiers(),
+                excludeQualifiers);
     }
 
     public static Var collectQualifiers(BeanDeployment beanDeployment, BlockCreator bc,
             AnnotationLiteralProcessor annotationLiterals, Set<AnnotationInstance> qualifiers) {
+        return collectQualifiers(beanDeployment, bc, annotationLiterals, qualifiers, Set.of());
+    }
+
+    public static Var collectQualifiers(BeanDeployment beanDeployment, BlockCreator bc,
+            AnnotationLiteralProcessor annotationLiterals, Set<AnnotationInstance> qualifiers,
+            Set<DotName> excludeQualifiers) {
         if (qualifiers.isEmpty()) {
             return Expr.staticField(FieldDescs.QUALIFIERS_IP_QUALIFIERS);
-        } else {
-            LocalVar qualifiersVar = bc.localVar("qualifiers", bc.new_(HashSet.class));
-            for (AnnotationInstance qualifier : qualifiers) {
-                BuiltinQualifier builtinQualifier = BuiltinQualifier.of(qualifier);
-                Expr qualifierExpr;
-                if (builtinQualifier != null) {
-                    qualifierExpr = builtinQualifier.getLiteralInstance();
-                } else {
-                    // Create annotation literal if needed
-                    qualifierExpr = annotationLiterals.create(bc, beanDeployment.getQualifier(qualifier.name()), qualifier);
-                }
-                bc.withSet(qualifiersVar).add(qualifierExpr);
-            }
-            return qualifiersVar;
         }
+
+        Set<AnnotationInstance> filteredQualifiers = qualifiers;
+        if (!excludeQualifiers.isEmpty()) {
+            // let's avoid creating a stream and a new set as the typical case for exclusion is @All and it won't be around in most cases
+            boolean needsFiltering = false;
+            for (AnnotationInstance qualifier : qualifiers) {
+                if (excludeQualifiers.contains(qualifier.name())) {
+                    needsFiltering = true;
+                    break;
+                }
+            }
+            if (needsFiltering) {
+                filteredQualifiers = qualifiers.stream()
+                        .filter(q -> !excludeQualifiers.contains(q.name()))
+                        .collect(Collectors.toSet());
+            }
+        }
+
+        LocalVar qualifiersVar = bc.localVar("qualifiers",
+                bc.setOf(Reproducibility.orderedAnnotations(filteredQualifiers), qualifier -> {
+                    BuiltinQualifier builtinQualifier = BuiltinQualifier.of(qualifier);
+                    Expr qualifierExpr;
+                    if (builtinQualifier != null) {
+                        qualifierExpr = builtinQualifier.getLiteralInstance();
+                    } else {
+                        // Create annotation literal if needed
+                        qualifierExpr = annotationLiterals.create(bc, beanDeployment.getQualifier(qualifier.name()),
+                                qualifier);
+                    }
+                    return qualifierExpr;
+                }));
+
+        return qualifiersVar;
     }
 
     static void destroyTransientReferences(BlockCreator bc, Iterable<TransientReference> transientReferences) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -348,7 +348,9 @@ public enum BuiltinBean {
             usesInstance = Const.of(false);
         }
         Var qualifiers = BeanGenerator.collectInjectionPointQualifiers(ctx.beanDeployment, ctx.constructor,
-                ctx.injectionPoint, ctx.annotationLiterals);
+                ctx.injectionPoint, ctx.annotationLiterals,
+                // the @All annotation is not a qualifier of the instances we need to resolve
+                Set.of(DotNames.ALL));
 
         // Note that we only collect the injection point metadata if needed, i.e. if any of the resolved beans is dependent,
         // and requires InjectionPoint metadata

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -411,7 +411,7 @@ public class InjectionPointInfo {
 
         public TypeAndQualifiers(Type type, Set<AnnotationInstance> qualifiers) {
             this.type = type;
-            this.qualifiers = qualifiers;
+            this.qualifiers = Unique.annotations(qualifiers);
         }
 
         @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ListProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ListProvider.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 
-import io.quarkus.arc.All;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableReferenceProvider;
 
@@ -30,8 +29,6 @@ public class ListProvider implements InjectableReferenceProvider<List<?>> {
         this.requiredType = requiredType;
         this.injectionPointType = injectionPointType;
         this.qualifiers = qualifiers;
-        // the @All annotation is not a qualifier of the instances we need to resolve
-        this.qualifiers.remove(All.Literal.INSTANCE);
         this.targetBean = targetBean;
         this.annotations = annotations;
         this.javaMember = javaMember;


### PR DESCRIPTION
The idea is to optimize allocations for this pattern in the _Bean constructor (see `var5` being an `HashSet` for one element):

```java
HashSet var5 = new HashSet();
var5.add(Literal.INSTANCE);
Object var6 = null;
Object var7 = null;
var7 = Class.forName("io.smallrye.health.api.AsyncHealthCheck", false, Thread.currentThread().getContextClassLoader());
Type[] var8 = new Type[]{(Type)var7};
Class var9 = Class.forName("jakarta.enterprise.inject.Instance", false, Thread.currentThread().getContextClassLoader());
Object var10 = null;
var6 = new ParameterizedTypeImpl(var9, var8, (Type)var10);
this.injectProviderSupplier1 = new FixedValueSupplier(new InstanceProvider((Type)var6, var5, null, Set.of(), null, -1, false));
```

This is a follow-up of the work started here:
https://github.com/quarkusio/quarkus/pull/52839

It uses the same patterns.
