### PR TITLE
Update default masked headers for rest client log

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1986,7 +1986,16 @@ To enable logging, add the `quarkus.rest-client.logging.scope` property to your 
 
 As HTTP messages can have large bodies, we limit the amount of body characters logged. The default limit is `100`, you can change it by specifying `quarkus.rest-client.logging.body-limit`.
 
-Sensitive request and response header values can be masked using `quarkus.rest-client.logging.masked-headers`. The value of any configured headers will be replaced with `****` in the logs.
+Sensitive request and response header values can be masked using `quarkus.rest-client.logging.masked-headers`. The value of any configured headers will be replaced with `<hidden>` in the logs.
+
+[IMPORTANT]
+.Default masked headers
+====
+
+The default value of `quarkus.rest-client.logging.masked-headers` (`Authorization` and `Cookie`) will be replaced when you explicitly configure a value.
+You *must* explicitly include them if you still need them masked.
+
+====
 
 These configuration properties work globally for all clients injected by CDI.
 If you want configure logging for a specific declarative client, you should do it by specifying named "client" properties, also known as `quarkus.rest-client."client".logging.*` properties.
@@ -1997,7 +2006,7 @@ An example logging configuration:
 ----
 quarkus.rest-client.logging.scope=request-response
 quarkus.rest-client.logging.body-limit=50
-quarkus.rest-client.logging.masked-headers=Authorization
+quarkus.rest-client.logging.masked-headers=Authorization,Cookie,x-super-secret
 
 quarkus.rest-client.extensions-api.logging.scope=all
 ----

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -410,11 +410,12 @@ public interface RestClientsConfig {
         /**
          * Which request and response headers values to mask in logs.
          * <p>
-         * The value of any matching header will be replaced with {@code "****"}.
-         * The header name itself remains visible. E.g. {@code Authorization=****}
+         * The value of any matching header will be replaced with {@code "<hidden>"}.
+         * The header name itself remains visible. E.g. {@code Authorization=<hidden>}
          * <p>
          * This property is not applicable to the Quarkus RESTEasy client (provided by the quarkus-resteasy-client dependency).
          */
+        @WithDefault("Authorization,Cookie")
         Optional<Set<String>> maskedHeaders();
     }
 

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientMaskedHeaderLogTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientMaskedHeaderLogTest.java
@@ -27,7 +27,7 @@ import io.quarkus.test.QuarkusUnitTest;
 
 public class ClientMaskedHeaderLogTest {
 
-    public static class NoMaskedHeadersTest {
+    public static class NoMaskedHeadersConfigTest {
         @RegisterExtension
         static final QuarkusUnitTest config = new QuarkusUnitTest()
                 .withApplicationRoot((jar) -> jar
@@ -43,7 +43,7 @@ public class ClientMaskedHeaderLogTest {
                     List<String> lines = records.stream().map(formatter::format).map(String::trim).collect(Collectors.toList());
 
                     assertThat(lines).containsExactly(
-                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=123 User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
+                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=<hidden> User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
                             "[INFO] Response: GET http://localhost:8081/resource/hello, Status[200 OK], Headers[x-locale=de-DE x-secret=super-sensitive-value content-length=0], Body:");
                 });
 
@@ -73,8 +73,8 @@ public class ClientMaskedHeaderLogTest {
                     List<String> lines = records.stream().map(formatter::format).map(String::trim).collect(Collectors.toList());
 
                     assertThat(lines).containsExactly(
-                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=**** User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
-                            "[INFO] Response: GET http://localhost:8081/resource/hello, Status[200 OK], Headers[x-locale=de-DE x-secret=**** content-length=0], Body:");
+                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=<hidden> User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
+                            "[INFO] Response: GET http://localhost:8081/resource/hello, Status[200 OK], Headers[x-locale=de-DE x-secret=<hidden> content-length=0], Body:");
                 });
 
         @RestClient
@@ -101,8 +101,8 @@ public class ClientMaskedHeaderLogTest {
                     List<String> lines = records.stream().map(formatter::format).map(String::trim).collect(Collectors.toList());
 
                     assertThat(lines).containsExactly(
-                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=**** User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
-                            "[INFO] Response: GET http://localhost:8081/resource/hello, Status[200 OK], Headers[x-locale=de-DE x-secret=**** content-length=0], Body:");
+                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=<hidden> User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
+                            "[INFO] Response: GET http://localhost:8081/resource/hello, Status[200 OK], Headers[x-locale=de-DE x-secret=<hidden> content-length=0], Body:");
                 });
 
         @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
