### PR TITLE
Resolve configuration access lock errors with Gradle 9

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -36,6 +36,7 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
 
     public static final String EXTENSION_DESCRIPTOR_TASK_NAME = "extensionDescriptor";
     public static final String VALIDATE_EXTENSION_TASK_NAME = "validateExtension";
+    private static final String DEPLOYMENT_CLASSPATH_CONFIGURATION_NAME = "quarkusDeploymentClasspath";
 
     public static final String QUARKUS_ANNOTATION_PROCESSOR = "io.quarkus:quarkus-extension-processor";
 
@@ -87,9 +88,21 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
                         javaPlugin -> addAnnotationProcessorDependency(deploymentProject));
 
                 validateExtensionTask.configure(task -> {
-                    Configuration deploymentModuleClasspath = deploymentProject.getConfigurations()
-                            .getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
-                    task.setDeploymentModuleClasspath(deploymentModuleClasspath);
+                    // Create a local resolvable configuration that depends on the deployment project.
+                    // This avoids cross-project configuration resolution issues in Gradle 9.x.
+                    Configuration deploymentClasspath = project.getConfigurations()
+                            .findByName(DEPLOYMENT_CLASSPATH_CONFIGURATION_NAME);
+                    if (deploymentClasspath == null) {
+                        deploymentClasspath = project.getConfigurations().create(DEPLOYMENT_CLASSPATH_CONFIGURATION_NAME);
+                        deploymentClasspath.setCanBeConsumed(false);
+                        deploymentClasspath.setCanBeResolved(true);
+                        deploymentClasspath.setTransitive(true);
+                        // Add project dependency on deployment module
+                        project.getDependencies().add(DEPLOYMENT_CLASSPATH_CONFIGURATION_NAME,
+                                project.getDependencies().project(
+                                        java.util.Map.of("path", deploymentProject.getPath())));
+                    }
+                    task.setDeploymentModuleClasspath(deploymentClasspath);
                 });
 
                 deploymentProject.getTasks().withType(Test.class).configureEach(test -> {

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTaskTest.java
@@ -22,8 +22,8 @@ public class ValidateExtensionTaskTest {
 
     @Test
     public void shouldValidateExtensionDependencies() throws IOException {
-        TestUtils.createExtensionProject(testProjectDir, false, List.of("io.quarkus:quarkus-core"),
-                List.of("io.quarkus:quarkus-core-deployment"));
+        TestUtils.createExtensionProject(testProjectDir, false, List.of("io.quarkus:quarkus-jdbc-h2"),
+                List.of("io.quarkus:quarkus-jdbc-h2-deployment"));
 
         BuildResult validationResult = GradleRunner.create()
                 .withPluginClasspath()
@@ -36,7 +36,7 @@ public class ValidateExtensionTaskTest {
     }
 
     @Test
-    public void shouldDetectMissionExtensionDependency() throws IOException {
+    public void shouldDetectMissingExtensionDependency() throws IOException {
         TestUtils.createExtensionProject(testProjectDir, false, List.of("io.quarkus:quarkus-jdbc-h2"), List.of());
 
         BuildResult validationResult = GradleRunner.create()
@@ -85,5 +85,44 @@ public class ValidateExtensionTaskTest {
 
         assertThat(validationResult.task(":runtime:" + QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME).getOutcome())
                 .isEqualTo(TaskOutcome.SKIPPED);
+    }
+
+    @Test
+    public void shouldValidateExtensionWithParallelExecution() throws IOException {
+        TestUtils.createExtensionProject(testProjectDir, false, List.of("io.quarkus:quarkus-jdbc-h2"),
+                List.of("io.quarkus:quarkus-jdbc-h2-deployment"));
+
+        BuildResult validationResult = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME, "--parallel")
+                .build();
+
+        assertThat(validationResult.task(":runtime:" + QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME).getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+
+        // Verify no unsafe configuration resolution errors in output
+        assertThat(validationResult.getOutput())
+                .doesNotContain("was attempted without an exclusive lock");
+    }
+
+    @Test
+    public void shouldDetectInvalidRuntimeDependencyWithParallelExecution() throws IOException {
+        TestUtils.createExtensionProject(testProjectDir, false,
+                List.of("io.quarkus:quarkus-jdbc-h2", "io.quarkus:quarkus-jdbc-h2-deployment"),
+                List.of());
+
+        BuildResult validationResult = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME, "--parallel")
+                .buildAndFail();
+
+        assertThat(validationResult.task(":runtime:" + QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME).getOutcome())
+                .isEqualTo(TaskOutcome.FAILED);
+        assertThat(validationResult.getOutput()).contains("Quarkus Extension Dependency Verification Error");
+        assertThat(validationResult.getOutput())
+                .contains("The following deployment artifact(s) appear on the runtime classpath:");
+        assertThat(validationResult.getOutput()).contains("- io.quarkus:quarkus-core-deployment");
     }
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

This PR is my attempt to resolve issues with building Quarkus extensions using Gradle 9.x As reported in #49115, running a parallel build with Gradle 9 results in the following error:

```
Resolution of the configuration ':deployment:runtimeClasspath' was attempted without an exclusive lock. This is unsafe and not allowed.
```

In Gradle 8.x, this was a warning but the build succeeded. Note that this behavior is only triggered by utilizing the `--parallel` flag or configuration option, which is not used in Quarkus' existing Gradle tests.

As I'm not a Gradle expert, I used Claude Opus to help identify the issue and the fix. It suggested creating a new `deploymentClasspath` in the runtime module, which contains the transitive dependencies for the deployment module. This not only resolves the configuration lock issue, but also avoids a circular dependency by having the runtime module use existing Gradle mechanisms to access the output artifacts. I will admit to being a bit confused as to how exactly this avoids the circular dependency, but this change does resolve the build issues in my internal application.

In addition, I added 2 new unit tests which verify the fix works as expected by directly passing the `--parallel` flag to the Gradle runner and asserting that the task both succeeds and still catches validation issues. I also noticed that the existing tests which use the `io.quarkus:quarkus-core` dependency do not work as expected because `quarks-arc` transitively depends on `quarks-core` so the tests always pass. I updated them to use the `quarkus-jdbc-h2` which will actually catch validation issues or regressions.

I was able to test this fix on our internal applications as well as the following reproducer:
https://github.com/quarkusio/quarkus/issues/49115#issuecomment-3801063312

The issue reported here: https://github.com/quarkusio/quarkus/issues/49115#issuecomment-3789187969 appears to be a separate issue, though I'm happy to investigate and potentially apply the same solution, if desired. 
<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

