### PR TITLE
Narayana JTA - Auto-enable recovery service when XA datasources are configured

### DIFF
--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -409,7 +409,9 @@ For more configuration information, see the *Narayana JTA - Transaction manager*
 ** JDBC datasources is part of `quarkus-agroal`, and it needs to use `quarkus.datasource.jdbc.transactions=XA`.
 ** ActiveMQ Artemis is part of `quarkus-pooled-jms`, and it needs to use `quarkus.pooled-jms.transaction=XA`.
 
-* To ensure data integrity in case of application crashes or failures, enable the transaction crash recovery with the `quarkus.transaction-manager.enable-recovery=true` configuration.
+* The transaction recovery service is automatically enabled when XA JDBC datasources are detected (i.e. `quarkus.datasource.jdbc.transactions=XA`).
+For other XA resource providers such as `quarkus-pooled-jms`, set `quarkus.transaction-manager.enable-recovery=true` to enable recovery.
+You can also set it to `false` to explicitly disable recovery even when XA datasources are present.
 
 [NOTE]
 ====

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -300,6 +300,7 @@ class AgroalProcessor {
                     aggregatedBuildTimeConfigBuildItem.getDbKind(),
                     aggregatedBuildTimeConfigBuildItem.getDataSourceConfig().dbVersion(),
                     aggregatedBuildTimeConfigBuildItem.getJdbcConfig().transactions() != TransactionIntegration.DISABLED,
+                    aggregatedBuildTimeConfigBuildItem.getJdbcConfig().transactions() == TransactionIntegration.XA,
                     aggregatedBuildTimeConfigBuildItem.isDefault()));
         }
     }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -258,13 +258,14 @@ public class DataSources {
             TransactionIntegration txIntegration = new NarayanaTransactionIntegration(transactionManager,
                     transactionSynchronizationRegistry, null, false,
                     dataSourceJdbcBuildTimeConfig.transactions() == io.quarkus.agroal.runtime.TransactionIntegration.XA
-                            && transactionRuntimeConfig.enableRecovery()
+                            && transactionRuntimeConfig.enableRecovery().orElse(true)
                                     ? xaResourceRecoveryRegistry
                                     : null);
             if (dataSourceJdbcBuildTimeConfig.transactions() == io.quarkus.agroal.runtime.TransactionIntegration.XA
-                    && !transactionRuntimeConfig.enableRecovery()) {
+                    && !transactionRuntimeConfig.enableRecovery().orElse(true)) {
                 log.warnv(
-                        "Datasource {0} enables XA but transaction recovery is not enabled. Please enable transaction recovery by setting quarkus.transaction-manager.enable-recovery=true, otherwise data may be lost if the application is terminated abruptly",
+                        "Datasource {0} enables XA but transaction recovery is disabled."
+                                + " Data may be lost if the application is terminated abruptly",
                         dataSourceName);
             }
             poolConfiguration.transactionIntegration(txIntegration);

--- a/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/JdbcDataSourceBuildItem.java
+++ b/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/JdbcDataSourceBuildItem.java
@@ -20,14 +20,26 @@ public final class JdbcDataSourceBuildItem extends MultiBuildItem {
 
     private final boolean transactionIntegrationEnabled;
 
+    private final boolean xaEnabled;
+
     private final boolean isDefault;
 
+    /**
+     * @deprecated Use {@link #JdbcDataSourceBuildItem(String, String, Optional, boolean, boolean, boolean)} instead.
+     */
+    @Deprecated
     public JdbcDataSourceBuildItem(String name, String kind, Optional<String> dbVersion,
             boolean transactionIntegrationEnabled, boolean isDefault) {
+        this(name, kind, dbVersion, transactionIntegrationEnabled, false, isDefault);
+    }
+
+    public JdbcDataSourceBuildItem(String name, String kind, Optional<String> dbVersion,
+            boolean transactionIntegrationEnabled, boolean xaEnabled, boolean isDefault) {
         this.name = name;
         this.dbKind = kind;
         this.dbVersion = dbVersion;
         this.transactionIntegrationEnabled = transactionIntegrationEnabled;
+        this.xaEnabled = xaEnabled;
         this.isDefault = isDefault;
     }
 
@@ -45,6 +57,10 @@ public final class JdbcDataSourceBuildItem extends MultiBuildItem {
 
     public boolean isTransactionIntegrationEnabled() {
         return transactionIntegrationEnabled;
+    }
+
+    public boolean isXaEnabled() {
+        return xaEnabled;
     }
 
     public boolean isDefault() {

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -189,7 +189,8 @@ class NarayanaJtaProcessor {
     @Record(RUNTIME_INIT)
     @Consume(NarayanaInitBuildItem.class)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
-    public void startRecoveryService(NarayanaJtaRecorder recorder, List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems) {
+    public void startRecoveryService(NarayanaJtaRecorder recorder, List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,
+            ShutdownContextBuildItem shutdownContextBuildItem) {
         Map<String, String> configuredDataSourcesConfigKeys = jdbcDataSourceBuildItems.stream()
                 .map(j -> j.getName())
                 .collect(Collectors.toMap(Function.identity(),
@@ -199,7 +200,10 @@ class NarayanaJtaProcessor {
                 .map(j -> j.getName())
                 .collect(Collectors.toSet());
 
-        recorder.startRecoveryService(configuredDataSourcesConfigKeys, dataSourcesWithTransactionIntegration);
+        boolean xaResourcesPresent = jdbcDataSourceBuildItems.stream()
+                .anyMatch(JdbcDataSourceBuildItem::isXaEnabled);
+        recorder.startRecoveryService(configuredDataSourcesConfigKeys, dataSourcesWithTransactionIntegration,
+                xaResourcesPresent, shutdownContextBuildItem);
     }
 
     @BuildStep(onlyIf = IsTest.class)

--- a/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryExplicitlyDisabledTest.java
+++ b/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryExplicitlyDisabledTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.narayana.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.narayana.jta.runtime.QuarkusRecoveryService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that explicitly setting {@code enable-recovery=false} prevents the recovery
+ * service from starting, even when XA datasources are configured.
+ */
+public class TransactionRecoveryExplicitlyDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("xa-recovery-auto-enable.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-agroal", Version.getVersion())))
+            .overrideConfigKey("quarkus.transaction-manager.enable-recovery", "false");
+
+    @Test
+    public void testRecoveryNotStartedWhenExplicitlyDisabled() {
+        assertFalse(QuarkusRecoveryService.isRunning(),
+                "Recovery service should not be running when recovery is explicitly disabled");
+    }
+}

--- a/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryExplicitlyEnabledWithoutXaTest.java
+++ b/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryExplicitlyEnabledWithoutXaTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.narayana.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.runtime.QuarkusRecoveryService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that explicitly setting {@code enable-recovery=true} starts the recovery
+ * service even when no XA datasources are configured.
+ */
+public class TransactionRecoveryExplicitlyEnabledWithoutXaTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.transaction-manager.enable-recovery", "true");
+
+    @Test
+    public void testRecoveryStartedWhenExplicitlyEnabled() {
+        assertTrue(QuarkusRecoveryService.isRunning(),
+                "Recovery service should be running when explicitly enabled, even without XA datasources");
+    }
+}

--- a/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryNotEnabledWithoutXaTest.java
+++ b/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryNotEnabledWithoutXaTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.narayana.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.runtime.QuarkusRecoveryService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that the recovery service is NOT started when no XA datasources
+ * are configured and {@code enable-recovery} is not explicitly set.
+ */
+public class TransactionRecoveryNotEnabledWithoutXaTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void testRecoveryNotStartedWithoutXaDatasources() {
+        assertFalse(QuarkusRecoveryService.isRunning(),
+                "Recovery service should not be running when no XA datasources are configured");
+    }
+}

--- a/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryXaAutoEnableTest.java
+++ b/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionRecoveryXaAutoEnableTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.narayana.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.narayana.jta.runtime.QuarkusRecoveryService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that the recovery service is automatically enabled when XA datasources
+ * are configured and {@code enable-recovery} is not explicitly set.
+ */
+public class TransactionRecoveryXaAutoEnableTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("xa-recovery-auto-enable.properties", "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-agroal", Version.getVersion())));
+
+    @Test
+    public void testRecoveryAutoEnabledWithXaDatasource() {
+        assertTrue(QuarkusRecoveryService.isRunning(),
+                "Recovery service should be running when XA datasources are configured");
+    }
+}

--- a/extensions/narayana-jta/deployment/src/test/resources/xa-recovery-auto-enable.properties
+++ b/extensions/narayana-jta/deployment/src/test/resources/xa-recovery-auto-enable.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+quarkus.datasource.jdbc.transactions=xa
+
+quarkus.datasource.devservices.enabled=false
+quarkus.devservices.enabled=false

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -165,7 +165,7 @@ public class NarayanaJtaRecorder {
     }
 
     public void startRecoveryService(Map<String, String> configuredDataSourcesConfigKeys,
-            Set<String> dataSourcesWithTransactionIntegration) {
+            Set<String> dataSourcesWithTransactionIntegration, boolean xaResourcesPresent, ShutdownContext context) {
 
         if (transactions.getValue().objectStore().type().equals(ObjectStoreType.JDBC)) {
             final String objectStoreDataSourceName;
@@ -206,25 +206,25 @@ public class NarayanaJtaRecorder {
                         objectStoreDataSourceName, configuredDataSourcesConfigKeys.get(objectStoreDataSourceName)));
             }
         }
