### PR TITLE
Fix Gradle 9.4 test failures by inlining warm-up build and removing test ordering

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
@@ -20,15 +20,10 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TasksConfigurationCacheCompatibilityTest {
 
     @TempDir
@@ -50,29 +45,14 @@ public class TasksConfigurationCacheCompatibilityTest {
         return Stream.of(DEPLOY_TASK_NAME);
     }
 
-    @Test
-    @Order(1)
-    public void quarkusBuildFooTest() throws IOException, URISyntaxException {
-        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
-        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
-        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
-
-        GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(testProjectDir.toFile())
-                .withArguments(QUARKUS_GENERATE_CODE_TASK_NAME, "--info", "--stacktrace", "--build-cache",
-                        "--configuration-cache")
-                .build();
-        assertTrue(true);
-    }
-
     @ParameterizedTest
-    @Order(2)
     @MethodSource("compatibleTasks")
     public void configurationCacheIsReusedTest(String taskName) throws IOException, URISyntaxException {
         URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
         FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
         FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+
+        buildResult(":help", "--configuration-cache");
 
         BuildResult firstBuild = buildResult(taskName, "--configuration-cache");
         assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
@@ -82,13 +62,14 @@ public class TasksConfigurationCacheCompatibilityTest {
     }
 
     @ParameterizedTest
-    @Order(3)
     @MethodSource("compatibleTasks")
     public void configurationCacheIsReusedWhenProjectIsolationIsUsedTest(String taskName)
             throws IOException, URISyntaxException {
         URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
         FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
         FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+
+        buildResult(":help", "--configuration-cache");
 
         BuildResult firstBuild = buildResult(taskName, "-Dorg.gradle.unsafe.isolated-projects=true");
         assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
@@ -98,7 +79,6 @@ public class TasksConfigurationCacheCompatibilityTest {
     }
 
     @ParameterizedTest
-    @Order(4)
     @MethodSource("nonCompatibleQuarkusBuildTasks")
     public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFail(String taskName)
             throws IOException, URISyntaxException {
@@ -113,7 +93,6 @@ public class TasksConfigurationCacheCompatibilityTest {
 
     @ParameterizedTest
     @MethodSource("nonCompatibleQuarkusBuildTasks")
-    @Order(5)
     public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFailWhenUsingConfigurationCache(String taskName)
             throws IOException, URISyntaxException {
         URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");


### PR DESCRIPTION
After observing configuration cache failing tests in 9.4.0 upgrade, we identified that the failures are caused by the randomized project directory path used during the tests. Since the path changes on every run, cache hits cannot occur and the build is forced to recompile, which resets the compiler environment and changes the system property value.

With Gradle 9.4.0 this behavior becomes more visible, causing subsequent test runs to fail as well.

Changes:

* Removed test sequencing: Deleted the @TestMethodOrder and @Order annotations so tests no longer rely on a specific execution order.

* Inlined the warm-up build: Instead of relying on a separate quarkusBuildFooTest to "prime" the environment, the warm build is now executed within the test itself.