### PR TITLE
Fix Keycloak devservice using wrong port when HTTPS is enabled with fixed port

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -598,7 +598,8 @@ public class KeycloakDevServicesProcessor {
             }
 
             if (fixedExposedPort.isPresent()) {
-                addFixedExposedPort(fixedExposedPort.getAsInt(), KEYCLOAK_PORT);
+                addFixedExposedPort(fixedExposedPort.getAsInt(),
+                        keycloakX && isHttps() ? KEYCLOAK_HTTPS_PORT : KEYCLOAK_PORT);
                 if (useSharedNetwork) {
                     // expose random port for which we are able to ask Testcontainers for the actual mapped port at runtime
                     // as from the host's perspective Testcontainers actually expose container ports on random host port
@@ -626,7 +627,7 @@ public class KeycloakDevServicesProcessor {
                 }
                 withCommand(finalStartCommand);
                 addUpConfigResource();
-                if (isHttps()) {
+                if (isHttps() && !fixedExposedPort.isPresent()) {
                     addExposedPort(KEYCLOAK_HTTPS_PORT);
                 }
             } else {


### PR DESCRIPTION
## Summary

- Map the fixed port to `KEYCLOAK_HTTPS_PORT` (8443) instead of `KEYCLOAK_PORT` (8080) when KeycloakX HTTPS is active, so `https://localhost:<fixedPort>` is reachable
- Skip exposing HTTPS port with a random mapping when a fixed port is already mapped to 8443, avoiding duplicate port exposure

Fixes: #49842

## Test plan

- [ ] Verify `quarkus.keycloak.devservices.port=12345` with HTTPS enabled maps `12345:8443`
- [ ] Verify without a fixed port, HTTPS port is still exposed with a random mapping
- [ ] Verify non-HTTPS fixed port still maps to `8080` as before
- [ ] Run Keycloak devservices and OIDC deployment tests