### PR TITLE
Support service annotations via application.properties

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkus.kubernetes.deployment.Constants.MAX_NODE_PORT_VALUE;
 import static io.quarkus.kubernetes.deployment.Constants.MAX_PORT_NUMBER;
 import static io.quarkus.kubernetes.deployment.Constants.MIN_NODE_PORT_VALUE;
 import static io.quarkus.kubernetes.deployment.Constants.MIN_PORT_NUMBER;
+import static io.quarkus.kubernetes.deployment.Constants.SERVICE;
 import static io.quarkus.kubernetes.deployment.KubernetesConfigUtil.MANAGEMENT_PORT_NAME;
 import static io.quarkus.kubernetes.deployment.KubernetesConfigUtil.managementPortIsEnabled;
 
@@ -153,6 +154,12 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
                     config.nodePort().orElseGet(
                             () -> getStablePortNumberInRange(context.name(), MIN_NODE_PORT_VALUE, MAX_NODE_PORT_VALUE)),
                     config.ingress().targetPort()));
+        }
+
+        if (config.service() != null) {
+            for (Map.Entry<String, String> annotation : config.service().annotations().entrySet()) {
+                context.add(new AddAnnotationDecorator(context.name(), annotation.getKey(), annotation.getValue(), SERVICE));
+            }
         }
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -17,6 +17,7 @@ public final class Constants {
     public static final String DEPLOYMENT_GROUP = "apps";
     public static final String DEPLOYMENT_VERSION = "v1";
     public static final String INGRESS = "Ingress";
+    public static final String SERVICE = "Service";
     public static final String BATCH_GROUP = "batch";
     public static final String BATCH_VERSION = "v1";
     public static final String JOB_API_VERSION = BATCH_GROUP + "/" + BATCH_VERSION;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -54,6 +54,11 @@ public interface KubernetesConfig extends PlatformConfiguration {
     OptionalInt nodePort();
 
     /**
+     * Service configuration
+     */
+    ServiceConfig service();
+
+    /**
      * Ingress configuration
      */
     IngressConfig ingress();

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ServiceConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ServiceConfig.java
@@ -1,0 +1,13 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+
+public interface ServiceConfig {
+    /**
+     * Custom annotations to add to the Service resource.
+     */
+    @ConfigDocMapKey("annotation-name")
+    Map<String, String> annotations();
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.kubernetes.deployment;
 
 import static io.quarkus.kubernetes.deployment.Constants.KUBERNETES;
+import static io.quarkus.kubernetes.deployment.Constants.SERVICE;
 import static io.quarkus.kubernetes.deployment.KubernetesCommonHelper.printMessageAboutPortsThatCantChange;
 import static io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem.VANILLA_KUBERNETES_PRIORITY;
 
@@ -13,6 +14,7 @@ import io.dekorate.kubernetes.config.DeploymentStrategy;
 import io.dekorate.kubernetes.config.IngressBuilder;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.kubernetes.config.RollingUpdateBuilder;
+import io.dekorate.kubernetes.decorator.AddAnnotationDecorator;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
 import io.dekorate.kubernetes.decorator.AddIngressTlsDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
@@ -213,6 +215,12 @@ public class VanillaKubernetesProcessor extends BaseVanillaKubernetesProcessor {
                 }
             } else if (config.nodePort().isPresent()) {
                 context.add(new AddNodePortDecorator(name, config.nodePort().getAsInt(), config.ingress().targetPort()));
+            }
+        }
+
+        if (config.service() != null) {
+            for (Map.Entry<String, String> annotation : config.service().annotations().entrySet()) {
+                context.add(new AddAnnotationDecorator(name, annotation.getKey(), annotation.getValue(), SERVICE));
             }
         }
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithServiceAnnotationsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithServiceAnnotationsTest.java
@@ -1,0 +1,55 @@
+
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithServiceAnnotationsTest {
+
+    private static final String APP_NAME = "kubernetes-with-service-annotations";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList).filteredOn(i -> "Service".equals(i.getKind())).singleElement().satisfies(item -> {
+            assertThat(item).isInstanceOfSatisfying(Service.class, s -> {
+                assertThat(s.getMetadata().getAnnotations())
+                        .contains(entry("example.com/my-annotation", "my-value"))
+                        .contains(entry("prometheus.io/scrape", "true"));
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-service-annotations.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-service-annotations.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.service.annotations."example.com/my-annotation"=my-value
+quarkus.kubernetes.service.annotations."prometheus.io/scrape"=true


### PR DESCRIPTION
## Summary

- Adds `quarkus.kubernetes.service.annotations."key"="value"` configuration support
- Allows custom annotations on generated Kubernetes Service resources (e.g., for cloud load balancers, Prometheus scraping, service mesh, external-dns)
- Follows the same established pattern used by `quarkus.kubernetes.ingress.annotations` and `quarkus.openshift.route.annotations`

## Changes

- New `ServiceConfig` interface with `Map<String, String> annotations()`
- Added `SERVICE` constant to `Constants.java`
- Wired `ServiceConfig service()` into `KubernetesConfig`
- Applied service annotations via `AddAnnotationDecorator` in both `VanillaKubernetesProcessor` and `BaseVanillaKubernetesProcessor`
- Added integration test verifying annotations appear on generated Service resource

## Usage

```properties
quarkus.kubernetes.service.annotations."example.com/my-annotation"=my-value
quarkus.kubernetes.service.annotations."prometheus.io/scrape"=true
```

Fixes #52920