### PR TITLE
Move network creation from IntegrationTestUtil into the DevServicesProcessor build step

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesNetworkIdBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesNetworkIdBuildItem.java
@@ -4,6 +4,11 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 /**
  * The network id of the network that the dev services are running on.
+ * This is intended to be consumed in the IntegrationTest launcher to ensure that the application is running on the same network
+ * as the dev services.
+ * <p>
+ * In the future if extensions consume this build item, it would create the shared network if it doesn't exist,
+ * and use it for the dev services and the test containers.
  */
 public final class DevServicesNetworkIdBuildItem extends SimpleBuildItem {
 

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
@@ -11,7 +11,7 @@ import static io.quarkus.devservices.common.ConfigureUtil.configureLabels;
 import static io.quarkus.devservices.common.ConfigureUtil.shouldConfigureSharedServiceLabel;
 import static io.quarkus.devservices.deployment.IsRuntimeModuleAvailable.IO_QUARKUS_DEVSERVICES_CONFIG_BUILDER_CLASS;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +27,8 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -51,6 +53,7 @@ import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
 import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
@@ -72,6 +75,8 @@ import io.quarkus.runtime.LaunchMode;
 
 public class DevServicesProcessor {
 
+    private static final Logger log = Logger.getLogger(DevServicesProcessor.class);
+
     private static final String EXEC_FORMAT = "%s exec -it %s /bin/bash";
 
     static volatile ConsoleStateManager.ConsoleContext context;
@@ -80,13 +85,45 @@ public class DevServicesProcessor {
 
     @BuildStep
     public DevServicesNetworkIdBuildItem networkId(
-            Optional<DevServicesLauncherConfigResultBuildItem> devServicesLauncherConfig,
+            DevServicesConfig devServicesConfig,
+            List<DevServicesSharedNetworkBuildItem> sharedNetworkBuildItems,
             Optional<DevServicesComposeProjectBuildItem> composeProjectBuildItem) {
-        String networkId = composeProjectBuildItem
-                .map(DevServicesComposeProjectBuildItem::getDefaultNetworkId)
-                .or(() -> devServicesLauncherConfig.flatMap(ignored -> getSharedNetworkId()))
-                .orElse(null);
+        Optional<String> configuredNetwork = ConfigProvider.getConfig().getOptionalValue(
+                "quarkus.test.container.network", String.class);
+        String networkId = configuredNetwork.flatMap(this::getOrCreateNetworkId)
+                .or(() -> composeProjectBuildItem.map(DevServicesComposeProjectBuildItem::getDefaultNetworkId))
+                .orElseGet(() -> (devServicesConfig.launchOnSharedNetwork() || !sharedNetworkBuildItems.isEmpty())
+                        ? getSharedNetworkId()
+                        : null);
         return new DevServicesNetworkIdBuildItem(networkId);
+    }
+
+    private Optional<String> getOrCreateNetworkId(String name) {
+        var networks = DockerClientFactory.lazyClient().listNetworksCmd().exec();
+        for (var network : networks) {
+            if (network.getName().equals(name)) {
+                return Optional.of(network.getId());
+            }
+        }
+        // if the network doesn't exist, create it
+        try {
+            // do the cleanup in a shutdown hook because there might be more services (launched via QuarkusTestResourceLifecycleManager) connected to the network
+            String id = DockerClientFactory.lazyClient().createNetworkCmd().withName(name).exec().getId();
+            Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        DockerClientFactory.lazyClient().removeNetworkCmd(id).exec();
+                    } catch (Exception e) {
+                        log.errorf("Unable to delete container network '%s'", id);
+                    }
+                }
+            }));
+            return Optional.of(id);
+        } catch (Exception e) {
+            log.warnf(e, "Creating container network '%s' completed unsuccessfully", name);
+            return Optional.empty();
+        }
     }
 
     @BuildStep(onlyIf = IsDevServicesSupportedByLaunchMode.class)
