### PR TITLE
Panache Next – remove HR types from PanacheOperations generic signature

### DIFF
--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheBlockingOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheBlockingOperations.java
@@ -14,7 +14,11 @@ import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 import io.quarkus.panache.common.Sort;
 
 public interface PanacheBlockingOperations extends
-        PanacheOperations<Object, List<?>, PanacheBlockingQuery<?>, Long, Void, Boolean, Session, StatelessSession> {
+        PanacheOperations<Object, List<?>, PanacheBlockingQuery<?>, Long, Void, Boolean> {
+
+    Session getSession(Class<?> entityClass);
+
+    StatelessSession getStatelessSession(Class<?> entityClass);
 
     Optional<?> findByIdOptional(Class<?> entityClass, Object id);
 

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheOperations.java
@@ -11,7 +11,7 @@ import io.quarkus.hibernate.panache.runtime.orm.ManagedBlockingOperations;
 import io.quarkus.hibernate.panache.runtime.orm.StatelessBlockingOperations;
 import io.quarkus.panache.common.Sort;
 
-public interface PanacheOperations<One, Many, Query, Count, Completion, Confirmation, Session, StatelessSession> {
+public interface PanacheOperations<One, Many, Query, Count, Completion, Confirmation> {
 
     static PanacheBlockingOperations getBlockingManaged() {
         return ManagedBlockingOperations.INSTANCE;
@@ -30,10 +30,6 @@ public interface PanacheOperations<One, Many, Query, Count, Completion, Confirma
     }
 
     // Operations
-
-    Session getSession(Class<?> entityClass);
-
-    StatelessSession getStatelessSession(Class<?> entityClass);
 
     Completion insert(Object entity);
 

--- a/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheReactiveOperations.java
+++ b/extensions/panache/hibernate-panache-next/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheReactiveOperations.java
@@ -2,8 +2,6 @@ package io.quarkus.hibernate.panache.runtime.spi;
 
 import java.util.List;
 
-import org.hibernate.Session;
-import org.hibernate.StatelessSession;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
@@ -11,6 +9,10 @@ import io.smallrye.mutiny.Uni;
 
 public interface PanacheReactiveOperations
         extends
-        PanacheOperations<Uni<Object>, Uni<List<?>>, PanacheReactiveQuery<?>, Uni<Long>, Uni<Void>, Uni<Boolean>, Uni<Mutiny.Session>, Uni<Mutiny.StatelessSession>> {
+        PanacheOperations<Uni<Object>, Uni<List<?>>, PanacheReactiveQuery<?>, Uni<Long>, Uni<Void>, Uni<Boolean>> {
+
+    Uni<Mutiny.Session> getSession(Class<?> entityClass);
+
+    Uni<Mutiny.StatelessSession> getStatelessSession(Class<?> entityClass);
 
 }


### PR DESCRIPTION
Fix #52270: Panache Next – remove HR types from PanacheOperations generic signature

Remove Session and StatelessSession as generic type parameters from
PanacheOperations, reducing the number of type parameters from 8 to 6.
This prevents spurious build-time WARN logs about Mutiny.Session and
Mutiny.StatelessSession when Hibernate Reactive is not on the classpath.

Root cause
PanacheReactiveOperations extended PanacheOperations using
Uni<Mutiny.Session> and Uni<Mutiny.StatelessSession> as type arguments.
This effectively embedded Hibernate Reactive types in the common SPI
generic signature.

Since PanacheEntityMarker (present on all entities) references
PanacheReactiveOperations transitively, Jandex and ReflectiveHierarchyStep
would always encounter these types, even in blocking-only projects.

Fix
Move getSession() and getStatelessSession() as concrete typed methods
into the specialized sub-interfaces:

- PanacheBlockingOperations: returns org.hibernate.Session and
  org.hibernate.StatelessSession
- PanacheReactiveOperations: returns Uni<Mutiny.Session> and
  Uni<Mutiny.StatelessSession>

The four implementation classes already exposed the correct concrete
return types and required no changes.

Tests
Add PanacheOperationsSpiTest with five reflection-based regression tests
to verify the SPI structure (e.g. no Mutiny types in PanacheOperations
generic parameters).

Fixes: #52270