### PR TITLE
Add unit tests for Avro code generation providers

### DIFF
--- a/extensions/avro/deployment/src/test/avro/protocol.avdl
+++ b/extensions/avro/deployment/src/test/avro/protocol.avdl
@@ -1,0 +1,22 @@
+/**
+ * An example protocol in Avro IDL
+ */
+@namespace("org.apache.avro.test")
+protocol Simple {
+	// Import the example file above
+	import idl "schema.avdl";
+
+	/** Errors are records that can be thrown from a method */
+	error TestError {
+		string message;
+	}
+
+	string hello(string greeting);
+	/** Return what was given. Demonstrates the use of backticks to name types/fields/messages/parameters after keywords */
+	TestRecord echo(TestRecord `record`);
+	int add(int arg1, int arg2);
+	bytes echoBytes(bytes data);
+	void `error`() throws TestError;
+	// The oneway keyword forces the method to return null.
+	void ping() oneway;
+}

--- a/extensions/avro/deployment/src/test/avro/protocol.avpr
+++ b/extensions/avro/deployment/src/test/avro/protocol.avpr
@@ -1,0 +1,53 @@
+{
+  "protocol": "ProtocolTest",
+  "namespace": "test",
+  "types": [
+    {
+      "type": "enum",
+      "name": "ProtocolPrivacy",
+      "symbols": [
+        "Public",
+        "Private"
+      ]
+    },
+    {
+      "type": "record",
+      "namespace": "test",
+      "name": "ProtocolUser",
+      "doc": "User Test Bean",
+      "fields": [
+        {
+          "name": "id",
+          "type": [
+            "null",
+            "string"
+          ],
+          "default": null
+        },
+        {
+          "name": "createdOn",
+          "type": [
+            "null",
+            "long"
+          ],
+          "default": null
+        },
+        {
+          "name": "privacy",
+          "type": [
+            "null",
+            "ProtocolPrivacy"
+          ],
+          "default": null
+        },
+        {
+          "name": "modifiedOn",
+          "type": {
+            "type": "long",
+            "logicalType": "timestamp-millis"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/extensions/avro/deployment/src/test/avro/schema.avdl
+++ b/extensions/avro/deployment/src/test/avro/schema.avdl
@@ -1,0 +1,36 @@
+// Optional default namespace (if absent, the default namespace is the null namespace).
+namespace org.apache.avro.test;
+
+// Optional main schema definition; if used, the IDL file is equivalent to a .avsc file.
+schema TestRecord;
+
+/** Documentation for the enum type Kind */
+@aliases(["org.foo.KindOf"])
+enum Kind {
+	FOO,
+	BAR, // the bar enum value
+	BAZ
+} = FOO;
+
+// For schema evolution purposes, unmatched values do not throw an error, but are resolved to FOO.
+/** MD5 hash; good enough to avoid most collisions, and smaller than (for example) SHA256. */
+fixed MD5(16);
+
+record TestRecord {
+	/** Record name; has no intrinsic order */
+	string @order("ignore") name;
+
+	Kind @order("descending") kind;
+
+	MD5 hash;
+	/*
+	Note that 'null' is the first union type. Just like .avsc / .avpr files, the default value must be of the first union type.
+	*/
+	union{null, MD5}
+			/** Optional field */
+			@aliases(["hash"]) nullableHash = null;
+	// Shorthand syntax; the null in this union is placed based on the default value (or first is there's no default).
+	MD5? anotherNullableHash = null;
+
+	array<long> arrayOfLongs;
+}

--- a/extensions/avro/deployment/src/test/avro/schema.avsc
+++ b/extensions/avro/deployment/src/test/avro/schema.avsc
@@ -1,0 +1,20 @@
+{
+  "type": "record",
+  "name": "LongList",
+  "aliases": [
+    "LinkedLongs"
+  ],
+  "fields": [
+    {
+      "name": "value",
+      "type": "long"
+    },
+    {
+      "name": "next",
+      "type": [
+        "null",
+        "LongList"
+      ]
+    }
+  ]
+}

--- a/extensions/avro/deployment/src/test/java/io/quarkus/avro/deployment/CompilationTest.java
+++ b/extensions/avro/deployment/src/test/java/io/quarkus/avro/deployment/CompilationTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.avro.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.nio.file.Path;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class CompilationTest {
+
+    private static final Config DEFAULT_CONFIG = new SmallRyeConfigBuilder()
+            .withDefaultValue("avro.codegen.stringType", "String")
+            .build();
+
+    @TempDir
+    Path outputDir;
+
+    @Test
+    public void testCanCompileIdlSchema() {
+        compileFile(new AvroIDLCodeGenProvider(), "src/test/avro/schema.avdl");
+    }
+
+    @Test
+    public void testCanCompileIdlProtocol() {
+        compileFile(new AvroIDLCodeGenProvider(), "src/test/avro/protocol.avdl");
+    }
+
+    @Test
+    public void testCanCompileAvscSchema() {
+        compileFile(new AvroSchemaCodeGenProvider(), "src/test/avro/schema.avsc");
+    }
+
+    @Test
+    public void testCanCompileAvprProtocol() {
+        compileFile(new AvroProtocolCodeGenProvider(), "src/test/avro/protocol.avpr");
+    }
+
+    private void compileFile(AvroCodeGenProviderBase provider, String filePath) {
+        AvroCodeGenProviderBase.AvroOptions options = provider.new AvroOptions(DEFAULT_CONFIG);
+        Path sourceFile = Path.of(filePath).toAbsolutePath();
+        assertDoesNotThrow(() -> provider.compileSingleFile(sourceFile, outputDir, options));
+    }
+}


### PR DESCRIPTION
Verify that each CodeGenProvider (avdl, avsc, avpr) can compile sample schemas.

Add failing and passing tests for the `quarkus-avro` extension.

Fixes: #52882
