### PR TITLE
Reintroduce `QuarkusClassLoader#parent()` and deprecate it

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -995,6 +995,14 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         }
     }
 
+    /**
+     * @deprecated use {@link #getParent()} instead, this method is only left for binary compatibility reasons
+     */
+    @Deprecated(since = "3.33.0", forRemoval = true)
+    public ClassLoader parent() {
+        return getParent();
+    }
+
     @Override
     public String getName() {
         return name;


### PR DESCRIPTION
Because this is part of the public API and it needs to be preserved for binary compatibility reasons
