### PR TITLE
Limit config property scanning to mapped classes for configuration cache stability

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -21,6 +21,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.process.JavaForkOptions;
+import org.gradle.util.GradleVersion;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.pkg.NativeConfig;
@@ -76,9 +77,10 @@ public abstract class AbstractQuarkusExtension {
                 .getFiles();
 
         EffectiveConfig effectiveConfig = EffectiveConfig.builder()
+                .withFilteredSystemProperties(getQuarkusRelevantSystemProperties())
                 .withTaskProperties(Collections.emptyMap())
                 .withBuildProperties(quarkusBuildProperties.get())
-                .withProjectProperties(project.getProperties())
+                .withProjectProperties(getQuarkusRelevantProjectProperties())
                 .withSourceDirectories(resourcesDirs)
                 .withProfile(quarkusProfile())
                 .build();
@@ -151,23 +153,80 @@ public abstract class AbstractQuarkusExtension {
     }
 
     private String quarkusProfile() {
-        String profile = System.getProperty(QUARKUS_PROFILE);
+        String profile = project.getProviders().systemProperty(QUARKUS_PROFILE).getOrNull();
         if (profile == null) {
-            profile = System.getenv("QUARKUS_PROFILE");
+            profile = project.getProviders().environmentVariable("QUARKUS_PROFILE").getOrNull();
         }
         if (profile == null) {
             profile = quarkusBuildProperties.get().get(QUARKUS_PROFILE);
         }
         if (profile == null) {
-            Object p = project.getProperties().get(QUARKUS_PROFILE);
-            if (p != null) {
-                profile = p.toString();
-            }
+            profile = getQuarkusRelevantProjectProperties().get(QUARKUS_PROFILE);
         }
         if (profile == null) {
             profile = "prod";
         }
         return profile;
+    }
+
+    /**
+     * Returns only quarkus-relevant project properties using the Gradle 8+ API when available,
+     * to avoid registering all project properties as configuration cache inputs.
+     */
+    private Map<String, String> getQuarkusRelevantProjectProperties() {
+        if (GradleVersion.current().compareTo(GradleVersion.version("8.0")) >= 0) {
+            Map<String, String> result = new HashMap<>(
+                    project.getProviders().gradlePropertiesPrefixedBy("quarkus.").get());
+            result.putAll(project.getProviders().gradlePropertiesPrefixedBy("platform.quarkus.").get());
+            return result;
+        } else {
+            Map<String, String> result = new HashMap<>();
+            for (Map.Entry<String, ?> entry : project.getProperties().entrySet()) {
+                if (entry.getValue() != null
+                        && (entry.getKey().startsWith("quarkus.") || entry.getKey().startsWith("platform.quarkus."))) {
+                    result.put(entry.getKey(), entry.getValue().toString());
+                }
+            }
+            return result;
+        }
+    }
+
+    /**
+     * JVM system properties referenced in Quarkus config default values:
+     * - {@code java.home}: NativeConfig.javaHome() defaults to {@code ${java.home}}
+     * - {@code user.home}: PackageConfig.DecompilerConfig.jarDirectory() defaults to {@code ${user.home}/.quarkus}
+     * These are stable across builds, so tracking them individually in the configuration cache is fine.
+     */
+    private static final List<String> JVM_PROPERTIES_FOR_CONFIG_EXPANSION = List.of(
+            "java.home", "user.home");
+
+    /**
+     * Returns only quarkus-relevant system properties plus well-known JVM properties needed for
+     * config expression expansion, using the Gradle 8+ API when available to avoid registering
+     * all system properties as configuration cache inputs.
+     */
+    private Map<String, String> getQuarkusRelevantSystemProperties() {
+        Map<String, String> result;
+        if (GradleVersion.current().compareTo(GradleVersion.version("8.1")) >= 0) {
+            result = new HashMap<>(project.getProviders().systemPropertiesPrefixedBy("quarkus.").get());
+            result.putAll(project.getProviders().systemPropertiesPrefixedBy("platform.quarkus.").get());
+        } else {
+            result = new HashMap<>();
+            for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+                String key = entry.getKey().toString();
+                if (key.startsWith("quarkus.") || key.startsWith("platform.quarkus.")) {
+                    result.put(key, entry.getValue().toString());
+                }
+            }
+        }
+        // Add well-known JVM properties needed for config expression expansion (e.g. ${java.home})
+        for (String key : JVM_PROPERTIES_FOR_CONFIG_EXPANSION) {
+            String value = project.getProviders().systemProperty(key).getOrNull();
+            if (value != null) {
+                result.put(key, value);
+            }
+        }
+        return result;
     }
 
     private static FileCollection dependencyClasspath(SourceSet mainSourceSet) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfig.java
