### PR TITLE
Fix build reproducibility of bytecode recorder return value proxy identifiers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -508,7 +508,8 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 }
             }
         }
-        for (var e : existingRecorderValues.entrySet()) {
+        for (var e : existingRecorderValues.entrySet().stream()
+                .sorted(Comparator.comparing(re -> re.getKey().getName())).toList()) {
             e.getValue().preWrite(parameterMap);
         }
 
@@ -525,7 +526,8 @@ public class BytecodeRecorderImpl implements RecorderContext {
         //allocates a new method
         SplitMethodContext context = new SplitMethodContext(array, mainMethod, file);
 
-        for (var i : this.existingRecorderValues.values()) {
+        for (var i : this.existingRecorderValues.values().stream()
+                .sorted(Comparator.comparing(newRecorder -> newRecorder.theClass.getName())).toList()) {
             i.prepare(context);
         }
         //now we invoke the actual method call

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -99,6 +99,8 @@ import io.smallrye.common.constraint.Assert;
  * - Objects with a constructor annotated with @RecordableConstructor with parameter names that match field names
  * - Any arbitrary object via the {@link #registerSubstitution(Class, Class, Class)} mechanism
  * - arrays, lists and maps of the above
+ * <p>
+ * We instantiate one instance of this class per recording build step method.
  */
 public class BytecodeRecorderImpl implements RecorderContext {
 
@@ -106,10 +108,17 @@ public class BytecodeRecorderImpl implements RecorderContext {
     private static final Class<?> SINGLETON_SET_CLASS = Collections.singleton(1).getClass();
     private static final Class<?> SINGLETON_MAP_CLASS = Collections.singletonMap(1, 1).getClass();
 
+    // Global counter for proxy class name suffixes. These are build time artifacts
+    // that don't affect the generated output bytecode, so non-deterministic ordering is fine.
     private static final AtomicInteger COUNT = new AtomicInteger();
     private static final String BASE_PACKAGE = "io.quarkus.runner.recorded.";
 
-    private static final String PROXY_KEY = "proxykey";
+    private static final String PROXY_KEY = "proxykey:";
+    // Per-instance counter for deterministic proxy keys. Since each BytecodeRecorderImpl
+    // corresponds to a single build step method running on a single thread, the sequence
+    // of increments within an instance is deterministic. Combined with the unique className,
+    // this produces globally unique and reproducible proxy keys.
+    private final AtomicInteger proxyKeyCount = new AtomicInteger();
 
     private static final MethodDescriptor COLLECTION_ADD = ofMethod(Collection.class, "add", boolean.class, Object.class);
     private static final MethodDescriptor MAP_PUT = ofMethod(Map.class, "put", Object.class, Object.class, Object.class);
@@ -418,7 +427,12 @@ public class BytecodeRecorderImpl implements RecorderContext {
             returnValueProxy.put(returnType, proxyFactory = new ProxyFactory<>(proxyConfiguration));
         }
 
-        String key = PROXY_KEY + COUNT.incrementAndGet();
+        // we will generate classes using className e.g. io.quarkus.runner.recorded.FooProcessor$buildStepMethod12345
+        // the simple class name makes for a good identifier e.g. FooProcessor$buildStepMethod12345
+        // as long as we record the method calls in order, we will have a stable ordering
+        int lastDot = className.lastIndexOf('.');
+        String simpleClassName = lastDot >= 0 ? className.substring(lastDot + 1) : className;
+        String key = PROXY_KEY + simpleClassName + ":" + proxyKeyCount.incrementAndGet();
         Object proxyInstance = proxyFactory.newInstance(new ReturnValueProxyInvocationHandler(key, returnType, staticInit));
         return new ProxyInstance(proxyInstance, key);
     }


### PR DESCRIPTION
This is the last issue I had identified when building a simple Quarkus REST app. I suspect there will be others in other extensions but I think that's a good start: it means our build system is supposedly reproducible.

Now, it's hard to have a complete proof but I had similar binaries 10 times in a row, which looks promising.

I was playing with @mkouba's idea of using the stack but I was a bit worried about the cost. Then, Claude Code pointed out to me that we are instantiating a new BytecodeRecorderImpl for each recording method and that we had a stable unique identifier already: the class name. And that we could use an instance counter instead of a static one to avoid interactions between the parallel threads.

All in all, this seems like a good solution so I went with it. I decided to strip the package name to reduce the size of the proxy identifier. I was intentionally conservative in keeping the constructors as is and dropping the package when generating the key, even if not optimal.

And, yes, this is a long comment but I wanted to make sure the intent was captured properly.

Supersedes #49047