### PR TITLE
Skip non-static Kotlin companion methods in Qute extension processing

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1786,6 +1786,15 @@ public class QuteProcessor {
         // Method-level annotations
         for (Entry<MethodInfo, AnnotationInstance> entry : methods.entrySet()) {
             MethodInfo method = entry.getKey();
+            // Skip non-static methods from Kotlin companion objects.
+            // Kotlin generates both a static method on the outer class and a non-static
+            // delegate on the companion class, both annotated with @TemplateExtension.
+            // The static method on the outer class is the one we want to process.
+            if (!Modifier.isStatic(method.flags()) && method.declaringClass().enclosingClass() != null) {
+                LOGGER.debugf("Skipping non-static method %s declared on inner class %s", method,
+                        method.declaringClass().name());
+                continue;
+            }
             AnnotationValue namespaceValue = entry.getValue().value(ExtensionMethodGenerator.NAMESPACE);
             ExtensionMethodGenerator.validate(method, namespaceValue != null ? namespaceValue.asString() : null);
             produceExtensionMethod(index, extensionMethods, method, entry.getValue());

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/KotlinCompanionExtensionMethodTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/KotlinCompanionExtensionMethodTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.qute.deployment.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateExtension;
+import io.quarkus.qute.deployment.Foo;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that non-static methods on inner classes (e.g. Kotlin companion objects)
+ * annotated with {@link TemplateExtension} are silently skipped rather than causing
+ * a build failure. Kotlin companion objects generate both a static method on the outer
+ * class and a non-static delegate on the inner {@code $Companion} class — both
+ * annotated with {@code @TemplateExtension}.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/52162">#52162</a>
+ */
+public class KotlinCompanionExtensionMethodTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Foo.class, KotlinLikeExtensions.class, KotlinLikeExtensions.Companion.class)
+                    .addAsResource(new StringAsset("{foo.uppercaseName}"),
+                            "templates/companion.txt"));
+
+    @Inject
+    Engine engine;
+
+    @Test
+    public void testStaticMethodProcessedAndCompanionSkipped() {
+        assertEquals("FANTOMAS",
+                engine.getTemplate("companion").data("foo", new Foo("Fantomas", 10L)).render());
+    }
+
+    /**
+     * Simulates what the Kotlin compiler generates for a companion object with {@code @JvmStatic}.
+     * The outer class gets a static method and the inner Companion class gets a non-static delegate,
+     * both annotated with {@code @TemplateExtension}.
+     */
+    public static class KotlinLikeExtensions {
+
+        // Static method on the outer class — this is the one Qute should process
+        @TemplateExtension
+        static String uppercaseName(Foo foo) {
+            return foo.name.toUpperCase();
+        }
+
+        // Simulates Kotlin's $Companion inner class
+        public static class Companion {
+
+            // Non-static delegate — Qute should skip this
+            @TemplateExtension
+            public String uppercaseName(Foo foo) {
+                return foo.name.toUpperCase();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Kotlin companion objects with `@JvmStatic` generate both a static method on the outer class and a non-static delegate on the inner `$Companion` class — both annotated with `@TemplateExtension`
- The non-static companion method caused `IllegalStateException: must be static` during build
- Skip non-static methods on inner classes in `collectTemplateExtensionMethods` so the static method on the outer class is processed correctly

## How it works

When the Kotlin compiler processes:
```kotlin
class Extensions {
    companion object {
        @TemplateExtension
        @JvmStatic
        fun discountedPrice(item: Item): BigDecimal = ...
    }
}
```

It generates:
- `Extensions.discountedPrice()` — **static**, annotated with `@TemplateExtension` ✅
- `Extensions$Companion.discountedPrice()` — **non-static** delegate, also annotated with `@TemplateExtension` ❌

The fix checks: if a method is not static AND its declaring class is an inner class (`enclosingClass != null`), skip it — the real static method on the outer class will be processed.

## Test plan

- [x] New `KotlinCompanionExtensionMethodTest` simulates the Kotlin companion pattern with a Java inner class
- [x] Existing extension method tests pass (12/12)

Fixes #52162