### PR TITLE
Use IdlReader instead of deprecated Idl parser in Avro extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4594,6 +4594,11 @@
                 <version>${avro.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-idl</artifactId>
+                <version>${avro.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-streams</artifactId>
                 <version>${kafka.version}</version>

--- a/extensions/avro/deployment/pom.xml
+++ b/extensions/avro/deployment/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>avro-compiler</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-idl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>

--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroIDLCodeGenProvider.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroIDLCodeGenProvider.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.apache.avro.Protocol;
-import org.apache.avro.compiler.idl.Idl;
-import org.apache.avro.compiler.idl.ParseException;
 import org.apache.avro.compiler.specific.SpecificCompiler;
+import org.apache.avro.idl.IdlFile;
+import org.apache.avro.idl.IdlReader;
 
 import io.quarkus.bootstrap.prebuild.CodeGenException;
 import io.quarkus.deployment.CodeGenProvider;
@@ -29,11 +29,18 @@ public class AvroIDLCodeGenProvider extends AvroCodeGenProviderBase implements C
 
     @Override
     void compileSingleFile(Path filePath, Path outputDir, AvroOptions options) throws CodeGenException {
-        try (Idl parser = new Idl(filePath.toFile())) {
-            Protocol idlProtocol = parser.CompilationUnit();
-            String json = idlProtocol.toString(false);
-            Protocol protocol = Protocol.parse(json);
-            final SpecificCompiler compiler = new SpecificCompiler(protocol);
+        try {
+            IdlReader reader = new IdlReader();
+            IdlFile idlFile = reader.parse(filePath);
+
+            final SpecificCompiler compiler;
+            Protocol protocol = idlFile.getProtocol();
+            if (protocol != null) {
+                compiler = new SpecificCompiler(protocol);
+            } else {
+                compiler = new SpecificCompiler(idlFile.getNamedSchemas().values());
+            }
+
             compiler.setTemplateDir(templateDirectory);
             compiler.setStringType(options.stringType);
             compiler.setFieldVisibility(SpecificCompiler.FieldVisibility.PRIVATE);
@@ -45,7 +52,7 @@ public class AvroIDLCodeGenProvider extends AvroCodeGenProviderBase implements C
 
             compiler.setOutputCharacterEncoding("UTF-8");
             compiler.compileToDestination(filePath.toFile(), outputDir.toFile());
-        } catch (IOException | ParseException e) {
+        } catch (IOException e) {
             throw new CodeGenException("Failed to compile avro IDL file: " + filePath.toString() + " to Java", e);
         }
     }

--- a/integration-tests/avro-reload/src/test/avro/NamedSchema.avdl
+++ b/integration-tests/avro-reload/src/test/avro/NamedSchema.avdl
@@ -1,0 +1,6 @@
+namespace test;
+
+record NamedSchemaRecord {
+    string name;
+    string description;
+}

--- a/integration-tests/avro-reload/src/test/java/io/quarkus/avro/deployment/AvroCodeReloadTest.java
+++ b/integration-tests/avro-reload/src/test/java/io/quarkus/avro/deployment/AvroCodeReloadTest.java
@@ -44,6 +44,11 @@ public class AvroCodeReloadTest {
     }
 
     @Test
+    void shouldCompileNamedSchemaIdl() {
+        assertThat(when().get("/named-schema").body().print()).isEqualTo("test,test description");
+    }
+
+    @Test
     void shouldAlterAvdl() throws InterruptedException {
         assertThat(when().get("/avdl").body().print().split(",")).containsExactlyInAnyOrder("LOW", "MEDIUM", "HIGH");
 

--- a/integration-tests/avro-reload/src/test/java/io/quarkus/avro/deployment/AvroReloadResource.java
+++ b/integration-tests/avro-reload/src/test/java/io/quarkus/avro/deployment/AvroReloadResource.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 import test.Level;
+import test.NamedSchemaRecord;
 import test.PrivacyImport;
 import test.ProtocolPrivacy;
 
@@ -28,6 +29,16 @@ public class AvroReloadResource {
     @Path("/avdl")
     public String getAvailableLevel() {
         return Arrays.stream(Level.values()).map(String::valueOf).collect(joining(","));
+    }
+
+    @GET
+    @Path("/named-schema")
+    public String getNamedSchemaFields() {
+        NamedSchemaRecord record = NamedSchemaRecord.newBuilder()
+                .setName("test")
+                .setDescription("test description")
+                .build();
+        return record.getName() + "," + record.getDescription();
     }
 
 }


### PR DESCRIPTION
## Summary

- Switch from deprecated `Idl` parser to `IdlReader` (from `avro-idl` artifact) in the Avro extension's IDL code generation
- `IdlReader` supports both the traditional protocol-wrapped syntax and the new named schema IDL syntax introduced in Avro 1.12.0
- Add `avro-idl` dependency to the BOM and the avro deployment module
- Add integration test covering named schema IDL compilation

Fixes #52882

## Test plan

- [x] Existing `shouldAlterAvdl` test passes (backward compatibility with protocol syntax)
- [x] New `shouldCompileNamedSchemaIdl` test passes (named schema syntax from the issue)
- [x] All 4 avro-reload integration tests pass