### PR TITLE
Add Quarkus Lifecycle MCP Server for AI coding agents

### DIFF
--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -68,6 +68,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mcp-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/devtools/cli/src/main/java/io/quarkus/cli/McpServer.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/McpServer.java
@@ -1,0 +1,31 @@
+package io.quarkus.cli;
+
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.common.HelpOption;
+import io.quarkus.cli.common.OutputOptionMixin;
+import io.quarkus.devtools.mcp.McpLifecycleServer;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "mcp-server", header = "Start the Quarkus MCP lifecycle server (stdio).", description = {
+        "%nStarts a Model Context Protocol (MCP) server over stdin/stdout that can manage",
+        "Quarkus application lifecycle (start, stop, restart, status, logs).",
+        "%nThis server is designed to be used by AI coding agents (e.g. Claude Code)",
+        "and survives application crashes, allowing agents to recover broken apps.",
+        "%nConfigure in your MCP client:",
+        "  {\"command\": \"quarkus\", \"args\": [\"mcp-server\"]}"
+})
+public class McpServer implements Callable<Integer> {
+
+    @CommandLine.Mixin(name = "output")
+    OutputOptionMixin output;
+
+    @CommandLine.Mixin
+    HelpOption helpOption;
+
+    @Override
+    public Integer call() throws Exception {
+        McpLifecycleServer.main(new String[0]);
+        return CommandLine.ExitCode.OK;
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -62,6 +62,7 @@ import picocli.CommandLine.UnmatchedArgumentException;
         Info.class,
         Update.class,
         Version.class,
+        McpServer.class,
         CliPlugins.class,
         Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true, versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n", headerHeading = "%n", parameterListHeading = "%n")
 public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<Integer> {

--- a/devtools/mcp-server/pom.xml
+++ b/devtools/mcp-server/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-mcp-server</artifactId>
+    <name>Quarkus - MCP Lifecycle Server</name>
+    <description>Standalone MCP stdio server for managing Quarkus application lifecycle</description>
+
+    <properties>
+        <langchain4j.version>1.9.1</langchain4j.version>
+        <langchain4j-community.version>1.9.1-beta17</langchain4j-community.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <!-- LangChain4j for RAG doc search -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId>
+            <version>${langchain4j-community.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-pgvector</artifactId>
+            <version>${langchain4j-community.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>io.quarkus.devtools.mcp.McpLifecycleServer</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.quarkus.devtools.mcp.McpLifecycleServer</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/DocSearchService.java
+++ b/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/DocSearchService.java
@@ -1,0 +1,311 @@
+package io.quarkus.devtools.mcp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.bgesmallenv15q.BgeSmallEnV15QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+
+/**
+ * Provides Quarkus documentation search using BGE embeddings + pgvector.
+ * Connects to a pgvector Docker container with pre-indexed Quarkus docs
+ * (produced by chappie-docling-rag).
+ */
+public class DocSearchService {
+
+    private static final String DEFAULT_IMAGE = "ghcr.io/quarkusio/chappie-ingestion-quarkus:3.31.4";
+    private static final String CONTAINER_NAME = "quarkus-docs-pgvector";
+    private static final int PG_PORT = 5433; // use non-default to avoid conflicts
+    private static final String PG_USER = "quarkus";
+    private static final String PG_PASSWORD = "quarkus";
+    private static final String PG_DB = "quarkus";
+    private static final String TABLE_NAME = "rag_documents";
+    private static final int DIMENSION = 384;
+    private static final double MIN_SCORE = 0.82;
+    private static final int SEARCH_CANDIDATES = 50; // fetch more for reranking
+    private static final int DEFAULT_MAX_RESULTS = 4;
+
+    private volatile EmbeddingModel embeddingModel;
+    private volatile PgVectorEmbeddingStore embeddingStore;
+
+    /**
+     * Search Quarkus documentation for the given query.
+     * Starts the pgvector Docker container if not already running.
+     */
+    public List<Map<String, Object>> search(String query, int maxResults) {
+        ensureInitialized();
+
+        Embedding queryEmbedding = embeddingModel.embed(query).content();
+
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .maxResults(SEARCH_CANDIDATES)
+                .minScore(MIN_SCORE)
+                .build();
+
+        EmbeddingSearchResult<TextSegment> result = embeddingStore.search(searchRequest);
+        List<EmbeddingMatch<TextSegment>> matches = result.matches();
+
+        // Apply metadata boosting
+        List<ScoredMatch> boosted = applyMetadataBoost(matches, query);
+
+        // Take top N
+        int limit = maxResults > 0 ? maxResults : DEFAULT_MAX_RESULTS;
+        List<Map<String, Object>> results = new ArrayList<>();
+        for (int i = 0; i < Math.min(limit, boosted.size()); i++) {
+            ScoredMatch sm = boosted.get(i);
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("score", Math.round(sm.score * 1000.0) / 1000.0);
+            entry.put("text", sm.match.embedded().text());
+
+            // Add metadata
+            Map<String, String> metadata = new LinkedHashMap<>();
+            sm.match.embedded().metadata().toMap().forEach((k, v) -> metadata.put(k, String.valueOf(v)));
+            if (!metadata.isEmpty()) {
+                entry.put("metadata", metadata);
+            }
+            results.add(entry);
+        }
+        return results;
+    }
+
+    private synchronized void ensureInitialized() {
+        if (embeddingModel == null) {
+            System.err.println("[mcp] Loading BGE Small EN v1.5 embedding model...");
+            embeddingModel = new BgeSmallEnV15QuantizedEmbeddingModel();
+            System.err.println("[mcp] Embedding model loaded.");
+        }
+        if (embeddingStore == null) {
+            ensureContainerRunning();
+            // Retry connection a few times — pgvector extension may need a moment
+            for (int attempt = 1; attempt <= 3; attempt++) {
+                try {
+                    System.err.println("[mcp] Connecting to pgvector at localhost:" + PG_PORT
+                            + " (attempt " + attempt + ")...");
+                    embeddingStore = PgVectorEmbeddingStore.builder()
+                            .host("localhost")
+                            .port(PG_PORT)
+                            .database(PG_DB)
+                            .user(PG_USER)
+                            .password(PG_PASSWORD)
+                            .table(TABLE_NAME)
+                            .dimension(DIMENSION)
+                            .createTable(false) // table already exists in the Docker image
+                            .useIndex(false) // index already exists in the Docker image
+                            .build();
+                    System.err.println("[mcp] Connected to pgvector.");
+                    break;
+                } catch (Exception e) {
+                    if (attempt == 3) {
+                        throw new RuntimeException("Failed to connect to pgvector after 3 attempts: " + e.getMessage(),
+                                e);
+                    }
+                    System.err.println("[mcp] Connection attempt " + attempt + " failed: " + e.getMessage()
+                            + ". Retrying in 3s...");
+                    try {
+                        Thread.sleep(3000);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted while connecting to pgvector", ie);
+                    }
+                }
+            }
+        }
+    }
+
+    private void ensureContainerRunning() {
+        if (isContainerRunning()) {
+            System.err.println("[mcp] pgvector container '" + CONTAINER_NAME + "' is already running.");
+            return;
+        }
+
+        // Check if container exists but is stopped
+        if (containerExists()) {
+            System.err.println("[mcp] Starting existing pgvector container...");
+            exec("docker", "start", CONTAINER_NAME);
+        } else {
+            System.err.println("[mcp] Pulling and starting pgvector container with Quarkus docs...");
+            exec("docker", "run", "-d",
+                    "--name", CONTAINER_NAME,
+                    "-p", PG_PORT + ":5432",
+                    "-e", "POSTGRES_USER=" + PG_USER,
+                    "-e", "POSTGRES_PASSWORD=" + PG_PASSWORD,
+                    "-e", "POSTGRES_DB=" + PG_DB,
+                    DEFAULT_IMAGE);
+        }
+
+        // Wait for PostgreSQL to be ready
+        System.err.println("[mcp] Waiting for PostgreSQL to be ready...");
+        for (int i = 0; i < 30; i++) {
+            try {
+                Thread.sleep(1000);
+                String result = execOutput("docker", "exec", CONTAINER_NAME,
+                        "pg_isready", "-U", PG_USER);
+                if (result.contains("accepting connections")) {
+                    // Verify the database and pgvector extension are ready
+                    try {
+                        String extCheck = execOutput("docker", "exec", CONTAINER_NAME,
+                                "psql", "-U", PG_USER, "-d", PG_DB, "-c",
+                                "SELECT count(*) FROM " + TABLE_NAME + " LIMIT 1");
+                        if (extCheck.contains("count")) {
+                            System.err.println("[mcp] PostgreSQL and pgvector are ready.");
+                            return;
+                        }
+                    } catch (Exception e) {
+                        // table not ready yet, keep waiting
+                    }
+                }
+            } catch (Exception e) {
+                // not ready yet
+            }
+        }
+        throw new RuntimeException("PostgreSQL did not become ready in 30 seconds");
+    }
+
+    private boolean isContainerRunning() {
+        try {
+            String output = execOutput("docker", "inspect", "-f", "{{.State.Running}}", CONTAINER_NAME);
+            return "true".equals(output.trim());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean containerExists() {
+        try {
+            execOutput("docker", "inspect", CONTAINER_NAME);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void exec(String... command) {
+        try {
+            Process p = new ProcessBuilder(command)
+                    .redirectErrorStream(true)
+                    .start();
+            p.getInputStream().transferTo(System.err);
+            int exit = p.waitFor();
+            if (exit != 0) {
+                throw new RuntimeException("Command failed (exit " + exit + "): " + String.join(" ", command));
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to execute: " + String.join(" ", command) + ": " + e.getMessage(), e);
+        }
+    }
+
+    private String execOutput(String... command) {
+        try {
+            Process p = new ProcessBuilder(command)
+                    .redirectErrorStream(true)
+                    .start();
+            String output;
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                output = reader.lines().reduce("", (a, b) -> a + b + "\n").trim();
+            }
+            int exit = p.waitFor();
+            if (exit != 0) {
+                throw new RuntimeException("Command failed (exit " + exit + "): " + output);
+            }
+            return output;
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to execute: " + String.join(" ", command) + ": " + e.getMessage(), e);
+        }
+    }
+
+    // --- Metadata boosting ---
+
+    private static final Map<String, String> SYNONYMS = Map.ofEntries(
+            Map.entry("startup", "lifecycle"),
+            Map.entry("injection", "cdi"),
+            Map.entry("di", "cdi"),
+            Map.entry("dependency injection", "cdi"),
+            Map.entry("rest", "resteasy"),
+            Map.entry("api", "rest"),
+            Map.entry("database", "datasource"),
+            Map.entry("db", "datasource"),
+            Map.entry("orm", "hibernate"),
+            Map.entry("jpa", "hibernate"),
+            Map.entry("security", "authentication"),
+            Map.entry("auth", "authentication"),
+            Map.entry("test", "testing"),
+            Map.entry("container", "docker"),
+            Map.entry("reactive", "mutiny"),
+            Map.entry("config", "configuration"),
+            Map.entry("deploy", "deployment"),
+            Map.entry("native", "native-image"),
+            Map.entry("grpc", "grpc"),
+            Map.entry("graphql", "graphql"),
+            Map.entry("websocket", "websockets"),
+            Map.entry("kafka", "messaging"),
+            Map.entry("amqp", "messaging"));
+
+    private List<ScoredMatch> applyMetadataBoost(List<EmbeddingMatch<TextSegment>> matches, String query) {
+        String queryLower = query.toLowerCase();
+        String[] queryTerms = queryLower.split("\\s+");
+
+        List<ScoredMatch> scored = new ArrayList<>();
+        for (EmbeddingMatch<TextSegment> match : matches) {
+            double score = match.score();
+            TextSegment segment = match.embedded();
+            if (segment == null) {
+                continue;
+            }
+
+            String title = segment.metadata().getString("title");
+            String repoPath = segment.metadata().getString("repo_path");
+            if (title == null) {
+                title = "";
+            }
+            if (repoPath == null) {
+                repoPath = "";
+            }
+            String titleLower = title.toLowerCase();
+            String pathLower = repoPath.toLowerCase();
+
+            for (String term : queryTerms) {
+                // Direct matches
+                if (titleLower.contains(term)) {
+                    score += 0.15;
+                }
+                if (pathLower.contains(term)) {
+                    score += 0.10;
+                }
+
+                // Synonym matches
+                String synonym = SYNONYMS.get(term);
+                if (synonym != null) {
+                    if (titleLower.contains(synonym)) {
+                        score += 0.12;
+                    }
+                    if (pathLower.contains(synonym)) {
+                        score += 0.08;
+                    }
+                }
+            }
+
+            scored.add(new ScoredMatch(match, score));
+        }
+
+        // Sort by boosted score descending
+        scored.sort((a, b) -> Double.compare(b.score, a.score));
+        return scored;
+    }
+
+    private record ScoredMatch(EmbeddingMatch<TextSegment> match, double score) {
+    }
+}

--- a/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/McpLifecycleServer.java
+++ b/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/McpLifecycleServer.java
@@ -1,0 +1,566 @@
+package io.quarkus.devtools.mcp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Standalone MCP stdio server for managing Quarkus application lifecycle.
+ * <p>
+ * This server runs as a separate process, communicating via JSON-RPC 2.0
+ * over stdin/stdout. It manages Quarkus dev mode instances as child processes,
+ * surviving app crashes so that AI coding agents can recover broken applications.
+ */
+public class McpLifecycleServer {
+
+    private static final String JSONRPC_VERSION = "2.0";
+    private static final String MCP_PROTOCOL_VERSION = "2025-03-26";
+    private static final String SERVER_NAME = "quarkus-lifecycle";
+    private static final String SERVER_VERSION = "1.0.0";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final QuarkusProcessManager processManager = new QuarkusProcessManager();
+    private final DocSearchService docSearchService = new DocSearchService();
+    private final PrintStream out;
+
+    public McpLifecycleServer(PrintStream out) {
+        this.out = out;
+    }
+
+    public static void main(String[] args) throws IOException {
+        // Use stdout for MCP JSON-RPC, redirect app logs to stderr
+        PrintStream mcpOut = System.out;
+        System.setOut(System.err);
+
+        McpLifecycleServer server = new McpLifecycleServer(mcpOut);
+
+        // Shut down all managed child processes when the MCP server exits
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.err.println("[mcp] Shutting down — stopping all managed Quarkus instances...");
+            server.processManager.stopAll();
+        }));
+
+        server.run();
+    }
+
+    public void run() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            line = line.trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+            try {
+                JsonNode request = mapper.readTree(line);
+                JsonNode response = handleRequest(request);
+                if (response != null) {
+                    sendResponse(response);
+                }
+            } catch (JsonProcessingException e) {
+                sendResponse(errorResponse(null, -32700, "Parse error: " + e.getMessage()));
+            }
+        }
+    }
+
+    private JsonNode handleRequest(JsonNode request) {
+        JsonNode idNode = request.get("id");
+        String method = request.has("method") ? request.get("method").asText() : null;
+        JsonNode params = request.get("params");
+
+        if (method == null) {
+            return errorResponse(idNode, -32600, "Invalid request: missing method");
+        }
+
+        // Notifications (no id) — don't send a response
+        if (idNode == null) {
+            handleNotification(method, params);
+            return null;
+        }
+
+        return switch (method) {
+            case "initialize" -> handleInitialize(idNode);
+            case "ping" -> successResponse(idNode, mapper.createObjectNode());
+            case "tools/list" -> handleToolsList(idNode);
+            case "tools/call" -> handleToolsCall(idNode, params);
+            default -> errorResponse(idNode, -32601, "Method not found: " + method);
+        };
+    }
+
+    private void handleNotification(String method, JsonNode params) {
+        // notifications like "initialized" or "notifications/cancelled" — no response needed
+        if ("initialized".equals(method)) {
+            System.err.println("[mcp] Client initialized");
+        }
+    }
+
+    private JsonNode handleInitialize(JsonNode id) {
+        ObjectNode result = mapper.createObjectNode();
+        result.put("protocolVersion", MCP_PROTOCOL_VERSION);
+
+        ObjectNode capabilities = mapper.createObjectNode();
+        capabilities.set("tools", mapper.createObjectNode());
+        result.set("capabilities", capabilities);
+
+        ObjectNode serverInfo = mapper.createObjectNode();
+        serverInfo.put("name", SERVER_NAME);
+        serverInfo.put("version", SERVER_VERSION);
+        result.set("serverInfo", serverInfo);
+
+        return successResponse(id, result);
+    }
+
+    private JsonNode handleToolsList(JsonNode id) {
+        List<Map<String, Object>> tools = List.of(
+                toolDef("quarkus/start", "Start a Quarkus application in dev mode",
+                        Map.of(
+                                "projectDir", propDef("string",
+                                        "Absolute path to the Quarkus project directory", true),
+                                "buildTool", propDef("string",
+                                        "Build tool to use: 'maven' or 'gradle' (auto-detected if omitted)", false))),
+                toolDef("quarkus/stop", "Stop a running Quarkus application",
+                        Map.of(
+                                "projectDir", propDef("string",
+                                        "Absolute path to the Quarkus project directory", true))),
+                toolDef("quarkus/restart", "Force restart a Quarkus application (sends 's' to dev mode console)",
+                        Map.of(
+                                "projectDir", propDef("string",
+                                        "Absolute path to the Quarkus project directory", true))),
+                toolDef("quarkus/status",
+                        "Get the status of a Quarkus application (not_started, starting, running, crashed, stopped)",
+                        Map.of(
+                                "projectDir", propDef("string",
+                                        "Absolute path to the Quarkus project directory", true))),
+                toolDef("quarkus/logs", "Get recent log output from a Quarkus application",
+                        Map.of(
+                                "projectDir", propDef("string",
+                                        "Absolute path to the Quarkus project directory", true),
+                                "lines", propDef("integer",
+                                        "Number of recent lines to return (default: 50)", false))),
+                toolDef("quarkus/list", "List all managed Quarkus application instances and their status",
+                        Map.of()),
+                toolDef("quarkus/searchTools",
+                        "Search available tools on a running Quarkus application's Dev MCP server. "
+                                + "Use this to discover what actions you can perform on the running app. "
+                                + "Available tools typically include: continuous testing (start/stop/run tests), "
+                                + "configuration management, extension add/remove, log level control, "
+                                + "dev services info, workspace file operations, and endpoint listing. "
+                                + "IMPORTANT: When the user asks to do something with a running Quarkus app "
+                                + "(e.g. 'run tests', 'start testing', 'change config', 'add extension'), "
+                                + "call this tool first to discover the tool name, then use quarkus/callTool to invoke it.",
+                        Map.of(
+                                "projectDir", propDef("string",
+                                        "Absolute path to the Quarkus project directory", true),
+                                "query", propDef("string",
+                                        "Search query to filter tools by name or description (case-insensitive). "
+                                                + "Examples: 'test' for testing tools, 'config' for configuration, "
+                                                + "'extension' for extension management. If omitted, returns all tools.",
+                                        false))),
+                toolDef("quarkus/callTool",
+                        "Call a tool on the running Quarkus application's Dev MCP server. "
+                                + "Use quarkus/searchTools first to discover available tool names and their required arguments, "
+                                + "then use this tool to invoke them. "
+                                + "Example: toolName='devui-continuous-testing_start' to start continuous testing.",
+                        Map.of(
+                                "projectDir", propDef("string",
+                                        "Absolute path to the Quarkus project directory", true),
+                                "toolName", propDef("string",
+                                        "The name of the Dev MCP tool to call (as returned by quarkus/searchTools)", true),
+                                "toolArguments", propDef("object",
+                                        "Arguments to pass to the tool (as a JSON object matching the tool's inputSchema). "
+                                                + "Omit if the tool takes no arguments.",
+                                        false))),
+                toolDef("quarkus/searchDocs",
+                        "Search the Quarkus documentation using semantic search. "
+                                + "Returns relevant documentation chunks matching the query. "
+                                + "Use this when the user needs help with Quarkus APIs, configuration, extensions, "
+                                + "or any Quarkus-related question. "
+                                + "The first call may take a moment to start the documentation database.",
+                        Map.of(
+                                "query", propDef("string",
+                                        "The search query describing what documentation you're looking for. "
+                                                + "Examples: 'how to configure datasource', 'CDI dependency injection', "
+                                                + "'REST client configuration', 'native image build'.",
+                                        true),
+                                "maxResults", propDef("integer",
+                                        "Maximum number of documentation chunks to return (default: 4).",
+                                        false))));
+
+        return successResponse(id, mapper.valueToTree(Map.of("tools", tools)));
+    }
+
+    private JsonNode handleToolsCall(JsonNode id, JsonNode params) {
+        if (params == null || !params.has("name")) {
+            return errorResponse(id, -32602, "Invalid params: missing tool name");
+        }
+
+        String toolName = params.get("name").asText();
+        JsonNode arguments = params.has("arguments") ? params.get("arguments") : mapper.createObjectNode();
+
+        try {
+            String result = switch (toolName) {
+                case "quarkus/start" -> toolStart(arguments);
+                case "quarkus/stop" -> toolStop(arguments);
+                case "quarkus/restart" -> toolRestart(arguments);
+                case "quarkus/status" -> toolStatus(arguments);
+                case "quarkus/logs" -> toolLogs(arguments);
+                case "quarkus/list" -> toolList();
+                case "quarkus/searchTools" -> toolSearchTools(arguments);
+                case "quarkus/callTool" -> toolCallTool(arguments);
+                case "quarkus/searchDocs" -> toolSearchDocs(arguments);
+                default -> throw new IllegalArgumentException("Unknown tool: " + toolName);
+            };
+
+            return successResponse(id, callToolResult(result, false));
+        } catch (Exception e) {
+            return successResponse(id, callToolResult(e.getMessage(), true));
+        }
+    }
+
+    // --- Tool implementations ---
+
+    private String toolStart(JsonNode args) {
+        String projectDir = requireString(args, "projectDir");
+        String buildTool = optString(args, "buildTool", null);
+        processManager.start(projectDir, buildTool);
+        return "Quarkus application starting in dev mode at: " + projectDir;
+    }
+
+    private String toolStop(JsonNode args) {
+        String projectDir = requireString(args, "projectDir");
+        processManager.stop(projectDir);
+        return "Quarkus application stopped at: " + projectDir;
+    }
+
+    private String toolRestart(JsonNode args) {
+        String projectDir = requireString(args, "projectDir");
+        processManager.restart(projectDir);
+        return "Quarkus application restart triggered at: " + projectDir;
+    }
+
+    private String toolStatus(JsonNode args) {
+        String projectDir = requireString(args, "projectDir");
+        QuarkusInstance instance = processManager.getInstance(projectDir);
+        if (instance == null) {
+            return "not_started";
+        }
+        String status = instance.getStatus().name().toLowerCase();
+        if (instance.getStatus() == QuarkusInstance.Status.RUNNING && instance.getHttpPort() > 0) {
+            return status + " (port: " + instance.getHttpPort()
+                    + "). Use quarkus/searchTools to discover available Dev MCP tools "
+                    + "(testing, config, extensions, etc.). "
+                    + "Use quarkus/searchDocs to search the Quarkus documentation for any Quarkus-related questions.";
+        }
+        return status + ". Use quarkus/searchDocs to search the Quarkus documentation for any Quarkus-related questions.";
+    }
+
+    private String toolLogs(JsonNode args) {
+        String projectDir = requireString(args, "projectDir");
+        int lines = optInt(args, "lines", 50);
+        QuarkusInstance instance = processManager.getInstance(projectDir);
+        if (instance == null) {
+            return "No instance found for: " + projectDir;
+        }
+        return instance.getRecentLogs(lines);
+    }
+
+    private String toolList() throws JsonProcessingException {
+        Map<String, String> instances = processManager.listInstances();
+        if (instances.isEmpty()) {
+            return "No managed Quarkus instances";
+        }
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(instances);
+    }
+
+    private String toolSearchDocs(JsonNode args) {
+        String query = requireString(args, "query");
+        int maxResults = optInt(args, "maxResults", 4);
+
+        List<Map<String, Object>> results = docSearchService.search(query, maxResults);
+        if (results.isEmpty()) {
+            return "No documentation found matching: " + query;
+        }
+
+        try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(results);
+        } catch (JsonProcessingException e) {
+            return results.toString();
+        }
+    }
+
+    private String toolSearchTools(JsonNode args) {
+        String projectDir = requireString(args, "projectDir");
+        String query = optString(args, "query", null);
+
+        QuarkusInstance instance = processManager.getInstance(projectDir);
+        if (instance == null || instance.getStatus() != QuarkusInstance.Status.RUNNING) {
+            throw new IllegalStateException(
+                    "Quarkus application is not running at: " + projectDir + ". Start it first with quarkus/start.");
+        }
+
+        int port = instance.getHttpPort();
+        if (port < 0) {
+            throw new IllegalStateException("Could not detect HTTP port for the running Quarkus application.");
+        }
+
+        // Query Dev MCP for tools/list
+        JsonNode tools = fetchDevMcpTools(port);
+        if (tools == null || !tools.isArray()) {
+            return "No tools available from Dev MCP";
+        }
+
+        // Filter by query if provided
+        List<JsonNode> matched = new ArrayList<>();
+        for (JsonNode tool : tools) {
+            if (query == null || query.isEmpty()) {
+                matched.add(tool);
+            } else {
+                String name = tool.has("name") ? tool.get("name").asText().toLowerCase() : "";
+                String desc = tool.has("description") ? tool.get("description").asText().toLowerCase() : "";
+                if (name.contains(query.toLowerCase()) || desc.contains(query.toLowerCase())) {
+                    matched.add(tool);
+                }
+            }
+        }
+
+        if (matched.isEmpty()) {
+            return "No Dev MCP tools found matching: " + query;
+        }
+
+        try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(matched);
+        } catch (JsonProcessingException e) {
+            return matched.toString();
+        }
+    }
+
+    private String toolCallTool(JsonNode args) {
+        String projectDir = requireString(args, "projectDir");
+        String toolName = requireString(args, "toolName");
+        JsonNode toolArguments = args.has("toolArguments") && !args.get("toolArguments").isNull()
+                ? args.get("toolArguments")
+                : mapper.createObjectNode();
+
+        QuarkusInstance instance = processManager.getInstance(projectDir);
+        if (instance == null || instance.getStatus() != QuarkusInstance.Status.RUNNING) {
+            throw new IllegalStateException(
+                    "Quarkus application is not running at: " + projectDir + ". Start it first with quarkus/start.");
+        }
+
+        int port = instance.getHttpPort();
+        if (port < 0) {
+            throw new IllegalStateException("Could not detect HTTP port for the running Quarkus application.");
+        }
+
+        // Call the Dev MCP tool via tools/call
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("name", toolName);
+        params.put("arguments", mapper.convertValue(toolArguments, Map.class));
+
+        JsonNode response = callDevMcp(port, "tools/call", params);
+
+        // Extract the result text
+        if (response != null && response.has("content") && response.get("content").isArray()) {
+            StringBuilder sb = new StringBuilder();
+            for (JsonNode content : response.get("content")) {
+                if (content.has("text")) {
+                    if (!sb.isEmpty()) {
+                        sb.append("\n");
+                    }
+                    sb.append(content.get("text").asText());
+                }
+            }
+            if (response.has("isError") && response.get("isError").asBoolean()) {
+                throw new RuntimeException("Dev MCP tool error: " + sb);
+            }
+            return sb.toString();
+        }
+
+        try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            return response != null ? response.toString() : "No response from Dev MCP";
+        }
+    }
+
+    // --- Dev MCP HTTP client ---
+
+    private JsonNode fetchDevMcpTools(int port) {
+        JsonNode result = callDevMcp(port, "tools/list", Map.of());
+        if (result != null && result.has("tools")) {
+            return result.get("tools");
+        }
+        return null;
+    }
+
+    private JsonNode callDevMcp(int port, String method, Map<String, Object> params) {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build();
+
+            String jsonRpcRequest = mapper.writeValueAsString(Map.of(
+                    "jsonrpc", "2.0",
+                    "id", 1,
+                    "method", method,
+                    "params", params));
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + port + "/q/dev-mcp"))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json, text/event-stream")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))
+                    .timeout(Duration.ofSeconds(10))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("Dev MCP returned HTTP " + response.statusCode());
+            }
+
+            JsonNode body = mapper.readTree(response.body());
+            if (body.has("result")) {
+                return body.get("result");
+            }
+            if (body.has("error")) {
+                String errorMsg = body.get("error").has("message")
+                        ? body.get("error").get("message").asText()
+                        : body.get("error").toString();
+                throw new RuntimeException("Dev MCP error: " + errorMsg);
+            }
+            return null;
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to call Dev MCP: " + e.getMessage(), e);
+        }
+    }
+
+    // --- JSON-RPC helpers ---
+
+    private JsonNode successResponse(JsonNode id, JsonNode result) {
+        ObjectNode response = mapper.createObjectNode();
+        response.put("jsonrpc", JSONRPC_VERSION);
+        response.set("id", id);
+        response.set("result", result);
+        return response;
+    }
+
+    private JsonNode errorResponse(JsonNode id, int code, String message) {
+        ObjectNode response = mapper.createObjectNode();
+        response.put("jsonrpc", JSONRPC_VERSION);
+        response.set("id", id != null ? id : mapper.nullNode());
+        ObjectNode error = mapper.createObjectNode();
+        error.put("code", code);
+        error.put("message", message);
+        response.set("error", error);
+        return response;
+    }
+
+    private JsonNode callToolResult(String text, boolean isError) {
+        ObjectNode result = mapper.createObjectNode();
+        ObjectNode content = mapper.createObjectNode();
+        content.put("type", "text");
+        content.put("text", text);
+        result.set("content", mapper.createArrayNode().add(content));
+        result.put("isError", isError);
+        return result;
+    }
+
+    private void sendResponse(JsonNode response) {
+        try {
+            String json = mapper.writeValueAsString(response);
+            out.println(json);
+            out.flush();
+        } catch (JsonProcessingException e) {
+            System.err.println("[mcp] Failed to serialize response: " + e.getMessage());
+        }
+    }
+
+    // --- Tool definition helpers ---
+
+    private Map<String, Object> toolDef(String name, String description, Map<String, Object> properties) {
+        Map<String, Object> tool = new LinkedHashMap<>();
+        tool.put("name", name);
+        tool.put("description", description);
+
+        Map<String, Object> inputSchema = new LinkedHashMap<>();
+        inputSchema.put("type", "object");
+        inputSchema.put("properties", properties);
+
+        List<String> required = properties.entrySet().stream()
+                .filter(e -> {
+                    Object val = e.getValue();
+                    return val instanceof Map && Boolean.TRUE.equals(((Map<?, ?>) val).get("required"));
+                })
+                .map(Map.Entry::getKey)
+                .toList();
+
+        // Remove the "required" field from each property (it's not part of JSON Schema property defs)
+        Map<String, Object> cleanedProps = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                Map<String, Object> prop = new LinkedHashMap<>((Map<String, Object>) entry.getValue());
+                prop.remove("required");
+                cleanedProps.put(entry.getKey(), prop);
+            } else {
+                cleanedProps.put(entry.getKey(), entry.getValue());
+            }
+        }
+        inputSchema.put("properties", cleanedProps);
+
+        if (!required.isEmpty()) {
+            inputSchema.put("required", required);
+        }
+
+        tool.put("inputSchema", inputSchema);
+        return tool;
+    }
+
+    private Map<String, Object> propDef(String type, String description, boolean required) {
+        Map<String, Object> prop = new LinkedHashMap<>();
+        prop.put("type", type);
+        prop.put("description", description);
+        if (required) {
+            prop.put("required", true);
+        }
+        return prop;
+    }
+
+    // --- Argument extraction helpers ---
+
+    private String requireString(JsonNode args, String field) {
+        if (!args.has(field) || args.get(field).isNull()) {
+            throw new IllegalArgumentException("Missing required argument: " + field);
+        }
+        return args.get(field).asText();
+    }
+
+    private String optString(JsonNode args, String field, String defaultValue) {
+        if (args.has(field) && !args.get(field).isNull()) {
+            return args.get(field).asText();
+        }
+        return defaultValue;
+    }
+
+    private int optInt(JsonNode args, String field, int defaultValue) {
+        if (args.has(field) && !args.get(field).isNull()) {
+            return args.get(field).asInt();
+        }
+        return defaultValue;
+    }
+}

