### PR TITLE
Re-enable injection of config from previous dev services to dependencies (regression fix)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -184,21 +184,26 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
 
             if (missingDependency == null) {
                 startable.start();
+
+                Map<String, String> config = request.getConfig(startable);
+                Map<String, String> overrideConfig = request.getOverrideConfig(startable);
+                configs.putAll(config);
+                configs.putAll(overrideConfig);
+
                 // We do not "copy" the config map here since it is created within the request.getConfig:
-                Map<String, String> combinedConfig = request.getConfig(startable);
                 // Some extensions may rely on adding/overriding config properties
                 //  depending on the results of the started dev services,
                 //  e.g. Hibernate Search/ORM may change the default schema management
                 //  if it detects that it runs over a dev service datasource/Elasticsearch distribution.
                 for (DevServicesAdditionalConfigBuildItem additionalConfigBuildItem : additionalConfigBuildItems) {
                     Map<String, String> extraFromBuildItem = additionalConfigBuildItem.getConfigProvider()
-                            .provide(combinedConfig);
+                            .provide(configs);
                     if (!extraFromBuildItem.isEmpty()) {
-                        combinedConfig.putAll(extraFromBuildItem);
+                        configs.putAll(extraFromBuildItem);
                     }
                 }
                 RunningService service = new RunningService(request.getName(), request.getDescription(),
-                        combinedConfig, request.getOverrideConfig(startable), startable.getContainerId(), startable);
+                        configs, request.getOverrideConfig(startable), startable.getContainerId(), startable);
                 this.addRunningService(request.getName(), request.getServiceName(), request.getServiceConfig(), service);
                 compressor.close();
 


### PR DESCRIPTION
While working on https://github.com/quarkusio/quarkus/pull/53000, re-enabling some disabled tests, I discovered that while the tests were disabled, a regression happened. The functionality added by https://github.com/quarkusio/quarkus/pull/51025 regressed while the test was disabled. It looks like https://github.com/quarkusio/quarkus/pull/52324 (which I reviewed!) removed a bit of code needed the new dependency ordering feature, which was easy to do, because there were no active tests.

I've applied a tactical fix (just adding back what we had before). The diff looks biggish, but compared to https://github.com/quarkusio/quarkus/pull/51025 it's a smaller diff. 

I couldn't find a good way to get a url for diffing a single file between two commits, but here's a manual one:

<img width="1048" height="561" alt="image" src="https://github.com/user-attachments/assets/13a1d253-a332-46f8-9db0-ab903aae6858" />

https://github.com/quarkusio/quarkus/actions/runs/22945590247/job/66598870813?pr=53000 is a CI run with only one unrelated error.
