### PR TITLE
A step towards making it clearer PathTree API is about visiting class path resources on a file system

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -251,7 +251,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
         try (OpenPathTree pathTree = appDep.getContentTree().open()) {
             pathTree.walkRaw(visit -> {
                 try {
-                    final String relativePath = visit.getRelativePath();
+                    final String relativePath = visit.getResourceName();
                     if (Files.isDirectory(visit.getPath())) {
                         if (!relativePath.isEmpty()) {
                             archiveCreator.addDirectory(relativePath);

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/GrafanaUtils.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/GrafanaUtils.java
@@ -87,7 +87,7 @@ public class GrafanaUtils {
                         tree.walkIfContains(META_INF_GRAFANA, visit -> {
                             Path visitPath = visit.getPath();
                             if (!Files.isDirectory(visitPath)) {
-                                String rel = visit.getRelativePath();
+                                String rel = visit.getResourceName();
                                 // Ensure that the relative path starts with the right prefix and suffix before calling substring
                                 if (rel.startsWith(META_INF_GRAFANA + "/grafana-dashboard-") && rel.endsWith(".json")) {
                                     // Strip the "META-INF/grafana/" prefix

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -2302,7 +2302,7 @@ public class QuteProcessor {
                         }
                         LOGGER.debugf("Found template: %s", path);
                         // remove templateRoot + /
-                        final String relativePath = visit.getRelativePath();
+                        final String relativePath = visit.getResourceName();
                         String templatePath = relativePath.substring(templateRoot.length() + 1);
                         for (Pattern p : excludePatterns) {
                             if (p.matcher(templatePath).matches()) {
@@ -2314,7 +2314,7 @@ public class QuteProcessor {
                         URI source = null;
                         if (module != null) {
                             for (SourceDir resources : module.getMainSources().getResourceDirs()) {
-                                Path sourcePath = resources.getDir().resolve(visit.getRelativePath());
+                                Path sourcePath = resources.getDir().resolve(visit.getResourceName());
                                 if (Files.isRegularFile(sourcePath)) {
                                     LOGGER.debugf("Source file found for template %s: %s", templatePath, sourcePath);
                                     source = sourcePath.toUri();

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
@@ -92,7 +92,7 @@ public class StaticResourcesProcessor {
             final Set<String> collectedDirs = new HashSet<>();
             visitRuntimeMetaInfResources(visit -> {
                 if (Files.isDirectory(visit.getPath())) {
-                    final String relativePath = visit.getRelativePath();
+                    final String relativePath = visit.getResourceName();
                     if (collectedDirs.add(relativePath)) {
                         producer.produce(new NativeImageResourceBuildItem(relativePath));
                     }
@@ -112,7 +112,7 @@ public class StaticResourcesProcessor {
         visitRuntimeMetaInfResources(visit -> {
             Path visitPath = visit.getPath();
             if (!Files.isDirectory(visitPath)) {
-                String rel = visit.getRelativePath();
+                String rel = visit.getResourceName();
                 // Ensure that the relative path starts with the prefix before calling substring
                 if (rel.startsWith(prefix)) {
                     // Strip the "META-INF/resources/" prefix and add the remainder

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -119,14 +119,15 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
     }
 
     @Override
-    public void walkIfContains(String relativePath, PathVisitor visitor) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    public void walkIfContains(String resourceDirName, PathVisitor visitor) {
+        ensureResourcePath(resourceDirName);
+        if (!PathFilter.isVisible(pathFilter, resourceDirName)) {
             return;
         }
         try (FileSystem fs = openFs()) {
+            final String dirPath = PathTreeVisit.resourceNameToFsPath(resourceDirName, fs);
             for (Path root : fs.getRootDirectories()) {
-                final Path walkDir = root.resolve(relativePath);
+                final Path walkDir = root.resolve(dirPath);
                 if (Files.exists(walkDir)) {
                     PathTreeVisit.walk(archive, root, walkDir, pathFilter, getMultiReleaseMapping(), visitor);
                 }
@@ -137,7 +138,7 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
     }
 
     private void ensureResourcePath(String path) {
-        OpenContainerPathTree.ensureResourcePath(archive.getFileSystem(), path);
+        PathTreeVisit.ensureResourcePath(archive.getFileSystem(), path);
     }
 
     @Override
@@ -145,16 +146,19 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         return resourceNames == null ? resourceNames = super.getResourceNames() : resourceNames;
     }
 
+    private String resolveResourceName(String resourceName, boolean manifestEnabled) {
+        return manifestEnabled ? toMultiReleaseResourceName(resourceName) : resourceName;
+    }
+
     @Override
-    protected <T> T apply(String relativePath, Function<PathVisit, T> func, boolean manifestEnabled) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    protected <T> T apply(String resourceName, Function<PathVisit, T> func, boolean manifestEnabled) {
+        ensureResourcePath(resourceName);
+        if (!PathFilter.isVisible(pathFilter, resourceName)) {
             return func.apply(null);
         }
-        if (manifestEnabled) {
-            relativePath = toMultiReleaseRelativePath(relativePath);
-        }
         try (FileSystem fs = openFs()) {
+            final String relativePath = PathTreeVisit.resourceNameToFsPath(
+                    resolveResourceName(resourceName, manifestEnabled), fs);
             for (Path root : fs.getRootDirectories()) {
                 final Path path = root.resolve(relativePath);
                 if (!Files.exists(path)) {
@@ -169,16 +173,15 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
     }
 
     @Override
-    public void accept(String relativePath, Consumer<PathVisit> consumer) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    public void accept(String resourceName, Consumer<PathVisit> consumer) {
+        ensureResourcePath(resourceName);
+        if (!PathFilter.isVisible(pathFilter, resourceName)) {
             consumer.accept(null);
             return;
         }
-        if (manifestEnabled) {
-            relativePath = toMultiReleaseRelativePath(relativePath);
-        }
         try (FileSystem fs = openFs()) {
+            final String relativePath = PathTreeVisit.resourceNameToFsPath(
+                    resolveResourceName(resourceName, manifestEnabled), fs);
             for (Path root : fs.getRootDirectories()) {
                 final Path path = root.resolve(relativePath);
                 if (!Files.exists(path)) {
@@ -194,15 +197,14 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
     }
 
     @Override
-    public boolean contains(String relativePath) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    public boolean contains(String resourceName) {
+        ensureResourcePath(resourceName);
+        if (!PathFilter.isVisible(pathFilter, resourceName)) {
             return false;
         }
-        if (manifestEnabled) {
-            relativePath = toMultiReleaseRelativePath(relativePath);
-        }
         try (FileSystem fs = openFs()) {
+            final String relativePath = PathTreeVisit.resourceNameToFsPath(
+                    resolveResourceName(resourceName, manifestEnabled), fs);
             for (Path root : fs.getRootDirectories()) {
                 final Path path = root.resolve(relativePath);
                 if (Files.exists(path)) {
@@ -326,22 +328,22 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         }
 
         @Override
-        protected <T> T apply(String relativePath, Function<PathVisit, T> func, boolean manifestEnabled) {
+        protected <T> T apply(String resourceName, Function<PathVisit, T> func, boolean manifestEnabled) {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                return super.apply(relativePath, func, manifestEnabled);
+                return super.apply(resourceName, func, manifestEnabled);
             } finally {
                 lock.readLock().unlock();
             }
         }
 
         @Override
-        public void accept(String relativePath, Consumer<PathVisit> consumer) {
+        public void accept(String resourceName, Consumer<PathVisit> consumer) {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                super.accept(relativePath, consumer);
+                super.accept(resourceName, consumer);
             } finally {
                 lock.readLock().unlock();
             }
@@ -370,11 +372,11 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         }
 
         @Override
-        public void walkIfContains(String relativePath, PathVisitor visitor) {
+        public void walkIfContains(String resourceDirName, PathVisitor visitor) {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                super.walkIfContains(relativePath, visitor);
+                super.walkIfContains(resourceDirName, visitor);
             } finally {
                 lock.readLock().unlock();
             }
@@ -386,22 +388,22 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         }
 
         @Override
-        public boolean contains(String relativePath) {
+        public boolean contains(String resourceName) {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                return super.contains(relativePath);
+                return super.contains(resourceName);
             } finally {
                 lock.readLock().unlock();
             }
         }
 
         @Override
-        public Path getPath(String relativePath) {
+        public Path getPath(String resourceName) {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                return super.getPath(relativePath);
+                return super.getPath(resourceName);
             } finally {
                 lock.readLock().unlock();
             }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
@@ -40,7 +40,7 @@ public class EmptyPathTree implements OpenPathTree {
     }
 
     @Override
-    public void walkIfContains(String relativePath, PathVisitor visitor) {
+    public void walkIfContains(String resourceDirName, PathVisitor visitor) {
     }
 
     @Override
@@ -49,17 +49,17 @@ public class EmptyPathTree implements OpenPathTree {
     }
 
     @Override
-    public <T> T apply(String relativePath, Function<PathVisit, T> func) {
+    public <T> T apply(String resourceName, Function<PathVisit, T> func) {
         return func.apply(null);
     }
 
     @Override
-    public void accept(String relativePath, Consumer<PathVisit> func) {
+    public void accept(String resourceName, Consumer<PathVisit> func) {
         func.accept(null);
     }
 
     @Override
-    public boolean contains(String relativePath) {
+    public boolean contains(String resourceName) {
         return false;
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
@@ -77,7 +77,7 @@ class FilePathTree implements OpenPathTree {
     }
 
     @Override
-    public void walkIfContains(String relativePath, PathVisitor visitor) {
+    public void walkIfContains(String resourceDirName, PathVisitor visitor) {
         throw new UnsupportedOperationException();
     }
 
@@ -87,8 +87,8 @@ class FilePathTree implements OpenPathTree {
     }
 
     @Override
-    public <T> T apply(String relativePath, Function<PathVisit, T> func) {
-        if (relativePath.isEmpty()) {
+    public <T> T apply(String resourceName, Function<PathVisit, T> func) {
+        if (resourceName.isEmpty()) {
             Path parent = file.getParent();
             return PathTreeVisit.process(parent, parent, file, pathFilter, func);
         }
@@ -96,8 +96,8 @@ class FilePathTree implements OpenPathTree {
     }
 
     @Override
-    public void accept(String relativePath, Consumer<PathVisit> func) {
-        if (relativePath.isEmpty()) {
+    public void accept(String resourceName, Consumer<PathVisit> func) {
+        if (resourceName.isEmpty()) {
             Path parent = file.getParent();
             PathTreeVisit.consume(parent, parent, file, pathFilter, func);
             return;
@@ -106,7 +106,7 @@ class FilePathTree implements OpenPathTree {
     }
 
     @Override
-    public boolean contains(String relativePath) {
+    public boolean contains(String resourceName) {
         return false;
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
@@ -51,46 +51,46 @@ public class FilteredPathTree implements PathTree {
     }
 
     @Override
-    public void walkIfContains(String relativePath, PathVisitor visitor) {
-        if (!PathFilter.isVisible(filter, relativePath)) {
+    public void walkIfContains(String resourceDirName, PathVisitor visitor) {
+        if (!PathFilter.isVisible(filter, resourceDirName)) {
             return;
         }
-        original.walkIfContains(relativePath, visit -> {
-            if (visit != null && filter.isVisible(visit.getRelativePath())) {
+        original.walkIfContains(resourceDirName, visit -> {
+            if (visit != null && filter.isVisible(visit.getResourceName())) {
                 visitor.visitPath(visit);
             }
         });
     }
 
     @Override
-    public <T> T apply(String relativePath, Function<PathVisit, T> func) {
-        if (!PathFilter.isVisible(filter, relativePath)) {
+    public <T> T apply(String resourceName, Function<PathVisit, T> func) {
+        if (!PathFilter.isVisible(filter, resourceName)) {
             return func.apply(null);
         }
-        return original.apply(relativePath, func);
+        return original.apply(resourceName, func);
     }
 
     @Override
-    public void accept(String relativePath, Consumer<PathVisit> consumer) {
-        if (!PathFilter.isVisible(filter, relativePath)) {
+    public void accept(String resourceName, Consumer<PathVisit> consumer) {
+        if (!PathFilter.isVisible(filter, resourceName)) {
             consumer.accept(null);
         } else {
-            original.accept(relativePath, consumer);
+            original.accept(resourceName, consumer);
         }
     }
 
     @Override
-    public void acceptAll(String relativePath, Consumer<PathVisit> consumer) {
-        if (!PathFilter.isVisible(filter, relativePath)) {
+    public void acceptAll(String resourceName, Consumer<PathVisit> consumer) {
+        if (!PathFilter.isVisible(filter, resourceName)) {
             consumer.accept(null);
         } else {
-            original.acceptAll(relativePath, consumer);
+            original.acceptAll(resourceName, consumer);
         }
     }
 
     @Override
-    public boolean contains(String relativePath) {
-        return PathFilter.isVisible(filter, relativePath) && original.contains(relativePath);
+    public boolean contains(String resourceName) {
+        return PathFilter.isVisible(filter, resourceName) && original.contains(resourceName);
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
@@ -80,12 +80,12 @@ public class MultiRootPathTree implements OpenPathTree {
     }
 
     @Override
-    public void walkIfContains(String relativePath, PathVisitor visitor) {
+    public void walkIfContains(String resourceDirName, PathVisitor visitor) {
         if (trees.length == 0) {
             return;
         }
         for (PathTree t : trees) {
-            t.walkIfContains(relativePath, visitor);
+            t.walkIfContains(resourceDirName, visitor);
         }
     }
 
@@ -98,7 +98,7 @@ public class MultiRootPathTree implements OpenPathTree {
         if (trees.length > 0) {
             Set<String> result = new HashSet<>();
             for (PathTree t : trees) {
-                t.walk(visit -> result.add(visit.getRelativePath()));
+                t.walk(visit -> result.add(visit.getResourceName()));
             }
             return result;
         }
@@ -106,9 +106,9 @@ public class MultiRootPathTree implements OpenPathTree {
     }
 
     @Override
-    public <T> T apply(String relativePath, Function<PathVisit, T> func) {
+    public <T> T apply(String resourceName, Function<PathVisit, T> func) {
         for (PathTree tree : trees) {
-            T result = tree.apply(relativePath, func);
+            T result = tree.apply(resourceName, func);
             if (result != null) {
                 return result;
             }
@@ -117,7 +117,7 @@ public class MultiRootPathTree implements OpenPathTree {
     }
 
     @Override
-    public void accept(String relativePath, Consumer<PathVisit> func) {
+    public void accept(String resourceName, Consumer<PathVisit> func) {
         final AtomicBoolean consumed = new AtomicBoolean();
         final Consumer<PathVisit> wrapper = new Consumer<>() {
             @Override
@@ -129,7 +129,7 @@ public class MultiRootPathTree implements OpenPathTree {
             }
         };
         for (PathTree tree : trees) {
-            tree.accept(relativePath, wrapper);
+            tree.accept(resourceName, wrapper);
             if (consumed.get()) {
                 break;
             }
@@ -140,7 +140,7 @@ public class MultiRootPathTree implements OpenPathTree {
     }
 
     @Override
-    public void acceptAll(String relativePath, Consumer<PathVisit> func) {
+    public void acceptAll(String resourceName, Consumer<PathVisit> func) {
         final AtomicBoolean consumed = new AtomicBoolean();
         final Consumer<PathVisit> wrapper = new Consumer<>() {
             @Override
@@ -152,7 +152,7 @@ public class MultiRootPathTree implements OpenPathTree {
             }
         };
         for (PathTree tree : trees) {
-            tree.accept(relativePath, wrapper);
+            tree.accept(resourceName, wrapper);
         }
         if (!consumed.get()) {
             func.accept(null);
@@ -160,9 +160,9 @@ public class MultiRootPathTree implements OpenPathTree {
     }
 
     @Override
-    public boolean contains(String relativePath) {
+    public boolean contains(String resourceName) {
         for (PathTree tree : trees) {
-            if (tree.contains(relativePath)) {
+            if (tree.contains(resourceName)) {
                 return true;
             }
         }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
@@ -1,7 +1,5 @@
 package io.quarkus.paths;
 
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -10,40 +8,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 public abstract class OpenContainerPathTree extends PathTreeWithManifest implements OpenPathTree {
-
-    private static final boolean USE_WINDOWS_ABSOLUTE_PATH_PATTERN = !FileSystems.getDefault().getSeparator().equals("/");
-
-    private static volatile Pattern windowsAbsolutePathPattern;
-
-    private static Pattern windowsAbsolutePathPattern() {
-        return windowsAbsolutePathPattern == null ? windowsAbsolutePathPattern = Pattern.compile("[a-zA-Z]:\\\\.*")
-                : windowsAbsolutePathPattern;
-    }
-
-    static boolean isAbsolutePath(String path) {
-        return path != null && !path.isEmpty()
-                && (path.charAt(0) == '/' // we want to check for '/' on every OS
-                        || USE_WINDOWS_ABSOLUTE_PATH_PATTERN
-                                && (windowsAbsolutePathPattern().matcher(path).matches())
-                        || path.startsWith(FileSystems.getDefault().getSeparator()));
-    }
-
-    static void ensureResourcePath(FileSystem fs, String path) {
-        if (isAbsolutePath(path)) {
-            throw new IllegalArgumentException("Expected a path relative to the root of the path tree but got " + path);
-        }
-        // this is to disallow reading outside the path tree root
-        if (path != null && path.contains("..")) {
-            for (Path pathElement : fs.getPath(path)) {
-                if (pathElement.toString().equals("..")) {
-                    throw new IllegalArgumentException("'..' cannot be used in resource paths, but got " + path);
-                }
-            }
-        }
-    }
 
     protected PathFilter pathFilter;
 
@@ -123,68 +89,78 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
     }
 
     @Override
-    public void walkIfContains(String relativePath, PathVisitor visitor) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    public void walkIfContains(String resourceDirName, PathVisitor visitor) {
+        ensureResourcePath(resourceDirName);
+        if (!PathFilter.isVisible(pathFilter, resourceDirName)) {
             return;
         }
-        final Path walkDir = getRootPath()
-                .resolve(manifestEnabled ? toMultiReleaseRelativePath(relativePath) : relativePath);
+        final Path walkDir = resolveResource(resourceDirName, manifestEnabled);
         if (!Files.exists(walkDir)) {
             return;
         }
-        PathTreeVisit.walk(getRootPath(), getRootPath(), walkDir, pathFilter, getMultiReleaseMapping(), visitor);
+        final Path root = getRootPath();
+        PathTreeVisit.walk(root, root, walkDir, pathFilter, getMultiReleaseMapping(), visitor);
     }
 
     private void ensureResourcePath(String path) {
-        ensureResourcePath(getRootPath().getFileSystem(), path);
+        PathTreeVisit.ensureResourcePath(getRootPath().getFileSystem(), path);
+    }
+
+    private Path resolveResource(String resourceName, boolean manifestEnabled) {
+        if (manifestEnabled) {
+            resourceName = toMultiReleaseResourceName(resourceName);
+        }
+        final Path root = getRootPath();
+        final String relativePath = PathTreeVisit.resourceNameToFsPath(resourceName, root.getFileSystem());
+        return root.resolve(relativePath);
     }
 
     @Override
-    protected <T> T apply(String relativePath, Function<PathVisit, T> func, boolean manifestEnabled) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    protected <T> T apply(String resourceName, Function<PathVisit, T> func, boolean manifestEnabled) {
+        ensureResourcePath(resourceName);
+        if (!PathFilter.isVisible(pathFilter, resourceName)) {
             return func.apply(null);
         }
-        final Path path = getRootPath().resolve(manifestEnabled ? toMultiReleaseRelativePath(relativePath) : relativePath);
+        final Path path = resolveResource(resourceName, manifestEnabled);
         if (!Files.exists(path)) {
             return func.apply(null);
         }
-        return PathTreeVisit.process(getRootPath(), getRootPath(), path, pathFilter, func);
+        final Path root = getRootPath();
+        return PathTreeVisit.process(root, root, path, pathFilter, func);
     }
 
     @Override
-    public void accept(String relativePath, Consumer<PathVisit> consumer) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    public void accept(String resourceName, Consumer<PathVisit> consumer) {
+        ensureResourcePath(resourceName);
+        if (!PathFilter.isVisible(pathFilter, resourceName)) {
             consumer.accept(null);
             return;
         }
-        final Path path = getRootPath().resolve(manifestEnabled ? toMultiReleaseRelativePath(relativePath) : relativePath);
+        final Path path = resolveResource(resourceName, manifestEnabled);
         if (!Files.exists(path)) {
             consumer.accept(null);
             return;
         }
-        PathTreeVisit.consume(getRootPath(), getRootPath(), path, pathFilter, consumer);
+        final Path root = getRootPath();
+        PathTreeVisit.consume(root, root, path, pathFilter, consumer);
     }
 
     @Override
-    public boolean contains(String relativePath) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    public boolean contains(String resourceName) {
+        ensureResourcePath(resourceName);
+        if (!PathFilter.isVisible(pathFilter, resourceName)) {
             return false;
         }
-        final Path path = getRootPath().resolve(manifestEnabled ? toMultiReleaseRelativePath(relativePath) : relativePath);
-        return Files.exists(path);
+        return Files.exists(resolveResource(resourceName, manifestEnabled));
     }
 
     @Override
-    public Path getPath(String relativePath) {
-        ensureResourcePath(relativePath);
-        if (!PathFilter.isVisible(pathFilter, relativePath)) {
+    public Path getPath(String resourceName) {
+        ensureResourcePath(resourceName);
+        if (!PathFilter.isVisible(pathFilter, resourceName)) {
             return null;
         }
-        final Path path = getRootPath().resolve(manifestEnabled ? toMultiReleaseRelativePath(relativePath) : relativePath);
+        final Path path = resolveResource(resourceName, manifestEnabled);
         return Files.exists(path) ? path : null;
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathFilter.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathFilter.java
@@ -55,11 +55,11 @@ public class PathFilter implements Mappable, Serializable {
         this.excludes = excludes;
     }
 
-    public boolean isVisible(String pathStr) {
+    public boolean isVisible(String resourceName) {
         if (includes != null && !includes.isEmpty()) {
             int i = 0;
             while (i < includes.size()) {
-                if (includes.get(i).matcher(pathStr).matches()) {
+                if (includes.get(i).matcher(resourceName).matches()) {
                     break;
                 }
                 ++i;
@@ -70,7 +70,7 @@ public class PathFilter implements Mappable, Serializable {
         }
         if (excludes != null) {
             for (Pattern pattern : excludes) {
-                if (pattern.matcher(pathStr).matches()) {
+                if (pattern.matcher(resourceName).matches()) {
                     return false;
                 }
             }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -10,6 +10,9 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * Classpath resource set backed by file system paths.
+ */
 public interface PathTree {
 
     static PathTree ofDirectoryOrFile(Path p) {
@@ -123,7 +126,7 @@ public interface PathTree {
      */
     default Set<String> getResourceNames() {
         Set<String> names = new HashSet<>();
-        walk(visit -> names.add(visit.getRelativePath()));
+        walk(visit -> names.add(visit.getResourceName()));
         return names;
     }
 
@@ -145,61 +148,60 @@ public interface PathTree {
     void walkRaw(PathVisitor visitor);
 
     /**
-     * Walks a subtree of this tree that begins with a passed in {@code relativePath},
-     * if the tree contains {@code relativePath}. If the tree does not contain {@code relativePath}
-     * then the method returns without an error.
+     * Walks a subtree of resources in this tree that begins with a passed in {@code resourceDirName}.
+     * If this tree does not contain resource {@code resourceDirName} then the method returns without an error.
      * <p>
-     * This method does not create a new {@link PathTree} with the root at {@code relativePath}.
+     * This method does not create a new {@link PathTree} with the root at {@code resourceDirName}.
      * It simply applies an inclusion filter to this {@link PathTree} instance, keeping the same root.
      *
-     * @param relativePath relative path from which the walk should begin
+     * @param resourceDirName directory resource name starting from which the walk should begin
      * @param visitor path visitor
      */
-    void walkIfContains(String relativePath, PathVisitor visitor);
+    void walkIfContains(String resourceDirName, PathVisitor visitor);
 
     /**
-     * Applies a function to a given path relative to the root of the tree.
-     * If the path isn't found in the tree, the {@link PathVisit} argument
+     * Applies a function to a given resource in the tree.
+     * If the resource isn't found in the tree, the {@link PathVisit} argument
      * passed to the function will be {@code null}.
      *
      * @param <T> resulting type
-     * @param relativePath relative path to process
+     * @param resourceName resource to process
      * @param func processing function
      * @return result of the function
      */
-    <T> T apply(String relativePath, Function<PathVisit, T> func);
+    <T> T apply(String resourceName, Function<PathVisit, T> func);
 
     /**
-     * Consumes a given path relative to the root of the tree.
-     * If the path isn't found in the tree, the {@link PathVisit} argument
+     * Consumes a given resource from the tree.
+     * If the resource isn't found in the tree, the {@link PathVisit} argument
      * passed to the consumer will be {@code null}.
      *
-     * @param relativePath relative path to consume
+     * @param resourceName resource to consume
      * @param consumer path consumer
      */
-    void accept(String relativePath, Consumer<PathVisit> consumer);
+    void accept(String resourceName, Consumer<PathVisit> consumer);
 
     /**
-     * Consumes a given path relative to the root of the tree.
-     * If the path isn't found in the tree, the {@link PathVisit} argument
+     * Consumes a given resource from the tree.
+     * If the resource isn't found in the tree, the {@link PathVisit} argument
      * passed to the consumer will be {@code null}.
-     *
+     * <p>
      * If multiple items match then the consumer will be called multiple times.
      *
-     * @param relativePath relative path to consume
+     * @param resourceName resource to consume
      * @param consumer path consumer
      */
-    default void acceptAll(String relativePath, Consumer<PathVisit> consumer) {
-        accept(relativePath, consumer);
+    default void acceptAll(String resourceName, Consumer<PathVisit> consumer) {
+        accept(resourceName, consumer);
     }
 
     /**
-     * Checks whether the tree contains a relative path.
+     * Checks whether the tree contains a resource.
      *
-     * @param relativePath path relative to the root of the tree
+     * @param resourceName resource name to check
      * @return true, in case the tree contains the path, otherwise - false
      */
-    boolean contains(String relativePath);
+    boolean contains(String resourceName);
 
     /**
      * Returns an {@link OpenPathTree} for this tree, which is supposed to be

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeVisit.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeVisit.java
@@ -2,6 +2,8 @@ package io.quarkus.paths;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -9,9 +11,45 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 class PathTreeVisit implements PathVisit {
+
+    private static final boolean USE_WINDOWS_ABSOLUTE_PATH_PATTERN = !FileSystems.getDefault().getSeparator().equals("/");
+
+    private static volatile Pattern windowsAbsolutePathPattern;
+
+    private static Pattern windowsAbsolutePathPattern() {
+        return windowsAbsolutePathPattern == null ? windowsAbsolutePathPattern = Pattern.compile("[a-zA-Z]:\\\\.*")
+                : windowsAbsolutePathPattern;
+    }
+
+    static boolean isAbsolutePath(String path) {
+        return path != null && !path.isEmpty()
+                && (path.charAt(0) == '/' // we want to check for '/' on every OS
+                        || USE_WINDOWS_ABSOLUTE_PATH_PATTERN
+                                && (windowsAbsolutePathPattern().matcher(path).matches())
+                        || path.startsWith(FileSystems.getDefault().getSeparator()));
+    }
+
+    static void ensureResourcePath(FileSystem fs, String path) {
+        if (isAbsolutePath(path)) {
+            throw new IllegalArgumentException("Expected a path relative to the root of the path tree but got " + path);
+        }
+        // this is to disallow reading outside the path tree root
+        if (path != null && path.contains("..")) {
+            for (Path pathElement : fs.getPath(path)) {
+                if (pathElement.toString().equals("..")) {
+                    throw new IllegalArgumentException("'..' cannot be used in resource paths, but got " + path);
+                }
+            }
+        }
+    }
+
+    static String resourceNameToFsPath(String resourceName, FileSystem fs) {
+        return fs.getSeparator().equals("/") ? resourceName : resourceName.replace("/", fs.getSeparator());
+    }
 
     static void walk(Path root, Path rootDir, Path walkDir, PathFilter pathFilter, Map<String, String> multiReleaseMapping,
             PathVisitor visitor) {
@@ -56,7 +94,7 @@ class PathTreeVisit implements PathVisit {
     private final Map<String, String> multiReleaseMapping;
 
     private Path current;
-    private String relativePath;
+    private String resourceName;
     private boolean stopWalking;
 
     private PathTreeVisit(Path root, Path rootDir, PathFilter pathFilter, Map<String, String> multiReleaseMapping) {
@@ -88,29 +126,29 @@ class PathTreeVisit implements PathVisit {
 
     @Override
     public String getRelativePath(String separator) {
-        if (relativePath == null) {
+        if (resourceName == null) {
             return PathTreeUtils.asString(relativize(baseDir, current), separator);
         }
-        if (!current.getFileSystem().getSeparator().equals(separator)) {
-            return relativePath.replace(current.getFileSystem().getSeparator(), separator);
+        if (!"/".equals(separator)) {
+            return resourceName.replace("/", separator);
         }
-        return relativePath;
+        return resourceName;
     }
 
     private boolean setCurrent(Path path) {
         current = path;
-        relativePath = null;
+        resourceName = null;
         if (pathFilter != null) {
-            relativePath = baseDir.relativize(path).toString();
-            if (!PathFilter.isVisible(pathFilter, relativePath)) {
+            resourceName = PathTreeUtils.asString(relativize(baseDir, current), "/");
+            if (!PathFilter.isVisible(pathFilter, resourceName)) {
                 return false;
             }
         }
         if (!multiReleaseMapping.isEmpty()) {
-            if (relativePath == null) {
-                relativePath = baseDir.relativize(path).toString();
+            if (resourceName == null) {
+                resourceName = PathTreeUtils.asString(relativize(baseDir, current), "/");
             }
-            final String mrPath = multiReleaseMapping.remove(relativePath);
+            final String mrPath = multiReleaseMapping.remove(resourceName);
             if (mrPath != null) {
                 current = baseDir.resolve(mrPath);
             }
@@ -120,8 +158,8 @@ class PathTreeVisit implements PathVisit {
 
     private void visitMultiReleasePaths(PathVisitor visitor) {
         for (Map.Entry<String, String> mrEntry : multiReleaseMapping.entrySet()) {
-            relativePath = mrEntry.getKey();
-            if (pathFilter != null && !PathFilter.isVisible(pathFilter, relativePath)) {
+            resourceName = mrEntry.getKey();
+            if (pathFilter != null && !PathFilter.isVisible(pathFilter, resourceName)) {
                 continue;
             }
             current = baseDir.resolve(mrEntry.getValue());

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeWithManifest.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeWithManifest.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -24,18 +23,12 @@ public abstract class PathTreeWithManifest implements PathTree {
 
     private static final String META_INF = "META-INF/";
     private static final String META_INF_VERSIONS = META_INF + "versions/";
-    public static final int JAVA_VERSION;
-
-    static {
-        try {
-            final String versionStr = "version";
-            Object v = Runtime.class.getMethod(versionStr).invoke(null);
-            List<Integer> list = (List<Integer>) v.getClass().getMethod(versionStr).invoke(v);
-            JAVA_VERSION = list.get(0);
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to obtain the Java version from java.lang.Runtime", e);
-        }
-    }
+    /**
+     * The feature-release version of the current Java runtime (e.g., 17, 21).
+     * Used to determine which {@code META-INF/versions/<N>} entries apply
+     * when resolving multi-release JAR resources.
+     */
+    public static final int JAVA_VERSION = Runtime.version().feature();
 
     protected boolean manifestEnabled;
     private final ReentrantReadWriteLock manifestInfoLock = new ReentrantReadWriteLock();
@@ -68,11 +61,11 @@ public abstract class PathTreeWithManifest implements PathTree {
     }
 
     @Override
-    public <T> T apply(String relativePath, Function<PathVisit, T> func) {
-        return apply(relativePath, func, manifestEnabled);
+    public <T> T apply(String resourceName, Function<PathVisit, T> func) {
+        return apply(resourceName, func, manifestEnabled);
     }
 
-    protected abstract <T> T apply(String relativePath, Function<PathVisit, T> func, boolean manifestEnabled);
+    protected abstract <T> T apply(String resourceName, Function<PathVisit, T> func, boolean manifestEnabled);
 
     @Override
     public ManifestAttributes getManifestAttributes() {
@@ -120,13 +113,27 @@ public abstract class PathTreeWithManifest implements PathTree {
         return manifestAttributes != null && manifestAttributes.isMultiRelease();
     }
 
+    /**
+     * Returns a mapping of classpath resource names to the corresponding version-specific
+     * resource names for resources found under {@code META-INF/versions/} in a multi-release JAR.
+     * <p>
+     * For example, in a multi-release JAR containing {@code META-INF/versions/11/com/example/Foo.class},
+     * running on Java 11 or later would produce a mapping from {@code com/example/Foo.class}
+     * to {@code META-INF/versions/11/com/example/Foo.class}.
+     * <p>
+     * When multiple version-specific entries exist for the same resource, the highest version
+     * that does not exceed {@link #JAVA_VERSION} takes precedence.
+     *
+     * @return a map from classpath resource names to their version-specific resource names,
+     *         or an empty map if this is not a multi-release JAR
+     */
     protected Map<String, String> getMultiReleaseMapping() {
         if (multiReleaseMapping != null) {
             return multiReleaseMapping;
         }
         final Map<String, String> mrMapping = isMultiReleaseJar()
-                ? apply(META_INF_VERSIONS, MultiReleaseMappingReader.INSTANCE, false)
-                : Collections.emptyMap();
+                ? apply(META_INF_VERSIONS, MultiReleaseResourceMapping.INSTANCE, false)
+                : Map.of();
         initMultiReleaseMapping(mrMapping);
         return mrMapping;
     }
@@ -135,29 +142,29 @@ public abstract class PathTreeWithManifest implements PathTree {
         multiReleaseMapping = mrMapping;
     }
 
-    protected String toMultiReleaseRelativePath(String relativePath) {
-        if (relativePath.startsWith(META_INF)) {
-            return relativePath;
+    protected String toMultiReleaseResourceName(String resourceName) {
+        if (resourceName.startsWith(META_INF)) {
+            return resourceName;
         }
 
-        return getMultiReleaseMapping().getOrDefault(relativePath, relativePath);
+        return getMultiReleaseMapping().getOrDefault(resourceName, resourceName);
     }
 
-    private static class MultiReleaseMappingReader implements Function<PathVisit, Map<String, String>> {
+    private static class MultiReleaseResourceMapping implements Function<PathVisit, Map<String, String>> {
 
-        private static final MultiReleaseMappingReader INSTANCE = new MultiReleaseMappingReader();
+        private static final MultiReleaseResourceMapping INSTANCE = new MultiReleaseResourceMapping();
 
         @Override
         public Map<String, String> apply(PathVisit visit) {
             if (visit == null) {
-                return Collections.emptyMap();
+                return Map.of();
             }
             final Path versionsDir = visit.getPath();
-            if (!Files.isDirectory(versionsDir)) {
-                return Collections.emptyMap();
-            }
             // get the root of the tree
-            final Path root = versionsDir.getParent().getParent();
+            final Path root = getTreeRootForVersionsDir(visit.getPath());
+            if (root == null) {
+                return Map.of();
+            }
             final TreeMap<Integer, Consumer<Map<String, String>>> versionContentMap = new TreeMap<>();
             try (Stream<Path> versions = Files.list(versionsDir)) {
                 versions.forEach(versionDir -> {
@@ -175,19 +182,16 @@ public abstract class PathTreeWithManifest implements PathTree {
                                 .debug("Failed to parse " + versionDir + " entry", e);
                         return;
                     }
-                    versionContentMap.put(version, new Consumer<Map<String, String>>() {
-                        @Override
-                        public void accept(Map<String, String> map) {
-                            try (Stream<Path> versionContent = Files.walk(versionDir)) {
-                                versionContent.forEach(p -> {
-                                    final String relativePath = asSubpath(versionDir, p);
-                                    if (!relativePath.isEmpty()) {
-                                        map.put(relativePath, asSubpath(root, p));
-                                    }
-                                });
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(e);
-                            }
+                    versionContentMap.put(version, map -> {
+                        try (Stream<Path> versionContent = Files.walk(versionDir)) {
+                            versionContent.forEach(p -> {
+                                final String resourceName = asResourceName(versionDir, p);
+                                if (!resourceName.isEmpty()) {
+                                    map.put(resourceName, asResourceName(root, p));
+                                }
+                            });
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
                         }
                     });
 
@@ -202,9 +206,23 @@ public abstract class PathTreeWithManifest implements PathTree {
             return multiReleaseMapping;
         }
 
-        private static String asSubpath(Path parentDir, Path childPath) {
-            return parentDir.getNameCount() == childPath.getNameCount() ? ""
-                    : childPath.subpath(parentDir.getNameCount(), childPath.getNameCount()).toString();
+        private static Path getTreeRootForVersionsDir(Path versionsDir) {
+            if (Files.isDirectory(versionsDir)) {
+                Path parent = versionsDir.getParent();
+                return parent == null ? null : parent.getParent();
+            }
+            return null;
+        }
+
+        private static String asResourceName(Path parentDir, Path child) {
+            if (parentDir.getNameCount() == child.getNameCount()) {
+                return "";
+            }
+            var sb = new StringBuilder().append(child.getName(parentDir.getNameCount()));
+            for (int i = parentDir.getNameCount() + 1; i < child.getNameCount(); i++) {
+                sb.append('/').append(child.getName(i));
+            }
+            return sb.toString();
         }
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathVisit.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathVisit.java
@@ -45,13 +45,23 @@ public interface PathVisit {
     }
 
     /**
+     * Visited class path resource name.
+     *
+     * @return visited resource name
+     */
+    default String getResourceName() {
+        return getRelativePath("/");
+    }
+
+    /**
      * Path relative to the root of the tree as a string with {@code /} as a path element separator.
      * This method calls {@link #getRelativePath(String)} passing {@code /} as an argument.
      *
      * @return path relative to the root of the tree as a string with {@code /} as a path element separator
      */
+    @Deprecated(forRemoval = true, since = "3.34.0")
     default String getRelativePath() {
-        return getRelativePath("/");
+        return getResourceName();
     }
 
     /**

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -185,8 +185,8 @@ class SharedArchivePathTree extends ArchivePathTree {
         }
 
         @Override
-        public void walkIfContains(String relativePath, PathVisitor visitor) {
-            delegate.walkIfContains(relativePath, visitor);
+        public void walkIfContains(String resourceDirName, PathVisitor visitor) {
+            delegate.walkIfContains(resourceDirName, visitor);
         }
 
         @Override
@@ -195,23 +195,23 @@ class SharedArchivePathTree extends ArchivePathTree {
         }
 
         @Override
-        public <T> T apply(String relativePath, Function<PathVisit, T> func) {
-            return delegate.apply(relativePath, func);
+        public <T> T apply(String resourceName, Function<PathVisit, T> func) {
+            return delegate.apply(resourceName, func);
         }
 
         @Override
-        public void accept(String relativePath, Consumer<PathVisit> consumer) {
-            delegate.accept(relativePath, consumer);
+        public void accept(String resourceName, Consumer<PathVisit> consumer) {
+            delegate.accept(resourceName, consumer);
         }
 
         @Override
-        public void acceptAll(String relativePath, Consumer<PathVisit> consumer) {
-            delegate.acceptAll(relativePath, consumer);
+        public void acceptAll(String resourceName, Consumer<PathVisit> consumer) {
+            delegate.acceptAll(resourceName, consumer);
         }
 
         @Override
-        public boolean contains(String relativePath) {
-            return delegate.contains(relativePath);
+        public boolean contains(String resourceName) {
+            return delegate.contains(resourceName);
         }
 
         @Override

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/GetResourceNamesTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/GetResourceNamesTest.java
@@ -106,7 +106,7 @@ public class GetResourceNamesTest {
         var tree = PathTree.ofDirectoryOrArchive(dir1);
         var resourceNames = tree.getResourceNames();
         var walkNames = new java.util.HashSet<String>();
-        tree.walk(visit -> walkNames.add(visit.getRelativePath()));
+        tree.walk(visit -> walkNames.add(visit.getResourceName()));
         assertThat(resourceNames).containsExactlyInAnyOrderElementsOf(walkNames);
     }
 }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/PathCollectingVisitor.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/PathCollectingVisitor.java
@@ -11,7 +11,7 @@ class PathCollectingVisitor implements PathVisitor {
 
     @Override
     public void visitPath(PathVisit visit) {
-        visitedPaths.put(visit.getRelativePath(), toResourceName((getRelativeToRoot(visit))));
+        visitedPaths.put(visit.getResourceName(), toResourceName((getRelativeToRoot(visit))));
     }
 
     private static String toResourceName(Path path) {

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/WalkSubtreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/WalkSubtreeTest.java
@@ -45,7 +45,7 @@ public class WalkSubtreeTest {
     public void walkDirectorySubtree() {
         var list = new ArrayList<String>();
         PathTree.ofDirectoryOrArchive(testDir)
-                .walkIfContains("a/aa", visit -> list.add(visit.getRelativePath()));
+                .walkIfContains("a/aa", visit -> list.add(visit.getResourceName()));
         assertThat(list).containsExactlyInAnyOrder(
                 "a/aa",
                 "a/aa/1.txt",
@@ -60,7 +60,7 @@ public class WalkSubtreeTest {
     public void walkJarSubtree() {
         var list = new ArrayList<String>();
         PathTree.ofDirectoryOrArchive(testZip)
-                .walkIfContains("a/aa", visit -> list.add(visit.getRelativePath()));
+                .walkIfContains("a/aa", visit -> list.add(visit.getResourceName()));
         assertThat(list).containsExactlyInAnyOrder(
                 "a/aa",
                 "a/aa/1.txt",

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
@@ -210,7 +210,7 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
         private volatile URL url;
 
         private Resource(PathVisit visit) {
-            name = visit.getRelativePath();
+            name = visit.getResourceName();
             path = visit.getPath();
         }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PlatformWithoutQuarkusBomTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PlatformWithoutQuarkusBomTest.java
@@ -107,12 +107,12 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
             var codestartsDir = fs.getPath("codestarts");
             Files.createDirectories(codestartsDir);
             PathTree.ofDirectoryOrArchive(dir).walk(visit -> {
-                final String relativePath = visit.getRelativePath();
+                final String relativePath = visit.getResourceName();
                 if (relativePath.isEmpty()) {
                     return;
                 }
                 try {
-                    Files.copy(visit.getPath(), codestartsDir.resolve(visit.getRelativePath()));
+                    Files.copy(visit.getPath(), codestartsDir.resolve(visit.getResourceName()));
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }


### PR DESCRIPTION
Mostly javadoc changes and `PathTree.getResourceName()` method that deprecates `PathTree.getRelativePath()` to make it clear this API is for classpath resource processing.