### PR TITLE
Fix class-level @Path with regex not matching multiple params

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/URITemplate.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/URITemplate.java
@@ -170,6 +170,11 @@ public class URITemplate implements Dumpable, Comparable<URITemplate> {
         if (nameAggregator != null) {
             if (!this.prefixMatch) {
                 regexAggregator.append("$");
+            } else {
+                // For prefix paths (class-level @Path), we need a boundary so lazy quantifiers
+                // like [^/]+? don't stop at a single character. (?=/|$) forces them to consume
+                // until the next '/' or end of string.
+                regexAggregator.append("(?=/|$)");
             }
             components.add(new TemplateComponent(Type.CUSTOM_REGEX, null, null, Pattern.compile(regexAggregator.toString()),
                     nameAggregator.toArray(new String[0]), groupAggregator.toArray(new String[0])));

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/ClassPathMultipleRegexParamsTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/ClassPathMultipleRegexParamsTest.java
@@ -1,0 +1,60 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ClassPathMultipleRegexParamsTest {
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClass(ResourceWithRegexOnClass.class);
+                }
+            });
+
+    @Test
+    public void testRegexWithMultipleParamsOnClassPath() {
+        given()
+                .when()
+                .get("/hello/foo758945c8-fcea-44dd-8608-371346e82cff/second/bar")
+                .then()
+                .statusCode(200)
+                .body(is("first:foo758945c8-fcea-44dd-8608-371346e82cff, third:bar"));
+    }
+
+    @Test
+    public void testNonMatchingRegex() {
+        given()
+                .when()
+                .get("/hello/INVALID/second/bar")
+                .then()
+                .statusCode(404);
+    }
+
+    @Path("/hello/{first:foo[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/second/{third}")
+    public static class ResourceWithRegexOnClass {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String greeting(@PathParam("first") String first, @PathParam("third") String third) {
+            return "first:%s, third:%s".formatted(first, third);
+        }
+    }
+}


### PR DESCRIPTION
Ran into this while migrating a service from resteasy-classic to quarkus-rest. When a class-level `@Path` has a custom regex param followed by more path segments, the route never matches.

For example this gives 404:
```java
@Path("/hello/{first:foo[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/second/{third}")
public class MyResource {
    @GET
    public String get(@PathParam("first") String first, @PathParam("third") String third) { ... }
}
```

The same path works fine when placed on the method instead of the class.

### Root cause

As @FroMage identified in the issue, the coalesced regex for class-level (prefix) paths ends with a lazy quantifier `[^/]+?` but no trailing anchor. Method-level paths get `$` appended which forces the lazy match to expand, but prefix paths skip `$` because more path may follow. The lazy `+?` then only matches a single character.

### Fix

For prefix paths, append `(?=/|$)` — a zero-width lookahead that forces the lazy quantifiers to consume until the next `/` or end of string, without actually consuming the `/` itself.

- **Before (prefix):** `(?<first>.*)\Q/second/\E(?<third>[^/]+?)` — `third` matches `b` from `bar`
- **After (prefix):** `(?<first>.*)\Q/second/\E(?<third>[^/]+?)(?=/|$)` — `third` matches `bar`

Fixes #48548