@@ -36,7 +36,7 @@ final class BaseConfig {
         manifest.attributes(manifestConfig.attributes());
         manifestConfig.sections().forEach((section, attribs) -> manifest.attributes(attribs, section));
 
-        values = config.getValues();
+        values = config.getCachingValues();
     }
 
     PackageConfig packageConfig() {
@@ -58,22 +58,26 @@ final class BaseConfig {
     Map<String, String> cachingRelevantProperties(List<String> propertyPatterns) {
         List<Pattern> patterns = propertyPatterns.stream().map(s -> "^(" + s + ")$").map(Pattern::compile)
                 .collect(Collectors.toList());
-        readMissingEnvVariables(propertyPatterns);
-        Predicate<Map.Entry<String, ?>> keyPredicate = e -> patterns.stream().anyMatch(p -> p.matcher(e.getKey()).matches());
-        return values.entrySet().stream()
-                .filter(keyPredicate)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (s, s2) -> {
-                    throw new IllegalArgumentException("Duplicate key");
-                }, TreeMap::new));
-    }
+        TreeMap<String, String> result = new TreeMap<>();
 
-    /**
-     * Reads missing environment variables that have been defined as `cachingRelevantProperties`.
-     * This ensures that the configuration cache tracks these variables as inputs and detects changes in them.
-     */
-    private void readMissingEnvVariables(List<String> cachingRelevantProperties) {
-        cachingRelevantProperties.stream()
-                .filter(name -> !values.containsKey(name))
-                .forEach(name -> System.getenv(name));
+        // Include matching properties from the caching values (PackageConfig/NativeConfig)
+        Predicate<Map.Entry<String, ?>> keyPredicate = e -> patterns.stream().anyMatch(p -> p.matcher(e.getKey()).matches());
+        values.entrySet().stream()
+                .filter(keyPredicate)
+                .forEach(e -> result.put(e.getKey(), e.getValue()));
+
+        // For caching-relevant properties not found in the values map, check environment variables.
+        // This ensures that user-declared caching properties (like env vars) are still tracked as task inputs
+        // and cause rebuilds when their values change.
+        for (String name : propertyPatterns) {
+            if (!values.containsKey(name)) {
+                String envValue = System.getenv(name);
+                if (envValue != null) {
+                    result.put(name, envValue);
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
@@ -27,10 +27,12 @@ import io.quarkus.deployment.configuration.ConfigCompatibility;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
+import io.quarkus.runtime.configuration.QuarkusConfigBuilderCustomizer;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Expressions;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.source.yaml.YamlConfigSourceLoader;
 
 /**
@@ -74,11 +76,32 @@ public final class EffectiveConfig {
             platformPropertiesConfigSource = new PropertiesConfigSource(builder.platformProperties, "platformProperties", 0);
         }
 
-        this.config = ConfigUtils.emptyConfigBuilder()
+        SmallRyeConfigBuilder configBuilder;
+        if (builder.useSystemSources) {
+            // Full builder with all default sources (including System.getProperties() and System.getenv()).
+            // Used during task execution where reading all system properties is fine.
+            configBuilder = ConfigUtils.emptyConfigBuilder()
+                    .addSystemSources();
+        } else {
+            // Minimal builder WITHOUT addDefaultSources() to avoid reading System.getProperties()/System.getenv(),
+            // which would cause Gradle's configuration cache to track all system properties as inputs.
+            // Used during configuration phase with only quarkus-prefixed properties passed explicitly.
+            configBuilder = new SmallRyeConfigBuilder()
+                    .withCustomizers(new QuarkusConfigBuilderCustomizer())
+                    .addDiscoveredConverters()
+                    .addDefaultInterceptors()
+                    .addDiscoveredInterceptors()
+                    .addDiscoveredSecretKeysHandlers();
+            if (builder.filteredSystemProperties != null) {
+                configBuilder.withSources(
+                        new PropertiesConfigSource(builder.filteredSystemProperties, "filteredSystemProperties", 400));
+            }
+        }
+        configBuilder
                 .forClassLoader(toUrlClassloader(builder.sourceDirectories))
                 .withSources(new PropertiesConfigSource(builder.forcedProperties, "forcedProperties", 600))
-                .withSources(new PropertiesConfigSource(asStringMap(builder.taskProperties), "taskProperties", 500))
-                .addSystemSources()
+                .withSources(new PropertiesConfigSource(asStringMap(builder.taskProperties), "taskProperties", 500));
+        this.config = configBuilder
                 .withSources(new PropertiesConfigSource(builder.buildProperties, "quarkusBuildProperties", 290))
                 .withSources(new PropertiesConfigSource(asStringMap(builder.projectProperties), "projectProperties", 280))
                 .withSources(new YamlConfigSourceLoader.InFileSystem())
@@ -237,6 +260,8 @@ public final class EffectiveConfig {
         private Map<String, String> defaultProperties = emptyMap();
         private Set<File> sourceDirectories = emptySet();
         private String profile = "prod";
+        private boolean useSystemSources = true;
+        private Map<String, String> filteredSystemProperties = null;
 
         EffectiveConfig build() {
             return new EffectiveConfig(this);
@@ -279,6 +304,21 @@ public final class EffectiveConfig {
 
         Builder withProfile(String profile) {
             this.profile = profile;
+            return this;
+        }
+
+        /**
+         * Replaces {@code addSystemSources()} (which reads ALL system properties and env vars) with
+         * a pre-filtered map of system properties. This avoids Gradle's configuration cache tracking
+         * all system properties as inputs, which would cause cache invalidation when any unrelated
+         * system property changes (e.g. IDE-injected properties).
+         * <p>
+         * The filtered properties are added at ordinal 400, matching the ordinal of
+         * {@code System.getProperties()} in the default config source ordering.
+         */
+        Builder withFilteredSystemProperties(Map<String, String> systemProperties) {
+            this.useSystemSources = false;
+            this.filteredSystemProperties = systemProperties;
             return this;
         }
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
@@ -44,8 +44,9 @@ import io.smallrye.config.source.yaml.YamlConfigSourceLoader;
  */
 public final class EffectiveConfig {
     private final SmallRyeConfig config;
-    private final Map<String, String> values;
-    private final Map<String, String> quarkusValues;
+    private volatile Map<String, String> values;
+    private volatile Map<String, String> quarkusValues;
+    private final Map<String, String> cachingValues;
 
     private EffectiveConfig(Builder builder) {
         // Effective "ordinals" for the config sources:
@@ -90,20 +91,50 @@ public final class EffectiveConfig {
                 .withMapping(NativeConfig.class)
                 .withInterceptors(ConfigCompatibility.FrontEnd.instance(), ConfigCompatibility.BackEnd.instance())
                 .build();
-        this.values = generateFullConfigMap(config);
-        this.quarkusValues = generateQuarkusConfigMap(config);
+        this.cachingValues = generateCachingConfigMap(config);
     }
 
     public SmallRyeConfig getConfig() {
         return config;
     }
 
+    /**
+     * Returns the full configuration map including all property names from all sources.
+     * <p>
+     * This method is lazily computed because it calls {@link SmallRyeConfig#getPropertyNames()} which reads
+     * all system properties. It should only be called during task execution, not during Gradle's configuration phase,
+     * to avoid unnecessary configuration cache invalidation.
+     */
     public Map<String, String> getValues() {
+        if (values == null) {
+            values = generateFullConfigMap(config);
+        }
         return values;
     }
 
+    /**
+     * Returns a configuration map containing only quarkus.* and platform.quarkus.* properties.
+     * <p>
+     * This method is lazily computed because it calls {@link SmallRyeConfig#getPropertyNames()} which reads
+     * all system properties. It should only be called during task execution, not during Gradle's configuration phase,
+     * to avoid unnecessary configuration cache invalidation.
+     */
     public Map<String, String> getQuarkusValues() {
+        if (quarkusValues == null) {
+            quarkusValues = generateQuarkusConfigMap(config);
+        }
         return quarkusValues;
+    }
+
+    /**
+     * Returns a configuration map containing only properties from {@link PackageConfig} and {@link NativeConfig}.
+     * <p>
+     * Unlike {@link #getValues()}, this method does not iterate all property names from all config sources,
+     * which avoids reading all system properties. This makes it safe to call during Gradle's configuration phase
+     * without causing unnecessary configuration cache invalidation when unrelated system properties change.
+     */
+    public Map<String, String> getCachingValues() {
+        return cachingValues;
     }
 
     private Map<String, String> asStringMap(Map<String, ?> map) {
@@ -158,6 +189,34 @@ public final class EffectiveConfig {
                                 || !configValue.isDefault())) {
                             properties.put(propertyName, configValue.getValue());
                         }
+                    }
+                }
+                return unmodifiableMap(properties);
+            }
+        });
+    }
+
+    /**
+     * Generates a configuration map containing only properties defined by {@link PackageConfig} and {@link NativeConfig}
+     * mapping classes. This avoids calling {@link SmallRyeConfig#getPropertyNames()} which would read all system
+     * properties and cause Gradle configuration cache invalidation when unrelated system properties change.
+     * <p>
+     * Instead, only the known property names from the mapping metadata are looked up individually in the config,
+     * so only those specific properties are tracked by Gradle's configuration cache.
+     */
+    @VisibleForTesting
+    static Map<String, String> generateCachingConfigMap(SmallRyeConfig config) {
+        Set<String> mappingPropertyNames = new HashSet<>();
+        mappingPropertyNames.addAll(configClass(PackageConfig.class).getProperties().keySet());
+        mappingPropertyNames.addAll(configClass(NativeConfig.class).getProperties().keySet());
+        return Expressions.withoutExpansion(new Supplier<Map<String, String>>() {
+            @Override
+            public Map<String, String> get() {
+                Map<String, String> properties = new HashMap<>();
+                for (String propertyName : mappingPropertyNames) {
+                    ConfigValue configValue = config.getConfigValue(propertyName);
+                    if (configValue.getValue() != null && !configValue.isDefault()) {
+                        properties.put(propertyName, configValue.getValue());
                     }
                 }
                 return unmodifiableMap(properties);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfigProvider.java
@@ -22,7 +22,7 @@ public class EffectiveConfigProvider {
     final ListProperty<String> ignoredEntries;
     final ConfigurableFileCollection mainResources;
     final MapProperty<String, String> forcedProperties;
-    final MapProperty<String, Object> projectProperties;
+    final MapProperty<String, String> projectProperties;
     final MapProperty<String, String> quarkusBuildProperties;
     final MapProperty<String, Object> manifestAttributes;
     final MapProperty<String, Attributes> manifestSections;
@@ -33,7 +33,7 @@ public class EffectiveConfigProvider {
     public EffectiveConfigProvider(ListProperty<String> ignoredEntries,
             ConfigurableFileCollection mainResources,
             MapProperty<String, String> forcedProperties,
-            MapProperty<String, Object> projectProperties,
+            MapProperty<String, String> projectProperties,
             MapProperty<String, String> quarkusBuildProperties,
             MapProperty<String, Object> manifestAttributes,
             MapProperty<String, Attributes> manifestSections,
@@ -110,10 +110,7 @@ public class EffectiveConfigProvider {
             profile = quarkusBuildProperties.get().get(QUARKUS_PROFILE);
         }
         if (profile == null) {
-            Object p = projectProperties.get().get(QUARKUS_PROFILE);
-            if (p != null) {
-                profile = p.toString();
-            }
+            profile = projectProperties.get().get(QUARKUS_PROFILE);
         }
         if (profile == null) {
             profile = "prod";

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -375,10 +375,9 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
                 buildSystemProperties.put(entry.getKey(), entry.getValue());
             }
         }
-        for (Map.Entry<String, ?> entry : getExtensionView().getProjectProperties().get().entrySet()) {
-            if ((entry.getKey().startsWith("quarkus.") || entry.getKey().startsWith("platform.quarkus."))
-                    && entry.getValue() != null) {
-                buildSystemProperties.put(entry.getKey(), entry.getValue().toString());
+        for (Map.Entry<String, String> entry : getExtensionView().getProjectProperties().get().entrySet()) {
+            if (entry.getValue() != null) {
+                buildSystemProperties.put(entry.getKey(), entry.getValue());
             }
         }
 
@@ -395,7 +394,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
                     continue;
                 }
 
-                expanded = (String) getExtensionView().getProjectProperties().get().get(reference);
+                expanded = getExtensionView().getProjectProperties().get().get(reference);
                 if (expanded != null) {
                     buildSystemProperties.put(reference, expanded);
                 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -58,13 +58,7 @@ public abstract class QuarkusPluginExtensionView {
         getQuarkusProfileEnvVariable().set(getProviderFactory().environmentVariable("QUARKUS_PROFILE"));
         getCachingRelevantProperties().set(extension.getCachingRelevantProperties());
         getForcedProperties().set(extension.forcedPropertiesProperty());
-        Map<String, Object> projectProperties = new HashMap<>();
-        for (Map.Entry<String, ?> entry : project.getProperties().entrySet()) {
-            if ((entry.getKey().startsWith("quarkus.") || entry.getKey().startsWith("platform.quarkus."))) {
-                projectProperties.put(entry.getKey(), entry.getValue());
-            }
-        }
-        getProjectProperties().set(projectProperties);
+        getProjectProperties().set(getQuarkusAndPlatformProjectProperties(project));
     }
 
     private Provider<Map<String, String>> getQuarkusRelevantProjectProperties(Project project) {
@@ -76,6 +70,24 @@ public abstract class QuarkusPluginExtensionView {
                     .filter(e -> e.getValue() != null)
                     .map(e -> Map.entry(e.getKey(), e.getValue().toString()))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        }
+    }
+
+    private Provider<Map<String, String>> getQuarkusAndPlatformProjectProperties(Project project) {
+        if (GradleVersion.current().compareTo(GradleVersion.version("8.0")) >= 0) {
+            Provider<Map<String, String>> quarkusProps = getProviderFactory().gradlePropertiesPrefixedBy("quarkus.");
+            Provider<Map<String, String>> platformProps = getProviderFactory()
+                    .gradlePropertiesPrefixedBy("platform.quarkus.");
+            return quarkusProps.zip(platformProps, (q, p) -> {
+                Map<String, String> merged = new HashMap<>(q);
+                merged.putAll(p);
+                return merged;
+            });
+        } else {
+            return getProviderFactory().provider(() -> project.getProperties().entrySet().stream()
+                    .filter(e -> e.getValue() != null)
+                    .filter(e -> e.getKey().startsWith("quarkus.") || e.getKey().startsWith("platform.quarkus."))
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString())));
         }
     }
 
@@ -99,7 +111,7 @@ public abstract class QuarkusPluginExtensionView {
     public abstract Property<String> getFinalName();
 
     @Input
-    public abstract MapProperty<String, Object> getProjectProperties();
+    public abstract MapProperty<String, String> getProjectProperties();
 
     @Nested
     public abstract ListProperty<Action<? super JavaForkOptions>> getCodeGenForkOptions();

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
@@ -15,11 +15,14 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +31,13 @@ public class TasksConfigurationCacheCompatibilityTest {
 
     @TempDir
     Path testProjectDir;
+
+    @BeforeEach
+    void setUp() throws IOException, URISyntaxException {
+        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
+        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
+        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+    }
 
     private static Stream<String> compatibleTasks() {
         return Stream.of(
@@ -47,76 +57,69 @@ public class TasksConfigurationCacheCompatibilityTest {
 
     @ParameterizedTest
     @MethodSource("compatibleTasks")
-    public void configurationCacheIsReusedTest(String taskName) throws IOException, URISyntaxException {
-        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
-        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
-        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
-
-        buildResult(":help", "--configuration-cache");
-
-        BuildResult firstBuild = buildResult(taskName, "--configuration-cache");
+    public void configurationCacheIsReusedTest(String taskName) throws IOException {
+        BuildResult firstBuild = runBuildWithConfigurationCache(taskName);
         assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
 
-        BuildResult secondBuild = buildResult(taskName, "--configuration-cache");
+        BuildResult secondBuild = runBuildWithConfigurationCache(taskName);
         assertTrue(secondBuild.getOutput().contains("Reusing configuration cache."));
     }
 
     @ParameterizedTest
     @MethodSource("compatibleTasks")
-    public void configurationCacheIsReusedWhenProjectIsolationIsUsedTest(String taskName)
-            throws IOException, URISyntaxException {
-        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
-        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
-        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
-
-        buildResult(":help", "--configuration-cache");
-
-        BuildResult firstBuild = buildResult(taskName, "-Dorg.gradle.unsafe.isolated-projects=true");
+    public void configurationCacheIsReusedWhenProjectIsolationIsUsedTest(String taskName) throws IOException {
+        BuildResult firstBuild = runBuildWithConfigurationCache(taskName,
+                "-Dorg.gradle.unsafe.isolated-projects=true");
         assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
 
-        BuildResult secondBuild = buildResult(taskName, "-Dorg.gradle.unsafe.isolated-projects=true");
+        BuildResult secondBuild = runBuildWithConfigurationCache(taskName,
+                "-Dorg.gradle.unsafe.isolated-projects=true");
+        assertTrue(secondBuild.getOutput().contains("Reusing configuration cache."));
+    }
+
+    @ParameterizedTest
+    @MethodSource("compatibleTasks")
+    public void configurationCacheIsReusedWhenNonQuarkusSystemPropertyChanges(String taskName) throws IOException {
+        BuildResult firstBuild = runBuildWithConfigurationCache(taskName, "-Da=1");
+        assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
+
+        BuildResult secondBuild = runBuildWithConfigurationCache(taskName, "-Da=2");
         assertTrue(secondBuild.getOutput().contains("Reusing configuration cache."));
     }
 
     @ParameterizedTest
     @MethodSource("nonCompatibleQuarkusBuildTasks")
-    public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFail(String taskName)
-            throws IOException, URISyntaxException {
-        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
-        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
-        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
-
-        BuildResult build = buildResult(taskName);
+    public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFail(String taskName) throws IOException {
+        BuildResult build = runBuildWithoutConfigurationCache(taskName);
         assertTrue(build.getOutput().contains("BUILD SUCCESSFUL"));
-
     }
 
     @ParameterizedTest
     @MethodSource("nonCompatibleQuarkusBuildTasks")
-    public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFailWhenUsingConfigurationCache(String taskName)
-            throws IOException, URISyntaxException {
-        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
-        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
-        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
-
-        BuildResult build = buildResult(taskName, "--no-configuration-cache");
+    public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFailWhenUsingConfigurationCache(
+            String taskName) throws IOException {
+        BuildResult build = runBuildWithoutConfigurationCache(taskName);
         assertTrue(build.getOutput().contains("BUILD SUCCESSFUL"));
-
     }
 
-    private BuildResult buildResult(String task, String configurationCacheCommand) {
+    private BuildResult runBuildWithConfigurationCache(String task, String... extraArgs) {
+        List<String> args = new ArrayList<>(
+                List.of(task, "--info", "--stacktrace", "--build-cache", "--configuration-cache"));
+        for (String arg : extraArgs) {
+            args.add(arg);
+        }
         return GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(testProjectDir.toFile())
-                .withArguments(task, "--info", "--stacktrace", "--build-cache", configurationCacheCommand)
+                .withArguments(args)
                 .build();
     }
 
-    private BuildResult buildResult(String task) {
+    private BuildResult runBuildWithoutConfigurationCache(String task) {
         return GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(testProjectDir.toFile())
-                .withArguments(task, "--info", "--stacktrace", "--build-cache")
+                .withArguments(task, "--info", "--stacktrace", "--build-cache", "--no-configuration-cache")
                 .build();
     }
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -58,8 +58,8 @@ public class ApplicationDeploymentClasspathBuilder {
     private static final String DISABLE_QUARKUS_COMPONENT_VARIANTS = "disableQuarkusComponentVariants";
 
     public static boolean isDisableComponentVariants(Project project) {
-        final Object value = project.getProperties().get(DISABLE_QUARKUS_COMPONENT_VARIANTS);
-        return value != null && Boolean.parseBoolean(String.valueOf(value));
+        final String value = project.getProviders().gradleProperty(DISABLE_QUARKUS_COMPONENT_VARIANTS).getOrNull();
+        return value != null && Boolean.parseBoolean(value);
     }
 
     public static String getLaunchModeAlias(LaunchMode mode) {


### PR DESCRIPTION
Based on the PR comments on this PR https://github.com/quarkusio/quarkus/pull/52507, this PR implements:
 - Added a new getCachingValues() method in EffectiveConfig that only looks up properties from PackageConfig and NativeConfig mappings (the known, relevant properties), avoiding the full getPropertyNames() scan.
  - Made getValues() and getQuarkusValues() lazy so they're only computed during task execution, not during configuration.
  - Refactored BaseConfig.cachingRelevantProperties() to use the new caching-safe values and directly include matching environment variables in the result map (instead of just reading them for side-effect tracking).

@radcortez @aloubyansky 