@@ -135,8 +135,8 @@ public class ClientMaskedHeaderLogTest {
                     List<String> lines = records.stream().map(formatter::format).map(String::trim).collect(Collectors.toList());
 
                     assertThat(lines).containsExactly(
-                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=**** User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
-                            "[INFO] Response: GET http://localhost:8081/resource/hello, Status[200 OK], Headers[x-locale=de-DE x-secret=**** content-length=0], Body:");
+                            "[INFO] Request: GET http://localhost:8081/resource/hello Headers[Accept=text/plain;charset=UTF-8 Authorization=<hidden> User-Agent=Quarkus REST Client x-requested-locale=en-US], Empty body",
+                            "[INFO] Response: GET http://localhost:8081/resource/hello, Status[200 OK], Headers[x-locale=de-DE x-secret=<hidden> content-length=0], Body:");
                 });
 
         @RestClient

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
@@ -295,8 +295,8 @@ public interface QuarkusRestClientBuilder extends Configurable<QuarkusRestClient
     /**
      * Which request and response headers values to mask in logs.
      * <p>
-     * The value of any matching header will be replaced with {@code "****"}.
-     * The header name itself remains visible. E.g. {@code Authorization=****}
+     * The value of any matching header will be replaced with {@code "<hidden>"}.
+     * The header name itself remains visible. E.g. {@code Authorization=<hidden>}
      */
     QuarkusRestClientBuilder loggingMaskedHeaders(Set<String> maskedHeaders);
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttribute.java
@@ -18,6 +18,7 @@ public class AllRequestHeadersAttribute implements ExchangeAttribute {
 
     private static final String AUTHORIZATION_HEADER = String.valueOf(HttpHeaders.AUTHORIZATION).toLowerCase();
     private static final String COOKIE_HEADER = String.valueOf(HttpHeaders.COOKIE).toLowerCase();
+    private static final String MASKED_VALUE = "<hidden>";
 
     private final Set<String> maskedHeaders;
     private final Set<String> maskedCookies;
@@ -74,7 +75,7 @@ public class AllRequestHeadersAttribute implements ExchangeAttribute {
         }
 
         if (maskedHeaders.contains(headerNameLowerCase)) {
-            return "...";
+            return MASKED_VALUE;
         }
 
         return headerValue;
@@ -85,9 +86,9 @@ public class AllRequestHeadersAttribute implements ExchangeAttribute {
         final String scheme = idx > 0 ? headerValue.substring(0, idx) : null;
 
         if (scheme != null) {
-            return scheme + " ...";
+            return scheme + " " + MASKED_VALUE;
         } else {
-            return "...";
+            return MASKED_VALUE;
         }
     }
 
@@ -97,7 +98,7 @@ public class AllRequestHeadersAttribute implements ExchangeAttribute {
         final String cookieName = idx > 0 ? headerValue.substring(0, idx) : null;
 
         if (cookieName != null && maskedCookies.contains(cookieName.toLowerCase())) {
-            return cookieName + "=...";
+            return cookieName + "=" + MASKED_VALUE;
         }
 
         return headerValue;

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttributeTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttributeTest.java
@@ -21,7 +21,7 @@ class AllRequestHeadersAttributeTest {
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("Authorization", "Bearer token");
         String attribute = new AllRequestHeadersAttribute().readAttribute(headers);
-        assertEquals("Authorization: Bearer ...", attribute);
+        assertEquals("Authorization: Bearer <hidden>", attribute);
     }
 
     @Test
@@ -29,7 +29,7 @@ class AllRequestHeadersAttributeTest {
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("Authorization", "DPoP token");
         String attribute = new AllRequestHeadersAttribute().readAttribute(headers);
-        assertEquals("Authorization: DPoP ...", attribute);
+        assertEquals("Authorization: DPoP <hidden>", attribute);
     }
 
     @Test
@@ -37,7 +37,7 @@ class AllRequestHeadersAttributeTest {
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("authorization", "token");
         String attribute = new AllRequestHeadersAttribute().readAttribute(headers);
-        assertEquals("authorization: ...", attribute);
+        assertEquals("authorization: <hidden>", attribute);
     }
 
 }

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -31,7 +31,7 @@
         <version.impsort.plugin>1.13.0</version.impsort.plugin>
         <version.install.plugin>3.1.4</version.install.plugin>
         <version.javadoc.plugin>3.12.0</version.javadoc.plugin>
-        <version.jar.plugin>3.5.0</version.jar.plugin>
+         <version.jar.plugin>3.5.0</version.jar.plugin>
         <version.plugin.plugin>3.15.2</version.plugin.plugin>
         <version.release.plugin>3.3.1</version.release.plugin>
         <version.resources.plugin>3.4.0</version.resources.plugin>

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/logging/DefaultClientLogger.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/logging/DefaultClientLogger.java
@@ -16,7 +16,7 @@ import io.vertx.core.http.HttpClientResponse;
 
 public class DefaultClientLogger implements ClientLogger {
     private static final Logger log = Logger.getLogger(DefaultClientLogger.class);
-    private static final String MASKED_VALUE = "****";
+    private static final String MASKED_VALUE = "<hidden>";
 
     private int bodySize;
 

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCase.java
@@ -55,13 +55,13 @@ public class AccessLogTestCase {
                                 "access log contains duplicated query params");
                         Assertions.assertTrue(line.contains("Accept: text/plain"),
                                 "access log doesn't contain the HTTP Accept header with a text/plain media type");
-                        Assertions.assertTrue(line.contains("Authorization: Bearer ..."),
+                        Assertions.assertTrue(line.contains("Authorization: Bearer <hidden>"),
                                 "access log must contain a masked value of the HTTP Authorizaton header's Bearer scheme");
-                        Assertions.assertTrue(line.contains("x-Token: ..."),
+                        Assertions.assertTrue(line.contains("x-Token: <hidden>"),
                                 "access log must contain a masked value of the HTTP X-Token header");
                         Assertions.assertTrue(line.contains("Cookie: visitcount=1"),
                                 "access log doesn't contain the HTTP Cookie visitorcount header with a value 1");
-                        Assertions.assertTrue(line.contains("Cookie: Session=..."),
+                        Assertions.assertTrue(line.contains("Cookie: Session=<hidden>"),
                                 "access log must contain a masked value of the HTTP Cookie session header");
                     }
                 });


### PR DESCRIPTION
And adjust the masked header value to be <hidden> instead of ... (for http access log), and *** for rest client log.

rest client log now masks Authorization and Cookie header.

The http access log *never* logged the Authorization header (and is even a bit nicer, since it logs the scheme and just masks the value).

follows up on the discussion from #52830