### PR TITLE
Reintroduce QuarkusClassLoader#parent()

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -995,6 +995,14 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         }
     }
 
+    /**
+     * @deprecated use {@link #getParent()} instead.
+     */
+    @Deprecated(since = "3.34", forRemoval = true)
+    public ClassLoader parent() {
+        return getParent();
+    }
+
     @Override
     public String getName() {
         return name;


### PR DESCRIPTION
It's breaking extensions unnecessarily. We can drop it in a few versions.
It's delegating to getParent() so we still get the benefits from #52922.
