### PR TITLE
Fix self-closing tags silently failing inside {#include} sections

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -483,7 +483,13 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
             // Initialize the block
             Scope currentScope = scopeStack.peek();
             Scope newScope = lastSection.factory.initializeBlock(currentScope, block);
-            scopeStack.addFirst(newScope);
+            if (isEmptySection) {
+                // Self-closing section block, e.g. {#header/} inside {#include}
+                // End the block immediately so currentBlock reverts to main
+                lastSection.endBlock();
+            } else {
+                scopeStack.addFirst(newScope);
+            }
 
         } else {
             // => New section

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
@@ -381,6 +381,21 @@ public class IncludeTest {
     }
 
     @Test
+    public void testSelfClosingBlockInInclude() {
+        Engine engine = Engine.builder().addDefaults().build();
+        engine.putTemplate("base", engine.parse(
+                "{#insert header}default header{/insert}::{#insert footer}default footer{/insert}"));
+
+        // Self-closing block overrides insert with empty content
+        assertEquals("::default footer",
+                engine.parse("{#include base}{#header/}{/include}").render());
+
+        // Self-closing block doesn't corrupt subsequent blocks
+        assertEquals("::custom footer",
+                engine.parse("{#include base}{#header/}{#footer}custom footer{/footer}{/include}").render());
+    }
+
+    @Test
     public void testTemplateNameWithUnderscorePrefix() {
         Engine engine = Engine.builder().addDefaults().build();
         engine.putTemplate("_root", engine.parse("<html><body>{#insert foo /}</body></html>"));


### PR DESCRIPTION
The block path in Parser.sectionStart() ignored the isEmptySection flag, so self-closing syntax like {#header/} inside {#include} would open a block that was never closed, leaking scope and producing no output. Call endBlock() immediately for self-closing section blocks to reset currentBlock back to main.

Fixes #23290

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

