### PR TITLE
Unwrap Arc subclass in Panache repository entity class lookup

### DIFF
--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -17,6 +17,7 @@ import org.hibernate.query.SelectionQuery;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.Subclass;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.panache.common.Parameters;
@@ -55,6 +56,9 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
     public static <Entity> Class<? extends Entity> getRepositoryEntityClass(
             // FIXME: if we move this to JpaOperations we can add a type constraint on the repo class
             Class<?> repositoryImplementationClass) {
+        if (Subclass.class.isAssignableFrom(repositoryImplementationClass)) {
+            repositoryImplementationClass = repositoryImplementationClass.getSuperclass();
+        }
         Class<?> ret = repositoryClassToEntityClass.get(repositoryImplementationClass);
         if (ret == null) {
             throw new RuntimeException("Your repository class " + repositoryImplementationClass


### PR DESCRIPTION
## Summary

- Fixes the entity class resolution failure when a `PanacheRepository` class has intercepted methods (`@Transactional`, `@Retry`, etc.)
- When Arc generates a subclass for interception, `getClass()` returns the generated `_Subclass` type, but `repositoryClassToEntityClass` only maps the original class
- The fix unwraps `io.quarkus.arc.Subclass` to its superclass before the map lookup in `AbstractJpaOperations.getRepositoryEntityClass()`

## Details

The `repositoryClassToEntityClass` map is populated at build time with the developer-defined repository class as the key. At runtime, `getEntityClass()` calls `getClass()` to look up the entity type. When a repository has intercepted methods, Arc generates a subclass (e.g., `CatRepo_Subclass`), and `getClass()` returns this generated type instead of the original `CatRepo`. The map lookup fails and throws:

```
Your repository class class foo.bar.CatRepo_Subclass was not properly detected and assigned an entity type
```

The fix checks if the repository class implements `io.quarkus.arc.Subclass` and resolves to the superclass before looking it up in the map. This covers all Panache variants (blocking, reactive, stateless) since they all delegate to the same `AbstractJpaOperations.getRepositoryEntityClass()`.

Fixes #52476