--- a/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/QuarkusInstance.java
+++ b/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/QuarkusInstance.java
@@ -1,0 +1,192 @@
+package io.quarkus.devtools.mcp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a single managed Quarkus dev mode instance.
+ * Tracks the child process, captures logs in a ring buffer,
+ * and detects application state from process output.
+ */
+public class QuarkusInstance {
+
+    public enum Status {
+        STARTING,
+        RUNNING,
+        CRASHED,
+        STOPPED
+    }
+
+    private static final int MAX_LOG_LINES = 500;
+
+    private final String projectDir;
+    private final Process process;
+    private final LinkedList<String> logBuffer = new LinkedList<>();
+    private volatile Status status = Status.STARTING;
+    private volatile int httpPort = -1;
+    private final Thread stdoutThread;
+    private final Thread stderrThread;
+
+    public QuarkusInstance(String projectDir, Process process) {
+        this.projectDir = projectDir;
+        this.process = process;
+
+        // Capture stdout
+        this.stdoutThread = new Thread(() -> captureStream(process.getInputStream()), "mcp-stdout-" + projectDir);
+        this.stdoutThread.setDaemon(true);
+        this.stdoutThread.start();
+
+        // Capture stderr
+        this.stderrThread = new Thread(() -> captureStream(process.getErrorStream()), "mcp-stderr-" + projectDir);
+        this.stderrThread.setDaemon(true);
+        this.stderrThread.start();
+
+        // Monitor process exit
+        Thread exitMonitor = new Thread(() -> {
+            try {
+                int exitCode = process.waitFor();
+                if (status != Status.STOPPED) {
+                    status = Status.CRASHED;
+                    appendLog("[mcp] Process exited with code: " + exitCode);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }, "mcp-exit-monitor-" + projectDir);
+        exitMonitor.setDaemon(true);
+        exitMonitor.start();
+    }
+
+    private void captureStream(InputStream inputStream) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                appendLog(line);
+                // Also echo to stderr so the user can see logs
+                System.err.println(line);
+
+                // Detect startup completion and parse port
+                if (line.contains("Listening on:")) {
+                    parsePort(line);
+                }
+                if (status == Status.STARTING && isStartedLine(line)) {
+                    status = Status.RUNNING;
+                }
+            }
+        } catch (IOException e) {
+            // Stream closed — expected on process termination
+        }
+    }
+
+    private boolean isStartedLine(String line) {
+        // Quarkus prints this on successful startup
+        return line.contains("Listening on:") || line.contains("installed features:");
+    }
+
+    private void parsePort(String line) {
+        // Parse port from "Listening on: http://localhost:8085"
+        int idx = line.indexOf("http://");
+        if (idx < 0) {
+            idx = line.indexOf("https://");
+        }
+        if (idx >= 0) {
+            String url = line.substring(idx).trim();
+            int lastColon = url.lastIndexOf(':');
+            if (lastColon > 5) { // after "http:"
+                try {
+                    httpPort = Integer.parseInt(url.substring(lastColon + 1).replaceAll("[^0-9]", ""));
+                } catch (NumberFormatException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    private synchronized void appendLog(String line) {
+        logBuffer.addLast(line);
+        while (logBuffer.size() > MAX_LOG_LINES) {
+            logBuffer.removeFirst();
+        }
+    }
+
+    public String getProjectDir() {
+        return projectDir;
+    }
+
+    public Status getStatus() {
+        // Re-check if process is still alive
+        if (status == Status.RUNNING && !process.isAlive()) {
+            status = Status.CRASHED;
+        }
+        return status;
+    }
+
+    public synchronized String getRecentLogs(int lines) {
+        int count = Math.min(lines, logBuffer.size());
+        return logBuffer.subList(logBuffer.size() - count, logBuffer.size())
+                .stream()
+                .collect(Collectors.joining("\n"));
+    }
+
+    /**
+     * Send a character to the dev mode console stdin (e.g., 's' for restart, 'q' for quit).
+     */
+    public void sendInput(char c) {
+        OutputStream os = process.getOutputStream();
+        try {
+            os.write(c);
+            os.write('\n');
+            os.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to send input to Quarkus process: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Force restart by sending 's' to the dev mode console.
+     */
+    public void restart() {
+        if (!process.isAlive()) {
+            throw new IllegalStateException(
+                    "Process is not running. Use quarkus/start to start a new instance.");
+        }
+        status = Status.STARTING;
+        sendInput('s');
+    }
+
+    /**
+     * Stop the Quarkus process gracefully by sending 'q', then force-kill if needed.
+     */
+    public void stop() {
+        status = Status.STOPPED;
+        if (process.isAlive()) {
+            try {
+                sendInput('q');
+                // Wait briefly for graceful shutdown
+                if (!process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                }
+            } catch (InterruptedException e) {
+                process.destroyForcibly();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    public boolean isAlive() {
+        return process.isAlive();
+    }
+
+    /**
+     * Returns the detected HTTP port, or -1 if not yet detected.
+     */
+    public int getHttpPort() {
+        return httpPort;
+    }
+}

--- a/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/QuarkusProcessManager.java
+++ b/devtools/mcp-server/src/main/java/io/quarkus/devtools/mcp/QuarkusProcessManager.java
@@ -1,0 +1,174 @@
+package io.quarkus.devtools.mcp;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages Quarkus dev mode child processes.
+ * Each project directory maps to at most one running instance.
+ */
+public class QuarkusProcessManager {
+
+    private final ConcurrentHashMap<String, QuarkusInstance> instances = new ConcurrentHashMap<>();
+
+    /**
+     * Start a Quarkus app in dev mode for the given project directory.
+     */
+    public void start(String projectDir, String buildTool) {
+        String normalizedDir = normalize(projectDir);
+
+        // Check for existing instance
+        QuarkusInstance existing = instances.get(normalizedDir);
+        if (existing != null && existing.isAlive()) {
+            throw new IllegalStateException("Quarkus instance already running at: " + normalizedDir);
+        }
+
+        String detectedBuildTool = buildTool != null ? buildTool : detectBuildTool(normalizedDir);
+        ProcessBuilder pb = createProcessBuilder(normalizedDir, detectedBuildTool);
+
+        try {
+            Process process = pb.start();
+            QuarkusInstance instance = new QuarkusInstance(normalizedDir, process);
+            instances.put(normalizedDir, instance);
+            System.err.println(
+                    "[mcp] Started Quarkus dev mode at: " + normalizedDir + " (build tool: " + detectedBuildTool + ")");
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to start Quarkus dev mode: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Stop the Quarkus app at the given project directory.
+     */
+    public void stop(String projectDir) {
+        String normalizedDir = normalize(projectDir);
+        QuarkusInstance instance = instances.get(normalizedDir);
+        if (instance == null) {
+            throw new IllegalStateException("No Quarkus instance found at: " + normalizedDir);
+        }
+        instance.stop();
+        instances.remove(normalizedDir);
+        System.err.println("[mcp] Stopped Quarkus instance at: " + normalizedDir);
+    }
+
+    /**
+     * Force restart the Quarkus app (sends 's' to dev mode console).
+     */
+    public void restart(String projectDir) {
+        String normalizedDir = normalize(projectDir);
+        QuarkusInstance instance = instances.get(normalizedDir);
+        if (instance == null) {
+            throw new IllegalStateException("No Quarkus instance found at: " + normalizedDir + ". Use quarkus/start first.");
+        }
+
+        if (!instance.isAlive()) {
+            // Process is dead — need to start a new one
+            instances.remove(normalizedDir);
+            start(normalizedDir, null);
+            System.err.println("[mcp] Re-started dead Quarkus instance at: " + normalizedDir);
+        } else {
+            instance.restart();
+            System.err.println("[mcp] Restart triggered at: " + normalizedDir);
+        }
+    }
+
+    /**
+     * Get the instance for a project directory, or null if not managed.
+     */
+    public QuarkusInstance getInstance(String projectDir) {
+        return instances.get(normalize(projectDir));
+    }
+
+    /**
+     * Stop all managed instances. Called during MCP server shutdown.
+     */
+    public void stopAll() {
+        for (Map.Entry<String, QuarkusInstance> entry : instances.entrySet()) {
+            try {
+                entry.getValue().stop();
+                System.err.println("[mcp] Stopped instance at: " + entry.getKey());
+            } catch (Exception e) {
+                System.err.println("[mcp] Error stopping instance at " + entry.getKey() + ": " + e.getMessage());
+            }
+        }
+        instances.clear();
+    }
+
+    /**
+     * List all managed instances with their status.
+     */
+    public Map<String, String> listInstances() {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (Map.Entry<String, QuarkusInstance> entry : instances.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().getStatus().name().toLowerCase());
+        }
+        return result;
+    }
+
+    private String normalize(String projectDir) {
+        try {
+            return new File(projectDir).getCanonicalPath();
+        } catch (IOException e) {
+            return new File(projectDir).getAbsolutePath();
+        }
+    }
+
+    private String detectBuildTool(String projectDir) {
+        File dir = new File(projectDir);
+        if (new File(dir, "pom.xml").exists()) {
+            return "maven";
+        } else if (new File(dir, "build.gradle").exists() || new File(dir, "build.gradle.kts").exists()) {
+            return "gradle";
+        }
+        throw new IllegalArgumentException(
+                "Cannot detect build tool at: " + projectDir + ". No pom.xml or build.gradle found.");
+    }
+
+    private ProcessBuilder createProcessBuilder(String projectDir, String buildTool) {
+        File dir = new File(projectDir);
+        if (!dir.isDirectory()) {
+            throw new IllegalArgumentException("Not a directory: " + projectDir);
+        }
+
+        ProcessBuilder pb;
+        if ("gradle".equalsIgnoreCase(buildTool)) {
+            pb = createGradleProcessBuilder(dir);
+        } else {
+            pb = createMavenProcessBuilder(dir);
+        }
+
+        pb.directory(dir);
+        // Don't inherit IO — we manage stdin/stdout/stderr ourselves
+        pb.redirectErrorStream(false);
+        return pb;
+    }
+
+    private ProcessBuilder createMavenProcessBuilder(File projectDir) {
+        // Prefer the Maven wrapper if available
+        String mvnCmd;
+        if (isWindows()) {
+            mvnCmd = new File(projectDir, "mvnw.cmd").exists() ? "mvnw.cmd" : "mvn";
+        } else {
+            mvnCmd = new File(projectDir, "mvnw").exists() ? "./mvnw" : "mvn";
+        }
+        return new ProcessBuilder(mvnCmd, "quarkus:dev", "-Dquarkus.console.basic=true");
+    }
+
+    private ProcessBuilder createGradleProcessBuilder(File projectDir) {
+        // Prefer the Gradle wrapper if available
+        String gradleCmd;
+        if (isWindows()) {
+            gradleCmd = new File(projectDir, "gradlew.bat").exists() ? "gradlew.bat" : "gradle";
+        } else {
+            gradleCmd = new File(projectDir, "gradlew").exists() ? "./gradlew" : "gradle";
+        }
+        return new ProcessBuilder(gradleCmd, "quarkusDev", "-Dquarkus.console.basic=true");
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase().contains("win");
+    }
+}

--- a/devtools/pom.xml
+++ b/devtools/pom.xml
@@ -26,6 +26,7 @@
         <module>maven</module>
         <module>gradle</module>
         <module>cli-common</module>
+        <module>mcp-server</module>
         <module>cli</module>
         <module>config-doc-maven-plugin</module>
     </modules>


### PR DESCRIPTION
NOTE: I have not yet looked at the code :) I share it here for others to play with. I still need to go through the code to review it and find a clean way to install this. One possible concern is the inclusion of Langchain4j dependencies to do the vector search

**Summary**         

  Adds a standalone stdio MCP (Model Context Protocol) server that enables AI coding agents (like Claude Code) to manage Quarkus application lifecycle and access documentation. Unlike the existing Dev
  MCP server which lives inside the running app and dies when the app crashes, this server runs as a separate process and survives application failures — allowing agents to recover broken apps.

  New module: devtools/mcp-server/

  9 MCP tools organized in 3 categories:

  **Lifecycle management:**
  - quarkus/start — Start a Quarkus app in dev mode (auto-detects Maven/Gradle)
  - quarkus/stop — Graceful shutdown via dev console
  - quarkus/restart — Force restart (or re-spawn if process died)
  - quarkus/status — Reports running/crashed/starting/stopped state
  - quarkus/logs — Recent log output from the managed process
  - quarkus/list — All managed instances and their status

  **Dev MCP proxy** (requires running app):
  - quarkus/searchTools — Discover available Dev MCP tools (testing, config, extensions, etc.)
  - quarkus/callTool — Invoke any Dev MCP tool by name with arguments

  **Documentation search**:
  - quarkus/searchDocs — Semantic search over Quarkus docs using BGE Small EN v1.5 embeddings + pgvector (24,885 indexed doc chunks, auto-starts Docker container on first use)

  New CLI command: quarkus mcp-server

  Registered in devtools/cli/ so users can configure their MCP client with:
  {"command": "quarkus", "args": ["mcp-server"]}

  **Key design decisions**

  - Separate process architecture — The MCP server wraps quarkus dev as a child process, so it stays alive when the app crashes. This is the key differentiator from Dev MCP.
  - Shutdown hook — All child processes are cleaned up when the MCP server exits (no orphaned processes holding ports).
  - No chappie dependency — Doc search reimplements the query path (~200 lines) using LangChain4j directly, consuming pre-built pgvector Docker images from chappie-docling-rag.
  - Metadata boosting — Doc search results are re-ranked using title/path keyword matching with synonym expansion.