### PR TITLE
config.adoc: replace dead link

### DIFF
--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -88,7 +88,7 @@ public class GreetingResource {
 
 == Inject the configuration
 
-Quarkus uses https://microprofile.io/project/eclipse/microprofile-config[MicroProfile Config] annotations to inject the
+Quarkus uses https://microprofile.io/specifications/config/[MicroProfile Config] annotations to inject the
 configuration properties in the application.
 
 [source,java]


### PR DESCRIPTION
The existing link leads to a placeholder site without content. I replaced it with something that seems to fit.