-        if (transactions.getValue().enableRecovery()) {
-            QuarkusRecoveryService.getInstance().create();
-            QuarkusRecoveryService.getInstance().start();
+        boolean recoveryEnabled = transactions.getValue().enableRecovery().orElse(xaResourcesPresent);
+        if (!recoveryEnabled) {
+            return;
         }
+        QuarkusRecoveryService.getInstance().create();
+        QuarkusRecoveryService.getInstance().start();
+        context.addShutdownTask(() -> {
+            try {
+                QuarkusRecoveryService.getInstance().stop();
+            } catch (Exception e) {
+                // the recovery manager throws IllegalStateException if it has already been shutdown
+                log.warn("The recovery manager has already been shutdown", e);
+            } finally {
+                QuarkusRecoveryService.getInstance().destroy();
+            }
+        });
     }
 
     public void handleShutdown(ShutdownContext context) {
-        context.addShutdownTask(() -> {
-            if (transactions.getValue().enableRecovery()) {
-                try {
-                    QuarkusRecoveryService.getInstance().stop();
-                } catch (Exception e) {
-                    // the recovery manager throws IllegalStateException if it has already been shutdown
-                    log.warn("The recovery manager has already been shutdown", e);
-                } finally {
-                    QuarkusRecoveryService.getInstance().destroy();
-                }
-            }
-        });
         context.addLastShutdownTask(() -> {
             TransactionReaper.terminate(false);
         });

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/QuarkusRecoveryService.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/QuarkusRecoveryService.java
@@ -60,6 +60,14 @@ public class QuarkusRecoveryService extends RecoveryManagerService {
         xaResources.clear();
     }
 
+    /**
+     * Returns whether the recovery service has been created and is currently active.
+     */
+    public static boolean isRunning() {
+        return recoveryManagerService instanceof QuarkusRecoveryService
+                && ((QuarkusRecoveryService) recoveryManagerService).isCreated;
+    }
+
     @Override
     public void stop() {
 

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerConfiguration.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerConfiguration.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -41,9 +42,12 @@ public interface TransactionManagerConfiguration {
 
     /**
      * Start the recovery service on startup.
+     * <p>
+     * If not set, the recovery service will be started automatically if XA datasources are configured.
+     * Set to {@code true} to always enable recovery, or {@code false} to explicitly disable it.
      */
-    @WithDefault("false")
-    boolean enableRecovery();
+    @ConfigDocDefault("`true` if XA datasources are configured, `false` otherwise")
+    Optional<Boolean> enableRecovery();
 
     /**
      * The list of recovery modules.


### PR DESCRIPTION
addresses https://github.com/quarkusio/quarkus/issues/28144 
See doc reference https://quarkus.io/guides/transaction#jdbcstore

This PR automatically enables the Narayana JTA transaction recovery service when XA datasources are detected at build time, removing the need for users to manually set
quarkus.transaction-manager.enable-recovery=true.
Without recovery enabled, XA transactions that fail mid-commit (e.g. due to a crash) can leave data in an inconsistent state.

Changes

Auto-detection of XA datasources at build time:

The enable-recovery config property has been moved from a runtime boolean (defaulting to false) to a build-time Optional. When unset, it defaults to true if  any XA datasource is configured, false otherwise.


Users retain full control:

- Setting quarkus.transaction-manager.enable-recovery=true forces recovery on (even without XA datasources).
- Setting quarkus.transaction-manager.enable-recovery=false forces recovery off (even with XA datasources).

Known limitations

- Auto-detection currently covers JDBC XA datasources only. Other transactional resources (e.g. JMS resource adapters) will still require manual configuration.
- The decision is made at build time, so datasources configured purely at runtime won't trigger auto-enablement.
