### PR TITLE
Add CLAIM option support to XREADGROUP command

### DIFF
--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -175,5 +175,12 @@
                 <redis.base.image>redis/redis-stack:7.0.6-RC9</redis.base.image>
             </properties>
         </profile>
+
+        <profile>
+            <id>redis-8.4</id>
+            <properties>
+                <redis.base.image>redis:8</redis.base.image>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -176,6 +176,7 @@
             </properties>
         </profile>
 
+        <!-- note that a small number of tests fail with Redis 8, so we don't use it by default yet -->
         <profile>
             <id>redis-8.4</id>
             <properties>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/StreamMessage.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/StreamMessage.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.datasource.stream;
 
+import java.time.Duration;
 import java.util.Map;
 
 /**
@@ -14,11 +15,19 @@ public class StreamMessage<K, F, V> {
     private final K stream;
     private final String id;
     private final Map<F, V> payload;
+    private final Duration durationSinceLastDelivery;
+    private final int deliveryCount;
 
     public StreamMessage(K stream, String id, Map<F, V> payload) {
+        this(stream, id, payload, null, 0);
+    }
+
+    public StreamMessage(K stream, String id, Map<F, V> payload, Duration durationSinceLastDelivery, int deliveryCount) {
         this.stream = stream;
         this.id = id;
         this.payload = payload;
+        this.durationSinceLastDelivery = durationSinceLastDelivery;
+        this.deliveryCount = deliveryCount;
     }
 
     /**
@@ -40,5 +49,23 @@ public class StreamMessage<K, F, V> {
      */
     public Map<F, V> payload() {
         return this.payload;
+    }
+
+    /**
+     * @return the duration since this message was last delivered to a consumer,
+     *         or {@code null} if this message was not reclaimed via the CLAIM option.
+     *         Only present when the XREADGROUP CLAIM option is used and this message was a pending entry.
+     */
+    public Duration durationSinceLastDelivery() {
+        return this.durationSinceLastDelivery;
+    }
+
+    /**
+     * @return the number of times this message has been delivered, or {@code 0} if this message was not reclaimed
+     *         via the CLAIM option.
+     *         Only present when the XREADGROUP CLAIM option is used and this message was a pending entry.
+     */
+    public int deliveryCount() {
+        return this.deliveryCount;
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XReadGroupArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XReadGroupArgs.java
@@ -17,6 +17,8 @@ public class XReadGroupArgs implements RedisCommandExtraArguments {
 
     private boolean noack;
 
+    private Duration claim;
+
     /**
      * Sets the max number of entries per stream to return
      *
@@ -36,6 +38,22 @@ public class XReadGroupArgs implements RedisCommandExtraArguments {
      */
     public XReadGroupArgs block(Duration block) {
         this.block = block;
+        return this;
+    }
+
+    /**
+     * Sets the CLAIM option with a minimum idle time. When set, the consumer will attempt to claim pending messages
+     * that have been idle for at least the specified duration before delivering new messages.
+     * <p>
+     * This option is only effective when the stream id is {@code >}.
+     * <p>
+     * Requires Redis 8.4+.
+     *
+     * @param minIdleTime the minimum idle time for claiming pending messages, must not be {@code null}
+     * @return the current {@code XReadGroupArgs}
+     */
+    public XReadGroupArgs claim(Duration minIdleTime) {
+        this.claim = minIdleTime;
         return this;
     }
 
@@ -61,6 +79,10 @@ public class XReadGroupArgs implements RedisCommandExtraArguments {
         if (block != null) {
             args.add("BLOCK");
             args.add(Long.toString(block.toMillis()));
+        }
+        if (claim != null) {
+            args.add("CLAIM");
+            args.add(Long.toString(claim.toMillis()));
         }
         if (noack) {
             args.add("NOACK");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStreamCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStreamCommandsImpl.java
@@ -112,6 +112,9 @@ public class ReactiveStreamCommandsImpl<K, F, V> extends AbstractStreamCommands<
         // the response is an array with two elements:
         // 1. the stream id
         // 2. the payload (another array)
+        // When XREADGROUP CLAIM is used, claimed (pending) entries have two extra elements:
+        // 3. milliseconds since last delivery
+        // 4. delivery count
 
         if (response == null) {
             return null;
@@ -124,6 +127,11 @@ public class ReactiveStreamCommandsImpl<K, F, V> extends AbstractStreamCommands<
             var streamId = response.get(0).toString();
             var payload = response.get(1);
             var content = decodeMessagePayload(payload);
+            if (response.size() > 2) {
+                var durationSinceLastDelivery = Duration.ofMillis(response.get(2).toLong());
+                var deliveryCount = response.get(3).toInteger();
+                return new StreamMessage<>(key, streamId, content, durationSinceLastDelivery, deliveryCount);
+            }
             return new StreamMessage<>(key, streamId, content);
         }
     }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Redis84OrHigherCondition.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Redis84OrHigherCondition.java
@@ -1,0 +1,43 @@
+package io.quarkus.redis.datasource;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+class Redis84OrHigherCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@RequiresRedis84OrHigher is not present");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<RequiresRedis84OrHigher> optional = AnnotationUtils.findAnnotation(context.getElement(),
+                RequiresRedis84OrHigher.class);
+
+        if (optional.isPresent()) {
+            String version = RedisServerExtension.getRedisVersion();
+
+            return isRedis84orHigher(version) ? enabled("Redis " + version + " >= 8.4")
+                    : disabled("Disabled, Redis " + version + " < 8.4");
+        }
+
+        return ENABLED_BY_DEFAULT;
+    }
+
+    public static boolean isRedis84orHigher(String version) {
+        String[] parts = version.split("\\.");
+        int major = Integer.parseInt(parts[0]);
+        if (major > 8) {
+            return true;
+        }
+        if (major == 8 && parts.length > 1) {
+            return Integer.parseInt(parts[1]) >= 4;
+        }
+        return false;
+    }
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis84OrHigher.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis84OrHigher.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@Target(ElementType.METHOD)
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @ExtendWith(Redis84OrHigherCondition.class)

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis84OrHigher.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis84OrHigher.java
@@ -1,0 +1,18 @@
+package io.quarkus.redis.datasource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@ExtendWith(Redis84OrHigherCondition.class)
+@interface RequiresRedis84OrHigher {
+
+    // Important the class must extend DatasourceTestBase.
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StreamCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StreamCommandsTest.java
@@ -527,10 +527,10 @@ public class StreamCommandsTest extends DatasourceTestBase {
                     assertThat(m.durationSinceLastDelivery().toMillis()).isGreaterThan(0);
                 });
 
-        // Non-claimed (new) messages should not have idle time info
+        // Non-claimed (new) messages have zero idle time
         messages.stream()
                 .filter(m -> m.deliveryCount() == 0)
-                .forEach(m -> assertThat(m.durationSinceLastDelivery()).isNull());
+                .forEach(m -> assertThat(m.durationSinceLastDelivery()).isEqualTo(Duration.ZERO));
     }
 
     @Test

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StreamCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StreamCommandsTest.java
@@ -489,6 +489,51 @@ public class StreamCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis84OrHigher
+    void xReadGroupWithClaim() throws InterruptedException {
+        String g1 = "my-group";
+        stream.xgroupCreate(key, g1, "$", new XGroupCreateArgs().mkstream());
+
+        Map<String, Integer> payload = Map.of("sensor-id", 1234, "temperature", 19);
+        for (int i = 0; i < 5; i++) {
+            stream.xadd(key, payload);
+        }
+
+        // c1 reads 3 messages but does not ack them
+        assertThat(stream.xreadgroup(g1, "c1", key, ">", new XReadGroupArgs().count(3)))
+                .hasSize(3);
+
+        // Wait a bit so the messages become idle
+        Thread.sleep(50);
+
+        // c2 reads remaining messages and claims c1's idle messages in one call
+        List<StreamMessage<String, String, Integer>> messages = stream.xreadgroup(g1, "c2", key, ">",
+                new XReadGroupArgs().claim(Duration.ofMillis(10)));
+
+        // Should get all 5 messages: 2 new + 3 claimed
+        assertThat(messages).hasSize(5);
+
+        // Claimed messages have deliveryCount > 0
+        long claimedCount = messages.stream()
+                .filter(m -> m.deliveryCount() > 0)
+                .count();
+        assertThat(claimedCount).isEqualTo(3);
+
+        // Claimed messages should have idle time info
+        messages.stream()
+                .filter(m -> m.deliveryCount() > 0)
+                .forEach(m -> {
+                    assertThat(m.durationSinceLastDelivery()).isNotNull();
+                    assertThat(m.durationSinceLastDelivery().toMillis()).isGreaterThan(0);
+                });
+
+        // Non-claimed (new) messages should not have idle time info
+        messages.stream()
+                .filter(m -> m.deliveryCount() == 0)
+                .forEach(m -> assertThat(m.durationSinceLastDelivery()).isNull());
+    }
+
+    @Test
     @RequiresRedis6OrHigher
     void xAutoClaim() throws InterruptedException {
         String g1 = "my-group";


### PR DESCRIPTION
## Summary

- Adds `CLAIM` option to `XReadGroupArgs` for the `XREADGROUP` command
- Exposes CLAIM response metadata (`durationSinceLastDelivery`, `deliveryCount`) on `StreamMessage`
- Enables resilient stream consumption where crashed consumers' pending messages are automatically reclaimed after a configurable idle timeout

## Usage

```java
// Claim pending messages idle for at least 30 seconds before reading new ones
stream.xreadgroup(group, consumer, key, ">",
    new XReadGroupArgs().claim(Duration.ofSeconds(30)));

// Access CLAIM metadata on reclaimed messages
for (StreamMessage<K, F, V> msg : messages) {
    if (msg.durationSinceLastDelivery() != null) {
        // This was a reclaimed pending message
        log.info("Reclaimed message {} idle for {}ms, delivered {} times",
            msg.id(), msg.durationSinceLastDelivery().toMillis(), msg.deliveryCount());
    }
}
```

## Changes

- **`XReadGroupArgs.java`** — Added `claim(Duration)` builder method and `CLAIM` in `toArgs()` (between BLOCK and NOACK per Redis spec)
- **`StreamMessage.java`** — Added optional `durationSinceLastDelivery` and `deliveryCount` fields with backward-compatible constructor
- **`ReactiveStreamCommandsImpl.java`** — Updated `decodeMessageWithStreamId()` to parse the extra CLAIM response fields when present

Requires Redis 8.4+.

Fixes #52921