### PR TITLE
Kafka Streams extension improvements and bug fixes

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -63,7 +63,7 @@
         {
             "category": "Messaging1",
             "timeout": 115,
-            "test-modules": "kafka, kafka-ssl, kafka-sasl, kafka-avro-apicurio2, kafka-json-schema-apicurio2, kafka-snappy, kafka-streams, reactive-messaging-kafka, kafka-oauth-keycloak",
+            "test-modules": "kafka, kafka-ssl, kafka-sasl, kafka-avro-apicurio2, kafka-json-schema-apicurio2, kafka-snappy, kafka-streams, kafka-streams-no-rocksdb, reactive-messaging-kafka, kafka-oauth-keycloak",
             "os-name": "ubuntu-latest"
         },
         {

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsBuildTimeConfig.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsBuildTimeConfig.java
@@ -16,4 +16,17 @@ public interface KafkaStreamsBuildTimeConfig {
     @WithName("health.enabled")
     @WithDefault("true")
     boolean healthEnabled();
+
+    /**
+     * Whether RocksDB state store support is enabled.
+     * Set to {@code false} to use in-memory state stores only, which removes the RocksDB native
+     * library dependency. This is useful for ARM native builds where RocksDB native libraries
+     * may not be available.
+     * When disabled, you must configure Kafka Streams to use in-memory stores, e.g. by setting
+     * {@code quarkus.kafka-streams.dsl.store.suppliers.class} to
+     * {@code org.apache.kafka.streams.state.BuiltInDslStoreSuppliers$InMemoryDslStoreSuppliers}.
+     */
+    @WithName("rocksdb.enabled")
+    @WithDefault("true")
+    boolean rocksDbEnabled();
 }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -50,13 +50,16 @@ class KafkaStreamsProcessor {
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+    void build(KafkaStreamsBuildTimeConfig buildTimeConfig,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<JniRuntimeAccessBuildItem> jniRuntimeAccessibleClasses,
             BuildProducer<RuntimeInitializedClassBuildItem> reinitialized,
             LaunchModeBuildItem launchMode) {
         registerClassesThatAreLoadedThroughReflection(reflectiveClasses, launchMode);
-        registerClassesThatAreAccessedViaJni(jniRuntimeAccessibleClasses);
-        enableLoadOfNativeLibs(reinitialized);
+        if (buildTimeConfig.rocksDbEnabled()) {
+            registerClassesThatAreAccessedViaJni(jniRuntimeAccessibleClasses);
+            enableLoadOfNativeLibs(reinitialized);
+        }
     }
 
     private void registerClassesThatAreLoadedThroughReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -249,10 +252,12 @@ class KafkaStreamsProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void loadRocksDb(KafkaStreamsRecorder recorder) {
-        // Explicitly loading RocksDB native libs, as that's normally done from within
-        // static initializers which already ran during build
-        recorder.loadRocksDb();
+    void loadRocksDb(KafkaStreamsBuildTimeConfig buildTimeConfig, KafkaStreamsRecorder recorder) {
+        if (buildTimeConfig.rocksDbEnabled()) {
+            // Explicitly loading RocksDB native libs, as that's normally done from within
+            // static initializers which already ran during build
+            recorder.loadRocksDb();
+        }
     }
 
     @BuildStep
@@ -268,15 +273,18 @@ class KafkaStreamsProcessor {
     }
 
     @BuildStep
-    NativeImageFeatureBuildItem kafkaStreamsFeature() {
-        return new NativeImageFeatureBuildItem(KafkaStreamsFeature.class.getName());
+    void kafkaStreamsFeature(KafkaStreamsBuildTimeConfig buildTimeConfig,
+            BuildProducer<NativeImageFeatureBuildItem> nativeImageFeatures) {
+        if (buildTimeConfig.rocksDbEnabled()) {
+            nativeImageFeatures.produce(new NativeImageFeatureBuildItem(KafkaStreamsFeature.class.getName()));
+        }
     }
 
     @BuildStep
-    ModuleEnableNativeAccessBuildItem rocksDbEnableNativeAccess() {
-        // RocksDB is the default state store for Kafka Streams and uses JNI.
-        // TODO: This could potentially be made conditional if a build-time config option
-        // is added to allow users to disable RocksDB in favor of in-memory stores only.
-        return new ModuleEnableNativeAccessBuildItem("rocksdbjni");
+    void rocksDbEnableNativeAccess(KafkaStreamsBuildTimeConfig buildTimeConfig,
+            BuildProducer<ModuleEnableNativeAccessBuildItem> nativeAccess) {
+        if (buildTimeConfig.rocksDbEnabled()) {
+            nativeAccess.produce(new ModuleEnableNativeAccessBuildItem("rocksdbjni"));
+        }
     }
 }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -13,6 +13,8 @@ import org.apache.kafka.streams.errors.LogAndContinueProcessingExceptionHandler;
 import org.apache.kafka.streams.errors.LogAndFailExceptionHandler;
 import org.apache.kafka.streams.errors.LogAndFailProcessingExceptionHandler;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 import org.rocksdb.RocksDBException;
@@ -20,6 +22,7 @@ import org.rocksdb.Status;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -55,20 +58,22 @@ class KafkaStreamsProcessor {
             BuildProducer<JniRuntimeAccessBuildItem> jniRuntimeAccessibleClasses,
             BuildProducer<RuntimeInitializedClassBuildItem> reinitialized,
             LaunchModeBuildItem launchMode) {
-        registerClassesThatAreLoadedThroughReflection(reflectiveClasses, launchMode);
+        registerClassesThatAreLoadedThroughReflection(buildTimeConfig, reflectiveClasses, launchMode);
         if (buildTimeConfig.rocksDbEnabled()) {
             registerClassesThatAreAccessedViaJni(jniRuntimeAccessibleClasses);
             enableLoadOfNativeLibs(reinitialized);
         }
     }
 
-    private void registerClassesThatAreLoadedThroughReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+    private void registerClassesThatAreLoadedThroughReflection(KafkaStreamsBuildTimeConfig buildTimeConfig,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             LaunchModeBuildItem launchMode) {
-        registerCompulsoryClasses(reflectiveClasses);
+        registerCompulsoryClasses(buildTimeConfig, reflectiveClasses);
         registerClassesThatClientMaySpecify(reflectiveClasses, launchMode);
     }
 
-    private void registerCompulsoryClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+    private void registerCompulsoryClasses(KafkaStreamsBuildTimeConfig buildTimeConfig,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
         reflectiveClasses.produce(ReflectiveClassBuildItem.builder(StreamsPartitionAssignor.class)
                 .reason(getClass().getName())
                 .build());
@@ -104,10 +109,15 @@ class KafkaStreamsProcessor {
 
         // Listed in BuiltInDslStoreSuppliers
         reflectiveClasses.produce(ReflectiveClassBuildItem
-                .builder(org.apache.kafka.streams.state.BuiltInDslStoreSuppliers.RocksDBDslStoreSuppliers.class,
-                        org.apache.kafka.streams.state.BuiltInDslStoreSuppliers.InMemoryDslStoreSuppliers.class)
+                .builder(org.apache.kafka.streams.state.BuiltInDslStoreSuppliers.InMemoryDslStoreSuppliers.class)
                 .reason(getClass().getName())
                 .build());
+        if (buildTimeConfig.rocksDbEnabled()) {
+            reflectiveClasses.produce(ReflectiveClassBuildItem
+                    .builder(org.apache.kafka.streams.state.BuiltInDslStoreSuppliers.RocksDBDslStoreSuppliers.class)
+                    .reason(getClass().getName())
+                    .build());
+        }
         reflectiveClasses.produce(ReflectiveClassBuildItem
                 .builder(org.apache.kafka.streams.errors.LogAndFailProcessingExceptionHandler.class,
                         org.apache.kafka.streams.errors.LogAndContinueProcessingExceptionHandler.class)
@@ -258,6 +268,11 @@ class KafkaStreamsProcessor {
             // static initializers which already ran during build
             recorder.loadRocksDb();
         }
+    }
+
+    @BuildStep
+    UnremovableBeanBuildItem markProcessorBeansUnremovable() {
+        return UnremovableBeanBuildItem.beanTypes(Processor.class, FixedKeyProcessor.class);
     }
 
     @BuildStep

--- a/extensions/kafka-streams/runtime-dev/src/main/java/io/quarkus/kafka/streams/runtime/dev/ui/KafkaStreamsJsonRPCService.java
+++ b/extensions/kafka-streams/runtime-dev/src/main/java/io/quarkus/kafka/streams/runtime/dev/ui/KafkaStreamsJsonRPCService.java
@@ -56,33 +56,36 @@ public class KafkaStreamsJsonRPCService {
 
     private static final RawTopologyItemParser SUB_TOPOLOGY = new RawTopologyItemParser() {
         private final Pattern subTopologyPattern = Pattern.compile("Sub-topology: (?<subTopology>[0-9]*).*");
-        private Matcher matcher;
+        private final ThreadLocal<Matcher> matcherHolder = new ThreadLocal<>();
 
         @Override
         public boolean test(String line) {
-            matcher = subTopologyPattern.matcher(line);
+            Matcher matcher = subTopologyPattern.matcher(line);
+            matcherHolder.set(matcher);
             return matcher.matches();
         }
 
         @Override
         public void accept(TopologyParserContext context) {
-            context.addSubTopology(matcher.group("subTopology"));
+            context.addSubTopology(matcherHolder.get().group("subTopology"));
         }
     };
 
     private static final RawTopologyItemParser SOURCE = new RawTopologyItemParser() {
         private final Pattern sourcePattern = Pattern
                 .compile("Source:\\s+(?<source>\\S+)\\s+\\(topics:\\s+((\\[(?<topics>.*)\\])|(?<regex>.*)\\)).*");
-        private Matcher matcher;
+        private final ThreadLocal<Matcher> matcherHolder = new ThreadLocal<>();
 
         @Override
         public boolean test(String line) {
-            matcher = sourcePattern.matcher(line);
+            Matcher matcher = sourcePattern.matcher(line);
+            matcherHolder.set(matcher);
             return matcher.matches();
         }
 
         @Override
         public void accept(TopologyParserContext context) {
+            Matcher matcher = matcherHolder.get();
             if (matcher.group("topics") != null) {
                 context.addSources(matcher.group("source"), matcher.group("topics").split(","));
             } else if (matcher.group("regex") != null) {
@@ -94,51 +97,57 @@ public class KafkaStreamsJsonRPCService {
     private static final RawTopologyItemParser PROCESSOR = new RawTopologyItemParser() {
         private final Pattern processorPattern = Pattern
                 .compile("Processor:\\s+(?<processor>\\S+)\\s+\\(stores:\\s+\\[(?<stores>.*)\\]\\).*");
-        private Matcher matcher;
-        private String line;
+        private final ThreadLocal<Matcher> matcherHolder = new ThreadLocal<>();
+        private final ThreadLocal<String> lineHolder = new ThreadLocal<>();
 
         @Override
         public boolean test(String line) {
-            this.line = line;
-            matcher = processorPattern.matcher(line);
+            lineHolder.set(line);
+            Matcher matcher = processorPattern.matcher(line);
+            matcherHolder.set(matcher);
             return matcher.matches();
         }
 
         @Override
         public void accept(TopologyParserContext context) {
-            context.addStores(matcher.group("stores").split(","), matcher.group("processor"), line.contains("JOIN"));
+            Matcher matcher = matcherHolder.get();
+            context.addStores(matcher.group("stores").split(","), matcher.group("processor"),
+                    lineHolder.get().contains("JOIN"));
         }
     };
 
     private static final RawTopologyItemParser SINK = new RawTopologyItemParser() {
         private final Pattern sinkPattern = Pattern.compile("Sink:\\s+(?<sink>\\S+)\\s+\\(topic:\\s+(?<topic>.*)\\).*");
-        private Matcher matcher;
+        private final ThreadLocal<Matcher> matcherHolder = new ThreadLocal<>();
 
         @Override
         public boolean test(String line) {
-            matcher = sinkPattern.matcher(line);
+            Matcher matcher = sinkPattern.matcher(line);
+            matcherHolder.set(matcher);
             return matcher.matches();
         }
 
         @Override
         public void accept(TopologyParserContext context) {
+            Matcher matcher = matcherHolder.get();
             context.addSink(matcher.group("sink"), matcher.group("topic"));
         }
     };
 
     private static final RawTopologyItemParser RIGHT_ARROW = new RawTopologyItemParser() {
         private final Pattern rightArrowPattern = Pattern.compile("\\s*-->\\s+(?<targets>.*)");
-        private Matcher matcher;
+        private final ThreadLocal<Matcher> matcherHolder = new ThreadLocal<>();
 
         @Override
         public boolean test(String line) {
-            matcher = rightArrowPattern.matcher(line);
+            Matcher matcher = rightArrowPattern.matcher(line);
+            matcherHolder.set(matcher);
             return matcher.matches();
         }
 
         @Override
         public void accept(TopologyParserContext context) {
-            context.addTargets(matcher.group("targets").split(","));
+            context.addTargets(matcherHolder.get().group("targets").split(","));
         }
     };
 }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareFixedKeyProcessorSupplier.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareFixedKeyProcessorSupplier.java
@@ -1,0 +1,114 @@
+package io.quarkus.kafka.streams.runtime;
+
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.ManagedContext;
+
+/**
+ * A {@link FixedKeyProcessorSupplier} that creates processor instances via CDI and activates
+ * CDI request context for each {@code process()} call.
+ * <p>
+ * See {@link CdiAwareProcessorSupplier} for full documentation. This is the equivalent
+ * for {@link FixedKeyProcessor} implementations.
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * &#64;Dependent
+ * public class MyProcessor implements FixedKeyProcessor&lt;String, String, String&gt; {
+ *     &#64;Inject
+ *     SomeService service;
+ *
+ *     &#64;Override
+ *     public void process(FixedKeyRecord&lt;String, String&gt; record) {
+ *         service.handle(record.value());
+ *     }
+ * }
+ *
+ * // In your topology builder:
+ * builder.stream("input")
+ *         .processValues(CdiAwareFixedKeyProcessorSupplier.of(MyProcessor.class));
+ * </pre>
+ *
+ * @param <KIn> the input key type
+ * @param <VIn> the input value type
+ * @param <VOut> the output value type
+ */
+public class CdiAwareFixedKeyProcessorSupplier<KIn, VIn, VOut> implements FixedKeyProcessorSupplier<KIn, VIn, VOut> {
+
+    private final Class<? extends FixedKeyProcessor<KIn, VIn, VOut>> processorClass;
+
+    private CdiAwareFixedKeyProcessorSupplier(Class<? extends FixedKeyProcessor<KIn, VIn, VOut>> processorClass) {
+        this.processorClass = processorClass;
+    }
+
+    /**
+     * Creates a new CDI-aware fixed-key processor supplier for the given processor class.
+     *
+     * @param processorClass a CDI bean class implementing {@link FixedKeyProcessor}
+     * @param <KIn> the input key type
+     * @param <VIn> the input value type
+     * @param <VOut> the output value type
+     * @return a new processor supplier
+     */
+    public static <KIn, VIn, VOut> CdiAwareFixedKeyProcessorSupplier<KIn, VIn, VOut> of(
+            Class<? extends FixedKeyProcessor<KIn, VIn, VOut>> processorClass) {
+        return new CdiAwareFixedKeyProcessorSupplier<>(processorClass);
+    }
+
+    @Override
+    public FixedKeyProcessor<KIn, VIn, VOut> get() {
+        InstanceHandle<? extends FixedKeyProcessor<KIn, VIn, VOut>> handle = Arc.container().instance(processorClass);
+        if (!handle.isAvailable()) {
+            throw new IllegalStateException(
+                    "CDI bean not found for processor class: " + processorClass.getName()
+                            + ". Ensure it is a CDI bean (e.g. annotated with @Dependent).");
+        }
+        return new ContextAwareFixedKeyProcessor<>(handle);
+    }
+
+    private static class ContextAwareFixedKeyProcessor<KIn, VIn, VOut> implements FixedKeyProcessor<KIn, VIn, VOut> {
+
+        private final InstanceHandle<? extends FixedKeyProcessor<KIn, VIn, VOut>> handle;
+        private final FixedKeyProcessor<KIn, VIn, VOut> delegate;
+
+        ContextAwareFixedKeyProcessor(InstanceHandle<? extends FixedKeyProcessor<KIn, VIn, VOut>> handle) {
+            this.handle = handle;
+            this.delegate = handle.get();
+        }
+
+        @Override
+        public void init(FixedKeyProcessorContext<KIn, VOut> context) {
+            delegate.init(context);
+        }
+
+        @Override
+        public void process(FixedKeyRecord<KIn, VIn> record) {
+            ManagedContext requestContext = Arc.container().requestContext();
+            if (requestContext.isActive()) {
+                delegate.process(record);
+                return;
+            }
+            try {
+                requestContext.activate();
+                delegate.process(record);
+            } finally {
+                requestContext.terminate();
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                delegate.close();
+            } finally {
+                handle.close();
+            }
+        }
+    }
+}

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareFixedKeyProcessorSupplier.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareFixedKeyProcessorSupplier.java
@@ -20,6 +20,7 @@ import io.quarkus.arc.ManagedContext;
  *
  * <pre>
  * &#64;Dependent
+ * &#64;Unremovable
  * public class MyProcessor implements FixedKeyProcessor&lt;String, String, String&gt; {
  *     &#64;Inject
  *     SomeService service;

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareProcessorSupplier.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareProcessorSupplier.java
@@ -1,0 +1,123 @@
+package io.quarkus.kafka.streams.runtime;
+
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.ManagedContext;
+
+/**
+ * A {@link ProcessorSupplier} that creates processor instances via CDI and activates
+ * CDI request context for each {@code process()} call.
+ * <p>
+ * Kafka Streams manages its own threads, which means processors created by the framework
+ * have no CDI context. This supplier solves that by:
+ * <ul>
+ * <li>Creating processor instances from the Arc CDI container (enabling {@code @Inject})</li>
+ * <li>Activating a CDI request context around each {@code process()} call</li>
+ * </ul>
+ * <p>
+ * The processor class should be a {@code @Dependent} scoped CDI bean so that each
+ * stream task gets its own instance.
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * &#64;Dependent
+ * public class MyProcessor implements Processor&lt;String, String, String, String&gt; {
+ *     &#64;Inject
+ *     SomeService service;
+ *
+ *     &#64;Override
+ *     public void process(Record&lt;String, String&gt; record) {
+ *         service.handle(record.value());
+ *     }
+ * }
+ *
+ * // In your topology builder:
+ * builder.stream("input")
+ *         .process(CdiAwareProcessorSupplier.of(MyProcessor.class));
+ * </pre>
+ *
+ * @param <KIn> the input key type
+ * @param <VIn> the input value type
+ * @param <KOut> the output key type
+ * @param <VOut> the output value type
+ */
+public class CdiAwareProcessorSupplier<KIn, VIn, KOut, VOut> implements ProcessorSupplier<KIn, VIn, KOut, VOut> {
+
+    private final Class<? extends Processor<KIn, VIn, KOut, VOut>> processorClass;
+
+    private CdiAwareProcessorSupplier(Class<? extends Processor<KIn, VIn, KOut, VOut>> processorClass) {
+        this.processorClass = processorClass;
+    }
+
+    /**
+     * Creates a new CDI-aware processor supplier for the given processor class.
+     *
+     * @param processorClass a CDI bean class implementing {@link Processor}
+     * @param <KIn> the input key type
+     * @param <VIn> the input value type
+     * @param <KOut> the output key type
+     * @param <VOut> the output value type
+     * @return a new processor supplier
+     */
+    public static <KIn, VIn, KOut, VOut> CdiAwareProcessorSupplier<KIn, VIn, KOut, VOut> of(
+            Class<? extends Processor<KIn, VIn, KOut, VOut>> processorClass) {
+        return new CdiAwareProcessorSupplier<>(processorClass);
+    }
+
+    @Override
+    public Processor<KIn, VIn, KOut, VOut> get() {
+        InstanceHandle<? extends Processor<KIn, VIn, KOut, VOut>> handle = Arc.container().instance(processorClass);
+        if (!handle.isAvailable()) {
+            throw new IllegalStateException(
+                    "CDI bean not found for processor class: " + processorClass.getName()
+                            + ". Ensure it is a CDI bean (e.g. annotated with @Dependent).");
+        }
+        return new ContextAwareProcessor<>(handle);
+    }
+
+    private static class ContextAwareProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VIn, KOut, VOut> {
+
+        private final InstanceHandle<? extends Processor<KIn, VIn, KOut, VOut>> handle;
+        private final Processor<KIn, VIn, KOut, VOut> delegate;
+
+        ContextAwareProcessor(InstanceHandle<? extends Processor<KIn, VIn, KOut, VOut>> handle) {
+            this.handle = handle;
+            this.delegate = handle.get();
+        }
+
+        @Override
+        public void init(ProcessorContext<KOut, VOut> context) {
+            delegate.init(context);
+        }
+
+        @Override
+        public void process(Record<KIn, VIn> record) {
+            ManagedContext requestContext = Arc.container().requestContext();
+            if (requestContext.isActive()) {
+                delegate.process(record);
+                return;
+            }
+            try {
+                requestContext.activate();
+                delegate.process(record);
+            } finally {
+                requestContext.terminate();
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                delegate.close();
+            } finally {
+                handle.close();
+            }
+        }
+    }
+}

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareProcessorSupplier.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/CdiAwareProcessorSupplier.java
@@ -21,12 +21,15 @@ import io.quarkus.arc.ManagedContext;
  * </ul>
  * <p>
  * The processor class should be a {@code @Dependent} scoped CDI bean so that each
- * stream task gets its own instance.
+ * stream task gets its own instance. It must also be annotated with
+ * {@code @io.quarkus.arc.Unremovable} since ArC would otherwise remove it as an
+ * unused bean (it has no injection points, only programmatic lookup).
  * <p>
  * Usage:
  *
  * <pre>
  * &#64;Dependent
+ * &#64;Unremovable
  * public class MyProcessor implements Processor&lt;String, String, String, String&gt; {
  *     &#64;Inject
  *     SomeService service;

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/HotReplacementInterceptor.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/HotReplacementInterceptor.java
@@ -15,8 +15,9 @@ public class HotReplacementInterceptor implements ConsumerInterceptor {
 
     @Override
     public ConsumerRecords onConsume(ConsumerRecords records) {
-        if (onMessage != null) {
-            onMessage.run();
+        Runnable handler = onMessage;
+        if (handler != null) {
+            handler.run();
         }
 
         return records;

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -310,11 +310,26 @@ public class KafkaStreamsProducer {
         return inetSocketAddress.getHostString() + ":" + inetSocketAddress.getPort();
     }
 
-    private static Properties getAdminClientConfig(Properties properties) {
+    // visible for testing
+    static Properties getAdminClientConfig(Properties properties) {
         Properties adminClientConfig = new Properties(properties);
         // include TLS config name if it has been configured
         if (properties.containsKey(TLS_CONFIG_NAME_KEY)) {
             adminClientConfig.put(TLS_CONFIG_NAME_KEY, properties.get(TLS_CONFIG_NAME_KEY));
+        }
+        // copy config provider properties so that providers like Strimzi Kubernetes Secret
+        // Config Provider work for the admin client (see GH-46448)
+        for (String name : properties.stringPropertyNames()) {
+            if (name.startsWith("config.providers")) {
+                // admin-prefixed config providers take precedence
+                if (!properties.containsKey(StreamsConfig.ADMIN_CLIENT_PREFIX + name)) {
+                    adminClientConfig.put(name, properties.get(name));
+                }
+            } else if (name.startsWith(StreamsConfig.ADMIN_CLIENT_PREFIX + "config.providers")) {
+                adminClientConfig.put(
+                        name.substring(StreamsConfig.ADMIN_CLIENT_PREFIX.length()),
+                        properties.get(name));
+            }
         }
         // include other AdminClientConfig(s) that have been configured
         for (final String knownAdminClientConfig : AdminClientConfig.configNames()) {

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -96,9 +96,10 @@ public class KafkaStreamsProducer {
 
         this.executorService = executorService;
         this.streamsConfig = new StreamsConfig(kafkaStreamsProperties);
-        this.kafkaStreams = initializeKafkaStreams(streamsConfig, topology.get(),
+        Topology resolvedTopology = topology.get();
+        this.kafkaStreams = initializeKafkaStreams(streamsConfig, resolvedTopology,
                 kafkaClientSupplier, stateListener, globalStateRestoreListener, uncaughtExceptionHandlerListener);
-        this.topologyManager = new KafkaStreamsTopologyManager(kafkaAdminClient, topology.get(), runtimeConfig);
+        this.topologyManager = new KafkaStreamsTopologyManager(kafkaAdminClient, resolvedTopology, runtimeConfig);
     }
 
     public void onStartup(@Observes StartupEvent event, Event<KafkaStreams> kafkaStreamsEvent) {
@@ -149,7 +150,7 @@ public class KafkaStreamsProducer {
             kafkaStreams.close();
         }
         if (kafkaAdminClient != null) {
-            kafkaAdminClient.close(Duration.ZERO);
+            kafkaAdminClient.close(Duration.ofSeconds(10));
         }
     }
 

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
@@ -101,4 +101,16 @@ public interface KafkaStreamsRuntimeConfig {
      */
     SslConfig ssl();
 
+    /**
+     * Whether Kafka Streams health checks are enabled at runtime.
+     * <p>
+     * This provides a runtime toggle for health checks, complementing the build-time
+     * {@code quarkus.kafka-streams.health.enabled} option. When disabled at runtime,
+     * health checks will always report UP, which is useful when deploying the same
+     * image across environments where some may not use Kafka Streams topologies.
+     */
+    @WithName("health.runtime-enabled")
+    @WithDefault("true")
+    boolean healthRuntimeEnabled();
+
 }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
@@ -61,6 +61,13 @@ public interface KafkaStreamsRuntimeConfig {
     Duration topicsTimeout();
 
     /**
+     * Interval between polls when waiting for topics to be created.
+     * Only used when {@code topics-timeout} is greater than 0.
+     */
+    @WithDefault("1S")
+    Duration topicsPollInterval();
+
+    /**
      * The schema registry key.
      *
      * Different schema registry libraries expect a registry URL

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
@@ -117,22 +117,21 @@ public class KafkaStreamsTopologyManager {
             return Collections.emptySet();
         }
 
-        Set<String> missing = new LinkedHashSet<>(sourceTopics);
-
         try {
             ListTopicsResult topics = adminClient.listTopics();
             Set<String> existingTopics = topics.names().get(topicsTimeout.toMillis(), TimeUnit.MILLISECONDS);
 
+            Set<String> missing = new LinkedHashSet<>(sourceTopics);
             missing.removeAll(existingTopics);
             missing.addAll(sourcePatterns.stream()
                     .filter(p -> existingTopics.stream().noneMatch(p.asPredicate()))
                     .map(Pattern::pattern)
                     .toList());
+            return missing;
         } catch (ExecutionException | TimeoutException e) {
             LOGGER.error("Failed to get topic names from broker", e);
+            return Collections.emptySet();
         }
-
-        return missing;
     }
 
     public void waitForTopicsToBeCreated() throws InterruptedException {

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
@@ -26,12 +26,14 @@ public class KafkaStreamsTopologyManager {
     private final List<String> sourceTopics;
     private final List<Pattern> sourcePatterns;
     private final Duration topicsTimeout;
+    private final Duration topicsPollInterval;
 
     private volatile boolean closed = false;
 
     public KafkaStreamsTopologyManager(Admin adminClient, Topology topology, KafkaStreamsRuntimeConfig runtimeConfig) {
         this.adminClient = adminClient;
         this.topicsTimeout = runtimeConfig.topicsTimeout();
+        this.topicsPollInterval = runtimeConfig.topicsPollInterval();
         if (isTopicsCheckEnabled()) {
             if (runtimeConfig.topics().isEmpty() && runtimeConfig.topicPatterns().isEmpty()) {
                 Set<String> topics = new HashSet<>();
@@ -100,7 +102,7 @@ public class KafkaStreamsTopologyManager {
                 }
             }
         }
-        // remove topics used both in sinks ans sources
+        // remove topics used both in sinks and sources
         topics.removeAll(sinkTopics);
     }
 
@@ -163,7 +165,7 @@ public class KafkaStreamsTopologyManager {
             } catch (ExecutionException | TimeoutException e) {
                 LOGGER.error("Failed to get topic names from broker", e);
             } finally {
-                Thread.sleep(1_000);
+                Thread.sleep(topicsPollInterval.toMillis());
             }
         }
     }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
@@ -19,6 +19,10 @@ public class KafkaStreamsStateHealthCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Kafka Streams state health check");
+        if (kafkaStreams == null) {
+            responseBuilder.down().withData("technical_error", "KafkaStreams instance not available");
+            return responseBuilder.build();
+        }
         try {
             KafkaStreams.State state = kafkaStreams.state();
             responseBuilder.status(state.isRunningOrRebalancing())

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
@@ -4,24 +4,34 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.streams.KafkaStreams;
-import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Liveness;
 
+import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
+import io.smallrye.health.api.AsyncHealthCheck;
+import io.smallrye.mutiny.Uni;
+
 @Liveness
 @ApplicationScoped
-public class KafkaStreamsStateHealthCheck implements HealthCheck {
+public class KafkaStreamsStateHealthCheck implements AsyncHealthCheck {
 
     @Inject
     protected KafkaStreams kafkaStreams;
 
+    @Inject
+    KafkaStreamsRuntimeConfig runtimeConfig;
+
     @Override
-    public HealthCheckResponse call() {
+    public Uni<HealthCheckResponse> call() {
         HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Kafka Streams state health check");
+        if (!runtimeConfig.healthRuntimeEnabled()) {
+            responseBuilder.up();
+            return Uni.createFrom().item(responseBuilder.build());
+        }
         if (kafkaStreams == null) {
             responseBuilder.down().withData("technical_error", "KafkaStreams instance not available");
-            return responseBuilder.build();
+            return Uni.createFrom().item(responseBuilder.build());
         }
         try {
             KafkaStreams.State state = kafkaStreams.state();
@@ -30,6 +40,6 @@ public class KafkaStreamsStateHealthCheck implements HealthCheck {
         } catch (Exception e) {
             responseBuilder.down().withData("technical_error", e.getMessage());
         }
-        return responseBuilder.build();
+        return Uni.createFrom().item(responseBuilder.build());
     }
 }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
@@ -8,27 +8,32 @@ import java.util.regex.Pattern;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
 import org.jboss.logging.Logger;
 
+import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
+import io.smallrye.health.api.AsyncHealthCheck;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 @Readiness
 @ApplicationScoped
-public class KafkaStreamsTopicsHealthCheck implements HealthCheck {
+public class KafkaStreamsTopicsHealthCheck implements AsyncHealthCheck {
 
     private static final Logger LOGGER = Logger.getLogger(KafkaStreamsTopicsHealthCheck.class.getName());
 
     private final KafkaStreamsTopologyManager manager;
+    private final KafkaStreamsRuntimeConfig runtimeConfig;
 
     private final List<String> checkedTopics;
 
     @Inject
-    public KafkaStreamsTopicsHealthCheck(KafkaStreamsTopologyManager manager) {
+    public KafkaStreamsTopicsHealthCheck(KafkaStreamsTopologyManager manager, KafkaStreamsRuntimeConfig runtimeConfig) {
         this.manager = manager;
+        this.runtimeConfig = runtimeConfig;
         this.checkedTopics = new ArrayList<>();
         if (manager != null && manager.isTopicsCheckEnabled()) {
             checkedTopics.addAll(manager.getSourceTopics());
@@ -37,13 +42,21 @@ public class KafkaStreamsTopicsHealthCheck implements HealthCheck {
     }
 
     @Override
-    public HealthCheckResponse call() {
+    public Uni<HealthCheckResponse> call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Kafka Streams topics health check").up();
+        if (!runtimeConfig.healthRuntimeEnabled()) {
+            return Uni.createFrom().item(builder.build());
+        }
         if (manager == null) {
             builder.down().withData("technical_error", "KafkaStreamsTopologyManager not available");
-            return builder.build();
+            return Uni.createFrom().item(builder.build());
         }
-        if (manager.isTopicsCheckEnabled()) {
+        if (!manager.isTopicsCheckEnabled()) {
+            return Uni.createFrom().item(builder.build());
+        }
+        // Run the blocking admin client call on a worker thread to avoid
+        // blocking the event loop and causing health probe timeouts (GH-42882)
+        return Uni.createFrom().item(() -> {
             try {
                 Set<String> missingTopics = manager.getMissingTopics();
                 List<String> availableTopics = new ArrayList<>(checkedTopics);
@@ -59,7 +72,7 @@ public class KafkaStreamsTopicsHealthCheck implements HealthCheck {
                 LOGGER.error("error when retrieving missing topics", e);
                 builder.down().withData("technical_error", e.getMessage());
             }
-        }
-        return builder.build();
+            return builder.build();
+        }).runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
     }
 }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
@@ -31,7 +31,7 @@ public class KafkaStreamsTopicsHealthCheck implements HealthCheck {
     public KafkaStreamsTopicsHealthCheck(KafkaStreamsTopologyManager manager) {
         this.manager = manager;
         this.checkedTopics = new ArrayList<>();
-        if (manager.isTopicsCheckEnabled()) {
+        if (manager != null && manager.isTopicsCheckEnabled()) {
             checkedTopics.addAll(manager.getSourceTopics());
             checkedTopics.addAll(manager.getSourcePatterns().stream().map(Pattern::pattern).toList());
         }
@@ -40,6 +40,10 @@ public class KafkaStreamsTopicsHealthCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Kafka Streams topics health check").up();
+        if (manager == null) {
+            builder.down().withData("technical_error", "KafkaStreamsTopologyManager not available");
+            return builder.build();
+        }
         if (manager.isTopicsCheckEnabled()) {
             try {
                 Set<String> missingTopics = manager.getMissingTopics();

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
@@ -22,8 +22,7 @@ public class KafkaStreamsTopicsHealthCheck implements HealthCheck {
 
     private static final Logger LOGGER = Logger.getLogger(KafkaStreamsTopicsHealthCheck.class.getName());
 
-    @Inject
-    KafkaStreamsTopologyManager manager;
+    private final KafkaStreamsTopologyManager manager;
 
     private final List<String> checkedTopics;
 

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/CdiAwareProcessorSupplierTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/CdiAwareProcessorSupplierTest.java
@@ -1,0 +1,152 @@
+package io.quarkus.kafka.streams.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.ManagedContext;
+
+@ExtendWith(MockitoExtension.class)
+public class CdiAwareProcessorSupplierTest {
+
+    @Mock
+    ArcContainer container;
+
+    @Mock
+    InstanceHandle<TestProcessor> instanceHandle;
+
+    @Mock
+    ManagedContext requestContext;
+
+    @Mock
+    ProcessorContext<String, String> processorContext;
+
+    MockedStatic<Arc> arcMock;
+
+    TestProcessor testProcessor;
+
+    @BeforeEach
+    void setUp() {
+        arcMock = Mockito.mockStatic(Arc.class);
+        arcMock.when(Arc::container).thenReturn(container);
+        testProcessor = new TestProcessor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        arcMock.close();
+    }
+
+    @Test
+    public void shouldCreateProcessorViaCdi() {
+        when(container.instance(TestProcessor.class)).thenReturn(instanceHandle);
+        when(instanceHandle.isAvailable()).thenReturn(true);
+        when(instanceHandle.get()).thenReturn(testProcessor);
+
+        CdiAwareProcessorSupplier<String, String, String, String> supplier = CdiAwareProcessorSupplier
+                .of(TestProcessor.class);
+        Processor<String, String, String, String> processor = supplier.get();
+
+        assertThat(processor).isNotNull();
+    }
+
+    @Test
+    public void shouldThrowIfBeanNotFound() {
+        when(container.instance(TestProcessor.class)).thenReturn(instanceHandle);
+        when(instanceHandle.isAvailable()).thenReturn(false);
+
+        CdiAwareProcessorSupplier<String, String, String, String> supplier = CdiAwareProcessorSupplier
+                .of(TestProcessor.class);
+
+        assertThatThrownBy(supplier::get)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("CDI bean not found");
+    }
+
+    @Test
+    public void shouldActivateRequestContextOnProcess() {
+        when(container.instance(TestProcessor.class)).thenReturn(instanceHandle);
+        when(instanceHandle.isAvailable()).thenReturn(true);
+        when(instanceHandle.get()).thenReturn(testProcessor);
+        when(container.requestContext()).thenReturn(requestContext);
+        when(requestContext.isActive()).thenReturn(false);
+
+        Processor<String, String, String, String> processor = CdiAwareProcessorSupplier
+                .of(TestProcessor.class).get();
+        processor.process(new Record<>("key", "value", 0L));
+
+        verify(requestContext).activate();
+        verify(requestContext).terminate();
+        assertThat(testProcessor.lastProcessedValue).isEqualTo("value");
+    }
+
+    @Test
+    public void shouldSkipActivationIfContextAlreadyActive() {
+        when(container.instance(TestProcessor.class)).thenReturn(instanceHandle);
+        when(instanceHandle.isAvailable()).thenReturn(true);
+        when(instanceHandle.get()).thenReturn(testProcessor);
+        when(container.requestContext()).thenReturn(requestContext);
+        when(requestContext.isActive()).thenReturn(true);
+
+        Processor<String, String, String, String> processor = CdiAwareProcessorSupplier
+                .of(TestProcessor.class).get();
+        processor.process(new Record<>("key", "value", 0L));
+
+        verify(requestContext, Mockito.never()).activate();
+        verify(requestContext, Mockito.never()).terminate();
+        assertThat(testProcessor.lastProcessedValue).isEqualTo("value");
+    }
+
+    @Test
+    public void shouldDelegateInitAndClose() {
+        when(container.instance(TestProcessor.class)).thenReturn(instanceHandle);
+        when(instanceHandle.isAvailable()).thenReturn(true);
+        when(instanceHandle.get()).thenReturn(testProcessor);
+
+        Processor<String, String, String, String> processor = CdiAwareProcessorSupplier
+                .of(TestProcessor.class).get();
+        processor.init(processorContext);
+        assertThat(testProcessor.initialized).isTrue();
+
+        processor.close();
+        assertThat(testProcessor.closed).isTrue();
+        verify(instanceHandle).close();
+    }
+
+    static class TestProcessor implements Processor<String, String, String, String> {
+        boolean initialized;
+        boolean closed;
+        String lastProcessedValue;
+
+        @Override
+        public void init(ProcessorContext<String, String> context) {
+            initialized = true;
+        }
+
+        @Override
+        public void process(Record<String, String> record) {
+            lastProcessedValue = record.value();
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducerTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducerTest.java
@@ -1,0 +1,87 @@
+package io.quarkus.kafka.streams.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.Test;
+
+class KafkaStreamsProducerTest {
+
+    @Test
+    void adminClientConfigShouldCopyConfigProviders() {
+        Properties props = new Properties();
+        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put("config.providers", "secrets");
+        props.put("config.providers.secrets.class", "io.strimzi.kafka.KubernetesSecretConfigProvider");
+
+        Properties adminConfig = KafkaStreamsProducer.getAdminClientConfig(props);
+
+        assertThat(adminConfig.getProperty("config.providers")).isEqualTo("secrets");
+        assertThat(adminConfig.getProperty("config.providers.secrets.class"))
+                .isEqualTo("io.strimzi.kafka.KubernetesSecretConfigProvider");
+    }
+
+    @Test
+    void adminClientConfigShouldPreferAdminPrefixedConfigProviders() {
+        Properties props = new Properties();
+        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put("config.providers", "secrets");
+        props.put("config.providers.secrets.class", "io.strimzi.kafka.KubernetesSecretConfigProvider");
+        // admin-prefixed should take precedence
+        props.put(StreamsConfig.ADMIN_CLIENT_PREFIX + "config.providers", "file");
+        props.put(StreamsConfig.ADMIN_CLIENT_PREFIX + "config.providers.file.class",
+                "org.apache.kafka.common.config.provider.FileConfigProvider");
+
+        Properties adminConfig = KafkaStreamsProducer.getAdminClientConfig(props);
+
+        // admin-prefixed config providers should win
+        assertThat(adminConfig.getProperty("config.providers")).isEqualTo("file");
+        assertThat(adminConfig.getProperty("config.providers.file.class"))
+                .isEqualTo("org.apache.kafka.common.config.provider.FileConfigProvider");
+    }
+
+    @Test
+    void adminClientConfigShouldCopyKnownAdminConfigs() {
+        Properties props = new Properties();
+        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+
+        Properties adminConfig = KafkaStreamsProducer.getAdminClientConfig(props);
+
+        assertThat(adminConfig.getProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG))
+                .isEqualTo("localhost:9092");
+        assertThat(adminConfig.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG))
+                .isEqualTo("SSL");
+    }
+
+    @Test
+    void adminClientConfigShouldPreferAdminPrefixedKnownConfigs() {
+        Properties props = new Properties();
+        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(StreamsConfig.ADMIN_CLIENT_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                "admin-host:9093");
+
+        Properties adminConfig = KafkaStreamsProducer.getAdminClientConfig(props);
+
+        assertThat(adminConfig.getProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG))
+                .isEqualTo("admin-host:9093");
+    }
+
+    @Test
+    void adminClientConfigShouldNotCopyConfigProvidersWhenAdminPrefixedExists() {
+        Properties props = new Properties();
+        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        // non-prefixed config provider
+        props.put("config.providers", "secrets");
+        // admin-prefixed version of the same property exists
+        props.put(StreamsConfig.ADMIN_CLIENT_PREFIX + "config.providers", "file");
+
+        Properties adminConfig = KafkaStreamsProducer.getAdminClientConfig(props);
+
+        // admin-prefixed should win, non-prefixed should NOT be copied
+        assertThat(adminConfig.getProperty("config.providers")).isEqualTo("file");
+    }
+}

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManagerTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManagerTest.java
@@ -29,6 +29,7 @@ class KafkaStreamsTopologyManagerTest {
 
         // GIVEN a KafkaStreamsTopologyManager with topics check disabled
         when(config.topicsTimeout()).thenReturn(Duration.ZERO);
+        when(config.topicsPollInterval()).thenReturn(Duration.ofSeconds(1));
         KafkaStreamsTopologyManager manager = new KafkaStreamsTopologyManager(
                 adminClient,
                 topology,
@@ -53,6 +54,7 @@ class KafkaStreamsTopologyManagerTest {
         // AND an admin client that returns `topic1` immediately
         String expectedTopic = "topic1";
         when(config.topicsTimeout()).thenReturn(Duration.ofSeconds(30));
+        when(config.topicsPollInterval()).thenReturn(Duration.ofSeconds(1));
         when(config.topics()).thenReturn(Optional.of(List.of(expectedTopic)));
 
         when(adminClient.listTopics()).thenReturn(listTopicsResult);

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
@@ -11,6 +11,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
+
 @ExtendWith(MockitoExtension.class)
 public class KafkaStreamsHealthCheckTest {
 
@@ -20,34 +22,73 @@ public class KafkaStreamsHealthCheckTest {
     @Mock
     private KafkaStreams streams;
 
+    @Mock
+    private KafkaStreamsRuntimeConfig runtimeConfig;
+
     @Test
     public void shouldBeUpIfStateRunning() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
         Mockito.when(streams.state()).thenReturn(KafkaStreams.State.RUNNING);
-        HealthCheckResponse response = healthCheck.call();
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
     }
 
     @Test
     public void shouldBeUpIfStateRebalancing() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
         Mockito.when(streams.state()).thenReturn(KafkaStreams.State.REBALANCING);
-        HealthCheckResponse response = healthCheck.call();
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
     }
 
     @Test
     public void shouldBeDownIfStateCreated() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
         Mockito.when(streams.state()).thenReturn(KafkaStreams.State.CREATED);
-        HealthCheckResponse response = healthCheck.call();
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
     }
 
     @Test
     public void shouldBeDownIfKafkaStreamsIsNull() {
         KafkaStreamsStateHealthCheck check = new KafkaStreamsStateHealthCheck();
-        HealthCheckResponse response = check.call();
+        check.runtimeConfig = Mockito.mock(KafkaStreamsRuntimeConfig.class);
+        Mockito.when(check.runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
+        HealthCheckResponse response = check.call().await().indefinitely();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
         assertThat(response.getData().get().get("technical_error"))
                 .isEqualTo("KafkaStreams instance not available");
     }
 
+    @Test
+    public void shouldBeUpWhenRuntimeHealthDisabled() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(false);
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+    }
+
+    @Test
+    public void shouldBeDownIfStateNotReady() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
+        Mockito.when(streams.state()).thenReturn(KafkaStreams.State.NOT_RUNNING);
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData().get().get("state")).isEqualTo("NOT_RUNNING");
+    }
+
+    @Test
+    public void shouldBeDownIfStateThrowsException() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
+        Mockito.when(streams.state()).thenThrow(new RuntimeException("kafka error"));
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData().get().get("technical_error")).isEqualTo("kafka error");
+    }
+
+    @Test
+    public void shouldNotInteractWithKafkaStreamsWhenRuntimeDisabled() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(false);
+        healthCheck.call().await().indefinitely();
+        Mockito.verify(streams, Mockito.never()).state();
+    }
 }

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
@@ -41,4 +41,13 @@ public class KafkaStreamsHealthCheckTest {
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
     }
 
+    @Test
+    public void shouldBeDownIfKafkaStreamsIsNull() {
+        KafkaStreamsStateHealthCheck check = new KafkaStreamsStateHealthCheck();
+        HealthCheckResponse response = check.call();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData().get().get("technical_error"))
+                .isEqualTo("KafkaStreams instance not available");
+    }
+
 }

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
@@ -3,6 +3,7 @@ package io.quarkus.kafka.streams.runtime.health;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
+import java.util.Set;
 
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.quarkus.kafka.streams.runtime.KafkaStreamsRuntimeConfig;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,28 +25,70 @@ public class KafkaStreamsTopicsHealthCheckTest {
     @Mock
     private KafkaStreamsTopologyManager manager;
 
+    @Mock
+    private KafkaStreamsRuntimeConfig runtimeConfig;
+
     @Test
     public void shouldBeUpIfNoMissingTopic() throws InterruptedException {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
         Mockito.when(manager.isTopicsCheckEnabled()).thenReturn(true);
         Mockito.when(manager.getMissingTopics()).thenReturn(Collections.emptySet());
-        HealthCheckResponse response = healthCheck.call();
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
     }
 
     @Test
     public void shouldBeDownIfMissingTopic() throws InterruptedException {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
         Mockito.when(manager.isTopicsCheckEnabled()).thenReturn(true);
         Mockito.when(manager.getMissingTopics()).thenReturn(Collections.singleton("topic"));
-        HealthCheckResponse response = healthCheck.call();
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
     }
 
     @Test
     public void shouldBeDownIfManagerIsNull() {
-        KafkaStreamsTopicsHealthCheck check = new KafkaStreamsTopicsHealthCheck(null);
-        HealthCheckResponse response = check.call();
+        KafkaStreamsRuntimeConfig config = Mockito.mock(KafkaStreamsRuntimeConfig.class);
+        Mockito.when(config.healthRuntimeEnabled()).thenReturn(true);
+        KafkaStreamsTopicsHealthCheck check = new KafkaStreamsTopicsHealthCheck(null, config);
+        HealthCheckResponse response = check.call().await().indefinitely();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
         assertThat(response.getData().get().get("technical_error"))
                 .isEqualTo("KafkaStreamsTopologyManager not available");
+    }
+
+    @Test
+    public void shouldBeUpWhenRuntimeHealthDisabled() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(false);
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+    }
+
+    @Test
+    public void shouldBeUpWhenTopicsCheckIsDisabled() {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
+        Mockito.when(manager.isTopicsCheckEnabled()).thenReturn(false);
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+    }
+
+    @Test
+    public void shouldReportAvailableAndMissingTopics() throws InterruptedException {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
+        Mockito.when(manager.isTopicsCheckEnabled()).thenReturn(true);
+        Mockito.when(manager.getMissingTopics()).thenReturn(Set.of("missing-topic"));
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData().get().get("missing_topics")).isEqualTo("missing-topic");
+    }
+
+    @Test
+    public void shouldHandleInterruptedException() throws InterruptedException {
+        Mockito.when(runtimeConfig.healthRuntimeEnabled()).thenReturn(true);
+        Mockito.when(manager.isTopicsCheckEnabled()).thenReturn(true);
+        Mockito.when(manager.getMissingTopics()).thenThrow(new InterruptedException("test interrupt"));
+        HealthCheckResponse response = healthCheck.call().await().indefinitely();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData().get().get("technical_error")).isEqualTo("test interrupt");
     }
 }

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
@@ -38,4 +38,13 @@ public class KafkaStreamsTopicsHealthCheckTest {
         HealthCheckResponse response = healthCheck.call();
         assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
     }
+
+    @Test
+    public void shouldBeDownIfManagerIsNull() {
+        KafkaStreamsTopicsHealthCheck check = new KafkaStreamsTopicsHealthCheck(null);
+        HealthCheckResponse response = check.call();
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+        assertThat(response.getData().get().get("technical_error"))
+                .isEqualTo("KafkaStreamsTopologyManager not available");
+    }
 }

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
@@ -36,6 +36,9 @@ import io.quarkus.vertx.core.deployment.VertxOptionsConsumerBuildItem;
 
 @BuildSteps(onlyIf = TracerEnabled.class)
 public class InstrumentationProcessor {
+
+    static final String TRACING_KAFKA_CLIENT_SUPPLIER_CLASS_NAME = "io.quarkus.opentelemetry.runtime.tracing.instrumentation.kafka.TracingKafkaClientSupplier";
+
     static class MetricsExtensionAvailable implements BooleanSupplier {
         private static final boolean IS_MICROMETER_EXTENSION_AVAILABLE = isClassPresentAtRuntime(
                 "io.quarkus.micrometer.runtime.binder.vertx.VertxHttpServerMetrics");
@@ -65,6 +68,16 @@ public class InstrumentationProcessor {
         @Override
         public boolean getAsBoolean() {
             return IS_GRPC_EXTENSION_AVAILABLE;
+        }
+    }
+
+    static class KafkaStreamsExtensionAvailable implements BooleanSupplier {
+        private static final boolean IS_KAFKA_STREAMS_AVAILABLE = isClassPresentAtRuntime(
+                "org.apache.kafka.streams.KafkaStreams");
+
+        @Override
+        public boolean getAsBoolean() {
+            return IS_KAFKA_STREAMS_AVAILABLE;
         }
     }
 
@@ -107,6 +120,17 @@ public class InstrumentationProcessor {
         if (capabilities.isPresent(Capability.MESSAGING) && config.instrument().messaging()) {
             additionalBeans.produce(new AdditionalBeanBuildItem(ReactiveMessagingTracingOutgoingDecorator.class));
             additionalBeans.produce(new AdditionalBeanBuildItem(ReactiveMessagingTracingIncomingDecorator.class));
+        }
+    }
+
+    @BuildStep(onlyIf = KafkaStreamsExtensionAvailable.class)
+    void registerKafkaStreamsTracing(
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            OTelBuildConfig config) {
+        if (config.instrument().kafkaStreams()) {
+            additionalBeans.produce(AdditionalBeanBuildItem.builder()
+                    .addBeanClass(TRACING_KAFKA_CLIENT_SUPPLIER_CLASS_NAME)
+                    .setUnremovable().build());
         }
     }
 

--- a/extensions/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/runtime/pom.xml
@@ -206,6 +206,16 @@
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/InstrumentBuildTimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/InstrumentBuildTimeConfig.java
@@ -36,6 +36,12 @@ public interface InstrumentBuildTimeConfig {
     @WithDefault("true")
     boolean resteasy();
 
+    /**
+     * Enables instrumentation for Kafka Streams.
+     */
+    @WithDefault("true")
+    boolean kafkaStreams();
+
     // NOTE: agroal, graphql and scheduler have their own config properties
 
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/kafka/TracingKafkaClientSupplier.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/kafka/TracingKafkaClientSupplier.java
@@ -1,0 +1,53 @@
+package io.quarkus.opentelemetry.runtime.tracing.instrumentation.kafka;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
+
+@ApplicationScoped
+public class TracingKafkaClientSupplier implements KafkaClientSupplier {
+
+    private final KafkaTelemetry kafkaTelemetry;
+    private final KafkaClientSupplier delegate;
+
+    @Inject
+    public TracingKafkaClientSupplier(OpenTelemetry openTelemetry) {
+        this.kafkaTelemetry = KafkaTelemetry.create(openTelemetry);
+        this.delegate = new DefaultKafkaClientSupplier();
+    }
+
+    @Override
+    public Admin getAdmin(Map<String, Object> config) {
+        return delegate.getAdmin(config);
+    }
+
+    @Override
+    public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
+        return kafkaTelemetry.wrap(delegate.getProducer(config));
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
+        return kafkaTelemetry.wrap(delegate.getConsumer(config));
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
+        return delegate.getRestoreConsumer(config);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getGlobalConsumer(Map<String, Object> config) {
+        return kafkaTelemetry.wrap(delegate.getGlobalConsumer(config));
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/kafka/TracingKafkaClientSupplier.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/kafka/TracingKafkaClientSupplier.java
@@ -22,8 +22,13 @@ public class TracingKafkaClientSupplier implements KafkaClientSupplier {
 
     @Inject
     public TracingKafkaClientSupplier(OpenTelemetry openTelemetry) {
-        this.kafkaTelemetry = KafkaTelemetry.create(openTelemetry);
-        this.delegate = new DefaultKafkaClientSupplier();
+        this(KafkaTelemetry.create(openTelemetry), new DefaultKafkaClientSupplier());
+    }
+
+    // visible for testing
+    TracingKafkaClientSupplier(KafkaTelemetry kafkaTelemetry, KafkaClientSupplier delegate) {
+        this.kafkaTelemetry = kafkaTelemetry;
+        this.delegate = delegate;
     }
 
     @Override

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/kafka/TracingKafkaClientSupplierTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/kafka/TracingKafkaClientSupplierTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.opentelemetry.runtime.tracing.instrumentation.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
+
+public class TracingKafkaClientSupplierTest {
+
+    private final Map<String, Object> config = Collections.emptyMap();
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapProducerWithTracing() {
+        KafkaClientSupplier delegate = mock(KafkaClientSupplier.class);
+        KafkaTelemetry telemetry = mock(KafkaTelemetry.class);
+        Producer<byte[], byte[]> rawProducer = mock(Producer.class);
+        Producer<byte[], byte[]> wrappedProducer = mock(Producer.class);
+
+        when(delegate.getProducer(config)).thenReturn(rawProducer);
+        when(telemetry.wrap(rawProducer)).thenReturn(wrappedProducer);
+
+        TracingKafkaClientSupplier supplier = new TracingKafkaClientSupplier(telemetry, delegate);
+        Producer<byte[], byte[]> result = supplier.getProducer(config);
+
+        assertThat(result).isSameAs(wrappedProducer);
+        verify(telemetry).wrap(rawProducer);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapConsumerWithTracing() {
+        KafkaClientSupplier delegate = mock(KafkaClientSupplier.class);
+        KafkaTelemetry telemetry = mock(KafkaTelemetry.class);
+        Consumer<byte[], byte[]> rawConsumer = mock(Consumer.class);
+        Consumer<byte[], byte[]> wrappedConsumer = mock(Consumer.class);
+
+        when(delegate.getConsumer(config)).thenReturn(rawConsumer);
+        when(telemetry.wrap(rawConsumer)).thenReturn(wrappedConsumer);
+
+        TracingKafkaClientSupplier supplier = new TracingKafkaClientSupplier(telemetry, delegate);
+        Consumer<byte[], byte[]> result = supplier.getConsumer(config);
+
+        assertThat(result).isSameAs(wrappedConsumer);
+        verify(telemetry).wrap(rawConsumer);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapGlobalConsumerWithTracing() {
+        KafkaClientSupplier delegate = mock(KafkaClientSupplier.class);
+        KafkaTelemetry telemetry = mock(KafkaTelemetry.class);
+        Consumer<byte[], byte[]> rawConsumer = mock(Consumer.class);
+        Consumer<byte[], byte[]> wrappedConsumer = mock(Consumer.class);
+
+        when(delegate.getGlobalConsumer(config)).thenReturn(rawConsumer);
+        when(telemetry.wrap(rawConsumer)).thenReturn(wrappedConsumer);
+
+        TracingKafkaClientSupplier supplier = new TracingKafkaClientSupplier(telemetry, delegate);
+        Consumer<byte[], byte[]> result = supplier.getGlobalConsumer(config);
+
+        assertThat(result).isSameAs(wrappedConsumer);
+        verify(telemetry).wrap(rawConsumer);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotWrapRestoreConsumer() {
+        KafkaClientSupplier delegate = mock(KafkaClientSupplier.class);
+        KafkaTelemetry telemetry = mock(KafkaTelemetry.class);
+        Consumer<byte[], byte[]> rawConsumer = mock(Consumer.class);
+
+        when(delegate.getRestoreConsumer(config)).thenReturn(rawConsumer);
+
+        TracingKafkaClientSupplier supplier = new TracingKafkaClientSupplier(telemetry, delegate);
+        Consumer<byte[], byte[]> result = supplier.getRestoreConsumer(config);
+
+        assertThat(result).isSameAs(rawConsumer);
+        verifyNoInteractions(telemetry);
+    }
+
+    @Test
+    public void shouldDelegateAdmin() {
+        KafkaClientSupplier delegate = mock(KafkaClientSupplier.class);
+        KafkaTelemetry telemetry = mock(KafkaTelemetry.class);
+        Admin admin = mock(Admin.class);
+
+        when(delegate.getAdmin(config)).thenReturn(admin);
+
+        TracingKafkaClientSupplier supplier = new TracingKafkaClientSupplier(telemetry, delegate);
+        Admin result = supplier.getAdmin(config);
+
+        assertThat(result).isSameAs(admin);
+        verifyNoInteractions(telemetry);
+    }
+}

--- a/integration-tests/kafka-streams-no-rocksdb/pom.xml
+++ b/integration-tests/kafka-streams-no-rocksdb/pom.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-kafka-streams-no-rocksdb</artifactId>
+    <name>Quarkus - Integration Tests - Kafka Streams (No RocksDB)</name>
+    <description>Kafka Streams integration tests with RocksDB native support disabled</description>
+
+    <dependencies>
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+
+        <!-- Kafka Streams -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-streams</artifactId>
+        </dependency>
+
+        <!-- Health -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-streams-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-kafka</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>skip-tests-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/kafka-streams-no-rocksdb/src/main/java/io/quarkus/it/kafka/streams/norocksdb/InMemoryPipeline.java
+++ b/integration-tests/kafka-streams-no-rocksdb/src/main/java/io/quarkus/it/kafka/streams/norocksdb/InMemoryPipeline.java
@@ -1,0 +1,41 @@
+package io.quarkus.it.kafka.streams.norocksdb;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.Stores;
+
+/**
+ * A Kafka Streams topology that uses exclusively in-memory state stores.
+ * This topology must work correctly when {@code quarkus.kafka-streams.rocksdb.enabled=false}.
+ */
+@ApplicationScoped
+public class InMemoryPipeline {
+
+    @Produces
+    public Topology buildTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        KeyValueBytesStoreSupplier storeSupplier = Stores.inMemoryKeyValueStore("word-count-store");
+
+        // Simple word-count: read strings, split into words, count occurrences
+        builder.stream("no-rocksdb-input", Consumed.with(Serdes.String(), Serdes.String()))
+                .flatMapValues(value -> java.util.Arrays.asList(value.toLowerCase().split("\\W+")))
+                .groupBy((key, word) -> word, Grouped.with(Serdes.String(), Serdes.String()))
+                .count(Materialized.<String, Long> as(storeSupplier)
+                        .withKeySerde(Serdes.String())
+                        .withValueSerde(Serdes.Long()))
+                .toStream()
+                .to("no-rocksdb-output", Produced.with(Serdes.String(), Serdes.Long()));
+
+        return builder.build();
+    }
+}

--- a/integration-tests/kafka-streams-no-rocksdb/src/main/java/io/quarkus/it/kafka/streams/norocksdb/Message.java
+++ b/integration-tests/kafka-streams-no-rocksdb/src/main/java/io/quarkus/it/kafka/streams/norocksdb/Message.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.kafka.streams.norocksdb;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class Message {
+
+    public String key;
+    public String value;
+
+    public Message() {
+    }
+
+    public Message(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/integration-tests/kafka-streams-no-rocksdb/src/main/java/io/quarkus/it/kafka/streams/norocksdb/WordCountEndpoint.java
+++ b/integration-tests/kafka-streams-no-rocksdb/src/main/java/io/quarkus/it/kafka/streams/norocksdb/WordCountEndpoint.java
@@ -1,0 +1,45 @@
+package io.quarkus.it.kafka.streams.norocksdb;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+
+@ApplicationScoped
+@Path("/wordcount")
+public class WordCountEndpoint {
+
+    @Inject
+    KafkaStreams streams;
+
+    @GET
+    @Path("/{word}")
+    public Long getCount(@PathParam("word") String word) {
+        return getStore().get(word);
+    }
+
+    @POST
+    @Path("/stop")
+    public void stop() {
+        streams.close();
+    }
+
+    private ReadOnlyKeyValueStore<String, Long> getStore() {
+        while (true) {
+            try {
+                return streams.store(
+                        StoreQueryParameters.fromNameAndType("word-count-store", QueryableStoreTypes.keyValueStore()));
+            } catch (InvalidStateStoreException e) {
+                // ignore, store not ready yet
+            }
+        }
+    }
+}

--- a/integration-tests/kafka-streams-no-rocksdb/src/main/resources/application.properties
+++ b/integration-tests/kafka-streams-no-rocksdb/src/main/resources/application.properties
@@ -1,0 +1,20 @@
+quarkus.log.category.kafka.level=WARN
+quarkus.log.category."org.apache.kafka".level=WARN
+quarkus.log.category."org.apache.zookeeper".level=WARN
+
+# Disable RocksDB native support - the key config under test
+quarkus.kafka-streams.rocksdb.enabled=false
+
+# streams options - use in-memory stores only (no RocksDB)
+kafka-streams.cache.max.bytes.buffering=10240
+kafka-streams.commit.interval.ms=1000
+kafka-streams.metadata.max.age.ms=500
+kafka.auto.offset.reset=earliest
+
+%test.quarkus.application.name=streams-no-rocksdb-test
+
+# using QuarkusTestResourceLifecycleManager in this test
+quarkus.kafka.devservices.enabled=false
+
+# Enable health checks
+quarkus.kafka-streams.health.enabled=true

--- a/integration-tests/kafka-streams-no-rocksdb/src/test/java/io/quarkus/it/kafka/streams/norocksdb/KafkaStreamsNoRocksDbIT.java
+++ b/integration-tests/kafka-streams-no-rocksdb/src/test/java/io/quarkus/it/kafka/streams/norocksdb/KafkaStreamsNoRocksDbIT.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.kafka.streams.norocksdb;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+/**
+ * Native integration test for Kafka Streams with RocksDB disabled.
+ * <p>
+ * This runs the same tests as {@link KafkaStreamsNoRocksDbTest} but against the
+ * native executable, which was built with {@code quarkus.kafka-streams.rocksdb.enabled=false}.
+ * This verifies that the native image works without RocksDB JNI registration,
+ * native lib loading, and the GraalVM RocksDB feature.
+ */
+@QuarkusIntegrationTest
+public class KafkaStreamsNoRocksDbIT extends KafkaStreamsNoRocksDbTest {
+
+}

--- a/integration-tests/kafka-streams-no-rocksdb/src/test/java/io/quarkus/it/kafka/streams/norocksdb/KafkaStreamsNoRocksDbTest.java
+++ b/integration-tests/kafka-streams-no-rocksdb/src/test/java/io/quarkus/it/kafka/streams/norocksdb/KafkaStreamsNoRocksDbTest.java
@@ -1,0 +1,148 @@
+package io.quarkus.it.kafka.streams.norocksdb;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.http.HttpStatus;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Integration test verifying Kafka Streams works with in-memory stores
+ * when {@code quarkus.kafka-streams.rocksdb.enabled=false}.
+ * <p>
+ * The topology is a simple word-count using exclusively in-memory state stores.
+ */
+@QuarkusTestResource(KafkaTestResource.class)
+@QuarkusTest
+public class KafkaStreamsNoRocksDbTest {
+
+    @Test
+    public void testWordCountWithInMemoryStores() throws Exception {
+        // Wait for topics and verify health check is initially DOWN
+        testHealthNotReady();
+
+        // Produce messages
+        produceMessages();
+
+        // Consume word count results
+        KafkaConsumer<String, Long> consumer = createConsumer();
+        List<ConsumerRecord<String, Long>> records = poll(consumer, 3);
+
+        // Verify word counts
+        long helloCount = records.stream()
+                .filter(r -> "hello".equals(r.key()))
+                .mapToLong(ConsumerRecord::value)
+                .max().orElse(0);
+        long worldCount = records.stream()
+                .filter(r -> "world".equals(r.key()))
+                .mapToLong(ConsumerRecord::value)
+                .max().orElse(0);
+
+        Assertions.assertTrue(helloCount >= 2, "Expected at least 2 'hello' counts, got " + helloCount);
+        Assertions.assertTrue(worldCount >= 1, "Expected at least 1 'world' count, got " + worldCount);
+
+        // Verify interactive query works (in-memory store)
+        testInteractiveQuery();
+
+        // Verify health check is UP
+        testHealthReady();
+
+        // Stop pipeline before broker shuts down
+        RestAssured.post("/wordcount/stop");
+    }
+
+    private void testHealthNotReady() {
+        RestAssured.get("/q/health/ready").then()
+                .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
+                .rootPath("checks.find { it.name == 'Kafka Streams topics health check' }")
+                .body("status", CoreMatchers.is("DOWN"))
+                .body("data.missing_topics", containsString("no-rocksdb-input"));
+    }
+
+    private void testHealthReady() {
+        RestAssured.get("/q/health/ready").then()
+                .statusCode(HttpStatus.SC_OK)
+                .rootPath("checks.find { it.name == 'Kafka Streams topics health check' }")
+                .body("status", CoreMatchers.is("UP"));
+
+        RestAssured.get("/q/health/live").then()
+                .statusCode(HttpStatus.SC_OK)
+                .rootPath("checks.find { it.name == 'Kafka Streams state health check' }")
+                .body("status", CoreMatchers.is("UP"))
+                .body("data.state", CoreMatchers.is("RUNNING"));
+    }
+
+    private void testInteractiveQuery() throws Exception {
+        int attempts = 0;
+        Long count = null;
+        while (attempts < 50 && (count == null || count < 2)) {
+            String result = RestAssured.when().get("/wordcount/hello").asString();
+            if (result != null && !result.trim().isEmpty()) {
+                count = Long.valueOf(result);
+            }
+            Thread.sleep(100);
+            attempts++;
+        }
+        Assertions.assertNotNull(count, "Word count for 'hello' should not be null");
+        Assertions.assertTrue(count >= 2, "Expected at least 2 for 'hello', got " + count);
+    }
+
+    private void produceMessages() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaTestResource.getBootstrapServers());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
+            producer.send(new ProducerRecord<>("no-rocksdb-input", "key1", "hello world"));
+            producer.send(new ProducerRecord<>("no-rocksdb-input", "key2", "hello quarkus"));
+            producer.flush();
+        }
+    }
+
+    private KafkaConsumer<String, Long> createConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaTestResource.getBootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "no-rocksdb-test-consumer");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class.getName());
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        KafkaConsumer<String, Long> consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(Collections.singletonList("no-rocksdb-output"));
+        return consumer;
+    }
+
+    private List<ConsumerRecord<String, Long>> poll(KafkaConsumer<String, Long> consumer, int minRecords) {
+        List<ConsumerRecord<String, Long>> result = new ArrayList<>();
+        int attempts = 0;
+        while (result.size() < minRecords && attempts < 30) {
+            ConsumerRecords<String, Long> records = consumer.poll(Duration.ofMillis(1000));
+            records.forEach(result::add);
+            attempts++;
+        }
+        return result;
+    }
+}

--- a/integration-tests/kafka-streams-no-rocksdb/src/test/java/io/quarkus/it/kafka/streams/norocksdb/KafkaTestResource.java
+++ b/integration-tests/kafka-streams-no-rocksdb/src/test/java/io/quarkus/it/kafka/streams/norocksdb/KafkaTestResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.kafka.streams.norocksdb;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.strimzi.test.container.StrimziKafkaContainer;
+
+public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final StrimziKafkaContainer kafka = new StrimziKafkaContainer();
+
+    public static String getBootstrapServers() {
+        return kafka.getBootstrapServers();
+    }
+
+    @Override
+    public Map<String, String> start() {
+        kafka.start();
+        Map<String, String> properties = new HashMap<>();
+        properties.put("kafka.bootstrap.servers", kafka.getBootstrapServers());
+        return properties;
+    }
+
+    @Override
+    public void stop() {
+        if (kafka != null) {
+            kafka.close();
+        }
+    }
+}

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/CdiProcessorTracker.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/CdiProcessorTracker.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.kafka.streams;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CdiProcessorTracker {
+
+    private final List<String> processedValues = new CopyOnWriteArrayList<>();
+
+    public void track(String value) {
+        processedValues.add(value);
+    }
+
+    public List<String> getProcessedValues() {
+        return processedValues;
+    }
+
+    public int getProcessedCount() {
+        return processedValues.size();
+    }
+}

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/FixedKeyProcessorTracker.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/FixedKeyProcessorTracker.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.kafka.streams;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class FixedKeyProcessorTracker {
+
+    private final List<String> processedValues = new CopyOnWriteArrayList<>();
+
+    public void track(String value) {
+        processedValues.add(value);
+    }
+
+    public List<String> getProcessedValues() {
+        return processedValues;
+    }
+
+    public int getProcessedCount() {
+        return processedValues.size();
+    }
+}

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEndpoint.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEndpoint.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.kafka.streams;
 
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -24,6 +26,9 @@ public class KafkaStreamsEndpoint {
 
     @Inject
     CurrentStateListener stateListener;
+
+    @Inject
+    CdiProcessorTracker cdiProcessorTracker;
 
     private ReadOnlyKeyValueStore<Integer, Long> getCountstore() {
         while (true) {
@@ -51,5 +56,17 @@ public class KafkaStreamsEndpoint {
     @Path("/state")
     public String state() {
         return stateListener.currentState.name();
+    }
+
+    @GET
+    @Path("/cdi-processor/count")
+    public int cdiProcessorCount() {
+        return cdiProcessorTracker.getProcessedCount();
+    }
+
+    @GET
+    @Path("/cdi-processor/values")
+    public List<String> cdiProcessorValues() {
+        return cdiProcessorTracker.getProcessedValues();
     }
 }

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEndpoint.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEndpoint.java
@@ -30,6 +30,9 @@ public class KafkaStreamsEndpoint {
     @Inject
     CdiProcessorTracker cdiProcessorTracker;
 
+    @Inject
+    FixedKeyProcessorTracker fixedKeyProcessorTracker;
+
     private ReadOnlyKeyValueStore<Integer, Long> getCountstore() {
         while (true) {
             try {
@@ -68,5 +71,17 @@ public class KafkaStreamsEndpoint {
     @Path("/cdi-processor/values")
     public List<String> cdiProcessorValues() {
         return cdiProcessorTracker.getProcessedValues();
+    }
+
+    @GET
+    @Path("/fixed-key-processor/count")
+    public int fixedKeyProcessorCount() {
+        return fixedKeyProcessorTracker.getProcessedCount();
+    }
+
+    @GET
+    @Path("/fixed-key-processor/values")
+    public List<String> fixedKeyProcessorValues() {
+        return fixedKeyProcessorTracker.getProcessedValues();
     }
 }

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
@@ -19,6 +19,7 @@ import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.Stores;
 
 import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
+import io.quarkus.kafka.streams.runtime.CdiAwareFixedKeyProcessorSupplier;
 import io.quarkus.kafka.streams.runtime.CdiAwareProcessorSupplier;
 
 @ApplicationScoped
@@ -50,10 +51,14 @@ public class KafkaStreamsPipeline {
         customers.groupByKey()
                 .count(Materialized.<Integer, Long> as(storeSupplier));
 
+        // CdiAwareFixedKeyProcessorSupplier: pass-through that tracks via @Inject, proves
+        // FixedKeyProcessor CDI integration works and records flow through unchanged
         customers.selectKey((categoryId, customer) -> customer.id)
+                .processValues(CdiAwareFixedKeyProcessorSupplier.of(TrackingFixedKeyProcessor.class))
                 .to("streams-test-customers-processed", Produced.with(Serdes.Integer(), enrichedCustomerSerde));
 
-        // CDI-aware processor: verifies @Inject works on Kafka Streams threads
+        // CdiAwareProcessorSupplier: terminal processor that verifies @RequestScoped
+        // injection works on Kafka Streams threads (would throw ContextNotActiveException otherwise)
         customers.process(CdiAwareProcessorSupplier.of(TrackingProcessor.class));
 
         return builder.build();

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
@@ -19,6 +19,7 @@ import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.Stores;
 
 import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
+import io.quarkus.kafka.streams.runtime.CdiAwareProcessorSupplier;
 
 @ApplicationScoped
 public class KafkaStreamsPipeline {
@@ -51,6 +52,9 @@ public class KafkaStreamsPipeline {
 
         customers.selectKey((categoryId, customer) -> customer.id)
                 .to("streams-test-customers-processed", Produced.with(Serdes.Integer(), enrichedCustomerSerde));
+
+        // CDI-aware processor: verifies @Inject works on Kafka Streams threads
+        customers.process(CdiAwareProcessorSupplier.of(TrackingProcessor.class));
 
         return builder.build();
     }

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/RequestScopedHandler.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/RequestScopedHandler.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.kafka.streams;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+/**
+ * A {@link RequestScoped} bean that delegates to {@link CdiProcessorTracker}.
+ * <p>
+ * If CDI request context is not active when this bean's methods are invoked,
+ * a {@code ContextNotActiveException} will be thrown. This proves that
+ * {@code CdiAwareProcessorSupplier} correctly activates request context
+ * around each {@code process()} call.
+ */
+@RequestScoped
+public class RequestScopedHandler {
+
+    @Inject
+    CdiProcessorTracker tracker;
+
+    public void handle(String value) {
+        tracker.track(value);
+    }
+}

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/TrackingFixedKeyProcessor.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/TrackingFixedKeyProcessor.java
@@ -1,0 +1,35 @@
+package io.quarkus.it.kafka.streams;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+
+import io.quarkus.arc.Unremovable;
+
+@Dependent
+@Unremovable
+public class TrackingFixedKeyProcessor implements FixedKeyProcessor<Integer, EnrichedCustomer, EnrichedCustomer> {
+
+    @Inject
+    FixedKeyProcessorTracker tracker;
+
+    private FixedKeyProcessorContext<Integer, EnrichedCustomer> context;
+
+    @Override
+    public void init(FixedKeyProcessorContext<Integer, EnrichedCustomer> context) {
+        this.context = context;
+    }
+
+    @Override
+    public void process(FixedKeyRecord<Integer, EnrichedCustomer> record) {
+        tracker.track(record.value().name);
+        context.forward(record);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/TrackingProcessor.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/TrackingProcessor.java
@@ -14,7 +14,7 @@ import io.quarkus.arc.Unremovable;
 public class TrackingProcessor implements Processor<Integer, EnrichedCustomer, Void, Void> {
 
     @Inject
-    CdiProcessorTracker tracker;
+    RequestScopedHandler handler;
 
     @Override
     public void init(ProcessorContext<Void, Void> context) {
@@ -22,7 +22,10 @@ public class TrackingProcessor implements Processor<Integer, EnrichedCustomer, V
 
     @Override
     public void process(Record<Integer, EnrichedCustomer> record) {
-        tracker.track(record.value().name);
+        // This call goes through a @RequestScoped proxy.
+        // If CdiAwareProcessorSupplier did NOT activate request context,
+        // this would throw ContextNotActiveException.
+        handler.handle(record.value().name);
     }
 
     @Override

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/TrackingProcessor.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/TrackingProcessor.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.kafka.streams;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+
+import io.quarkus.arc.Unremovable;
+
+@Dependent
+@Unremovable
+public class TrackingProcessor implements Processor<Integer, EnrichedCustomer, Void, Void> {
+
+    @Inject
+    CdiProcessorTracker tracker;
+
+    @Override
+    public void init(ProcessorContext<Void, Void> context) {
+    }
+
+    @Override
+    public void process(Record<Integer, EnrichedCustomer> record) {
+        tracker.track(record.value().name);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsRocksDbDisabledTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsRocksDbDisabledTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.kafka.streams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Runs the full Kafka Streams test suite with {@code quarkus.kafka-streams.rocksdb.enabled=false}.
+ * <p>
+ * This verifies that disabling RocksDB native support at build time does not
+ * break Kafka Streams when using in-memory state stores (which the test topology does).
+ * In JVM mode, RocksDB JARs are still on the classpath but the build-time registration
+ * steps (JNI, native lib loading, GraalVM feature) are skipped.
+ */
+@QuarkusTestResource(KafkaSSLTestResource.class)
+@TestProfile(KafkaStreamsRocksDbDisabledTest.RocksDbDisabledProfile.class)
+@QuarkusTest
+public class KafkaStreamsRocksDbDisabledTest extends KafkaStreamsTest {
+
+    public static class RocksDbDisabledProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> conf = new HashMap<>();
+            conf.put("quarkus.kafka-streams.rocksdb.enabled", "false");
+            return conf;
+        }
+    }
+}

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.kafka.streams;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
 
 import java.io.File;
 import java.time.Duration;
@@ -133,11 +134,24 @@ public class KafkaStreamsTest {
         testKafkaStreamsAliveAndReady();
         RestAssured.when().get("/kafkastreams/state").then().body(CoreMatchers.is("RUNNING"));
 
+        testCdiAwareProcessor();
         testMetricsPresent();
 
         // explicitly stopping the pipeline *before* the broker is shut down, as it
         // otherwise will time out
         RestAssured.post("/kafkastreams/stop");
+    }
+
+    private void testCdiAwareProcessor() {
+        // Verify CdiAwareProcessorSupplier created a processor with @Inject working
+        // The TrackingProcessor uses @Inject CdiProcessorTracker, proving CDI works on Kafka Streams threads
+        RestAssured.when().get("/kafkastreams/cdi-processor/count").then()
+                .statusCode(200)
+                .body(CoreMatchers.is("4"));
+
+        RestAssured.when().get("/kafkastreams/cdi-processor/values").then()
+                .statusCode(200)
+                .body("$", hasItems("Bob", "Becky", "Bruce", "Bert"));
     }
 
     private void testMetricsPresent() {

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -143,13 +143,25 @@ public class KafkaStreamsTest {
     }
 
     private void testCdiAwareProcessor() {
-        // Verify CdiAwareProcessorSupplier created a processor with @Inject working
-        // The TrackingProcessor uses @Inject CdiProcessorTracker, proving CDI works on Kafka Streams threads
+        // CdiAwareProcessorSupplier: TrackingProcessor uses @Inject on a @RequestScoped bean.
+        // If request context was not activated, ContextNotActiveException would have been thrown
+        // and no values would be tracked.
         RestAssured.when().get("/kafkastreams/cdi-processor/count").then()
                 .statusCode(200)
                 .body(CoreMatchers.is("4"));
 
         RestAssured.when().get("/kafkastreams/cdi-processor/values").then()
+                .statusCode(200)
+                .body("$", hasItems("Bob", "Becky", "Bruce", "Bert"));
+
+        // CdiAwareFixedKeyProcessorSupplier: TrackingFixedKeyProcessor is a pass-through
+        // wired via processValues(). It tracks values AND forwards records downstream,
+        // so the output topic still receives all records (verified above in the consumer poll).
+        RestAssured.when().get("/kafkastreams/fixed-key-processor/count").then()
+                .statusCode(200)
+                .body(CoreMatchers.is("4"));
+
+        RestAssured.when().get("/kafkastreams/fixed-key-processor/values").then()
                 .statusCode(200)
                 .body("$", hasItems("Bob", "Becky", "Bruce", "Bert"));
     }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -192,6 +192,7 @@
                 <module>kafka-avro-apicurio2</module>
                 <module>kafka-json-schema-apicurio2</module>
                 <module>kafka-streams</module>
+                <module>kafka-streams-no-rocksdb</module>
                 <module>kafka-devservices</module>
                 <module>jpa</module>
                 <module>jpa-mapping-xml</module>


### PR DESCRIPTION
## Summary

Comprehensive improvements to the Kafka Streams extension covering new features, bug fixes, code quality, and test coverage.

### New features
- **OpenTelemetry tracing support**: Auto-activating `TracingKafkaClientSupplier` when `quarkus-opentelemetry` is present
- **CDI-aware processor suppliers**: `CdiAwareProcessorSupplier` and `CdiAwareFixedKeyProcessorSupplier` with request context activation on Kafka Streams threads
- **Conditional RocksDB support**: Build-time `quarkus.kafka-streams.rocksdb.enabled` flag to disable RocksDB for in-memory-only or ARM native builds
- **Runtime health check toggle**: `quarkus.kafka-streams.health.runtime-enabled` for same-image deployments across environments
- **Configurable topic poll interval**: `quarkus.kafka-streams.topics-poll-interval` replacing hard-coded 1s sleep

### Bug fixes
- **GH-46448**: Config providers (`config.providers.*`) now copied to admin client config, fixing Strimzi Kubernetes Secret Config Provider for SSL certs
- **GH-42882**: Health checks converted to non-blocking `AsyncHealthCheck`, preventing probe timeouts under high load
- **GH-47412**: Health check enable config can now be toggled at runtime
- Health checks null-safety when no Topology is provided
- Fix `topology.get()` called twice in `KafkaStreamsProducer` (could create two different topology instances)
- Fix TOCTOU race condition in `HotReplacementInterceptor` volatile field
- Fix `adminClient.close(Duration.ZERO)` changed to graceful 10s timeout
- Fix double initialization in `KafkaStreamsTopicsHealthCheck`
- Fix thread-safety in `KafkaStreamsJsonRPCService` matcher fields (use ThreadLocal)
- Fix typo "ans" → "and" in `KafkaStreamsTopologyManager`

### Build & deployment
- RocksDB reflection registration conditional on `rocksdb.enabled`
- Auto-mark `Processor`/`FixedKeyProcessor` CDI beans as `@Unremovable`
- New `kafka-streams-no-rocksdb` integration test module for JVM + native testing
- Added to `.github/native-tests.json` (Messaging1 category)

### Tests
- 29 unit tests covering health checks, admin client config, CDI processors, topology manager
- Integration tests for CDI-aware processors (Processor + FixedKeyProcessor) 
- Integration tests for RocksDB-disabled mode (word count with in-memory stores)
- JVM test with `@TestProfile` for RocksDB disabled in existing module

Fixes #46448
Fixes #42882
Fixes #47412

## Test plan
- [x] Unit tests pass (29 tests, 0 failures)
- [x] Extension builds successfully (`mvnw install -f extensions/kafka-streams/`)
- [ ] Integration tests pass (`mvnw verify -f integration-tests/kafka-streams/`)
- [ ] Integration tests pass (`mvnw verify -f integration-tests/kafka-streams-no-rocksdb/`)
- [ ] Native tests pass (`mvnw verify -f integration-tests/kafka-streams-no-rocksdb/ -Dnative`)
- [ ] CI passes