@@ -114,29 +151,27 @@ public class DevServicesProcessor {
     }
 
     /**
-     * Get the network id from the shared testcontainers network, without forcing the creation of the network.
+     * Get the network id from the shared testcontainers network, Creates the SHARED Network instance if not already created
      *
-     * @return the network id if available, empty otherwise
+     * @return the network id if available, null otherwise
      */
-    private Optional<String> getSharedNetworkId() {
+    private String getSharedNetworkId() {
         try {
-            Field id;
+            Method id;
             Object sharedNetwork;
             var tccl = Thread.currentThread().getContextClassLoader();
             if (tccl.getName().contains("Deployment")) {
                 Class<?> networkClass = tccl.getParent().loadClass("org.testcontainers.containers.Network");
                 sharedNetwork = networkClass.getField("SHARED").get(null);
                 Class<?> networkImplClass = tccl.getParent().loadClass("org.testcontainers.containers.Network$NetworkImpl");
-                id = networkImplClass.getDeclaredField("id");
+                id = networkImplClass.getDeclaredMethod("getId");
             } else {
                 sharedNetwork = Network.SHARED;
-                id = Network.NetworkImpl.class.getDeclaredField("id");
+                id = Network.NetworkImpl.class.getDeclaredMethod("getId");
             }
-            id.setAccessible(true);
-            String value = (String) id.get(sharedNetwork);
-            return Optional.ofNullable(value);
+            return (String) id.invoke(sharedNetwork);
         } catch (Exception e) {
-            return Optional.empty();
+            return null;
         }
     }
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
@@ -48,6 +48,7 @@ public interface ArtifactLauncher<T extends ArtifactLauncher.InitContext> extend
 
             String networkId();
 
+            @Deprecated
             boolean manageNetwork();
 
             CuratedApplication getCuratedApplication();

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -1,6 +1,5 @@
 package io.quarkus.test.junit;
 
-import static io.quarkus.deployment.util.ContainerRuntimeUtil.detectContainerRuntime;
 import static io.quarkus.runtime.configuration.QuarkusConfigBuilderCustomizer.QUARKUS_PROFILE;
 import static io.quarkus.test.common.PathTestHelper.getAppClassLocationForTestLocation;
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
@@ -25,8 +24,6 @@ import java.util.function.Consumer;
 
 import jakarta.inject.Inject;
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.jandex.Index;
@@ -46,7 +43,6 @@ import io.quarkus.deployment.builditem.DevServicesCustomizerBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
 import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
-import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.logging.LoggingSetupRecorder;
@@ -58,7 +54,6 @@ import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.test.config.ValueRegistryInjector;
 import io.quarkus.value.registry.ValueRegistry;
-import io.smallrye.common.process.ProcessBuilder;
 import io.smallrye.config.SmallRyeConfig;
 
 public final class IntegrationTestUtil {
@@ -235,7 +230,6 @@ public final class IntegrationTestUtil {
 
         Map<String, String> propertyMap = new HashMap<>();
         AugmentAction augmentAction;
-        String networkId = null;
         if (isDockerAppLaunch) {
             // when the application is going to be launched as a docker container, we need to make containers started by DevServices
             // use a shared network that the application container can then use as well
@@ -254,55 +248,8 @@ public final class IntegrationTestUtil {
         }, DevServicesLauncherConfigResultBuildItem.class.getName(), DevServicesNetworkIdBuildItem.class.getName(),
                 DevServicesRegistryBuildItem.class.getName(), DevServicesCustomizerBuildItem.class.getName());
 
-        networkId = propertyMap.get("quarkus.test.container.network");
-        boolean manageNetwork = false;
-        if (isDockerAppLaunch) {
-            if (networkId == null) {
-                // use the network the use has specified or else just generate one if none is configured
-                Optional<String> networkIdOpt = ConfigProvider.getConfig().getOptionalValue(
-                        "quarkus.test.container.network", String.class);
-                if (networkIdOpt.isPresent()) {
-                    networkId = networkIdOpt.get();
-                } else {
-                    networkId = "quarkus-integration-test-" + RandomStringUtils.insecure().next(5, true, false);
-                    manageNetwork = true;
-                }
-            }
-        }
-
-        DefaultDevServicesLaunchResult result = new DefaultDevServicesLaunchResult(propertyMap, networkId, manageNetwork,
-                curatedApplication);
-        createNetworkIfNecessary(result);
-        return result;
-    }
-
-    // this probably isn't the best place for this method, but we need to create the docker container before
-    // user code is aware of the network
-    private static void createNetworkIfNecessary(
-            final ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult) {
-        if (devServicesLaunchResult.manageNetwork() && (devServicesLaunchResult.networkId() != null)) {
-            ContainerRuntimeUtil.ContainerRuntime containerRuntime = detectContainerRuntime(true);
-
-            try {
-                ProcessBuilder.exec(containerRuntime.getExecutableName(), "network", "create",
-                        devServicesLaunchResult.networkId());
-                // do the cleanup in a shutdown hook because there might be more services (launched via QuarkusTestResourceLifecycleManager) connected to the network
-                Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            ProcessBuilder.exec(containerRuntime.getExecutableName(), "network", "rm",
-                                    devServicesLaunchResult.networkId());
-                        } catch (Exception e) {
-                            System.out.printf("Unable to delete container network '%s'", devServicesLaunchResult.networkId());
-                        }
-                    }
-                }));
-            } catch (Exception e) {
-                throw new RuntimeException("Creating container network '%s' completed unsuccessfully"
-                        .formatted(devServicesLaunchResult.networkId()), e);
-            }
-        }
+        String networkId = propertyMap.get("quarkus.test.container.network");
+        return new DefaultDevServicesLaunchResult(propertyMap, networkId, curatedApplication);
     }
 
     static void activateLogging() {
@@ -323,14 +270,12 @@ public final class IntegrationTestUtil {
     static class DefaultDevServicesLaunchResult implements ArtifactLauncher.InitContext.DevServicesLaunchResult {
         private final Map<String, String> properties;
         private final String networkId;
-        private final boolean manageNetwork;
         private final CuratedApplication curatedApplication;
 
         DefaultDevServicesLaunchResult(Map<String, String> properties, String networkId,
-                boolean manageNetwork, CuratedApplication curatedApplication) {
+                CuratedApplication curatedApplication) {
             this.properties = properties;
             this.networkId = networkId;
-            this.manageNetwork = manageNetwork;
             this.curatedApplication = curatedApplication;
         }
 
@@ -344,7 +289,7 @@ public final class IntegrationTestUtil {
 
         @Override
         public boolean manageNetwork() {
-            return manageNetwork;
+            return false;
         }
 
         @Override


### PR DESCRIPTION
`DevServicesProcessor` uses the Docker Java API, instead of `IntegrationTestUtil`, which created the `quarkus-integration-test-[random]` network via CLI commands. 

`DevServicesNetworkIdBuildItem` is **for now** **only** consumed by the `IntegrationTestUtil`, which triggers the creation of the SHARED network before the containerized app launch. This means that `quarkus-integration-test-[random]` is no longer created. @geoand : I am not sure if we need to be more defensive and keep that network creation fallback just in case.

- Deprecate `DevServicesLaunchResult.manageNetwork()`, returns false now
- `quarkus.devservices.launchOnSharedNetwork=true` still creates the shared network correctly, but only when `DevServicesNetworkIdBuildItem` is consumed, so on `IntegrationTestUtil` containerized app launch.
- Use the SHARED network when `launchOnSharedNetwork` is enabled or `DevServicesSharedNetworkBuildItem` is present, instead of generating random network names
- `quarkus.test.container.network` config property still works for configured network names
- Compose dev services default network still takes priority 

In the future, we can use `DevServicesNetworkIdBuildItem` in extensions to configure the network in which we create dev services in more scenarios. This only matters for now when `launchOnSharedNetwork=true`.

- Resolves: #50087 
- Resolves: #52809 
