### PR TITLE
Pass Jib JVM arguments to AOT cache training command

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JvmStartupOptimizerAdditionalArgsBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JvmStartupOptimizerAdditionalArgsBuildItem.java
@@ -1,0 +1,26 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import java.util.List;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Carries additional JVM arguments (e.g. from container image extensions like Jib)
+ * that should be included when generating the AOT cache training command.
+ * <p>
+ * This ensures that JVM arguments configured for the container runtime
+ * (such as {@code quarkus.jib.jvm-additional-arguments}) are also applied
+ * during AOT cache generation so the resulting cache is compatible.
+ */
+public final class JvmStartupOptimizerAdditionalArgsBuildItem extends SimpleBuildItem {
+
+    private final List<String> additionalArgs;
+
+    public JvmStartupOptimizerAdditionalArgsBuildItem(List<String> additionalArgs) {
+        this.additionalArgs = additionalArgs;
+    }
+
+    public List<String> getAdditionalArgs() {
+        return additionalArgs;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JvmStartupOptimizerArchiveBuildStep.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerAdditionalArgsBuildItem;
 import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveContainerImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveRequestedBuildItem;
 import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveResultBuildItem;
@@ -140,6 +141,7 @@ public class JvmStartupOptimizerArchiveBuildStep {
             JarBuildItem jarResult, OutputTargetBuildItem outputTarget, PackageConfig packageConfig,
             CompiledJavaVersionBuildItem compiledJavaVersion,
             Optional<JvmStartupOptimizerArchiveContainerImageBuildItem> jvmStartupOptimizerArchiveContainerImage,
+            Optional<JvmStartupOptimizerAdditionalArgsBuildItem> jvmStartupOptimizerAdditionalArgs,
             BuildProducer<JvmStartupOptimizerArchiveResultBuildItem> jvmStartupOptimizerArchive,
             BuildProducer<ArtifactResultBuildItem> artifactResult) throws Exception {
         if (requested.isEmpty()) {
@@ -169,8 +171,12 @@ public class JvmStartupOptimizerArchiveBuildStep {
             archivePath = createAppCDSFromExit(jarResult, outputTarget, javaBinPath, containerImage,
                     isFastJar);
         } else if (archiveType == JvmStartupOptimizerArchiveType.AOT) {
-            archivePath = createAot(jarResult, outputTarget, javaBinPath, containerImage, isFastJar,
+            List<String> additionalArgs = new ArrayList<>(
                     packageConfig.jar().aot().additionalRecordingArgs().orElse(List.of()));
+            jvmStartupOptimizerAdditionalArgs
+                    .ifPresent(buildItem -> additionalArgs.addAll(buildItem.getAdditionalArgs()));
+            archivePath = createAot(jarResult, outputTarget, javaBinPath, containerImage, isFastJar,
+                    additionalArgs);
         } else {
             throw new IllegalStateException("Unsupported archive type: " + archiveType);
         }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -84,6 +84,7 @@ import io.quarkus.deployment.pkg.builditem.BuildAotOptimizedContainerImageResult
 import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerAdditionalArgsBuildItem;
 import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveContainerImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.JvmStartupOptimizerArchiveResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
@@ -142,6 +143,26 @@ public class JibProcessor {
 
         producer.produce(
                 new JvmStartupOptimizerArchiveContainerImageBuildItem(determineBaseJvmImage(jibConfig, compiledJavaVersion)));
+    }
+
+    // when AOT cache generation is enabled and a container image build via Jib has been requested,
+    // we want the AOT training command to include the same JVM arguments that will be used
+    // in the final container entrypoint, so the resulting cache is compatible
+    @BuildStep(onlyIf = JibBuild.class)
+    public void jvmStartupOptimizerAdditionalArgs(ContainerImageConfig containerImageConfig,
+            ContainerImageJibConfig jibConfig,
+            BuildProducer<JvmStartupOptimizerAdditionalArgsBuildItem> producer) {
+
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()) {
+            return;
+        }
+
+        List<String> effectiveJvmArguments = new ArrayList<>(jibConfig.jvmArguments());
+        jibConfig.jvmAdditionalArguments().ifPresent(effectiveJvmArguments::addAll);
+
+        if (!effectiveJvmArguments.isEmpty()) {
+            producer.produce(new JvmStartupOptimizerAdditionalArgsBuildItem(effectiveJvmArguments));
+        }
     }
 
     private String determineBaseJvmImage(ContainerImageJibConfig jibConfig, CompiledJavaVersionBuildItem compiledJavaVersion) {


### PR DESCRIPTION
## Summary

- Fixes the issue where `quarkus.jib.jvm-arguments` and `quarkus.jib.jvm-additional-arguments` were ignored during AOT cache generation
- Introduces `JvmStartupOptimizerAdditionalArgsBuildItem` to propagate JVM arguments from `JibProcessor` to `JvmStartupOptimizerArchiveBuildStep`
- The AOT training command now includes both `quarkus.package.jar.aot.additional-recording-args` and Jib's JVM arguments, ensuring the generated cache is compatible with the container runtime

## Details

The AOT cache training run (`createAot()` in `JvmStartupOptimizerArchiveBuildStep`) was only receiving arguments from `quarkus.package.jar.aot.additional-recording-args`. When building with Jib, the JVM arguments configured via `quarkus.jib.jvm-arguments` / `quarkus.jib.jvm-additional-arguments` were applied to the container entrypoint but not to the AOT training command. This could result in an incompatible AOT cache at runtime.

The fix follows the existing pattern used by `JvmStartupOptimizerArchiveContainerImageBuildItem` (which already carries the container image from Jib to the AOT step). A new `@BuildStep` in `JibProcessor` produces the build item with the effective JVM arguments, and `JvmStartupOptimizerArchiveBuildStep.build()` consumes it as an `Optional` and merges the args into the training command.

Fixes #52935