### PR TITLE
Show friendly error for unknown 'quarkus create' subcommands

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -28,6 +28,20 @@ public class Create implements Callable<Integer> {
     List<String> unmatchedArgs;
 
     public Integer call() throws Exception {
+        // If the user passed a non-flag argument that isn't a known subcommand,
+        // they likely mistyped a subcommand name (e.g. "create ext" instead of "create extension").
+        // Give a clear error instead of falling through to CreateApp which would fail with
+        // a cryptic picocli UnmatchedArgumentException.
+        if (unmatchedArgs != null && !unmatchedArgs.isEmpty()) {
+            String first = unmatchedArgs.get(0);
+            if (!first.startsWith("-")) {
+                output.error("Unknown subcommand '%s' for 'quarkus create'.", first);
+                output.info("Available subcommands are: %s", String.join(", ", spec.subcommands().keySet()));
+                output.info("See 'quarkus create --help' for more information.");
+                return CommandLine.ExitCode.USAGE;
+            }
+        }
+
         output.info("Creating an app (default project type, see --help).");
 
         ParseResult result = spec.commandLine().getParseResult();


### PR DESCRIPTION
## Summary

- Fixes the cryptic picocli `UnmatchedArgumentException` stack trace when running commands like `quarkus create ext abc -e`
- `Create.call()` now detects non-flag unmatched arguments (likely mistyped subcommands) and prints a clear error with available subcommands instead of falling through to `CreateApp`

## Details

The `Create` command uses `@Unmatched` to absorb unknown arguments, then `Create.call()` unconditionally forwards all args to `CreateApp`. When the user passes an unknown subcommand like `ext` (instead of `extension`), `CreateApp` receives it as an unmatched argument and throws:

```
picocli.CommandLine$UnmatchedArgumentException: Unmatched argument at index 2: 'abc'
```

With this fix, the user now sees:
```
Unknown subcommand 'ext' for 'quarkus create'.
Available subcommands are: app, cli, extension
See 'quarkus create --help' for more information.
```

The check only triggers for non-flag arguments (not starting with `-`), so valid flag-only invocations like `quarkus create --java 17` still forward to `CreateApp` as before.

Fixes #41161