### PR TITLE
Use dev services for ITs in hibernate-reactive-orm-compatibility

### DIFF
--- a/integration-tests/hibernate-reactive-orm-compatibility/pom.xml
+++ b/integration-tests/hibernate-reactive-orm-compatibility/pom.xml
@@ -125,6 +125,12 @@
 
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/integration-tests/hibernate-reactive-orm-compatibility/pom.xml
+++ b/integration-tests/hibernate-reactive-orm-compatibility/pom.xml
@@ -13,11 +13,6 @@
     <name>Quarkus - Integration Tests - Hibernate Reactive - Compatibility with ORM</name>
     <description>Hibernate Reactive related tests to make sure Reactive and ORM can work together</description>
 
-    <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-        <postgres.blocking.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.blocking.url>
-    </properties>
-
     <dependencies>
 
         <!-- Hibernate reactive -->
@@ -130,12 +125,6 @@
 
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -195,85 +184,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>docker-postgresql</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${postgres.image}</name>
-                                    <alias>postgresql</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
-                                             and that's the truth the second time only.
-                                             See https://github.com/fabric8io/docker-maven-plugin/issues/628
-                                             See also how the condition is configured in testcontainers:
-                                             https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
-                                            <time>20000</time>
-                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all postgres images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 

--- a/integration-tests/hibernate-reactive-orm-compatibility/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-orm-compatibility/src/main/resources/application.properties
@@ -1,12 +1,1 @@
-# Hibernate config
-#quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.database.generation=drop-and-create
-
-# Reactive config
-quarkus.datasource.reactive.url=${postgres.reactive.url}
-
-# ORM Config
-quarkus.datasource.jdbc.url=${postgres.blocking.url}
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=hibernate_orm_test
-quarkus.datasource.password=hibernate_orm_test


### PR DESCRIPTION
Replace docker-maven-plugin with Quarkus Dev Services for automatic PostgreSQL provisioning, consistent with other hibernate-reactive ITs.

* Fixes #52943

