### PR TITLE
DRAFT feat: add support for generic tenant identifiers

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1352,7 +1352,7 @@ import io.vertx.ext.web.RoutingContext;
 
 @PersistenceUnitExtension // <1>
 @RequestScoped // <2>
-public class CustomTenantResolver implements TenantResolver {
+public class CustomTenantResolver implements TenantResolver<String> { // <3>
 
     @Inject
     RoutingContext context;
@@ -1382,6 +1382,9 @@ to tell Quarkus it should be used in the default persistence unit.
 +
 For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`.
 <2> The bean is made `@RequestScoped` as the tenant resolution depends on the incoming request.
+<3> `TenantResolver` is generic over the tenant identifier type.
+Use `TenantResolver<String>` unless you rely on a custom tenant identifier type supported by Hibernate ORM,
+such as `TenantResolver<Long>`.
 
 From the implementation above, tenants are resolved from the request path so that in case no tenant could be inferred, the default tenant identifier is returned.
 
@@ -1398,7 +1401,7 @@ import io.vertx.ext.web.RoutingContext;
 
 @PersistenceUnitExtension
 @RequestScoped
-public class CustomTenantResolver implements TenantResolver {
+public class CustomTenantResolver implements TenantResolver<String> {
 
     @Inject
     RoutingContext context; <1>
@@ -1623,7 +1626,7 @@ Here is an implementation example of a `TenantConnectionResolver` implementation
 ----
 @ApplicationScoped
 @PersistenceUnitExtension
-public class ExampleTenantConnectionResolver implements TenantConnectionResolver {
+public class ExampleTenantConnectionResolver implements TenantConnectionResolver<String> {
 
     private final jakarta.transaction.TransactionManager transactionManager;
     private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -42,6 +42,7 @@ import javax.xml.namespace.QName;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
+import jakarta.inject.Singleton;
 import jakarta.persistence.PersistenceUnitTransactionType;
 import jakarta.xml.bind.JAXBElement;
 
@@ -151,6 +152,7 @@ import io.quarkus.hibernate.orm.runtime.recording.RecordedConfig;
 import io.quarkus.hibernate.orm.runtime.schema.SchemaManagementIntegrator;
 import io.quarkus.hibernate.orm.runtime.service.FlatClassLoaderService;
 import io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver;
+import io.quarkus.hibernate.orm.runtime.tenant.MultiTenancyResolverClasses;
 import io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver;
 import io.quarkus.hibernate.validator.spi.BeanValidationTraversableResolverBuildItem;
 import io.quarkus.panache.hibernate.common.deployment.HibernateEnhancersRegisteredBuildItem;
@@ -1020,6 +1022,43 @@ public final class HibernateOrmProcessor {
                     .produce(new UnremovableBeanBuildItem(new BeanTypeExclusion(ClassNames.TENANT_CONNECTION_RESOLVER)));
             unremovableBeans.produce(new UnremovableBeanBuildItem(new BeanTypeExclusion(ClassNames.TENANT_RESOLVER)));
         }
+    }
+
+    /**
+     * {@code TenantResolver} and {@code TenantConnectionResolver} are generic interfaces, so their implementations
+     * expose a parameterized bean type (e.g. {@code TenantResolver<Long>}) that Arc typesafe resolution does not match
+     * against the raw interface type. We collect the implementation classes here and expose them as an immutable
+     * {@link MultiTenancyResolverClasses} bean so they can be looked up by their concrete class at runtime.
+     */
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    public void collectTenantResolverClasses(HibernateOrmRecorder recorder,
+            RecorderContext recorderContext,
+            CombinedIndexBuildItem combinedIndex,
+            List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+        boolean multitenancyEnabled = persistenceUnitDescriptors.stream()
+                .anyMatch(pu -> pu.getConfig().getMultiTenancyStrategy() != MultiTenancyStrategy.NONE);
+        if (!multitenancyEnabled) {
+            return;
+        }
+        syntheticBeans.produce(SyntheticBeanBuildItem.configure(MultiTenancyResolverClasses.class)
+                .scope(Singleton.class)
+                .unremovable()
+                .setRuntimeInit()
+                .supplier(recorder.multiTenancyResolverClasses(
+                        resolverClassProxies(combinedIndex, recorderContext, ClassNames.TENANT_RESOLVER),
+                        resolverClassProxies(combinedIndex, recorderContext, ClassNames.TENANT_CONNECTION_RESOLVER)))
+                .done());
+    }
+
+    private static Set<Class<?>> resolverClassProxies(CombinedIndexBuildItem combinedIndex,
+            RecorderContext recorderContext, DotName resolverInterface) {
+        Set<Class<?>> classProxies = new HashSet<>();
+        for (ClassInfo implementor : combinedIndex.getIndex().getAllKnownImplementors(resolverInterface)) {
+            classProxies.add(recorderContext.classProxy(implementor.name().toString()));
+        }
+        return classProxies;
     }
 
     @BuildStep

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/Company.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/Company.java
@@ -1,0 +1,30 @@
+package io.quarkus.hibernate.orm.multitenancy.database;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Company {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public Company() {
+    }
+
+    public Company(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/CompanyService.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/CompanyService.java
@@ -1,0 +1,29 @@
+package io.quarkus.hibernate.orm.multitenancy.database;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class CompanyService {
+
+    @Inject
+    EntityManager entityManager;
+
+    @Transactional
+    @ActivateRequestContext
+    public void create(String name) {
+        entityManager.persist(new Company(name));
+    }
+
+    @Transactional
+    @ActivateRequestContext
+    public List<String> listNames() {
+        return entityManager.createQuery("select c.name from Company c order by c.id", String.class)
+                .getResultList();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/CustomLongConnectionResolver.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/CustomLongConnectionResolver.java
@@ -1,0 +1,36 @@
+package io.quarkus.hibernate.orm.multitenancy.database;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.customized.QuarkusConnectionProvider;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver;
+
+/**
+ * A custom {@link TenantConnectionResolver} using a non-{@link String} tenant identifier ({@link Long}).
+ * <p>
+ * All tenants map to the same datasource here; the test only needs to prove that this generic connection resolver is
+ * discovered (by its concrete class) and invoked with a {@code Long} tenant identifier.
+ */
+@PersistenceUnitExtension
+@ApplicationScoped
+public class CustomLongConnectionResolver implements TenantConnectionResolver<Long> {
+
+    @Inject
+    @DataSource("tenant")
+    AgroalDataSource dataSource;
+
+    @Inject
+    TenantAccessLog accessLog;
+
+    @Override
+    public ConnectionProvider resolve(Long tenantId) {
+        accessLog.record(tenantId);
+        return new QuarkusConnectionProvider(dataSource);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/DatabaseMultitenancyCustomLongConnectionResolverTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/DatabaseMultitenancyCustomLongConnectionResolverTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.hibernate.orm.multitenancy.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies the {@code database} multitenancy strategy with a custom
+ * {@link io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver} using a non-{@link String} ({@link Long})
+ * tenant identifier.
+ * <p>
+ * This exercises a path not covered elsewhere: a user-provided <em>generic</em> connection resolver being discovered
+ * (by its concrete class) and the {@code Long} tenant identifier flowing from the {@code TenantResolver} through to
+ * {@code TenantConnectionResolver.resolve(Long)}. The existing tenancy integration tests are all {@code String}-based,
+ * and the discriminator test has no connection resolver at all.
+ */
+public class DatabaseMultitenancyCustomLongConnectionResolverTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(Company.class, DatabaseTenantResolver.class,
+                    CustomLongConnectionResolver.class, TenantAccessLog.class, CompanyService.class))
+            // The persistence unit gets its connections from the custom resolver, so there is no default datasource
+            // and the dialect must be set explicitly (it cannot be inferred from a static datasource).
+            .overrideConfigKey("quarkus.datasource.active", "false")
+            .overrideConfigKey("quarkus.datasource.tenant.db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.tenant.jdbc.url", "jdbc:h2:mem:custom-long-conn")
+            .overrideConfigKey("quarkus.hibernate-orm.multitenant", "database")
+            .overrideConfigKey("quarkus.hibernate-orm.dialect", "org.hibernate.dialect.H2Dialect")
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "drop-and-create");
+
+    @Inject
+    CompanyService companyService;
+
+    @Inject
+    TenantAccessLog accessLog;
+
+    @Test
+    public void customConnectionResolverIsDiscoveredWithLongTenant() {
+        // A successful round-trip proves the custom (generic) TenantConnectionResolver was discovered and used:
+        // the default DataSourceTenantConnectionResolver is vetoed once a user bean exists, and would fail anyway.
+        companyService.create("Acme");
+        assertThat(companyService.listNames()).containsExactly("Acme");
+
+        // And it was invoked with the Long tenant identifier produced by the TenantResolver.
+        assertThat(accessLog.resolvedTenants()).contains(DatabaseTenantResolver.TENANT_ID);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/DatabaseTenantResolver.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/DatabaseTenantResolver.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.multitenancy.database;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
+
+/**
+ * A {@link TenantResolver} using a non-{@link String} tenant identifier ({@link Long}), so the {@code Long} flows into
+ * the custom {@link CustomLongConnectionResolver}.
+ */
+@PersistenceUnitExtension
+@ApplicationScoped
+public class DatabaseTenantResolver implements TenantResolver<Long> {
+
+    static final Long TENANT_ID = 7L;
+
+    @Override
+    public Long getDefaultTenantId() {
+        return TENANT_ID;
+    }
+
+    @Override
+    public Long resolveTenantId() {
+        return TENANT_ID;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/TenantAccessLog.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/database/TenantAccessLog.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.orm.multitenancy.database;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Observable record of the tenant identifiers the custom {@link CustomLongConnectionResolver} was asked to resolve.
+ * <p>
+ * A separate {@code @Default} bean is used (rather than injecting the resolver directly) because the resolver carries
+ * the {@code @PersistenceUnitExtension} qualifier and therefore is not a {@code @Default} bean.
+ */
+@ApplicationScoped
+public class TenantAccessLog {
+
+    private final List<Long> resolvedTenants = new CopyOnWriteArrayList<>();
+
+    public void record(Long tenantId) {
+        resolvedTenants.add(tenantId);
+    }
+
+    public List<Long> resolvedTenants() {
+        return resolvedTenants;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/CurrentTenant.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/CurrentTenant.java
@@ -1,0 +1,21 @@
+package io.quarkus.hibernate.orm.multitenancy.discriminator;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Holds the tenant identifier selected by the test. Kept application-scoped so the test can switch tenants across
+ * request boundaries.
+ */
+@ApplicationScoped
+public class CurrentTenant {
+
+    private volatile Long tenantId = 0L;
+
+    public Long get() {
+        return tenantId;
+    }
+
+    public void set(Long tenantId) {
+        this.tenantId = tenantId;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/DiscriminatorMultitenancyWithLongTenantIdTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/DiscriminatorMultitenancyWithLongTenantIdTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.hibernate.orm.multitenancy.discriminator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that a {@link io.quarkus.hibernate.orm.runtime.tenant.TenantResolver} using a non-{@link String} tenant
+ * identifier ({@link Long}) is discovered and drives discriminator-based multitenancy end to end.
+ * <p>
+ * Since implementations of the generic {@code TenantResolver<T>} interface cannot be resolved through a raw
+ * {@code TenantResolver.class} Arc lookup, this exercises the build-time collection of implementation classes.
+ */
+public class DiscriminatorMultitenancyWithLongTenantIdTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(Product.class, CurrentTenant.class, LongTenantResolver.class,
+                    ProductService.class))
+            .overrideConfigKey("quarkus.datasource.db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:tenant-long")
+            .overrideConfigKey("quarkus.hibernate-orm.multitenant", "discriminator")
+            .overrideConfigKey("quarkus.hibernate-orm.schema-management.strategy", "drop-and-create");
+
+    @Inject
+    ProductService productService;
+
+    @Inject
+    CurrentTenant currentTenant;
+
+    @Test
+    public void nonStringTenantIdentifierIsResolvedAndIsolatesData() {
+        currentTenant.set(1L);
+        productService.create("apple");
+        productService.create("banana");
+
+        currentTenant.set(2L);
+        productService.create("carrot");
+
+        // The Long tenant identifier must be persisted into the discriminator column as-is.
+        assertThat(productService.tenantIdOfSingleProduct()).isEqualTo(2L);
+
+        // Data must be isolated per (Long) tenant.
+        currentTenant.set(1L);
+        assertThat(productService.listNames()).containsExactly("apple", "banana");
+
+        currentTenant.set(2L);
+        assertThat(productService.listNames()).containsExactly("carrot");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/LongTenantResolver.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/LongTenantResolver.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.multitenancy.discriminator;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
+
+/**
+ * A {@link TenantResolver} using a non-{@link String} tenant identifier ({@link Long}).
+ * <p>
+ * This exercises the generic bean discovery: the bean's only {@code TenantResolver} bean type is the parameterized
+ * {@code TenantResolver<Long>}, so it can only be found through the build-time-collected implementation classes.
+ */
+@PersistenceUnitExtension
+@RequestScoped
+public class LongTenantResolver implements TenantResolver<Long> {
+
+    @Inject
+    CurrentTenant currentTenant;
+
+    @Override
+    public Long getDefaultTenantId() {
+        return 0L;
+    }
+
+    @Override
+    public Long resolveTenantId() {
+        return currentTenant.get();
+    }
+
+    @Override
+    public boolean isRoot(Long tenantId) {
+        // No tenant used in this test is negative, so this is always false;
+        // it exists only to prove that isRoot(T) with a non-String type compiles and is invoked.
+        return tenantId != null && tenantId < 0;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/Product.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/Product.java
@@ -1,0 +1,40 @@
+package io.quarkus.hibernate.orm.multitenancy.discriminator;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.TenantId;
+
+@Entity
+public class Product {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    // A non-String tenant identifier: the whole point of this test.
+    @TenantId
+    private Long tenantId;
+
+    private String name;
+
+    public Product() {
+    }
+
+    public Product(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getTenantId() {
+        return tenantId;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/ProductService.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multitenancy/discriminator/ProductService.java
@@ -1,0 +1,41 @@
+package io.quarkus.hibernate.orm.multitenancy.discriminator;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+/**
+ * Drives persistence inside an active request context so that {@code HibernateCurrentTenantIdentifierResolver}
+ * (which only resolves a tenant when a request context is active) consults the {@link LongTenantResolver}.
+ */
+@ApplicationScoped
+public class ProductService {
+
+    @Inject
+    EntityManager entityManager;
+
+    @Transactional
+    @ActivateRequestContext
+    public void create(String name) {
+        entityManager.persist(new Product(name));
+    }
+
+    @Transactional
+    @ActivateRequestContext
+    public List<String> listNames() {
+        return entityManager.createQuery("select p.name from Product p order by p.name", String.class)
+                .getResultList();
+    }
+
+    @Transactional
+    @ActivateRequestContext
+    public Long tenantIdOfSingleProduct() {
+        return entityManager.createQuery("select p.tenantId from Product p", Long.class)
+                .setMaxResults(1)
+                .getSingleResult();
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -37,6 +37,7 @@ import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
 import io.quarkus.hibernate.orm.runtime.schema.SchemaManagementIntegrator;
 import io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver;
+import io.quarkus.hibernate.orm.runtime.tenant.MultiTenancyResolverClasses;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -101,6 +102,16 @@ public class HibernateOrmRecorder {
                 return new DataSourceTenantConnectionResolver(persistenceUnitName, dataSourceName, multiTenancyStrategy);
             }
         };
+    }
+
+    /**
+     * Supplies the {@link MultiTenancyResolverClasses} holder carrying the classes implementing
+     * {@code TenantResolver} / {@code TenantConnectionResolver}, collected at build time, so that these generic beans
+     * can be looked up by their concrete implementation class at runtime.
+     */
+    public Supplier<MultiTenancyResolverClasses> multiTenancyResolverClasses(Set<Class<?>> tenantResolverClasses,
+            Set<Class<?>> tenantConnectionResolverClasses) {
+        return () -> new MultiTenancyResolverClasses(tenantResolverClasses, tenantConnectionResolverClasses);
     }
 
     public Supplier<JPAConfig> jpaConfigSupplier() {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitUtil.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitUtil.java
@@ -3,11 +3,17 @@ package io.quarkus.hibernate.orm.runtime;
 import static io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig.puPropertyKey;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Default;
 
@@ -15,8 +21,11 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class PersistenceUnitUtil {
@@ -79,48 +88,132 @@ public class PersistenceUnitUtil {
         }
     }
 
-    @Deprecated
-    public static <T> InjectableInstance<T> legacySingleExtensionInstanceForPersistenceUnit(Class<T> beanType,
-            String persistenceUnitName) {
-        InjectableInstance<T> instance = singleExtensionInstanceForPersistenceUnit(
-                beanType, persistenceUnitName);
-        if (instance.isUnsatisfied()) {
-            // Legacy behavior
-            if (PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
-                instance = Arc.container().select(beanType, Default.Literal.INSTANCE);
-                if (!instance.isUnsatisfied()
-                        // As long as this legacy support exists, the default,
-                        // Quarkus-defined beans need to use this legacy support,
-                        // in order to not override user beans.
-                        // So let's not log a warning when we just default to the Quarkus-defined beans...
-                        && !isDefaultBean(instance)) {
-                    LOG.warnf("A bean of type %1$s is being retrieved even though it doesn't have a @%2$s qualifier."
-                            + " This is deprecated usage and will not work in future versions of Quarkus."
-                            + " Annotate this bean with @%2$s to make it future-proof.",
-                            beanType.getName(), PersistenceUnitExtension.class.getSimpleName());
-                }
+    /**
+     * Retrieves the single {@link TenantResolver} bean assigned to the given persistence unit, if any.
+     * <p>
+     * {@link TenantResolver} is a generic interface, so implementations expose a parameterized bean type
+     * (e.g. {@code TenantResolver<Long>}) that Arc typesafe resolution does not match against a raw
+     * {@code TenantResolver.class} required type. We therefore look the bean up by its concrete implementation class,
+     * using the set of implementation classes collected at build time (see {@link MultiTenancyResolverClasses}).
+     */
+    @SuppressWarnings("unchecked")
+    public static Optional<InstanceHandle<TenantResolver<Object>>> singleTenantResolver(
+            Set<Class<?>> tenantResolverClasses, String persistenceUnitName) {
+        return (Optional<InstanceHandle<TenantResolver<Object>>>) (Optional<?>) singleGenericExtensionInstanceForPersistenceUnit(
+                tenantResolverClasses, TenantResolver.class, persistenceUnitName);
+    }
+
+    /**
+     * Retrieves the single {@link TenantConnectionResolver} bean assigned to the given persistence unit, if any.
+     *
+     * @see #singleTenantResolver(Set, String)
+     */
+    @SuppressWarnings("unchecked")
+    public static Optional<InstanceHandle<TenantConnectionResolver<Object>>> singleTenantConnectionResolver(
+            Set<Class<?>> tenantConnectionResolverClasses, String persistenceUnitName) {
+        return (Optional<InstanceHandle<TenantConnectionResolver<Object>>>) (Optional<?>) singleGenericExtensionInstanceForPersistenceUnit(
+                tenantConnectionResolverClasses, TenantConnectionResolver.class, persistenceUnitName);
+    }
+
+    /**
+     * Resolves the single bean of a generic {@code @PersistenceUnitExtension} interface for a persistence unit.
+     * <p>
+     * Because the interface is generic, beans are selected by their concrete implementation class rather than by the
+     * interface type. The interface class itself is included in the lookup so that raw-typed beans (such as the
+     * Quarkus-provided {@code @DefaultBean}, whose only exposed type is the raw interface) are still found.
+     * <p>
+     * The {@code @PersistenceUnitExtension} qualifier is tried first; if nothing matches, the deprecated fallback to the
+     * {@code @Default} / {@code @PersistenceUnit} qualifiers is applied, matching the behavior of the non-generic
+     * extension lookups.
+     */
+    private static Optional<InstanceHandle<Object>> singleGenericExtensionInstanceForPersistenceUnit(
+            Set<Class<?>> beanClasses, Class<?> interfaceType, String persistenceUnitName) {
+        Set<Class<?>> lookupClasses = new LinkedHashSet<>();
+        lookupClasses.add(interfaceType);
+        lookupClasses.addAll(beanClasses);
+
+        List<InstanceHandle<Object>> handles = uniqueBeanHandles(lookupClasses,
+                new PersistenceUnitExtension.Literal(persistenceUnitName));
+        boolean usedLegacyQualifier = false;
+        if (handles.isEmpty()) {
+            // Legacy behavior: fall back to the @Default / @PersistenceUnit qualifiers.
+            Annotation legacyQualifier = isDefaultPersistenceUnit(persistenceUnitName)
+                    ? Default.Literal.INSTANCE
+                    : new PersistenceUnit.PersistenceUnitLiteral(persistenceUnitName);
+            handles = uniqueBeanHandles(lookupClasses, legacyQualifier);
+            usedLegacyQualifier = true;
+        }
+
+        if (handles.isEmpty()) {
+            return Optional.empty();
+        }
+        // Replicate the @DefaultBean semantics that Arc typesafe resolution would normally apply:
+        // because we select beans by their concrete implementation class, a Quarkus-provided @DefaultBean
+        // (e.g. DataSourceTenantConnectionResolver) can be resolved through its own class even when a
+        // user-provided bean also matches through the interface type. Arc would suppress the default bean in
+        // that situation, so we do the same here: as soon as a non-default bean is present, drop the default one(s).
+        handles = suppressDefaultBeans(handles);
+        if (handles.size() > 1) {
+            List<String> ambiguousClassNames = handles.stream()
+                    .map(h -> h.getBean().getBeanClass().getCanonicalName()).toList();
+            throw new IllegalStateException(String.format(Locale.ROOT,
+                    "Multiple instances of %1$s were found for persistence unit %2$s. "
+                            + "At most one instance can be assigned to each persistence unit. Instances found: %3$s",
+                    interfaceType.getSimpleName(), persistenceUnitName, ambiguousClassNames));
+        }
+
+        InstanceHandle<Object> handle = handles.get(0);
+        // As long as this legacy support exists, the default, Quarkus-defined beans need to use this legacy support,
+        // in order to not override user beans. So let's not log a warning when we just default to the Quarkus-defined beans...
+        if (usedLegacyQualifier && !handle.getBean().isDefaultBean()) {
+            if (isDefaultPersistenceUnit(persistenceUnitName)) {
+                LOG.warnf("A bean of type %1$s is being retrieved even though it doesn't have a @%2$s qualifier."
+                        + " This is deprecated usage and will not work in future versions of Quarkus."
+                        + " Annotate this bean with @%2$s to make it future-proof.",
+                        interfaceType.getName(), PersistenceUnitExtension.class.getSimpleName());
             } else {
-                instance = Arc.container().select(beanType,
-                        new PersistenceUnit.PersistenceUnitLiteral(persistenceUnitName));
-                if (!instance.isUnsatisfied()
-                        // As long as this legacy support exists, the default,
-                        // Quarkus-defined beans need to use this legacy support,
-                        // in order to not override user beans.
-                        // So let's not log a warning when we just default to the Quarkus-defined beans...
-                        && !isDefaultBean(instance)) {
-                    LOG.warnf("A bean of type %1$s is being retrieved even though it doesn't have a @%2$s qualifier."
-                            + " This is deprecated usage and will not work in future versions of Quarkus."
-                            + " Annotate this bean with @%2$s(\"%4$s\") instead of @%3$s(\"%4$s\") to make it future-proof.",
-                            beanType.getName(), PersistenceUnitExtension.class.getSimpleName(),
-                            PersistenceUnit.class.getSimpleName(), persistenceUnitName);
+                LOG.warnf("A bean of type %1$s is being retrieved even though it doesn't have a @%2$s qualifier."
+                        + " This is deprecated usage and will not work in future versions of Quarkus."
+                        + " Annotate this bean with @%2$s(\"%4$s\") instead of @%3$s(\"%4$s\") to make it future-proof.",
+                        interfaceType.getName(), PersistenceUnitExtension.class.getSimpleName(),
+                        PersistenceUnit.class.getSimpleName(), persistenceUnitName);
+            }
+        }
+        return Optional.of(handle);
+    }
+
+    /**
+     * Retrieves the available bean handles for the given classes and qualifiers, deduplicated by bean.
+     * <p>
+     * A single bean can be reachable through multiple of the given classes; to avoid returning it more than once we key
+     * the handles by bean identifier. Note that collecting instances in an identity-based set would not work, because
+     * dependent-scoped beans would yield a distinct instance per lookup.
+     */
+    private static List<InstanceHandle<Object>> uniqueBeanHandles(Set<Class<?>> beanClasses, Annotation... qualifiers) {
+        Map<String, InstanceHandle<Object>> handlesByBeanId = new LinkedHashMap<>();
+        for (Class<?> beanClass : beanClasses) {
+            @SuppressWarnings("unchecked")
+            Class<Object> castBeanClass = (Class<Object>) beanClass;
+            InjectableInstance<Object> instance = Arc.container().select(castBeanClass, qualifiers);
+            for (InstanceHandle<Object> handle : instance.handles()) {
+                if (handle.isAvailable()) {
+                    handlesByBeanId.putIfAbsent(handle.getBean().getIdentifier(), handle);
                 }
             }
         }
-        return instance;
+        return new ArrayList<>(handlesByBeanId.values());
     }
 
-    private static <T> boolean isDefaultBean(InjectableInstance<T> instance) {
-        return instance.isResolvable() && instance.getHandle().getBean().isDefaultBean();
+    /**
+     * Drops {@code @DefaultBean} handles as soon as at least one non-default bean is present, mirroring the resolution
+     * that Arc performs for typesafe lookups. When only default beans are available, the list is returned unchanged.
+     */
+    private static List<InstanceHandle<Object>> suppressDefaultBeans(List<InstanceHandle<Object>> handles) {
+        boolean hasNonDefaultBean = handles.stream().anyMatch(handle -> !handle.getBean().isDefaultBean());
+        if (!hasNonDefaultBean) {
+            return handles;
+        }
+        return handles.stream().filter(handle -> !handle.getBean().isDefaultBean()).collect(Collectors.toList());
     }
 
     public static ConfigurationException unableToFindDataSource(String persistenceUnitName,

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
@@ -22,7 +22,7 @@ import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
  * @author Michael Schnell
  *
  */
-public class DataSourceTenantConnectionResolver implements TenantConnectionResolver {
+public class DataSourceTenantConnectionResolver implements TenantConnectionResolver<String> {
 
     private static final Logger LOG = Logger.getLogger(DataSourceTenantConnectionResolver.class);
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateCurrentTenantIdentifierResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateCurrentTenantIdentifierResolver.java
@@ -6,36 +6,41 @@ import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 
 /**
  * Maps from the Quarkus {@link TenantResolver} to the Hibernate {@link CurrentTenantIdentifierResolver} model.
+ * <p>
+ * The tenant identifier type is intentionally erased to {@link Object} here: the actual type is defined by the
+ * user-provided {@link TenantResolver} implementation and Hibernate ORM treats the identifier as an opaque value.
  *
  * @author Michael Schnell
  *
  */
-// TODO support other tenant ID types than String; see https://github.com/quarkusio/quarkus/issues/36831
-public final class HibernateCurrentTenantIdentifierResolver implements CurrentTenantIdentifierResolver<String> {
+public final class HibernateCurrentTenantIdentifierResolver implements CurrentTenantIdentifierResolver<Object> {
 
     private static final Logger LOG = Logger.getLogger(HibernateCurrentTenantIdentifierResolver.class);
 
     private final String persistenceUnitName;
+
+    // Cached once (lazily, at first resolution) to avoid repeating the container lookup on every tenant resolution.
+    private volatile MultiTenancyResolverClasses resolverClasses;
 
     public HibernateCurrentTenantIdentifierResolver(String persistenceUnitName) {
         this.persistenceUnitName = persistenceUnitName;
     }
 
     @Override
-    public String resolveCurrentTenantIdentifier() {
+    public Object resolveCurrentTenantIdentifier() {
 
         // Make sure that we're in a request
         if (!Arc.container().requestContext().isActive()) {
             return null;
         }
 
-        TenantResolver resolver = tenantResolver(persistenceUnitName);
-        String tenantId = resolver.resolveTenantId();
+        TenantResolver<Object> resolver = tenantResolver(persistenceUnitName);
+        Object tenantId = resolver.resolveTenantId();
         if (tenantId == null) {
             throw new IllegalStateException("Method 'TenantResolver.resolveTenantId()' returned a null value. "
                     + "Unfortunately Hibernate ORM does not allow null for tenant identifiers. "
@@ -52,28 +57,34 @@ public final class HibernateCurrentTenantIdentifierResolver implements CurrentTe
     }
 
     @Override
-    public boolean isRoot(String tenantId) {
+    public boolean isRoot(Object tenantId) {
         // Make sure that we're in a request
         if (!Arc.container().requestContext().isActive()) {
             return false;
         }
-        TenantResolver resolver = tenantResolver(persistenceUnitName);
+        TenantResolver<Object> resolver = tenantResolver(persistenceUnitName);
         if (resolver == null) {
             return false;
         }
         return resolver.isRoot(tenantId);
     }
 
-    private static TenantResolver tenantResolver(String persistenceUnitName) {
-        InjectableInstance<TenantResolver> instance = PersistenceUnitUtil.legacySingleExtensionInstanceForPersistenceUnit(
-                TenantResolver.class, persistenceUnitName);
-        if (instance.isUnsatisfied()) {
-            throw new IllegalStateException(String.format(Locale.ROOT,
-                    "No instance of %1$s was found for persistence unit %2$s. "
-                            + "You need to create an implementation for this interface to allow resolving the current tenant identifier.",
-                    TenantResolver.class.getSimpleName(), persistenceUnitName));
+    private TenantResolver<Object> tenantResolver(String persistenceUnitName) {
+        return PersistenceUnitUtil.singleTenantResolver(resolverClasses().tenantResolverClasses(), persistenceUnitName)
+                .map(InstanceHandle::get)
+                .orElseThrow(() -> new IllegalStateException(String.format(Locale.ROOT,
+                        "No instance of %1$s was found for persistence unit %2$s. "
+                                + "You need to create an implementation for this interface to allow resolving the current tenant identifier.",
+                        TenantResolver.class.getSimpleName(), persistenceUnitName)));
+    }
+
+    private MultiTenancyResolverClasses resolverClasses() {
+        MultiTenancyResolverClasses local = resolverClasses;
+        if (local == null) {
+            local = Arc.container().select(MultiTenancyResolverClasses.class).get();
+            resolverClasses = local;
         }
-        return instance.get();
+        return local;
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateMultiTenantConnectionProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateMultiTenantConnectionProvider.java
@@ -13,23 +13,28 @@ import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 
 /**
  * Maps from the Quarkus {@link TenantConnectionResolver} to the {@link HibernateMultiTenantConnectionProvider} model.
+ * <p>
+ * The tenant identifier type is intentionally erased to {@link Object} here: the actual type is defined by the
+ * user-provided {@link TenantResolver} / {@link TenantConnectionResolver} implementations and Hibernate ORM treats the
+ * identifier as an opaque value.
  *
  * @author Michael Schnell
  */
-// TODO support other tenant ID types than String; see https://github.com/quarkusio/quarkus/issues/36831
-public final class HibernateMultiTenantConnectionProvider extends AbstractMultiTenantConnectionProvider<String> {
+public final class HibernateMultiTenantConnectionProvider extends AbstractMultiTenantConnectionProvider<Object> {
 
     private static final Logger LOG = Logger.getLogger(HibernateMultiTenantConnectionProvider.class);
 
     private final String persistenceUnitName;
-    private final Map<String, ConnectionProvider> providerMap = new ConcurrentHashMap<>();
+    private final Map<Object, ConnectionProvider> providerMap = new ConcurrentHashMap<>();
+
+    // Cached once (lazily, at first resolution) to avoid repeating the container lookup on every tenant resolution.
+    private volatile MultiTenancyResolverClasses resolverClasses;
 
     public HibernateMultiTenantConnectionProvider(String persistenceUnitName) {
         this.persistenceUnitName = persistenceUnitName;
@@ -37,8 +42,8 @@ public final class HibernateMultiTenantConnectionProvider extends AbstractMultiT
 
     @Override
     protected ConnectionProvider getAnyConnectionProvider() {
-        InstanceHandle<TenantResolver> tenantResolver = tenantResolver(persistenceUnitName);
-        String tenantId;
+        InstanceHandle<TenantResolver<Object>> tenantResolver = tenantResolver(persistenceUnitName);
+        Object tenantId;
         // Activate RequestScope if the TenantResolver is @RequestScoped or @SessionScoped
         ManagedContext requestContext = Arc.container().requestContext();
         Class<? extends Annotation> tenantScope = tenantResolver.getBean().getScope();
@@ -62,7 +67,7 @@ public final class HibernateMultiTenantConnectionProvider extends AbstractMultiT
     }
 
     @Override
-    protected ConnectionProvider selectConnectionProvider(final String tenantIdentifier) {
+    protected ConnectionProvider selectConnectionProvider(final Object tenantIdentifier) {
         LOG.debugv("selectConnectionProvider(persistenceUnitName={0}, tenantIdentifier={1})", persistenceUnitName,
                 tenantIdentifier);
 
@@ -76,26 +81,19 @@ public final class HibernateMultiTenantConnectionProvider extends AbstractMultiT
 
     }
 
-    private static ConnectionProvider resolveConnectionProvider(String persistenceUnitName, String tenantIdentifier) {
+    private ConnectionProvider resolveConnectionProvider(String persistenceUnitName, Object tenantIdentifier) {
         LOG.debugv("resolveConnectionProvider(persistenceUnitName={0}, tenantIdentifier={1})", persistenceUnitName,
                 tenantIdentifier);
-        // TODO when we switch to the non-legacy method, don't forget to update the definition of the default bean
-        //   of type DataSourceTenantConnectionResolver (add the @PersistenceUnitExtension qualifier to that bean)
-        InjectableInstance<TenantConnectionResolver> instance = PersistenceUnitUtil
-                .legacySingleExtensionInstanceForPersistenceUnit(
-                        TenantConnectionResolver.class, persistenceUnitName);
-        if (instance.isUnsatisfied()) {
-            throw new IllegalStateException(
-                    String.format(
-                            Locale.ROOT, "No instance of %1$s was found for persistence unit %2$s. "
-                                    + "You need to create an implementation for this interface to allow resolving the current tenant connection.",
-                            TenantConnectionResolver.class.getSimpleName(), persistenceUnitName));
-        }
-        TenantConnectionResolver resolver = instance.get();
-        ConnectionProvider cp = resolver.resolve(tenantIdentifier);
+        InstanceHandle<TenantConnectionResolver<Object>> instance = PersistenceUnitUtil
+                .singleTenantConnectionResolver(resolverClasses().tenantConnectionResolverClasses(), persistenceUnitName)
+                .orElseThrow(() -> new IllegalStateException(String.format(Locale.ROOT,
+                        "No instance of %1$s was found for persistence unit %2$s. "
+                                + "You need to create an implementation for this interface to allow resolving the current tenant connection.",
+                        TenantConnectionResolver.class.getSimpleName(), persistenceUnitName)));
+        ConnectionProvider cp = instance.get().resolve(tenantIdentifier);
         if (cp == null) {
             throw new IllegalStateException("Method 'TenantConnectionResolver."
-                    + "resolve(String)' returned a null value. This violates the contract of the interface!");
+                    + "resolve(Object)' returned a null value. This violates the contract of the interface!");
         }
         return cp;
     }
@@ -105,19 +103,21 @@ public final class HibernateMultiTenantConnectionProvider extends AbstractMultiT
      *
      * @return Current tenant resolver.
      */
-    private static InstanceHandle<TenantResolver> tenantResolver(String persistenceUnitName) {
-        InjectableInstance<TenantResolver> instance = PersistenceUnitUtil
-                .legacySingleExtensionInstanceForPersistenceUnit(
-                        TenantResolver.class, persistenceUnitName);
+    private InstanceHandle<TenantResolver<Object>> tenantResolver(String persistenceUnitName) {
+        return PersistenceUnitUtil.singleTenantResolver(resolverClasses().tenantResolverClasses(), persistenceUnitName)
+                .orElseThrow(() -> new IllegalStateException(String.format(Locale.ROOT,
+                        "No instance of %1$s was found for persistence unit %2$s. "
+                                + "You need to create an implementation for this interface to allow resolving the current tenant identifier.",
+                        TenantResolver.class.getSimpleName(), persistenceUnitName)));
+    }
 
-        if (instance.isUnsatisfied()) {
-            throw new IllegalStateException(String.format(Locale.ROOT,
-                    "No instance of %1$s was found for persistence unit %2$s. "
-                            + "You need to create an implementation for this interface to allow resolving the current tenant identifier.",
-                    TenantResolver.class.getSimpleName(), persistenceUnitName));
+    private MultiTenancyResolverClasses resolverClasses() {
+        MultiTenancyResolverClasses local = resolverClasses;
+        if (local == null) {
+            local = Arc.container().select(MultiTenancyResolverClasses.class).get();
+            resolverClasses = local;
         }
-
-        return instance.getHandle();
+        return local;
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/MultiTenancyResolverClasses.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/MultiTenancyResolverClasses.java
@@ -1,0 +1,35 @@
+package io.quarkus.hibernate.orm.runtime.tenant;
+
+import java.util.Set;
+
+/**
+ * Holds the classes implementing {@link TenantResolver} / {@link TenantConnectionResolver}, collected at build time.
+ * <p>
+ * These generic interfaces cannot be looked up reliably through Arc typesafe resolution (a raw {@code TenantResolver}
+ * required type does not match a bean implementing {@code TenantResolver<NotAWildcard>}), so the beans are selected by
+ * their concrete implementation class instead. See
+ * {@code io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor#collectTenantResolverClasses} and
+ * <a href="https://github.com/quarkusio/quarkus/pull/30447">quarkus#30447</a> for the analogous ValueExtractor
+ * workaround.
+ * <p>
+ * This is an immutable value carried by a synthetic bean, so no mutable static state is needed.
+ */
+public final class MultiTenancyResolverClasses {
+
+    private final Set<Class<?>> tenantResolverClasses;
+    private final Set<Class<?>> tenantConnectionResolverClasses;
+
+    public MultiTenancyResolverClasses(Set<Class<?>> tenantResolverClasses,
+            Set<Class<?>> tenantConnectionResolverClasses) {
+        this.tenantResolverClasses = tenantResolverClasses;
+        this.tenantConnectionResolverClasses = tenantConnectionResolverClasses;
+    }
+
+    public Set<Class<?>> tenantResolverClasses() {
+        return tenantResolverClasses;
+    }
+
+    public Set<Class<?>> tenantConnectionResolverClasses() {
+        return tenantConnectionResolverClasses;
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/TenantConnectionResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/TenantConnectionResolver.java
@@ -5,10 +5,13 @@ import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 /**
  * Resolves the {@link ConnectionProvider} for tenants dynamically.
  *
+ * @param <T> the type of the tenant identifier. Use {@link String} unless you rely on a custom tenant identifier type
+ *        supported by Hibernate ORM.
+ *
  * @author Michael Schnell
  *
  */
-public interface TenantConnectionResolver {
+public interface TenantConnectionResolver<T> {
 
     /**
      * Returns a connection provider for the current tenant based on the context.
@@ -16,6 +19,6 @@ public interface TenantConnectionResolver {
      * @param tenantId the tenant identifier. Required value that cannot be {@literal null}.
      * @return Hibernate connection provider for the current provider. A non-{@literal null} value is required.
      */
-    ConnectionProvider resolve(String tenantId);
+    ConnectionProvider resolve(T tenantId);
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/TenantResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/TenantResolver.java
@@ -3,17 +3,20 @@ package io.quarkus.hibernate.orm.runtime.tenant;
 /**
  * Resolves tenant identifier dynamically so that the proper configuration can be used.
  *
+ * @param <T> the type of the tenant identifier. Use {@link String} unless you rely on a custom tenant identifier type
+ *        supported by Hibernate ORM.
+ *
  * @author Michael Schnell
  *
  */
-public interface TenantResolver {
+public interface TenantResolver<T> {
 
     /**
      * Returns the identifier of the default tenant.
      *
      * @return Default tenant.A non-{@literal null} value is required.
      */
-    String getDefaultTenantId();
+    T getDefaultTenantId();
 
     /**
      * Returns the current tenant identifier.
@@ -21,7 +24,7 @@ public interface TenantResolver {
      * @return the tenant identifier. This value will be used to select the proper configuration at runtime. A
      *         non-{@literal null} value is required.
      */
-    String resolveTenantId();
+    T resolveTenantId();
 
     /**
      * Does the given tenant id represent a "root" tenant with access to all partitions?
@@ -30,7 +33,7 @@ public interface TenantResolver {
      *
      * @return true is this is root tenant
      */
-    default boolean isRoot(String tenantId) {
+    default boolean isRoot(T tenantId) {
         return false;
     }
 

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/java/io/quarkus/it/hibernate/multitenancy/CustomTenantConnectionResolver.java
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/java/io/quarkus/it/hibernate/multitenancy/CustomTenantConnectionResolver.java
@@ -20,7 +20,7 @@ import io.quarkus.hibernate.orm.runtime.customized.QuarkusConnectionProvider;
 import io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver;
 
 @Vetoed
-class CustomTenantConnectionResolver implements Closeable, TenantConnectionResolver {
+class CustomTenantConnectionResolver implements Closeable, TenantConnectionResolver<String> {
 
     private static final Logger LOG = Logger.getLogger(CustomTenantConnectionResolver.class);
 

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/java/io/quarkus/it/hibernate/multitenancy/CustomTenantConnectionResolver.java
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/java/io/quarkus/it/hibernate/multitenancy/CustomTenantConnectionResolver.java
@@ -20,7 +20,7 @@ import io.quarkus.hibernate.orm.runtime.customized.QuarkusConnectionProvider;
 import io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver;
 
 @Vetoed
-class CustomTenantConnectionResolver implements Closeable, TenantConnectionResolver {
+class CustomTenantConnectionResolver implements Closeable, TenantConnectionResolver<String> {
 
     private static final Logger LOG = Logger.getLogger(CustomTenantConnectionResolver.class);
 

--- a/integration-tests/hibernate-orm-tenancy/discriminator/src/main/java/io/quarkus/it/hibernate/multitenancy/fruit/CustomTenantResolver.java
+++ b/integration-tests/hibernate-orm-tenancy/discriminator/src/main/java/io/quarkus/it/hibernate/multitenancy/fruit/CustomTenantResolver.java
@@ -11,7 +11,7 @@ import io.vertx.ext.web.RoutingContext;
 
 @PersistenceUnitExtension
 @RequestScoped
-public class CustomTenantResolver implements TenantResolver {
+public class CustomTenantResolver implements TenantResolver<String> {
 
     private static final Logger LOG = Logger.getLogger(CustomTenantResolver.class);
 


### PR DESCRIPTION
This is a draft for solving #36831 by using a generic typed TenantResolver Interface while keeping backwards compatibility. 

Therefor a new TypedTenantResolver<> was introduced and the TenantResolver now extends the TypedTenantResolver<String>. For resolving the generic typed interface with the Arc Container, a non generic Marker Interface was introduced named TenantResolverMarker from which the TypedTenantResolver extends. On resolving the TypedTenantResolver, all beans of the TenantResolverMarker interface are collected and checked for being an instance of TypedTenantResolver and the generic type is handled as object.