### PR TITLE
Some more polishing of the new AotRunnerClassLoader

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
@@ -87,8 +87,8 @@ public class AotRunnerClassLoader extends ClassLoader {
             return createCachedResourceURL(name, data);
         }
 
-        String dirName = getDirNameFromResourceName(name);
-        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+        if (!fullyIndexedResources.contains(name)
+                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
             return null;
         }
 
@@ -107,8 +107,8 @@ public class AotRunnerClassLoader extends ClassLoader {
             return createCachedResourceURL(name, data);
         }
 
-        String dirName = getDirNameFromResourceName(name);
-        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+        if (!fullyIndexedResources.contains(name)
+                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
             return null;
         }
 
@@ -164,8 +164,8 @@ public class AotRunnerClassLoader extends ClassLoader {
             return Collections.emptyEnumeration();
         }
 
-        String dirName = getDirNameFromResourceName(name);
-        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+        if (!fullyIndexedResources.contains(name)
+                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
             return Collections.emptyEnumeration();
         }
 
@@ -193,8 +193,8 @@ public class AotRunnerClassLoader extends ClassLoader {
                     createCachedResourceURL(name, data)));
         }
 
-        String dirName = getDirNameFromResourceName(name);
-        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+        if (!fullyIndexedResources.contains(name)
+                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
             return Collections.emptyEnumeration();
         }
 
@@ -212,8 +212,8 @@ public class AotRunnerClassLoader extends ClassLoader {
             return new ByteArrayInputStream(data);
         }
 
-        String dirName = getDirNameFromResourceName(name);
-        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+        if (!fullyIndexedResources.contains(name)
+                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
             return null;
         }
 

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
@@ -92,8 +92,9 @@ public class AotRunnerClassLoader extends ClassLoader {
             return null;
         }
 
-        // if it exists, and is not cached, then delegate to the parent
-        return super.getResource(name);
+        // if it exists, and is not cached, then delegate to the parent directly
+        // (bypassing super.getResource which would redundantly call this.findResource)
+        return getParent().getResource(name);
     }
 
     @Override
@@ -168,7 +169,9 @@ public class AotRunnerClassLoader extends ClassLoader {
             return Collections.emptyEnumeration();
         }
 
-        return super.getResources(name);
+        // Delegate to parent directly; super.getResources would redundantly call this.findResources
+        // and wrap results in a CompoundEnumeration for no benefit
+        return getParent().getResources(name);
     }
 
     /**

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
@@ -202,6 +202,24 @@ public class AotRunnerClassLoader extends ClassLoader {
         return super.findResources(name);
     }
 
+    @Override
+    public InputStream getResourceAsStream(String name) {
+        name = sanitizeName(name);
+
+        // For cached resources, return the stream directly without URL/URLConnection overhead
+        final byte[] data = serviceFiles.get(name);
+        if (data != null) {
+            return new ByteArrayInputStream(data);
+        }
+
+        String dirName = getDirNameFromResourceName(name);
+        if (fullyIndexedDirectories.contains(dirName) && !fullyIndexedResources.contains(name)) {
+            return null;
+        }
+
+        return getParent().getResourceAsStream(name);
+    }
+
     private URL createCachedResourceURL(String name, byte[] data) {
         try {
             return new URL(null, "cached:".concat(name), new CachedResourceURLStreamHandler(data));

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
@@ -107,12 +107,8 @@ public class AotRunnerClassLoader extends ClassLoader {
             return createCachedResourceURL(name, data);
         }
 
-        if (!fullyIndexedResources.contains(name)
-                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
-            return null;
-        }
-
-        return super.findResource(name);
+        // No need to check fullyIndexedDirectories: either way, if it's not cached we don't have it.
+        return null;
     }
 
     /**
@@ -183,7 +179,7 @@ public class AotRunnerClassLoader extends ClassLoader {
      * @throws IOException if I/O errors occur
      */
     @Override
-    public Enumeration<URL> findResources(String name) throws IOException {
+    protected Enumeration<URL> findResources(String name) throws IOException {
         name = sanitizeName(name);
 
         // The cached version already contains the concatenated content from all jars
@@ -193,13 +189,8 @@ public class AotRunnerClassLoader extends ClassLoader {
                     createCachedResourceURL(name, data)));
         }
 
-        if (!fullyIndexedResources.contains(name)
-                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
-            return Collections.emptyEnumeration();
-        }
-
-        // Not cached - delegate to parent implementation (will scan jars)
-        return super.findResources(name);
+        // No need to check fullyIndexedDirectories: either way, if it's not cached we don't have it.
+        return Collections.emptyEnumeration();
     }
 
     @Override

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotRunnerClassLoader.java
@@ -87,8 +87,7 @@ public class AotRunnerClassLoader extends ClassLoader {
             return createCachedResourceURL(name, data);
         }
 
-        if (!fullyIndexedResources.contains(name)
-                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
+        if (isKnownAbsentResource(name)) {
             return null;
         }
 
@@ -160,8 +159,7 @@ public class AotRunnerClassLoader extends ClassLoader {
             return Collections.emptyEnumeration();
         }
 
-        if (!fullyIndexedResources.contains(name)
-                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
+        if (isKnownAbsentResource(name)) {
             return Collections.emptyEnumeration();
         }
 
@@ -203,8 +201,7 @@ public class AotRunnerClassLoader extends ClassLoader {
             return new ByteArrayInputStream(data);
         }
 
-        if (!fullyIndexedResources.contains(name)
-                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name))) {
+        if (isKnownAbsentResource(name)) {
             return null;
         }
 
@@ -260,6 +257,16 @@ public class AotRunnerClassLoader extends ClassLoader {
         public int getContentLength() {
             return data.length;
         }
+    }
+
+    /**
+     * Returns true if the resource's directory is fully indexed and the resource is not in the index,
+     * meaning we know for certain it doesn't exist.
+     */
+    private boolean isKnownAbsentResource(final String name) {
+        return !fullyIndexedResources.contains(name)
+                //We intentionally check in this order to possibly avoid invoking getDirNameFromResourceName(String):
+                && fullyIndexedDirectories.contains(getDirNameFromResourceName(name));
     }
 
     private static String sanitizeName(String name) {


### PR DESCRIPTION
A follow-up to #52955 : these changes are slightly less straight forward, but I believe they strictly honour the existing semantics so should be safe.
Kept each small optimisation in a separate commit to make it easier to follow.