### PR TITLE
Re-enable dev services integration tests

### DIFF
--- a/integration-tests/devservices/dependent-extension/pom.xml
+++ b/integration-tests/devservices/dependent-extension/pom.xml
@@ -15,7 +15,7 @@
 
 
     <modules>
-        <module>deployment</module>
         <module>runtime</module>
+        <module>deployment</module>
     </modules>
 </project>

--- a/integration-tests/devservices/simple-extension/pom.xml
+++ b/integration-tests/devservices/simple-extension/pom.xml
@@ -15,7 +15,7 @@
 
 
     <modules>
-        <module>deployment</module>
         <module>runtime</module>
+        <module>deployment</module>
     </modules>
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -285,7 +285,7 @@
                 <module>reactive-mysql-client</module>
                 <module>reactive-mssql-client</module>
                 <module>reactive-oracle-client</module>
-<!--   disabled because of incremental build problems             <module>devservices</module>-->
+                <module>devservices</module>
                 <module>test-extension</module>
                 <module>amazon-lambda</module>
                 <module>amazon-lambda-s3event</module>


### PR DESCRIPTION
#### Problem 1 (apparently minor) 

These tests pass in the CIs that add them, but can fail in incremental builds with 

```
Failed to execute goal on project quarkus-integration-test-devservices-simple-extension-deployment: Could not resolve dependencies for project io.quarkus:quarkus-integration-test-devservices-simple-extension-deployment:jar:999-SNAPSHOT
dependency: io.quarkus:quarkus-integration-test-devservices-simple-extension:jar:999-SNAPSHOT (compile)
	Could not find artifact io.quarkus:quarkus-integration-test-devservices-simple-extension:jar:999-SNAPSHOT
```

I'm hoping swapping the dependency order in the reactor pom will help. 

#### Problem 2 (bigger, oops)

It turns out that the functionality added by https://github.com/quarkusio/quarkus/pull/51025 regressed while the test was disabled. I've raised #53019 with the fix.