### PR TITLE
Detect IDE and show actionable guidance for integration test failures

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -374,8 +374,19 @@ public final class IntegrationTestUtil {
                 }
             } else if (testLauncher == TestLauncher.GRADLE) {
                 errorMessage += "Make sure this test is run after the 'quarkusBuild' Gradle task.";
+            } else if (testLauncher == TestLauncher.INTELLIJ) {
+                errorMessage += "It looks like this test is being run from IntelliJ IDEA. "
+                        + "Integration tests require the Quarkus application to be built first. "
+                        + "Please add a 'Run Maven Goal' (mvn package) or 'Run Gradle Task' (quarkusBuild) "
+                        + "in the 'Before launch' section of your Run Configuration.";
+            } else if (testLauncher == TestLauncher.ECLIPSE) {
+                errorMessage += "It looks like this test is being run from Eclipse. "
+                        + "Integration tests require the Quarkus application to be built first. "
+                        + "Please run 'mvn package' (Maven) or the 'quarkusBuild' task (Gradle) before executing this test.";
             } else {
-                errorMessage += "Make sure this test is run after the Quarkus artifact is built from your build tool.";
+                errorMessage += "Make sure this test is run after the Quarkus artifact is built from your build tool. "
+                        + "If you are running this test from an IDE, configure a pre-build step to run "
+                        + "'mvn package' (Maven) or the 'quarkusBuild' task (Gradle) before executing this test.";
             }
             throw new IllegalStateException(errorMessage);
         }
@@ -421,6 +432,15 @@ public final class IntegrationTestUtil {
             }
             if (className.startsWith("org.gradle")) {
                 testLauncher = TestLauncher.GRADLE;
+                break;
+            }
+            if (className.startsWith("com.intellij.rt.")) {
+                testLauncher = TestLauncher.INTELLIJ;
+                break;
+            }
+            if (className.startsWith("org.eclipse.jdt.internal.junit.")) {
+                testLauncher = TestLauncher.ECLIPSE;
+                break;
             }
             if (i == 0) {
                 break;
@@ -432,6 +452,8 @@ public final class IntegrationTestUtil {
     private enum TestLauncher {
         MAVEN,
         GRADLE,
+        INTELLIJ,
+        ECLIPSE,
         UNKNOWN
     }
 


### PR DESCRIPTION
fix #48273

## Summary

When `@QuarkusIntegrationTest` fails due to missing build artifacts in a clean workspace, the error message is now IDE-aware:

- **IntelliJ IDEA**: Detected via `com.intellij.rt.*` in the stack trace. Suggests adding a "Run Maven Goal" or "Run Gradle Task" in the "Before launch" section of the Run Configuration.
- **Eclipse**: Detected via `org.eclipse.jdt.internal.junit.*` in the stack trace. Suggests running `mvn package` or `quarkusBuild` before executing the test.
- **Unknown/other IDEs**: Improved fallback message now mentions IDE pre-build step configuration.

Also fixes a missing `break` in the Gradle branch of `determineTestLauncher()`.

## Test plan

- Run a `@QuarkusIntegrationTest` from IntelliJ without prior `mvn package` → verify error mentions IntelliJ and "Before launch" configuration
- Run from Eclipse → verify error mentions Eclipse
- Run from CLI without Maven/Gradle → verify improved generic message with IDE guidance