### PR TITLE
Use seconds as base time unit for micrometer-opentelemetry bridge

### DIFF
--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/HttpCompatibilityTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/HttpCompatibilityTest.java
@@ -144,7 +144,7 @@ public class HttpCompatibilityTest {
                     assertThat(clientMetricData)
                             .hasName("http.client.requests") // in OTel it should be "http.server.request.duration"
                             .hasDescription("") // in OTel it should be "Duration of HTTP client requests."
-                            .hasUnit("ms") // OTel has seconds
+                            .hasUnit("s")
                             .hasHistogramSatisfying(histogram -> histogram.isCumulative()
                                     .hasPointsSatisfying(
                                             // valid entries
@@ -174,7 +174,7 @@ public class HttpCompatibilityTest {
         assertThat(metricData)
                 .hasName("http.server.requests") // in OTel it should be "http.server.request.duration"
                 .hasDescription("HTTP server request processing time") // in OTel it should be "Duration of HTTP server requests."
-                .hasUnit("ms") // OTel has seconds
+                .hasUnit("s")
                 .hasHistogramSatisfying(histogram -> histogram.isCumulative()
                         .hasPointsSatisfying(
                                 // valid entries

--- a/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
+++ b/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
@@ -31,7 +31,7 @@ public class MicrometerOtelBridgeRecorder {
                 MeterRegistry meterRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry.get())
                         .setPrometheusMode(false)
                         .setMicrometerHistogramGaugesEnabled(true)
-                        .setBaseTimeUnit(TimeUnit.MILLISECONDS)
+                        .setBaseTimeUnit(TimeUnit.SECONDS)
                         .setClock(Clock.SYSTEM)
                         .build();
                 Metrics.addRegistry(meterRegistry);


### PR DESCRIPTION
fix #52649

## Summary

Per the [OpenTelemetry HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration), duration metrics must use **seconds** as the unit. The micrometer-opentelemetry bridge currently uses milliseconds, causing metric names like `http_server_connections_duration_milliseconds` instead of `http_server_connections_duration_seconds`.

## Changes

- `MicrometerOtelBridgeRecorder`: Change `.setBaseTimeUnit(TimeUnit.MILLISECONDS)` to `.setBaseTimeUnit(TimeUnit.SECONDS)`
- `HttpCompatibilityTest`: Update unit assertions from `"ms"` to `"s"`

## Test plan

- Existing `HttpCompatibilityTest` updated to assert `"s"` unit
- Verify `http.server.requests` and `http.client.requests` metrics report duration in seconds