### PR TITLE
Upgrade sshd to 2.17.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -207,7 +207,7 @@
         <jose4j.version>0.9.6</jose4j.version>
         <java-buildpack-client.version>0.0.14</java-buildpack-client.version>
         <crac.version>1.5.0</crac.version>
-        <sshd-common.version>2.12.1</sshd-common.version>
+        <sshd-common.version>2.17.1</sshd-common.version>
         <mime4j.version>0.8.12</mime4j.version>
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
         <pulsar-client.version>3.3.0</pulsar-client.version>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

We want to get all org.apache.sshd dependencies aligned between Quarkus and Camel Quarkus.
Camel's last LTS 4.18 is currently on sshd 2.17.1 and the version has not been upgraded for a long while in quarkus.

We will also need it backported on 3.32 branch for future 3.33 version.

FYI @jamesnetherton 
@karesti if we bump sshd-common to 2.17.1 for Quarkus 3.33.x, is that going to cause issues for Infinispan?

Follow-up from this discussion: [#dev > Apache sshd upgrade](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Apache.20sshd.20upgrade/with/578091511)

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

