### PR TITLE
Enable legacy patch filter when resteasy-jackson is present

### DIFF
--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -65,8 +65,10 @@ import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.Transformation;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.capabilities.Capabilities;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
@@ -207,7 +209,8 @@ public class ResteasyServerCommonProcessor {
             CombinedIndexBuildItem combinedIndexBuildItem,
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,
             Optional<ResteasyServletMappingBuildItem> resteasyServletMappingBuildItem,
-            CustomScopeAnnotationsBuildItem scopes) throws Exception {
+            CustomScopeAnnotationsBuildItem scopes,
+            Capabilities capabilities) throws Exception {
         IndexView index = combinedIndexBuildItem.getIndex();
 
         final AnnotationInstance applicationPath;
@@ -420,6 +423,10 @@ public class ResteasyServerCommonProcessor {
         }
         resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_UNWRAPPED_EXCEPTIONS,
                 ArcUndeclaredThrowableException.class.getName());
+
+        if (capabilities.isCapabilityWithPrefixPresent(Capability.RESTEASY_JSON_JACKSON)) {
+            resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_PATCH_FILTER_LEGACY, "true");
+        }
 
         resteasyServerConfig.produce(new ResteasyServerConfigBuildItem(rootPath, path, resteasyInitParameters));
 


### PR DESCRIPTION
## Summary

- Automatically sets `resteasy.patchfilter.legacy=true` when `quarkus-resteasy-jackson` is on the classpath
- This makes `@PATCH` endpoints using Jackson for JSON merge-patch work correctly out of the box
- The fix is in `ResteasyServerCommonProcessor.build()`, following the same pattern as the existing GZIP config

## Context

When using RESTEasy Classic with Jackson (`quarkus-resteasy-jackson`), `@PATCH` endpoints fail because RESTEasy's default patch filter doesn't use Jackson for JSON merge-patch operations. The workaround is to manually set `resteasy.patchfilter.legacy=true`, but this should be done automatically when the Jackson serialization layer is present.

Fixes #33186

## Test plan

- [ ] Verify `@PATCH` endpoint with Jackson serialization works without manual config
- [ ] Verify no regression when `quarkus-resteasy-jackson` is not present
- [ ] Verify existing GZIP and other init parameter behavior is unchanged